### PR TITLE
feat(backoffice): support cases handles all cases instead of just appeals

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -38,6 +38,7 @@ from polar.integrations.plain.service import (
 )
 from polar.integrations.plain.service import plain as plain_service
 from polar.integrations.stripe.service import stripe as stripe_service
+from polar.kit.pagination import count_subquery
 from polar.kit.sorting import Sorting
 from polar.models import (
     AccountCredit,
@@ -60,8 +61,6 @@ from polar.models.organization_agent_review import OrganizationAgentReview
 from polar.models.organization_review import OrganizationReview
 from polar.models.support_case import (
     ReviewAppealSupportCase,
-    SupportCaseAttachment,
-    SupportCaseMessageAuthorKind,
 )
 from polar.models.transaction import TransactionType
 from polar.models.user import IdentityVerificationStatus
@@ -97,7 +96,6 @@ from polar.startup_program.service import (
     startup_program as startup_program_service,
 )
 from polar.support_case.repository import (
-    SupportCaseAttachmentRepository,
     SupportCaseMessageRepository,
 )
 from polar.transaction.service.transaction import transaction as transaction_service
@@ -107,6 +105,8 @@ from ..components import button, modal
 from ..dependencies import get_admin
 from ..layout import layout
 from ..responses import HXRedirectResponse
+from ..support_cases.queries import cases_statement, open_case_organization_ids
+from ..support_cases.urls import append_return_to, case_detail_url
 from ..toast import add_toast
 from . import priority as review_priority
 from .analytics import (
@@ -139,7 +139,7 @@ from .views.sections.overview_section import OverviewSection
 from .views.sections.payout_account_section import PayoutAccountSection
 from .views.sections.reviews_section import ReviewsSection
 from .views.sections.settings_section import SettingsSection
-from .views.sections.support_case_section import SupportCaseSection
+from .views.sections.support_cases_list_section import SupportCasesListSection
 from .views.sections.team_section import TeamSection
 
 router = APIRouter(prefix="/organizations", tags=["organizations"])
@@ -261,64 +261,29 @@ async def count_test_sales(
 REVIEW_TAB_MAX_COHORT = 2000
 
 
-def _open_case_org_ids() -> Select[tuple[uuid.UUID]]:
-    """Select of organization ids that have at least one open support case."""
-    return (
-        select(OrganizationReview.organization_id)
-        .join(
-            ReviewAppealSupportCase,
-            ReviewAppealSupportCase.organization_review_id == OrganizationReview.id,
-        )
-        .where(
-            ReviewAppealSupportCase.deleted_at.is_(None),
-            SupportCaseMessageRepository.is_open_expression(),
-        )
-        .distinct()
-    )
-
-
 async def _orgs_with_open_cases(
     session: AsyncSession, organizations: Sequence[Organization]
 ) -> set[uuid.UUID]:
-    """Org ids (among the given page) with at least one open support case."""
+    """Org ids (among the given page) with at least one open support case
+    (appeal or dispute)."""
     org_ids = [org.id for org in organizations]
     if not org_ids:
         return set()
-    statement = _open_case_org_ids().where(
-        OrganizationReview.organization_id.in_(org_ids)
-    )
-    result = await session.execute(statement)
+    result = await session.execute(open_case_organization_ids(organization_ids=org_ids))
     return set(result.scalars().all())
-
-
-def _awaiting_reply_org_ids() -> Select[tuple[uuid.UUID]]:
-    """Select of organization ids with an open case awaiting a platform reply."""
-    return (
-        select(OrganizationReview.organization_id)
-        .join(
-            ReviewAppealSupportCase,
-            ReviewAppealSupportCase.organization_review_id == OrganizationReview.id,
-        )
-        .where(
-            ReviewAppealSupportCase.deleted_at.is_(None),
-            SupportCaseMessageRepository.is_open_expression(),
-            SupportCaseMessageRepository.awaiting_platform_expression(),
-        )
-        .distinct()
-    )
 
 
 async def _orgs_awaiting_reply(
     session: AsyncSession, organizations: Sequence[Organization]
 ) -> set[uuid.UUID]:
-    """Org ids (among the given page) with an open case awaiting a reply."""
+    """Org ids (among the given page) with an open case (appeal or dispute)
+    awaiting a platform reply."""
     org_ids = [org.id for org in organizations]
     if not org_ids:
         return set()
-    statement = _awaiting_reply_org_ids().where(
-        OrganizationReview.organization_id.in_(org_ids)
+    result = await session.execute(
+        open_case_organization_ids(organization_ids=org_ids, awaiting_reply=True)
     )
-    result = await session.execute(statement)
     return set(result.scalars().all())
 
 
@@ -500,7 +465,7 @@ async def list_organizations(
     elif selected_open_cases:
         # Don't apply the default denied/blocked exclusion: open cases
         # typically live on denied organizations.
-        stmt = stmt.where(Organization.id.in_(_open_case_org_ids()))
+        stmt = stmt.where(Organization.id.in_(open_case_organization_ids()))
     elif not q:
         # By default, exclude denied and blocked organizations (but not when searching)
         stmt = stmt.where(
@@ -656,7 +621,9 @@ async def list_organizations(
         countries = await list_view.get_distinct_countries()
         open_cases_count = (
             await session.scalar(
-                select(func.count()).select_from(_open_case_org_ids().subquery())
+                select(func.count()).select_from(
+                    open_case_organization_ids().subquery()
+                )
             )
             or 0
         )
@@ -768,7 +735,7 @@ async def get_organization_detail(
             organization.id
         )
 
-    # Appeal support case state (drives the nav badge and the review-card link)
+    # Appeal support case state (drives the review-card link in the overview).
     appeal_case = None
     appeal_case_open = False
     if organization.review is not None:
@@ -777,6 +744,16 @@ async def get_organization_detail(
             message_repository = SupportCaseMessageRepository.from_session(session)
             appeal_case_open = await message_repository.is_open(appeal_case.id)
 
+    # Any open case (appeal or dispute) lights the Support Cases nav badge.
+    open_case_count = await session.scalar(
+        select(func.count()).select_from(
+            count_subquery(
+                cases_statement(organization_id=organization.id, status="open")
+            )
+        )
+    )
+    has_open_case = bool(open_case_count)
+
     # Create views
     detail_view = OrganizationDetailView(
         organization,
@@ -784,7 +761,7 @@ async def get_organization_detail(
         owner_email=owner_email,
         impersonate_user=impersonate_user,
         startup_program_status=startup_program_status,
-        appeal_case_open=appeal_case_open,
+        has_open_case=has_open_case,
     )
 
     # Fetch analytics data for overview section
@@ -1006,47 +983,16 @@ async def get_organization_detail(
                 with reviews_section.render(request):
                     pass
             elif section == "support_case":
-                thread = None
-                author_emails: dict[uuid.UUID, str] = {}
-                attachments_by_message: dict[
-                    uuid.UUID, list[SupportCaseAttachment]
-                ] = {}
-                if organization.review is not None:
-                    thread = await appeal_case_service.get_thread(
-                        session, organization.review, visible_to=None
+                case_rows = (
+                    await session.execute(
+                        cases_statement(organization_id=organization.id)
                     )
-                if thread is not None:
-                    case_, _is_open, thread_messages = thread
-                    author_ids = {
-                        m.author_user_id
-                        for m in thread_messages
-                        if m.author_user_id is not None
-                    }
-                    if case_.assigned_user_id is not None:
-                        author_ids.add(case_.assigned_user_id)
-                    if author_ids:
-                        email_result = await session.execute(
-                            select(User.id, User.email).where(User.id.in_(author_ids))
-                        )
-                        author_emails = {
-                            row.id: row.email for row in email_result.all()
-                        }
-                    attachments = await SupportCaseAttachmentRepository.from_session(
-                        session
-                    ).list_by_case(case_.id)
-                    for attachment in attachments:
-                        if attachment.message_id is not None:
-                            attachments_by_message.setdefault(
-                                attachment.message_id, []
-                            ).append(attachment)
-                support_case_section = SupportCaseSection(
+                ).all()
+                support_cases_section = SupportCasesListSection(
                     organization,
-                    thread=thread,
-                    author_emails=author_emails,
-                    current_user_id=user_session.user_id,
-                    attachments_by_message=attachments_by_message,
+                    case_rows,  # type: ignore[arg-type]
                 )
-                with support_case_section.render(request):
+                with support_cases_section.render(request):
                     pass
             elif section == "history":
                 # TODO: Implement history section
@@ -1677,48 +1623,15 @@ async def _load_org_with_appeal_case(
 
 
 def _support_case_redirect(
-    request: Request, organization_id: UUID4
+    request: Request, case_id: UUID4, return_to: str | None = None
 ) -> HXRedirectResponse:
+    """Send the staff member back to the case detail page after an action,
+    preserving the origin they came from."""
     return HXRedirectResponse(
         request,
-        str(request.url_for("organizations:detail", organization_id=organization_id))
-        + "?section=support_case",
+        case_detail_url(request, case_id, return_to=return_to),
         303,
     )
-
-
-@router.post(
-    "/{organization_id}/appeal-case/reply",
-    name="organizations:appeal_case_reply",
-    response_model=None,
-)
-async def appeal_case_reply(
-    request: Request,
-    organization_id: UUID4,
-    session: AsyncSession = Depends(get_db_session),
-    user_session: UserSession = Depends(get_admin),
-) -> HXRedirectResponse:
-    """Post a staff reply (or internal note) to the appeal case."""
-    _, case = await _load_org_with_appeal_case(session, organization_id)
-
-    form_data = await request.form()
-    body = str(form_data.get("body", "")).strip()
-    internal = bool(form_data.get("internal"))
-
-    if body:
-        try:
-            await appeal_case_service.add_reply(
-                session,
-                case,
-                author_kind=SupportCaseMessageAuthorKind.platform,
-                author_user=user_session.user,
-                body=body,
-                internal=internal,
-            )
-        except AppealCaseError as e:
-            await add_toast(request, e.args[0], variant="error")
-
-    return _support_case_redirect(request, organization_id)
 
 
 @router.api_route(
@@ -1735,6 +1648,7 @@ async def appeal_case_approve_dialog(
 ) -> HXRedirectResponse | None:
     """Approve the appeal: reactivate the organization and close the case."""
     organization, case = await _load_org_with_appeal_case(session, organization_id)
+    return_to = request.query_params.get("return_to")
 
     error_message: str | None = None
 
@@ -1772,15 +1686,18 @@ async def appeal_case_approve_dialog(
                 await session.rollback()
                 error_message = e.args[0]
             else:
-                return _support_case_redirect(request, organization_id)
+                return _support_case_redirect(request, case.id, return_to)
 
     with modal("Approve Appeal", open=True):
         with tag.form(
-            hx_post=str(
-                request.url_for(
-                    "organizations:appeal_case_approve_dialog",
-                    organization_id=organization_id,
-                )
+            hx_post=append_return_to(
+                str(
+                    request.url_for(
+                        "organizations:appeal_case_approve_dialog",
+                        organization_id=organization_id,
+                    )
+                ),
+                return_to,
             ),
             hx_target="#modal",
             classes="flex flex-col gap-4",
@@ -1834,6 +1751,7 @@ async def appeal_case_deny_dialog(
     to make — the decision records the outcome on the case and locks it.
     """
     organization, case = await _load_org_with_appeal_case(session, organization_id)
+    return_to = request.query_params.get("return_to")
 
     error_message: str | None = None
 
@@ -1865,15 +1783,18 @@ async def appeal_case_deny_dialog(
             await session.rollback()
             error_message = e.args[0]
         else:
-            return _support_case_redirect(request, organization_id)
+            return _support_case_redirect(request, case.id, return_to)
 
     with modal("Deny Appeal", open=True):
         with tag.form(
-            hx_post=str(
-                request.url_for(
-                    "organizations:appeal_case_deny_dialog",
-                    organization_id=organization_id,
-                )
+            hx_post=append_return_to(
+                str(
+                    request.url_for(
+                        "organizations:appeal_case_deny_dialog",
+                        organization_id=organization_id,
+                    )
+                ),
+                return_to,
             ),
             hx_target="#modal",
             classes="flex flex-col gap-4",

--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -45,13 +45,13 @@ class OrganizationDetailView:
         owner_email: str | None = None,
         impersonate_user: User | None = None,
         startup_program_status: str | None = None,
-        appeal_case_open: bool = False,
+        has_open_case: bool = False,
     ):
         self.org = organization
         self.ai_verdict = ai_verdict
         self.owner_email = owner_email
         self.impersonate_user = impersonate_user
-        self.appeal_case_open = appeal_case_open
+        self.has_open_case = has_open_case
         # Startup Program status string is derived via the Polar API and
         # populated by the endpoint; ``None`` means "feature disabled" OR
         # "not invited". The card collapses both into the same rendering.
@@ -104,13 +104,13 @@ class OrganizationDetailView:
                 active=current_section == "reviews",
             ),
             Tab(
-                "Support Case",
+                "Support Cases",
                 str(
                     request.url_for("organizations:detail", organization_id=self.org.id)
                 )
                 + "?section=support_case",
                 active=current_section == "support_case",
-                dot=self.appeal_case_open,
+                dot=self.has_open_case,
                 badge_variant="warning",
             ),
             Tab(

--- a/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
@@ -1,4 +1,6 @@
-"""Support case section: the appeal human-review thread and staff actions."""
+"""Support case section: a support-case thread (appeal or dispute) and staff
+actions. Appeals carry an approve/deny decision; disputes are bank-decided and
+read-only beyond the staff ↔ merchant conversation."""
 
 import contextlib
 from collections.abc import Generator, Sequence
@@ -10,14 +12,16 @@ from tagflow import tag, text
 
 from polar.models import Organization
 from polar.models.support_case import (
-    ReviewAppealSupportCase,
+    SupportCase,
     SupportCaseAttachment,
     SupportCaseMessage,
     SupportCaseMessageAuthorKind,
     SupportCaseMessageType,
+    SupportCaseType,
 )
 
 from ....components import button, card
+from ....support_cases.urls import append_return_to
 
 _AUTHOR_LABELS: dict[SupportCaseMessageAuthorKind, str] = {
     SupportCaseMessageAuthorKind.platform: "Support",
@@ -26,14 +30,41 @@ _AUTHOR_LABELS: dict[SupportCaseMessageAuthorKind, str] = {
     SupportCaseMessageAuthorKind.system: "System",
 }
 
+_CASE_TITLES: dict[SupportCaseType, str] = {
+    SupportCaseType.review_appeal: "Appeal Support Case",
+    SupportCaseType.dispute: "Dispute Support Case",
+}
+
+# The "opened" milestone reads differently per case type (a merchant-requested
+# appeal vs. a system-opened dispute).
+_OPENED_TITLES: dict[SupportCaseType, str] = {
+    SupportCaseType.review_appeal: "Human review requested",
+    SupportCaseType.dispute: "Dispute opened",
+}
+
+# Outcome milestones surfaced as header badges: (badge classes, icon, label).
+_OUTCOMES: dict[SupportCaseMessageType, tuple[str, str, str]] = {
+    SupportCaseMessageType.appeal_approved: (
+        "badge-success",
+        "icon-check",
+        "Appeal approved",
+    ),
+    SupportCaseMessageType.appeal_denied: ("badge-error", "icon-x", "Appeal denied"),
+    SupportCaseMessageType.dispute_won: ("badge-success", "icon-check", "Dispute won"),
+    SupportCaseMessageType.dispute_lost: ("badge-error", "icon-x", "Dispute lost"),
+}
+
 # Milestone events: title + (lucide icon, node circle classes). These render as
 # timeline milestones, visually distinct from conversation messages.
 _EVENT_TITLES: dict[SupportCaseMessageType, str] = {
-    SupportCaseMessageType.opened: "Human review requested",
+    SupportCaseMessageType.opened: "Case opened",
     SupportCaseMessageType.closed: "Case closed",
     SupportCaseMessageType.appeal_approved: "Appeal approved",
     SupportCaseMessageType.appeal_denied: "Appeal denied",
     SupportCaseMessageType.info_requested: "Information requested",
+    SupportCaseMessageType.dispute_under_review: "Dispute under review",
+    SupportCaseMessageType.dispute_won: "Dispute won",
+    SupportCaseMessageType.dispute_lost: "Dispute lost",
     SupportCaseMessageType.assigned: "Case assigned",
     SupportCaseMessageType.released: "Case unassigned",
 }
@@ -52,15 +83,24 @@ _EVENT_NODES: dict[SupportCaseMessageType, tuple[str, str]] = {
         "icon-message-square-text",
         "bg-info text-info-content",
     ),
+    SupportCaseMessageType.dispute_under_review: (
+        "icon-gavel",
+        "bg-info text-info-content",
+    ),
+    SupportCaseMessageType.dispute_won: (
+        "icon-check",
+        "bg-success text-success-content",
+    ),
+    SupportCaseMessageType.dispute_lost: ("icon-x", "bg-error text-error-content"),
     SupportCaseMessageType.assigned: ("icon-user-check", _MUTED_NODE),
     SupportCaseMessageType.released: ("icon-user-x", _MUTED_NODE),
 }
 
-Thread = tuple[ReviewAppealSupportCase, bool, Sequence[SupportCaseMessage]]
+Thread = tuple[SupportCase, bool, Sequence[SupportCaseMessage]]
 
 
 class SupportCaseSection:
-    """Render the appeal support case: status header, timeline and actions."""
+    """Render a support case: status header, timeline and actions."""
 
     def __init__(
         self,
@@ -69,12 +109,21 @@ class SupportCaseSection:
         author_emails: dict[UUID, str] | None = None,
         current_user_id: UUID | None = None,
         attachments_by_message: dict[UUID, list[SupportCaseAttachment]] | None = None,
+        return_to: str | None = None,
     ) -> None:
         self.org = organization
         self.thread = thread
         self.author_emails = author_emails or {}
         self.current_user_id = current_user_id
         self.attachments_by_message = attachments_by_message or {}
+        # Origin to come back to after an action (e.g. the org page), threaded
+        # through every action URL so the flow stays anchored to it.
+        self.return_to = return_to
+        # Set from the thread's case at render time; drives type-aware labels.
+        self._case_type: SupportCaseType = SupportCaseType.review_appeal
+
+    def _with_return_to(self, url: str) -> str:
+        return append_return_to(url, self.return_to)
 
     @contextlib.contextmanager
     def render(self, request: Request) -> Generator[None]:
@@ -82,18 +131,19 @@ class SupportCaseSection:
             if self.thread is None:
                 with card(bordered=True):
                     with tag.h2(classes="text-lg font-semibold mb-1"):
-                        text("Appeal Support Case")
+                        text("Support Case")
                     with tag.p(classes="text-sm text-base-content/50"):
                         text("No support case for this organization.")
                 yield
                 return
 
             case, is_open, messages = self.thread
+            self._case_type = case.type
             with card(bordered=True):
                 self._render_header(request, case, is_open, messages)
                 self._render_timeline(request, messages)
                 if is_open:
-                    self._render_composer(request)
+                    self._render_composer(request, case)
             yield
 
     # -- Header -------------------------------------------------------------
@@ -102,21 +152,19 @@ class SupportCaseSection:
         self, messages: Sequence[SupportCaseMessage]
     ) -> SupportCaseMessageType | None:
         for message in messages:
-            if message.type in (
-                SupportCaseMessageType.appeal_approved,
-                SupportCaseMessageType.appeal_denied,
-            ):
+            if message.type in _OUTCOMES:
                 return message.type
         return None
 
     def _render_header(
         self,
         request: Request,
-        case: ReviewAppealSupportCase,
+        case: SupportCase,
         is_open: bool,
         messages: Sequence[SupportCaseMessage],
     ) -> None:
         outcome = self._outcome(messages)
+        is_appeal = self._case_type == SupportCaseType.review_appeal
         with tag.div(classes="flex items-start justify-between gap-4 mb-8"):
             with tag.div(classes="flex items-start gap-4"):
                 with tag.div(
@@ -129,30 +177,27 @@ class SupportCaseSection:
                         pass
                 with tag.div(classes="flex flex-col gap-2"):
                     with tag.h2(classes="text-xl font-semibold leading-none"):
-                        text("Appeal Support Case")
+                        text(_CASE_TITLES.get(self._case_type, "Support Case"))
                     with tag.div(classes="flex items-center gap-2"):
                         status = "badge-success" if is_open else "badge-neutral"
                         with tag.div(classes=f"badge {status} badge-sm"):
                             text("Open" if is_open else "Closed")
-                        if outcome == SupportCaseMessageType.appeal_approved:
-                            with tag.div(classes="badge badge-success badge-sm gap-1"):
-                                with tag.span(classes="icon-check"):
+                        if outcome is not None:
+                            badge, icon, label = _OUTCOMES[outcome]
+                            with tag.div(classes=f"badge {badge} badge-sm gap-1"):
+                                with tag.span(classes=icon):
                                     pass
-                                text("Appeal approved")
-                        elif outcome == SupportCaseMessageType.appeal_denied:
-                            with tag.div(classes="badge badge-error badge-sm gap-1"):
-                                with tag.span(classes="icon-x"):
-                                    pass
-                                text("Appeal denied")
-                        elif is_open:
+                                text(label)
+                        elif is_open and is_appeal:
                             with tag.div(classes="badge badge-ghost badge-sm"):
                                 text("Awaiting decision")
                         if is_open:
                             self._render_assignment_chip(case)
-            if is_open:
+            # Appeals carry a staff decision; disputes are bank-decided.
+            if is_open and is_appeal:
                 self._render_decision_actions(request, case)
 
-    def _render_assignment_chip(self, case: ReviewAppealSupportCase) -> None:
+    def _render_assignment_chip(self, case: SupportCase) -> None:
         assignee_id = case.assigned_user_id
         if assignee_id is None:
             icon, label = "icon-user", "Unassigned"
@@ -166,29 +211,33 @@ class SupportCaseSection:
                 pass
             text(label)
 
-    def _assignment_urls(
-        self, request: Request, case: ReviewAppealSupportCase
-    ) -> tuple[str, str]:
+    def _assignment_urls(self, request: Request, case: SupportCase) -> tuple[str, str]:
         # Assignment is advisory and generic to any case type, so it posts to
-        # the case-keyed support_cases endpoints and returns here afterwards.
-        detail = request.url_for("organizations:detail", organization_id=self.org.id)
-        return_to = f"{detail.path}?section=support_case"
-        take_url = f"{request.url_for('support_cases:take', case_id=case.id)}?{urlencode({'return_to': return_to})}"
-        release_url = f"{request.url_for('support_cases:release', case_id=case.id)}?{urlencode({'return_to': return_to})}"
+        # the case-keyed support_cases endpoints and returns to the case detail
+        # page afterwards — keeping the original origin so the back link holds.
+        detail_path = append_return_to(
+            request.url_for("support_cases:detail", case_id=case.id).path,
+            self.return_to,
+        )
+        take_url = f"{request.url_for('support_cases:take', case_id=case.id)}?{urlencode({'return_to': detail_path})}"
+        release_url = f"{request.url_for('support_cases:release', case_id=case.id)}?{urlencode({'return_to': detail_path})}"
         return take_url, release_url
 
-    def _render_decision_actions(
-        self, request: Request, case: ReviewAppealSupportCase
-    ) -> None:
-        approve_url = str(
-            request.url_for(
-                "organizations:appeal_case_approve_dialog",
-                organization_id=self.org.id,
+    def _render_decision_actions(self, request: Request, case: SupportCase) -> None:
+        approve_url = self._with_return_to(
+            str(
+                request.url_for(
+                    "organizations:appeal_case_approve_dialog",
+                    organization_id=self.org.id,
+                )
             )
         )
-        deny_url = str(
-            request.url_for(
-                "organizations:appeal_case_deny_dialog", organization_id=self.org.id
+        deny_url = self._with_return_to(
+            str(
+                request.url_for(
+                    "organizations:appeal_case_deny_dialog",
+                    organization_id=self.org.id,
+                )
             )
         )
         take_url, release_url = self._assignment_urls(request, case)
@@ -268,6 +317,8 @@ class SupportCaseSection:
         return "icon-headset", "bg-info/15 text-info"
 
     def _title(self, message: SupportCaseMessage, internal: bool) -> str:
+        if message.type == SupportCaseMessageType.opened:
+            return _OPENED_TITLES.get(self._case_type, "Case opened")
         if message.type != SupportCaseMessageType.chat:
             return _EVENT_TITLES[message.type]
         if internal:
@@ -367,11 +418,9 @@ class SupportCaseSection:
 
     # -- Composer -----------------------------------------------------------
 
-    def _render_composer(self, request: Request) -> None:
-        reply_url = str(
-            request.url_for(
-                "organizations:appeal_case_reply", organization_id=self.org.id
-            )
+    def _render_composer(self, request: Request, case: SupportCase) -> None:
+        reply_url = self._with_return_to(
+            str(request.url_for("support_cases:reply", case_id=case.id))
         )
         with tag.div(classes="mt-8 pt-6 border-t border-base-200"):
             with tag.form(hx_post=reply_url, classes="flex flex-col gap-3"):

--- a/server/polar/backoffice/organizations_v2/views/sections/support_cases_list_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/support_cases_list_section.py
@@ -1,0 +1,92 @@
+"""Organization 'Support Cases' tab: the org's support cases (appeals and
+disputes), each linking to the shared case detail page."""
+
+import contextlib
+from collections.abc import Generator, Sequence
+
+from fastapi import Request
+from tagflow import tag, text
+
+from polar.models import Organization
+
+from ....components import card
+from ....support_cases.queries import TYPE_LABELS, Row
+from ....support_cases.urls import case_detail_url
+
+
+class SupportCasesListSection:
+    """List the organization's support cases with links to their detail page."""
+
+    def __init__(self, organization: Organization, rows: Sequence[Row]) -> None:
+        self.org = organization
+        self.rows = rows
+
+    @contextlib.contextmanager
+    def render(self, request: Request) -> Generator[None]:
+        with tag.div(classes="space-y-6"):
+            with card(bordered=True):
+                with tag.h2(classes="text-lg font-semibold mb-4"):
+                    text("Support Cases")
+                if not self.rows:
+                    with tag.p(classes="text-sm text-base-content/50"):
+                        text("No support cases for this organization.")
+                else:
+                    self._render_table(request)
+            yield
+
+    def _render_table(self, request: Request) -> None:
+        # Coming from the org page, the case detail's back link should return
+        # here rather than to the global case list.
+        return_to = (
+            f"{request.url_for('organizations:detail', organization_id=self.org.id).path}"
+            "?section=support_case"
+        )
+        with tag.div(classes="overflow-x-auto"):
+            with tag.table(classes="table table-zebra"):
+                with tag.thead():
+                    with tag.tr():
+                        for header in ("Type", "Status", "Assignee", "Opened"):
+                            with tag.th():
+                                text(header)
+                with tag.tbody():
+                    for (
+                        case,
+                        _organization,
+                        is_open,
+                        assignee_email,
+                        awaiting_platform,
+                    ) in self.rows:
+                        case_url = case_detail_url(
+                            request, case.id, return_to=return_to
+                        )
+                        with tag.tr(
+                            classes="hover cursor-pointer",
+                            _=f"on click set window.location to '{case_url}'",
+                        ):
+                            with tag.td():
+                                with tag.a(href=case_url, classes="link"):
+                                    text(TYPE_LABELS.get(case.type, case.type.value))
+                            with tag.td():
+                                with tag.div(classes="flex items-center gap-2"):
+                                    variant = (
+                                        "badge-success" if is_open else "badge-ghost"
+                                    )
+                                    with tag.div(classes=f"badge {variant} badge-sm"):
+                                        text("Open" if is_open else "Closed")
+                                    if awaiting_platform:
+                                        with tag.span(
+                                            classes="tooltip text-warning",
+                                            data_tip="Awaiting reply",
+                                        ):
+                                            text("●")
+                            with tag.td():
+                                if assignee_email:
+                                    text(assignee_email)
+                                else:
+                                    with tag.span(classes="text-base-content/40"):
+                                        text("Unassigned")
+                            with tag.td(classes="text-base-content/60"):
+                                text(case.created_at.strftime("%b %-d, %Y %H:%M UTC"))
+
+
+__all__ = ["SupportCasesListSection"]

--- a/server/polar/backoffice/support_cases/endpoints.py
+++ b/server/polar/backoffice/support_cases/endpoints.py
@@ -1,5 +1,6 @@
+import uuid
 from collections.abc import Sequence
-from typing import Annotated, Any
+from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import RedirectResponse
@@ -9,11 +10,17 @@ from sqlalchemy.orm import joinedload
 from tagflow import tag, text
 
 from polar.file.service import file as file_service
-from polar.kit.pagination import PaginationParamsQuery
+from polar.kit.pagination import PaginationParamsQuery, count_subquery
 from polar.models import Organization, User
-from polar.models.organization_review import OrganizationReview
-from polar.models.support_case import ReviewAppealSupportCase, SupportCaseAttachment
+from polar.models.support_case import (
+    SupportCase,
+    SupportCaseAttachment,
+    SupportCaseAudience,
+    SupportCaseMessageAuthorKind,
+    SupportCaseType,
+)
 from polar.models.user_session import UserSession
+from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncSession, get_db_read_session, get_db_session
 from polar.support_case.repository import (
     SupportCaseAttachmentRepository,
@@ -21,24 +28,39 @@ from polar.support_case.repository import (
     SupportCaseRepository,
 )
 from polar.support_case.service import support_case as support_case_service
+from polar.worker import enqueue_job
 
 from ..components import datatable, support_tier_badge
 from ..components._tab_nav import Tab, tab_nav
 from ..dependencies import get_admin
 from ..layout import layout
+from ..organizations_v2.views.sections.support_case_section import SupportCaseSection
 from ..responses import HXRedirectResponse
+from ..toast import add_toast
+from .queries import TYPE_LABELS, Row, cases_statement
+from .urls import case_detail_url, is_safe_return_to
 
 router = APIRouter()
 
-# (case, organization, is_open, assignee_email)
-Row = tuple[ReviewAppealSupportCase, Organization, bool, str | None, bool]
 
-
-def _list_tabs(request: Request, status: str, assigned: str, sort: str) -> list[Tab]:
+def _list_url(
+    request: Request, *, status: str, assigned: str, sort: str, case_type: str
+) -> str:
     base = str(request.url_for("support_cases:list"))
+    return f"{base}?status={status}&assigned={assigned}&sort={sort}&type={case_type}"
 
-    def url(status: str, assigned: str) -> str:
-        return f"{base}?status={status}&assigned={assigned}&sort={sort}"
+
+def _list_tabs(
+    request: Request, status: str, assigned: str, sort: str, case_type: str
+) -> list[Tab]:
+    def url(new_status: str, new_assigned: str) -> str:
+        return _list_url(
+            request,
+            status=new_status,
+            assigned=new_assigned,
+            sort=sort,
+            case_type=case_type,
+        )
 
     # Status (left) filters preserve the current assignment. The assignment
     # filters (right, pushed via ml-auto) toggle: clicking the active one
@@ -61,10 +83,42 @@ def _list_tabs(request: Request, status: str, assigned: str, sort: str) -> list[
     ]
 
 
+def _type_tabs(
+    request: Request, status: str, assigned: str, sort: str, case_type: str
+) -> list[Tab]:
+    def url(new_type: str) -> str:
+        return _list_url(
+            request,
+            status=status,
+            assigned=assigned,
+            sort=sort,
+            case_type=new_type,
+        )
+
+    return [
+        Tab("All types", url=url("all"), active=case_type == "all"),
+        Tab(
+            "Appeals",
+            url=url(SupportCaseType.review_appeal.value),
+            active=case_type == SupportCaseType.review_appeal.value,
+        ),
+        Tab(
+            "Disputes",
+            url=url(SupportCaseType.dispute.value),
+            active=case_type == SupportCaseType.dispute.value,
+        ),
+    ]
+
+
 def _status_badge(is_open: bool) -> None:
     variant = "badge-success" if is_open else "badge-ghost"
     with tag.div(classes=f"badge {variant} badge-sm"):
         text("Open" if is_open else "Closed")
+
+
+def _type_badge(case_type: SupportCaseType) -> None:
+    with tag.div(classes="badge badge-outline badge-sm"):
+        text(TYPE_LABELS.get(case_type, case_type.value))
 
 
 def _tier_sort_header(request: Request, sort: str) -> None:
@@ -103,14 +157,8 @@ def _render_table(request: Request, rows: Sequence[Row], sort: str) -> None:
                     assignee_email,
                     awaiting_platform,
                 ) in rows:
-                    case_url = (
-                        str(
-                            request.url_for(
-                                "organizations:detail",
-                                organization_id=organization.id,
-                            )
-                        )
-                        + "?section=support_case"
+                    case_url = str(
+                        request.url_for("support_cases:detail", case_id=case.id)
                     )
                     with tag.tr(
                         classes="hover cursor-pointer",
@@ -122,8 +170,7 @@ def _render_table(request: Request, rows: Sequence[Row], sort: str) -> None:
                         with tag.td():
                             support_tier_badge(organization.support_tier)
                         with tag.td():
-                            with tag.div(classes="badge badge-outline badge-sm"):
-                                text("Review appeal")
+                            _type_badge(case.type)
                         with tag.td():
                             with tag.div(classes="flex items-center gap-2"):
                                 _status_badge(is_open)
@@ -144,10 +191,37 @@ def _render_table(request: Request, rows: Sequence[Row], sort: str) -> None:
 
 
 def _safe_return_to(request: Request, return_to: str | None) -> str:
-    """Same-site relative path only, to avoid an open redirect."""
-    if return_to and return_to.startswith("/") and not return_to.startswith("//"):
+    """Same-site relative path only, falling back to the case list."""
+    if is_safe_return_to(return_to):
+        assert return_to is not None
         return return_to
     return str(request.url_for("support_cases:list"))
+
+
+def _detail_redirect(
+    request: Request, case_id: uuid.UUID, return_to: str | None = None
+) -> HXRedirectResponse:
+    return HXRedirectResponse(
+        request, case_detail_url(request, case_id, return_to=return_to), 303
+    )
+
+
+async def _load_case_and_organization(
+    session: AsyncSession, case_id: uuid.UUID
+) -> tuple[SupportCase, Organization]:
+    """Load a case and the organization it belongs to, or raise 404."""
+    case = await SupportCaseRepository.from_session(session).get_by_id(case_id)
+    if case is None:
+        raise HTTPException(status_code=404, detail="Support case not found")
+    organization_id = await support_case_service.get_organization_id(session, case)
+    organization = None
+    if organization_id is not None:
+        organization = await OrganizationRepository.from_session(session).get_by_id(
+            organization_id, include_blocked=True
+        )
+    if organization is None:
+        raise HTTPException(status_code=404, detail="Organization not found")
+    return case, organization
 
 
 @router.post("/{case_id}/take", name="support_cases:take", response_model=None)
@@ -182,6 +256,48 @@ async def release_case(
     return HXRedirectResponse(request, _safe_return_to(request, return_to), 303)
 
 
+@router.post("/{case_id}/reply", name="support_cases:reply", response_model=None)
+async def reply_case(
+    request: Request,
+    case_id: UUID4,
+    return_to: Annotated[str | None, Query()] = None,
+    session: AsyncSession = Depends(get_db_session),
+    user_session: UserSession = Depends(get_admin),
+) -> HXRedirectResponse:
+    """Post a staff reply (or internal note) to any case, then notify the
+    organization if it's merchant-visible."""
+    case = await SupportCaseRepository.from_session(session).get_by_id(case_id)
+    if case is None:
+        raise HTTPException(status_code=404, detail="Support case not found")
+
+    message_repository = SupportCaseMessageRepository.from_session(session)
+    if not await message_repository.is_open(case.id):
+        await add_toast(request, "This case is closed.", variant="error")
+        return _detail_redirect(request, case_id, return_to)
+
+    form_data = await request.form()
+    body = str(form_data.get("body", "")).strip()
+    internal = bool(form_data.get("internal"))
+
+    if body:
+        audience = [] if internal else [SupportCaseAudience.merchant]
+        message = await support_case_service.post_message(
+            session,
+            case,
+            author_kind=SupportCaseMessageAuthorKind.platform,
+            author_user=user_session.user,
+            body=body,
+            audience=audience,
+        )
+        if not internal:
+            enqueue_job(
+                "support_case.notify_organization_of_new_message",
+                message_id=message.id,
+            )
+
+    return _detail_redirect(request, case_id, return_to)
+
+
 @router.get(
     "/attachments/{attachment_id}/download",
     name="support_cases:attachment_download",
@@ -203,6 +319,74 @@ async def download_attachment(
     return RedirectResponse(url)
 
 
+@router.get("/{case_id}", name="support_cases:detail")
+async def case_detail(
+    request: Request,
+    case_id: UUID4,
+    return_to: Annotated[str | None, Query()] = None,
+    session: AsyncSession = Depends(get_db_read_session),
+    user_session: UserSession = Depends(get_admin),
+) -> None:
+    case, organization = await _load_case_and_organization(session, case_id)
+
+    message_repository = SupportCaseMessageRepository.from_session(session)
+    is_open = await message_repository.is_open(case.id)
+    messages = await message_repository.list_by_case(case.id, visible_to=None)
+
+    author_ids = {m.author_user_id for m in messages if m.author_user_id is not None}
+    if case.assigned_user_id is not None:
+        author_ids.add(case.assigned_user_id)
+    author_emails: dict[uuid.UUID, str] = {}
+    if author_ids:
+        email_result = await session.execute(
+            select(User.id, User.email).where(User.id.in_(author_ids))
+        )
+        author_emails = {row.id: row.email for row in email_result.all()}
+
+    attachments_by_message: dict[uuid.UUID, list[SupportCaseAttachment]] = {}
+    attachments = await SupportCaseAttachmentRepository.from_session(
+        session
+    ).list_by_case(case.id)
+    for attachment in attachments:
+        if attachment.message_id is not None:
+            attachments_by_message.setdefault(attachment.message_id, []).append(
+                attachment
+            )
+
+    section = SupportCaseSection(
+        organization,
+        thread=(case, is_open, messages),
+        author_emails=author_emails,
+        current_user_id=user_session.user_id,
+        attachments_by_message=attachments_by_message,
+        return_to=return_to if is_safe_return_to(return_to) else None,
+    )
+
+    came_from_org = is_safe_return_to(return_to)
+    assert not came_from_org or return_to is not None
+    back_href = (
+        return_to if came_from_org else str(request.url_for("support_cases:list"))
+    )
+    back_label = "← Back to organization" if came_from_org else "← Back to cases"
+
+    with layout(
+        request,
+        [
+            (organization.name, case_detail_url(request, case.id, return_to=return_to)),
+            ("Cases", str(request.url_for("support_cases:list"))),
+        ],
+        "support_cases:list",
+    ):
+        with tag.div(classes="flex flex-col gap-4"):
+            with tag.a(
+                href=back_href,
+                classes="link text-sm text-base-content/60",
+            ):
+                text(back_label)
+            with section.render(request):
+                pass
+
+
 @router.get("/", name="support_cases:list")
 async def list_cases(
     request: Request,
@@ -210,64 +394,27 @@ async def list_cases(
     status: Annotated[str, Query()] = "open",
     assigned: Annotated[str, Query()] = "all",
     sort: Annotated[str, Query()] = "recency",
+    type: Annotated[str, Query()] = "all",
     session: AsyncSession = Depends(get_db_read_session),
     user_session: UserSession = Depends(get_admin),
 ) -> None:
-    is_open = SupportCaseMessageRepository.is_open_expression()
-    awaiting_platform = SupportCaseMessageRepository.awaiting_platform_expression()
-    statement = (
-        select(
-            ReviewAppealSupportCase,
-            Organization,
-            is_open.label("is_open"),
-            User.email.label("assignee_email"),
-            awaiting_platform.label("awaiting_platform"),
-        )
-        .join(
-            OrganizationReview,
-            ReviewAppealSupportCase.organization_review_id == OrganizationReview.id,
-        )
-        .join(Organization, OrganizationReview.organization_id == Organization.id)
-        .outerjoin(User, ReviewAppealSupportCase.assigned_user_id == User.id)
-        .where(ReviewAppealSupportCase.deleted_at.is_(None))
+    statement = cases_statement(
+        status=status,
+        assigned=assigned,
+        assigned_user_id=user_session.user_id,
+        case_type=type,
+        sort=sort,
     )
-    count_statement = (
-        select(func.count())
-        .select_from(ReviewAppealSupportCase)
-        .where(ReviewAppealSupportCase.deleted_at.is_(None))
-    )
-    if status == "open":
-        statement = statement.where(is_open)
-        count_statement = count_statement.where(is_open)
-    elif status == "closed":
-        statement = statement.where(~is_open)
-        count_statement = count_statement.where(~is_open)
-
-    if assigned == "me":
-        mine = ReviewAppealSupportCase.assigned_user_id == user_session.user_id
-        statement = statement.where(mine)
-        count_statement = count_statement.where(mine)
-    elif assigned == "unassigned":
-        unassigned = ReviewAppealSupportCase.assigned_user_id.is_(None)
-        statement = statement.where(unassigned)
-        count_statement = count_statement.where(unassigned)
-
-    # Opt-in tier sort: highest tier first, recency as the tiebreaker. Default
-    # stays pure recency so an urgent low-tier case is never buried.
-    order_by: tuple[Any, ...]
-    if sort == "tier":
-        order_by = (
-            Organization.support_tier.desc().nullslast(),
-            ReviewAppealSupportCase.created_at.desc(),
+    count = (
+        await session.scalar(
+            select(func.count()).select_from(count_subquery(statement))
         )
-    else:
-        order_by = (ReviewAppealSupportCase.created_at.desc(),)
-
-    count = await session.scalar(count_statement) or 0
+        or 0
+    )
     result = await session.execute(
-        statement.order_by(*order_by)
-        .limit(pagination.limit)
-        .offset((pagination.page - 1) * pagination.limit)
+        statement.limit(pagination.limit).offset(
+            (pagination.page - 1) * pagination.limit
+        )
     )
     rows: Sequence[Row] = result.all()  # type: ignore[assignment]
 
@@ -279,7 +426,9 @@ async def list_cases(
         with tag.div(classes="flex flex-col gap-4"):
             with tag.h1(classes="text-4xl"):
                 text("Cases")
-            with tab_nav(_list_tabs(request, status, assigned, sort)):
+            with tab_nav(_list_tabs(request, status, assigned, sort, type)):
+                pass
+            with tab_nav(_type_tabs(request, status, assigned, sort, type)):
                 pass
             if rows:
                 _render_table(request, rows, sort)

--- a/server/polar/backoffice/support_cases/queries.py
+++ b/server/polar/backoffice/support_cases/queries.py
@@ -1,0 +1,143 @@
+"""Shared query for backoffice support-case lists.
+
+Both the dedicated Cases list and an organization's Support Cases tab read the
+same polymorphic ``SupportCase`` set. The organization is resolved per type:
+appeals link through their review, disputes through their dispute → order.
+"""
+
+from collections.abc import Sequence
+from typing import Any, cast
+from uuid import UUID
+
+from sqlalchemy import Select, func, select
+
+from polar.models import Dispute, Order, Organization, User
+from polar.models.organization_review import OrganizationReview
+from polar.models.support_case import (
+    DisputeSupportCase,
+    ReviewAppealSupportCase,
+    SupportCase,
+    SupportCaseType,
+)
+from polar.support_case.repository import SupportCaseMessageRepository
+
+# (case, organization, is_open, assignee_email, awaiting_platform)
+Row = tuple[SupportCase, Organization, bool, str | None, bool]
+
+# Human-readable label per case type, shared by every case list.
+TYPE_LABELS: dict[SupportCaseType, str] = {
+    SupportCaseType.review_appeal: "Review appeal",
+    SupportCaseType.dispute: "Dispute",
+}
+
+_TYPE_FILTERS = {SupportCaseType.review_appeal.value, SupportCaseType.dispute.value}
+
+
+def cases_statement(
+    *,
+    organization_id: UUID | None = None,
+    status: str = "all",
+    assigned: str = "all",
+    assigned_user_id: UUID | None = None,
+    case_type: str = "all",
+    sort: str = "recency",
+) -> Select[Row]:
+    """Polymorphic case list with its organization, open state and assignee.
+
+    ``status`` (open/closed/all), ``assigned`` (me/unassigned/all) and
+    ``case_type`` (review_appeal/dispute/all) narrow the set; ``sort`` is either
+    pure recency or support tier first with recency as the tiebreaker.
+    """
+    is_open = SupportCaseMessageRepository.is_open_expression()
+    awaiting_platform = SupportCaseMessageRepository.awaiting_platform_expression()
+    statement = (
+        select(
+            SupportCase,
+            Organization,
+            is_open.label("is_open"),
+            User.email.label("assignee_email"),
+            awaiting_platform.label("awaiting_platform"),
+        )
+        .outerjoin(
+            OrganizationReview,
+            ReviewAppealSupportCase.organization_review_id == OrganizationReview.id,
+        )
+        .outerjoin(Dispute, DisputeSupportCase.dispute_id == Dispute.id)
+        .outerjoin(Order, Dispute.order_id == Order.id)
+        .join(
+            Organization,
+            Organization.id
+            == func.coalesce(OrganizationReview.organization_id, Order.organization_id),
+        )
+        .outerjoin(User, SupportCase.assigned_user_id == User.id)
+        .where(SupportCase.deleted_at.is_(None))
+    )
+
+    if organization_id is not None:
+        statement = statement.where(Organization.id == organization_id)
+    if status == "open":
+        statement = statement.where(is_open)
+    elif status == "closed":
+        statement = statement.where(~is_open)
+    if assigned == "me" and assigned_user_id is not None:
+        statement = statement.where(SupportCase.assigned_user_id == assigned_user_id)
+    elif assigned == "unassigned":
+        statement = statement.where(SupportCase.assigned_user_id.is_(None))
+    if case_type in _TYPE_FILTERS:
+        statement = statement.where(SupportCase.type == case_type)
+
+    order_by: tuple[Any, ...]
+    if sort == "tier":
+        order_by = (
+            Organization.support_tier.desc().nullslast(),
+            SupportCase.created_at.desc(),
+        )
+    else:
+        order_by = (SupportCase.created_at.desc(),)
+    # ``assignee_email`` is NULL for unassigned cases (outer join), which the
+    # column type doesn't capture; ``Row`` models it as ``str | None``.
+    return cast("Select[Row]", statement.order_by(*order_by))
+
+
+def open_case_organization_ids(
+    *,
+    organization_ids: Sequence[UUID] | None = None,
+    awaiting_reply: bool = False,
+) -> Select[tuple[UUID]]:
+    """Distinct ids of organizations with at least one open support case of any
+    type. With ``awaiting_reply``, only those whose open case is waiting on a
+    platform reply. ``organization_ids`` narrows the scan to a known page.
+    """
+    organization_id = func.coalesce(
+        OrganizationReview.organization_id, Order.organization_id
+    )
+    statement = (
+        select(organization_id)
+        .select_from(SupportCase)
+        .outerjoin(
+            OrganizationReview,
+            ReviewAppealSupportCase.organization_review_id == OrganizationReview.id,
+        )
+        .outerjoin(Dispute, DisputeSupportCase.dispute_id == Dispute.id)
+        .outerjoin(Order, Dispute.order_id == Order.id)
+        .where(
+            SupportCase.deleted_at.is_(None),
+            SupportCaseMessageRepository.is_open_expression(),
+        )
+        .distinct()
+    )
+    if awaiting_reply:
+        statement = statement.where(
+            SupportCaseMessageRepository.awaiting_platform_expression()
+        )
+    if organization_ids is not None:
+        statement = statement.where(organization_id.in_(organization_ids))
+    return statement
+
+
+__all__ = [
+    "TYPE_LABELS",
+    "Row",
+    "cases_statement",
+    "open_case_organization_ids",
+]

--- a/server/polar/backoffice/support_cases/urls.py
+++ b/server/polar/backoffice/support_cases/urls.py
@@ -1,0 +1,34 @@
+"""URL helpers for support-case pages, shared by the endpoints and the thread
+renderer. Kept import-light (no models/endpoints) to avoid an import cycle."""
+
+from urllib.parse import urlencode
+from uuid import UUID
+
+from fastapi import Request
+
+
+def is_safe_return_to(return_to: str | None) -> bool:
+    """Same-site relative path only, to avoid an open redirect."""
+    return bool(
+        return_to and return_to.startswith("/") and not return_to.startswith("//")
+    )
+
+
+def append_return_to(url: str, return_to: str | None) -> str:
+    """Append a validated ``return_to`` query arg to a URL; a no-op otherwise."""
+    if not is_safe_return_to(return_to):
+        return url
+    separator = "&" if "?" in url else "?"
+    return f"{url}{separator}{urlencode({'return_to': return_to})}"
+
+
+def case_detail_url(
+    request: Request, case_id: UUID, *, return_to: str | None = None
+) -> str:
+    """The case detail page, carrying a validated ``return_to`` so the back link
+    and post-action redirects come back to wherever the staff member started."""
+    url = str(request.url_for("support_cases:detail", case_id=case_id))
+    return append_return_to(url, return_to)
+
+
+__all__ = ["append_return_to", "case_detail_url", "is_safe_return_to"]

--- a/server/polar/support_case/service.py
+++ b/server/polar/support_case/service.py
@@ -1,7 +1,12 @@
 from collections.abc import Sequence
+from uuid import UUID
 
-from polar.models import Customer, File, Organization, User
+from sqlalchemy.orm import joinedload
+
+from polar.models import Customer, Dispute, File, Organization, User
 from polar.models.support_case import (
+    DisputeSupportCase,
+    ReviewAppealSupportCase,
     SupportCase,
     SupportCaseAttachment,
     SupportCaseAudience,
@@ -10,10 +15,13 @@ from polar.models.support_case import (
     SupportCaseMessageType,
     SupportCaseParticipant,
     SupportCaseParticipantKind,
+    SupportCaseType,
 )
-from polar.postgres import AsyncSession
+from polar.postgres import AsyncReadSession, AsyncSession
 
 from .repository import (
+    DisputeSupportCaseRepository,
+    ReviewAppealSupportCaseRepository,
     SupportCaseAttachmentRepository,
     SupportCaseMessageRepository,
     SupportCaseParticipantRepository,
@@ -43,6 +51,30 @@ class SupportCaseService:
             audience=audience,
         )
         return case
+
+    async def get_organization_id(
+        self, session: AsyncSession | AsyncReadSession, case: SupportCase
+    ) -> UUID | None:
+        """The organization that owns a case, resolved through its domain object."""
+        if case.type == SupportCaseType.review_appeal:
+            appeal = await ReviewAppealSupportCaseRepository.from_session(
+                session
+            ).get_by_id(
+                case.id,
+                options=(joinedload(ReviewAppealSupportCase.organization_review),),
+            )
+            return appeal.organization_review.organization_id if appeal else None
+        if case.type == SupportCaseType.dispute:
+            dispute_case = await DisputeSupportCaseRepository.from_session(
+                session
+            ).get_by_id(
+                case.id,
+                options=(
+                    joinedload(DisputeSupportCase.dispute).joinedload(Dispute.order),
+                ),
+            )
+            return dispute_case.dispute.order.organization_id if dispute_case else None
+        return None
 
     async def add_participant(
         self,

--- a/server/polar/support_case/tasks.py
+++ b/server/polar/support_case/tasks.py
@@ -1,7 +1,5 @@
 from uuid import UUID
 
-from sqlalchemy.orm import joinedload
-
 from polar.config import settings
 from polar.email.schemas import (
     SupportCaseOrganizationNewMessageEmail,
@@ -9,14 +7,14 @@ from polar.email.schemas import (
 )
 from polar.email.sender import enqueue_email_template
 from polar.models.support_case import (
-    ReviewAppealSupportCase,
     SupportCaseMessageAuthorKind,
     SupportCaseType,
 )
 from polar.support_case.repository import (
-    ReviewAppealSupportCaseRepository,
     SupportCaseMessageRepository,
+    SupportCaseRepository,
 )
+from polar.support_case.service import support_case as support_case_service
 from polar.user_organization.service import (
     user_organization as user_organization_service,
 )
@@ -49,16 +47,22 @@ async def notify_organization_of_new_message(message_id: UUID) -> None:
         if message.author_kind != SupportCaseMessageAuthorKind.platform:
             return
 
-        case = await ReviewAppealSupportCaseRepository.from_session(session).get_by_id(
-            message.case_id,
-            options=(joinedload(ReviewAppealSupportCase.organization_review),),
+        case = await SupportCaseRepository.from_session(session).get_by_id(
+            message.case_id
         )
         if case is None:
             return
+        # Dispute cases have no merchant-facing thread yet, so an email would
+        # point to a page with nothing to act on. Suppress it until that UI
+        # exists; the message is still recorded on the case. Remove this guard
+        # when the merchant dispute view ships.
+        if case.type == SupportCaseType.dispute:
+            return
+        organization_id = await support_case_service.get_organization_id(session, case)
+        if organization_id is None:
+            return
 
-        members = await user_organization_service.list_by_org(
-            session, case.organization_review.organization_id
-        )
+        members = await user_organization_service.list_by_org(session, organization_id)
         if not members:
             return
         organization = members[0].organization

--- a/server/tests/backoffice/support_cases/test_queries.py
+++ b/server/tests/backoffice/support_cases/test_queries.py
@@ -1,0 +1,202 @@
+"""Tests for the shared backoffice support-case list query — the polymorphic
+join that resolves an organization for both appeal and dispute cases."""
+
+import pytest
+
+from polar.backoffice.support_cases.queries import (
+    Row,
+    cases_statement,
+    open_case_organization_ids,
+)
+from polar.models import Customer, Organization, OrganizationReview, Product
+from polar.models.support_case import (
+    DisputeSupportCase,
+    ReviewAppealSupportCase,
+    SupportCase,
+    SupportCaseAudience,
+    SupportCaseMessage,
+    SupportCaseMessageAuthorKind,
+    SupportCaseMessageType,
+    SupportCaseType,
+)
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import (
+    create_dispute,
+    create_order,
+    create_payment,
+)
+
+
+async def _opened(save_fixture: SaveFixture, case: SupportCase) -> None:
+    await save_fixture(
+        SupportCaseMessage(
+            case_id=case.id,
+            type=SupportCaseMessageType.opened,
+            author_kind=SupportCaseMessageAuthorKind.system,
+            audience=[],
+        )
+    )
+
+
+async def _appeal_case(
+    save_fixture: SaveFixture, organization: Organization
+) -> ReviewAppealSupportCase:
+    review = OrganizationReview(
+        organization_id=organization.id,
+        verdict=OrganizationReview.Verdict.FAIL,
+        risk_score=90.0,
+        violated_sections=[],
+        reason="denied",
+        model_used="test",
+    )
+    await save_fixture(review)
+    case = ReviewAppealSupportCase(organization_review_id=review.id)
+    await save_fixture(case)
+    await _opened(save_fixture, case)
+    return case
+
+
+async def _dispute_case(
+    save_fixture: SaveFixture,
+    organization: Organization,
+    customer: Customer,
+    product: Product,
+) -> DisputeSupportCase:
+    order = await create_order(save_fixture, customer=customer, product=product)
+    payment = await create_payment(save_fixture, organization, order=order)
+    dispute = await create_dispute(save_fixture, order, payment)
+    case = DisputeSupportCase(dispute_id=dispute.id)
+    await save_fixture(case)
+    await _opened(save_fixture, case)
+    return case
+
+
+async def _rows(session: AsyncSession, **kwargs: object) -> list[Row]:
+    result = await session.execute(cases_statement(**kwargs))  # type: ignore[arg-type]
+    return list(result.all())  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+class TestCasesStatement:
+    async def test_returns_both_case_types_for_organization(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        appeal = await _appeal_case(save_fixture, organization)
+        dispute = await _dispute_case(save_fixture, organization, customer, product)
+
+        rows = await _rows(session, organization_id=organization.id)
+
+        by_id = {row[0].id: row for row in rows}
+        assert appeal.id in by_id
+        assert dispute.id in by_id
+        # Each row resolves to the owning organization, regardless of type.
+        for case, org, is_open, _assignee, _awaiting in rows:
+            assert org.id == organization.id
+            assert is_open is True
+        assert by_id[appeal.id][0].type == SupportCaseType.review_appeal
+        assert by_id[dispute.id][0].type == SupportCaseType.dispute
+
+    async def test_type_filter_narrows_to_disputes(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        await _appeal_case(save_fixture, organization)
+        dispute = await _dispute_case(save_fixture, organization, customer, product)
+
+        rows = await _rows(
+            session,
+            organization_id=organization.id,
+            case_type=SupportCaseType.dispute.value,
+        )
+
+        assert [row[0].id for row in rows] == [dispute.id]
+
+    async def test_closed_case_excluded_by_open_status(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        dispute = await _dispute_case(save_fixture, organization, customer, product)
+        await save_fixture(
+            SupportCaseMessage(
+                case_id=dispute.id,
+                type=SupportCaseMessageType.closed,
+                author_kind=SupportCaseMessageAuthorKind.system,
+                audience=[],
+            )
+        )
+
+        open_rows = await _rows(session, organization_id=organization.id, status="open")
+        closed_rows = await _rows(
+            session, organization_id=organization.id, status="closed"
+        )
+
+        assert dispute.id not in [row[0].id for row in open_rows]
+        assert dispute.id in [row[0].id for row in closed_rows]
+
+
+@pytest.mark.asyncio
+class TestOpenCaseOrganizationIds:
+    async def test_includes_org_with_open_dispute_case(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        await _dispute_case(save_fixture, organization, customer, product)
+
+        result = await session.execute(
+            open_case_organization_ids(organization_ids=[organization.id])
+        )
+
+        assert organization.id in set(result.scalars().all())
+
+    async def test_awaiting_reply_requires_merchant_last_message(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        case = await _dispute_case(save_fixture, organization, customer, product)
+
+        # Opened only (lifecycle, no audience): not awaiting a platform reply.
+        result = await session.execute(
+            open_case_organization_ids(
+                organization_ids=[organization.id], awaiting_reply=True
+            )
+        )
+        assert organization.id not in set(result.scalars().all())
+
+        # A merchant-visible message from the merchant flips it to awaiting.
+        await save_fixture(
+            SupportCaseMessage(
+                case_id=case.id,
+                type=SupportCaseMessageType.chat,
+                author_kind=SupportCaseMessageAuthorKind.merchant,
+                body="Here is my evidence.",
+                audience=[SupportCaseAudience.merchant],
+            )
+        )
+        result = await session.execute(
+            open_case_organization_ids(
+                organization_ids=[organization.id], awaiting_reply=True
+            )
+        )
+        assert organization.id in set(result.scalars().all())

--- a/server/tests/backoffice/support_cases/test_urls.py
+++ b/server/tests/backoffice/support_cases/test_urls.py
@@ -1,0 +1,36 @@
+"""Tests for the support-case URL helpers — notably the open-redirect guard on
+``return_to``."""
+
+from polar.backoffice.support_cases.urls import append_return_to, is_safe_return_to
+
+
+class TestIsSafeReturnTo:
+    def test_same_site_relative_path_allowed(self) -> None:
+        assert is_safe_return_to("/backoffice/organizations/1?section=support_case")
+
+    def test_none_and_empty_rejected(self) -> None:
+        assert not is_safe_return_to(None)
+        assert not is_safe_return_to("")
+
+    def test_protocol_relative_and_absolute_rejected(self) -> None:
+        assert not is_safe_return_to("//evil.example.com")
+        assert not is_safe_return_to("https://evil.example.com")
+        assert not is_safe_return_to("javascript:alert(1)")
+
+
+class TestAppendReturnTo:
+    def test_appends_with_question_mark(self) -> None:
+        assert (
+            append_return_to("/cases/abc", "/org/1")
+            == "/cases/abc?return_to=%2Forg%2F1"
+        )
+
+    def test_appends_with_ampersand_when_query_present(self) -> None:
+        assert (
+            append_return_to("/cases/abc?x=1", "/org/1")
+            == "/cases/abc?x=1&return_to=%2Forg%2F1"
+        )
+
+    def test_noop_for_unsafe_return_to(self) -> None:
+        assert append_return_to("/cases/abc", "//evil.example.com") == "/cases/abc"
+        assert append_return_to("/cases/abc", None) == "/cases/abc"

--- a/server/tests/support_case/test_tasks.py
+++ b/server/tests/support_case/test_tasks.py
@@ -6,9 +6,17 @@ from collections.abc import AsyncIterator, Sequence
 import pytest
 from pytest_mock import MockerFixture
 
-from polar.models import Organization, OrganizationReview, UserOrganization
+from polar.models import (
+    Customer,
+    Organization,
+    OrganizationReview,
+    Product,
+    UserOrganization,
+)
 from polar.models.support_case import (
+    DisputeSupportCase,
     ReviewAppealSupportCase,
+    SupportCase,
     SupportCaseAudience,
     SupportCaseMessage,
     SupportCaseMessageAuthorKind,
@@ -17,6 +25,11 @@ from polar.models.support_case import (
 from polar.postgres import AsyncSession
 from polar.support_case.tasks import notify_organization_of_new_message
 from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import (
+    create_dispute,
+    create_order,
+    create_payment,
+)
 
 # Unwrap to bypass the actor decorator (which needs the Dramatiq broker).
 _notify = notify_organization_of_new_message.__wrapped__  # type: ignore[attr-defined]
@@ -44,9 +57,23 @@ async def _appeal_case(
     return case
 
 
+async def _dispute_case(
+    save_fixture: SaveFixture,
+    organization: Organization,
+    customer: Customer,
+    product: Product,
+) -> DisputeSupportCase:
+    order = await create_order(save_fixture, customer=customer, product=product)
+    payment = await create_payment(save_fixture, organization, order=order)
+    dispute = await create_dispute(save_fixture, order, payment)
+    case = DisputeSupportCase(dispute_id=dispute.id)
+    await save_fixture(case)
+    return case
+
+
 async def _message(
     save_fixture: SaveFixture,
-    case: ReviewAppealSupportCase,
+    case: SupportCase,
     *,
     author_kind: SupportCaseMessageAuthorKind,
     audience: Sequence[SupportCaseAudience],
@@ -95,6 +122,34 @@ class TestNotifyOrganization:
         # disconnected Plain thread).
         assert kwargs["from_email_addr"].startswith("noreply@")
         assert kwargs["reply_to_email_addr"] is None
+
+    async def test_suppresses_dispute_case_until_merchant_ui(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+        user_organization: UserOrganization,
+    ) -> None:
+        # No merchant-facing dispute thread yet, so its emails are gated off.
+        case = await _dispute_case(save_fixture, organization, customer, product)
+        message = await _message(
+            save_fixture,
+            case,
+            author_kind=SupportCaseMessageAuthorKind.platform,
+            audience=[SupportCaseAudience.merchant],
+        )
+        enqueue = mocker.patch("polar.support_case.tasks.enqueue_email_template")
+        mocker.patch(
+            "polar.support_case.tasks.AsyncSessionMaker",
+            return_value=_session_maker(session),
+        )
+
+        await _notify(message.id)
+
+        enqueue.assert_not_called()
 
     async def test_skips_non_staff_message(
         self,


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/84269dab-9069-4fbe-9818-ad88c7caca3c


<!-- Brief description of what this PR does -->

## What

Instead of directly displaying the appeal case in the org page, displays a list of cases and add a specific case page.
Customize UI depending on case type (i.e. dispute has no "accept" / "deny" button)

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backoffice now handles all support case types (appeals and disputes) end to end with a shared case detail page and unified lists. The org page gets a “Support Cases” tab that links into the new detail, and actions preserve the user’s origin via `return_to`.

- **New Features**
  - New case detail page at `/backoffice/support-cases/{case_id}` renders any case thread, supports assignment and staff replies; approve/deny actions show only for appeals, with a smart back link to the org or case list.
  - Organization “Support Cases” tab lists all cases (appeals + disputes) with status, assignee, “awaiting reply,” and opened date; each links to the detail page. The nav dot lights up when any case is open.
  - Global Cases list adds a Type filter (All/Appeals/Disputes) and type badges; Tier/Recency sort retained; rows link to the detail page.

- **Refactors**
  - Added polymorphic query `cases_statement` and `open_case_organization_ids`; used by org pages, lists, and open-case counts.
  - Replaced org-scoped reply route with generic `support_cases:reply`; actions/dialogs use `return_to` via `case_detail_url`/`append_return_to` with an open-redirect guard.
  - Service resolves the owning organization for any case via `get_organization_id`; dispute notification emails are suppressed until merchant UI exists. Added tests for queries, URLs, and tasks.

<sup>Written for commit 4efc432173da3896e6fb40cef544a63a86427fb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

