### PR TITLE
fix(organization): close appeal case on deletion

### DIFF
--- a/server/polar/backoffice/support_cases/endpoints.py
+++ b/server/polar/backoffice/support_cases/endpoints.py
@@ -216,8 +216,10 @@ async def _load_case_and_organization(
     organization_id = await support_case_service.get_organization_id(session, case)
     organization = None
     if organization_id is not None:
+        # Soft-deleted orgs keep their cases viewable, matching the
+        # org detail pages
         organization = await OrganizationRepository.from_session(session).get_by_id(
-            organization_id, include_blocked=True
+            organization_id, include_deleted=True, include_blocked=True
         )
     if organization is None:
         raise HTTPException(status_code=404, detail="Organization not found")

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -751,6 +751,16 @@ class OrganizationService:
 
         organization = await repository.update(organization, update_dict=update_dict)
         await repository.soft_delete(organization)
+
+        # Close an open *appeal* support case — it's moot once the org is gone.
+        # Only appeals: dispute and refund cases are deliberately left open, as
+        # they're financial matters (chargebacks, refunds) that outlive the
+        # merchant deleting their account.
+        review_repository = OrganizationReviewRepository.from_session(session)
+        review = await review_repository.get_by_organization(organization.id)
+        if review is not None:
+            await appeal_case_service.close_for_organization_deletion(session, review)
+
         polar_self_service.enqueue_delete_customer(organization_id=organization.id)
 
         log.info(

--- a/server/polar/organization_review/appeal_case.py
+++ b/server/polar/organization_review/appeal_case.py
@@ -213,6 +213,30 @@ class AppealCaseService:
             session, case, approved=approved, staff_user=staff_user, reason=reason
         )
 
+    async def close_for_organization_deletion(
+        self, session: AsyncSession, review: OrganizationReview
+    ) -> SupportCaseMessage | None:
+        """Close the review's appeal case when its organization is deleted.
+
+        A silent, internal lifecycle close (system author, no decision, no
+        merchant email) — the merchant is gone, so the case should stop sitting
+        open in the backoffice. No-op when there's no case or it's already
+        closed.
+        """
+        case = await self.get_case(session, review)
+        if case is None:
+            return None
+        message_repository = SupportCaseMessageRepository.from_session(session)
+        if not await message_repository.is_open(case.id):
+            return None
+        return await support_case_service.close(
+            session,
+            case,
+            author_kind=SupportCaseMessageAuthorKind.system,
+            body="Organization deleted.",
+            audience=[],
+        )
+
     async def get_case(
         self, session: AsyncSession | AsyncReadSession, review: OrganizationReview
     ) -> ReviewAppealSupportCase | None:

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -9,6 +9,7 @@ from sqlalchemy import update
 
 from polar.auth.models import AuthSubject
 from polar.config import settings
+from polar.dispute.dispute_case import dispute_case as dispute_case_service
 from polar.enums import (
     InvoiceNumbering,
     PayoutAccountType,
@@ -52,8 +53,10 @@ from polar.organization.schemas import (
 )
 from polar.organization.service import OrganizationError
 from polar.organization.service import organization as organization_service
+from polar.organization_review.appeal_case import appeal_case as appeal_case_service
 from polar.organization_review.schemas import ReviewContext, ReviewVerdict
 from polar.postgres import AsyncSession
+from polar.support_case.repository import SupportCaseMessageRepository
 from polar.user_organization.service import (
     user_organization as user_organization_service,
 )
@@ -61,7 +64,9 @@ from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_benefit,
     create_checkout_link,
+    create_dispute,
     create_order,
+    create_payment,
     create_payout_account,
     create_product,
     create_webhook_endpoint,
@@ -3115,6 +3120,65 @@ class TestSoftDeleteOrganization:
         enqueue_delete_customer_mock.assert_called_once_with(
             organization_id=organization.id
         )
+
+    async def test_closes_open_appeal_case(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        mocker.patch("polar.organization.service.polar_self_service")
+        review = OrganizationReview(
+            organization_id=organization.id,
+            verdict=OrganizationReview.Verdict.FAIL,
+            risk_score=90.0,
+            violated_sections=[],
+            reason="Automated review denied.",
+            model_used="test",
+            appeal_submitted_at=datetime.now(UTC),
+            appeal_reason="Please reconsider.",
+            appeal_reviewed_at=datetime.now(UTC),
+            appeal_decision=OrganizationReview.AppealDecision.REJECTED,
+        )
+        await save_fixture(review)
+        case = await appeal_case_service.request_human_review(
+            session,
+            review,
+            reason="Here is the additional context for the review.",
+            requested_by_user=user,
+            organization=organization,
+        )
+
+        await organization_service.soft_delete_organization(session, organization)
+
+        message_repository = SupportCaseMessageRepository.from_session(session)
+        assert await message_repository.is_open(case.id) is False
+
+    async def test_leaves_dispute_case_open(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        # Disputes are live financial matters — they must outlive the merchant
+        # deleting their account.
+        mocker.patch("polar.organization.service.polar_self_service")
+        order = await create_order(save_fixture, customer=customer, product=product)
+        payment = await create_payment(save_fixture, organization, order=order)
+        dispute = await create_dispute(save_fixture, order, payment)
+        case = await dispute_case_service.open_case(
+            session, dispute, organization=organization
+        )
+
+        await organization_service.soft_delete_organization(session, organization)
+
+        message_repository = SupportCaseMessageRepository.from_session(session)
+        assert await message_repository.is_open(case.id) is True
 
     async def test_anonymizes_pii_and_releases_slug(
         self,


### PR DESCRIPTION

## Summary

When an organization submits a review appeal and then deletes itself (soft delete), its open appeal support case was never closed — it sat open in the backoffice queue forever — and the backoffice support-case detail page 404'd for the deleted org.

<!-- Brief description of what this PR does -->

## What

- Close an organization's open **appeal** support case when the org is soft-deleted.
- Stop the backoffice support-case **detail** page from 404ing for a soft-deleted org (it now loads anonymized/deleted orgs, like the org detail pages already do).

## Why

Reported internally

## How

Appeals are the only case type that's moot once the org is gone. **Disputes and refund requests are deliberately left open** — they're live financial matters (chargebacks, refunds) that outlive the merchant deleting their account, and staff must still be able to work them (which is exactly why the detail page must keep loading deleted orgs).

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically close an organization’s open appeal support case when the org is soft-deleted, and keep support cases viewable for deleted orgs to prevent 404s. Only appeal cases are auto-closed; disputes and refunds remain open.

- **Bug Fixes**
  - Auto-close appeal case on org soft delete.
  - Support-case detail page now loads soft-deleted orgs (include_deleted), matching org detail pages.
  - Tests cover closing appeals and keeping dispute cases open.

<sup>Written for commit ce73cf3222cc531f9ad2f493c872842da2ad4f79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

