### PR TITLE
feat(appeal-case): all paths close the case

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -6943,6 +6943,17 @@ export interface components {
      * @enum {string}
      */
     AppealDecision: 'approved' | 'rejected'
+    /** AppealNotRejectedError */
+    AppealNotRejectedError: {
+      /**
+       * Error
+       * @example AppealNotRejectedError
+       * @constant
+       */
+      error: 'AppealNotRejectedError'
+      /** Detail */
+      detail: string
+    }
     /**
      * AttachedCustomField
      * @description Schema of a custom field attached to a resource.
@@ -35804,7 +35815,9 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['CaseAlreadyExistsError']
+          'application/json':
+            | components['schemas']['AppealNotRejectedError']
+            | components['schemas']['CaseAlreadyExistsError']
         }
       }
       /** @description Validation Error */

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -35798,7 +35798,7 @@ export interface operations {
           'application/json': components['schemas']['ResourceNotFound']
         }
       }
-      /** @description A human-review case already exists for this review. */
+      /** @description The appeal has not been rejected, or a human-review case already exists for this review. */
       409: {
         headers: {
           [name: string]: unknown

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -1661,8 +1661,11 @@ async def appeal_case_approve_dialog(
     if request.method == "POST":
         form_data = await request.form()
         reason = str(form_data.get("reason", "")).strip() or None
+        message_repository = SupportCaseMessageRepository.from_session(session)
         if not reason:
             error_message = "A reason is required to approve the appeal."
+        elif not await message_repository.is_open(case.id):
+            error_message = "This appeal case is already closed."
         else:
             review_repo = OrganizationReviewRepository.from_session(session)
             try:

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -1534,8 +1534,10 @@ async def deny_appeal_dialog(
             reason=reason,
         )
 
-        # Deny the appeal
-        await organization_service.deny_appeal(session, organization)
+        # Deny the appeal (also closes any open appeal case as denied)
+        await organization_service.deny_appeal(
+            session, organization, staff_user=user_session.user, reason=reason
+        )
 
         return HXRedirectResponse(
             request,

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -1395,7 +1395,11 @@ async def approve_denied_dialog(
 
             # Approve the organization
             await organization_service.backoffice_approve(
-                session, organization, threshold, reason=override_reason
+                session,
+                organization,
+                threshold,
+                reason=override_reason,
+                staff_user=user_session.user,
             )
 
             return HXRedirectResponse(
@@ -1672,13 +1676,7 @@ async def appeal_case_approve_dialog(
                     organization,
                     reason=reason,
                     internal_note="Appeal approved — see support case.",
-                )
-                await appeal_case_service.record_decision(
-                    session,
-                    case,
-                    approved=True,
                     staff_user=user_session.user,
-                    reason=reason,
                 )
             except (OrganizationError, AppealCaseError) as e:
                 # Discard the recorded decision so a failure can't commit
@@ -1874,7 +1872,11 @@ async def unblock_approve_dialog(
 
             # Approve the organization
             await organization_service.backoffice_approve(
-                session, organization, threshold, reason=override_reason
+                session,
+                organization,
+                threshold,
+                reason=override_reason,
+                staff_user=user_session.user,
             )
 
             return HXRedirectResponse(

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -66,6 +66,7 @@ from polar.organization.repository import (
     OrganizationReviewRepository,
 )
 from polar.organization_review.appeal_case import (
+    AppealNotRejectedError,
     CaseAlreadyExistsError,
     CaseClosedError,
 )
@@ -758,7 +759,7 @@ async def submit_appeal(
                 "The appeal has not been rejected, or a human-review case "
                 "already exists for this review."
             ),
-            "model": CaseAlreadyExistsError.schema(),
+            "model": AppealNotRejectedError.schema() | CaseAlreadyExistsError.schema(),
         },
     },
     tags=[APITag.private],

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -754,7 +754,10 @@ async def submit_appeal(
         200: {"description": "Human review case opened."},
         404: SupportCaseNotFound,
         409: {
-            "description": "A human-review case already exists for this review.",
+            "description": (
+                "The appeal has not been rejected, or a human-review case "
+                "already exists for this review."
+            ),
             "model": CaseAlreadyExistsError.schema(),
         },
     },

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -59,6 +59,9 @@ from polar.models.webhook_endpoint import WebhookEventType
 from polar.organization_access_token.repository import (
     OrganizationAccessTokenRepository,
 )
+from polar.organization_review.appeal_case import (
+    appeal_case as appeal_case_service,
+)
 from polar.organization_review.repository import (
     OrganizationReviewRepository as AgentReviewRepository,
 )
@@ -1210,6 +1213,7 @@ class OrganizationService:
         *,
         reason: str,
         internal_note: str | None = None,
+        staff_user: User | None = None,
     ) -> Organization:
         """Backoffice override to re-activate a DENIED or BLOCKED organization.
 
@@ -1219,7 +1223,10 @@ class OrganizationService:
         complete, otherwise to CREATED.
 
         If a review with a submitted appeal exists, the appeal is recorded as
-        APPROVED so the merchant's frontend reflects the approval.
+        APPROVED so the merchant's frontend reflects the approval. When
+        ``staff_user`` is given, any open appeal support case is also closed as
+        approved (decision message + merchant notification) — so every approval
+        entry point keeps the case in sync, not just the dedicated one.
 
         ``internal_note`` overrides the default reactivation note (and omits the
         reason line) so callers can record a context-specific note instead — the
@@ -1238,14 +1245,18 @@ class OrganizationService:
 
         review_repository = OrganizationReviewRepository.from_session(session)
         review = await review_repository.get_by_organization(organization.id)
-        if (
-            review
-            and review.appeal_submitted_at
-            and review.appeal_decision != OrganizationReview.AppealDecision.APPROVED
-        ):
-            review.appeal_decision = OrganizationReview.AppealDecision.APPROVED
-            review.appeal_reviewed_at = datetime.now(UTC)
-            session.add(review)
+        if review is not None:
+            if (
+                review.appeal_submitted_at
+                and review.appeal_decision != OrganizationReview.AppealDecision.APPROVED
+            ):
+                review.appeal_decision = OrganizationReview.AppealDecision.APPROVED
+                review.appeal_reviewed_at = datetime.now(UTC)
+                session.add(review)
+            if staff_user is not None:
+                await appeal_case_service.approve_open_case(
+                    session, review, staff_user=staff_user, reason=reason
+                )
 
         note = (
             internal_note if internal_note is not None else notes[organization.status]

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1953,9 +1953,19 @@ class OrganizationService:
         return review
 
     async def deny_appeal(
-        self, session: AsyncSession, organization: Organization
+        self,
+        session: AsyncSession,
+        organization: Organization,
+        *,
+        staff_user: User | None = None,
+        reason: str | None = None,
     ) -> OrganizationReview:
-        """Deny an organization's appeal and keep payment access blocked."""
+        """Deny an organization's appeal and keep payment access blocked.
+
+        When ``staff_user`` is given, any open appeal support case is also
+        closed as denied — the denial twin of ``backoffice_approve``, so no
+        deny path can resolve the appeal while leaving the case open.
+        """
 
         repository = OrganizationReviewRepository.from_session(session)
         review = await repository.get_by_organization(organization.id)
@@ -1973,6 +1983,11 @@ class OrganizationService:
         review.appeal_reviewed_at = datetime.now(UTC)
 
         session.add(review)
+
+        if staff_user is not None:
+            await appeal_case_service.deny_open_case(
+                session, review, staff_user=staff_user, reason=reason
+            )
 
         return review
 

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1213,7 +1213,7 @@ class OrganizationService:
         *,
         reason: str,
         internal_note: str | None = None,
-        staff_user: User | None = None,
+        staff_user: User,
     ) -> Organization:
         """Backoffice override to re-activate a DENIED or BLOCKED organization.
 
@@ -1222,11 +1222,9 @@ class OrganizationService:
         an appeal). Synchronously transitions to ACTIVE if onboarding is
         complete, otherwise to CREATED.
 
-        If a review with a submitted appeal exists, the appeal is recorded as
-        APPROVED so the merchant's frontend reflects the approval. When
-        ``staff_user`` is given, any open appeal support case is also closed as
-        approved (decision message + merchant notification) — so every approval
-        entry point keeps the case in sync, not just the dedicated one.
+        If a review with a submitted appeal exists, the appeal is recorded
+        as APPROVED so the merchant's frontend reflects it, and any open appeal
+        support case is closed as approved
 
         ``internal_note`` overrides the default reactivation note (and omits the
         reason line) so callers can record a context-specific note instead — the
@@ -1253,10 +1251,9 @@ class OrganizationService:
                 review.appeal_decision = OrganizationReview.AppealDecision.APPROVED
                 review.appeal_reviewed_at = datetime.now(UTC)
                 session.add(review)
-            if staff_user is not None:
-                await appeal_case_service.approve_open_case(
-                    session, review, staff_user=staff_user, reason=reason
-                )
+            await appeal_case_service.approve_open_case(
+                session, review, staff_user=staff_user, reason=reason
+            )
 
         note = (
             internal_note if internal_note is not None else notes[organization.status]
@@ -1962,9 +1959,11 @@ class OrganizationService:
     ) -> OrganizationReview:
         """Deny an organization's appeal and keep payment access blocked.
 
-        When ``staff_user`` is given, any open appeal support case is also
-        closed as denied — the denial twin of ``backoffice_approve``, so no
-        deny path can resolve the appeal while leaving the case open.
+        With ``staff_user`` (the backoffice deny dialog), any open appeal
+        support case is also closed as denied — the denial twin of
+        ``backoffice_approve``, so no deny path resolves the appeal while
+        leaving the case open. The automated AI appeal task calls this without
+        a ``staff_user`` (no human actor, and no case exists at that point).
         """
 
         repository = OrganizationReviewRepository.from_session(session)

--- a/server/polar/organization_review/appeal_case.py
+++ b/server/polar/organization_review/appeal_case.py
@@ -145,10 +145,33 @@ class AppealCaseService:
             "support_case.notify_organization_of_new_message", message_id=message.id
         )
         # This records the decision on the case only. The caller drives org
-        # state: approve via organization.backoffice_approve (built to override
-        # a denial after the AI rejected the appeal); deny needs no change, as
+        # state: approve goes through organization.backoffice_approve, which
+        # closes the case via approve_open_case; deny needs no org change, as
         # the org is already denied.
         return message
+
+    async def approve_open_case(
+        self,
+        session: AsyncSession,
+        review: OrganizationReview,
+        *,
+        staff_user: User,
+        reason: str | None = None,
+    ) -> SupportCaseMessage | None:
+        """Close the review's appeal case as approved, if one is open.
+
+        No-op when there's no case or it is already closed, so any approval
+        path can call it idempotently to keep the case in sync with the org.
+        """
+        case = await self.get_case(session, review)
+        if case is None:
+            return None
+        message_repository = SupportCaseMessageRepository.from_session(session)
+        if not await message_repository.is_open(case.id):
+            return None
+        return await self.record_decision(
+            session, case, approved=True, staff_user=staff_user, reason=reason
+        )
 
     async def get_case(
         self, session: AsyncSession | AsyncReadSession, review: OrganizationReview

--- a/server/polar/organization_review/appeal_case.py
+++ b/server/polar/organization_review/appeal_case.py
@@ -39,6 +39,15 @@ class CaseClosedError(AppealCaseError):
         super().__init__(f"Case {case_id} is closed.", 409)
 
 
+class AppealNotRejectedError(AppealCaseError):
+    def __init__(self, organization_review_id: UUID) -> None:
+        super().__init__(
+            f"Review {organization_review_id} has no rejected appeal to escalate "
+            "to human review.",
+            409,
+        )
+
+
 class AppealCaseService:
     async def request_human_review(
         self,
@@ -49,6 +58,11 @@ class AppealCaseService:
         reason: str,
         requested_by_user: User,
     ) -> ReviewAppealSupportCase:
+        # A human-review case only makes sense once the AI rejected the appeal.
+        # The frontend gates on this; enforce it here too so a direct API call
+        # can't open a case while the appeal is pending or approved.
+        if review.appeal_decision != OrganizationReview.AppealDecision.REJECTED:
+            raise AppealNotRejectedError(review.id)
         if await self.get_case(session, review) is not None:
             raise CaseAlreadyExistsError(review.id)
 

--- a/server/polar/organization_review/appeal_case.py
+++ b/server/polar/organization_review/appeal_case.py
@@ -158,10 +158,36 @@ class AppealCaseService:
         staff_user: User,
         reason: str | None = None,
     ) -> SupportCaseMessage | None:
-        """Close the review's appeal case as approved, if one is open.
+        """Close the review's appeal case as approved, if one is open."""
+        return await self._decide_open_case(
+            session, review, approved=True, staff_user=staff_user, reason=reason
+        )
 
-        No-op when there's no case or it is already closed, so any approval
-        path can call it idempotently to keep the case in sync with the org.
+    async def deny_open_case(
+        self,
+        session: AsyncSession,
+        review: OrganizationReview,
+        *,
+        staff_user: User,
+        reason: str | None = None,
+    ) -> SupportCaseMessage | None:
+        """Close the review's appeal case as denied, if one is open."""
+        return await self._decide_open_case(
+            session, review, approved=False, staff_user=staff_user, reason=reason
+        )
+
+    async def _decide_open_case(
+        self,
+        session: AsyncSession,
+        review: OrganizationReview,
+        *,
+        approved: bool,
+        staff_user: User,
+        reason: str | None = None,
+    ) -> SupportCaseMessage | None:
+        """Record an appeal decision on the review's case and close it, if a
+        case is open. No-op when there's no case or it is already closed, so any
+        approve/deny path can call it idempotently to keep the case in sync.
         """
         case = await self.get_case(session, review)
         if case is None:
@@ -170,7 +196,7 @@ class AppealCaseService:
         if not await message_repository.is_open(case.id):
             return None
         return await self.record_decision(
-            session, case, approved=True, staff_user=staff_user, reason=reason
+            session, case, approved=approved, staff_user=staff_user, reason=reason
         )
 
     async def get_case(

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1445,23 +1445,25 @@ class TestBackofficeApprove:
         self,
         session: AsyncSession,
         organization: Organization,
+        user: User,
     ) -> None:
         organization.status = OrganizationStatus.REVIEW
 
         with pytest.raises(OrganizationError, match="DENIED or BLOCKED"):
             await organization_service.backoffice_approve(
-                session, organization, reason="Test"
+                session, organization, reason="Test", staff_user=user
             )
 
     async def test_reverts_to_created_when_not_activation_ready(
         self,
         session: AsyncSession,
         organization: Organization,
+        user: User,
     ) -> None:
         organization.status = OrganizationStatus.DENIED
 
         await organization_service.backoffice_approve(
-            session, organization, reason="Support escalation"
+            session, organization, reason="Support escalation", staff_user=user
         )
 
         assert organization.status == OrganizationStatus.CREATED
@@ -1470,6 +1472,7 @@ class TestBackofficeApprove:
         self,
         session: AsyncSession,
         organization: Organization,
+        user: User,
     ) -> None:
         """Support-contact escalation: AI rejected the appeal, admin overrides."""
         organization.status = OrganizationStatus.DENIED
@@ -1491,7 +1494,7 @@ class TestBackofficeApprove:
         await session.flush()
 
         await organization_service.backoffice_approve(
-            session, organization, 15000, reason="Appeal re-examined"
+            session, organization, 15000, reason="Appeal re-examined", staff_user=user
         )
 
         assert organization.status == OrganizationStatus.CREATED
@@ -4048,13 +4051,18 @@ class TestStatusTransitions:
         mocker: MockerFixture,
         session: AsyncSession,
         organization: Organization,
+        user: User,
     ) -> None:
         organization.status = current
         organization.initially_reviewed_at = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
         mocker.patch("polar.organization.service.enqueue_job")
 
         result = await organization_service.backoffice_approve(
-            session, organization, 15000, reason="Merchant provided additional docs"
+            session,
+            organization,
+            15000,
+            reason="Merchant provided additional docs",
+            staff_user=user,
         )
 
         assert result.status == OrganizationStatus.CREATED
@@ -4068,6 +4076,7 @@ class TestStatusTransitions:
         mocker: MockerFixture,
         session: AsyncSession,
         organization: Organization,
+        user: User,
     ) -> None:
         organization.status = OrganizationStatus.DENIED
         organization.initially_reviewed_at = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
@@ -4078,6 +4087,7 @@ class TestStatusTransitions:
             organization,
             reason="Lives on the support case, not the note",
             internal_note="Appeal approved — see support case.",
+            staff_user=user,
         )
 
         assert result.internal_notes is not None
@@ -4120,7 +4130,11 @@ class TestStatusTransitions:
         mocker.patch("polar.organization.service.enqueue_job")
 
         result = await organization_service.backoffice_approve(
-            session, organization, 15000, reason="Merchant provided additional docs"
+            session,
+            organization,
+            15000,
+            reason="Merchant provided additional docs",
+            staff_user=user,
         )
 
         assert result.status == OrganizationStatus.ACTIVE

--- a/server/tests/organization_review/test_appeal_case_decision.py
+++ b/server/tests/organization_review/test_appeal_case_decision.py
@@ -141,6 +141,36 @@ class TestApproveDecision:
         assert organization.status != OrganizationStatus.DENIED
         assert review.appeal_decision == OrganizationReview.AppealDecision.APPROVED
 
+    async def test_approve_open_case_is_noop_on_closed_case(
+        self,
+        session: AsyncSession,
+        denied_review_with_case: tuple[
+            Organization, OrganizationReview, ReviewAppealSupportCase
+        ],
+        user: User,
+    ) -> None:
+        # Once the case is closed (here, denied), approving must not write a
+        # conflicting decision onto it — it's a no-op, so no inconsistent
+        # approved-message-on-a-denied-case record is created.
+        _organization, review, case = denied_review_with_case
+        await appeal_case_service.deny_open_case(
+            session, review, staff_user=user, reason="Denied."
+        )
+        message_repository = SupportCaseMessageRepository.from_session(session)
+        assert await message_repository.is_open(case.id) is False
+
+        result = await appeal_case_service.approve_open_case(
+            session, review, staff_user=user, reason="Override."
+        )
+
+        assert result is None
+        messages = await message_repository.list_by_case(
+            case.id, visible_to=SupportCaseAudience.merchant
+        )
+        assert not [
+            m for m in messages if m.type == SupportCaseMessageType.appeal_approved
+        ]
+
     async def test_approve_appeal_would_reject_already_reviewed(
         self,
         session: AsyncSession,

--- a/server/tests/organization_review/test_appeal_case_decision.py
+++ b/server/tests/organization_review/test_appeal_case_decision.py
@@ -208,3 +208,28 @@ class TestDenyDecision:
             await appeal_case_service.record_decision(
                 session, case, approved=True, staff_user=user, reason="oops"
             )
+
+    async def test_deny_open_case_closes_open_case(
+        self,
+        session: AsyncSession,
+        denied_review_with_case: tuple[
+            Organization, OrganizationReview, ReviewAppealSupportCase
+        ],
+        user: User,
+    ) -> None:
+        # The deny twin of approve_open_case: keeps the case in sync on any
+        # deny path, like backoffice_approve does for approval.
+        _organization, review, case = denied_review_with_case
+
+        await appeal_case_service.deny_open_case(
+            session, review, staff_user=user, reason="Still doesn't meet policy."
+        )
+
+        message_repository = SupportCaseMessageRepository.from_session(session)
+        assert await message_repository.is_open(case.id) is False
+        merchant_messages = await message_repository.list_by_case(
+            case.id, visible_to=SupportCaseAudience.merchant
+        )
+        assert any(
+            m.type == SupportCaseMessageType.appeal_denied for m in merchant_messages
+        )

--- a/server/tests/organization_review/test_appeal_case_decision.py
+++ b/server/tests/organization_review/test_appeal_case_decision.py
@@ -84,16 +84,14 @@ class TestApproveDecision:
     ) -> None:
         organization, review, case = denied_review_with_case
 
-        # Exactly what appeal_case_approve_dialog does on POST.
+        # Every approval entry point funnels through backoffice_approve, which
+        # now closes the open appeal case itself — no path can reactivate the
+        # org while leaving the case open.
         await organization_service.backoffice_approve(
-            session, organization, reason="Looks legitimate after human review."
-        )
-        await appeal_case_service.record_decision(
             session,
-            case,
-            approved=True,
-            staff_user=user,
+            organization,
             reason="Looks legitimate after human review.",
+            staff_user=user,
         )
 
         # Org reactivated (CREATED, since onboarding gates aren't met in tests).
@@ -109,6 +107,39 @@ class TestApproveDecision:
         assert any(
             m.type == SupportCaseMessageType.appeal_approved for m in merchant_messages
         )
+
+    async def test_approve_without_open_case_is_noop(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        # A denied org whose appeal never escalated to a human-review case:
+        # approval still reactivates and records the decision, with no case to
+        # close and no error.
+        organization.status = OrganizationStatus.DENIED
+        await save_fixture(organization)
+        review = OrganizationReview(
+            organization_id=organization.id,
+            verdict=OrganizationReview.Verdict.FAIL,
+            risk_score=90.0,
+            violated_sections=[],
+            reason="Automated review denied.",
+            model_used="test",
+            appeal_submitted_at=datetime.now(UTC),
+            appeal_reason="My appeal text.",
+            appeal_reviewed_at=datetime.now(UTC),
+            appeal_decision=OrganizationReview.AppealDecision.REJECTED,
+        )
+        await save_fixture(review)
+
+        await organization_service.backoffice_approve(
+            session, organization, reason="No case here.", staff_user=user
+        )
+
+        assert organization.status != OrganizationStatus.DENIED
+        assert review.appeal_decision == OrganizationReview.AppealDecision.APPROVED
 
     async def test_approve_appeal_would_reject_already_reviewed(
         self,

--- a/server/tests/organization_review/test_appeal_case_endpoints.py
+++ b/server/tests/organization_review/test_appeal_case_endpoints.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime
+
 import pytest
 import pytest_asyncio
 from httpx import AsyncClient
@@ -115,6 +117,34 @@ class TestRequestHumanReview:
             organization=organization,
         )
         await session.flush()
+        response = await client.post(
+            f"/v1/organizations/{organization.id}/appeal/human-review",
+            json={"reason": REASON},
+        )
+        assert response.status_code == 409
+
+    @pytest.mark.auth
+    async def test_rejects_when_appeal_not_rejected(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        # Appeal still pending (AI hasn't decided): a human-review case cannot
+        # be opened yet — the frontend gate is enforced server-side too.
+        review = OrganizationReview(
+            organization_id=organization.id,
+            verdict=OrganizationReview.Verdict.FAIL,
+            risk_score=90.0,
+            violated_sections=[],
+            reason="Automated review denied.",
+            model_used="test",
+            appeal_submitted_at=datetime.now(UTC),
+            appeal_reason="My pending appeal.",
+        )
+        await save_fixture(review)
+
         response = await client.post(
             f"/v1/organizations/{organization.id}/appeal/human-review",
             json={"reason": REASON},


### PR DESCRIPTION
## Summary


Close the support case when the appeal is approved / denied using another button than the primary path (happened this morning)

Also add a server side gate to prevent appeal cases from being created on an un-rejected org (was only protected by UI)

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically close appeal support cases when an appeal is approved or denied from any path, and enforce that human-review cases only open after the AI rejects the appeal. Adds clearer 409 errors and requires a staff user for backoffice approvals.

- **New Features**
  - Server-side gate: opening a human-review case requires a REJECTED appeal; returns 409 `AppealNotRejectedError`.
  - Add idempotent `approve_open_case` / `deny_open_case` helpers; used by all approve/deny flows to close the case and notify the merchant.
  - Make `backoffice_approve` require a `staff_user` and close any open appeal case as approved.
  - Update 409 response docs and client schema in `clients/packages/client/src/v1.ts`.

- **Bug Fixes**
  - Close appeal cases on every approval/denial path (dialogs and backoffice), avoiding cases left open.
  - Appeal approve dialog no longer writes the decision manually; it now errors if the case is already closed.
  - Tests cover no-case and closed-case no-ops, and the new server-side gate.

<sup>Written for commit fc34234f956706d509bd25f3182c0e1ebcc70104. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

