### PR TITLE
server/tax: add Mauritius TAN Tax ID support

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -31600,6 +31600,7 @@ export interface components {
       | 've_rif'
       | 'vn_tin'
       | 'za_vat'
+      | 'mu_tan'
     /**
      * TaxJurisdiction
      * @description Aggregated tax remitted by Polar for a single jurisdiction.
@@ -59918,6 +59919,7 @@ export const taxIDFormatValues: ReadonlyArray<
   've_rif',
   'vn_tin',
   'za_vat',
+  'mu_tan',
 ]
 export const taxJurisdictionSortPropertyValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['TaxJurisdictionSortProperty']

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -113,7 +113,13 @@ from polar.subscription.service import subscription as subscription_service
 from polar.tax.calculation import TaxCode
 from polar.tax.calculation import tax_calculation as tax_calculation_service
 from polar.tax.calculation.base import TaxCalculationLogicalError
-from polar.tax.tax_id import InvalidTaxID, TaxID, to_stripe_tax_id, validate_tax_id
+from polar.tax.tax_id import (
+    IncompatibleTaxIDFormat,
+    InvalidTaxID,
+    TaxID,
+    to_stripe_tax_id,
+    validate_tax_id,
+)
 from polar.trial_redemption.service import trial_redemption as trial_redemption_service
 from polar.webhook.service import webhook as webhook_service
 from polar.worker import enqueue_job
@@ -126,6 +132,7 @@ from .sorting import CheckoutSortProperty
 if typing.TYPE_CHECKING:
     from stripe.params._customer_create_params import (
         CustomerCreateParams,
+        CustomerCreateParamsTaxIdDatum,
     )
     from stripe.params._customer_modify_params import CustomerModifyParams
     from stripe.params._payment_intent_create_params import PaymentIntentCreateParams
@@ -2601,9 +2608,12 @@ class CheckoutService:
             if checkout.customer_billing_address is not None:
                 create_params["address"] = checkout.customer_billing_address.to_dict()  # type: ignore
             if checkout.customer_tax_id is not None:
-                create_params["tax_id_data"] = [
-                    to_stripe_tax_id(checkout.customer_tax_id)
-                ]
+                try:
+                    create_params["tax_id_data"] = [
+                        to_stripe_tax_id(checkout.customer_tax_id)
+                    ]
+                except IncompatibleTaxIDFormat:
+                    pass
             stripe_customer = await stripe_service.create_customer(**create_params)
             stripe_customer_id = stripe_customer.id
         else:
@@ -2614,14 +2624,14 @@ class CheckoutService:
                 update_params["name"] = customer_name
             if checkout.customer_billing_address is not None:
                 update_params["address"] = checkout.customer_billing_address.to_dict()  # type: ignore
+            tax_id: CustomerCreateParamsTaxIdDatum | None = None
+            if checkout.customer_tax_id is not None:
+                try:
+                    tax_id = to_stripe_tax_id(checkout.customer_tax_id)
+                except IncompatibleTaxIDFormat:
+                    pass
             await stripe_service.update_customer(
-                stripe_customer_id,
-                tax_id=(
-                    to_stripe_tax_id(checkout.customer_tax_id)
-                    if checkout.customer_tax_id is not None
-                    else None
-                ),
-                **update_params,
+                stripe_customer_id, tax_id=tax_id, **update_params
             )
 
         # Only populate customer.name when creating a new customer. For existing

--- a/server/polar/customer_portal/service/customer.py
+++ b/server/polar/customer_portal/service/customer.py
@@ -17,7 +17,12 @@ from polar.order.service import order as order_service
 from polar.payment_method.repository import PaymentMethodRepository
 from polar.payment_method.service import payment_method as payment_method_service
 from polar.postgres import AsyncSession
-from polar.tax.tax_id import InvalidTaxID, to_stripe_tax_id, validate_tax_id
+from polar.tax.tax_id import (
+    IncompatibleTaxIDFormat,
+    InvalidTaxID,
+    to_stripe_tax_id,
+    validate_tax_id,
+)
 
 from ..repository.payment_method import CustomerPaymentMethodRepository
 from ..schemas.customer import (
@@ -30,7 +35,10 @@ from ..schemas.customer import (
 )
 
 if TYPE_CHECKING:
-    from stripe.params._customer_create_params import CustomerCreateParams
+    from stripe.params._customer_create_params import (
+        CustomerCreateParams,
+        CustomerCreateParamsTaxIdDatum,
+    )
     from stripe.params._modify_customer_params import ModifyCustomerParams
 
 
@@ -170,12 +178,14 @@ class CustomerService:
                 params["invoice_settings"] = {
                     "default_payment_method": new_default_payment_method.processor_id,
                 }
+            stripe_tax_id: CustomerCreateParamsTaxIdDatum | None = None
+            if customer.tax_id is not None:
+                try:
+                    stripe_tax_id = to_stripe_tax_id(customer.tax_id)
+                except IncompatibleTaxIDFormat:
+                    stripe_tax_id = None
             await stripe_service.update_customer(
-                customer.stripe_customer_id,
-                tax_id=to_stripe_tax_id(customer.tax_id)
-                if customer.tax_id is not None
-                else None,
-                **params,
+                customer.stripe_customer_id, tax_id=stripe_tax_id, **params
             )
 
         if new_default_payment_method is not None:
@@ -227,7 +237,10 @@ class CustomerService:
             if customer.billing_address is not None:
                 params["address"] = customer.billing_address.to_dict()  # type: ignore
             if customer.tax_id is not None:
-                params["tax_id_data"] = [to_stripe_tax_id(customer.tax_id)]
+                try:
+                    params["tax_id_data"] = [to_stripe_tax_id(customer.tax_id)]
+                except IncompatibleTaxIDFormat:
+                    pass
             stripe_customer = await stripe_service.create_customer(**params)
             repository = CustomerRepository.from_session(session)
             customer = await repository.update(

--- a/server/polar/tax/calculation/stripe.py
+++ b/server/polar/tax/calculation/stripe.py
@@ -1,7 +1,7 @@
 import hashlib
 import uuid
 from datetime import datetime
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import stripe as stripe_lib
 import structlog
@@ -12,7 +12,7 @@ from polar.integrations.stripe.service import stripe as stripe_service
 from polar.kit.address import Address
 from polar.logging import Logger
 
-from ..tax_id import TaxID, to_stripe_tax_id
+from ..tax_id import IncompatibleTaxIDFormat, TaxID, to_stripe_tax_id
 from .base import (
     AlreadyRevertedError,
     TaxabilityReason,
@@ -24,6 +24,11 @@ from .base import (
     TaxRevertError,
     TaxServiceProtocol,
 )
+
+if TYPE_CHECKING:
+    from stripe.params.tax._calculation_create_params import (
+        CalculationCreateParamsCustomerDetailsTaxId,
+    )
 
 log: Logger = structlog.get_logger()
 
@@ -119,6 +124,13 @@ class StripeTaxService(TaxServiceProtocol):
         idempotency_key_str = f"{identifier}:{currency}:{amount}:{tax_code}:{address_str}:{tax_ids_str}:{taxability_override}:{tax_behavior}"
         idempotency_key = hashlib.sha256(idempotency_key_str.encode()).hexdigest()
 
+        stripe_tax_ids: list[CalculationCreateParamsCustomerDetailsTaxId] = []
+        for tax_id in tax_ids:
+            try:
+                stripe_tax_ids.append(to_stripe_tax_id(tax_id))
+            except IncompatibleTaxIDFormat:
+                pass
+
         try:
             calculation = await stripe_service.create_tax_calculation(
                 currency=currency,
@@ -134,7 +146,7 @@ class StripeTaxService(TaxServiceProtocol):
                 customer_details={
                     "address": address.to_dict(),
                     "address_source": "billing",
-                    "tax_ids": [to_stripe_tax_id(tax_id) for tax_id in tax_ids],
+                    "tax_ids": stripe_tax_ids,
                     "taxability_override": taxability_override,
                 },
                 idempotency_key=idempotency_key,

--- a/server/polar/tax/tax_id.py
+++ b/server/polar/tax/tax_id.py
@@ -111,6 +111,18 @@ class TaxIDFormat(StrEnum):
     vn_tin = "vn_tin"
     za_vat = "za_vat"
 
+    # Additional tax ID formats that are not supported by Stripe but are used for validation purposes only.
+    mu_tan = "mu_tan"
+
+    def is_stripe_supported(self) -> bool:
+        """
+        Check if the tax ID format is supported by Stripe.
+
+        Returns:
+            True if the tax ID format is supported by Stripe, False otherwise.
+        """
+        return self not in {self.mu_tan}
+
 
 COUNTRY_TAX_ID_MAP: dict[str, Sequence[TaxIDFormat]] = {
     "AD": (TaxIDFormat.ad_nrt,),
@@ -169,6 +181,7 @@ COUNTRY_TAX_ID_MAP: dict[str, Sequence[TaxIDFormat]] = {
     "LV": (TaxIDFormat.eu_vat,),
     "MT": (TaxIDFormat.eu_vat,),
     "MK": (TaxIDFormat.mk_vat,),
+    "MU": (TaxIDFormat.mu_tan,),
     "MX": (TaxIDFormat.mx_rfc,),
     "MY": (TaxIDFormat.my_frp, TaxIDFormat.my_itn, TaxIDFormat.my_sst),
     "NG": (TaxIDFormat.ng_tin,),
@@ -213,6 +226,14 @@ class UnsupportedTaxIDFormat(TaxIDError):
     def __init__(self, tax_id_type: TaxIDFormat) -> None:
         self.tax_id_type = tax_id_type
         super().__init__(f"Tax ID format {tax_id_type} is not supported.")
+
+
+class IncompatibleTaxIDFormat(TaxIDError):
+    def __init__(self, tax_id_type: TaxIDFormat) -> None:
+        self.tax_id_type = tax_id_type
+        super().__init__(
+            f"Tax ID format {tax_id_type} is not compatible with this tax provider."
+        )
 
 
 class InvalidTaxID(TaxIDError):
@@ -378,6 +399,19 @@ class GEVATValidator(ValidatorProtocol):
         return number
 
 
+class MUTANValidator(ValidatorProtocol):
+    def validate(self, number: str, country: str) -> str:
+        # Remove spaces, dashes, and other common separators
+        number = number.replace(" ", "").replace("-", "").replace(".", "").strip()
+        # Validate: must be exactly 8 digits
+        if len(number) != 8 or not number.isdigit():
+            raise InvalidTaxID(number, country)
+        # First digit must be 2 or 3
+        if number[0] not in ("2", "3"):
+            raise InvalidTaxID(number, country)
+        return number
+
+
 def _get_validator(tax_id_type: TaxIDFormat) -> ValidatorProtocol:
     match tax_id_type:
         case TaxIDFormat.ae_trn:
@@ -402,6 +436,8 @@ def _get_validator(tax_id_type: TaxIDFormat) -> ValidatorProtocol:
             return INGSTValidator()
         case TaxIDFormat.vn_tin:
             return VNTINValidator()
+        case TaxIDFormat.mu_tan:
+            return MUTANValidator()
         case _:
             return StdNumValidator(tax_id_type)
 
@@ -443,8 +479,15 @@ def to_stripe_tax_id(value: TaxID) -> CustomerCreateParamsTaxIdDatum:
 
     Returns:
         A dictionary containing the tax ID in the format expected by Stripe.
+
+    Raises:
+        IncompatibleTaxIDFormat: The tax ID format is not compatible with Stripe.
     """
     tax_id, tax_id_type = value
+
+    if not tax_id_type.is_stripe_supported():
+        raise IncompatibleTaxIDFormat(tax_id_type)
+
     return {
         "type": str(tax_id_type),  # type: ignore
         "value": tax_id,

--- a/server/polar/tax/tax_id.py
+++ b/server/polar/tax/tax_id.py
@@ -1,4 +1,3 @@
-import json
 import re
 from collections.abc import Sequence
 from enum import StrEnum
@@ -507,10 +506,8 @@ class TaxIDType(TypeDecorator[Any]):
 
     def process_result_value(self, value: Any, dialect: Dialect) -> Any:
         if value is not None:
-            # Handle legacy double-serialized values (stored as JSON strings)
-            if isinstance(value, str):
-                value = json.loads(value)
-            return tuple(value)
+            tax_id, tax_id_type = value
+            return (tax_id, TaxIDFormat(tax_id_type))
         return value
 
 

--- a/server/tests/tax/test_tax_id.py
+++ b/server/tests/tax/test_tax_id.py
@@ -67,6 +67,7 @@ from polar.tax.tax_id import InvalidTaxID, TaxID, TaxIDFormat, validate_tax_id
         ("123-456-789", "GE", ("123456789", TaxIDFormat.ge_vat)),
         ("12345678901", "GE", ("12345678901", TaxIDFormat.ge_vat)),
         ("GE12345678901", "GE", ("12345678901", TaxIDFormat.ge_vat)),
+        ("28392339", "MU", ("28392339", TaxIDFormat.mu_tan)),
     ],
 )
 def test_validate_tax_id_valid(number: str, country: str, expected: TaxID) -> None:
@@ -99,6 +100,7 @@ def test_validate_tax_id_valid(number: str, country: str, expected: TaxID) -> No
         ("1234567890", "GE"),  # Between supported lengths (10)
         ("123456789012", "GE"),  # Too long
         ("12345678A", "GE"),  # Non-digit
+        ("88392339", "MU"),  # Wrong leading digit
     ],
 )
 def test_validate_tax_id_invalid(number: str, country: str) -> None:


### PR DESCRIPTION
Fix #12312

- server/tax: add Mauritius TAN Tax ID support

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Mauritius TAN (Tax Account Number) support: we validate and store MU TANs, but skip sending them to Stripe Tax since it’s unsupported (per POL-12312).

- **New Features**
  - Added `TaxIDFormat.mu_tan` and `MUTANValidator` (8 digits; starts with 2 or 3); mapped MU to it.
  - Introduced `IncompatibleTaxIDFormat`; `to_stripe_tax_id` raises for unsupported formats; skip incompatible tax IDs when creating/updating customers and during Stripe Tax calculations.
  - Ensure DB deserialization returns `(value, TaxIDFormat)` with a proper enum, preventing type mismatches.
  - Updated OpenAPI client to include `mu_tan`; added tests for valid and invalid MU TANs.

<sup>Written for commit 381cbf1364fb8cf9d92316792556facc2341e0a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

