### PR TITLE
Allow editing member names from the dashboard & sync customer name to its member

### DIFF
--- a/clients/apps/web/src/components/Customer/CustomerPage.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerPage.tsx
@@ -657,9 +657,8 @@ export const CustomerPage: React.FC<CustomerPageProps> = ({
       {showMembersTab && (
         <TabsContent value="members" className="flex flex-col gap-y-8">
           <MembersSection
-            customerId={customer.id}
+            customer={customer}
             organizationId={organization.id}
-            customerType={customer.type ?? undefined}
           />
         </TabsContent>
       )}

--- a/clients/apps/web/src/components/Customer/EditMemberModal.tsx
+++ b/clients/apps/web/src/components/Customer/EditMemberModal.tsx
@@ -1,0 +1,126 @@
+import { useUpdateMember } from '@/hooks/queries/members'
+import { setValidationErrors } from '@/utils/api/errors'
+import { isValidationError, schemas } from '@polar-sh/client'
+import { Button, Input, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@polar-sh/ui/components/ui/form'
+import { useForm } from 'react-hook-form'
+import { toast } from '../Toast/use-toast'
+
+type MemberUpdateForm = Pick<schemas['MemberUpdate'], 'name'>
+
+export const EditMemberModal = ({
+  member,
+  customerId,
+  isCustomer,
+  onClose,
+}: {
+  member: schemas['Member']
+  customerId: string
+  isCustomer: boolean
+  onClose: () => void
+}) => {
+  const form = useForm<MemberUpdateForm>({
+    defaultValues: {
+      name: member.name ?? '',
+    },
+  })
+
+  const updateMember = useUpdateMember(member.id, customerId)
+
+  const handleUpdateMember = (memberUpdate: MemberUpdateForm) => {
+    updateMember.mutateAsync(memberUpdate).then(({ error }) => {
+      if (error) {
+        if (error.detail) {
+          if (isValidationError(error.detail)) {
+            setValidationErrors(error.detail, form.setError)
+          } else {
+            toast({
+              title: 'Member Update Failed',
+              description: `Error updating member ${member.email}: ${error.detail}`,
+            })
+          }
+        }
+        return
+      }
+
+      toast({
+        title: 'Member Updated',
+        description: `Member ${member.email} updated successfully`,
+      })
+      onClose()
+    })
+  }
+
+  return (
+    <Box
+      flexDirection="column"
+      gap="2xl"
+      overflowY="auto"
+      paddingHorizontal="2xl"
+      paddingVertical="3xl"
+    >
+      <Box alignItems="center" columnGap="l">
+        <Text as="h2" variant="heading-xs">
+          Edit Member
+        </Text>
+      </Box>
+      <Form {...form}>
+        <Box
+          as="form"
+          onSubmit={form.handleSubmit(handleUpdateMember)}
+          flexDirection="column"
+          gap="2xl"
+        >
+          <Box flexDirection="column" gap="l">
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormDescription>
+                A member&apos;s email can&apos;t be changed.
+              </FormDescription>
+              <FormControl>
+                <Input value={member.email} disabled />
+              </FormControl>
+            </FormItem>
+            <FormField
+              control={form.control}
+              name="name"
+              disabled={isCustomer}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  {isCustomer && (
+                    <FormDescription>
+                      This member is the customer account, so their name is
+                      managed on the customer and can&apos;t be edited here.
+                    </FormDescription>
+                  )}
+                  <FormControl>
+                    <Input {...field} value={field.value || ''} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </Box>
+          <Button
+            type="submit"
+            className="self-start"
+            loading={updateMember.isPending}
+            disabled={isCustomer}
+          >
+            Save Member
+          </Button>
+        </Box>
+      </Form>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/components/Customer/MembersSection.tsx
+++ b/clients/apps/web/src/components/Customer/MembersSection.tsx
@@ -123,9 +123,7 @@ export const MembersSection = ({
               isCustomer={selectedMember.email === customer.email}
               onClose={hideEditMemberModal}
             />
-          ) : (
-            <></>
-          )
+          ) : null
         }
       />
     </div>

--- a/clients/apps/web/src/components/Customer/MembersSection.tsx
+++ b/clients/apps/web/src/components/Customer/MembersSection.tsx
@@ -1,11 +1,14 @@
 'use client'
 
+import { useModal } from '@/components/Modal/useModal'
 import { useMembers } from '@/hooks/queries/members'
 import { useOrganization } from '@/hooks/queries/org'
-import { DataTable, type StatusColor } from '@polar-sh/orbit'
+import { schemas } from '@polar-sh/client'
+import { DataTable, InlineModal, type StatusColor } from '@polar-sh/orbit'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import { Status } from '@polar-sh/orbit'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
+import { EditMemberModal } from './EditMemberModal'
 
 const roleDisplayConfig: Record<
   'owner' | 'billing_manager' | 'member',
@@ -17,27 +20,34 @@ const roleDisplayConfig: Record<
 }
 
 interface MembersSectionProps {
-  customerId: string
+  customer: schemas['Customer']
   organizationId: string
-  customerType?: 'individual' | 'team'
 }
 
 export const MembersSection = ({
-  customerId,
+  customer,
   organizationId,
-  customerType,
 }: MembersSectionProps) => {
   const { data: organization } = useOrganization(
     organizationId,
     !!organizationId,
   )
-  const { data: membersData, isLoading } = useMembers(customerId)
+  const { data: membersData, isLoading } = useMembers(customer.id)
+
+  const [selectedMember, setSelectedMember] = useState<
+    schemas['Member'] | null
+  >(null)
+  const {
+    show: showEditMemberModal,
+    hide: hideEditMemberModal,
+    isShown: isEditMemberModalShown,
+  } = useModal()
 
   // Only show Members section for team customers when member model is enabled
   const isEnabled =
     organization?.feature_settings?.member_model_enabled &&
     organization?.feature_settings?.seat_based_pricing_enabled &&
-    customerType === 'team'
+    customer.type === 'team'
 
   const members = useMemo(
     () => membersData?.pages.flatMap((page) => page.items) ?? [],
@@ -97,6 +107,26 @@ export const MembersSection = ({
         ]}
         isLoading={isLoading}
         className="text-sm"
+        onRowClick={({ original }) => {
+          setSelectedMember(original)
+          showEditMemberModal()
+        }}
+      />
+      <InlineModal
+        isShown={isEditMemberModalShown}
+        hide={hideEditMemberModal}
+        modalContent={
+          selectedMember ? (
+            <EditMemberModal
+              member={selectedMember}
+              customerId={customer.id}
+              isCustomer={selectedMember.email === customer.email}
+              onClose={hideEditMemberModal}
+            />
+          ) : (
+            <></>
+          )
+        }
       />
     </div>
   )

--- a/clients/apps/web/src/components/Customer/MembersSection.tsx
+++ b/clients/apps/web/src/components/Customer/MembersSection.tsx
@@ -46,8 +46,7 @@ export const MembersSection = ({
   // Only show Members section for team customers when member model is enabled
   const isEnabled =
     organization?.feature_settings?.member_model_enabled &&
-    organization?.feature_settings?.seat_based_pricing_enabled &&
-    customer.type === 'team'
+    organization?.feature_settings?.seat_based_pricing_enabled
 
   const members = useMemo(
     () => membersData?.pages.flatMap((page) => page.items) ?? [],

--- a/clients/apps/web/src/hooks/queries/members.ts
+++ b/clients/apps/web/src/hooks/queries/members.ts
@@ -1,6 +1,7 @@
+import { getQueryClient } from '@/utils/api/query'
 import { api } from '@/utils/client'
-import { operations, unwrap } from '@polar-sh/client'
-import { useInfiniteQuery } from '@tanstack/react-query'
+import { operations, schemas, unwrap } from '@polar-sh/client'
+import { useInfiniteQuery, useMutation } from '@tanstack/react-query'
 import { defaultRetry } from './retry'
 
 /**
@@ -40,4 +41,21 @@ export const useMembers = (
       return lastPageParam + 1
     },
     enabled: !!customerId,
+  })
+
+/**
+ * Update a member by ID.
+ */
+export const useUpdateMember = (memberId: string, customerId: string) =>
+  useMutation({
+    mutationFn: (body: schemas['MemberUpdate']) =>
+      api.PATCH('/v1/members/{id}', {
+        params: { path: { id: memberId } },
+        body,
+      }),
+    onSuccess: async () => {
+      getQueryClient().invalidateQueries({
+        queryKey: ['members', customerId],
+      })
+    },
   })

--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -533,6 +533,9 @@ class CustomerService:
         if email_changed:
             await member_service.sync_owner_email(session, updated_customer)
 
+        if customer_update.name is not None:
+            await member_service.sync_customer_name_with_member(session, updated_customer)
+
         return updated_customer
 
     async def delete(

--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -534,7 +534,9 @@ class CustomerService:
             await member_service.sync_owner_email(session, updated_customer)
 
         if customer_update.name is not None:
-            await member_service.sync_customer_name_with_member(session, updated_customer)
+            await member_service.sync_customer_name_with_member(
+                session, updated_customer
+            )
 
         return updated_customer
 

--- a/server/polar/member/service.py
+++ b/server/polar/member/service.py
@@ -275,7 +275,7 @@ class MemberService:
 
         old_name = member.name
 
-        await repository.update(member, update_dict={"name": customer.name})
+        await self.update(session, member, name=customer.name)
 
         log.info(
             "member.sync_customer_name_with_member",

--- a/server/polar/member/service.py
+++ b/server/polar/member/service.py
@@ -247,6 +247,44 @@ class MemberService:
             new_email=customer.email,
         )
 
+    async def sync_customer_name_with_member(
+        self, session: AsyncSession, customer: Customer
+    ) -> None:
+        """Mirror customer.name onto the member that represents the customer
+        itself — the one auto-created with the same email as the customer.
+
+        A team customer always has exactly one member whose email matches
+        customer.email (its "self" member, independent of who holds the owner
+        role). When the customer is renamed, that member's name would otherwise
+        drift, so we keep it in sync. Other team members have their own
+        distinct names and are left untouched."""
+        if customer.email is None:
+            return
+
+        repository = MemberRepository.from_session(session)
+
+        member = await repository.get_by_customer_id_and_email(
+            customer.id, customer.email
+        )
+
+        if member is None:
+            return
+
+        if member.name == customer.name:
+            return
+
+        old_name = member.name
+
+        await repository.update(member, update_dict={"name": customer.name})
+
+        log.info(
+            "member.sync_customer_name_with_member",
+            customer_id=customer.id,
+            member_id=member.id,
+            old_name=old_name,
+            new_name=customer.name,
+        )
+
     async def create_owner_member(
         self,
         session: AsyncSession,

--- a/server/tests/member/test_service.py
+++ b/server/tests/member/test_service.py
@@ -1222,7 +1222,7 @@ class TestSyncCustomerNameWithMember:
 
         assert member.name == "New Team Name"
 
-    async def test_individual_customer_is_skipped(
+    async def test_individual_customer_syncs_matching_email_member(
         self,
         save_fixture: SaveFixture,
         session: AsyncSession,
@@ -1247,7 +1247,7 @@ class TestSyncCustomerNameWithMember:
 
         await member_service.sync_customer_name_with_member(session, customer)
 
-        assert member.name == "Old Member Name"
+        assert member.name == "New Customer Name"
 
     async def test_no_member_for_customer_email_is_noop(
         self,

--- a/server/tests/member/test_service.py
+++ b/server/tests/member/test_service.py
@@ -1164,3 +1164,145 @@ class TestGetOrCreateByEmail:
         )
 
         assert member.role == MemberRole.owner
+
+
+@pytest.mark.asyncio
+class TestSyncCustomerNameWithMember:
+    async def test_team_customer_syncs_matching_email_member(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="team@example.com",
+            name="New Team Name",
+        )
+        customer.type = CustomerType.team
+        await save_fixture(customer)
+
+        member = await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            email="team@example.com",
+            name="Old Member Name",
+        )
+
+        await member_service.sync_customer_name_with_member(session, customer)
+
+        assert member.name == "New Team Name"
+
+    async def test_matches_member_email_case_insensitively(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="Team@Example.com",
+            name="New Team Name",
+        )
+        customer.type = CustomerType.team
+        await save_fixture(customer)
+
+        member = await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            email="team@example.com",
+            name="Old Member Name",
+        )
+
+        await member_service.sync_customer_name_with_member(session, customer)
+
+        assert member.name == "New Team Name"
+
+    async def test_individual_customer_is_skipped(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="person@example.com",
+            name="New Customer Name",
+        )
+        customer.type = CustomerType.individual
+        await save_fixture(customer)
+
+        member = await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            email="person@example.com",
+            name="Old Member Name",
+        )
+
+        await member_service.sync_customer_name_with_member(session, customer)
+
+        assert member.name == "Old Member Name"
+
+    async def test_no_member_for_customer_email_is_noop(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="team@example.com",
+            name="New Team Name",
+        )
+        customer.type = CustomerType.team
+        await save_fixture(customer)
+
+        member = await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            email="someone-else@example.com",
+            name="Old Member Name",
+        )
+
+        await member_service.sync_customer_name_with_member(session, customer)
+
+        assert member.name == "Old Member Name"
+
+    async def test_name_already_in_sync_does_not_update(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        mocker: MockerFixture,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="team@example.com",
+            name="Same Name",
+        )
+        customer.type = CustomerType.team
+        await save_fixture(customer)
+
+        member = await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            email="team@example.com",
+            name="Same Name",
+        )
+
+        update_spy = mocker.spy(MemberRepository, "update")
+
+        await member_service.sync_customer_name_with_member(session, customer)
+
+        update_spy.assert_not_called()
+        assert member.name == "Same Name"


### PR DESCRIPTION
## Summary

Adds the ability to edit a member's name from the customer dashboard, and keeps a customer's "self" member (the one auto-created with the same email as the customer) in sync when the customer is renamed.

Next up: Member name to be changed by owner in customer portal

Backend
- New MemberService.sync_customer_name_with_member: when a customer is updated, mirrors customer.name onto the member whose email matches customer.email. Writes through member_service.update() so the member.updated webhook fires (consistent with every other member-name change).
- Unit tests covering sync, case-insensitive email match, no-matching-member no-op, and the unchanged short-circuit.


Frontend
- New EditMemberModal for editing a member's name (email shown read-only, since it can't be changed; name field locked when the member is the customer account itself).


| Edit Member Modal |
|---|
| <img width="500" alt="Screenshot 2026-06-16 at 16 11 54" src="https://github.com/user-attachments/assets/bcf6aa91-f05a-45d2-8802-23ca0eaddddc" /> |


<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [X] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [X] The diff is reasonably sized and easy to review
- [X] New functionality is covered by tests
- [X] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [X] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable editing a member’s name from the dashboard and keep the customer’s self-member name in sync when the customer is renamed.

- **New Features**
  - Added an Edit Member modal in the dashboard Members tab; click a row to edit name, email is read-only, and the self-member’s name is locked.
  - Connected the UI to `PATCH /v1/members/{id}` with cache invalidation for the members list.
  - On customer updates, `MemberService.sync_customer_name_with_member` mirrors `customer.name` to the member with the same email (case-insensitive) via `member_service.update()`; tests cover sync, no-op, and individual/team cases.

<sup>Written for commit 527eb155fe44d095dd56ed8f6d9186af06ddfeba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

