### PR TITLE
benefit/grant: add unique scope index to prevent duplicate grants

### DIFF
--- a/server/migrations/versions/2026-06-16-1022_add_unique_scope_index_on_benefit_grants.py
+++ b/server/migrations/versions/2026-06-16-1022_add_unique_scope_index_on_benefit_grants.py
@@ -1,0 +1,45 @@
+"""add unique scope index on benefit_grants
+
+Revision ID: 01cce9b1fcc2
+Revises: e5522ef4ec57
+Create Date: 2026-06-16 10:22:05.261607
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "01cce9b1fcc2"
+down_revision = "9cc1600f3dab"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Build concurrently to avoid blocking writes on the large benefit_grants
+    # table. CREATE INDEX CONCURRENTLY cannot run inside a transaction, so we
+    # use an autocommit block (which also means no transactional lock_timeout).
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_benefit_grants_scope_unique",
+            "benefit_grants",
+            ["customer_id", "benefit_id", "member_id", "subscription_id", "order_id"],
+            unique=True,
+            postgresql_concurrently=True,
+            postgresql_nulls_not_distinct=True,
+            postgresql_where=sa.text("deleted_at IS NULL"),
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_benefit_grants_scope_unique",
+            table_name="benefit_grants",
+            postgresql_concurrently=True,
+            postgresql_nulls_not_distinct=True,
+            postgresql_where=sa.text("deleted_at IS NULL"),
+        )

--- a/server/polar/models/benefit_grant.py
+++ b/server/polar/models/benefit_grant.py
@@ -7,9 +7,11 @@ from sqlalchemy import (
     Boolean,
     ColumnElement,
     ForeignKey,
+    Index,
     UniqueConstraint,
     Uuid,
     and_,
+    text,
     type_coerce,
 )
 from sqlalchemy.dialects.postgresql import JSONB
@@ -93,6 +95,17 @@ class BenefitGrant(RecordModel):
             "member_id",
             "benefit_id",
             name="benefit_grants_smb_key",
+        ),
+        Index(
+            "ix_benefit_grants_scope_unique",
+            "customer_id",
+            "benefit_id",
+            "member_id",
+            "subscription_id",
+            "order_id",
+            unique=True,
+            postgresql_nulls_not_distinct=True,
+            postgresql_where=text("deleted_at IS NULL"),
         ),
     )
 

--- a/server/tests/benefit/grant/test_service.py
+++ b/server/tests/benefit/grant/test_service.py
@@ -1073,11 +1073,13 @@ class TestEnqueueCustomerGrantDeletions:
 
         await benefit_grant_service.enqueue_customer_grant_deletions(session, customer)
 
+        # The deletion order is irrelevant, so don't assert on it.
         enqueue_job_mock.assert_has_calls(
             [
                 call("benefit.delete_grant", benefit_grant_id=grant1.id),
                 call("benefit.delete_grant", benefit_grant_id=grant2.id),
-            ]
+            ],
+            any_order=True,
         )
 
 


### PR DESCRIPTION
Add unique index on `benefit_grants` to prevent duplicated benefit grant rows for a given order. This solves a race condition bug if/when we get concurrent stripe webhooks.

Production db readiness:
```
SELECT
    benefit_id,
    customer_id,
    subscription_id,
    order_id,
    member_id,
    COUNT(*) AS grant_count,
    ARRAY_AGG(id ORDER BY granted_at IS NULL, created_at, id) AS grant_ids
FROM benefit_grants
WHERE deleted_at IS NULL
GROUP BY benefit_id, customer_id, subscription_id, order_id, member_id
HAVING COUNT(*) > 1
ORDER BY grant_count DESC;
```

=> no rows


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a partial unique index on `benefit_grants` to prevent duplicate grants for the same scope, including order-based grants. This aligns DB constraints with the idempotent `benefit.grant` logic and stops doubled grants.

- **Bug Fixes**
  - Added unique partial index on `(customer_id, benefit_id, member_id, subscription_id, order_id)` with NULLS NOT DISTINCT and `WHERE deleted_at IS NULL`; built concurrently and defined on the `BenefitGrant` model.
  - In concurrent races, the second insert now fails with an integrity error; the task retries and reuses the existing grant.
  - Updated the deletion enqueue test to be order-agnostic since the new index changes scan order in a query without `ORDER BY`.

<sup>Written for commit a204ae85863acd1bb451ed7b51863ba0d5f5c0a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



