### PR TITLE
Make user notification settings non-nullable (migration only)

### DIFF
--- a/server/migrations/versions/2026-06-17-1200_make_user_organization_notification_non_nullable.py
+++ b/server/migrations/versions/2026-06-17-1200_make_user_organization_notification_non_nullable.py
@@ -1,0 +1,94 @@
+"""make user_organization.notification_settings non-nullable and drop organization.notification_settings
+
+Revision ID: c4e1a9f3b2d7
+Revises: 7a3f0b9c2d1e
+Create Date: 2026-06-17 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "c4e1a9f3b2d7"
+down_revision = "7a3f0b9c2d1e"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '5s'")
+
+    # Safety net: production rows are backfilled out-of-band by
+    # `scripts/backfill_user_organization_notification_settings.py` before this
+    # migration runs. This inline UPDATE covers any rows that script missed
+    # (fresh/local/CI/sandbox), copying the value down from the organization so
+    # the NOT NULL validation below can't trip on lingering NULLs. Idempotent —
+    # a no-op once the backfill has already run.
+    op.execute(
+        """
+        UPDATE user_organizations uo
+            SET notification_settings = o.notification_settings
+            FROM organizations o
+            WHERE uo.organization_id = o.id
+              AND uo.notification_settings IS NULL
+        """
+    )
+
+    # Use the NOT VALID / VALIDATE pattern to avoid a full-table ACCESS EXCLUSIVE
+    # lock when setting NOT NULL.
+    #
+    # Step 1: add the check constraint as NOT VALID — takes only SHARE UPDATE
+    #         EXCLUSIVE, so concurrent reads and writes are unblocked.
+    op.execute(
+        """
+        ALTER TABLE user_organizations
+            ADD CONSTRAINT user_organizations_notification_settings_not_null
+            CHECK (notification_settings IS NOT NULL) NOT VALID
+        """
+    )
+
+    # Step 2: validate the constraint — also SHARE UPDATE EXCLUSIVE. Postgres
+    #         scans the table for violations here, but concurrent DML is still
+    #         allowed (it must simply not introduce new NULLs).
+    op.execute(
+        """
+        ALTER TABLE user_organizations
+            VALIDATE CONSTRAINT user_organizations_notification_settings_not_null
+        """
+    )
+
+    # Step 3: set NOT NULL — because a validated check constraint already proves
+    #         no NULLs exist, Postgres 12+ skips the full table scan and holds
+    #         ACCESS EXCLUSIVE for only a very short time.
+    op.alter_column(
+        "user_organizations",
+        "notification_settings",
+        existing_type=postgresql.JSONB(astext_type=sa.Text()),
+        nullable=False,
+    )
+
+    # Step 4: the check constraint is now redundant — the NOT NULL column
+    #         constraint takes over.
+    op.execute(
+        """
+        ALTER TABLE user_organizations
+            DROP CONSTRAINT user_organizations_notification_settings_not_null
+        """
+    )
+
+
+def downgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '5s'")
+
+    op.alter_column(
+        "user_organizations",
+        "notification_settings",
+        existing_type=postgresql.JSONB(astext_type=sa.Text()),
+        nullable=True,
+    )

--- a/server/polar/models/user_organization.py
+++ b/server/polar/models/user_organization.py
@@ -18,7 +18,6 @@ class OrganizationRole(StrEnum):
     member = "member"
 
 
-# duplicated from Organization.notification_settings, (will be cleaned up in a future PR)
 class OrganizationNotificationSettings(TypedDict):
     new_order: bool
     new_subscription: bool
@@ -62,7 +61,7 @@ class UserOrganization(TimestampedModel):
     )
 
     notification_settings: Mapped[OrganizationNotificationSettings] = mapped_column(
-        JSONB, nullable=True, default=_default_notification_settings
+        JSONB, nullable=False, default=_default_notification_settings
     )
 
     @declared_attr


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make `user_organizations.notification_settings` non-nullable with a safe, low-lock migration. The model now enforces `nullable=False` with a default to keep writes consistent.

- **Migration**
  - Inline backfill from `organizations.notification_settings` for any NULLs; assumes an external backfill ran, covers misses.
  - Add a NOT VALID CHECK, validate it, then set NOT NULL; drop the temporary CHECK.
  - Set `lock_timeout` to 5s to reduce lock contention.
  - Update `UserOrganization.notification_settings` to `nullable=False` with `_default_notification_settings`.

<sup>Written for commit d21d9d086945abb46aeeaec2967889cf712bc695. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

