### PR TITLE
feat(appeal-case): hide banner and make button more visible

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -950,7 +950,7 @@ async def get_organization_detail(
                     unrefunded_orders_count=unrefunded_orders_count,
                     agent_report=parsed_agent_report,
                     agent_reviewed_at=agent_reviewed_at,
-                    has_appeal_case=appeal_case is not None,
+                    has_open_appeal_case=appeal_case is not None and appeal_case_open,
                 )
                 with overview.render(
                     request, setup_data=setup_data, payment_stats=payment_stats

--- a/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
@@ -40,14 +40,14 @@ class OverviewSection(ChecklistMixin):
         unrefunded_orders_count: int = 0,
         agent_report: AnyAgentReport | None = None,
         agent_reviewed_at: datetime | None = None,
-        has_appeal_case: bool = False,
+        has_open_appeal_case: bool = False,
     ) -> None:
         self.org = organization
         self.orders_count = orders_count
         self.unrefunded_orders_count = unrefunded_orders_count
         self.agent_report = agent_report
         self.agent_reviewed_at = agent_reviewed_at
-        self.has_appeal_case = has_appeal_case
+        self.has_open_appeal_case = has_open_appeal_case
 
     # ------------------------------------------------------------------
     # Full-width: Organization Review card (primary content)
@@ -105,7 +105,7 @@ class OverviewSection(ChecklistMixin):
         """Full-width AI review card — the primary decision content."""
 
         with card(bordered=True):
-            if self.has_appeal_case:
+            if self.has_open_appeal_case:
                 support_case_url = (
                     str(
                         request.url_for(

--- a/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
@@ -199,9 +199,7 @@ class SupportCaseSection:
                     text("Release")
             else:
                 label = "Take over" if assignee_id is not None else "Take case"
-                with button(
-                    variant="neutral", size="sm", outline=True, hx_post=take_url
-                ):
+                with button(variant="neutral", size="sm", hx_post=take_url):
                     text(label)
             with button(
                 variant="error",


### PR DESCRIPTION
## Summary

Asked by the team in first feedbacks

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the human-review banner on the organization overview once the appeal case is closed, so it only shows for open cases. Make the backoffice "Take case" action button solid (no outline) to improve visibility.

<sup>Written for commit 162d30da279e124370a54e82953681f8941e1d90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

