### PR TITLE
slack: Handle archive and unarchive into the same channel

### DIFF
--- a/server/polar/benefit/strategies/slack_shared_channel/service.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/service.py
@@ -128,6 +128,11 @@ class BenefitSlackSharedChannelService(
         if existing_channel_id:
             channel_id = existing_channel_id
             channel_name = grant_properties.get("channel_name", "")
+            await self._unarchive_channel(
+                bot_token=bot_token,
+                channel=channel_id,
+                bound_logger=bound_logger,
+            )
         elif sibling_channel := await self._find_sibling_channel(benefit, customer):
             channel_id, channel_name = sibling_channel
         else:
@@ -210,12 +215,9 @@ class BenefitSlackSharedChannelService(
 
         properties = self._get_properties(benefit)
         channel_id = grant_properties.get("channel_id")
-        revoked_properties: BenefitGrantSlackSharedChannelProperties = {
-            "invited_email": grant_properties.get("invited_email", "")
-        }
 
         if not properties.get("archive_on_revoke") or not channel_id:
-            return revoked_properties
+            return self._revoked_properties(grant_properties, keep_channel=True)
 
         grant_repository = BenefitGrantRepository.from_session(self.session)
         total_grants = (
@@ -236,12 +238,12 @@ class BenefitSlackSharedChannelService(
                 "Slack channel still used by other grants; skipping archive",
                 channel_id=channel_id,
             )
-            return revoked_properties
+            return self._revoked_properties(grant_properties, keep_channel=True)
 
         integration = await self._get_integration(benefit)
         if integration is None or integration.bot_token is None:
             bound_logger.info("Slack integration uninstalled; skipping archive")
-            return revoked_properties
+            return self._revoked_properties(grant_properties, keep_channel=True)
 
         try:
             result = await self._client.conversations_archive(
@@ -255,13 +257,33 @@ class BenefitSlackSharedChannelService(
             error = result.get("error", "")
             if error in _ARCHIVE_NOOP_ERRORS:
                 bound_logger.info("Slack channel already archived or gone", error=error)
-                return revoked_properties
+                return self._revoked_properties(
+                    grant_properties, keep_channel=error != "channel_not_found"
+                )
             bound_logger.warning("Slack archive returned error", error=error)
             if error in _ARCHIVE_TRANSIENT_ERRORS:
                 raise BenefitRetriableError()
             raise BenefitActionRequiredError(f"Slack archive error: {error}")
 
-        return revoked_properties
+        return self._revoked_properties(grant_properties, keep_channel=True)
+
+    def _revoked_properties(
+        self,
+        grant_properties: BenefitGrantSlackSharedChannelProperties,
+        *,
+        keep_channel: bool,
+    ) -> BenefitGrantSlackSharedChannelProperties:
+        revoked: BenefitGrantSlackSharedChannelProperties = {
+            "invited_email": grant_properties.get("invited_email", "")
+        }
+        if keep_channel:
+            channel_id = grant_properties.get("channel_id")
+            if channel_id:
+                revoked["channel_id"] = channel_id
+                channel_name = grant_properties.get("channel_name")
+                if channel_name:
+                    revoked["channel_name"] = channel_name
+        return revoked
 
     async def requires_update(
         self,

--- a/server/polar/benefit/strategies/slack_shared_channel/service.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/service.py
@@ -378,7 +378,10 @@ class BenefitSlackSharedChannelService(
         while True:
             try:
                 result = await self._client.conversations_list(
-                    bot_token=bot_token, cursor=cursor, types=types
+                    bot_token=bot_token,
+                    cursor=cursor,
+                    types=types,
+                    exclude_archived=False,
                 )
             except httpx.HTTPError as e:
                 raise BenefitRetriableError() from e
@@ -398,6 +401,15 @@ class BenefitSlackSharedChannelService(
                 channel_id = channel.get("id")
                 if not isinstance(channel_id, str):
                     continue
+
+                if channel.get("is_archived"):
+                    unarchived = await self._unarchive_channel(
+                        bot_token=bot_token,
+                        channel=channel_id,
+                        bound_logger=bound_logger,
+                    )
+                    if not unarchived:
+                        return None
 
                 if channel.get("is_private"):
                     if not channel.get("is_member"):
@@ -442,6 +454,30 @@ class BenefitSlackSharedChannelService(
 
         bound_logger.info(
             "Slack public channel join skipped",
+            channel_id=channel,
+            error=result.get("error"),
+        )
+        return False
+
+    async def _unarchive_channel(
+        self,
+        *,
+        bot_token: str,
+        channel: str,
+        bound_logger: Any,
+    ) -> bool:
+        try:
+            result = await self._client.conversations_unarchive(
+                bot_token=bot_token, channel=channel
+            )
+        except httpx.HTTPError as e:
+            raise BenefitRetriableError() from e
+
+        if result.get("ok") or result.get("error") == "not_archived":
+            return True
+
+        bound_logger.info(
+            "Slack channel unarchive skipped",
             channel_id=channel,
             error=result.get("error"),
         )

--- a/server/polar/integrations/slack/client.py
+++ b/server/polar/integrations/slack/client.py
@@ -143,6 +143,18 @@ class SlackClient:
             json={"channel": channel},
         )
 
+    async def conversations_unarchive(
+        self,
+        *,
+        bot_token: str,
+        channel: str,
+    ) -> dict[str, Any]:
+        return await self._post_authed(
+            "/conversations.unarchive",
+            bot_token=bot_token,
+            json={"channel": channel},
+        )
+
     async def chat_post_message(
         self,
         *,

--- a/server/polar/integrations/slack/endpoints.py
+++ b/server/polar/integrations/slack/endpoints.py
@@ -261,14 +261,19 @@ async def events(
     x_slack_request_timestamp: Annotated[str | None, Header()] = None,
     session: AsyncSession = Depends(get_db_session),
 ) -> Any:
-    if x_slack_signature is None or x_slack_request_timestamp is None:
-        raise Unauthorized()
-
     body = await request.body()
     try:
         payload = json.loads(body)
     except json.JSONDecodeError as e:
         raise BadRequest("Invalid JSON.") from e
+
+    payload_type = payload.get("type")
+    if payload_type == "url_verification":
+        challenge = payload.get("challenge", "")
+        return JSONResponse({"challenge": challenge})
+
+    if x_slack_signature is None or x_slack_request_timestamp is None:
+        raise Unauthorized()
 
     api_app_id = payload.get("api_app_id")
     if not isinstance(api_app_id, str):
@@ -286,11 +291,6 @@ async def events(
         timestamp_header=x_slack_request_timestamp,
     ):
         raise Unauthorized()
-
-    payload_type = payload.get("type")
-    if payload_type == "url_verification":
-        challenge = payload.get("challenge", "")
-        return JSONResponse({"challenge": challenge})
 
     if payload_type == "event_callback":
         event = payload.get("event") or {}

--- a/server/polar/integrations/slack/manifest.py
+++ b/server/polar/integrations/slack/manifest.py
@@ -22,6 +22,7 @@ _BOT_EVENTS = [
     "tokens_revoked",
     "app_uninstalled",
     "channel_shared",
+    "channel_id_changed",
 ]
 
 

--- a/server/polar/integrations/slack/service.py
+++ b/server/polar/integrations/slack/service.py
@@ -318,6 +318,12 @@ class SlackAppService:
             )
             return
 
+        if event_type == "channel_id_changed":
+            await self._handle_channel_id_changed(
+                session, integration=integration, event=event
+            )
+            return
+
         log.debug(
             "slack.events.unhandled",
             api_app_id=api_app_id,
@@ -356,6 +362,39 @@ class SlackAppService:
             properties = dict(grant.properties or {})
             if isinstance(connected_team_id, str):
                 properties["connected_team_id"] = connected_team_id
+            await grant_repository.update(grant, update_dict={"properties": properties})
+
+    async def _handle_channel_id_changed(
+        self,
+        session: AsyncSession,
+        *,
+        integration: SlackApp,
+        event: dict[str, Any],
+    ) -> None:
+        old_channel_id = event.get("old_channel_id")
+        new_channel_id = event.get("new_channel_id")
+        if not isinstance(old_channel_id, str) or not isinstance(new_channel_id, str):
+            return
+
+        benefit_repository = BenefitRepository.from_session(session)
+        benefits = await benefit_repository.list_by_slack_integration_id(
+            integration.organization_id, integration.id
+        )
+
+        grant_repository = BenefitGrantRepository.from_session(session)
+        for benefit in benefits:
+            grant = await grant_repository.get_by_property_and_organization(
+                integration.organization_id,
+                "channel_id",
+                old_channel_id,
+                benefit_id=benefit.id,
+                for_update=True,
+            )
+            if grant is None:
+                continue
+
+            properties = dict(grant.properties or {})
+            properties["channel_id"] = new_channel_id
             await grant_repository.update(grant, update_dict={"properties": properties})
 
     async def _validate_credentials(

--- a/server/tests/benefit/strategies/test_slack_shared_channel.py
+++ b/server/tests/benefit/strategies/test_slack_shared_channel.py
@@ -107,6 +107,7 @@ def _mock_client(mocker: MockerFixture, **overrides: Any) -> AsyncMock:
             }
         ),
         "conversations_archive": AsyncMock(return_value={"ok": True}),
+        "conversations_unarchive": AsyncMock(return_value={"ok": True}),
     }
     defaults.update(overrides)
     client = AsyncMock()
@@ -362,6 +363,176 @@ class TestSlackSharedChannelGrant:
             channel="GEXIST",
             email="admin@customer.example",
         )
+
+    async def test_grant_unarchives_existing_public_channel_by_rendered_name(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        customer.name = "Acme"
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_create=AsyncMock(
+                return_value={"ok": False, "error": "name_taken"}
+            ),
+            conversations_list=AsyncMock(
+                return_value={
+                    "ok": True,
+                    "channels": [
+                        {
+                            "id": "CEXIST",
+                            "name": "support-acme",
+                            "is_private": False,
+                            "is_member": False,
+                            "is_archived": True,
+                        }
+                    ],
+                }
+            ),
+        )
+        strategy = _strategy(session, redis, client)
+
+        result = await strategy.grant(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example"},
+        )
+
+        assert result["channel_id"] == "CEXIST"
+        assert result["channel_name"] == "support-acme"
+        client.conversations_unarchive.assert_awaited_once_with(
+            bot_token="xoxb-test-token", channel="CEXIST"
+        )
+        client.conversations_join.assert_awaited_once_with(
+            bot_token="xoxb-test-token", channel="CEXIST"
+        )
+        client.conversations_create.assert_awaited_once()
+        client.conversations_invite_shared.assert_awaited_once_with(
+            bot_token="xoxb-test-token",
+            channel="CEXIST",
+            email="admin@customer.example",
+        )
+
+    async def test_grant_unarchives_existing_private_channel_when_app_is_member(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        customer.name = "Acme"
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties={**_BASE_PROPERTIES, "private": True},
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_create=AsyncMock(
+                return_value={"ok": False, "error": "name_taken"}
+            ),
+            conversations_list=AsyncMock(
+                return_value={
+                    "ok": True,
+                    "channels": [
+                        {
+                            "id": "GEXIST",
+                            "name": "support-acme",
+                            "is_private": True,
+                            "is_member": True,
+                            "is_archived": True,
+                        }
+                    ],
+                }
+            ),
+        )
+        strategy = _strategy(session, redis, client)
+
+        result = await strategy.grant(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example"},
+        )
+
+        assert result["channel_id"] == "GEXIST"
+        client.conversations_unarchive.assert_awaited_once_with(
+            bot_token="xoxb-test-token", channel="GEXIST"
+        )
+        client.conversations_join.assert_not_awaited()
+        client.conversations_create.assert_awaited_once()
+
+    async def test_grant_creates_suffixed_channel_when_unarchive_fails(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        customer.name = "Acme"
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_create=AsyncMock(
+                side_effect=[
+                    {"ok": False, "error": "name_taken"},
+                    {"ok": True, "channel": {"id": "C123", "name": "support-acme"}},
+                ]
+            ),
+            conversations_list=AsyncMock(
+                return_value={
+                    "ok": True,
+                    "channels": [
+                        {
+                            "id": "CEXIST",
+                            "name": "support-acme",
+                            "is_private": False,
+                            "is_member": False,
+                            "is_archived": True,
+                        }
+                    ],
+                }
+            ),
+            conversations_unarchive=AsyncMock(
+                return_value={"ok": False, "error": "restricted_action"}
+            ),
+        )
+        strategy = _strategy(session, redis, client)
+
+        result = await strategy.grant(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example"},
+        )
+
+        assert result["channel_id"] == "C123"
+        client.conversations_unarchive.assert_awaited_once_with(
+            bot_token="xoxb-test-token", channel="CEXIST"
+        )
+        client.conversations_join.assert_not_awaited()
+        assert client.conversations_create.await_count == 2
 
     async def test_grant_creates_channel_when_existing_public_channel_cannot_be_joined(
         self,

--- a/server/tests/benefit/strategies/test_slack_shared_channel.py
+++ b/server/tests/benefit/strategies/test_slack_shared_channel.py
@@ -1007,6 +1007,43 @@ class TestSlackSharedChannelGrant:
             email="admin@customer.example",
         )
 
+    async def test_grant_unarchives_reused_channel_by_id(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+
+        existing: BenefitGrantSlackSharedChannelProperties = {
+            "invited_email": "admin@customer.example",
+            "channel_id": "CEXIST",
+            "channel_name": "support-existing",
+        }
+        result = await strategy.grant(benefit, customer, existing)
+
+        assert result["channel_id"] == "CEXIST"
+        client.conversations_unarchive.assert_awaited_once_with(
+            bot_token="xoxb-test-token", channel="CEXIST"
+        )
+        client.conversations_create.assert_not_awaited()
+        client.conversations_invite_shared.assert_awaited_once_with(
+            bot_token="xoxb-test-token",
+            channel="CEXIST",
+            email="admin@customer.example",
+        )
+
     async def test_grant_retries_on_name_taken(
         self,
         session: AsyncSession,
@@ -1308,7 +1345,10 @@ class TestSlackSharedChannelRevoke:
         client.conversations_archive.assert_awaited_once_with(
             bot_token="xoxb-test-token", channel="C123"
         )
-        assert result == {"invited_email": "admin@customer.example"}
+        assert result == {
+            "invited_email": "admin@customer.example",
+            "channel_id": "C123",
+        }
 
     async def test_revoke_archives_when_last_grant_on_channel(
         self,
@@ -1348,7 +1388,10 @@ class TestSlackSharedChannelRevoke:
         client.conversations_archive.assert_awaited_once_with(
             bot_token="xoxb-test-token", channel="C123"
         )
-        assert result == {"invited_email": "admin@customer.example"}
+        assert result == {
+            "invited_email": "admin@customer.example",
+            "channel_id": "C123",
+        }
 
     async def test_revoke_skips_archive_when_channel_used_by_other_benefit(
         self,
@@ -1402,7 +1445,10 @@ class TestSlackSharedChannelRevoke:
         )
 
         client.conversations_archive.assert_not_awaited()
-        assert result == {"invited_email": "admin@customer.example"}
+        assert result == {
+            "invited_email": "admin@customer.example",
+            "channel_id": "C123",
+        }
 
     async def test_revoke_skips_when_archive_disabled(
         self,
@@ -1575,7 +1621,13 @@ class TestSlackSharedChannelRevoke:
             {"invited_email": "admin@customer.example", "channel_id": "C123"},
         )
 
-        assert result == {"invited_email": "admin@customer.example"}
+        if error == "channel_not_found":
+            assert result == {"invited_email": "admin@customer.example"}
+        else:
+            assert result == {
+                "invited_email": "admin@customer.example",
+                "channel_id": "C123",
+            }
 
     async def test_revoke_archive_permanent_error_raises_action_required(
         self,

--- a/server/tests/integrations/slack/test_endpoints.py
+++ b/server/tests/integrations/slack/test_endpoints.py
@@ -648,27 +648,17 @@ class TestEvents:
         assert response.status_code == 401
 
     async def test_url_verification_returns_challenge(
-        self,
-        client: AsyncClient,
-        save_fixture: SaveFixture,
-        organization: Organization,
+        self, client: AsyncClient
     ) -> None:
-        await _create_integration(save_fixture, organization)
         payload = {
+            "token": "Jhj5dZrVaK7ZwHHjRyZWjbDl",
             "type": "url_verification",
-            "api_app_id": "A0TESTAPPID",
             "challenge": "abc123",
         }
-        body = json.dumps(payload).encode()
-        ts, sig = _slack_signature(signing_secret="ss-test-secret", body=body)
         response = await client.post(
             "/v1/integrations/slack/events",
-            content=body,
-            headers={
-                "x-slack-signature": sig,
-                "x-slack-request-timestamp": ts,
-                "content-type": "application/json",
-            },
+            content=json.dumps(payload).encode(),
+            headers={"content-type": "application/json"},
         )
         assert response.status_code == 200
         assert response.json() == {"challenge": "abc123"}

--- a/server/tests/integrations/slack/test_service.py
+++ b/server/tests/integrations/slack/test_service.py
@@ -496,6 +496,102 @@ class TestHandleEvent:
         assert refreshed is not None
         assert "connected_team_id" not in (refreshed.properties or {})
 
+    async def test_channel_id_changed_remaps_grants(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        benefit = await _create_benefit(save_fixture, organization)
+        other_benefit = await _create_benefit(save_fixture, organization)
+        await _create_integration(save_fixture, organization, benefit=benefit)
+        grant = await create_benefit_grant(
+            save_fixture,
+            customer,
+            benefit,
+            properties={"invited_email": "a@example.com", "channel_id": "G123"},
+        )
+        untouched = await create_benefit_grant(
+            save_fixture,
+            customer,
+            other_benefit,
+            properties={"invited_email": "a@example.com", "channel_id": "G999"},
+        )
+        await session.flush()
+        service, _client = _service_with_mock(mocker)
+
+        await service.handle_event(
+            session,
+            api_app_id="A0TESTAPPID",
+            event={
+                "type": "channel_id_changed",
+                "old_channel_id": "G123",
+                "new_channel_id": "C123",
+            },
+        )
+
+        repo = BenefitGrantRepository.from_session(session)
+        refreshed = await repo.get_by_id(grant.id)
+        assert refreshed is not None
+        assert (refreshed.properties or {}).get("channel_id") == "C123"
+        refreshed_untouched = await repo.get_by_id(untouched.id)
+        assert refreshed_untouched is not None
+        assert (refreshed_untouched.properties or {}).get("channel_id") == "G999"
+
+    async def test_channel_id_changed_scopes_to_integration(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        benefit = await _create_benefit(save_fixture, organization)
+        other_benefit = await _create_benefit(save_fixture, organization)
+        await _create_integration(
+            save_fixture, organization, benefit=benefit, slack_app_id="A0TESTAPPID"
+        )
+        await _create_integration(
+            save_fixture,
+            organization,
+            benefit=other_benefit,
+            slack_app_id="A0OTHERAPP",
+        )
+        grant = await create_benefit_grant(
+            save_fixture,
+            customer,
+            benefit,
+            properties={"invited_email": "a@example.com", "channel_id": "G123"},
+        )
+        other_grant = await create_benefit_grant(
+            save_fixture,
+            customer,
+            other_benefit,
+            properties={"invited_email": "a@example.com", "channel_id": "G123"},
+        )
+        await session.flush()
+        service, _client = _service_with_mock(mocker)
+
+        await service.handle_event(
+            session,
+            api_app_id="A0TESTAPPID",
+            event={
+                "type": "channel_id_changed",
+                "old_channel_id": "G123",
+                "new_channel_id": "C123",
+            },
+        )
+
+        repo = BenefitGrantRepository.from_session(session)
+        refreshed = await repo.get_by_id(grant.id)
+        assert refreshed is not None
+        assert (refreshed.properties or {}).get("channel_id") == "C123"
+        refreshed_other = await repo.get_by_id(other_grant.id)
+        assert refreshed_other is not None
+        assert (refreshed_other.properties or {}).get("channel_id") == "G123"
+
 
 @pytest.mark.asyncio
 class TestDelete:


### PR DESCRIPTION
- Fixes URL verification
- Stores the channel ID so that it can be reused for unarchiving into the same channel

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuse the same Slack shared channel by unarchiving it on re-grant (by stored ID or discovered name), and keep channel metadata on revoke for future reuse. Also fixes Slack URL verification to return the challenge without signature checks.

- **New Features**
  - Unarchive an existing channel on grant (by stored `channel_id` or discovered name); fall back to creating a suffixed channel if unarchive fails.
  - Preserve `channel_id` (and `channel_name` when available) on revoke so the same channel can be reused later; skip preserving only when Slack returns `channel_not_found`.
  - Handle Slack `channel_id_changed` events to remap existing grants to the new channel ID.
  - Add Slack client support for `conversations.unarchive` and include archived channels when listing.

- **Bug Fixes**
  - URL verification now returns the `challenge` before signature validation, matching Slack’s expected flow.

<sup>Written for commit 596e59d7acff6303a5da49cef67db38e3833615a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

