### PR TITLE
feat(appeal-case): add internal note on approve/deny

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -1754,7 +1754,10 @@ async def appeal_case_approve_dialog(
                     reason=reason,
                 )
                 await organization_service.backoffice_approve(
-                    session, organization, reason=reason
+                    session,
+                    organization,
+                    reason=reason,
+                    internal_note="Appeal approved — see support case.",
                 )
                 await appeal_case_service.record_decision(
                     session,
@@ -1830,7 +1833,7 @@ async def appeal_case_deny_dialog(
     opened after the AI appeal was rejected), so there is no org-status change
     to make — the decision records the outcome on the case and locks it.
     """
-    _, case = await _load_org_with_appeal_case(session, organization_id)
+    organization, case = await _load_org_with_appeal_case(session, organization_id)
 
     error_message: str | None = None
 
@@ -1852,6 +1855,9 @@ async def appeal_case_deny_dialog(
                 approved=False,
                 staff_user=user_session.user,
                 reason=reason,
+            )
+            await organization_service.add_internal_note(
+                session, organization, "Appeal denied — see support case."
             )
         except AppealCaseError as e:
             # Discard the recorded decision so a failure can't commit it

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1212,6 +1212,7 @@ class OrganizationService:
         next_review_threshold: int | None = None,
         *,
         reason: str,
+        internal_note: str | None = None,
     ) -> Organization:
         """Backoffice override to re-activate a DENIED or BLOCKED organization.
 
@@ -1222,6 +1223,10 @@ class OrganizationService:
 
         If a review with a submitted appeal exists, the appeal is recorded as
         APPROVED so the merchant's frontend reflects the approval.
+
+        ``internal_note`` overrides the default reactivation note (and omits the
+        reason line) so callers can record a context-specific note instead — the
+        appeal flow points to the support case rather than repeating its reason.
         """
         notes = {
             OrganizationStatus.DENIED: "Organization reactivated from denied.",
@@ -1245,11 +1250,12 @@ class OrganizationService:
             review.appeal_reviewed_at = datetime.now(UTC)
             session.add(review)
 
+        note = internal_note if internal_note is not None else notes[organization.status]
         target_status = await self._reactivate_organization(
             session,
             organization,
-            note=notes[organization.status],
-            reason=reason,
+            note=note,
+            reason=None if internal_note is not None else reason,
             next_review_threshold=next_review_threshold,
         )
         log.info(
@@ -1260,6 +1266,13 @@ class OrganizationService:
             slug=organization.slug,
         )
         return organization
+
+    async def add_internal_note(
+        self, session: AsyncSession, organization: Organization, message: str
+    ) -> None:
+        """Append a timestamped, admin-only internal note (append-only)."""
+        _append_internal_note(organization, message)
+        session.add(organization)
 
     async def handle_ongoing_review_verdict(
         self,

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1250,7 +1250,9 @@ class OrganizationService:
             review.appeal_reviewed_at = datetime.now(UTC)
             session.add(review)
 
-        note = internal_note if internal_note is not None else notes[organization.status]
+        note = (
+            internal_note if internal_note is not None else notes[organization.status]
+        )
         target_status = await self._reactivate_organization(
             session,
             organization,

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -4087,6 +4087,29 @@ class TestStatusTransitions:
         assert "Merchant provided additional docs" in result.internal_notes
         assert "pending Stripe Identity" in result.internal_notes
 
+    async def test_internal_note_overrides_default_note_and_omits_reason(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.DENIED
+        organization.initially_reviewed_at = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
+        mocker.patch("polar.organization.service.enqueue_job")
+
+        result = await organization_service.backoffice_approve(
+            session,
+            organization,
+            reason="Lives on the support case, not the note",
+            internal_note="Appeal approved — see support case.",
+        )
+
+        assert result.internal_notes is not None
+        assert "Appeal approved — see support case." in result.internal_notes
+        # The default reactivation wording and the reason are both dropped.
+        assert "reactivated from denied" not in result.internal_notes
+        assert "Lives on the support case" not in result.internal_notes
+
     @pytest.mark.parametrize(
         "current",
         [OrganizationStatus.DENIED, OrganizationStatus.BLOCKED],


### PR DESCRIPTION
## Summary

Internal note was filled only on approval (not denial); and contained the full content of the approve message.
This pass a small "Appeal approved/denied — see support case" internal note as asked by support team.


## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds consistent, short internal notes on appeal outcomes. On approve or deny, we record “Appeal approved/denied — see support case.” instead of copying the full message.

- **New Features**
  - `backoffice_approve` accepts `internal_note`; uses it as the note and drops the reason.
  - Added `add_internal_note(...)` to append timestamped admin-only notes.
  - Approve passes the short note; deny appends it directly; tests cover the override behavior.

<sup>Written for commit 319d3f80168138782f8d9380cea8a741eefaa052. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

