### PR TITLE
feat(plain): show organization status on support cards

### DIFF
--- a/server/polar/integrations/plain/service.py
+++ b/server/polar/integrations/plain/service.py
@@ -83,6 +83,10 @@ log = structlog.get_logger(__name__)
 
 PLAIN_WORKSPACE_ID = "w_01JE9TRRX9KT61D8P2CH77XDQM"
 
+# Plain caches customer cards for this duration. Keep it short so dynamic fields
+# like the organization status stay in sync with the dashboard.
+CUSTOMER_CARD_TTL_SECONDS = 60 * 60
+
 
 def plain_thread_url(thread_id: str) -> str:
     return f"https://app.plain.com/workspace/{PLAIN_WORKSPACE_ID}/thread/{thread_id}"
@@ -497,7 +501,7 @@ class PlainService:
 
         return CustomerCard(
             key=CustomerCardKey.user,
-            timeToLiveSeconds=86400,
+            timeToLiveSeconds=CUSTOMER_CARD_TTL_SECONDS,
             components=[
                 component.model_dump(by_alias=True, exclude_none=True)
                 for component in components
@@ -552,7 +556,7 @@ class PlainService:
 
         return CustomerCard(
             key=CustomerCardKey.organization,
-            timeToLiveSeconds=86400,
+            timeToLiveSeconds=CUSTOMER_CARD_TTL_SECONDS,
             components=[
                 component.model_dump(by_alias=True, exclude_none=True)
                 for component in components
@@ -594,6 +598,25 @@ class PlainService:
                 ComponentContainerContentInput(
                     component_divider=ComponentDividerInput(
                         divider_spacing_size=ComponentDividerSpacingSize.M
+                    )
+                ),
+                ComponentContainerContentInput(
+                    component_row=ComponentRowInput(
+                        row_main_content=[
+                            ComponentRowContentInput(
+                                component_text=ComponentTextInput(
+                                    text="Status",
+                                    text_size=ComponentTextSize.S,
+                                    text_color=ComponentTextColor.MUTED,
+                                )
+                            ),
+                            ComponentRowContentInput(
+                                component_text=ComponentTextInput(
+                                    text=organization.status.get_display_name(),
+                                )
+                            ),
+                        ],
+                        row_aside_content=[],
                     )
                 ),
                 ComponentContainerContentInput(
@@ -864,7 +887,7 @@ class PlainService:
 
         return CustomerCard(
             key=CustomerCardKey.customer,
-            timeToLiveSeconds=86400,
+            timeToLiveSeconds=CUSTOMER_CARD_TTL_SECONDS,
             components=[
                 component.model_dump(by_alias=True, exclude_none=True)
                 for component in components
@@ -1137,7 +1160,7 @@ class PlainService:
 
         return CustomerCard(
             key=CustomerCardKey.order,
-            timeToLiveSeconds=86400,
+            timeToLiveSeconds=CUSTOMER_CARD_TTL_SECONDS,
             components=[
                 component.model_dump(by_alias=True, exclude_none=True)
                 for component in components
@@ -1279,7 +1302,7 @@ class PlainService:
 
         return CustomerCard(
             key=CustomerCardKey.snippets,
-            timeToLiveSeconds=86400,
+            timeToLiveSeconds=CUSTOMER_CARD_TTL_SECONDS,
             components=[
                 component.model_dump(by_alias=True, exclude_none=True)
                 for component in components

--- a/server/tests/integrations/plain/test_service.py
+++ b/server/tests/integrations/plain/test_service.py
@@ -1,21 +1,25 @@
 import contextlib
 import uuid
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from plain_client import (
+    ComponentTextInput,
     CustomerByEmailCustomerByEmail,
     UpsertCustomerUpsertCustomer,
 )
 from pytest_mock import MockerFixture
 
 from polar.integrations.plain.service import (
+    CUSTOMER_CARD_TTL_SECONDS,
     PlainCustomerError,
     PlainService,
 )
-from polar.models import Feedback, User
+from polar.models import Feedback, Organization, User
 from polar.models.feedback import FeedbackType
+from polar.models.organization import OrganizationStatus
 
 
 @contextlib.asynccontextmanager
@@ -328,3 +332,42 @@ class TestUpsertCustomer:
             await plain_service.upsert_customer(
                 external_id=external_id, email="user@example.com"
             )
+
+
+def _organization(status: OrganizationStatus) -> Organization:
+    return Organization(
+        id=uuid.uuid4(),
+        name="Acme",
+        slug="acme",
+        email=None,
+        status=status,
+        created_at=datetime(2025, 1, 1, tzinfo=UTC),
+    )
+
+
+def _status_value(organization: Organization) -> ComponentTextInput | None:
+    container = PlainService()._get_organization_component_container(organization)
+    for content in container.container_content:
+        row = content.component_row
+        if row is None:
+            continue
+        main = row.row_main_content
+        if (
+            main
+            and main[0].component_text is not None
+            and main[0].component_text.text == "Status"
+        ):
+            return main[1].component_text
+    return None
+
+
+class TestOrganizationCard:
+    def test_ttl_is_one_hour(self) -> None:
+        assert CUSTOMER_CARD_TTL_SECONDS == 60 * 60
+
+    @pytest.mark.parametrize("status", list(OrganizationStatus))
+    def test_renders_status_display_name(self, status: OrganizationStatus) -> None:
+        value = _status_value(_organization(status))
+
+        assert value is not None
+        assert value.text == status.get_display_name()


### PR DESCRIPTION
## Summary

Show each organization's status on its Plain support card, and lower the customer-card cache TTL from 24h to 1h so the status stays in sync with the dashboard.

## What

- Add a **Status** row to the organization customer card, rendering the status display name in the default text color.
- Replace the hardcoded `86400` TTL on all five customer cards with a shared `CUSTOMER_CARD_TTL_SECONDS = 60 * 60` constant.

## Why

Support agents had no visibility into an org's status from Plain, and the 24h card cache meant any status they did see could be a full day stale.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a Status row to the Plain organization support card so agents can see the org’s current status. Also lowered the customer-card cache TTL from 24h to 1h via a shared `CUSTOMER_CARD_TTL_SECONDS` to keep status and other dynamic fields in sync with the dashboard.

<sup>Written for commit 63aea73dcc2ce5245211e6f2046e43bc4f3d3316. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

