### PR TITLE
Redo `backfill_support_tiers` without looping all organizations

### DIFF
--- a/server/scripts/backfill_support_tiers.py
+++ b/server/scripts/backfill_support_tiers.py
@@ -1,22 +1,20 @@
-import asyncio
-import traceback
 import uuid
+from collections import defaultdict
 from dataclasses import dataclass, field
 
 import typer
-from rich.progress import Progress, TaskID
+from polar_sdk import Polar
+from polar_sdk.models import Benefit, BenefitGrant
 
 from polar.config import settings
-from polar.integrations.polar.client import get_client
 from polar.integrations.polar.service import polar_self as polar_self_service
 from polar.kit.db.postgres import (
     AsyncSessionMaker,
     create_async_sessionmaker,
 )
-from polar.models import Organization
 from polar.models.organization import SupportTier
 from polar.organization.repository import OrganizationRepository
-from polar.postgres import AsyncSession, create_async_engine
+from polar.postgres import create_async_engine
 
 from .helper import configure_script_logging, typer_async
 
@@ -26,137 +24,152 @@ cli = typer.Typer()
 @dataclass
 class BackfillResult:
     tiers_set: int = 0
-    free_skipped: int = 0
+    untiered_skipped: int = 0
+    not_found_skipped: int = 0
     errors: int = 0
     error_details: list[tuple[str, str]] = field(default_factory=list)
 
 
-async def resolve_support_tier(organization_id: uuid.UUID) -> SupportTier | None:
-    """Derive an org's support level from its active Polar support grant.
+def resolve_tiers(
+    benefit_tiers: dict[str, SupportTier | None],
+    grants: list[BenefitGrant],
+) -> tuple[dict[uuid.UUID, SupportTier], BackfillResult]:
+    """Group active support grants by organization and resolve each org's tier.
 
-    The same value the benefit-grant webhook stores, but read-only: no DB write
-    and no Plain push. The webhook only fires on future grant changes, so this
-    populates the column for existing paying orgs. Returns None (free) when
-    there's no Polar customer or no support grant.
+    Mirrors the benefit-grant webhook's invariant that a customer holds at most
+    one active support grant: an org with more than one (across any support
+    benefit, any level) is flagged as an error rather than silently resolved.
+    An org whose single grant maps to no known tier is skipped — its column
+    stays NULL, like a free org.
     """
-    customer = await get_client().get_customer_by_external_id_or_none(
-        str(organization_id)
+    result = BackfillResult()
+    resolved: dict[uuid.UUID, SupportTier] = {}
+
+    grants_by_external_id: dict[str, list[BenefitGrant]] = defaultdict(list)
+    for grant in grants:
+        external_id = grant.customer.external_id
+        if not isinstance(external_id, str) or not external_id:
+            result.errors += 1
+            result.error_details.append(
+                (grant.id, f"grant {grant.id} customer has no external_id")
+            )
+            continue
+        grants_by_external_id[external_id].append(grant)
+
+    for external_id, organization_grants in grants_by_external_id.items():
+        if len(organization_grants) > 1:
+            benefit_ids = [grant.benefit_id for grant in organization_grants]
+            result.errors += 1
+            result.error_details.append(
+                (
+                    external_id,
+                    f"holds {len(organization_grants)} active support grants, "
+                    f"expected at most 1: {benefit_ids}",
+                )
+            )
+            continue
+
+        tier = benefit_tiers.get(organization_grants[0].benefit_id)
+        if tier is None:
+            result.untiered_skipped += 1
+            continue
+
+        try:
+            organization_id = uuid.UUID(external_id)
+        except ValueError:
+            result.errors += 1
+            result.error_details.append(
+                (external_id, "customer external_id is not a UUID")
+            )
+            continue
+
+        resolved[organization_id] = tier
+
+    return resolved, result
+
+
+async def _list_support_benefits(sdk: Polar) -> list[Benefit]:
+    benefits: list[Benefit] = []
+    response = await sdk.benefits.list_async(
+        organization_id=settings.POLAR_ORGANIZATION_ID,
+        metadata={"type": "support"},
+        page=1,
+        limit=100,
     )
-    if customer is None:
-        return None
-    grant = await polar_self_service._fetch_active_grant(customer.id, "support")
-    if grant is None:
-        return None
+    while response is not None:
+        benefits.extend(response.result.items)
+        response = response.next()
+    return benefits
+
+
+async def _list_benefit_grants(sdk: Polar, benefit_id: str) -> list[BenefitGrant]:
+    grants: list[BenefitGrant] = []
+    response = await sdk.benefits.grants_async(
+        id=benefit_id,
+        is_granted=True,
+        page=1,
+        limit=100,
+    )
+    while response is not None:
+        grants.extend(response.result.items)
+        response = response.next()
+    return grants
+
+
+def _benefit_tier(benefit: Benefit) -> SupportTier | None:
     level, _, _, _ = polar_self_service._extract_support(
-        grant.benefit.metadata or {}, grant.benefit_id
+        benefit.metadata or {}, benefit.id
     )
     return SupportTier.from_level(level)
 
 
-async def _process_organization(
+async def run_backfill(
     *,
-    organization_id: uuid.UUID,
-    organization_name: str,
     sessionmaker: AsyncSessionMaker,
-    semaphore: asyncio.Semaphore,
-    result: BackfillResult,
-    result_lock: asyncio.Lock,
-    progress: Progress,
-    task_id: TaskID,
-    dry_run: bool,
-) -> None:
-    async with semaphore:
-        try:
-            tier = await resolve_support_tier(organization_id)
-        except Exception:
-            async with result_lock:
-                result.errors += 1
-                result.error_details.append(
-                    (str(organization_id), traceback.format_exc())
-                )
-            progress.advance(task_id)
-            return
+    dry_run: bool = False,
+) -> BackfillResult:
+    sdk = Polar(
+        access_token=settings.POLAR_ACCESS_TOKEN,
+        server_url=settings.POLAR_API_URL,
+    )
+    self_org_external_id = settings.POLAR_ORGANIZATION_ID
 
-        # Free orgs are already NULL by column default — nothing to write.
-        if tier is None:
-            async with result_lock:
-                result.free_skipped += 1
-            progress.advance(task_id)
-            return
+    typer.echo("Loading support benefits...")
+    support_benefits = await _list_support_benefits(sdk)
+    typer.echo(f"Found {len(support_benefits)} support benefit(s)")
 
-        if dry_run:
-            typer.echo(
-                f"  Would set {organization_name} ({organization_id}) "
-                f"-> {tier.get_display_name()}"
-            )
-            async with result_lock:
-                result.tiers_set += 1
-            progress.advance(task_id)
-            return
+    benefit_tiers = {benefit.id: _benefit_tier(benefit) for benefit in support_benefits}
 
-        async with sessionmaker() as task_session:
-            repository = OrganizationRepository.from_session(task_session)
+    grants: list[BenefitGrant] = []
+    for benefit in support_benefits:
+        grants.extend(await _list_benefit_grants(sdk, benefit.id))
+    # Defensively skip the Polar org's own customer if it ever holds a grant.
+    grants = [
+        grant for grant in grants if grant.customer.external_id != self_org_external_id
+    ]
+    typer.echo(f"Found {len(grants)} active support grant(s)")
+
+    resolved, result = resolve_tiers(benefit_tiers, grants)
+
+    async with sessionmaker() as session:
+        repository = OrganizationRepository.from_session(session)
+        for organization_id, tier in resolved.items():
             organization = await repository.get_by_id(
                 organization_id, include_blocked=True
             )
-            if organization is not None:
-                organization.support_tier = tier
-                await task_session.commit()
-        async with result_lock:
-            result.tiers_set += 1
-        progress.advance(task_id)
-
-
-async def run_backfill(
-    *,
-    session: AsyncSession,
-    sessionmaker: AsyncSessionMaker,
-    dry_run: bool = False,
-    limit: int | None = None,
-    concurrency: int = 20,
-) -> BackfillResult:
-    result = BackfillResult()
-
-    self_org_id = uuid.UUID(settings.POLAR_ORGANIZATION_ID)
-    organization_repository = OrganizationRepository.from_session(session)
-
-    typer.echo("Loading organizations...")
-    organizations_statement = (
-        organization_repository.get_base_statement()
-        .where(
-            Organization.can_authenticate,
-            Organization.id != self_org_id,
-        )
-        .order_by(Organization.created_at)
-    )
-    if limit is not None:
-        organizations_statement = organizations_statement.limit(limit)
-    organizations = await organization_repository.get_all(organizations_statement)
-    typer.echo(f"Loaded {len(organizations)} organizations to check")
-
-    semaphore = asyncio.Semaphore(concurrency)
-    result_lock = asyncio.Lock()
-
-    with Progress() as progress:
-        task_id = progress.add_task(
-            "[cyan]Resolving support tiers...", total=len(organizations)
-        )
-        await asyncio.gather(
-            *(
-                _process_organization(
-                    organization_id=organization.id,
-                    organization_name=organization.name,
-                    sessionmaker=sessionmaker,
-                    semaphore=semaphore,
-                    result=result,
-                    result_lock=result_lock,
-                    progress=progress,
-                    task_id=task_id,
-                    dry_run=dry_run,
+            if organization is None:
+                result.not_found_skipped += 1
+                continue
+            if dry_run:
+                typer.echo(
+                    f"  Would set {organization.name} ({organization_id}) "
+                    f"-> {tier.get_display_name()}"
                 )
-                for organization in organizations
-            )
-        )
+            else:
+                organization.support_tier = tier
+            result.tiers_set += 1
+        if not dry_run:
+            await session.commit()
 
     return result
 
@@ -167,17 +180,13 @@ async def backfill(
     dry_run: bool = typer.Option(
         True, help="Print what would be set without writing to the database"
     ),
-    limit: int | None = typer.Option(
-        None, help="Maximum number of organizations to process"
-    ),
-    concurrency: int = typer.Option(
-        20, help="Number of organizations to process in parallel"
-    ),
 ) -> None:
     """Backfill Organization.support_tier from active Polar support grants.
 
     The benefit-grant webhook only fires on future grant changes, so existing
-    paying orgs need this one-off pass. Free orgs stay NULL (the column default).
+    paying orgs need this one-off pass. It reads from the support benefits'
+    active grants — never the full organizations table. Free/untiered orgs stay
+    NULL (the column default).
     """
     configure_script_logging()
 
@@ -192,26 +201,18 @@ async def backfill(
     sessionmaker = create_async_sessionmaker(engine)
 
     try:
-        async with sessionmaker() as session:
-            result = await run_backfill(
-                session=session,
-                sessionmaker=sessionmaker,
-                dry_run=dry_run,
-                limit=limit,
-                concurrency=concurrency,
-            )
+        result = await run_backfill(sessionmaker=sessionmaker, dry_run=dry_run)
 
         typer.echo(
             f"\nDone: {result.tiers_set} tiers set, "
-            f"{result.free_skipped} free/untiered skipped, "
+            f"{result.untiered_skipped} untiered skipped, "
+            f"{result.not_found_skipped} not found, "
             f"{result.errors} errors"
         )
         if result.error_details:
             typer.echo("\nErrors:")
-            for organization_id, tb in result.error_details:
-                typer.echo(f"\n  {organization_id}:")
-                for line in tb.rstrip().splitlines():
-                    typer.echo(f"    {line}")
+            for identifier, message in result.error_details:
+                typer.echo(f"  {identifier}: {message}")
     finally:
         await engine.dispose()
 

--- a/server/tests/scripts/test_backfill_support_tiers.py
+++ b/server/tests/scripts/test_backfill_support_tiers.py
@@ -1,108 +1,107 @@
 import uuid
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
 
-import pytest
 from polar_sdk.models import BenefitGrant
-from pytest_mock import MockerFixture
 
 from polar.models.organization import SupportTier
-from scripts.backfill_support_tiers import resolve_support_tier
+from scripts.backfill_support_tiers import resolve_tiers
 
 ORG_ID = uuid.UUID("00000000-0000-0000-0000-00000000000a")
 _CUSTOMER_ID = "00000000-0000-0000-0000-000000000002"
-_BENEFIT_ID = "00000000-0000-0000-0000-0000000000b1"
-
-_CUSTOMER_DICT: dict[str, Any] = {
-    "id": _CUSTOMER_ID,
-    "created_at": "2026-01-01T00:00:00Z",
-    "modified_at": None,
-    "metadata": {},
-    "email": "c@example.com",
-    "email_verified": True,
-    "type": "individual",
-    "name": "c",
-    "billing_name": None,
-    "billing_address": None,
-    "tax_id": None,
-    "organization_id": "00000000-0000-0000-0000-000000000099",
-    "deleted_at": None,
-    "avatar_url": "",
-    "external_id": str(ORG_ID),
-}
+_SCALE_BENEFIT_ID = "00000000-0000-0000-0000-0000000000b1"
+_GROWTH_BENEFIT_ID = "00000000-0000-0000-0000-0000000000b2"
 
 
-def _make_grant(*, metadata: dict[str, Any]) -> BenefitGrant:
+def _make_grant(*, benefit_id: str, external_id: str) -> BenefitGrant:
     return BenefitGrant.model_validate(
         {
             "created_at": "2026-01-01T00:00:00Z",
             "modified_at": None,
-            "id": "00000000-0000-0000-0000-0000000000a1",
+            "id": f"grant-{benefit_id}",
             "is_granted": True,
             "is_revoked": False,
             "subscription_id": "00000000-0000-0000-0000-000000000001",
             "order_id": None,
             "customer_id": _CUSTOMER_ID,
-            "benefit_id": _BENEFIT_ID,
-            "customer": _CUSTOMER_DICT,
-            "benefit": {
-                "id": _BENEFIT_ID,
-                "type": "custom",
-                "created_at": "2026-01-01T00:00:00Z",
-                "modified_at": None,
-                "description": "",
-                "selectable": True,
-                "deletable": True,
-                "is_deleted": False,
-                "visibility": "public",
-                "visibility_configurable": True,
-                "organization_id": _CUSTOMER_DICT["organization_id"],
-                "metadata": metadata,
-                "properties": {"note": None},
-            },
+            "benefit_id": benefit_id,
+            "customer": _customer_dict(external_id),
+            "benefit": _benefit_dict(benefit_id),
             "properties": {},
         }
     )
 
 
-def _patch_client(
-    mocker: MockerFixture,
-    *,
-    customer: object,
-    grants: list[BenefitGrant] | None = None,
-) -> None:
-    client = MagicMock()
-    client.get_customer_by_external_id_or_none = AsyncMock(return_value=customer)
-    client.list_customer_benefit_grants = AsyncMock(return_value=grants or [])
-    # resolve_support_tier resolves the customer through the script's client,
-    # then defers to the service's _fetch_active_grant, which resolves grants
-    # through the service module's client. Patch both to the same mock.
-    mocker.patch("scripts.backfill_support_tiers.get_client", return_value=client)
-    mocker.patch("polar.integrations.polar.service.get_client", return_value=client)
+def _customer_dict(external_id: str) -> dict[str, Any]:
+    return {
+        "id": _CUSTOMER_ID,
+        "created_at": "2026-01-01T00:00:00Z",
+        "modified_at": None,
+        "metadata": {},
+        "email": "c@example.com",
+        "email_verified": True,
+        "type": "individual",
+        "name": "c",
+        "billing_name": None,
+        "billing_address": None,
+        "tax_id": None,
+        "organization_id": "00000000-0000-0000-0000-000000000099",
+        "deleted_at": None,
+        "avatar_url": "",
+        "external_id": external_id,
+    }
 
 
-@pytest.mark.asyncio
-class TestResolveSupportTier:
-    async def test_no_customer_returns_none(self, mocker: MockerFixture) -> None:
-        _patch_client(mocker, customer=None)
+def _benefit_dict(benefit_id: str) -> dict[str, Any]:
+    return {
+        "id": benefit_id,
+        "type": "custom",
+        "created_at": "2026-01-01T00:00:00Z",
+        "modified_at": None,
+        "description": "",
+        "selectable": True,
+        "deletable": True,
+        "is_deleted": False,
+        "visibility": "public",
+        "visibility_configurable": True,
+        "organization_id": "00000000-0000-0000-0000-000000000099",
+        "metadata": {"type": "support"},
+        "properties": {"note": None},
+    }
 
-        assert await resolve_support_tier(ORG_ID) is None
 
-    async def test_no_support_grant_returns_none(self, mocker: MockerFixture) -> None:
-        _patch_client(mocker, customer=MagicMock(id=_CUSTOMER_ID), grants=[])
+class TestResolveTiers:
+    def test_resolves_single_grant(self) -> None:
+        grant = _make_grant(benefit_id=_SCALE_BENEFIT_ID, external_id=str(ORG_ID))
 
-        assert await resolve_support_tier(ORG_ID) is None
-
-    async def test_resolves_tier_from_active_grant(self, mocker: MockerFixture) -> None:
-        grant = _make_grant(
-            metadata={
-                "type": "support",
-                "level": "4",
-                "slack": "false",
-                "prioritized": "true",
-                "plain_tier_external_id": "scale",
-            }
+        resolved, result = resolve_tiers(
+            {_SCALE_BENEFIT_ID: SupportTier.scale}, [grant]
         )
-        _patch_client(mocker, customer=MagicMock(id=_CUSTOMER_ID), grants=[grant])
 
-        assert await resolve_support_tier(ORG_ID) == SupportTier.scale
+        assert resolved == {ORG_ID: SupportTier.scale}
+        assert result.errors == 0
+
+    def test_flags_multiple_grants_as_error(self) -> None:
+        grants = [
+            _make_grant(benefit_id=_SCALE_BENEFIT_ID, external_id=str(ORG_ID)),
+            _make_grant(benefit_id=_GROWTH_BENEFIT_ID, external_id=str(ORG_ID)),
+        ]
+
+        resolved, result = resolve_tiers(
+            {
+                _SCALE_BENEFIT_ID: SupportTier.scale,
+                _GROWTH_BENEFIT_ID: SupportTier.growth,
+            },
+            grants,
+        )
+
+        assert resolved == {}
+        assert result.errors == 1
+
+    def test_skips_untiered_grant(self) -> None:
+        grant = _make_grant(benefit_id=_SCALE_BENEFIT_ID, external_id=str(ORG_ID))
+
+        resolved, result = resolve_tiers({_SCALE_BENEFIT_ID: None}, [grant])
+
+        assert resolved == {}
+        assert result.untiered_skipped == 1
+        assert result.errors == 0


### PR DESCRIPTION
Don't loop all organizations, get all support tier grants and loop those.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworked the support tier backfill to resolve tiers from active support benefit grants instead of scanning all organizations. This speeds up the script and only updates orgs that actually hold a support grant.

- **Refactors**
  - Use `polar_sdk` to list support benefits and their active grants, map benefit → `SupportTier`, group by customer external_id, and skip the Polar org itself.
  - Enforce one active support grant per org, skip untiered grants, add clear counters (`tiers_set`, `untiered_skipped`, `not_found_skipped`, `errors`), and simplify error messages.

- **Migration**
  - Removed `--limit` and `--concurrency` options; dry-run stays default (`--dry-run`/`--no-dry-run`).
  - No data changes needed; run the script to backfill existing paying orgs.

<sup>Written for commit 275d137afca9f4107b0a92780d070a97b809cd37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

