### PR TITLE
Reflect support tiers in backoffice

### DIFF
--- a/server/polar/backoffice/components/__init__.py
+++ b/server/polar/backoffice/components/__init__.py
@@ -12,6 +12,7 @@ from ._metric_card import metric_card
 from ._modal import modal
 from ._state import card, empty_state, loading_state
 from ._status_badge import status_badge
+from ._support_tier_badge import support_tier_badge
 from ._tab_nav import Tab, tab_nav
 
 __all__ = [
@@ -32,5 +33,6 @@ __all__ = [
     "modal",
     "navigation",
     "status_badge",
+    "support_tier_badge",
     "tab_nav",
 ]

--- a/server/polar/backoffice/components/_support_tier_badge.py
+++ b/server/polar/backoffice/components/_support_tier_badge.py
@@ -2,8 +2,6 @@ from tagflow import tag, text
 
 from polar.models.organization import SupportTier
 
-# Escalating emphasis with tier. Free / NULL renders nothing — it's the floor,
-# so a badge on every free org would just be noise.
 _TIER_BADGE_CLASS: dict[SupportTier, str] = {
     SupportTier.pro: "badge-ghost border border-base-300",
     SupportTier.growth: "badge-info",
@@ -12,7 +10,6 @@ _TIER_BADGE_CLASS: dict[SupportTier, str] = {
 
 
 def support_tier_badge(level: int | None, *, size: str = "badge-sm") -> None:
-    """Render a support-tier badge, or nothing for free / NULL (the floor)."""
     tier = SupportTier.from_level(level)
     if tier is None:
         return

--- a/server/polar/backoffice/components/_support_tier_badge.py
+++ b/server/polar/backoffice/components/_support_tier_badge.py
@@ -8,13 +8,13 @@ _TIER_BADGE_CLASS: dict[SupportTier, str] = {
     SupportTier.pro: "badge-ghost border border-base-300",
     SupportTier.growth: "badge-info",
     SupportTier.scale: "badge-secondary",
-    SupportTier.enterprise: "badge-primary",
 }
 
 
-def support_tier_badge(tier: SupportTier | None, *, size: str = "badge-sm") -> None:
+def support_tier_badge(level: int | None, *, size: str = "badge-sm") -> None:
     """Render a support-tier badge, or nothing for free / NULL (the floor)."""
-    if tier is None or tier == SupportTier.free:
+    tier = SupportTier.from_level(level)
+    if tier is None:
         return
     with tag.span(
         classes=f"badge {size} {_TIER_BADGE_CLASS[tier]}",

--- a/server/polar/backoffice/components/_support_tier_badge.py
+++ b/server/polar/backoffice/components/_support_tier_badge.py
@@ -1,0 +1,27 @@
+from tagflow import tag, text
+
+from polar.models.organization import SupportTier
+
+# Escalating emphasis with tier. Free / NULL renders nothing — it's the floor,
+# so a badge on every free org would just be noise.
+_TIER_BADGE_CLASS: dict[SupportTier, str] = {
+    SupportTier.pro: "badge-ghost border border-base-300",
+    SupportTier.growth: "badge-info",
+    SupportTier.scale: "badge-secondary",
+    SupportTier.enterprise: "badge-primary",
+}
+
+
+def support_tier_badge(tier: SupportTier | None, *, size: str = "badge-sm") -> None:
+    """Render a support-tier badge, or nothing for free / NULL (the floor)."""
+    if tier is None or tier == SupportTier.free:
+        return
+    with tag.span(
+        classes=f"badge {size} {_TIER_BADGE_CLASS[tier]}",
+        title=f"{tier.get_display_name()} support tier",
+        **{"aria-label": "support tier"},
+    ):
+        text(tier.get_display_name())
+
+
+__all__ = ["support_tier_badge"]

--- a/server/polar/backoffice/feedbacks/endpoints.py
+++ b/server/polar/backoffice/feedbacks/endpoints.py
@@ -15,7 +15,13 @@ from polar.models.feedback import FeedbackStatus, FeedbackType
 from polar.postgres import AsyncSession, get_db_read_session, get_db_session
 
 from .. import forms
-from ..components import button, confirmation_dialog, datatable, description_list
+from ..components import (
+    button,
+    confirmation_dialog,
+    datatable,
+    description_list,
+    support_tier_badge,
+)
 from ..components._tab_nav import Tab, tab_nav
 from ..layout import layout
 from ..responses import HXRedirectResponse
@@ -125,9 +131,10 @@ async def _render_list(
     route_name: str,
     breadcrumb_label: str,
     feedback_type: FeedbackType | None,
+    sort: str,
 ) -> None:
     repository = FeedbackRepository.from_session(session)
-    statement = repository.get_by_status_statement(status).options(
+    statement = repository.get_by_status_statement(status, sort=sort).options(
         joinedload(Feedback.user), joinedload(Feedback.organization)
     )
     if feedback_type is not None:
@@ -162,7 +169,7 @@ async def _render_list(
                 ):
                     pass
             if items:
-                _render_table(request, items)
+                _render_table(request, items, sort)
             else:
                 with tag.div(classes="text-center py-12 text-gray-500"):
                     text("No feedback in this view.")
@@ -170,18 +177,30 @@ async def _render_list(
                 pass
 
 
-def _render_table(request: Request, items: Sequence[Feedback]) -> None:
+def _tier_sort_header(request: Request, sort: str) -> None:
+    """Clickable 'Tier' header toggling the opt-in tier sort, preserving the
+    current tab (inbox/triaged) and type filter."""
+    params = dict(request.query_params)
+    params["sort"] = "recency" if sort == "tier" else "tier"
+    query = "&".join(f"{k}={v}" for k, v in params.items())
+    with tag.a(href=f"{request.url.path}?{query}", classes="link link-hover"):
+        text("Tier ↓" if sort == "tier" else "Tier")
+
+
+def _render_table(request: Request, items: Sequence[Feedback], sort: str) -> None:
     with tag.div(classes="overflow-x-auto"):
         with tag.table(classes="table table-zebra"):
             with tag.thead():
                 with tag.tr():
-                    for header in (
-                        "Type",
-                        "Message",
-                        "Organization",
-                        "User",
-                        "Submitted",
-                    ):
+                    with tag.th():
+                        text("Type")
+                    with tag.th():
+                        text("Message")
+                    with tag.th():
+                        text("Organization")
+                    with tag.th():
+                        _tier_sort_header(request, sort)
+                    for header in ("User", "Submitted"):
                         with tag.th():
                             text(header)
             with tag.tbody():
@@ -210,6 +229,8 @@ def _render_row(request: Request, feedback: Feedback) -> None:
             ):
                 text(feedback.organization.name)
         with tag.td():
+            support_tier_badge(feedback.organization.support_tier)
+        with tag.td():
             with tag.a(
                 href=str(request.url_for("users:get", id=feedback.user_id)),
                 classes="link",
@@ -224,6 +245,7 @@ async def list_inbox(
     request: Request,
     pagination: PaginationParamsQuery,
     feedback_type: Annotated[FeedbackType | None, Query(alias="type")] = None,
+    sort: Annotated[str, Query()] = "recency",
     session: AsyncSession = Depends(get_db_read_session),
 ) -> None:
     await _render_list(
@@ -234,6 +256,7 @@ async def list_inbox(
         route_name="feedbacks:list",
         breadcrumb_label="Inbox",
         feedback_type=feedback_type,
+        sort=sort,
     )
 
 
@@ -242,6 +265,7 @@ async def list_triaged(
     request: Request,
     pagination: PaginationParamsQuery,
     feedback_type: Annotated[FeedbackType | None, Query(alias="type")] = None,
+    sort: Annotated[str, Query()] = "recency",
     session: AsyncSession = Depends(get_db_read_session),
 ) -> None:
     await _render_list(
@@ -252,6 +276,7 @@ async def list_triaged(
         route_name="feedbacks:list_triaged",
         breadcrumb_label="Triaged",
         feedback_type=feedback_type,
+        sort=sort,
     )
 
 

--- a/server/polar/backoffice/organizations_v2/priority.py
+++ b/server/polar/backoffice/organizations_v2/priority.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from polar.models import Organization
-from polar.models.organization import SupportTier
 from polar.organization_review.schemas import PaymentMetrics
 
 # Aging: 2.5 pts per day, capped at 50.
@@ -44,12 +43,10 @@ FAST_MOVER_MIN_PAYMENTS = 25
 # A flat boost for having any held payout, regardless of how many.
 HELD_PAYOUT_PTS = 25.0
 
-# Support tier (SLA): a paying merchant shouldn't languish in review. A modest,
-# ordinal-scaled nudge — capped below the risk/payment/fast-mover signals so it
-# orders *within* a risk band but never lets "they paid" outrank real risk or
-# aging. free=0, pro=5, growth=10, scale/enterprise=15.
-SUPPORT_TIER_PTS_PER_RANK = 5.0
-SUPPORT_TIER_MAX_PTS = 15.0
+# Support tier (SLA): a paying merchant shouldn't languish in review. A modest
+# nudge keyed off the benefit level (pro=2, growth=3, scale=4)
+# NULL/free=0, pro=5, growth=10, scale=15.
+SUPPORT_TIER_PTS_PER_LEVEL = 5.0
 
 
 @dataclass
@@ -142,9 +139,11 @@ def _held_payout_component(held_payout_count: int) -> float:
 
 
 def _support_tier_component(org: Organization) -> float:
-    # Ordinal-scaled SLA nudge; NULL (free) contributes nothing.
-    tier = SupportTier.coalesce(org.support_tier)
-    return min(tier.rank * SUPPORT_TIER_PTS_PER_RANK, SUPPORT_TIER_MAX_PTS)
+    # SLA nudge scaled by levels above the free floor; NULL (free) adds nothing.
+    level = org.support_tier
+    if level is None:
+        return 0.0
+    return (level - 1) * SUPPORT_TIER_PTS_PER_LEVEL
 
 
 def compute(

--- a/server/polar/backoffice/organizations_v2/priority.py
+++ b/server/polar/backoffice/organizations_v2/priority.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 
 from polar.models import Organization
+from polar.models.organization import SupportTier
 from polar.organization_review.schemas import PaymentMetrics
 
 # Aging: 2.5 pts per day, capped at 50.
@@ -43,6 +44,13 @@ FAST_MOVER_MIN_PAYMENTS = 25
 # A flat boost for having any held payout, regardless of how many.
 HELD_PAYOUT_PTS = 25.0
 
+# Support tier (SLA): a paying merchant shouldn't languish in review. A modest,
+# ordinal-scaled nudge — capped below the risk/payment/fast-mover signals so it
+# orders *within* a risk band but never lets "they paid" outrank real risk or
+# aging. free=0, pro=5, growth=10, scale/enterprise=15.
+SUPPORT_TIER_PTS_PER_RANK = 5.0
+SUPPORT_TIER_MAX_PTS = 15.0
+
 
 @dataclass
 class Signals:
@@ -51,6 +59,7 @@ class Signals:
     payment_pts: float = 0.0
     fast_mover_pts: float = 0.0
     held_payout_pts: float = 0.0
+    support_tier_pts: float = 0.0
 
     @property
     def priority(self) -> float:
@@ -60,6 +69,7 @@ class Signals:
             + self.payment_pts
             + self.fast_mover_pts
             + self.held_payout_pts
+            + self.support_tier_pts
         )
 
 
@@ -131,6 +141,12 @@ def _held_payout_component(held_payout_count: int) -> float:
     return HELD_PAYOUT_PTS if held_payout_count > 0 else 0.0
 
 
+def _support_tier_component(org: Organization) -> float:
+    # Ordinal-scaled SLA nudge; NULL (free) contributes nothing.
+    tier = SupportTier.coalesce(org.support_tier)
+    return min(tier.rank * SUPPORT_TIER_PTS_PER_RANK, SUPPORT_TIER_MAX_PTS)
+
+
 def compute(
     org: Organization,
     *,
@@ -149,4 +165,5 @@ def compute(
         payment_pts=_payment_component(metrics),
         fast_mover_pts=_fast_mover_component(org, metrics, now),
         held_payout_pts=_held_payout_component(held_payout_count),
+        support_tier_pts=_support_tier_component(org),
     )

--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -25,6 +25,7 @@ from ...components import (
     action_bar,
     empty_state,
     status_badge,
+    support_tier_badge,
     tab_nav,
 )
 from ..priority import Signals
@@ -266,6 +267,8 @@ class OrganizationListView:
                                     data_tip="Awaiting reply",
                                 ):
                                     text("●")
+                    # Support tier (SLA priority) — paid tiers only
+                    support_tier_badge(org.support_tier, size="badge-xs")
 
             # Priority — Review tab only, sits next to Organization
             if signals is not None:
@@ -274,7 +277,8 @@ class OrganizationListView:
                     f"Risk {signals.risk_pts:.0f} + "
                     f"Payments {signals.payment_pts:.0f} + "
                     f"Fast Mover {signals.fast_mover_pts:.0f} + "
-                    f"Held Payouts {signals.held_payout_pts:.0f}"
+                    f"Held Payouts {signals.held_payout_pts:.0f} + "
+                    f"Support Tier {signals.support_tier_pts:.0f}"
                 )
                 with tag.td(classes="text-sm font-bold text-center"):
                     with tag.span(title=tooltip):

--- a/server/polar/backoffice/support_cases/endpoints.py
+++ b/server/polar/backoffice/support_cases/endpoints.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import RedirectResponse
@@ -11,6 +11,7 @@ from tagflow import tag, text
 from polar.file.service import file as file_service
 from polar.kit.pagination import PaginationParamsQuery
 from polar.models import Organization, User
+from polar.models.organization import support_tier_sql_rank
 from polar.models.organization_review import OrganizationReview
 from polar.models.support_case import ReviewAppealSupportCase, SupportCaseAttachment
 from polar.models.user_session import UserSession
@@ -22,7 +23,7 @@ from polar.support_case.repository import (
 )
 from polar.support_case.service import support_case as support_case_service
 
-from ..components import datatable
+from ..components import datatable, support_tier_badge
 from ..components._tab_nav import Tab, tab_nav
 from ..dependencies import get_admin
 from ..layout import layout
@@ -34,11 +35,11 @@ router = APIRouter()
 Row = tuple[ReviewAppealSupportCase, Organization, bool, str | None, bool]
 
 
-def _list_tabs(request: Request, status: str, assigned: str) -> list[Tab]:
+def _list_tabs(request: Request, status: str, assigned: str, sort: str) -> list[Tab]:
     base = str(request.url_for("support_cases:list"))
 
     def url(status: str, assigned: str) -> str:
-        return f"{base}?status={status}&assigned={assigned}"
+        return f"{base}?status={status}&assigned={assigned}&sort={sort}"
 
     # Status (left) filters preserve the current assignment. The assignment
     # filters (right, pushed via ml-auto) toggle: clicking the active one
@@ -67,13 +68,27 @@ def _status_badge(is_open: bool) -> None:
         text("Open" if is_open else "Closed")
 
 
-def _render_table(request: Request, rows: Sequence[Row]) -> None:
+def _tier_sort_header(request: Request, sort: str) -> None:
+    """Clickable 'Tier' header that toggles the opt-in tier sort, preserving
+    the current tab/assignment filters."""
+    params = dict(request.query_params)
+    params["sort"] = "recency" if sort == "tier" else "tier"
+    query = "&".join(f"{k}={v}" for k, v in params.items())
+    href = f"{request.url_for('support_cases:list')}?{query}"
+    with tag.a(href=href, classes="link link-hover"):
+        text("Tier ↓" if sort == "tier" else "Tier")
+
+
+def _render_table(request: Request, rows: Sequence[Row], sort: str) -> None:
     with tag.div(classes="overflow-x-auto"):
         with tag.table(classes="table table-zebra"):
             with tag.thead():
                 with tag.tr():
+                    with tag.th():
+                        text("Organization")
+                    with tag.th():
+                        _tier_sort_header(request, sort)
                     for header in (
-                        "Organization",
                         "Type",
                         "Status",
                         "Assignee",
@@ -105,6 +120,8 @@ def _render_table(request: Request, rows: Sequence[Row]) -> None:
                         with tag.td():
                             with tag.a(href=case_url, classes="link"):
                                 text(organization.name)
+                        with tag.td():
+                            support_tier_badge(organization.support_tier)
                         with tag.td():
                             with tag.div(classes="badge badge-outline badge-sm"):
                                 text("Review appeal")
@@ -193,6 +210,7 @@ async def list_cases(
     pagination: PaginationParamsQuery,
     status: Annotated[str, Query()] = "open",
     assigned: Annotated[str, Query()] = "all",
+    sort: Annotated[str, Query()] = "recency",
     session: AsyncSession = Depends(get_db_read_session),
     user_session: UserSession = Depends(get_admin),
 ) -> None:
@@ -235,9 +253,20 @@ async def list_cases(
         statement = statement.where(unassigned)
         count_statement = count_statement.where(unassigned)
 
+    # Opt-in tier sort: highest tier first, recency as the tiebreaker. Default
+    # stays pure recency so an urgent low-tier case is never buried.
+    order_by: tuple[Any, ...]
+    if sort == "tier":
+        order_by = (
+            support_tier_sql_rank(Organization.support_tier).desc(),
+            ReviewAppealSupportCase.created_at.desc(),
+        )
+    else:
+        order_by = (ReviewAppealSupportCase.created_at.desc(),)
+
     count = await session.scalar(count_statement) or 0
     result = await session.execute(
-        statement.order_by(ReviewAppealSupportCase.created_at.desc())
+        statement.order_by(*order_by)
         .limit(pagination.limit)
         .offset((pagination.page - 1) * pagination.limit)
     )
@@ -251,10 +280,10 @@ async def list_cases(
         with tag.div(classes="flex flex-col gap-4"):
             with tag.h1(classes="text-4xl"):
                 text("Cases")
-            with tab_nav(_list_tabs(request, status, assigned)):
+            with tab_nav(_list_tabs(request, status, assigned, sort)):
                 pass
             if rows:
-                _render_table(request, rows)
+                _render_table(request, rows, sort)
             else:
                 with tag.div(classes="text-center py-12 text-base-content/50"):
                     text("No cases in this view.")

--- a/server/polar/backoffice/support_cases/endpoints.py
+++ b/server/polar/backoffice/support_cases/endpoints.py
@@ -11,7 +11,6 @@ from tagflow import tag, text
 from polar.file.service import file as file_service
 from polar.kit.pagination import PaginationParamsQuery
 from polar.models import Organization, User
-from polar.models.organization import support_tier_sql_rank
 from polar.models.organization_review import OrganizationReview
 from polar.models.support_case import ReviewAppealSupportCase, SupportCaseAttachment
 from polar.models.user_session import UserSession
@@ -258,7 +257,7 @@ async def list_cases(
     order_by: tuple[Any, ...]
     if sort == "tier":
         order_by = (
-            support_tier_sql_rank(Organization.support_tier).desc(),
+            Organization.support_tier.desc().nullslast(),
             ReviewAppealSupportCase.created_at.desc(),
         )
     else:

--- a/server/polar/feedback/repository.py
+++ b/server/polar/feedback/repository.py
@@ -9,7 +9,7 @@ from polar.kit.repository import (
 )
 from polar.models import Feedback
 from polar.models.feedback import FeedbackStatus, FeedbackType
-from polar.models.organization import Organization, support_tier_sql_rank
+from polar.models.organization import Organization
 
 
 class FeedbackRepository(
@@ -27,12 +27,14 @@ class FeedbackRepository(
             # Opt-in: highest support tier first, recency as the tiebreaker.
             # Correlated scalar subquery keeps the joinedload(organization) the
             # caller adds untouched.
-            tier_rank = (
-                select(support_tier_sql_rank(Organization.support_tier))
+            tier_level = (
+                select(Organization.support_tier)
                 .where(Organization.id == Feedback.organization_id)
                 .scalar_subquery()
             )
-            return statement.order_by(tier_rank.desc(), Feedback.created_at.desc())
+            return statement.order_by(
+                tier_level.desc().nullslast(), Feedback.created_at.desc()
+            )
         return statement.order_by(Feedback.created_at.desc())
 
     async def get_type_counts(self, status: FeedbackStatus) -> dict[FeedbackType, int]:

--- a/server/polar/feedback/repository.py
+++ b/server/polar/feedback/repository.py
@@ -9,6 +9,7 @@ from polar.kit.repository import (
 )
 from polar.models import Feedback
 from polar.models.feedback import FeedbackStatus, FeedbackType
+from polar.models.organization import Organization, support_tier_sql_rank
 
 
 class FeedbackRepository(
@@ -19,13 +20,20 @@ class FeedbackRepository(
     model = Feedback
 
     def get_by_status_statement(
-        self, status: FeedbackStatus
+        self, status: FeedbackStatus, *, sort: str = "recency"
     ) -> Select[tuple[Feedback]]:
-        return (
-            self.get_base_statement()
-            .where(Feedback.status == status)
-            .order_by(Feedback.created_at.desc())
-        )
+        statement = self.get_base_statement().where(Feedback.status == status)
+        if sort == "tier":
+            # Opt-in: highest support tier first, recency as the tiebreaker.
+            # Correlated scalar subquery keeps the joinedload(organization) the
+            # caller adds untouched.
+            tier_rank = (
+                select(support_tier_sql_rank(Organization.support_tier))
+                .where(Organization.id == Feedback.organization_id)
+                .scalar_subquery()
+            )
+            return statement.order_by(tier_rank.desc(), Feedback.created_at.desc())
+        return statement.order_by(Feedback.created_at.desc())
 
     async def get_type_counts(self, status: FeedbackStatus) -> dict[FeedbackType, int]:
         """Return the number of (non-deleted) feedbacks per type for a status."""

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -954,7 +954,6 @@ class PolarSelfService:
         effective_tier_external_id = (
             plain_tier_external_id or settings.PLAIN_DEFAULT_TIER_EXTERNAL_ID
         )
-        support_tier = SupportTier.from_plain_external_id(plain_tier_external_id)
 
         with logfire.span(
             "polar_self.webhook.support.applied",
@@ -964,20 +963,14 @@ class PolarSelfService:
             prioritized=prioritized,
             plain_tier_external_id=plain_tier_external_id,
             effective_tier_external_id=effective_tier_external_id,
-            support_tier=support_tier,
         ):
-            # Denormalize the tier onto the org for internal triage (review queue,
-            # support/feedback panels). The benefit grant stays the source of
-            # truth; NULL = free, so a revoked grant resets to NULL.
             organization_repository = OrganizationRepository.from_session(session)
             organization = await organization_repository.get_by_id(
                 organization_id, include_blocked=True
             )
             if organization is not None:
-                organization.support_tier = support_tier
+                organization.support_tier = SupportTier.from_level(level)
 
-            # Plain keeps receiving the raw tier id (full fidelity for bespoke
-            # tiers); org NULL <=> Plain's default tier.
             await plain_service.update_tenant_tier(
                 tenant_external_id=str(organization_id),
                 tier_external_id=effective_tier_external_id,

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -27,6 +27,7 @@ from polar.email.schemas import (
 )
 from polar.email.sender import Attachment, enqueue_email_template
 from polar.integrations.plain.service import plain as plain_service
+from polar.models.organization import SupportTier
 from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncReadSession, AsyncSession
 from polar.startup_program.service import (
@@ -953,6 +954,7 @@ class PolarSelfService:
         effective_tier_external_id = (
             plain_tier_external_id or settings.PLAIN_DEFAULT_TIER_EXTERNAL_ID
         )
+        support_tier = SupportTier.from_plain_external_id(plain_tier_external_id)
 
         with logfire.span(
             "polar_self.webhook.support.applied",
@@ -962,7 +964,20 @@ class PolarSelfService:
             prioritized=prioritized,
             plain_tier_external_id=plain_tier_external_id,
             effective_tier_external_id=effective_tier_external_id,
+            support_tier=support_tier,
         ):
+            # Denormalize the tier onto the org for internal triage (review queue,
+            # support/feedback panels). The benefit grant stays the source of
+            # truth; NULL = free, so a revoked grant resets to NULL.
+            organization_repository = OrganizationRepository.from_session(session)
+            organization = await organization_repository.get_by_id(
+                organization_id, include_blocked=True
+            )
+            if organization is not None:
+                organization.support_tier = support_tier
+
+            # Plain keeps receiving the raw tier id (full fidelity for bespoke
+            # tiers); org NULL <=> Plain's default tier.
             await plain_service.update_tenant_tier(
                 tenant_external_id=str(organization_id),
                 tier_external_id=effective_tier_external_id,
@@ -1011,6 +1026,29 @@ class PolarSelfService:
                 f"{benefit_type!r} benefit grants, expected at most 1: {benefit_ids}"
             )
         return matching[0] if matching else None
+
+    async def resolve_support_tier(
+        self, organization_id: uuid.UUID
+    ) -> SupportTier | None:
+        """Derive an org's support tier from its active Polar support grant.
+
+        The same mapping the benefit-grant webhook applies, but read-only: no DB
+        write and no Plain push. Used by the backfill to populate the column for
+        existing paying orgs (the webhook only fires on future grant changes).
+        Returns None (free) when there's no Polar customer or no support grant.
+        """
+        customer = await get_client().get_customer_by_external_id_or_none(
+            str(organization_id)
+        )
+        if customer is None:
+            return None
+        grant = await self._fetch_active_grant(customer.id, "support")
+        if grant is None:
+            return None
+        _, _, _, plain_tier_external_id = self._extract_support(
+            grant.benefit.metadata or {}, grant.benefit_id
+        )
+        return SupportTier.from_plain_external_id(plain_tier_external_id)
 
 
 polar_self = PolarSelfService()

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -1027,28 +1027,5 @@ class PolarSelfService:
             )
         return matching[0] if matching else None
 
-    async def resolve_support_tier(
-        self, organization_id: uuid.UUID
-    ) -> SupportTier | None:
-        """Derive an org's support tier from its active Polar support grant.
-
-        The same mapping the benefit-grant webhook applies, but read-only: no DB
-        write and no Plain push. Used by the backfill to populate the column for
-        existing paying orgs (the webhook only fires on future grant changes).
-        Returns None (free) when there's no Polar customer or no support grant.
-        """
-        customer = await get_client().get_customer_by_external_id_or_none(
-            str(organization_id)
-        )
-        if customer is None:
-            return None
-        grant = await self._fetch_active_grant(customer.id, "support")
-        if grant is None:
-            return None
-        _, _, _, plain_tier_external_id = self._extract_support(
-            grant.benefit.metadata or {}, grant.benefit_id
-        )
-        return SupportTier.from_plain_external_id(plain_tier_external_id)
-
 
 polar_self = PolarSelfService()

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -1,5 +1,5 @@
 from datetime import UTC, datetime
-from enum import StrEnum
+from enum import IntEnum, StrEnum
 from typing import TYPE_CHECKING, Annotated, Any, Literal, NotRequired, Self, TypedDict
 from urllib.parse import urlparse
 from uuid import UUID
@@ -10,7 +10,6 @@ from sqlalchemy import (
     BigInteger,
     CheckConstraint,
     ColumnElement,
-    ColumnExpressionArgument,
     ForeignKey,
     Integer,
     String,
@@ -18,7 +17,6 @@ from sqlalchemy import (
     UniqueConstraint,
     Uuid,
     and_,
-    case,
     or_,
 )
 from sqlalchemy.dialects.postgresql import CITEXT, JSONB
@@ -239,72 +237,28 @@ class SnoozeType(StrEnum):
         }[self]
 
 
-class SupportTier(StrEnum):
-    """Support priority tier, denormalized from the active Polar support benefit.
+class SupportTier(IntEnum):
+    """Named support tiers, keyed by the benefit's metadata ``level``."""
 
-    Declaration order *is* the priority rank (``free`` lowest, ``enterprise`` the
-    open-universe catch-all for bespoke tiers). The column persists only paid
-    tiers; ``free`` is represented by ``NULL`` and reached via :meth:`coalesce`.
-    The benefit grant remains the source of truth — this is a read cache for
-    internal triage (review queue, support/feedback panels) and is not exposed
-    on any merchant-facing API.
-    """
-
-    free = "free"
-    pro = "pro"
-    growth = "growth"
-    scale = "scale"
-    enterprise = "enterprise"
-
-    @property
-    def rank(self) -> int:
-        """Priority rank from declaration order; mirrored by ``support_tier_sql_rank``."""
-        return tuple(SupportTier).index(self)
+    pro = 2
+    growth = 3
+    scale = 4
 
     def get_display_name(self) -> str:
-        return self.value.capitalize()
+        return self.name.capitalize()
 
     @classmethod
-    def coalesce(cls, tier: "SupportTier | None") -> "SupportTier":
-        """Read a (nullable) stored tier as a total value — ``NULL`` is ``free``."""
-        return tier if tier is not None else cls.free
+    def from_level(cls, level: int | None) -> "SupportTier | None":
+        """Map a benefit's metadata ``level`` to a known tier, or ``None``.
 
-    @classmethod
-    def from_plain_external_id(cls, external_id: str | None) -> "SupportTier | None":
-        """Map a benefit's Plain tier external id to the internal tier.
-
-        Names diverge (Plain's ``"startup"`` is our ``growth``). A missing/empty
-        id means the default (free) tier → ``None``; any unrecognized non-empty
-        id is a bespoke deal → ``enterprise``.
+        Only the self-serve tiers are recognized.
         """
-        if not external_id:
+        if level is None:
             return None
-        return _PLAIN_TIER_EXTERNAL_IDS.get(external_id, cls.enterprise)
-
-
-# Plain tier external id -> internal SupportTier. ``free`` has no id (it's the
-# Plain default tier / NULL). Unknown non-empty ids fall through to enterprise.
-_PLAIN_TIER_EXTERNAL_IDS: dict[str, SupportTier] = {
-    "pro": SupportTier.pro,
-    "startup": SupportTier.growth,
-    "scale": SupportTier.scale,
-}
-
-
-def support_tier_sql_rank(
-    column: ColumnExpressionArgument[SupportTier | None],
-) -> ColumnElement[int]:
-    """SQL rank for sorting by ``SupportTier`` declaration order.
-
-    ``NULL`` (free) ranks lowest, so ``ORDER BY support_tier_sql_rank(col).desc()``
-    surfaces the highest tier first. Mirrors :attr:`SupportTier.rank` so the SQL
-    sort and the Python rank can't drift.
-    """
-    return case(
-        {tier.value: tier.rank for tier in SupportTier},
-        value=column,
-        else_=SupportTier.free.rank,
-    )
+        try:
+            return cls(level)
+        except ValueError:
+            return None
 
 
 class OrganizationCapabilities(TypedDict):
@@ -574,10 +528,11 @@ class Organization(RateLimitGroupMixin, RecordModel):
         StringEnum(SnoozeType), nullable=True, default=None
     )
 
-    # Support priority tier, denormalized from the active Polar support benefit
-    # grant (see SupportTier). NULL = free; only paid tiers are persisted.
-    support_tier: Mapped[SupportTier | None] = mapped_column(
-        StringEnum(SupportTier, length=16), nullable=True, default=None
+    # Support priority tier — the benefit's metadata ``level``, denormalized
+    # from the active Polar support grant (see SupportTier). NULL = free; only
+    # paid tiers are persisted, higher level = higher priority.
+    support_tier: Mapped[int | None] = mapped_column(
+        Integer, nullable=True, default=None
     )
 
     total_balance: Mapped[int | None] = mapped_column(

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -1,5 +1,5 @@
 from datetime import UTC, datetime
-from enum import IntEnum, StrEnum
+from enum import StrEnum
 from typing import TYPE_CHECKING, Annotated, Any, Literal, NotRequired, Self, TypedDict
 from urllib.parse import urlparse
 from uuid import UUID
@@ -10,6 +10,7 @@ from sqlalchemy import (
     BigInteger,
     CheckConstraint,
     ColumnElement,
+    ColumnExpressionArgument,
     ForeignKey,
     Integer,
     String,
@@ -17,6 +18,7 @@ from sqlalchemy import (
     UniqueConstraint,
     Uuid,
     and_,
+    case,
     or_,
 )
 from sqlalchemy.dialects.postgresql import CITEXT, JSONB
@@ -237,28 +239,72 @@ class SnoozeType(StrEnum):
         }[self]
 
 
-class SupportTier(IntEnum):
-    """Named support tiers, keyed by the benefit's metadata ``level``."""
+class SupportTier(StrEnum):
+    """Support priority tier, denormalized from the active Polar support benefit.
 
-    pro = 2
-    growth = 3
-    scale = 4
+    Declaration order *is* the priority rank (``free`` lowest, ``enterprise`` the
+    open-universe catch-all for bespoke tiers). The column persists only paid
+    tiers; ``free`` is represented by ``NULL`` and reached via :meth:`coalesce`.
+    The benefit grant remains the source of truth — this is a read cache for
+    internal triage (review queue, support/feedback panels) and is not exposed
+    on any merchant-facing API.
+    """
+
+    free = "free"
+    pro = "pro"
+    growth = "growth"
+    scale = "scale"
+    enterprise = "enterprise"
+
+    @property
+    def rank(self) -> int:
+        """Priority rank from declaration order; mirrored by ``support_tier_sql_rank``."""
+        return tuple(SupportTier).index(self)
 
     def get_display_name(self) -> str:
-        return self.name.capitalize()
+        return self.value.capitalize()
 
     @classmethod
-    def from_level(cls, level: int | None) -> "SupportTier | None":
-        """Map a benefit's metadata ``level`` to a known tier, or ``None``.
+    def coalesce(cls, tier: "SupportTier | None") -> "SupportTier":
+        """Read a (nullable) stored tier as a total value — ``NULL`` is ``free``."""
+        return tier if tier is not None else cls.free
 
-        Only the self-serve tiers are recognized.
+    @classmethod
+    def from_plain_external_id(cls, external_id: str | None) -> "SupportTier | None":
+        """Map a benefit's Plain tier external id to the internal tier.
+
+        Names diverge (Plain's ``"startup"`` is our ``growth``). A missing/empty
+        id means the default (free) tier → ``None``; any unrecognized non-empty
+        id is a bespoke deal → ``enterprise``.
         """
-        if level is None:
+        if not external_id:
             return None
-        try:
-            return cls(level)
-        except ValueError:
-            return None
+        return _PLAIN_TIER_EXTERNAL_IDS.get(external_id, cls.enterprise)
+
+
+# Plain tier external id -> internal SupportTier. ``free`` has no id (it's the
+# Plain default tier / NULL). Unknown non-empty ids fall through to enterprise.
+_PLAIN_TIER_EXTERNAL_IDS: dict[str, SupportTier] = {
+    "pro": SupportTier.pro,
+    "startup": SupportTier.growth,
+    "scale": SupportTier.scale,
+}
+
+
+def support_tier_sql_rank(
+    column: ColumnExpressionArgument[SupportTier | None],
+) -> ColumnElement[int]:
+    """SQL rank for sorting by ``SupportTier`` declaration order.
+
+    ``NULL`` (free) ranks lowest, so ``ORDER BY support_tier_sql_rank(col).desc()``
+    surfaces the highest tier first. Mirrors :attr:`SupportTier.rank` so the SQL
+    sort and the Python rank can't drift.
+    """
+    return case(
+        {tier.value: tier.rank for tier in SupportTier},
+        value=column,
+        else_=SupportTier.free.rank,
+    )
 
 
 class OrganizationCapabilities(TypedDict):
@@ -528,11 +574,10 @@ class Organization(RateLimitGroupMixin, RecordModel):
         StringEnum(SnoozeType), nullable=True, default=None
     )
 
-    # Support priority tier — the benefit's metadata ``level``, denormalized
-    # from the active Polar support grant (see SupportTier). NULL = free; only
-    # paid tiers are persisted, higher level = higher priority.
-    support_tier: Mapped[int | None] = mapped_column(
-        Integer, nullable=True, default=None
+    # Support priority tier, denormalized from the active Polar support benefit
+    # grant (see SupportTier). NULL = free; only paid tiers are persisted.
+    support_tier: Mapped[SupportTier | None] = mapped_column(
+        StringEnum(SupportTier, length=16), nullable=True, default=None
     )
 
     total_balance: Mapped[int | None] = mapped_column(

--- a/server/scripts/backfill_support_tiers.py
+++ b/server/scripts/backfill_support_tiers.py
@@ -7,12 +7,14 @@ import typer
 from rich.progress import Progress, TaskID
 
 from polar.config import settings
+from polar.integrations.polar.client import get_client
 from polar.integrations.polar.service import polar_self as polar_self_service
 from polar.kit.db.postgres import (
     AsyncSessionMaker,
     create_async_sessionmaker,
 )
 from polar.models import Organization
+from polar.models.organization import SupportTier
 from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncSession, create_async_engine
 
@@ -29,6 +31,28 @@ class BackfillResult:
     error_details: list[tuple[str, str]] = field(default_factory=list)
 
 
+async def resolve_support_tier(organization_id: uuid.UUID) -> SupportTier | None:
+    """Derive an org's support tier from its active Polar support grant.
+
+    The same mapping the benefit-grant webhook applies, but read-only: no DB
+    write and no Plain push. The webhook only fires on future grant changes, so
+    this populates the column for existing paying orgs. Returns None (free)
+    when there's no Polar customer or no support grant.
+    """
+    customer = await get_client().get_customer_by_external_id_or_none(
+        str(organization_id)
+    )
+    if customer is None:
+        return None
+    grant = await polar_self_service._fetch_active_grant(customer.id, "support")
+    if grant is None:
+        return None
+    _, _, _, plain_tier_external_id = polar_self_service._extract_support(
+        grant.benefit.metadata or {}, grant.benefit_id
+    )
+    return SupportTier.from_plain_external_id(plain_tier_external_id)
+
+
 async def _process_organization(
     *,
     organization_id: uuid.UUID,
@@ -43,7 +67,7 @@ async def _process_organization(
 ) -> None:
     async with semaphore:
         try:
-            tier = await polar_self_service.resolve_support_tier(organization_id)
+            tier = await resolve_support_tier(organization_id)
         except Exception:
             async with result_lock:
                 result.errors += 1

--- a/server/scripts/backfill_support_tiers.py
+++ b/server/scripts/backfill_support_tiers.py
@@ -32,12 +32,12 @@ class BackfillResult:
 
 
 async def resolve_support_tier(organization_id: uuid.UUID) -> SupportTier | None:
-    """Derive an org's support tier from its active Polar support grant.
+    """Derive an org's support level from its active Polar support grant.
 
-    The same mapping the benefit-grant webhook applies, but read-only: no DB
-    write and no Plain push. The webhook only fires on future grant changes, so
-    this populates the column for existing paying orgs. Returns None (free)
-    when there's no Polar customer or no support grant.
+    The same value the benefit-grant webhook stores, but read-only: no DB write
+    and no Plain push. The webhook only fires on future grant changes, so this
+    populates the column for existing paying orgs. Returns None (free) when
+    there's no Polar customer or no support grant.
     """
     customer = await get_client().get_customer_by_external_id_or_none(
         str(organization_id)
@@ -47,10 +47,10 @@ async def resolve_support_tier(organization_id: uuid.UUID) -> SupportTier | None
     grant = await polar_self_service._fetch_active_grant(customer.id, "support")
     if grant is None:
         return None
-    _, _, _, plain_tier_external_id = polar_self_service._extract_support(
+    level, _, _, _ = polar_self_service._extract_support(
         grant.benefit.metadata or {}, grant.benefit_id
     )
-    return SupportTier.from_plain_external_id(plain_tier_external_id)
+    return SupportTier.from_level(level)
 
 
 async def _process_organization(
@@ -86,7 +86,8 @@ async def _process_organization(
 
         if dry_run:
             typer.echo(
-                f"  Would set {organization_name} ({organization_id}) -> {tier.value}"
+                f"  Would set {organization_name} ({organization_id}) "
+                f"-> {tier.get_display_name()}"
             )
             async with result_lock:
                 result.tiers_set += 1

--- a/server/scripts/backfill_support_tiers.py
+++ b/server/scripts/backfill_support_tiers.py
@@ -1,0 +1,195 @@
+import asyncio
+import traceback
+import uuid
+from dataclasses import dataclass, field
+
+import typer
+from rich.progress import Progress, TaskID
+
+from polar.config import settings
+from polar.integrations.polar.service import polar_self as polar_self_service
+from polar.kit.db.postgres import (
+    AsyncSessionMaker,
+    create_async_sessionmaker,
+)
+from polar.models import Organization
+from polar.organization.repository import OrganizationRepository
+from polar.postgres import AsyncSession, create_async_engine
+
+from .helper import configure_script_logging, typer_async
+
+cli = typer.Typer()
+
+
+@dataclass
+class BackfillResult:
+    tiers_set: int = 0
+    free_skipped: int = 0
+    errors: int = 0
+    error_details: list[tuple[str, str]] = field(default_factory=list)
+
+
+async def _process_organization(
+    *,
+    organization_id: uuid.UUID,
+    organization_name: str,
+    sessionmaker: AsyncSessionMaker,
+    semaphore: asyncio.Semaphore,
+    result: BackfillResult,
+    result_lock: asyncio.Lock,
+    progress: Progress,
+    task_id: TaskID,
+    dry_run: bool,
+) -> None:
+    async with semaphore:
+        try:
+            tier = await polar_self_service.resolve_support_tier(organization_id)
+        except Exception:
+            async with result_lock:
+                result.errors += 1
+                result.error_details.append(
+                    (str(organization_id), traceback.format_exc())
+                )
+            progress.advance(task_id)
+            return
+
+        # Free orgs are already NULL by column default — nothing to write.
+        if tier is None:
+            async with result_lock:
+                result.free_skipped += 1
+            progress.advance(task_id)
+            return
+
+        if dry_run:
+            typer.echo(
+                f"  Would set {organization_name} ({organization_id}) -> {tier.value}"
+            )
+            async with result_lock:
+                result.tiers_set += 1
+            progress.advance(task_id)
+            return
+
+        async with sessionmaker() as task_session:
+            repository = OrganizationRepository.from_session(task_session)
+            organization = await repository.get_by_id(
+                organization_id, include_blocked=True
+            )
+            if organization is not None:
+                organization.support_tier = tier
+                await task_session.commit()
+        async with result_lock:
+            result.tiers_set += 1
+        progress.advance(task_id)
+
+
+async def run_backfill(
+    *,
+    session: AsyncSession,
+    sessionmaker: AsyncSessionMaker,
+    dry_run: bool = False,
+    limit: int | None = None,
+    concurrency: int = 20,
+) -> BackfillResult:
+    result = BackfillResult()
+
+    self_org_id = uuid.UUID(settings.POLAR_ORGANIZATION_ID)
+    organization_repository = OrganizationRepository.from_session(session)
+
+    typer.echo("Loading organizations...")
+    organizations_statement = (
+        organization_repository.get_base_statement()
+        .where(
+            Organization.can_authenticate,
+            Organization.id != self_org_id,
+        )
+        .order_by(Organization.created_at)
+    )
+    if limit is not None:
+        organizations_statement = organizations_statement.limit(limit)
+    organizations = await organization_repository.get_all(organizations_statement)
+    typer.echo(f"Loaded {len(organizations)} organizations to check")
+
+    semaphore = asyncio.Semaphore(concurrency)
+    result_lock = asyncio.Lock()
+
+    with Progress() as progress:
+        task_id = progress.add_task(
+            "[cyan]Resolving support tiers...", total=len(organizations)
+        )
+        await asyncio.gather(
+            *(
+                _process_organization(
+                    organization_id=organization.id,
+                    organization_name=organization.name,
+                    sessionmaker=sessionmaker,
+                    semaphore=semaphore,
+                    result=result,
+                    result_lock=result_lock,
+                    progress=progress,
+                    task_id=task_id,
+                    dry_run=dry_run,
+                )
+                for organization in organizations
+            )
+        )
+
+    return result
+
+
+@cli.command()
+@typer_async
+async def backfill(
+    dry_run: bool = typer.Option(
+        True, help="Print what would be set without writing to the database"
+    ),
+    limit: int | None = typer.Option(
+        None, help="Maximum number of organizations to process"
+    ),
+    concurrency: int = typer.Option(
+        20, help="Number of organizations to process in parallel"
+    ),
+) -> None:
+    """Backfill Organization.support_tier from active Polar support grants.
+
+    The benefit-grant webhook only fires on future grant changes, so existing
+    paying orgs need this one-off pass. Free orgs stay NULL (the column default).
+    """
+    configure_script_logging()
+
+    if not settings.POLAR_SELF_ENABLED:
+        typer.echo(
+            "POLAR_ACCESS_TOKEN, POLAR_ORGANIZATION_ID, or POLAR_FREE_PRODUCT_ID "
+            "is not configured, aborting."
+        )
+        raise typer.Exit(1)
+
+    engine = create_async_engine("script")
+    sessionmaker = create_async_sessionmaker(engine)
+
+    try:
+        async with sessionmaker() as session:
+            result = await run_backfill(
+                session=session,
+                sessionmaker=sessionmaker,
+                dry_run=dry_run,
+                limit=limit,
+                concurrency=concurrency,
+            )
+
+        typer.echo(
+            f"\nDone: {result.tiers_set} tiers set, "
+            f"{result.free_skipped} free/untiered skipped, "
+            f"{result.errors} errors"
+        )
+        if result.error_details:
+            typer.echo("\nErrors:")
+            for organization_id, tb in result.error_details:
+                typer.echo(f"\n  {organization_id}:")
+                for line in tb.rstrip().splitlines():
+                    typer.echo(f"    {line}")
+    finally:
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/scripts/seed_polar_for_polar.py
+++ b/server/scripts/seed_polar_for_polar.py
@@ -100,7 +100,7 @@ BENEFITS: list[dict[str, object]] = [
         "description": "Support (Tier 4)",
         "metadata": {
             "type": "support",
-            "level": 3,
+            "level": 4,
             "slack": True,
             "prioritized": True,
             "plain_tier_external_id": "scale",

--- a/server/tests/backoffice/organizations_v2/test_priority.py
+++ b/server/tests/backoffice/organizations_v2/test_priority.py
@@ -17,8 +17,10 @@ from polar.backoffice.organizations_v2.priority import (
     AGING_DAILY_PTS,
     AGING_MAX_PTS,
     HELD_PAYOUT_PTS,
+    SUPPORT_TIER_MAX_PTS,
     compute,
 )
+from polar.models.organization import SupportTier
 from polar.organization_review.schemas import PaymentMetrics
 
 
@@ -49,6 +51,7 @@ def _org(
     created_days_ago: int = 100,
     days_in_status: int = 0,
     total_balance: int | None = 0,
+    support_tier: SupportTier | None = None,
 ) -> Any:
     """Build a fake Organization with just the timestamps the formula reads.
 
@@ -60,6 +63,7 @@ def _org(
     org.created_at = NOW - timedelta(days=created_days_ago)
     org.status_updated_at = NOW - timedelta(days=days_in_status)
     org.total_balance = total_balance
+    org.support_tier = support_tier
     return org
 
 
@@ -90,6 +94,39 @@ class TestAgingComponent:
             now=NOW,
         )
         assert aged.priority > fresh.priority
+
+
+class TestSupportTierComponent:
+    def test_free_or_null_contributes_nothing(self) -> None:
+        assert compute(_org(), now=NOW).support_tier_pts == 0.0
+        assert (
+            compute(_org(support_tier=SupportTier.free), now=NOW).support_tier_pts
+            == 0.0
+        )
+
+    def test_ordinal_scaled(self) -> None:
+        assert compute(
+            _org(support_tier=SupportTier.pro), now=NOW
+        ).support_tier_pts == pytest.approx(5.0)
+        assert compute(
+            _org(support_tier=SupportTier.growth), now=NOW
+        ).support_tier_pts == pytest.approx(10.0)
+
+    def test_caps_at_max(self) -> None:
+        assert compute(
+            _org(support_tier=SupportTier.scale), now=NOW
+        ).support_tier_pts == pytest.approx(SUPPORT_TIER_MAX_PTS)
+        assert compute(
+            _org(support_tier=SupportTier.enterprise), now=NOW
+        ).support_tier_pts == pytest.approx(SUPPORT_TIER_MAX_PTS)
+
+    def test_never_outranks_aging(self) -> None:
+        # A fresh top-tier org (15) must not beat a moderately-stale free org (aging 25).
+        enterprise_fresh = compute(
+            _org(days_in_status=0, support_tier=SupportTier.enterprise), now=NOW
+        )
+        aged_free = compute(_org(days_in_status=10), now=NOW)
+        assert aged_free.priority > enterprise_fresh.priority
 
 
 class TestRiskComponent:

--- a/server/tests/backoffice/organizations_v2/test_priority.py
+++ b/server/tests/backoffice/organizations_v2/test_priority.py
@@ -17,7 +17,6 @@ from polar.backoffice.organizations_v2.priority import (
     AGING_DAILY_PTS,
     AGING_MAX_PTS,
     HELD_PAYOUT_PTS,
-    SUPPORT_TIER_MAX_PTS,
     compute,
 )
 from polar.models.organization import SupportTier
@@ -51,7 +50,7 @@ def _org(
     created_days_ago: int = 100,
     days_in_status: int = 0,
     total_balance: int | None = 0,
-    support_tier: SupportTier | None = None,
+    support_tier: int | None = None,
 ) -> Any:
     """Build a fake Organization with just the timestamps the formula reads.
 
@@ -98,35 +97,20 @@ class TestAgingComponent:
 
 class TestSupportTierComponent:
     def test_free_or_null_contributes_nothing(self) -> None:
+        # Free has no grant — it's stored as NULL (None).
         assert compute(_org(), now=NOW).support_tier_pts == 0.0
-        assert (
-            compute(_org(support_tier=SupportTier.free), now=NOW).support_tier_pts
-            == 0.0
-        )
+        assert compute(_org(support_tier=None), now=NOW).support_tier_pts == 0.0
 
-    def test_ordinal_scaled(self) -> None:
+    def test_level_scaled(self) -> None:
         assert compute(
             _org(support_tier=SupportTier.pro), now=NOW
         ).support_tier_pts == pytest.approx(5.0)
         assert compute(
             _org(support_tier=SupportTier.growth), now=NOW
         ).support_tier_pts == pytest.approx(10.0)
-
-    def test_caps_at_max(self) -> None:
         assert compute(
             _org(support_tier=SupportTier.scale), now=NOW
-        ).support_tier_pts == pytest.approx(SUPPORT_TIER_MAX_PTS)
-        assert compute(
-            _org(support_tier=SupportTier.enterprise), now=NOW
-        ).support_tier_pts == pytest.approx(SUPPORT_TIER_MAX_PTS)
-
-    def test_never_outranks_aging(self) -> None:
-        # A fresh top-tier org (15) must not beat a moderately-stale free org (aging 25).
-        enterprise_fresh = compute(
-            _org(days_in_status=0, support_tier=SupportTier.enterprise), now=NOW
-        )
-        aged_free = compute(_org(days_in_status=10), now=NOW)
-        assert aged_free.priority > enterprise_fresh.priority
+        ).support_tier_pts == pytest.approx(15.0)
 
 
 class TestRiskComponent:

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -856,45 +856,6 @@ class TestSupportTier:
 
 
 @pytest.mark.asyncio
-class TestResolveSupportTier:
-    async def test_no_customer_returns_none(self, mocker: MockerFixture) -> None:
-        client = MagicMock()
-        client.get_customer_by_external_id_or_none = AsyncMock(return_value=None)
-        mocker.patch("polar.integrations.polar.service.get_client", return_value=client)
-
-        assert await polar_self.resolve_support_tier(ORG_A) is None
-
-    async def test_no_support_grant_returns_none(self, mocker: MockerFixture) -> None:
-        client = MagicMock()
-        client.get_customer_by_external_id_or_none = AsyncMock(
-            return_value=MagicMock(id=_CUSTOMER_ID)
-        )
-        client.list_customer_benefit_grants = AsyncMock(return_value=[])
-        mocker.patch("polar.integrations.polar.service.get_client", return_value=client)
-
-        assert await polar_self.resolve_support_tier(ORG_A) is None
-
-    async def test_resolves_tier_from_active_grant(self, mocker: MockerFixture) -> None:
-        grant = _make_grant(
-            metadata={
-                "type": "support",
-                "level": "2",
-                "slack": "false",
-                "prioritized": "true",
-                "plain_tier_external_id": "scale",
-            }
-        )
-        client = MagicMock()
-        client.get_customer_by_external_id_or_none = AsyncMock(
-            return_value=MagicMock(id=_CUSTOMER_ID)
-        )
-        client.list_customer_benefit_grants = AsyncMock(return_value=[grant])
-        mocker.patch("polar.integrations.polar.service.get_client", return_value=client)
-
-        assert await polar_self.resolve_support_tier(ORG_A) == SupportTier.scale
-
-
-@pytest.mark.asyncio
 class TestHandleBenefitGrantEvent:
     async def test_created_with_transaction_fee_applies_current_state(
         self,

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -660,8 +660,11 @@ class TestApplySupport:
         plain_update_tenant_tier_mock.assert_awaited_once_with(
             tenant_external_id=str(ORG_A), tier_external_id=None
         )
-        # No plain_tier_external_id on the grant -> free (NULL) on the org.
-        assert organization_repository_mock.get_by_id.return_value.support_tier is None
+
+        assert (
+            organization_repository_mock.get_by_id.return_value.support_tier
+            == SupportTier.pro
+        )
 
     async def test_active_grant_with_plain_tier(
         self,
@@ -687,61 +690,6 @@ class TestApplySupport:
         assert (
             organization_repository_mock.get_by_id.return_value.support_tier
             == SupportTier.pro
-        )
-
-    async def test_plain_startup_tier_maps_to_growth(
-        self,
-        session_mock: AsyncSession,
-        organization_repository_mock: MagicMock,
-        plain_update_tenant_tier_mock: AsyncMock,
-    ) -> None:
-        # Names diverge: Plain's "startup" is our growth. Plain still gets "startup".
-        grant = _make_grant(
-            metadata={
-                "type": "support",
-                "level": "3",
-                "slack": "true",
-                "prioritized": "true",
-                "plain_tier_external_id": "startup",
-            }
-        )
-
-        await polar_self._apply_support(session_mock, ORG_A, grant)
-
-        plain_update_tenant_tier_mock.assert_awaited_once_with(
-            tenant_external_id=str(ORG_A), tier_external_id="startup"
-        )
-        assert (
-            organization_repository_mock.get_by_id.return_value.support_tier
-            == SupportTier.growth
-        )
-
-    async def test_unknown_plain_tier_maps_to_enterprise(
-        self,
-        session_mock: AsyncSession,
-        organization_repository_mock: MagicMock,
-        plain_update_tenant_tier_mock: AsyncMock,
-    ) -> None:
-        # Bespoke/unrecognized tier id -> enterprise (open universe), but Plain
-        # keeps full fidelity with the raw id.
-        grant = _make_grant(
-            metadata={
-                "type": "support",
-                "level": "3",
-                "slack": "true",
-                "prioritized": "true",
-                "plain_tier_external_id": "bespoke-deal",
-            }
-        )
-
-        await polar_self._apply_support(session_mock, ORG_A, grant)
-
-        plain_update_tenant_tier_mock.assert_awaited_once_with(
-            tenant_external_id=str(ORG_A), tier_external_id="bespoke-deal"
-        )
-        assert (
-            organization_repository_mock.get_by_id.return_value.support_tier
-            == SupportTier.enterprise
         )
 
     async def test_no_grant_unsets_tier(
@@ -770,23 +718,6 @@ class TestApplySupport:
         await polar_self._apply_support(session_mock, ORG_A, None)
 
         # Plain gets the default tier; the org stays NULL (the two agree).
-        plain_update_tenant_tier_mock.assert_awaited_once_with(
-            tenant_external_id=str(ORG_A), tier_external_id="free"
-        )
-        assert organization_repository_mock.get_by_id.return_value.support_tier is None
-
-    async def test_grant_without_tier_falls_back_to_default(
-        self,
-        session_mock: AsyncSession,
-        organization_repository_mock: MagicMock,
-        plain_update_tenant_tier_mock: AsyncMock,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        monkeypatch.setattr(settings, "PLAIN_DEFAULT_TIER_EXTERNAL_ID", "free")
-        grant = _make_support_grant()
-
-        await polar_self._apply_support(session_mock, ORG_A, grant)
-
         plain_update_tenant_tier_mock.assert_awaited_once_with(
             tenant_external_id=str(ORG_A), tier_external_id="free"
         )
@@ -828,31 +759,14 @@ class TestApplySupport:
 
 
 class TestSupportTier:
-    def test_from_plain_external_id_known(self) -> None:
-        assert SupportTier.from_plain_external_id("pro") == SupportTier.pro
-        # Names diverge: Plain's "startup" is our growth.
-        assert SupportTier.from_plain_external_id("startup") == SupportTier.growth
-        assert SupportTier.from_plain_external_id("scale") == SupportTier.scale
+    def test_from_level_known(self) -> None:
+        assert SupportTier.from_level(2) == SupportTier.pro
+        assert SupportTier.from_level(3) == SupportTier.growth
+        assert SupportTier.from_level(4) == SupportTier.scale
 
-    def test_from_plain_external_id_unknown_is_enterprise(self) -> None:
-        assert SupportTier.from_plain_external_id("bespoke") == SupportTier.enterprise
-
-    @pytest.mark.parametrize("value", [None, ""])
-    def test_from_plain_external_id_empty_is_none(self, value: str | None) -> None:
-        assert SupportTier.from_plain_external_id(value) is None
-
-    def test_rank_follows_declaration_order(self) -> None:
-        assert (
-            SupportTier.free.rank
-            < SupportTier.pro.rank
-            < SupportTier.growth.rank
-            < SupportTier.scale.rank
-            < SupportTier.enterprise.rank
-        )
-
-    def test_coalesce_treats_none_as_free(self) -> None:
-        assert SupportTier.coalesce(None) == SupportTier.free
-        assert SupportTier.coalesce(SupportTier.scale) == SupportTier.scale
+    @pytest.mark.parametrize("level", [None, 0, 1, 5, 99])
+    def test_from_level_unknown_or_none_is_none(self, level: int | None) -> None:
+        assert SupportTier.from_level(level) is None
 
 
 @pytest.mark.asyncio

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -32,7 +32,7 @@ from polar.integrations.polar.exceptions import (
     TransactionFeeBenefitError,
 )
 from polar.integrations.polar.service import polar_self
-from polar.models.organization import Organization
+from polar.models.organization import Organization, SupportTier
 from polar.postgres import AsyncReadSession, AsyncSession
 
 SELF_ORG_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
@@ -650,6 +650,7 @@ class TestApplySupport:
     async def test_active_grant(
         self,
         session_mock: AsyncSession,
+        organization_repository_mock: MagicMock,
         plain_update_tenant_tier_mock: AsyncMock,
     ) -> None:
         grant = _make_support_grant()
@@ -659,10 +660,13 @@ class TestApplySupport:
         plain_update_tenant_tier_mock.assert_awaited_once_with(
             tenant_external_id=str(ORG_A), tier_external_id=None
         )
+        # No plain_tier_external_id on the grant -> free (NULL) on the org.
+        assert organization_repository_mock.get_by_id.return_value.support_tier is None
 
     async def test_active_grant_with_plain_tier(
         self,
         session_mock: AsyncSession,
+        organization_repository_mock: MagicMock,
         plain_update_tenant_tier_mock: AsyncMock,
     ) -> None:
         grant = _make_grant(
@@ -679,11 +683,71 @@ class TestApplySupport:
 
         plain_update_tenant_tier_mock.assert_awaited_once_with(
             tenant_external_id=str(ORG_A), tier_external_id="pro"
+        )
+        assert (
+            organization_repository_mock.get_by_id.return_value.support_tier
+            == SupportTier.pro
+        )
+
+    async def test_plain_startup_tier_maps_to_growth(
+        self,
+        session_mock: AsyncSession,
+        organization_repository_mock: MagicMock,
+        plain_update_tenant_tier_mock: AsyncMock,
+    ) -> None:
+        # Names diverge: Plain's "startup" is our growth. Plain still gets "startup".
+        grant = _make_grant(
+            metadata={
+                "type": "support",
+                "level": "3",
+                "slack": "true",
+                "prioritized": "true",
+                "plain_tier_external_id": "startup",
+            }
+        )
+
+        await polar_self._apply_support(session_mock, ORG_A, grant)
+
+        plain_update_tenant_tier_mock.assert_awaited_once_with(
+            tenant_external_id=str(ORG_A), tier_external_id="startup"
+        )
+        assert (
+            organization_repository_mock.get_by_id.return_value.support_tier
+            == SupportTier.growth
+        )
+
+    async def test_unknown_plain_tier_maps_to_enterprise(
+        self,
+        session_mock: AsyncSession,
+        organization_repository_mock: MagicMock,
+        plain_update_tenant_tier_mock: AsyncMock,
+    ) -> None:
+        # Bespoke/unrecognized tier id -> enterprise (open universe), but Plain
+        # keeps full fidelity with the raw id.
+        grant = _make_grant(
+            metadata={
+                "type": "support",
+                "level": "3",
+                "slack": "true",
+                "prioritized": "true",
+                "plain_tier_external_id": "bespoke-deal",
+            }
+        )
+
+        await polar_self._apply_support(session_mock, ORG_A, grant)
+
+        plain_update_tenant_tier_mock.assert_awaited_once_with(
+            tenant_external_id=str(ORG_A), tier_external_id="bespoke-deal"
+        )
+        assert (
+            organization_repository_mock.get_by_id.return_value.support_tier
+            == SupportTier.enterprise
         )
 
     async def test_no_grant_unsets_tier(
         self,
         session_mock: AsyncSession,
+        organization_repository_mock: MagicMock,
         plain_update_tenant_tier_mock: AsyncMock,
     ) -> None:
         await polar_self._apply_support(session_mock, ORG_A, None)
@@ -691,10 +755,13 @@ class TestApplySupport:
         plain_update_tenant_tier_mock.assert_awaited_once_with(
             tenant_external_id=str(ORG_A), tier_external_id=None
         )
+        # Revocation resets the org tier to NULL (free).
+        assert organization_repository_mock.get_by_id.return_value.support_tier is None
 
     async def test_no_grant_falls_back_to_default_tier(
         self,
         session_mock: AsyncSession,
+        organization_repository_mock: MagicMock,
         plain_update_tenant_tier_mock: AsyncMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -702,13 +769,16 @@ class TestApplySupport:
 
         await polar_self._apply_support(session_mock, ORG_A, None)
 
+        # Plain gets the default tier; the org stays NULL (the two agree).
         plain_update_tenant_tier_mock.assert_awaited_once_with(
             tenant_external_id=str(ORG_A), tier_external_id="free"
         )
+        assert organization_repository_mock.get_by_id.return_value.support_tier is None
 
     async def test_grant_without_tier_falls_back_to_default(
         self,
         session_mock: AsyncSession,
+        organization_repository_mock: MagicMock,
         plain_update_tenant_tier_mock: AsyncMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -720,10 +790,12 @@ class TestApplySupport:
         plain_update_tenant_tier_mock.assert_awaited_once_with(
             tenant_external_id=str(ORG_A), tier_external_id="free"
         )
+        assert organization_repository_mock.get_by_id.return_value.support_tier is None
 
     async def test_grant_tier_overrides_default(
         self,
         session_mock: AsyncSession,
+        organization_repository_mock: MagicMock,
         plain_update_tenant_tier_mock: AsyncMock,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -742,6 +814,10 @@ class TestApplySupport:
 
         plain_update_tenant_tier_mock.assert_awaited_once_with(
             tenant_external_id=str(ORG_A), tier_external_id="pro"
+        )
+        assert (
+            organization_repository_mock.get_by_id.return_value.support_tier
+            == SupportTier.pro
         )
 
     async def test_invalid_metadata_raises(self, session_mock: AsyncSession) -> None:
@@ -749,6 +825,73 @@ class TestApplySupport:
 
         with pytest.raises(SupportBenefitError):
             await polar_self._apply_support(session_mock, ORG_A, grant)
+
+
+class TestSupportTier:
+    def test_from_plain_external_id_known(self) -> None:
+        assert SupportTier.from_plain_external_id("pro") == SupportTier.pro
+        # Names diverge: Plain's "startup" is our growth.
+        assert SupportTier.from_plain_external_id("startup") == SupportTier.growth
+        assert SupportTier.from_plain_external_id("scale") == SupportTier.scale
+
+    def test_from_plain_external_id_unknown_is_enterprise(self) -> None:
+        assert SupportTier.from_plain_external_id("bespoke") == SupportTier.enterprise
+
+    @pytest.mark.parametrize("value", [None, ""])
+    def test_from_plain_external_id_empty_is_none(self, value: str | None) -> None:
+        assert SupportTier.from_plain_external_id(value) is None
+
+    def test_rank_follows_declaration_order(self) -> None:
+        assert (
+            SupportTier.free.rank
+            < SupportTier.pro.rank
+            < SupportTier.growth.rank
+            < SupportTier.scale.rank
+            < SupportTier.enterprise.rank
+        )
+
+    def test_coalesce_treats_none_as_free(self) -> None:
+        assert SupportTier.coalesce(None) == SupportTier.free
+        assert SupportTier.coalesce(SupportTier.scale) == SupportTier.scale
+
+
+@pytest.mark.asyncio
+class TestResolveSupportTier:
+    async def test_no_customer_returns_none(self, mocker: MockerFixture) -> None:
+        client = MagicMock()
+        client.get_customer_by_external_id_or_none = AsyncMock(return_value=None)
+        mocker.patch("polar.integrations.polar.service.get_client", return_value=client)
+
+        assert await polar_self.resolve_support_tier(ORG_A) is None
+
+    async def test_no_support_grant_returns_none(self, mocker: MockerFixture) -> None:
+        client = MagicMock()
+        client.get_customer_by_external_id_or_none = AsyncMock(
+            return_value=MagicMock(id=_CUSTOMER_ID)
+        )
+        client.list_customer_benefit_grants = AsyncMock(return_value=[])
+        mocker.patch("polar.integrations.polar.service.get_client", return_value=client)
+
+        assert await polar_self.resolve_support_tier(ORG_A) is None
+
+    async def test_resolves_tier_from_active_grant(self, mocker: MockerFixture) -> None:
+        grant = _make_grant(
+            metadata={
+                "type": "support",
+                "level": "2",
+                "slack": "false",
+                "prioritized": "true",
+                "plain_tier_external_id": "scale",
+            }
+        )
+        client = MagicMock()
+        client.get_customer_by_external_id_or_none = AsyncMock(
+            return_value=MagicMock(id=_CUSTOMER_ID)
+        )
+        client.list_customer_benefit_grants = AsyncMock(return_value=[grant])
+        mocker.patch("polar.integrations.polar.service.get_client", return_value=client)
+
+        assert await polar_self.resolve_support_tier(ORG_A) == SupportTier.scale
 
 
 @pytest.mark.asyncio

--- a/server/tests/scripts/test_backfill_support_tiers.py
+++ b/server/tests/scripts/test_backfill_support_tiers.py
@@ -97,7 +97,7 @@ class TestResolveSupportTier:
         grant = _make_grant(
             metadata={
                 "type": "support",
-                "level": "2",
+                "level": "4",
                 "slack": "false",
                 "prioritized": "true",
                 "plain_tier_external_id": "scale",

--- a/server/tests/scripts/test_backfill_support_tiers.py
+++ b/server/tests/scripts/test_backfill_support_tiers.py
@@ -1,0 +1,108 @@
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from polar_sdk.models import BenefitGrant
+from pytest_mock import MockerFixture
+
+from polar.models.organization import SupportTier
+from scripts.backfill_support_tiers import resolve_support_tier
+
+ORG_ID = uuid.UUID("00000000-0000-0000-0000-00000000000a")
+_CUSTOMER_ID = "00000000-0000-0000-0000-000000000002"
+_BENEFIT_ID = "00000000-0000-0000-0000-0000000000b1"
+
+_CUSTOMER_DICT: dict[str, Any] = {
+    "id": _CUSTOMER_ID,
+    "created_at": "2026-01-01T00:00:00Z",
+    "modified_at": None,
+    "metadata": {},
+    "email": "c@example.com",
+    "email_verified": True,
+    "type": "individual",
+    "name": "c",
+    "billing_name": None,
+    "billing_address": None,
+    "tax_id": None,
+    "organization_id": "00000000-0000-0000-0000-000000000099",
+    "deleted_at": None,
+    "avatar_url": "",
+    "external_id": str(ORG_ID),
+}
+
+
+def _make_grant(*, metadata: dict[str, Any]) -> BenefitGrant:
+    return BenefitGrant.model_validate(
+        {
+            "created_at": "2026-01-01T00:00:00Z",
+            "modified_at": None,
+            "id": "00000000-0000-0000-0000-0000000000a1",
+            "is_granted": True,
+            "is_revoked": False,
+            "subscription_id": "00000000-0000-0000-0000-000000000001",
+            "order_id": None,
+            "customer_id": _CUSTOMER_ID,
+            "benefit_id": _BENEFIT_ID,
+            "customer": _CUSTOMER_DICT,
+            "benefit": {
+                "id": _BENEFIT_ID,
+                "type": "custom",
+                "created_at": "2026-01-01T00:00:00Z",
+                "modified_at": None,
+                "description": "",
+                "selectable": True,
+                "deletable": True,
+                "is_deleted": False,
+                "visibility": "public",
+                "visibility_configurable": True,
+                "organization_id": _CUSTOMER_DICT["organization_id"],
+                "metadata": metadata,
+                "properties": {"note": None},
+            },
+            "properties": {},
+        }
+    )
+
+
+def _patch_client(
+    mocker: MockerFixture,
+    *,
+    customer: object,
+    grants: list[BenefitGrant] | None = None,
+) -> None:
+    client = MagicMock()
+    client.get_customer_by_external_id_or_none = AsyncMock(return_value=customer)
+    client.list_customer_benefit_grants = AsyncMock(return_value=grants or [])
+    # resolve_support_tier resolves the customer through the script's client,
+    # then defers to the service's _fetch_active_grant, which resolves grants
+    # through the service module's client. Patch both to the same mock.
+    mocker.patch("scripts.backfill_support_tiers.get_client", return_value=client)
+    mocker.patch("polar.integrations.polar.service.get_client", return_value=client)
+
+
+@pytest.mark.asyncio
+class TestResolveSupportTier:
+    async def test_no_customer_returns_none(self, mocker: MockerFixture) -> None:
+        _patch_client(mocker, customer=None)
+
+        assert await resolve_support_tier(ORG_ID) is None
+
+    async def test_no_support_grant_returns_none(self, mocker: MockerFixture) -> None:
+        _patch_client(mocker, customer=MagicMock(id=_CUSTOMER_ID), grants=[])
+
+        assert await resolve_support_tier(ORG_ID) is None
+
+    async def test_resolves_tier_from_active_grant(self, mocker: MockerFixture) -> None:
+        grant = _make_grant(
+            metadata={
+                "type": "support",
+                "level": "2",
+                "slack": "false",
+                "prioritized": "true",
+                "plain_tier_external_id": "scale",
+            }
+        )
+        _patch_client(mocker, customer=MagicMock(id=_CUSTOMER_ID), grants=[grant])
+
+        assert await resolve_support_tier(ORG_ID) == SupportTier.scale


### PR DESCRIPTION
Very vibe coded, sorry

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show and prioritize support tiers in backoffice. Adds `Organization.support_tier`, paid-tier badges, opt-in tier-first sorting in Cases and Feedback, and a backfill to populate tiers for existing customers.

- **New Features**
  - Added `Organization.support_tier` with `SupportTier` enum (pro=2, growth=3, scale=4); `NULL` = free.
  - Backoffice: tier badges on Organizations (review list), Support Cases, and Feedback; added a “Tier” column with a toggle to sort by tier (recency tiebreaker, default is recency).
  - Review priority: added support-tier points (free=0, pro=5, growth=10, scale=15) and exposed them in the tooltip.
  - Polar Self integration: stores the grant’s `level` on the org via `SupportTier.from_level(level)`; revocation or unknown/missing levels keep it `NULL`.

- **Migration**
  - Run the Alembic migration to add `support_tier` to `organizations`.
  - Backfill existing paying orgs: run `server/scripts/backfill_support_tiers.py` (supports `--dry-run`, `--limit`, `--concurrency`).

<sup>Written for commit 3234a10ecd36fd32d56e1828d7828e626e3a0cc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

