### PR TITLE
docs: add "Migrate Away from Polar" offboarding guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -33,7 +33,7 @@
         "groups": [
           {
             "group": "Bootup",
-            "pages": ["introduction", "migrate", "migrate-away"]
+            "pages": ["introduction", "migrate"]
           },
           {
             "group": "Features",
@@ -205,7 +205,8 @@
               "merchant-of-record/fees",
               "merchant-of-record/supported-countries",
               "merchant-of-record/acceptable-use",
-              "merchant-of-record/account-reviews"
+              "merchant-of-record/account-reviews",
+              "migrate-away"
             ]
           }
         ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -33,7 +33,7 @@
         "groups": [
           {
             "group": "Bootup",
-            "pages": ["introduction", "migrate"]
+            "pages": ["introduction", "migrate", "migrate-away"]
           },
           {
             "group": "Features",

--- a/docs/migrate-away.mdx
+++ b/docs/migrate-away.mdx
@@ -55,7 +55,7 @@ After 120 days, your remaining balance is released and you can withdraw it.
     We coordinate a secure transfer of your customers and their saved payment methods to your new account. Stripe-to-Stripe is a direct account-to-account copy. For other providers, we use Stripe's PAN export to send card data to your PCI-compliant processor. No card data passes through you, keeping the migration PCI-compliant.
   </Step>
   <Step title="Recreate your catalog on the new provider">
-    Set up your products, prices, discounts, and benefits on your new provider. These configurations live in Polar and don't transfer automatically. Depending on your new provider, this can often be automated using their APIs or bulk import tools and we don't offer personalzied exports of data.
+    Set up your products, prices, discounts, and benefits on your new provider. These configurations live in Polar and don't transfer automatically. Depending on your new provider, this can often be automated using their APIs or bulk import tools and we don't offer personalized exports of data.
   </Step>
   <Step title="Recreate your subscriptions">
     Recreate active subscriptions on your new provider, aligned to each customer's existing Polar billing cycle, then cancel them on Polar. See the warning below to avoid double billing.

--- a/docs/migrate-away.mdx
+++ b/docs/migrate-away.mdx
@@ -49,13 +49,13 @@ After 120 days, your remaining balance is released and you can withdraw it.
 
 <Steps>
   <Step title="Tell us where you're going">
-    Email [support@polar.sh](mailto:support@polar.sh) with the Stripe account (or other provider) you want to migrate to. We confirm the details and set your organization to offboarding.
+    Email [support@polar.sh](mailto:support@polar.sh) with the Stripe account (or other provider) you want to migrate to. We will confirm the details and set your organization to offboarding. The destination account must already exist and be under your control before we can begin the migration.
   </Step>
   <Step title="We transfer your customers and payment methods">
     We coordinate a secure transfer of your customers and their saved payment methods to your new account. Stripe-to-Stripe is a direct account-to-account copy. For other providers, we use Stripe's PAN export to send card data to your PCI-compliant processor. No card data passes through you, keeping the migration PCI-compliant.
   </Step>
   <Step title="Recreate your catalog on the new provider">
-    Set up your products, prices, discounts, and benefits on your new provider. These configurations live in Polar and don't transfer automatically.
+    Set up your products, prices, discounts, and benefits on your new provider. These configurations live in Polar and don't transfer automatically. Depending on your new provider, this can often be automated using their APIs or bulk import tools and we don't offer personalzied exports of data.
   </Step>
   <Step title="Recreate your subscriptions">
     Recreate active subscriptions on your new provider, aligned to each customer's existing Polar billing cycle, then cancel them on Polar. See the warning below to avoid double billing.
@@ -70,12 +70,14 @@ After 120 days, your remaining balance is released and you can withdraw it.
 To keep billing seamless, recreate each active subscription on your new provider so its **first charge lands on the same date as the next Polar renewal**. This way the customer is billed once per period, by exactly one provider.
 
 <Warning>
-**Cancel your Polar subscriptions to avoid double billing**
+**Cancel your Polar subscriptions once you've migrated them**
 
-Once a subscription is live on your new provider, cancel the matching Polar subscription so Polar stops generating renewals for it. If you leave both active, your customer will be charged twice for the same period.
+Once a subscription is live on your new provider, cancel the matching Polar subscription so Polar stops generating renewals for it. If you leave both subscriptions active, your customer may be charged twice for the same billing period.
+
+Your existing subscriptions will continue to renew on Polar until you cancel them. We recommend migrating customers to your new provider and canceling the corresponding Polar subscriptions as soon as possible.
+
+The 120-day holding period begins after your final transaction on Polar. Leaving subscriptions active will continue generating transactions and delay the release of your remaining balance.
 </Warning>
-
-You can cancel subscriptions individually from the dashboard. See [Manage Subscriptions](/features/subscriptions/manage) for the details. We recommend canceling at the end of the current period so customers keep access through the time they've already paid for.
 
 ## Withdrawing your remaining balance
 
@@ -84,7 +86,13 @@ After the 120-day holding period ends, your remaining balance is released and yo
 ## Frequently asked questions
 
 <AccordionGroup>
-  <Accordion title="Will my customers notice the migration?">
+    <Accordion title="How long does a migration take?">
+    The timeline depends on the payment provider you're migrating to. If you're migrating to your own Stripe account, migrations can typically be completed within a few business days.For other billing providers, migrations usually take several weeks due to coordination between multiple parties.
+  </Accordion>
+<Accordion title="Does Polar charge for migrations?">
+  No. Polar does not charge a fee to migrate your customers or saved payment methods to another provider.
+</Accordion>
+<Accordion title="Will my customers notice the migration?">
     They shouldn't experience an interruption. Subscriptions keep renewing on Polar until you cancel them, and we transfer saved payment methods so they don't need to re-enter card details. The main visible change is who appears on their statement once you start billing from your new provider.
   </Accordion>
   <Accordion title="Can I move to a provider other than Stripe?">
@@ -95,6 +103,9 @@ After the 120-day holding period ends, your remaining balance is released and yo
   </Accordion>
   <Accordion title="What happens to refunds and chargebacks during the holding period?">
     We continue to process refunds and handle any chargebacks on payments made while you were on Polar, drawing from your held balance. This is the reason for the 120-day hold.
+  </Accordion>
+  <Accordion title="What happens to my historical sales data?">
+    Your historical orders, invoices, and reporting remain available in Polar during the offboarding period. We retain transaction records for compliance purposes for at least five years after processing, even after your migration is complete.
   </Accordion>
   <Accordion title="How do I start?">
     Email [support@polar.sh](mailto:support@polar.sh) with your destination account and we'll take it from there.

--- a/docs/migrate-away.mdx
+++ b/docs/migrate-away.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Migrate Away from Polar"
 sidebarTitle: "Migrate Away"
-description: "Move your customers, payment methods, and subscriptions to another payment provider whenever you choose."
+description: "Move your customers and saved payment methods to another payment provider whenever you choose."
 ---
 
 You own your business, and that includes the freedom to leave. If you decide Polar isn't the right fit, we'll help you move your customers and their saved payment methods to another payment provider so your subscribers experience as little disruption as possible.

--- a/docs/migrate-away.mdx
+++ b/docs/migrate-away.mdx
@@ -1,0 +1,102 @@
+---
+title: "Migrate Away from Polar"
+sidebarTitle: "Migrate Away"
+description: "Move your customers, payment methods, and subscriptions to another payment provider whenever you choose."
+---
+
+You own your business, and that includes the freedom to leave. If you decide Polar isn't the right fit, we'll help you move your customers and their saved payment methods to another payment provider so your subscribers experience as little disruption as possible.
+
+Because Polar is a [Merchant of Record](/merchant-of-record/introduction), your customers' payment methods are securely vaulted with our payment processor (Stripe). Moving them to your own account is a coordinated, support-assisted process rather than a one-click export, so we can do it securely and in line with card network rules.
+
+<Note>
+**This process is handled by our team**
+
+Migrations are not self-serve today. To get started, email [support@polar.sh](mailto:support@polar.sh) with the account you want to migrate to, and we'll guide you through every step.
+</Note>
+
+## What can be moved
+
+| Data | Moves to your new provider | Notes |
+| --- | --- | --- |
+| Customers | Yes | Name, email, and billing details. |
+| Saved payment methods | Yes | Easiest Stripe-to-Stripe. We can also move them to any PCI-compliant provider via Stripe's secure PAN export. |
+| Products, prices, discounts, benefits | No, recreate them | These live in your Polar configuration and need to be set up again on your new provider. |
+| Active subscriptions | No, recreate them | Recreate them on your new provider following your existing billing cycle, then cancel on Polar. See [Recreating your subscriptions](#recreating-your-subscriptions). |
+
+<Note>
+**Stripe to Stripe is the simplest path**
+
+If your new provider is Stripe, we transfer your customers and their saved payment methods directly between Stripe accounts. Moving to a different provider is also supported through Stripe's secure PAN export, which sends card data to any PCI-compliant processor. Both paths are handled by our team, so no card data ever passes through you and your customers don't need to re-enter their details.
+</Note>
+
+## The holding period
+
+When you start a migration, we set your Polar organization to an **offboarding** state. While offboarding:
+
+- Your existing subscriptions keep renewing until you cancel them, so customers are never cut off mid-transition.
+- New checkouts are disabled, since you're moving your business elsewhere.
+- **Payouts are paused for 120 days.**
+
+<Warning>
+**Why payouts are held for 120 days**
+
+We hold your remaining balance for 120 days to cover any refunds and chargebacks that may still come in on payments processed while you were on Polar. Disputes can be filed weeks or months after a purchase, and as Merchant of Record we're liable for them. Holding the balance protects both you and us from a negative balance after you've already withdrawn.
+
+After 120 days, your remaining balance is released and you can withdraw it.
+</Warning>
+
+## How the migration works
+
+<Steps>
+  <Step title="Tell us where you're going">
+    Email [support@polar.sh](mailto:support@polar.sh) with the Stripe account (or other provider) you want to migrate to. We confirm the details and set your organization to offboarding.
+  </Step>
+  <Step title="We transfer your customers and payment methods">
+    We coordinate a secure transfer of your customers and their saved payment methods to your new account. Stripe-to-Stripe is a direct account-to-account copy. For other providers, we use Stripe's PAN export to send card data to your PCI-compliant processor. No card data passes through you, keeping the migration PCI-compliant.
+  </Step>
+  <Step title="Recreate your catalog on the new provider">
+    Set up your products, prices, discounts, and benefits on your new provider. These configurations live in Polar and don't transfer automatically.
+  </Step>
+  <Step title="Recreate your subscriptions">
+    Recreate active subscriptions on your new provider, aligned to each customer's existing Polar billing cycle, then cancel them on Polar. See the warning below to avoid double billing.
+  </Step>
+  <Step title="Withdraw your remaining balance">
+    After the 120-day holding period, withdraw your released balance. See [Withdrawing your remaining balance](#withdrawing-your-remaining-balance).
+  </Step>
+</Steps>
+
+## Recreating your subscriptions
+
+To keep billing seamless, recreate each active subscription on your new provider so its **first charge lands on the same date as the next Polar renewal**. This way the customer is billed once per period, by exactly one provider.
+
+<Warning>
+**Cancel your Polar subscriptions to avoid double billing**
+
+Once a subscription is live on your new provider, cancel the matching Polar subscription so Polar stops generating renewals for it. If you leave both active, your customer will be charged twice for the same period.
+</Warning>
+
+You can cancel subscriptions individually from the dashboard. See [Manage Subscriptions](/features/subscriptions/manage) for the details. We recommend canceling at the end of the current period so customers keep access through the time they've already paid for.
+
+## Withdrawing your remaining balance
+
+After the 120-day holding period ends, your remaining balance is released and you can withdraw it to your connected bank account, subject to the standard minimum payout threshold. If your balance is below the minimum for your country, reach out to support and we'll help you withdraw the remainder.
+
+## Frequently asked questions
+
+<AccordionGroup>
+  <Accordion title="Will my customers notice the migration?">
+    They shouldn't experience an interruption. Subscriptions keep renewing on Polar until you cancel them, and we transfer saved payment methods so they don't need to re-enter card details. The main visible change is who appears on their statement once you start billing from your new provider.
+  </Accordion>
+  <Accordion title="Can I move to a provider other than Stripe?">
+    Yes. Stripe-to-Stripe is the easiest path, but we can also move your saved payment methods to another provider through Stripe's secure PAN export, as long as your new processor is PCI-compliant and able to receive the data.
+  </Accordion>
+  <Accordion title="Why can't I just export the card numbers myself?">
+    Raw card data is subject to strict PCI and card network rules and is never handed to merchants directly. Payment methods are moved account-to-account through the processor's secure migration process, which is why this step is handled by our team.
+  </Accordion>
+  <Accordion title="What happens to refunds and chargebacks during the holding period?">
+    We continue to process refunds and handle any chargebacks on payments made while you were on Polar, drawing from your held balance. This is the reason for the 120-day hold.
+  </Accordion>
+  <Accordion title="How do I start?">
+    Email [support@polar.sh](mailto:support@polar.sh) with your destination account and we'll take it from there.
+  </Accordion>
+</AccordionGroup>

--- a/docs/migrate-away.mdx
+++ b/docs/migrate-away.mdx
@@ -87,7 +87,7 @@ After the 120-day holding period ends, your remaining balance is released and yo
 
 <AccordionGroup>
     <Accordion title="How long does a migration take?">
-    The timeline depends on the payment provider you're migrating to. If you're migrating to your own Stripe account, migrations can typically be completed within a few business days.For other billing providers, migrations usually take several weeks due to coordination between multiple parties.
+    The timeline depends on the payment provider you're migrating to. If you're migrating to your own Stripe account, migrations can typically be completed within a few business days. For other billing providers, migrations usually take several weeks due to coordination between multiple parties.
   </Accordion>
 <Accordion title="Does Polar charge for migrations?">
   No. Polar does not charge a fee to migrate your customers or saved payment methods to another provider.


### PR DESCRIPTION
## Summary

**Related Issue**: N/A

Adds a public documentation page describing how a merchant migrates away from Polar to another payment provider (e.g. Stripe).

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests (docs-only change, N/A)
- [ ] Linting and type checking pass (docs-only change, N/A)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public offboarding guide to help merchants move customers and saved payment methods to another provider with minimal disruption. The page is listed under Merchant of Record in the docs nav.

- **New Features**
  - New `docs/migrate-away.mdx`: support‑assisted migration (`support@polar.sh`); what moves (customers + saved payment methods via Stripe‑to‑Stripe or PAN export) and what doesn’t; offboarding state (renewals continue, new checkouts off, 120‑day payout hold with rationale, starts after final transaction and ongoing renewals delay release); steps to recreate catalog and subscriptions (align to next renewal, cancel on Polar to avoid double billing; destination account must exist and be under your control; no personalized data exports); balance withdrawal after hold (subject to minimum payout threshold; support helps if below minimum); FAQ on timeline (days for Stripe, weeks for others), fees (no fee), non‑Stripe providers, PCI limits, customer impact, disputes during hold, and historical data.

- **Dependencies**
  - Updated `docs/docs.json` to add “Migrate Away” under Merchant of Record.

<sup>Written for commit 3a8e358d19106dce70b64cf4f6a97598134eb101. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



