### PR TITLE
docs: point Stripe setup at the central secrets file, not server/.env

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -105,9 +105,20 @@ You can override the secrets file location with `POLAR_SECRETS_FILE` environment
 
 If you want to work with payments and subscriptions, you'll need to set up a Stripe development environment:
 
+> [!IMPORTANT]
+> Put all Stripe values in the central secrets file `~/.config/polar/secrets.env`, **not** in `server/.env`.
+> `setup-environment` regenerates `server/.env` from the central file on every run (including each Conductor
+> worktree launch and `dev up --clean`), and the central file's values win — so edits made directly to
+> `server/.env` are overwritten.
+>
+> Do **not** rely on `dev stripe` for the webhook secrets when using the dashboard-endpoint flow below: it
+> derives the secret from `stripe listen --print-secret` (the Stripe CLI listener, a different secret) and
+> writes that one value to *both* `POLAR_STRIPE_WEBHOOK_SECRET` and `POLAR_STRIPE_CONNECT_WEBHOOK_SECRET`,
+> clobbering your two distinct dashboard secrets. Set those by hand in the central file.
+
 1. **Create a Stripe account** at [https://dashboard.stripe.com/register](https://dashboard.stripe.com/register)
 
-2. **Copy your API keys** from the [Stripe API Keys page](https://dashboard.stripe.com/test/apikeys) and add them to your `server/.env` file:
+2. **Copy your API keys** from the [Stripe API Keys page](https://dashboard.stripe.com/test/apikeys) and add them to your `~/.config/polar/secrets.env` file:
 
     ```
     POLAR_STRIPE_SECRET_KEY=sk_test_...
@@ -124,14 +135,14 @@ If you want to work with payments and subscriptions, you'll need to set up a Str
     - Set enabled events to only the events listed in `DIRECT_IMPLEMENTED_WEBHOOKS` (see `polar/integrations/stripe/endpoints.py`)
     - Click continue, Select Webhook endpoint
     - Set the endpoint URL to: `https://your-domain.ngrok-free.app/v1/integrations/stripe/webhook`
-    - Copy the webhook signing secret and add it to your `server/.env` file:
+    - Copy the webhook signing secret and add it to your `~/.config/polar/secrets.env` file:
         ```
         POLAR_STRIPE_WEBHOOK_SECRET=whsec_...
         ```
     - Restart the same operation with:
         - events listed in `CONNECT_IMPLEMENTED_WEBHOOKS` (see `polar/integrations/stripe/endpoints.py`)
         - Set the endpoint URL to: `https://your-domain.ngrok-free.app/v1/integrations/stripe/webhook-connect`
-        - Copy the webhook signing secret and add it to your `server/.env` file:
+        - Copy the webhook signing secret and add it to your `~/.config/polar/secrets.env` file:
             ```
             POLAR_STRIPE_CONNECT_WEBHOOK_SECRET=whsec_...
             ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -107,9 +107,9 @@ If you want to work with payments and subscriptions, you'll need to set up a Str
 
 > [!IMPORTANT]
 > Put all Stripe values in the central secrets file `~/.config/polar/secrets.env`, **not** in `server/.env`.
-> `setup-environment` regenerates `server/.env` from the central file on every run (including each Conductor
-> worktree launch and `dev up --clean`), and the central file's values win — so edits made directly to
-> `server/.env` are overwritten.
+> Whenever `setup-environment` regenerates `server/.env` (a fresh clone or worktree, `dev up --clean`,
+> `dev stripe`, or a manual run), it rebuilds the file from the central secrets and those values win — so
+> edits made directly to `server/.env` are overwritten.
 >
 > Do **not** rely on `dev stripe` for the webhook secrets when using the dashboard-endpoint flow below: it
 > derives the secret from `stripe listen --print-secret` (the Stripe CLI listener, a different secret) and


### PR DESCRIPTION

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Stripe dev setup docs to use the central secrets file `~/.config/polar/secrets.env` instead of `server/.env`. Clarifies when `setup-environment` overwrites `server/.env`, warns that `dev stripe` can clobber distinct webhook secrets, and rephrases the multi-sessions note for clarity.

- **Migration**
  - Move all Stripe keys and webhook secrets to `~/.config/polar/secrets.env` (e.g., `POLAR_STRIPE_SECRET_KEY`, `POLAR_STRIPE_PUBLISHABLE_KEY`, `POLAR_STRIPE_WEBHOOK_SECRET`, `POLAR_STRIPE_CONNECT_WEBHOOK_SECRET`).
  - For dashboard webhooks, don’t use `dev stripe`/`stripe listen --print-secret` for secrets; set both webhook secrets manually.

<sup>Written for commit a3a9659554caa0177a35489a22feaccc752ee277. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

