### PR TITLE
tf: Render add base env group

### DIFF
--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -242,6 +242,26 @@ resource "render_env_group" "memory_profile" {
   }
 }
 
+resource "render_env_group" "base" {
+  environment_id = var.render_environment_id
+  name           = "base-${var.environment}"
+  env_vars = {
+    POLAR_POSTGRES_DATABASE      = { value = var.api_service_config.postgres_database }
+    POLAR_POSTGRES_HOST          = { value = var.postgres_config.host }
+    POLAR_POSTGRES_PORT          = { value = var.postgres_config.port }
+    POLAR_POSTGRES_USER          = { value = var.postgres_config.user }
+    POLAR_POSTGRES_PWD           = { value = var.postgres_config.password }
+    POLAR_POSTGRES_READ_DATABASE = { value = var.api_service_config.postgres_read_database }
+    POLAR_POSTGRES_READ_HOST     = { value = var.postgres_config.read_host }
+    POLAR_POSTGRES_READ_PORT     = { value = var.postgres_config.read_port }
+    POLAR_POSTGRES_READ_USER     = { value = var.postgres_config.read_user }
+    POLAR_POSTGRES_READ_PWD      = { value = var.postgres_config.read_password }
+    POLAR_REDIS_HOST             = { value = var.redis_config.host }
+    POLAR_REDIS_PORT             = { value = var.redis_config.port }
+    POLAR_REDIS_DB               = { value = var.api_service_config.redis_db }
+  }
+}
+
 # Services
 
 
@@ -423,6 +443,11 @@ locals {
 }
 
 # Env group links
+resource "render_env_group_link" "base" {
+  env_group_id = render_env_group.base.id
+  service_ids  = local.all_service_ids
+}
+
 resource "render_env_group_link" "aws_s3" {
   env_group_id = render_env_group.aws_s3.id
   service_ids  = local.all_service_ids

--- a/terraform/scripts/plan-diff.sh
+++ b/terraform/scripts/plan-diff.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Print the per-attribute before -> after for every changed resource in a TFC
+# plan, unmasking values the TFC UI shows as "(sensitive value)".
+#
+# Usage:
+#   ./plan-diff.sh run-XXXXXXXX [FILTER]
+#   FILTER: optional substring matched against the resource address or type
+#           e.g. ./plan-diff.sh run-XXXX render_web_service
+#
+# Token: read from $TFE_TOKEN, else from ~/.terraform.d/credentials.tfrc.json
+# Host:  override with $TFE_HOST (default app.terraform.io)
+
+set -euo pipefail
+
+RUN_ID="${1:-}"
+FILTER="${2:-}"
+TFE_HOST="${TFE_HOST:-app.terraform.io}"
+
+if [[ -z "$RUN_ID" ]]; then
+  echo "usage: $0 run-XXXXXXXX [FILTER]   (run ID from the TFC run URL)" >&2
+  exit 2
+fi
+
+TOKEN="${TFE_TOKEN:-}"
+if [[ -z "$TOKEN" ]]; then
+  TOKEN=$(jq -r --arg h "$TFE_HOST" '.credentials[$h].token // empty' \
+    "$HOME/.terraform.d/credentials.tfrc.json" 2>/dev/null || true)
+fi
+if [[ -z "$TOKEN" ]]; then
+  echo "no token: set TFE_TOKEN or run 'terraform login'" >&2
+  exit 1
+fi
+
+API="https://$TFE_HOST/api/v2"
+H=(-H "Authorization: Bearer $TOKEN" -H "Content-Type: application/vnd.api+json")
+
+PLAN_ID=$(curl -s "${H[@]}" "$API/runs/$RUN_ID" | jq -r '.data.relationships.plan.data.id')
+if [[ -z "$PLAN_ID" || "$PLAN_ID" == "null" ]]; then
+  echo "could not resolve a plan for $RUN_ID (check the run ID and token access)" >&2
+  exit 1
+fi
+
+# /json-output is unredacted (needs elevated workspace access); else redacted.
+JSON=$(curl -sfL "${H[@]}" "$API/plans/$PLAN_ID/json-output" 2>/dev/null || true)
+if [[ -z "$JSON" ]]; then
+  echo "note: no access to unredacted plan; using json-output-redacted (sensitive values shown as '(sensitive)')" >&2
+  JSON=$(curl -sfL "${H[@]}" "$API/plans/$PLAN_ID/json-output-redacted")
+fi
+
+echo "$JSON" | jq -r --arg filter "$FILTER" '
+  def fmt($v): if $v == null then "null" else ($v|tostring) end;
+
+  .resource_changes[]
+  | select(.change.actions != ["no-op"])
+  | select($filter == "" or (.address | contains($filter)) or (.type | contains($filter)))
+  | (.change.before // {}) as $b
+  | (.change.after  // {}) as $a
+  | (.change.after_unknown    // {}) as $u
+  | (.change.before_sensitive // {}) as $bs
+  | (.change.after_sensitive  // {}) as $as
+  | ( ([$b|paths(scalars)] + [$a|paths(scalars)]) | unique ) as $paths
+  | [ $paths[]
+      | . as $p
+      | ($b|getpath($p)) as $bv
+      | ($a|getpath($p)) as $av
+      | select($bv != $av)
+      | ($p|map(tostring)|join(".")) as $key
+      | (if ($bv == null and (($bs|getpath($p)?) == true)) then "(sensitive)" else fmt($bv) end) as $bshow
+      | (if ($u|getpath($p)?) == true then "(known after apply)"
+         elif ($av == null and (($as|getpath($p)?) == true)) then "(sensitive)"
+         else fmt($av) end) as $ashow
+      | "  \($key):  \($bshow)  ->  \($ashow)" ] as $lines
+  | "\(.address)  (\(.change.actions|join("+")))",
+    (if ($lines|length) > 0 then $lines[] else "  (no attribute-value changes; metadata/order only)" end),
+    ""
+'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a base Render environment group for shared Postgres/Redis env vars and link it to all services; also add a helper script to diff Terraform Cloud plan changes.

- **New Features**
  - Added `render_env_group "base"` named `base-${var.environment}` using `var.render_environment_id`, and linked to `local.all_service_ids`.
  - Populates Postgres (read/write) and Redis env vars (`POLAR_POSTGRES_*`, `POLAR_REDIS_*`) from module inputs.
  - Added `terraform/scripts/plan-diff.sh` to show per-attribute before/after from TFC plans (uses unredacted output when available).

<sup>Written for commit e539d380766cbf973b1ff3b48fb388de65551632. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

