### PR TITLE
feat: display organization status in Plain customer card

### DIFF
--- a/server/polar/integrations/plain/service.py
+++ b/server/polar/integrations/plain/service.py
@@ -552,7 +552,9 @@ class PlainService:
 
         return CustomerCard(
             key=CustomerCardKey.organization,
-            timeToLiveSeconds=86400,
+            # Short TTL so the organization status stays in sync on all
+            # threads (including old ones) shortly after it changes.
+            timeToLiveSeconds=3600,
             components=[
                 component.model_dump(by_alias=True, exclude_none=True)
                 for component in components
@@ -620,6 +622,25 @@ class PlainService:
                                 )
                             )
                         ],
+                    )
+                ),
+                ComponentContainerContentInput(
+                    component_row=ComponentRowInput(
+                        row_main_content=[
+                            ComponentRowContentInput(
+                                component_text=ComponentTextInput(
+                                    text="Status",
+                                    text_size=ComponentTextSize.S,
+                                    text_color=ComponentTextColor.MUTED,
+                                )
+                            ),
+                            ComponentRowContentInput(
+                                component_text=ComponentTextInput(
+                                    text=organization.status.get_display_name(),
+                                )
+                            ),
+                        ],
+                        row_aside_content=[],
                     )
                 ),
                 ComponentContainerContentInput(


### PR DESCRIPTION
## Summary

Add a Status row to the organization customer card showing the org's current status, and lower the organization card TTL

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Status row to the organization customer card in Plain, showing the org’s current status. Lowered the card TTL from 86400s to 3600s so the status stays fresh across all threads.

<sup>Written for commit 15d6bbc2a949a40fb5abe10f7fd1ec7e1876bf4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

