### PR TITLE
tf/render: Split base group into db and redis

### DIFF
--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -242,9 +242,9 @@ resource "render_env_group" "memory_profile" {
   }
 }
 
-resource "render_env_group" "base" {
+resource "render_env_group" "database" {
   environment_id = var.render_environment_id
-  name           = "base-${var.environment}"
+  name           = "database-${var.environment}"
   env_vars = {
     POLAR_POSTGRES_DATABASE      = { value = var.api_service_config.postgres_database }
     POLAR_POSTGRES_HOST          = { value = var.postgres_config.host }
@@ -256,9 +256,16 @@ resource "render_env_group" "base" {
     POLAR_POSTGRES_READ_PORT     = { value = var.postgres_config.read_port }
     POLAR_POSTGRES_READ_USER     = { value = var.postgres_config.read_user }
     POLAR_POSTGRES_READ_PWD      = { value = var.postgres_config.read_password }
-    POLAR_REDIS_HOST             = { value = var.redis_config.host }
-    POLAR_REDIS_PORT             = { value = var.redis_config.port }
-    POLAR_REDIS_DB               = { value = var.api_service_config.redis_db }
+  }
+}
+
+resource "render_env_group" "redis" {
+  environment_id = var.render_environment_id
+  name           = "redis-${var.environment}"
+  env_vars = {
+    POLAR_REDIS_HOST = { value = var.redis_config.host }
+    POLAR_REDIS_PORT = { value = var.redis_config.port }
+    POLAR_REDIS_DB   = { value = var.api_service_config.redis_db }
   }
 }
 
@@ -443,8 +450,13 @@ locals {
 }
 
 # Env group links
-resource "render_env_group_link" "base" {
-  env_group_id = render_env_group.base.id
+resource "render_env_group_link" "database" {
+  env_group_id = render_env_group.database.id
+  service_ids  = local.all_service_ids
+}
+
+resource "render_env_group_link" "redis" {
+  env_group_id = render_env_group.redis.id
   service_ids  = local.all_service_ids
 }
 


### PR DESCRIPTION
To make both of them independently configurable


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the `render_env_group` into `database-${var.environment}` and `redis-${var.environment}` so DB and Redis can be configured independently. Database env vars stay in the DB group; Redis vars moved to the new Redis group, and all services now link to both.

<sup>Written for commit 54cef3a24cb2190f866a73e43322b9ae3a08a0ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

