### PR TITLE
tf/render: Remove shared env variables from being set specifically

### DIFF
--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -328,25 +328,12 @@ resource "render_web_service" "api" {
   custom_domains = var.api_service_config.custom_domains
 
   env_vars = {
-    SERVICE_NAME                 = { value = "api${local.env_suffix}" }
-    WEB_CONCURRENCY              = { value = var.api_service_config.web_concurrency }
-    FORWARDED_ALLOW_IPS          = { value = var.api_service_config.forwarded_allow_ips }
-    POLAR_ALLOWED_HOSTS          = { value = var.api_service_config.allowed_hosts }
-    POLAR_CORS_ORIGINS           = { value = var.api_service_config.cors_origins }
-    POLAR_DATABASE_POOL_SIZE     = { value = var.api_service_config.database_pool_size }
-    POLAR_POSTGRES_DATABASE      = { value = var.api_service_config.postgres_database }
-    POLAR_POSTGRES_HOST          = { value = var.postgres_config.host }
-    POLAR_POSTGRES_PORT          = { value = var.postgres_config.port }
-    POLAR_POSTGRES_USER          = { value = var.postgres_config.user }
-    POLAR_POSTGRES_PWD           = { value = var.postgres_config.password }
-    POLAR_POSTGRES_READ_DATABASE = { value = var.api_service_config.postgres_read_database }
-    POLAR_POSTGRES_READ_HOST     = { value = var.postgres_config.read_host }
-    POLAR_POSTGRES_READ_PORT     = { value = var.postgres_config.read_port }
-    POLAR_POSTGRES_READ_USER     = { value = var.postgres_config.read_user }
-    POLAR_POSTGRES_READ_PWD      = { value = var.postgres_config.read_password }
-    POLAR_REDIS_HOST             = { value = var.redis_config.host }
-    POLAR_REDIS_PORT             = { value = var.redis_config.port }
-    POLAR_REDIS_DB               = { value = var.api_service_config.redis_db }
+    SERVICE_NAME             = { value = "api${local.env_suffix}" }
+    WEB_CONCURRENCY          = { value = var.api_service_config.web_concurrency }
+    FORWARDED_ALLOW_IPS      = { value = var.api_service_config.forwarded_allow_ips }
+    POLAR_ALLOWED_HOSTS      = { value = var.api_service_config.allowed_hosts }
+    POLAR_CORS_ORIGINS       = { value = var.api_service_config.cors_origins }
+    POLAR_DATABASE_POOL_SIZE = { value = var.api_service_config.database_pool_size }
   }
 }
 
@@ -379,22 +366,9 @@ resource "render_web_service" "worker" {
   custom_domains = length(each.value.custom_domains) > 0 ? each.value.custom_domains : null
 
   env_vars = {
-    SERVICE_NAME                 = { value = each.key }
-    dramatiq_prom_port           = { value = each.value.dramatiq_prom_port }
-    POLAR_DATABASE_POOL_SIZE     = { value = each.value.database_pool_size }
-    POLAR_POSTGRES_DATABASE      = { value = var.api_service_config.postgres_database }
-    POLAR_POSTGRES_HOST          = { value = var.postgres_config.host }
-    POLAR_POSTGRES_PORT          = { value = var.postgres_config.port }
-    POLAR_POSTGRES_USER          = { value = var.postgres_config.user }
-    POLAR_POSTGRES_PWD           = { value = var.postgres_config.password }
-    POLAR_POSTGRES_READ_DATABASE = { value = var.api_service_config.postgres_read_database }
-    POLAR_POSTGRES_READ_HOST     = { value = var.postgres_config.read_host }
-    POLAR_POSTGRES_READ_PORT     = { value = var.postgres_config.read_port }
-    POLAR_POSTGRES_READ_USER     = { value = var.postgres_config.read_user }
-    POLAR_POSTGRES_READ_PWD      = { value = var.postgres_config.read_password }
-    POLAR_REDIS_HOST             = { value = var.redis_config.host }
-    POLAR_REDIS_PORT             = { value = var.redis_config.port }
-    POLAR_REDIS_DB               = { value = var.api_service_config.redis_db }
+    SERVICE_NAME             = { value = each.key }
+    dramatiq_prom_port       = { value = each.value.dramatiq_prom_port }
+    POLAR_DATABASE_POOL_SIZE = { value = each.value.database_pool_size }
   }
 }
 
@@ -422,23 +396,10 @@ resource "render_cron_job" "cron" {
   # and write it to a temp file in the start command. POLAR_JWKS is set here
   # to override the env group value (/etc/secrets/jwks.json) which doesn't exist.
   env_vars = {
-    SERVICE_NAME                 = { value = each.key }
-    POLAR_DATABASE_POOL_SIZE     = { value = each.value.database_pool_size }
-    POLAR_JWKS                   = { value = "/tmp/jwks.json" }
-    POLAR_JWKS_CONTENT           = { value = var.backend_secrets.jwks }
-    POLAR_POSTGRES_DATABASE      = { value = var.api_service_config.postgres_database }
-    POLAR_POSTGRES_HOST          = { value = var.postgres_config.host }
-    POLAR_POSTGRES_PORT          = { value = var.postgres_config.port }
-    POLAR_POSTGRES_USER          = { value = var.postgres_config.user }
-    POLAR_POSTGRES_PWD           = { value = var.postgres_config.password }
-    POLAR_POSTGRES_READ_DATABASE = { value = var.api_service_config.postgres_read_database }
-    POLAR_POSTGRES_READ_HOST     = { value = var.postgres_config.read_host }
-    POLAR_POSTGRES_READ_PORT     = { value = var.postgres_config.read_port }
-    POLAR_POSTGRES_READ_USER     = { value = var.postgres_config.read_user }
-    POLAR_POSTGRES_READ_PWD      = { value = var.postgres_config.read_password }
-    POLAR_REDIS_HOST             = { value = var.redis_config.host }
-    POLAR_REDIS_PORT             = { value = var.redis_config.port }
-    POLAR_REDIS_DB               = { value = var.api_service_config.redis_db }
+    SERVICE_NAME             = { value = each.key }
+    POLAR_DATABASE_POOL_SIZE = { value = each.value.database_pool_size }
+    POLAR_JWKS               = { value = "/tmp/jwks.json" }
+    POLAR_JWKS_CONTENT       = { value = var.backend_secrets.jwks }
   }
 }
 


### PR DESCRIPTION
Now that we have moved out DB and redis env variables into two groups, we can remove them from being explicitly set on the service.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed explicit DB and Redis env vars from the Terraform Render services; these now come from shared env groups to reduce duplication and drift. Affects `render_web_service.api`, `render_web_service.worker`, and `render_cron_job.cron`, leaving only service-specific vars.

<sup>Written for commit f8e5e0f5429b76d6e20be6877258752d018e667b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12434?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

