### PR TITLE
ci: Deploy by tag instead of digest

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -108,12 +108,13 @@ jobs:
 
       - name: Deploy Backend to Render
         run: |
+          TAG="sha-${GITHUB_SHA::7}"
           ./.github/workflows/deploy_server.sh \
-            "${{ inputs.docker-digest }}" \
+            "$TAG" \
             "${{ inputs.has-migrations }}" \
             "${{ inputs.render-api-service-id }}" \
             "${{ inputs.render-worker-service-ids }}" \
-            "${{ inputs.docker-digest-playwright }}" \
+            "$TAG" \
             "${{ inputs.render-playwright-worker-service-ids }}"
         env:
           RENDER_API_TOKEN: ${{ secrets.RENDER_API_TOKEN }}
@@ -140,13 +141,16 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6.0.3
+      - name: Resolve image tag
+        id: tag
+        run: echo "tag=sha-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
       - uses: getsentry/action-release@v3.7.0
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
         with:
           environment: ${{ inputs.environment }}
-          dist: ${{ inputs.docker-digest }}
+          dist: ${{ steps.tag.outputs.tag }}
           release: ${{ github.sha }}
           projects: server
           working_directory: ./server

--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -9,10 +9,6 @@ on:
         description: "Environment to deploy to (sandbox or production)"
         required: true
         type: string
-      docker-digest:
-        description: "Docker image digest to deploy"
-        required: true
-        type: string
       render-api-service-id:
         description: "Render API service ID"
         required: true
@@ -37,11 +33,6 @@ on:
         required: false
         type: boolean
         default: false
-      docker-digest-playwright:
-        description: "Playwright Docker image digest to deploy"
-        required: false
-        type: string
-        default: ""
       render-playwright-worker-service-ids:
         description: "Comma-separated list of Render playwright worker service IDs"
         required: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -182,9 +182,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    outputs:
-      digest: ${{ steps.push.outputs.digest }}
-      digest-playwright: ${{ steps.push-playwright.outputs.digest }}
     steps:
       - uses: actions/checkout@v6.0.3
 
@@ -257,15 +254,13 @@ jobs:
     # `!failure() && !cancelled()` mirrors deploy-production: if the `changes`
     # job fails, `build` is skipped (no `if: always()`), and on a
     # workflow_dispatch the OR-clause below would otherwise let this job run
-    # with an EMPTY docker-digest. Guarding on !failure() blocks that path.
+    # against an image that was never built. Guarding on !failure() blocks that path.
     if: always() && !failure() && !cancelled() && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.changes.outputs.backend-sandbox == 'true' || needs.changes.outputs.frontend-sandbox == 'true' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/deploy-environment.yml
     with:
       environment: sandbox
-      docker-digest: ${{ needs.build.outputs.digest }}
       render-api-service-id: "srv-crkocgbtq21c73ddsdbg"
       render-worker-service-ids: "srv-d62q7vh4tr6s73fk44ng,srv-d733cp15pdvs73f6vqng,srv-d7unnjhj2pic73c2vr60"
-      docker-digest-playwright: ${{ needs.build.outputs.digest-playwright }}
       render-playwright-worker-service-ids: "srv-d089jj7diees73934kgg"
       has-migrations: ${{ needs.changes.outputs.migrations-sandbox == 'true' || github.event_name == 'workflow_dispatch' }}
       skip-backend: ${{ needs.changes.outputs.backend-sandbox != 'true' && github.event_name != 'workflow_dispatch' }}
@@ -285,10 +280,8 @@ jobs:
     uses: ./.github/workflows/deploy-environment.yml
     with:
       environment: production
-      docker-digest: ${{ needs.build.outputs.digest }}
       render-api-service-id: "srv-ci4r87h8g3ne0dmvvl60"
       render-worker-service-ids: "srv-d4k62svpm1nc73af5e3g,srv-d3hrh1j3fgac73a1t4r0,srv-d4uto5ili9vc73dd37tg,srv-d5l0oekhg0os73clofm0,srv-d733djuuk2gs73e98h1g,srv-d7us9je7r5hc73be5ieg"
-      docker-digest-playwright: ${{ needs.build.outputs.digest-playwright }}
       render-playwright-worker-service-ids: "srv-d4k6otfgi27c73cicnpg"
       has-migrations: ${{ needs.changes.outputs.migrations-production == 'true' || github.event_name == 'workflow_dispatch' }}
       skip-backend: ${{ needs.changes.outputs.backend-production != 'true' && github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/deploy_server.sh
+++ b/.github/workflows/deploy_server.sh
@@ -2,14 +2,14 @@
 
 set -euo pipefail
 
-# Usage: ./deploy_server.sh <docker_digest> <has_migrations> <api_service_id> <worker_service_ids> [playwright_digest] [playwright_worker_service_ids]
+# Usage: ./deploy_server.sh <docker_tag> <has_migrations> <api_service_id> <worker_service_ids> [playwright_tag] [playwright_worker_service_ids]
 if [ $# -lt 4 ]; then
-  echo "Usage: $0 <docker_digest> <has_migrations> <api_service_id> <worker_service_ids> [playwright_digest] [playwright_worker_service_ids]"
-  echo "Example: $0 sha256:abc123... true srv-123 srv-456,srv-789 sha256:def456... srv-999"
+  echo "Usage: $0 <docker_tag> <has_migrations> <api_service_id> <worker_service_ids> [playwright_tag] [playwright_worker_service_ids]"
+  echo "Example: $0 sha-abc1234 true srv-123 srv-456,srv-789 sha-def5678 srv-999"
   exit 1
 fi
 
-IMG="ghcr.io/polarsource/polar@${1}"
+IMG="ghcr.io/polarsource/polar:${1}"
 HAS_MIGRATIONS="${2}"
 API_SERVICE_ID="${3}"
 WORKER_SERVICE_IDS="${4}"
@@ -127,12 +127,12 @@ deploy_servers() {
 }
 
 # Parse playwright configuration
-PLAYWRIGHT_DIGEST="${5:-}"
+PLAYWRIGHT_TAG="${5:-}"
 PLAYWRIGHT_WORKER_IDS="${6:-}"
 PLAYWRIGHT_SERVERS=()
 PLAYWRIGHT_IMG=""
-if [[ -n "$PLAYWRIGHT_DIGEST" && -n "$PLAYWRIGHT_WORKER_IDS" ]]; then
-  PLAYWRIGHT_IMG="ghcr.io/polarsource/polar-playwright@${PLAYWRIGHT_DIGEST}"
+if [[ -n "$PLAYWRIGHT_TAG" && -n "$PLAYWRIGHT_WORKER_IDS" ]]; then
+  PLAYWRIGHT_IMG="ghcr.io/polarsource/polar-playwright:${PLAYWRIGHT_TAG}"
   IFS=',' read -ra PLAYWRIGHT_SERVERS <<< "$PLAYWRIGHT_WORKER_IDS"
 fi
 


### PR DESCRIPTION
It looks like the image source treats digests as a tag. Given a digest (e.g. `image@sha256:abc`) the non-mutually exclusive if statements will mark it as both digest (image, sha256:abc) and tag (image@sha256, abc). 

https://github.com/render-oss/terraform-provider-render/blob/b24a8b46ff4821f5bec08ad3db3ea402b8a97d3e/internal/provider/common/models.go#L262-L272

Given the preference of tags over digests in the runtimesource 
https://github.com/render-oss/terraform-provider-render/blob/v1.8.0/internal/provider/common/runtimesource.go#L175-L183

The terraform provider will try to use the invalid reference as a tag.

This causes all deploys that comes from Terraform to fail since we are referencing an image tag that does not actually exist.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch deployment to image tags instead of digests to prevent the Terraform provider from misparsing `@sha256` and breaking Render deploys. Cleaned up workflows by removing digest plumbing and using the same tag for Sentry `dist`.

- **Bug Fixes**
  - Use `TAG="sha-${GITHUB_SHA::7}"` in `deploy-environment.yml`, pass it to `deploy_server.sh`, and set Sentry `dist` to this tag.
  - Update `deploy_server.sh` to accept tags and use `ghcr.io/polarsource/polar:${TAG}` and `ghcr.io/polarsource/polar-playwright:${TAG}`.
  - Remove unused digest inputs/outputs and related steps from `deploy.yml` and `deploy-environment.yml`.

<sup>Written for commit 1600d2533798efa79d70a79a632e31ef19541267. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12412?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

