### PR TITLE
Send chargeback prevention notices

### DIFF
--- a/server/emails/src/emails/chargeback_prevention_refund.tsx
+++ b/server/emails/src/emails/chargeback_prevention_refund.tsx
@@ -1,0 +1,112 @@
+import {
+  Divider,
+  Footer,
+  Heading,
+  List,
+  Text,
+  WrapperPolar,
+} from '../components/foundation'
+import type { schemas } from '../types'
+
+export function ChargebackPreventionRefund({
+  email,
+  order_number,
+  customer_name,
+  formatted_amount,
+  refund_date,
+}: schemas['ChargebackPreventionRefundProps']) {
+  const formattedDate = refund_date
+    ? new Date(refund_date).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+    : refund_date
+
+  return (
+    <WrapperPolar
+      preview={`We've issued a chargeback prevention refund for order ${order_number}`}
+    >
+      <Text>Hello,</Text>
+      <Text>We have issued a chargeback prevention refund for this order:</Text>
+      <Divider />
+      <Text noMargin>
+        <Text as="span" weight="bold">
+          Order:
+        </Text>{' '}
+        {order_number}
+      </Text>
+      <Text noMargin>
+        <Text as="span" weight="bold">
+          Customer:
+        </Text>{' '}
+        {customer_name}
+      </Text>
+      <Text noMargin>
+        <Text as="span" weight="bold">
+          Amount Refunded:
+        </Text>{' '}
+        {formatted_amount}
+      </Text>
+      <Text noMargin>
+        <Text as="span" weight="bold">
+          Date:
+        </Text>{' '}
+        {formattedDate}
+      </Text>
+      <Divider />
+      <Heading>Why was this refund issued?</Heading>
+      <Text>
+        Polar receives early-warning alerts from some card issuers and banking
+        partners when a cardholder attempts to dispute a transaction. These
+        alerts come in before a formal chargeback is filed with the card
+        networks.
+      </Text>
+      <Text>
+        Our early warning system indicated a high likelihood that this
+        transaction would result in a formal chargeback. To help you avoid
+        possible losses and fees, we refunded the payment before a dispute was
+        officially filed.
+      </Text>
+      <Text>
+        Although a refund is not ideal, it is often the least expensive option.
+        A formal chargeback can lead to:
+      </Text>
+      <List>
+        <List.Item>Loss of the transaction amount</List.Item>
+        <List.Item>Chargeback and dispute-related fees</List.Item>
+        <List.Item>
+          Additional overhead to manage and respond to the dispute
+        </List.Item>
+        <List.Item>
+          Increased dispute ratios that can negatively impact payment processing
+          over time
+        </List.Item>
+      </List>
+      <Text>
+        By refunding the transaction before a chargeback was filed, we helped
+        you avoid these extra costs and issues.
+      </Text>
+      <Text>
+        Polar usually treats completed sales as the merchant's and does not
+        issue refunds to customers unless there are special circumstances. We
+        only use chargeback-prevention refunds when it is likely to be better
+        than letting a formal dispute happen.
+      </Text>
+      <Text>If you have any questions, just reply to this email.</Text>
+      <Footer email={email} />
+    </WrapperPolar>
+  )
+}
+
+ChargebackPreventionRefund.PreviewProps = {
+  email: 'merchant@example.com',
+  order_number: 'POLAR-2026-00042',
+  customer_name: 'Bob Ross',
+  amount: 4595,
+  currency: 'usd',
+  formatted_amount: '$45.95',
+  refund_date: '2026-06-16T20:41:00Z',
+}
+
+export default ChargebackPreventionRefund

--- a/server/emails/src/emails/index.ts
+++ b/server/emails/src/emails/index.ts
@@ -1,3 +1,4 @@
+import { ChargebackPreventionRefund } from './chargeback_prevention_refund'
 import { CustomerEmailChangedNotification } from './customer_email_changed_notification'
 import { CustomerEmailUpdateVerification } from './customer_email_update_verification'
 import { CustomerSessionCode } from './customer_session_code'
@@ -61,6 +62,7 @@ const TEMPLATES: Record<string, React.FC<never>> = {
   notification_new_sale: NotificationNewSale,
   notification_new_subscription: NotificationNewSubscription,
   notification_credits_granted: NotificationCreditsGranted,
+  chargeback_prevention_refund: ChargebackPreventionRefund,
   polar_self_subscription_confirmation: PolarSelfSubscriptionConfirmation,
   polar_self_subscription_cycled: PolarSelfSubscriptionCycled,
   polar_self_startup_program_welcome: PolarSelfStartupProgramWelcome,

--- a/server/emails/src/types/openapi.ts
+++ b/server/emails/src/types/openapi.ts
@@ -939,6 +939,36 @@ export interface components {
      * @enum {string}
      */
     BenefitVisibility: 'draft' | 'private' | 'public'
+    /** ChargebackPreventionRefundEmail */
+    ChargebackPreventionRefundEmail: {
+      /**
+       * Template
+       * @default chargeback_prevention_refund
+       * @constant
+       */
+      template: 'chargeback_prevention_refund'
+      props: components['schemas']['ChargebackPreventionRefundProps']
+    }
+    /** ChargebackPreventionRefundProps */
+    ChargebackPreventionRefundProps: {
+      /** Email */
+      email: string
+      /** Order Number */
+      order_number: string
+      /** Customer Name */
+      customer_name: string
+      /** Amount */
+      amount: number
+      /**
+       * Currency
+       * @default usd
+       */
+      currency: string
+      /** Refund Date */
+      refund_date: string
+      /** Formatted Amount */
+      readonly formatted_amount: string
+    }
     /**
      * CustomerCancellationReason
      * @enum {string}

--- a/server/polar/email/schemas.py
+++ b/server/polar/email/schemas.py
@@ -3,9 +3,16 @@ import sys
 from enum import StrEnum
 from typing import Annotated, Literal
 
-from pydantic import AfterValidator, BaseModel, Discriminator, TypeAdapter
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    Discriminator,
+    TypeAdapter,
+    computed_field,
+)
 
 from polar.benefit.schemas import Benefit
+from polar.kit.currency import format_currency
 from polar.kit.visibility import Visibility
 from polar.notifications.notification import (
     MaintainerAccountCreditsGrantedNotificationPayload,
@@ -48,6 +55,7 @@ class EmailTemplate(StrEnum):
     notification_new_sale = "notification_new_sale"
     notification_new_subscription = "notification_new_subscription"
     notification_credits_granted = "notification_credits_granted"
+    chargeback_prevention_refund = "chargeback_prevention_refund"
     polar_self_subscription_confirmation = "polar_self_subscription_confirmation"
     polar_self_subscription_cycled = "polar_self_subscription_cycled"
     polar_self_startup_program_welcome = "polar_self_startup_program_welcome"
@@ -406,6 +414,26 @@ class NotificationCreditsGrantedEmail(BaseModel):
     props: MaintainerAccountCreditsGrantedNotificationPayload
 
 
+class ChargebackPreventionRefundProps(EmailProps):
+    order_number: str
+    customer_name: str
+    amount: int
+    currency: str = "usd"
+    refund_date: str
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def formatted_amount(self) -> str:
+        return format_currency(self.amount, self.currency)
+
+
+class ChargebackPreventionRefundEmail(BaseModel):
+    template: Literal[EmailTemplate.chargeback_prevention_refund] = (
+        EmailTemplate.chargeback_prevention_refund
+    )
+    props: ChargebackPreventionRefundProps
+
+
 class PolarSelfSubscriptionConfirmationProps(EmailProps):
     product_name: str
 
@@ -482,6 +510,7 @@ Email = Annotated[
     | NotificationNewSaleEmail
     | NotificationNewSubscriptionEmail
     | NotificationCreditsGrantedEmail
+    | ChargebackPreventionRefundEmail
     | PolarSelfSubscriptionConfirmationEmail
     | PolarSelfSubscriptionCycledEmail
     | PolarSelfStartupProgramWelcomeEmail,

--- a/server/polar/refund/service.py
+++ b/server/polar/refund/service.py
@@ -465,6 +465,9 @@ class RefundService:
         session: AsyncSession,
         refund: Refund,
     ) -> None:
+        if refund.reason == RefundReason.dispute_prevention:
+            enqueue_job("refund.send_chargeback_prevention_notice", refund.id)
+
         try:
             await refund_transaction_service.create(session, refund=refund)
         except RefundTransactionAlreadyExistsError:

--- a/server/polar/refund/tasks.py
+++ b/server/polar/refund/tasks.py
@@ -1,0 +1,66 @@
+import uuid
+
+from sqlalchemy.orm import joinedload
+
+from polar.email.schemas import (
+    ChargebackPreventionRefundEmail,
+    ChargebackPreventionRefundProps,
+)
+from polar.email.sender import enqueue_email_template
+from polar.models import Order, Refund
+from polar.models.user_organization import OrganizationRole
+from polar.user_organization.service import (
+    user_organization as user_organization_service,
+)
+from polar.worker import AsyncSessionMaker, TaskPriority, actor
+
+from .repository import RefundRepository
+
+_NOTICE_RECIPIENT_ROLES = (OrganizationRole.owner, OrganizationRole.admin)
+
+
+@actor(
+    actor_name="refund.send_chargeback_prevention_notice",
+    priority=TaskPriority.LOW,
+)
+async def send_chargeback_prevention_notice(refund_id: uuid.UUID) -> None:
+    async with AsyncSessionMaker() as session:
+        repository = RefundRepository.from_session(session)
+        refund = await repository.get_by_id(
+            refund_id,
+            options=(joinedload(Refund.order).joinedload(Order.customer),),
+        )
+        if refund is None:
+            return
+
+        order = refund.order
+        if order is None:
+            return
+
+        order_number = order.invoice_number or str(order.id)
+        customer_name = order.customer.display_name
+        subject = f"Chargeback prevented for order {order_number}"
+
+        members = await user_organization_service.list_by_org(
+            session, order.organization_id
+        )
+        for member in members:
+            if member.role not in _NOTICE_RECIPIENT_ROLES:
+                continue
+            recipient = member.user.email
+            if not recipient:
+                continue
+            enqueue_email_template(
+                ChargebackPreventionRefundEmail(
+                    props=ChargebackPreventionRefundProps(
+                        email=recipient,
+                        order_number=order_number,
+                        customer_name=customer_name,
+                        amount=refund.total_amount,
+                        currency=refund.currency,
+                        refund_date=refund.created_at.isoformat(),
+                    )
+                ),
+                to_email_addr=recipient,
+                subject=subject,
+            )

--- a/server/polar/tasks.py
+++ b/server/polar/tasks.py
@@ -29,6 +29,7 @@ from polar.payout import tasks as payout
 from polar.personal_access_token import tasks as personal_access_token
 from polar.processor_transaction import tasks as processor_transaction
 from polar.receipt import tasks as receipt
+from polar.refund import tasks as refund
 from polar.subscription import tasks as subscription
 from polar.support_case import tasks as support_case
 from polar.transaction import tasks as transaction
@@ -64,6 +65,7 @@ __all__ = [
     "polar_self",
     "processor_transaction",
     "receipt",
+    "refund",
     "slo_report",
     "stripe",
     "subscription",

--- a/server/tests/refund/test_service.py
+++ b/server/tests/refund/test_service.py
@@ -1028,3 +1028,128 @@ class TestOrganizationRefundsBlocked:
         # Verify refund was created
         assert refund is not None
         assert refund.order_id == order.id
+
+
+NOTICE_ACTOR = "refund.send_chargeback_prevention_notice"
+
+
+def _notice_calls(enqueue_job_mock: MagicMock) -> list[Any]:
+    return [
+        call
+        for call in enqueue_job_mock.call_args_list
+        if call.args and call.args[0] == NOTICE_ACTOR
+    ]
+
+
+@pytest.mark.asyncio
+class TestChargebackPreventionNotice:
+    async def test_enqueues_on_create_from_dispute(
+        self,
+        session: AsyncSession,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.refund.service.enqueue_job")
+
+        order, payment, _ = await create_order_and_payment(
+            save_fixture,
+            product=product,
+            customer=customer,
+            subtotal_amount=1000,
+            tax_amount=250,
+        )
+        dispute = await create_dispute(
+            save_fixture, order, payment, amount=1000, tax_amount=250
+        )
+
+        refund = await refund_service.create_from_dispute(
+            session, dispute, "DISPUTE_BALANCE_TRANSACTION_ID"
+        )
+
+        notice_calls = _notice_calls(enqueue_job_mock)
+        assert len(notice_calls) == 1
+        assert notice_calls[0].args == (NOTICE_ACTOR, refund.id)
+
+    async def test_enqueues_once_on_stripe_transition_to_succeeded(
+        self,
+        session: AsyncSession,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.refund.service.enqueue_job")
+
+        order, payment, _ = await create_order_and_payment(
+            save_fixture,
+            product=product,
+            customer=customer,
+            subtotal_amount=1000,
+            tax_amount=250,
+        )
+        await create_dispute(
+            save_fixture,
+            order,
+            payment,
+            payment_processor_id=None,
+            alert_processor=DisputeAlertProcessor.chargeback_stop,
+            alert_processor_id="CHARGEBACK_STOP_ALERT_ID",
+        )
+
+        pending_stripe_refund = build_stripe_refund(
+            status="pending",
+            amount=100,
+            id="re_stripe_refund_cbs",
+            charge_id=payment.processor_id,
+            metadata={"cbs_related_alert_id": "CHARGEBACK_STOP_ALERT_ID"},
+        )
+        refund = await refund_service.upsert_from_stripe(session, pending_stripe_refund)
+        assert refund.reason == RefundReason.dispute_prevention
+        assert refund.status == RefundStatus.pending
+        # No notice while the refund is still pending.
+        assert _notice_calls(enqueue_job_mock) == []
+
+        succeeded_stripe_refund = build_stripe_refund(
+            id=pending_stripe_refund.id,
+            status="succeeded",
+            amount=100,
+            charge_id=payment.processor_id,
+            metadata={"cbs_related_alert_id": "CHARGEBACK_STOP_ALERT_ID"},
+        )
+        refund = await refund_service.upsert_from_stripe(
+            session, succeeded_stripe_refund
+        )
+        assert refund.status == RefundStatus.succeeded
+
+        notice_calls = _notice_calls(enqueue_job_mock)
+        assert len(notice_calls) == 1
+        assert notice_calls[0].args == (NOTICE_ACTOR, refund.id)
+
+    async def test_does_not_enqueue_for_other_reason(
+        self,
+        session: AsyncSession,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.refund.service.enqueue_job")
+
+        order, payment, _ = await create_order_and_payment(
+            save_fixture,
+            product=product,
+            customer=customer,
+            subtotal_amount=1000,
+            tax_amount=250,
+        )
+
+        stripe_refund = build_stripe_refund(
+            status="succeeded", amount=1250, charge_id=payment.processor_id
+        )
+        refund = await refund_service.create_from_stripe(session, stripe_refund)
+        assert refund.status == RefundStatus.succeeded
+        assert refund.reason != RefundReason.dispute_prevention
+
+        assert _notice_calls(enqueue_job_mock) == []

--- a/server/tests/refund/test_tasks.py
+++ b/server/tests/refund/test_tasks.py
@@ -1,0 +1,203 @@
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from polar.email.schemas import ChargebackPreventionRefundEmail
+from polar.kit.currency import format_currency
+from polar.models import Customer, Organization, Product, User
+from polar.models.refund import RefundReason
+from polar.models.user_organization import OrganizationRole, UserOrganization
+from polar.refund.tasks import send_chargeback_prevention_notice
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import (
+    create_order_and_payment,
+    create_refund,
+    create_user,
+)
+
+
+@pytest.fixture(autouse=True)
+def enqueue_email_template_mock(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("polar.refund.tasks.enqueue_email_template")
+
+
+async def _add_member(
+    save_fixture: SaveFixture,
+    organization: Organization,
+    user: User,
+    role: OrganizationRole,
+) -> None:
+    await save_fixture(
+        UserOrganization(
+            user_id=user.id,
+            organization_id=organization.id,
+            role=role,
+        )
+    )
+
+
+@pytest.mark.asyncio
+class TestSendChargebackPreventionNotice:
+    async def test_missing_refund_is_noop(
+        self, enqueue_email_template_mock: MagicMock
+    ) -> None:
+        await send_chargeback_prevention_notice(uuid.uuid4())
+        enqueue_email_template_mock.assert_not_called()
+
+    async def test_fans_out_to_owner_and_admins_only(
+        self,
+        save_fixture: SaveFixture,
+        enqueue_email_template_mock: MagicMock,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        owner = await create_user(save_fixture)
+        admin = await create_user(save_fixture)
+        member = await create_user(save_fixture)
+        await _add_member(save_fixture, organization, owner, OrganizationRole.owner)
+        await _add_member(save_fixture, organization, admin, OrganizationRole.admin)
+        await _add_member(save_fixture, organization, member, OrganizationRole.member)
+
+        order, payment, _ = await create_order_and_payment(
+            save_fixture,
+            product=product,
+            customer=customer,
+            subtotal_amount=1000,
+            tax_amount=250,
+        )
+        refund = await create_refund(
+            save_fixture,
+            order,
+            payment,
+            amount=1000,
+            tax_amount=250,
+            reason=RefundReason.dispute_prevention,
+        )
+
+        await send_chargeback_prevention_notice(refund.id)
+
+        recipients = {
+            call.kwargs["to_email_addr"]
+            for call in enqueue_email_template_mock.call_args_list
+        }
+        assert recipients == {owner.email, admin.email}
+        assert member.email not in recipients
+        assert enqueue_email_template_mock.call_count == 2
+
+    async def test_no_admins_sends_nothing(
+        self,
+        save_fixture: SaveFixture,
+        enqueue_email_template_mock: MagicMock,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        member = await create_user(save_fixture)
+        await _add_member(save_fixture, organization, member, OrganizationRole.member)
+
+        order, payment, _ = await create_order_and_payment(
+            save_fixture,
+            product=product,
+            customer=customer,
+            subtotal_amount=1000,
+            tax_amount=250,
+        )
+        refund = await create_refund(
+            save_fixture,
+            order,
+            payment,
+            amount=1000,
+            tax_amount=250,
+            reason=RefundReason.dispute_prevention,
+        )
+
+        await send_chargeback_prevention_notice(refund.id)
+
+        enqueue_email_template_mock.assert_not_called()
+
+    async def test_email_props_and_subject(
+        self,
+        save_fixture: SaveFixture,
+        enqueue_email_template_mock: MagicMock,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        owner = await create_user(save_fixture)
+        await _add_member(save_fixture, organization, owner, OrganizationRole.owner)
+
+        order, payment, _ = await create_order_and_payment(
+            save_fixture,
+            product=product,
+            customer=customer,
+            subtotal_amount=1000,
+            tax_amount=250,
+        )
+        order.invoice_number = "POLAR-2026-00042"
+        await save_fixture(order)
+
+        refund = await create_refund(
+            save_fixture,
+            order,
+            payment,
+            amount=1000,
+            tax_amount=250,
+            reason=RefundReason.dispute_prevention,
+        )
+
+        await send_chargeback_prevention_notice(refund.id)
+
+        enqueue_email_template_mock.assert_called_once()
+        call = enqueue_email_template_mock.call_args
+        email = call.args[0]
+        assert isinstance(email, ChargebackPreventionRefundEmail)
+        assert email.props.email == owner.email
+        assert email.props.order_number == "POLAR-2026-00042"
+        assert email.props.customer_name == customer.display_name
+        assert email.props.amount == refund.total_amount
+        assert email.props.formatted_amount == format_currency(
+            refund.total_amount, refund.currency
+        )
+        assert call.kwargs["to_email_addr"] == owner.email
+        assert (
+            call.kwargs["subject"] == "Chargeback prevented for order POLAR-2026-00042"
+        )
+
+    async def test_order_number_falls_back_to_id(
+        self,
+        save_fixture: SaveFixture,
+        enqueue_email_template_mock: MagicMock,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        owner = await create_user(save_fixture)
+        await _add_member(save_fixture, organization, owner, OrganizationRole.owner)
+
+        order, payment, _ = await create_order_and_payment(
+            save_fixture,
+            product=product,
+            customer=customer,
+            subtotal_amount=1000,
+            tax_amount=250,
+        )
+        order.invoice_number = None
+        await save_fixture(order)
+
+        refund = await create_refund(
+            save_fixture,
+            order,
+            payment,
+            amount=1000,
+            tax_amount=250,
+            reason=RefundReason.dispute_prevention,
+        )
+
+        await send_chargeback_prevention_notice(refund.id)
+
+        call = enqueue_email_template_mock.call_args
+        assert call.args[0].props.order_number == str(order.id)
+        assert call.kwargs["subject"] == f"Chargeback prevented for order {order.id}"


### PR DESCRIPTION
<img width="1064" height="1177" alt="image" src="https://github.com/user-attachments/assets/8a579e22-565c-49d9-8191-6f238ebd71b0" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send chargeback-prevention notices to organization owners and admins when a dispute-prevention refund is issued. Adds a new email template and a background task that fans out to the right recipients.

- **New Features**
  - Added `chargeback_prevention_refund` email template with order number, customer name, amount, currency, and refund date; includes computed `formatted_amount`.
  - Enqueues `refund.send_chargeback_prevention_notice` when a `dispute_prevention` refund is created from a dispute, and when a pending Stripe refund transitions to `succeeded` (ignored for other reasons).
  - Task loads the order, builds subject “Chargeback prevented for order {order_number}”, and emails org `owner` and `admin` members only; falls back to order ID if no invoice number.
  - Registered the task in `server/polar/tasks.py` and exposed the template in `emails/src/emails/index.ts`; added OpenAPI and Python schemas for template props.
  - Tests cover enqueue timing (create vs. transition, once), role-based fan-out, subject/props, and order number fallback.

<sup>Written for commit 2a963a3ec537d981f7325892de9d42e550c52b4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

