### PR TITLE
allow editing member name from dashboard

### DIFF
--- a/clients/apps/web/src/components/Customer/EditMemberModal.tsx
+++ b/clients/apps/web/src/components/Customer/EditMemberModal.tsx
@@ -112,7 +112,7 @@ export const EditMemberModal = ({
           </Box>
           <Button
             type="submit"
-            className="self-start"
+            className="self-end"
             loading={updateMember.isPending}
           >
             Save Member

--- a/clients/apps/web/src/components/Customer/EditMemberModal.tsx
+++ b/clients/apps/web/src/components/Customer/EditMemberModal.tsx
@@ -1,0 +1,116 @@
+import { useUpdateMember } from '@/hooks/queries/members'
+import { setValidationErrors } from '@/utils/api/errors'
+import { isValidationError, schemas } from '@polar-sh/client'
+import { Button, Input, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@polar-sh/ui/components/ui/form'
+import { useForm } from 'react-hook-form'
+import { toast } from '../Toast/use-toast'
+
+type MemberUpdateForm = Pick<schemas['MemberUpdate'], 'name'>
+
+export const EditMemberModal = ({
+  member,
+  customerId,
+  onClose,
+}: {
+  member: schemas['Member']
+  customerId: string
+  onClose: () => void
+}) => {
+  const form = useForm<MemberUpdateForm>({
+    defaultValues: {
+      name: member.name ?? '',
+    },
+  })
+
+  const updateMember = useUpdateMember(member.id, customerId)
+
+  const handleUpdateMember = (memberUpdate: MemberUpdateForm) => {
+    updateMember.mutateAsync(memberUpdate).then(({ error }) => {
+      if (error) {
+        if (error.detail) {
+          if (isValidationError(error.detail)) {
+            setValidationErrors(error.detail, form.setError)
+          } else {
+            toast({
+              title: 'Member Update Failed',
+              description: `Error updating member ${member.email}: ${error.detail}`,
+            })
+          }
+        }
+        return
+      }
+
+      toast({
+        title: 'Member Updated',
+        description: `Member ${member.email} updated successfully`,
+      })
+      onClose()
+    })
+  }
+
+  return (
+    <Box
+      flexDirection="column"
+      gap="2xl"
+      overflowY="auto"
+      paddingHorizontal="2xl"
+      paddingVertical="3xl"
+    >
+      <Box alignItems="center" columnGap="l">
+        <Text as="h2" variant="heading-xs">
+          Edit Member
+        </Text>
+      </Box>
+      <Form {...form}>
+        <Box
+          as="form"
+          onSubmit={form.handleSubmit(handleUpdateMember)}
+          flexDirection="column"
+          gap="2xl"
+        >
+          <Box flexDirection="column" gap="l">
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormDescription>
+                A member&apos;s email can&apos;t be changed.
+              </FormDescription>
+              <FormControl>
+                <Input value={member.email} disabled />
+              </FormControl>
+            </FormItem>
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <Input {...field} value={field.value || ''} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </Box>
+          <Button
+            type="submit"
+            className="self-start"
+            loading={updateMember.isPending}
+          >
+            Save Member
+          </Button>
+        </Box>
+      </Form>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/components/Customer/EditMemberModal.tsx
+++ b/clients/apps/web/src/components/Customer/EditMemberModal.tsx
@@ -35,27 +35,35 @@ export const EditMemberModal = ({
   const updateMember = useUpdateMember(member.id, customerId)
 
   const handleUpdateMember = (memberUpdate: MemberUpdateForm) => {
-    updateMember.mutateAsync(memberUpdate).then(({ error }) => {
-      if (error) {
-        if (error.detail) {
-          if (isValidationError(error.detail)) {
-            setValidationErrors(error.detail, form.setError)
-          } else {
-            toast({
-              title: 'Member Update Failed',
-              description: `Error updating member ${member.email}: ${error.detail}`,
-            })
+    updateMember
+      .mutateAsync(memberUpdate)
+      .then(({ error }) => {
+        if (error) {
+          if (error.detail) {
+            if (isValidationError(error.detail)) {
+              setValidationErrors(error.detail, form.setError)
+            } else {
+              toast({
+                title: 'Member Update Failed',
+                description: `Error updating member ${member.email}: ${error.detail}`,
+              })
+            }
           }
+          return
         }
-        return
-      }
 
-      toast({
-        title: 'Member Updated',
-        description: `Member ${member.email} updated successfully`,
+        toast({
+          title: 'Member Updated',
+          description: `Member ${member.email} updated successfully`,
+        })
+        onClose()
       })
-      onClose()
-    })
+      .catch(() => {
+        toast({
+          title: 'Member Update Failed',
+          description: `Error updating member ${member.email}. Please try again.`,
+        })
+      })
   }
 
   return (

--- a/clients/apps/web/src/components/Customer/MembersSection.tsx
+++ b/clients/apps/web/src/components/Customer/MembersSection.tsx
@@ -1,11 +1,14 @@
 'use client'
 
+import { useModal } from '@/components/Modal/useModal'
 import { useMembers } from '@/hooks/queries/members'
 import { useOrganization } from '@/hooks/queries/org'
-import { DataTable, type StatusColor } from '@polar-sh/orbit'
+import { schemas } from '@polar-sh/client'
+import { DataTable, InlineModal, type StatusColor } from '@polar-sh/orbit'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import { Status } from '@polar-sh/orbit'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
+import { EditMemberModal } from './EditMemberModal'
 
 const roleDisplayConfig: Record<
   'owner' | 'billing_manager' | 'member',
@@ -32,6 +35,15 @@ export const MembersSection = ({
     !!organizationId,
   )
   const { data: membersData, isLoading } = useMembers(customerId)
+
+  const [selectedMember, setSelectedMember] = useState<
+    schemas['Member'] | null
+  >(null)
+  const {
+    show: showEditMemberModal,
+    hide: hideEditMemberModal,
+    isShown: isEditMemberModalShown,
+  } = useModal()
 
   // Only show Members section for team customers when member model is enabled
   const isEnabled =
@@ -97,6 +109,23 @@ export const MembersSection = ({
         ]}
         isLoading={isLoading}
         className="text-sm"
+        onRowClick={({ original }) => {
+          setSelectedMember(original)
+          showEditMemberModal()
+        }}
+      />
+      <InlineModal
+        isShown={isEditMemberModalShown}
+        hide={hideEditMemberModal}
+        modalContent={
+          selectedMember ? (
+            <EditMemberModal
+              member={selectedMember}
+              customerId={customerId}
+              onClose={hideEditMemberModal}
+            />
+          ) : null
+        }
       />
     </div>
   )

--- a/clients/apps/web/src/hooks/queries/members.ts
+++ b/clients/apps/web/src/hooks/queries/members.ts
@@ -53,7 +53,10 @@ export const useUpdateMember = (memberId: string, customerId: string) =>
         params: { path: { id: memberId } },
         body,
       }),
-    onSuccess: async () => {
+    onSuccess: async ({ error }) => {
+      if (error) {
+        return
+      }
       getQueryClient().invalidateQueries({
         queryKey: ['members', customerId],
       })

--- a/clients/apps/web/src/hooks/queries/members.ts
+++ b/clients/apps/web/src/hooks/queries/members.ts
@@ -1,6 +1,7 @@
+import { getQueryClient } from '@/utils/api/query'
 import { api } from '@/utils/client'
-import { operations, unwrap } from '@polar-sh/client'
-import { useInfiniteQuery } from '@tanstack/react-query'
+import { operations, schemas, unwrap } from '@polar-sh/client'
+import { useInfiniteQuery, useMutation } from '@tanstack/react-query'
 import { defaultRetry } from './retry'
 
 /**
@@ -40,4 +41,21 @@ export const useMembers = (
       return lastPageParam + 1
     },
     enabled: !!customerId,
+  })
+
+/**
+ * Update a member by ID.
+ */
+export const useUpdateMember = (memberId: string, customerId: string) =>
+  useMutation({
+    mutationFn: (body: schemas['MemberUpdate']) =>
+      api.PATCH('/v1/members/{id}', {
+        params: { path: { id: memberId } },
+        body,
+      }),
+    onSuccess: async () => {
+      getQueryClient().invalidateQueries({
+        queryKey: ['members', customerId],
+      })
+    },
   })


### PR DESCRIPTION
## Summary

Adds the ability to edit a member's name from the customer dashboard

Next up: Member name to be changed by owner in customer portal

- New EditMemberModal for editing a member's name (email shown read-only, since it can't be changed; name field locked when the member is the customer account itself).

| Edit Member Modal |
|---|
| <img width="500" alt="Screenshot 2026-06-16 at 16 11 54" src="https://github.com/user-attachments/assets/bcf6aa91-f05a-45d2-8802-23ca0eaddddc" /> |


<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [X] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [X] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [X] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [X] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable editing a member’s name from the customer dashboard. Clicking a member opens a modal to update the name, saves via API, and refreshes the list.

- **New Features**
  - Added `EditMemberModal` with editable name, read-only email, success/error toasts, and a right‑aligned Save action.
  - Row click in Members table opens an `InlineModal` to edit the selected member.
  - Introduced `useUpdateMember` to PATCH `/v1/members/{id}` and invalidate `['members', customerId]` for fresh data.

<sup>Written for commit f847c2d706fc85e47075658c1536c79188a9168e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

