### PR TITLE
Always include the owner member on a customer

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -63,7 +63,6 @@ from polar.kit.sorting import Sorting
 from polar.kit.utils import utc_now
 from polar.kit.visibility import Visibility
 from polar.logging import Logger
-from polar.member.repository import MemberRepository
 from polar.member.service import member_service
 from polar.models import (
     Checkout,
@@ -582,10 +581,7 @@ class CheckoutService:
                 and checkout.customer.email is None
                 and checkout.customer.type == CustomerType.team
             ):
-                member_repository = MemberRepository.from_session(session)
-                owner_member = await member_repository.get_owner_by_customer_id(
-                    checkout.customer.id
-                )
+                owner_member = checkout.customer.owner
                 if owner_member is not None and owner_member.email is not None:
                     checkout.customer_email = owner_member.email
 

--- a/server/polar/customer_seat/service.py
+++ b/server/polar/customer_seat/service.py
@@ -144,15 +144,11 @@ class SeatAssignmentTarget:
 
 
 class SeatService:
-    async def _resolve_billing_manager_display(
-        self, session: AsyncSession, customer: Customer
-    ) -> str:
+    def _resolve_billing_manager_display(self, customer: Customer) -> str:
         """Resolve billing manager display string for invitation emails."""
         if customer.email is not None:
             return customer.email
-        owner = await MemberRepository.from_session(session).get_owner_by_customer_id(
-            customer.id
-        )
+        owner = customer.owner
         return (owner.email if owner else None) or customer.display_name
 
     def _get_product(self, container: SeatContainer) -> Product | None:
@@ -402,10 +398,8 @@ class SeatService:
             )
             if organization:
                 if target.seat_member_email is not None:
-                    billing_manager_display = (
-                        await self._resolve_billing_manager_display(
-                            session, billing_manager_customer
-                        )
+                    billing_manager_display = self._resolve_billing_manager_display(
+                        billing_manager_customer
                     )
                     send_seat_invitation_email(
                         customer_email=target.seat_member_email,
@@ -728,8 +722,8 @@ class SeatService:
             order_id=seat.order_id,
         )
 
-        billing_manager_display = await self._resolve_billing_manager_display(
-            session, billing_customer
+        billing_manager_display = self._resolve_billing_manager_display(
+            billing_customer
         )
 
         send_seat_invitation_email(

--- a/server/polar/models/customer.py
+++ b/server/polar/models/customer.py
@@ -247,6 +247,28 @@ class Customer(MetadataMixin, RecordModel):
             cascade="all, delete-orphan",
         )
 
+    @declared_attr
+    def owner(cls) -> Mapped["Member | None"]:
+        # Always loaded: the owner member is needed wherever we resolve a team
+        # customer's billing identity. `viewonly` + `overlaps="members"` because
+        # this re-maps the same `Member.customer_id` rows the writable `members`
+        # relationship owns (which carries the delete-orphan cascade — `owner`
+        # must never touch it). Filtered to a single active owner via `uselist`.
+        return relationship(
+            "Member",
+            lazy="selectin",
+            viewonly=True,
+            uselist=False,
+            primaryjoin=(
+                "and_("
+                "Customer.id == Member.customer_id, "
+                "Member.role == 'owner', "
+                "Member.deleted_at.is_(None)"
+                ")"
+            ),
+            overlaps="members",
+        )
+
     default_payment_method_id: Mapped[UUID | None] = mapped_column(
         "default_payment_method_id",
         Uuid,

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -70,6 +70,7 @@ from polar.models.custom_field import CustomFieldType
 from polar.models.customer import CustomerType
 from polar.models.customer_seat import SeatStatus
 from polar.models.discount import DiscountDuration, DiscountType
+from polar.models.member import MemberRole
 from polar.models.order import OrderBillingReasonInternal, OrderStatus
 from polar.models.organization import OrganizationStatus
 from polar.models.product_price import (
@@ -108,6 +109,7 @@ from tests.fixtures.random_objects import (
     create_customer,
     create_customer_seat,
     create_discount,
+    create_member,
     create_order,
     create_product,
     create_product_fixed_and_seat,
@@ -1653,6 +1655,51 @@ class TestCreate:
         assert checkout.customer_name is None
         assert checkout.customer_billing_address == customer.billing_address
         assert checkout.customer_tax_id == customer.tax_id
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="user"),
+        AuthSubjectFixture(subject="organization"),
+    )
+    async def test_valid_team_customer_without_email_uses_owner_email(
+        self,
+        stripe_service_mock: MagicMock,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        user_organization: UserOrganization,
+        product_one_time: Product,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        stripe_service_mock.create_customer_session.return_value = SimpleNamespace(
+            client_secret="STRIPE_CUSTOMER_SESSION_SECRET",
+        )
+
+        customer.type = CustomerType.team
+        customer.email = None
+        await save_fixture(customer)
+        owner = await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            role=MemberRole.owner,
+            email="owner@example.com",
+        )
+
+        price = product_one_time.prices[0]
+        assert isinstance(price, ProductPriceFixed)
+
+        checkout = await checkout_service.create(
+            session,
+            CheckoutPriceCreate(
+                product_price_id=price.id,
+                customer_id=customer.id,
+            ),
+            auth_subject,
+        )
+
+        assert checkout.customer == customer
+        assert checkout.customer_email == owner.email
 
     @pytest.mark.auth(
         AuthSubjectFixture(subject="user"),

--- a/server/tests/customer/test_repository.py
+++ b/server/tests/customer/test_repository.py
@@ -4,9 +4,11 @@ from pytest_mock import MockerFixture
 from polar.customer.repository import CustomerRepository
 from polar.event.system import SystemEvent
 from polar.models import Customer, Organization
+from polar.models.member import MemberRole
 from polar.models.webhook_endpoint import WebhookEventType
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_member
 
 
 @pytest.fixture
@@ -96,3 +98,83 @@ async def test_update_without_changes_emits_empty_updated_fields(
         SystemEvent.customer_updated,
         {},
     )
+
+
+@pytest.mark.asyncio
+class TestOwnerRelationship:
+    """The `owner` relationship is eager-loaded (`lazy="selectin"`) on every
+    customer query, so accessing it never raises and always reflects the single
+    active owner member."""
+
+    async def test_loaded_on_fetch(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        repository: CustomerRepository,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        owner = await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            role=MemberRole.owner,
+        )
+        await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            role=MemberRole.member,
+            email="member@example.com",
+        )
+
+        session.expunge_all()
+        result = await repository.get_by_id(customer.id)
+
+        assert result is not None
+        assert result.owner is not None
+        assert result.owner.id == owner.id
+
+    async def test_none_without_owner(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        repository: CustomerRepository,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            role=MemberRole.billing_manager,
+        )
+
+        session.expunge_all()
+        result = await repository.get_by_id(customer.id)
+
+        assert result is not None
+        assert result.owner is None
+
+    async def test_ignores_soft_deleted_owner(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        repository: CustomerRepository,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        owner = await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            role=MemberRole.owner,
+        )
+        owner.set_deleted_at()
+        await save_fixture(owner)
+
+        session.expunge_all()
+        result = await repository.get_by_id(customer.id)
+
+        assert result is not None
+        assert result.owner is None


### PR DESCRIPTION
Preparation work for a follow-up PR to fallback to `customer.owner.email` when `customer.email` is null. Apart from that, it feels nice to always have `customer.owner` available to access both the customer (intangible entity) and the owner (the tangible person behind the customer)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always load the owner member on `Customer` and use it to resolve billing identity. This removes ad‑hoc lookups and lets checkouts and seat invites use the owner email when a team customer has no email.

- **New Features**
  - Added `Customer.owner` relationship (`selectin` lazy, `viewonly`, single active owner, ignores soft‑deleted).
  - Used `customer.owner.email` to prefill `checkout.customer_email` for team customers without `customer.email`, and in seat invitation billing manager display.

- **Refactors**
  - Replaced `MemberRepository.get_owner_by_customer_id` usages with `customer.owner`.
  - Simplified billing manager display resolver to not require a `session`.

<sup>Written for commit add053b782e8ab9fa6d237875d4693c2ef811bf8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

