### PR TITLE
feat(organization): expose List Organizations as an MCP tool

### DIFF
--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -148,7 +148,7 @@ OrganizationNotFound = {
     "/",
     summary="List Organizations",
     response_model=ListResource[OrganizationSchema],
-    tags=[APITag.public],
+    tags=[APITag.public, APITag.mcp],
     operation_id="organizations:list",
 )
 async def list_organizations(


### PR DESCRIPTION
Make it possible for MCP consumers to list what organizations they belong to. Currently that's not possible, but since we switched to using user based tokens instead of org based it makes sense - since users can belong to multiple orgs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose List Organizations as an MCP tool by tagging `organizations:list` with `APITag.mcp`. This lets MCP clients list organizations the current auth subject can access, with no behavior change.

- **New Features**
  - Added `APITag.mcp` to `GET /v1/organizations/` (`operation_id: organizations:list`), emitting `x-speakeasy-mcp` and generating the tool.
  - Results stay scoped: user-backed tokens → member orgs; org-backed tokens → that org.
  - Requires `organizations_read` (or `organizations_write`) for MCP tokens.

<sup>Written for commit 424bdbbaf0e5c35ed77dd44cdc968a90939e71c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

