### PR TITLE
feat(dispute): sync support case from Stripe webhooks

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -31437,6 +31437,9 @@ export interface components {
       | 'appeal_approved'
       | 'appeal_denied'
       | 'info_requested'
+      | 'dispute_under_review'
+      | 'dispute_won'
+      | 'dispute_lost'
     /** SupportCaseThread */
     SupportCaseThread: {
       case: components['schemas']['SupportCase']
@@ -59830,6 +59833,9 @@ export const supportCaseMessageTypeValues: ReadonlyArray<
   'appeal_approved',
   'appeal_denied',
   'info_requested',
+  'dispute_under_review',
+  'dispute_won',
+  'dispute_lost',
 ]
 export const supportCaseTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SupportCaseType']

--- a/server/polar/dispute/dispute_case.py
+++ b/server/polar/dispute/dispute_case.py
@@ -71,6 +71,12 @@ class DisputeCaseService:
         repository = DisputeSupportCaseRepository.from_session(session)
         return await repository.get_by_dispute(dispute.id)
 
+    async def is_open(
+        self, session: AsyncSession | AsyncReadSession, case: DisputeSupportCase
+    ) -> bool:
+        repository = SupportCaseMessageRepository.from_session(session)
+        return await repository.is_open(case.id)
+
     async def close(
         self,
         session: AsyncSession,
@@ -91,8 +97,7 @@ class DisputeCaseService:
     async def _assert_open(
         self, session: AsyncSession, case: DisputeSupportCase
     ) -> None:
-        repository = SupportCaseMessageRepository.from_session(session)
-        if not await repository.is_open(case.id):
+        if not await self.is_open(session, case):
             raise CaseClosedError(case.id)
 
 

--- a/server/polar/dispute/dispute_case.py
+++ b/server/polar/dispute/dispute_case.py
@@ -7,6 +7,7 @@ from polar.models.support_case import (
     SupportCaseAudience,
     SupportCaseMessage,
     SupportCaseMessageAuthorKind,
+    SupportCaseMessageType,
     SupportCaseParticipantKind,
 )
 from polar.postgres import AsyncReadSession, AsyncSession
@@ -77,6 +78,34 @@ class DisputeCaseService:
         repository = SupportCaseMessageRepository.from_session(session)
         return await repository.is_open(case.id)
 
+    async def mark_under_review(
+        self, session: AsyncSession, case: DisputeSupportCase
+    ) -> SupportCaseMessage:
+        """Record that the dispute's evidence is now under review by the bank."""
+        return await support_case_service.post_message(
+            session,
+            case,
+            type=SupportCaseMessageType.dispute_under_review,
+            author_kind=SupportCaseMessageAuthorKind.system,
+            audience=[SupportCaseAudience.merchant],
+        )
+
+    async def resolve(
+        self, session: AsyncSession, case: DisputeSupportCase, *, won: bool
+    ) -> SupportCaseMessage:
+        """Record the dispute outcome, then close the case."""
+        await self._assert_open(session, case)
+        await support_case_service.post_message(
+            session,
+            case,
+            type=SupportCaseMessageType.dispute_won
+            if won
+            else SupportCaseMessageType.dispute_lost,
+            author_kind=SupportCaseMessageAuthorKind.system,
+            audience=[SupportCaseAudience.merchant],
+        )
+        return await self.close(session, case)
+
     async def close(
         self,
         session: AsyncSession,
@@ -84,7 +113,7 @@ class DisputeCaseService:
         *,
         body: str | None = None,
     ) -> SupportCaseMessage:
-        """Close the case once the dispute is resolved (won/lost)."""
+        """Close the case once the dispute is resolved (won/lost/prevented)."""
         await self._assert_open(session, case)
         return await support_case_service.close(
             session,

--- a/server/polar/dispute/dispute_case.py
+++ b/server/polar/dispute/dispute_case.py
@@ -78,6 +78,18 @@ class DisputeCaseService:
         repository = SupportCaseMessageRepository.from_session(session)
         return await repository.is_open(case.id)
 
+    async def reopen(
+        self, session: AsyncSession, case: DisputeSupportCase
+    ) -> SupportCaseMessage:
+        """Reopen a closed case when its dispute needs a response again."""
+        return await support_case_service.post_message(
+            session,
+            case,
+            type=SupportCaseMessageType.opened,
+            author_kind=SupportCaseMessageAuthorKind.system,
+            audience=[SupportCaseAudience.merchant],
+        )
+
     async def mark_under_review(
         self, session: AsyncSession, case: DisputeSupportCase
     ) -> SupportCaseMessage:

--- a/server/polar/dispute/repository.py
+++ b/server/polar/dispute/repository.py
@@ -94,7 +94,7 @@ class DisputeRepository(
 
     def get_eager_options(self) -> Options:
         return (
-            joinedload(Dispute.payment),
+            joinedload(Dispute.payment).joinedload(Payment.organization),
             joinedload(Dispute.order),
         )
 

--- a/server/polar/dispute/service.py
+++ b/server/polar/dispute/service.py
@@ -141,6 +141,7 @@ class DisputeService:
             )
 
         was_closed = dispute.closed
+        previous_status = dispute.status
         dispute.payment_processor = PaymentProcessor.stripe
         dispute.payment_processor_id = stripe_dispute.id
 
@@ -194,24 +195,45 @@ class DisputeService:
                 await self._revoke(session, dispute)
 
         dispute = await repository.update(dispute)
-        await self._sync_support_case(session, dispute)
+        await self._sync_support_case(session, dispute, previous_status=previous_status)
         return dispute
 
-    async def _sync_support_case(self, session: AsyncSession, dispute: Dispute) -> None:
+    async def _sync_support_case(
+        self,
+        session: AsyncSession,
+        dispute: Dispute,
+        *,
+        previous_status: DisputeStatus | None,
+    ) -> None:
         """Reconcile the merchant support case with the dispute's status.
 
-        Open it the first time the dispute needs a response, close it once the
-        dispute is resolved. Idempotent: a no-op on repeated/retried webhooks.
+        Opens the case the first time the dispute needs a response, posts the
+        milestone updates (under review, won, lost) and closes it on resolution.
+        Idempotent: opening is guarded by the existing case, the closing
+        milestones by the case being open, and the (non-closing) under-review
+        milestone by an actual status change — so retried webhooks are no-ops.
         """
         case = await dispute_case_service.get_case(session, dispute)
+
         if dispute.status == DisputeStatus.needs_response:
             if case is None:
                 await dispute_case_service.open_case(
                     session, dispute, organization=dispute.payment.organization
                 )
-        elif dispute.closed and case is not None:
-            if await dispute_case_service.is_open(session, case):
-                await dispute_case_service.close(session, case)
+            return
+
+        if case is None or not await dispute_case_service.is_open(session, case):
+            return
+
+        if dispute.status == DisputeStatus.under_review:
+            if dispute.status != previous_status:
+                await dispute_case_service.mark_under_review(session, case)
+        elif dispute.status in (DisputeStatus.won, DisputeStatus.lost):
+            await dispute_case_service.resolve(
+                session, case, won=dispute.status == DisputeStatus.won
+            )
+        elif dispute.closed:  # prevented: silent close, the merchant never acted
+            await dispute_case_service.close(session, case)
 
     async def upsert_from_chargeback_stop(
         self, session: AsyncSession, alert: ChargebackStopAlert

--- a/server/polar/dispute/service.py
+++ b/server/polar/dispute/service.py
@@ -220,6 +220,10 @@ class DisputeService:
                 await dispute_case_service.open_case(
                     session, dispute, organization=dispute.payment.organization
                 )
+            elif not await dispute_case_service.is_open(session, case):
+                # Dispute reopened after we'd closed the case (e.g. a prevented
+                # dispute that Stripe escalated back to needs_response).
+                await dispute_case_service.reopen(session, case)
             return
 
         if case is None or not await dispute_case_service.is_open(session, case):

--- a/server/polar/dispute/service.py
+++ b/server/polar/dispute/service.py
@@ -10,6 +10,7 @@ from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
 from polar.benefit.grant.service import benefit_grant as benefit_grant_service
 from polar.customer.repository import CustomerRepository
+from polar.dispute.dispute_case import dispute_case as dispute_case_service
 from polar.enums import PaymentProcessor
 from polar.exceptions import PolarError
 from polar.integrations.chargeback_stop.types import ChargebackStopAlert
@@ -192,7 +193,25 @@ class DisputeService:
                 )
                 await self._revoke(session, dispute)
 
-        return await repository.update(dispute)
+        dispute = await repository.update(dispute)
+        await self._sync_support_case(session, dispute)
+        return dispute
+
+    async def _sync_support_case(self, session: AsyncSession, dispute: Dispute) -> None:
+        """Reconcile the merchant support case with the dispute's status.
+
+        Open it the first time the dispute needs a response, close it once the
+        dispute is resolved. Idempotent: a no-op on repeated/retried webhooks.
+        """
+        case = await dispute_case_service.get_case(session, dispute)
+        if dispute.status == DisputeStatus.needs_response:
+            if case is None:
+                await dispute_case_service.open_case(
+                    session, dispute, organization=dispute.payment.organization
+                )
+        elif dispute.closed and case is not None:
+            if await dispute_case_service.is_open(session, case):
+                await dispute_case_service.close(session, case)
 
     async def upsert_from_chargeback_stop(
         self, session: AsyncSession, alert: ChargebackStopAlert
@@ -258,7 +277,9 @@ class DisputeService:
     ) -> tuple[Payment, Order]:
         payment_repository = PaymentRepository.from_session(session)
         payment = await payment_repository.get_by_processor_id(
-            PaymentProcessor.stripe, processor_id, options=(joinedload(Payment.order),)
+            PaymentProcessor.stripe,
+            processor_id,
+            options=(joinedload(Payment.order), joinedload(Payment.organization)),
         )
         if payment is None or payment.order is None:
             raise DisputePaymentNotFoundError(processor, processor_id)

--- a/server/polar/models/support_case.py
+++ b/server/polar/models/support_case.py
@@ -76,6 +76,10 @@ class SupportCaseMessageType(StrEnum):
     appeal_approved = "appeal_approved"
     appeal_denied = "appeal_denied"
     info_requested = "info_requested"
+    # actions (dispute)
+    dispute_under_review = "dispute_under_review"
+    dispute_won = "dispute_won"
+    dispute_lost = "dispute_lost"
 
 
 class SupportCase(RecordModel):

--- a/server/tests/dispute/test_service.py
+++ b/server/tests/dispute/test_service.py
@@ -755,6 +755,59 @@ class TestUpsertFromStripeDisputeCase:
         assert case is not None
         assert not await dispute_case_service.is_open(session, case)
 
+    async def test_reopens_case_when_dispute_returns_to_needs_response(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        organization: Organization,
+        dispute_transaction_service_mock: MagicMock,
+        refund_service_mock: MagicMock,
+    ) -> None:
+        order = await create_order(save_fixture, customer=customer)
+        charge_id = "STRIPE_CHARGE_ID"
+        await create_payment(
+            save_fixture, organization, order=order, processor_id=charge_id
+        )
+        needs_response = build_stripe_dispute(
+            status="needs_response",
+            charge_id=charge_id,
+            amount=order.subtotal_amount + order.tax_amount,
+            balance_transactions=[],
+        )
+        dispute = await dispute_service.upsert_from_stripe(session, needs_response)
+        case = await dispute_case_service.get_case(session, dispute)
+        assert case is not None
+        assert await dispute_case_service.is_open(session, case)
+
+        # Rapid-resolution: dispute becomes prevented and the case is closed.
+        prevented = build_stripe_dispute(
+            status="lost",
+            id=needs_response.id,
+            charge_id=charge_id,
+            amount=order.subtotal_amount + order.tax_amount,
+            balance_transactions=[
+                build_stripe_balance_transaction(
+                    amount=-order.due_amount, reporting_category="dispute", fee=0
+                )
+            ],
+        )
+        dispute = await dispute_service.upsert_from_stripe(session, prevented)
+        assert dispute.status == DisputeStatus.prevented
+        assert not await dispute_case_service.is_open(session, case)
+
+        # Stripe escalates it back to needs_response: the case must reopen.
+        reopened = build_stripe_dispute(
+            status="needs_response",
+            id=needs_response.id,
+            charge_id=charge_id,
+            amount=order.subtotal_amount + order.tax_amount,
+            balance_transactions=[],
+        )
+        dispute = await dispute_service.upsert_from_stripe(session, reopened)
+        assert dispute.status == DisputeStatus.needs_response
+        assert await dispute_case_service.is_open(session, case)
+
     async def test_posts_under_review_message_on_transition(
         self,
         save_fixture: SaveFixture,

--- a/server/tests/dispute/test_service.py
+++ b/server/tests/dispute/test_service.py
@@ -6,6 +6,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from polar.benefit.grant.service import BenefitGrantService
+from polar.dispute.dispute_case import dispute_case as dispute_case_service
 from polar.dispute.service import DisputePaymentNotFoundError
 from polar.dispute.service import dispute as dispute_service
 from polar.enums import PaymentProcessor, TaxProcessor
@@ -614,6 +615,135 @@ class TestUpsertFromStripe:
 
         dispute_transaction_service_mock.create_dispute.assert_awaited_once()
         assert subscription.status == "canceled"
+
+
+@pytest.mark.asyncio
+class TestUpsertFromStripeDisputeCase:
+    async def test_opens_case_when_needs_response(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        order = await create_order(save_fixture, customer=customer)
+        charge_id = "STRIPE_CHARGE_ID"
+        await create_payment(
+            save_fixture, organization, order=order, processor_id=charge_id
+        )
+        stripe_dispute = build_stripe_dispute(
+            status="needs_response",
+            charge_id=charge_id,
+            amount=order.subtotal_amount + order.tax_amount,
+            balance_transactions=[],
+        )
+
+        dispute = await dispute_service.upsert_from_stripe(session, stripe_dispute)
+
+        case = await dispute_case_service.get_case(session, dispute)
+        assert case is not None
+        assert case.dispute_id == dispute.id
+        assert await dispute_case_service.is_open(session, case)
+
+    async def test_open_is_idempotent_on_repeated_webhook(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        order = await create_order(save_fixture, customer=customer)
+        charge_id = "STRIPE_CHARGE_ID"
+        await create_payment(
+            save_fixture, organization, order=order, processor_id=charge_id
+        )
+        stripe_dispute = build_stripe_dispute(
+            status="needs_response",
+            charge_id=charge_id,
+            amount=order.subtotal_amount + order.tax_amount,
+            balance_transactions=[],
+        )
+
+        dispute = await dispute_service.upsert_from_stripe(session, stripe_dispute)
+        first_case = await dispute_case_service.get_case(session, dispute)
+
+        # A retried/duplicate webhook must not raise nor open a second case.
+        dispute = await dispute_service.upsert_from_stripe(session, stripe_dispute)
+        second_case = await dispute_case_service.get_case(session, dispute)
+
+        assert first_case is not None
+        assert second_case is not None
+        assert second_case.id == first_case.id
+
+    async def test_does_not_open_case_when_prevented(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        organization: Organization,
+        dispute_transaction_service_mock: MagicMock,
+        refund_service_mock: MagicMock,
+    ) -> None:
+        order = await create_order(save_fixture, customer=customer)
+        charge_id = "STRIPE_CHARGE_ID"
+        await create_payment(
+            save_fixture, organization, order=order, processor_id=charge_id
+        )
+        # Rapid-resolution dispute: resolved as prevented, no merchant response
+        # is needed, so no case should be opened.
+        stripe_dispute = build_stripe_dispute(
+            status="lost",
+            charge_id=charge_id,
+            amount=order.subtotal_amount + order.tax_amount,
+            balance_transactions=[
+                build_stripe_balance_transaction(
+                    amount=-order.due_amount, reporting_category="dispute", fee=0
+                )
+            ],
+        )
+
+        dispute = await dispute_service.upsert_from_stripe(session, stripe_dispute)
+
+        assert dispute.status == DisputeStatus.prevented
+        assert await dispute_case_service.get_case(session, dispute) is None
+
+    async def test_closes_case_when_resolved(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        organization: Organization,
+        dispute_transaction_service_mock: MagicMock,
+    ) -> None:
+        order = await create_order(save_fixture, customer=customer)
+        charge_id = "STRIPE_CHARGE_ID"
+        await create_payment(
+            save_fixture, organization, order=order, processor_id=charge_id
+        )
+        needs_response = build_stripe_dispute(
+            status="needs_response",
+            charge_id=charge_id,
+            amount=order.subtotal_amount + order.tax_amount,
+            balance_transactions=[],
+        )
+        dispute = await dispute_service.upsert_from_stripe(session, needs_response)
+        case = await dispute_case_service.get_case(session, dispute)
+        assert case is not None
+        assert await dispute_case_service.is_open(session, case)
+
+        won = build_stripe_dispute(
+            status="won",
+            id=needs_response.id,
+            charge_id=charge_id,
+            amount=order.subtotal_amount + order.tax_amount,
+            balance_transactions=[],
+        )
+        dispute = await dispute_service.upsert_from_stripe(session, won)
+
+        assert dispute.status == DisputeStatus.won
+        case = await dispute_case_service.get_case(session, dispute)
+        assert case is not None
+        assert not await dispute_case_service.is_open(session, case)
 
 
 @pytest.mark.asyncio

--- a/server/tests/dispute/test_service.py
+++ b/server/tests/dispute/test_service.py
@@ -13,8 +13,10 @@ from polar.enums import PaymentProcessor, TaxProcessor
 from polar.integrations.chargeback_stop.types import ChargebackStopAlert
 from polar.models import Customer, Organization, Product
 from polar.models.dispute import DisputeAlertProcessor, DisputeStatus
+from polar.models.support_case import DisputeSupportCase, SupportCaseMessageType
 from polar.postgres import AsyncSession
 from polar.refund.service import RefundService
+from polar.support_case.repository import SupportCaseMessageRepository
 from polar.tax.calculation.base import AlreadyRevertedError
 from polar.transaction.service.dispute import DisputeTransactionService
 from tests.fixtures.database import SaveFixture
@@ -69,6 +71,14 @@ def build_chargeback_stop_alert(
         transaction_amount_in_cents=transaction_amount_in_cents,
         transaction_currency_code=transaction_currency_code.upper(),
     )
+
+
+async def _message_types(
+    session: AsyncSession, case: DisputeSupportCase
+) -> list[SupportCaseMessageType]:
+    repository = SupportCaseMessageRepository.from_session(session)
+    messages = await repository.list_by_case(case.id)
+    return [message.type for message in messages]
 
 
 @pytest.mark.asyncio
@@ -744,6 +754,156 @@ class TestUpsertFromStripeDisputeCase:
         case = await dispute_case_service.get_case(session, dispute)
         assert case is not None
         assert not await dispute_case_service.is_open(session, case)
+
+    async def test_posts_under_review_message_on_transition(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        order = await create_order(save_fixture, customer=customer)
+        charge_id = "STRIPE_CHARGE_ID"
+        await create_payment(
+            save_fixture, organization, order=order, processor_id=charge_id
+        )
+        needs_response = build_stripe_dispute(
+            status="needs_response",
+            charge_id=charge_id,
+            amount=order.subtotal_amount + order.tax_amount,
+            balance_transactions=[],
+        )
+        await dispute_service.upsert_from_stripe(session, needs_response)
+
+        under_review = build_stripe_dispute(
+            status="under_review",
+            id=needs_response.id,
+            charge_id=charge_id,
+            amount=order.subtotal_amount + order.tax_amount,
+            balance_transactions=[],
+        )
+        dispute = await dispute_service.upsert_from_stripe(session, under_review)
+
+        case = await dispute_case_service.get_case(session, dispute)
+        assert case is not None
+        assert await dispute_case_service.is_open(session, case)
+        types = await _message_types(session, case)
+        assert types.count(SupportCaseMessageType.dispute_under_review) == 1
+
+    async def test_under_review_message_not_duplicated_on_retry(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        order = await create_order(save_fixture, customer=customer)
+        charge_id = "STRIPE_CHARGE_ID"
+        await create_payment(
+            save_fixture, organization, order=order, processor_id=charge_id
+        )
+        needs_response = build_stripe_dispute(
+            status="needs_response",
+            charge_id=charge_id,
+            amount=order.subtotal_amount + order.tax_amount,
+            balance_transactions=[],
+        )
+        await dispute_service.upsert_from_stripe(session, needs_response)
+        under_review = build_stripe_dispute(
+            status="under_review",
+            id=needs_response.id,
+            charge_id=charge_id,
+            amount=order.subtotal_amount + order.tax_amount,
+            balance_transactions=[],
+        )
+        await dispute_service.upsert_from_stripe(session, under_review)
+        dispute = await dispute_service.upsert_from_stripe(session, under_review)
+
+        case = await dispute_case_service.get_case(session, dispute)
+        assert case is not None
+        types = await _message_types(session, case)
+        assert types.count(SupportCaseMessageType.dispute_under_review) == 1
+
+    async def test_posts_won_outcome_then_closes(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        organization: Organization,
+        dispute_transaction_service_mock: MagicMock,
+    ) -> None:
+        order = await create_order(save_fixture, customer=customer)
+        charge_id = "STRIPE_CHARGE_ID"
+        await create_payment(
+            save_fixture, organization, order=order, processor_id=charge_id
+        )
+        needs_response = build_stripe_dispute(
+            status="needs_response",
+            charge_id=charge_id,
+            amount=order.subtotal_amount + order.tax_amount,
+            balance_transactions=[],
+        )
+        await dispute_service.upsert_from_stripe(session, needs_response)
+
+        won = build_stripe_dispute(
+            status="won",
+            id=needs_response.id,
+            charge_id=charge_id,
+            amount=order.subtotal_amount + order.tax_amount,
+            balance_transactions=[],
+        )
+        dispute = await dispute_service.upsert_from_stripe(session, won)
+
+        case = await dispute_case_service.get_case(session, dispute)
+        assert case is not None
+        assert not await dispute_case_service.is_open(session, case)
+        types = await _message_types(session, case)
+        # Outcome event is recorded before the case is closed.
+        assert types.index(SupportCaseMessageType.dispute_won) < types.index(
+            SupportCaseMessageType.closed
+        )
+
+    async def test_posts_lost_outcome_then_closes(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        organization: Organization,
+        dispute_transaction_service_mock: MagicMock,
+    ) -> None:
+        order = await create_order(save_fixture, customer=customer)
+        charge_id = "STRIPE_CHARGE_ID"
+        await create_payment(
+            save_fixture, organization, order=order, processor_id=charge_id
+        )
+        needs_response = build_stripe_dispute(
+            status="needs_response",
+            charge_id=charge_id,
+            amount=order.subtotal_amount + order.tax_amount,
+            balance_transactions=[],
+        )
+        await dispute_service.upsert_from_stripe(session, needs_response)
+
+        lost = build_stripe_dispute(
+            status="lost",
+            id=needs_response.id,
+            charge_id=charge_id,
+            amount=order.subtotal_amount + order.tax_amount,
+            balance_transactions=[
+                build_stripe_balance_transaction(
+                    amount=-order.due_amount, reporting_category="dispute", fee=1500
+                )
+            ],
+        )
+        dispute = await dispute_service.upsert_from_stripe(session, lost)
+
+        case = await dispute_case_service.get_case(session, dispute)
+        assert case is not None
+        assert not await dispute_case_service.is_open(session, case)
+        types = await _message_types(session, case)
+        assert types.index(SupportCaseMessageType.dispute_lost) < types.index(
+            SupportCaseMessageType.closed
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Wire Stripe dispute webhooks to the dispute support case: open it when a merchant needs to respond, post status milestones as the dispute progresses, and close it on resolution.

This is the readonly part of the "dispute in product". Next step is to be able to submit evidence from the in app chat.

## What

- Open a `DisputeSupportCase` when a dispute reaches `needs_response` (merchant added as participant, system-authored).
- Post system milestone messages to the case as the dispute moves through Stripe statuses: `dispute_under_review`, `dispute_won`, `dispute_lost`  (new typed message types).
- Close the case on resolution — outcome event (`dispute_won`/`dispute_lost`) followed by the generic `closed` lifecycle event; `prevented` closes silently.
- Add `is_open`, `mark_under_review`, and `resolve` to `DisputeCaseService`.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs Stripe dispute webhooks with merchant support cases: open a case on `needs_response`, post milestones as it changes, and close on resolution. Reopens a closed case if the dispute goes back to `needs_response`; idempotent to avoid duplicate cases or messages.

- **New Features**
  - Open on `needs_response`; no case for `prevented` (silent close).
  - Reopen the case if a previously closed dispute returns to `needs_response`.
  - Post milestones and close: `dispute_under_review` on status change (once), then `dispute_won`/`dispute_lost` before `closed`.
  - Service and SDK: add `is_open`, `reopen`, `mark_under_review`, `resolve`; expose new message types in the generated `client`; eager-load `Payment.organization` for case creation.

<sup>Written for commit 5ac762b3f3082b2b90a69bdd88877768a2ecc877. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

