### PR TITLE
tf: Add lifecycle rules

### DIFF
--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -91,6 +91,11 @@ resource "render_postgres" "db" {
   depends_on = [render_registry_credential.ghcr, render_project.polar]
 }
 
+import {
+  to = render_postgres.db
+  id = "dpg-d8m0n4poagis73du7gr0-a"
+}
+
 # =============================================================================
 # Redis
 # =============================================================================

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -79,9 +79,12 @@ resource "render_postgres" "db" {
   ]
 
   lifecycle {
+    prevent_destroy = true
     ignore_changes = [
       ip_allow_list,
       disk_size_gb,
+      database_user,
+      database_name,
     ]
   }
 

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -71,7 +71,7 @@ resource "render_postgres" "db" {
   version        = "15"
   disk_size_gb   = 500
 
-  high_availability_enabled = true
+  high_availability_enabled = false
 
   read_replicas = [
     { name = "polar-read" },

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -50,8 +50,11 @@ resource "render_postgres" "db" {
   ]
 
   lifecycle {
+    prevent_destroy = true
     ignore_changes = [
       ip_allow_list,
+      database_user,
+      database_name,
     ]
   }
 


### PR DESCRIPTION
Prevent database_user, name to be changed via TF.
Prevent destroy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Terraform lifecycle rules to `render_postgres` in test and production: set `prevent_destroy = true` and ignore changes to `database_user`, `database_name`, and `ip_allow_list` (plus `disk_size_gb` in production). Import the existing production DB into state to prevent replacement, and temporarily set `high_availability_enabled = false` in production.

<sup>Written for commit f47ab6427bf43c1dff0ebc4f6097e403222b89ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

