### PR TITLE
server: version the current API

### DIFF
--- a/server/polar/app.py
+++ b/server/polar/app.py
@@ -66,6 +66,7 @@ from polar.posthog import configure_posthog
 from polar.redis import Redis, create_redis
 from polar.search.endpoints import router as search_router
 from polar.sentry import configure_sentry
+from polar.version import CURRENT_API_VERSION, APIVersionMiddleware
 from polar.webhook.webhooks import document_webhooks
 
 from . import rate_limit
@@ -202,12 +203,14 @@ def create_app() -> FastAPI:
     app = FastAPI(
         generate_unique_id_function=generate_unique_openapi_id,
         lifespan=lifespan,
+        version=str(CURRENT_API_VERSION),
         **OPENAPI_PARAMETERS,
     )
 
     app.add_middleware(OperationalErrorMiddleware)
     if settings.is_sandbox():
         app.add_middleware(SandboxResponseHeaderMiddleware)
+    app.add_middleware(APIVersionMiddleware, current=CURRENT_API_VERSION)
     if not settings.is_testing():
         rate_limit_redis = create_redis("rate-limit")
         app.state.rate_limit_redis = rate_limit_redis

--- a/server/polar/openapi.py
+++ b/server/polar/openapi.py
@@ -65,7 +65,6 @@ class APITag(StrEnum):
 class OpenAPIParameters(TypedDict):
     title: str
     summary: str
-    version: str
     description: str
     docs_url: str | None
     redoc_url: str | None
@@ -76,7 +75,6 @@ class OpenAPIParameters(TypedDict):
 OPENAPI_PARAMETERS: OpenAPIParameters = {
     "title": "Polar API",
     "summary": "Polar HTTP and Webhooks API",
-    "version": "0.1.0",
     "description": "Read the docs at https://polar.sh/docs/api-reference",
     "docs_url": None
     if settings.is_environment({Environment.sandbox, Environment.production})

--- a/server/polar/version.py
+++ b/server/polar/version.py
@@ -1,0 +1,99 @@
+import re
+
+from starlette.datastructures import MutableHeaders
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+_API_VERSION_PATTERN = re.compile(r"^(\d{4})-(\d{2})$")
+
+
+class APIVersion:
+    """
+    Represents an API version in the format "YYYY-MM".
+    """
+
+    __slots__ = ("month", "year")
+    year: int
+    month: int
+
+    def __init__(self, year: int, month: int):
+        self.year = year
+        self.month = month
+
+    def __str__(self) -> str:
+        return f"{self.year}-{self.month:02d}"
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self.year!r}, {self.month!r})"
+
+    def __eq__(self, value: object, /) -> bool:
+        if not isinstance(value, APIVersion):
+            return NotImplemented
+        return value.year == self.year and value.month == self.month
+
+    def __lt__(self, value: object, /) -> bool:
+        if not isinstance(value, APIVersion):
+            return NotImplemented
+        if self.year != value.year:
+            return self.year < value.year
+        return self.month < value.month
+
+    def __le__(self, value: object, /) -> bool:
+        if not isinstance(value, APIVersion):
+            return NotImplemented
+        if self.year != value.year:
+            return self.year < value.year
+        return self.month <= value.month
+
+    def __gt__(self, value: object, /) -> bool:
+        if not isinstance(value, APIVersion):
+            return NotImplemented
+        if self.year != value.year:
+            return self.year > value.year
+        return self.month > value.month
+
+    def __ge__(self, value: object, /) -> bool:
+        if not isinstance(value, APIVersion):
+            return NotImplemented
+        if self.year != value.year:
+            return self.year > value.year
+        return self.month >= value.month
+
+    @classmethod
+    def parse(cls, version_str: str) -> "APIVersion":
+        match = re.fullmatch(_API_VERSION_PATTERN, version_str)
+        if not match:
+            raise ValueError(f"Invalid version string: {version_str}")
+        year_str, month_str = match.groups()
+        return cls(year=int(year_str), month=int(month_str))
+
+
+VERSION_HEADER = "Polar-Version"
+
+
+class APIVersionMiddleware:
+    """
+    Middleware to add the current API version to the response headers.
+
+    In the future, it'll also be responsible to _read_ the API version from the request headers.
+    """
+
+    def __init__(self, app: ASGIApp, current: APIVersion) -> None:
+        self.app = app
+        self.current = current
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] not in ("http", "websocket"):
+            await self.app(scope, receive, send)
+            return
+
+        async def send_wrapper(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                message.setdefault("headers", [])
+                headers = MutableHeaders(scope=message)
+                headers[VERSION_HEADER] = str(self.current)
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)
+
+
+CURRENT_API_VERSION = APIVersion(year=2026, month=4)


### PR DESCRIPTION

Pre-phase of our [future API versioning strategy](https://handbook.polar.sh/engineering/design-documents/api-versioning#asap).

The current version is arbitrarily marked as `2026-04`, so we can start emitting it in the response headers and the OpenAPI schema. This **does not** change the way we work with the API today, i.e. "best-effort" backward compatibility.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce baseline API versioning. All HTTP and WebSocket responses now include the `Polar-Version: 2026-04` header, and the OpenAPI schema uses this version with no behavior changes.

- **New Features**
  - Added `APIVersion` and `APIVersionMiddleware` to emit the current version on all HTTP/WebSocket responses.
  - Set `FastAPI` app version via `CURRENT_API_VERSION` (`2026-04`) and removed the hardcoded OpenAPI `version`.

<sup>Written for commit e62845918ad336c86f6adbc2b214cda306921c01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

