### PR TITLE
fix(customer-portal): show downloadables to members via benefit grants

### DIFF
--- a/server/polar/customer_portal/repository/downloadable.py
+++ b/server/polar/customer_portal/repository/downloadable.py
@@ -13,7 +13,7 @@ class DownloadableRepository(RepositoryBase[Downloadable]):
     def get_customer_statement(
         self, auth_subject: AuthSubject[Customer | Member]
     ) -> Select[tuple[Downloadable]]:
-        from polar.models import Benefit
+        from polar.models import Benefit, BenefitGrant
 
         statement = (
             sql.select(Downloadable)
@@ -31,8 +31,22 @@ class DownloadableRepository(RepositoryBase[Downloadable]):
         )
 
         if is_member(auth_subject):
+            member = auth_subject.subject
+            # A downloadable's files are defined on the benefit, so any member
+            # holding an active grant for that benefit is entitled to the same
+            # files. We gate visibility on the member's benefit grants rather
+            # than on Downloadable.member_id: a downloadable row is unique per
+            # (customer, file, benefit) and shared across the customer's members,
+            # so its member_id can only ever reference a single one of them (see
+            # DownloadableService.grant_for_benefit_file).
+            granted_benefit_ids = sql.select(BenefitGrant.benefit_id).where(
+                BenefitGrant.member_id == member.id,
+                BenefitGrant.is_granted.is_(True),
+                BenefitGrant.is_deleted.is_(False),
+            )
             statement = statement.where(
-                Downloadable.member_id == auth_subject.subject.id,
+                Downloadable.customer_id == member.customer_id,
+                Downloadable.benefit_id.in_(granted_benefit_ids),
             )
         else:
             statement = statement.where(

--- a/server/tests/customer_portal/endpoints/test_downloadables.py
+++ b/server/tests/customer_portal/endpoints/test_downloadables.py
@@ -11,12 +11,14 @@ from polar.benefit.strategies.downloadables.schemas import (
     BenefitDownloadablesCreateProperties,
 )
 from polar.customer_portal.schemas.downloadables import DownloadableRead
-from polar.models import Customer, File, Organization, Product
+from polar.models import Customer, Downloadable, File, Member, Organization, Product
+from polar.models.file import DownloadableFile, FileServiceTypes
 from polar.postgres import AsyncSession, sql
 from polar.redis import Redis
-from tests.fixtures.auth import CUSTOMER_AUTH_SUBJECT
+from tests.fixtures.auth import CUSTOMER_AUTH_SUBJECT, MEMBER_AUTH_SUBJECT
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.downloadable import TestDownloadable
+from tests.fixtures.random_objects import create_benefit_grant, create_member
 
 
 @pytest.mark.asyncio
@@ -273,3 +275,154 @@ class TestDownloadablesEndpoints:
         assert downloadable["file"]["checksum_sha256_base64"] == downloaded_base64
         assert uploaded_logo_jpg.checksum_sha256_hex == downloaded_hex
         assert downloadable["file"]["checksum_sha256_hex"] == downloaded_hex
+
+
+async def _create_downloadable_file(
+    save_fixture: SaveFixture, organization: Organization, name: str = "asset.bin"
+) -> File:
+    """Create an uploaded, enabled downloadable File row without hitting S3."""
+    file = DownloadableFile(
+        organization_id=organization.id,
+        name=name,
+        path=f"downloadables/{name}",
+        mime_type="application/octet-stream",
+        size=1024,
+        service=FileServiceTypes.downloadable,
+        is_uploaded=True,
+        is_enabled=True,
+    )
+    await save_fixture(file)
+    return file
+
+
+@pytest.mark.asyncio
+class TestDownloadablesMemberAccess:
+    """Members are entitled to a downloadable through their own benefit grant,
+    not through Downloadable.member_id (which is shared across a customer's
+    members)."""
+
+    @pytest.mark.auth(MEMBER_AUTH_SUBJECT)
+    async def test_member_with_grant_sees_downloadables(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+        member: Member,
+    ) -> None:
+        file = await _create_downloadable_file(save_fixture, organization)
+        benefit, _ = await TestDownloadable.create_benefit_and_grant(
+            session,
+            redis,
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            product=product,
+            properties=BenefitDownloadablesCreateProperties(files=[file.id]),
+        )
+
+        # The member is entitled via their own benefit grant.
+        await create_benefit_grant(
+            save_fixture,
+            customer,
+            benefit,
+            granted=True,
+            member=member,
+        )
+
+        response = await client.get("/v1/customer-portal/downloadables/")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pagination"]["total_count"] == 1
+        assert len(data["items"]) == 1
+
+    @pytest.mark.auth(MEMBER_AUTH_SUBJECT)
+    async def test_member_without_grant_sees_nothing(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+        member: Member,
+    ) -> None:
+        file = await _create_downloadable_file(save_fixture, organization)
+        await TestDownloadable.create_benefit_and_grant(
+            session,
+            redis,
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            product=product,
+            properties=BenefitDownloadablesCreateProperties(files=[file.id]),
+        )
+
+        # No benefit grant for this member -> no downloadables visible.
+        response = await client.get("/v1/customer-portal/downloadables/")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pagination"]["total_count"] == 0
+        assert len(data["items"]) == 0
+
+    @pytest.mark.auth(MEMBER_AUTH_SUBJECT)
+    async def test_member_sees_downloadable_attributed_to_other_member(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+        member: Member,
+    ) -> None:
+        """Reproduces the seat-based collision: a single downloadable row is
+        shared per (customer, file, benefit), so its member_id points at whoever
+        was granted first. A member entitled via their own grant must still see
+        it."""
+        file = await _create_downloadable_file(save_fixture, organization)
+        benefit, _ = await TestDownloadable.create_benefit_and_grant(
+            session,
+            redis,
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            product=product,
+            properties=BenefitDownloadablesCreateProperties(files=[file.id]),
+        )
+
+        # Attribute the shared downloadable row to a different member.
+        other_member = await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            email="other.member@example.com",
+        )
+        await session.execute(
+            sql.update(Downloadable)
+            .where(Downloadable.customer_id == customer.id)
+            .values(member_id=other_member.id)
+        )
+
+        # This member is entitled via their own grant.
+        await create_benefit_grant(
+            save_fixture,
+            customer,
+            benefit,
+            granted=True,
+            member=member,
+        )
+
+        response = await client.get("/v1/customer-portal/downloadables/")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pagination"]["total_count"] == 1
+        assert len(data["items"]) == 1


### PR DESCRIPTION
I believe this was never finished, and I think it makes more sense to _remove_ `member_id` from downloadables instead of duplicating a downloadables row per member, whereas for e.g. license keys it was required to generate a license key _per member_.

## Generated description

Members in the customer portal could not see downloadables. The repository
filtered by `Downloadable.member_id == member.id`, but a downloadable row is
unique per (customer, file, benefit) and shared across a customer's members,
so its member_id can only ever reference one of them. On seat-based products
the same file/benefit is granted to several members, they collide on that one
row, and only the first-granted member gets attributed — everyone else sees
nothing.

A downloadables benefit defines its files at the benefit level, so every
member holding an active grant for that benefit is entitled to the same files.
Gate member visibility on the member's benefit grants (the source of truth for
per-member entitlement, which already works) instead of on the shared
Downloadable.member_id column. This also fixes legacy rows that never had
member_id backfilled. No migration required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes member visibility of downloadables in the customer portal by checking active benefit grants instead of Downloadable.member_id. Restores access for seat-based products and legacy rows without member_id.

- Bug Fixes
  - Filter member results by customer_id and active, non-deleted benefit grants.
  - Supports shared rows across members (seat-based products) and legacy rows without member_id.
  - Added API tests for member with grant, without grant, and shared-row collision; no migration needed.

<sup>Written for commit d2f10570945f98a59a1a5b9366dbcde396794b30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

