### PR TITLE
fix(oauth2): default clients without default_sub_type to user-scoped tokens

### DIFF
--- a/server/polar/models/oauth2_client.py
+++ b/server/polar/models/oauth2_client.py
@@ -36,4 +36,4 @@ class OAuth2Client(RateLimitGroupMixin, RecordModel, OAuth2ClientMixin):
         try:
             return SubType(self.client_metadata["default_sub_type"])
         except KeyError:
-            return SubType.organization
+            return SubType.user

--- a/server/tests/oauth2/endpoints/test_oauth2.py
+++ b/server/tests/oauth2/endpoints/test_oauth2.py
@@ -450,6 +450,36 @@ class TestOAuth2Authorize:
         assert json["sub_type"] == expected_sub_type
 
     @pytest.mark.auth
+    async def test_dynamically_registered_client_defaults_to_user(
+        self, client: AsyncClient
+    ) -> None:
+        """`default_sub_type` is not an RFC 7591 registered claim, so it's
+        stripped from the metadata of dynamically-registered clients. The
+        authorize flow must then fall back to a user-scoped grant instead of
+        forcing organization selection."""
+        register_response = await client.post(
+            "/v1/oauth2/register",
+            json={
+                "client_name": "Test DCR Client",
+                "redirect_uris": ["https://example.com/callback"],
+                "scope": "openid profile email",
+            },
+        )
+        assert register_response.status_code == 201
+        client_id = register_response.json()["client_id"]
+
+        params = {
+            "client_id": client_id,
+            "response_type": "code",
+            "redirect_uri": "https://example.com/callback",
+            "scope": "openid profile email",
+        }
+        response = await client.get("/v1/oauth2/authorize", params=params)
+
+        assert response.status_code == 200
+        assert response.json()["sub_type"] == "user"
+
+    @pytest.mark.auth
     async def test_authenticated_prompt_login(
         self, client: AsyncClient, oauth2_client: OAuth2Client
     ) -> None:


### PR DESCRIPTION
## Problem

Newly dynamically-registered (DCR) OAuth2 clients — e.g. the Claude.ai MCP connector — were forcing **organization selection** on admins/owners and **organization creation** on members during the authorize flow, instead of issuing a user-scoped token.

Root cause: `default_sub_type` is not an RFC 7591 registered claim, so authlib's `ClientRegistrationEndpoint` strips it from `client_metadata` on every registration (DCR *and* dashboard). The persisted metadata never contains the key, so `OAuth2Client.default_sub_type`'s `KeyError` fallback is the *effective* default for every newly-registered client — and it was still `organization`.

This is why #12415 (which changed the Pydantic schema default to `user`) had **no runtime effect**: that value is stripped before it reaches `client_metadata`. The earlier 2025-10-16 migration had already backfilled existing clients to `user`; only the fallback for new clients remained `organization`.

## Fix

Flip the model-property fallback to `SubType.user`, aligning it with #12415's intent and the migration:

```python
# server/polar/models/oauth2_client.py
except KeyError:
    return SubType.user  # was SubType.organization
```

#12415's schema/docs/generated-client changes are kept as-is — they already declare `user` and are now consistent with actual behavior.

## Test

Added `TestOAuth2Authorize.test_dynamically_registered_client_defaults_to_user`, which exercises the real DCR path end-to-end: register a client via `POST /v1/oauth2/register` (authlib strips `default_sub_type`), then `GET /v1/oauth2/authorize` with no `sub_type` and assert the grant resolves to `sub_type == "user"`.

Verified it's a genuine guard: it **fails** with the fallback reverted to `organization` and **passes** with the fix. (The existing `test_authenticated[None → organization]` case uses a fixture that sets `default_sub_type` explicitly, so it never covered the missing-key fallback that caused this bug.)

## Checks

- `uv run pytest tests/oauth2/` → 110 passed
- `uv run task lint_types` → no issues (1414 files)
- `uv run task lint` → all checks passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default newly registered OAuth2 clients without `default_sub_type` to user-scoped tokens, fixing the authorize flow that was forcing org selection or creation for DCR clients. This affects integrations like the Claude.ai MCP connector and restores the intended user-scoped behavior.

- **Bug Fixes**
  - Fallback in `OAuth2Client.default_sub_type` now returns `SubType.user` when `client_metadata` lacks `default_sub_type` (stripped by `authlib` per RFC 7591).
  - Added end-to-end test `test_dynamically_registered_client_defaults_to_user` to cover the DCR path and prevent regressions.

<sup>Written for commit ccaee9e598bc9862f95b8834cd20dc6f17e787e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

