### PR TITLE
Fallback to `customer.owner` for `avatar_url` on customer

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -15725,7 +15725,7 @@ export interface components {
        * Avatar Url
        * @example https://www.gravatar.com/avatar/xxx?d=404
        */
-      readonly avatar_url: string
+      avatar_url: string | null
     }
     /** CustomerIndividualCreate */
     CustomerIndividualCreate: {
@@ -17286,6 +17286,11 @@ export interface components {
        */
       deleted_at: string | null
       /**
+       * Avatar Url
+       * @example https://www.gravatar.com/avatar/xxx?d=404
+       */
+      avatar_url: string | null
+      /**
        * Active Subscriptions
        * @description The customer's active subscriptions.
        */
@@ -17300,11 +17305,6 @@ export interface components {
        * @description The customer's active meters.
        */
       active_meters: components['schemas']['CustomerStateMeter'][]
-      /**
-       * Avatar Url
-       * @example https://www.gravatar.com/avatar/xxx?d=404
-       */
-      readonly avatar_url: string
     }
     /**
      * CustomerStateMeter
@@ -17609,6 +17609,11 @@ export interface components {
        */
       deleted_at: string | null
       /**
+       * Avatar Url
+       * @example https://www.gravatar.com/avatar/xxx?d=404
+       */
+      avatar_url: string | null
+      /**
        * Active Subscriptions
        * @description The customer's active subscriptions.
        */
@@ -17623,11 +17628,6 @@ export interface components {
        * @description The customer's active meters.
        */
       active_meters: components['schemas']['CustomerStateMeter'][]
-      /**
-       * Avatar Url
-       * @example https://www.gravatar.com/avatar/xxx?d=404
-       */
-      readonly avatar_url: string
     }
     /** CustomerSubscription */
     CustomerSubscription: {
@@ -18086,7 +18086,7 @@ export interface components {
        * Avatar Url
        * @example https://www.gravatar.com/avatar/xxx?d=404
        */
-      readonly avatar_url: string
+      avatar_url: string | null
     }
     /** CustomerTeamCreate */
     CustomerTeamCreate: {
@@ -20768,7 +20768,7 @@ export interface components {
        * Avatar Url
        * @example https://www.gravatar.com/avatar/xxx?d=404
        */
-      readonly avatar_url: string
+      avatar_url: string | null
     }
     /** LicenseKeyDeactivate */
     LicenseKeyDeactivate: {
@@ -23130,7 +23130,7 @@ export interface components {
        * Avatar Url
        * @example https://www.gravatar.com/avatar/xxx?d=404
        */
-      readonly avatar_url: string
+      avatar_url: string | null
     }
     /**
      * OrderFinalize
@@ -30208,7 +30208,7 @@ export interface components {
        * Avatar Url
        * @example https://www.gravatar.com/avatar/xxx?d=404
        */
-      readonly avatar_url: string
+      avatar_url: string | null
     }
     /**
      * SubscriptionCycledEvent

--- a/server/polar/customer/schemas/customer.py
+++ b/server/polar/customer/schemas/customer.py
@@ -1,4 +1,3 @@
-import hashlib
 from datetime import datetime
 from typing import Annotated, Literal
 
@@ -10,12 +9,10 @@ from pydantic import (
     Field,
     Tag,
     TypeAdapter,
-    computed_field,
     model_validator,
 )
 from pydantic.aliases import AliasChoices
 
-from polar.config import settings
 from polar.kit.address import Address, AddressInput
 from polar.kit.email import EmailStrDNS
 from polar.kit.locale import Locale
@@ -172,19 +169,6 @@ class CustomerUpdateExternalID(CustomerUpdateBase): ...
 # --- Read schemas ---
 
 
-def _avatar_url_for_email(email: str) -> str:
-    domain = email.split("@")[-1].lower()
-
-    if (
-        not settings.LOGO_DEV_PUBLISHABLE_KEY
-        or domain in settings.PERSONAL_EMAIL_DOMAINS
-    ):
-        email_hash = hashlib.sha256(email.lower().encode()).hexdigest()
-        return f"https://www.gravatar.com/avatar/{email_hash}?d=404"
-
-    return f"https://img.logo.dev/{domain}?size=64&retina=true&token={settings.LOGO_DEV_PUBLISHABLE_KEY}&fallback=404"
-
-
 class CustomerBase(MetadataOutputMixin, TimestampedSchema, IDSchema):
     id: UUID4 = Field(
         description="The ID of the customer.", examples=[CUSTOMER_ID_EXAMPLE]
@@ -245,14 +229,9 @@ class CustomerBase(MetadataOutputMixin, TimestampedSchema, IDSchema):
         description="Timestamp for when the customer was soft deleted."
     )
 
-    @computed_field(examples=["https://www.gravatar.com/avatar/xxx?d=404"])  # type: ignore[prop-decorator]
-    @property
-    def avatar_url(self) -> str:
-        if self.email is not None:
-            return _avatar_url_for_email(self.email)
-        identifier = self.name or str(self.id)
-        email_hash = hashlib.sha256(identifier.lower().encode()).hexdigest()
-        return f"https://www.gravatar.com/avatar/{email_hash}?d=404"
+    avatar_url: str | None = Field(
+        examples=["https://www.gravatar.com/avatar/xxx?d=404"],
+    )
 
 
 class CustomerIndividual(CustomerBase):

--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -886,7 +886,7 @@ class CustomerService:
     ) -> CustomerState:
         # 👋 Whenever you change the state schema,
         # please also update the cache key with a version number.
-        cache_key = f"polar:customer_state:v5:{customer.id}"
+        cache_key = f"polar:customer_state:v6:{customer.id}"
 
         if cache:
             raw_state = await redis.get(cache_key)

--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -325,7 +325,7 @@ class CustomerService:
         try:
             if send_webhooks:
                 async with repository.create_context(customer) as created:
-                    await member_service.create_owner_member(
+                    owner = await member_service.create_owner_member(
                         session,
                         created,
                         organization,
@@ -335,7 +335,7 @@ class CustomerService:
                     )
             else:
                 created = await repository.create(customer, flush=True)
-                await member_service.create_owner_member(
+                owner = await member_service.create_owner_member(
                     session,
                     created,
                     organization,
@@ -369,14 +369,12 @@ class CustomerService:
                 ) from e
             raise
 
-        # When the customer has no email of its own, `Customer.avatar_url` falls
-        # back to the owner member's email. `owner` is eager-loaded
-        # (lazy="selectin") on queries, but `created` is a freshly built object
-        # whose relationship was never loaded — so we load it here, otherwise
-        # response serialization would emit IO mid-render (raising MissingGreenlet).
-        if created.email is None:
-            await session.flush()
-            await session.refresh(created, attribute_names=["owner"])
+        # `create_owner_member` fills `created.owner` in-memory when it resolves a
+        # member; if none was created (member model feature disabled), mark the
+        # relationship as loaded-and-empty here.
+        # Without this, response serialization would emit IO mid-render
+        if created.email is None and owner is None:
+            created.owner = None
         return created
 
     async def update(

--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -333,7 +333,6 @@ class CustomerService:
                         owner_name=owner_name,
                         owner_external_id=owner_external_id,
                     )
-                    return created
             else:
                 created = await repository.create(customer, flush=True)
                 await member_service.create_owner_member(
@@ -344,7 +343,6 @@ class CustomerService:
                     owner_name=owner_name,
                     owner_external_id=owner_external_id,
                 )
-                return created
         except IntegrityError as e:
             error_str = str(e)
             if "ix_customers_organization_id_email_not_null" in error_str:
@@ -370,6 +368,16 @@ class CustomerService:
                     ]
                 ) from e
             raise
+
+        # When the customer has no email of its own, `Customer.avatar_url` falls
+        # back to the owner member's email. `owner` is eager-loaded
+        # (lazy="selectin") on queries, but `created` is a freshly built object
+        # whose relationship was never loaded — so we load it here, otherwise
+        # response serialization would emit IO mid-render (raising MissingGreenlet).
+        if created.email is None:
+            await session.flush()
+            await session.refresh(created, attribute_names=["owner"])
+        return created
 
     async def update(
         self,

--- a/server/polar/member/service.py
+++ b/server/polar/member/service.py
@@ -310,6 +310,7 @@ class MemberService:
         # customer) produces a duplicate owner on the next sign-in.
         existing_owner = await repository.get_owner_by_customer_id(customer.id)
         if existing_owner is not None:
+            customer.owner = existing_owner
             log.debug(
                 "member.create_owner_member.skipped",
                 reason="owner_already_exists",
@@ -330,6 +331,7 @@ class MemberService:
 
         try:
             created_member = await repository.create(member, flush=True)
+            customer.owner = created_member
             log.info(
                 "member.create_owner_member.success",
                 customer_id=customer.id,
@@ -354,6 +356,7 @@ class MemberService:
             )
             existing_owner = await repository.get_owner_by_customer_id(customer.id)
             if existing_owner is not None:
+                customer.owner = existing_owner
                 log.info(
                     "member.create_owner_member.found_existing",
                     customer_id=customer.id,

--- a/server/polar/models/customer.py
+++ b/server/polar/models/customer.py
@@ -1,4 +1,5 @@
 import dataclasses
+import hashlib
 import string
 import time
 from collections.abc import Sequence
@@ -29,6 +30,7 @@ from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
+from polar.config import settings
 from polar.kit.address import Address, AddressType
 from polar.kit.db.models import RecordModel
 from polar.kit.metadata import MetadataMixin
@@ -98,6 +100,19 @@ class CustomerOAuthAccount:
 class CustomerType(StrEnum):
     individual = "individual"
     team = "team"
+
+
+def _avatar_url_for_email(email: str) -> str:
+    domain = email.split("@")[-1].lower()
+
+    if (
+        not settings.LOGO_DEV_PUBLISHABLE_KEY
+        or domain in settings.PERSONAL_EMAIL_DOMAINS
+    ):
+        email_hash = hashlib.sha256(email.lower().encode()).hexdigest()
+        return f"https://www.gravatar.com/avatar/{email_hash}?d=404"
+
+    return f"https://img.logo.dev/{domain}?size=64&retina=true&token={settings.LOGO_DEV_PUBLISHABLE_KEY}&fallback=404"
 
 
 class Customer(MetadataMixin, RecordModel):
@@ -335,6 +350,11 @@ class Customer(MetadataMixin, RecordModel):
     @property
     def legacy_user_id(self) -> UUID:
         return self._legacy_user_id or self.id
+
+    @property
+    def avatar_url(self) -> str | None:
+        email = self.email or (self.owner.email if self.owner else None)
+        return _avatar_url_for_email(email) if email else None
 
     @property
     def display_name(self) -> str:

--- a/server/tests/customer/test_endpoints.py
+++ b/server/tests/customer/test_endpoints.py
@@ -11,6 +11,7 @@ from polar.models import (
     Product,
     UserOrganization,
 )
+from polar.models.customer import _avatar_url_for_email
 from polar.models.subscription import SubscriptionStatus
 from polar.postgres import AsyncSession
 from polar.tax.tax_id import TaxIDFormat
@@ -613,6 +614,33 @@ class TestCreateCustomer:
         assert owner.name == "Owner Name"
         assert owner.external_id == "owner_ext_456"
         assert owner.role == "owner"
+
+    @pytest.mark.auth
+    async def test_team_without_email_uses_owner_avatar(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        organization.feature_settings = {"member_model_enabled": True}
+        await save_fixture(organization)
+
+        response = await client.post(
+            "/v1/customers/",
+            json={
+                "type": "team",
+                "name": "Acme Inc.",
+                "organization_id": str(organization.id),
+                "owner": {"email": "owner@polar.sh", "name": "Owner Name"},
+            },
+        )
+
+        assert response.status_code == 201
+
+        json = response.json()
+        assert json["email"] is None
+        assert json["avatar_url"] == _avatar_url_for_email("owner@polar.sh")
 
 
 @pytest.mark.asyncio

--- a/server/tests/customer/test_endpoints.py
+++ b/server/tests/customer/test_endpoints.py
@@ -642,6 +642,32 @@ class TestCreateCustomer:
         assert json["email"] is None
         assert json["avatar_url"] == _avatar_url_for_email("owner@polar.sh")
 
+    @pytest.mark.auth
+    async def test_team_without_email_or_owner_member_serializes_null_avatar(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        # With the member model disabled, no owner member is created, so the
+        # customer's `owner` relationship stays empty. Serialization must not
+        # lazy-load it (MissingGreenlet) when resolving `avatar_url`.
+        response = await client.post(
+            "/v1/customers/",
+            json={
+                "type": "team",
+                "name": "Acme Inc.",
+                "organization_id": str(organization.id),
+                "owner": {"email": "owner@polar.sh"},
+            },
+        )
+
+        assert response.status_code == 201
+
+        json = response.json()
+        assert json["email"] is None
+        assert json["avatar_url"] is None
+
 
 @pytest.mark.asyncio
 class TestUpdateCustomer:

--- a/server/tests/customer/test_repository.py
+++ b/server/tests/customer/test_repository.py
@@ -4,6 +4,7 @@ from pytest_mock import MockerFixture
 from polar.customer.repository import CustomerRepository
 from polar.event.system import SystemEvent
 from polar.models import Customer, Organization
+from polar.models.customer import CustomerType, _avatar_url_for_email
 from polar.models.member import MemberRole
 from polar.models.webhook_endpoint import WebhookEventType
 from polar.postgres import AsyncSession
@@ -178,3 +179,100 @@ class TestOwnerRelationship:
 
         assert result is not None
         assert result.owner is None
+
+
+@pytest.mark.asyncio
+class TestAvatarUrl:
+    """`avatar_url` derives from the customer's own email, falling back to the
+    owner member's email for customers without one, and is `None` when no email
+    is available anywhere."""
+
+    async def test_uses_customer_email(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        repository: CustomerRepository,
+        organization: Organization,
+    ) -> None:
+        customer = Customer(email="individual@example.com", organization=organization)
+        await save_fixture(customer)
+
+        session.expunge_all()
+        result = await repository.get_by_id(customer.id)
+
+        assert result is not None
+        assert result.avatar_url == _avatar_url_for_email("individual@example.com")
+
+    async def test_prefers_customer_email_over_owner(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        repository: CustomerRepository,
+        organization: Organization,
+    ) -> None:
+        customer = Customer(
+            email="team@example.com",
+            type=CustomerType.team,
+            organization=organization,
+        )
+        await save_fixture(customer)
+        await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            role=MemberRole.owner,
+            email="owner@example.com",
+        )
+
+        session.expunge_all()
+        result = await repository.get_by_id(customer.id)
+
+        assert result is not None
+        assert result.avatar_url == _avatar_url_for_email("team@example.com")
+
+    async def test_falls_back_to_owner_email(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        repository: CustomerRepository,
+        organization: Organization,
+    ) -> None:
+        customer = Customer(
+            email=None,
+            type=CustomerType.team,
+            organization=organization,
+        )
+        await save_fixture(customer)
+        await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            role=MemberRole.owner,
+            email="owner@example.com",
+        )
+
+        session.expunge_all()
+        result = await repository.get_by_id(customer.id)
+
+        assert result is not None
+        assert result.avatar_url == _avatar_url_for_email("owner@example.com")
+
+    async def test_none_without_email_or_owner(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        repository: CustomerRepository,
+        organization: Organization,
+    ) -> None:
+        customer = Customer(
+            email=None,
+            type=CustomerType.team,
+            organization=organization,
+        )
+        await save_fixture(customer)
+
+        session.expunge_all()
+        result = await repository.get_by_id(customer.id)
+
+        assert result is not None
+        assert result.avatar_url is None

--- a/server/tests/customer/test_repository.py
+++ b/server/tests/customer/test_repository.py
@@ -183,96 +183,47 @@ class TestOwnerRelationship:
 
 @pytest.mark.asyncio
 class TestAvatarUrl:
-    """`avatar_url` derives from the customer's own email, falling back to the
-    owner member's email for customers without one, and is `None` when no email
-    is available anywhere."""
+    """`avatar_url` uses the customer's own email, falls back to the owner
+    member's email when the customer has none, and is `None` otherwise."""
 
-    async def test_uses_customer_email(
+    @pytest.mark.parametrize(
+        ("customer_email", "owner_email", "expected_email"),
+        [
+            ("individual@example.com", None, "individual@example.com"),
+            ("team@example.com", "owner@example.com", "team@example.com"),
+            (None, "owner@example.com", "owner@example.com"),
+            (None, None, None),
+        ],
+    )
+    async def test_avatar_url(
         self,
         save_fixture: SaveFixture,
         session: AsyncSession,
         repository: CustomerRepository,
         organization: Organization,
-    ) -> None:
-        customer = Customer(email="individual@example.com", organization=organization)
-        await save_fixture(customer)
-
-        session.expunge_all()
-        result = await repository.get_by_id(customer.id)
-
-        assert result is not None
-        assert result.avatar_url == _avatar_url_for_email("individual@example.com")
-
-    async def test_prefers_customer_email_over_owner(
-        self,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        repository: CustomerRepository,
-        organization: Organization,
+        customer_email: str | None,
+        owner_email: str | None,
+        expected_email: str | None,
     ) -> None:
         customer = Customer(
-            email="team@example.com",
+            email=customer_email,
             type=CustomerType.team,
             organization=organization,
         )
         await save_fixture(customer)
-        await create_member(
-            save_fixture,
-            customer=customer,
-            organization=organization,
-            role=MemberRole.owner,
-            email="owner@example.com",
-        )
+        if owner_email is not None:
+            await create_member(
+                save_fixture,
+                customer=customer,
+                organization=organization,
+                role=MemberRole.owner,
+                email=owner_email,
+            )
 
         session.expunge_all()
         result = await repository.get_by_id(customer.id)
 
         assert result is not None
-        assert result.avatar_url == _avatar_url_for_email("team@example.com")
-
-    async def test_falls_back_to_owner_email(
-        self,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        repository: CustomerRepository,
-        organization: Organization,
-    ) -> None:
-        customer = Customer(
-            email=None,
-            type=CustomerType.team,
-            organization=organization,
+        assert result.avatar_url == (
+            _avatar_url_for_email(expected_email) if expected_email else None
         )
-        await save_fixture(customer)
-        await create_member(
-            save_fixture,
-            customer=customer,
-            organization=organization,
-            role=MemberRole.owner,
-            email="owner@example.com",
-        )
-
-        session.expunge_all()
-        result = await repository.get_by_id(customer.id)
-
-        assert result is not None
-        assert result.avatar_url == _avatar_url_for_email("owner@example.com")
-
-    async def test_none_without_email_or_owner(
-        self,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        repository: CustomerRepository,
-        organization: Organization,
-    ) -> None:
-        customer = Customer(
-            email=None,
-            type=CustomerType.team,
-            organization=organization,
-        )
-        await save_fixture(customer)
-
-        session.expunge_all()
-        result = await repository.get_by_id(customer.id)
-
-        assert result is not None
-        assert result.avatar_url is None

--- a/server/tests/customer/test_schemas.py
+++ b/server/tests/customer/test_schemas.py
@@ -9,11 +9,10 @@ from polar.customer.schemas.customer import CustomerResponse as Customer
 from polar.customer.schemas.state import CustomerState
 from polar.models import Organization
 from polar.models.customer import Customer as CustomerModel
-from polar.models.customer import CustomerType, _avatar_url_for_email
-from polar.models.member import MemberRole
+from polar.models.customer import CustomerType
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_customer, create_member
+from tests.fixtures.random_objects import create_customer
 
 _CustomerAdapter: TypeAdapter[Customer] = TypeAdapter(Customer)
 _CustomerStateAdapter: TypeAdapter[CustomerState] = TypeAdapter(CustomerState)
@@ -71,32 +70,6 @@ async def test_state_external_id(
         customer_state_json
     )
     assert customer_state_deserialized.external_id == "EXTERNAL_ID"
-
-
-@pytest.mark.asyncio
-async def test_avatar_url_team_falls_back_to_owner(
-    save_fixture: SaveFixture,
-    session: AsyncSession,
-    organization: Organization,
-) -> None:
-    customer = CustomerModel(
-        email=None, type=CustomerType.team, organization=organization
-    )
-    await save_fixture(customer)
-    await create_member(
-        save_fixture,
-        customer=customer,
-        organization=organization,
-        role=MemberRole.owner,
-        email="owner@example.com",
-    )
-
-    session.expunge_all()
-    loaded = await CustomerRepository.from_session(session).get_by_id(customer.id)
-    assert loaded is not None
-
-    customer_schema = _CustomerAdapter.validate_python(loaded, from_attributes=True)
-    assert customer_schema.avatar_url == _avatar_url_for_email("owner@example.com")
 
 
 @pytest.mark.asyncio

--- a/server/tests/customer/test_schemas.py
+++ b/server/tests/customer/test_schemas.py
@@ -4,11 +4,16 @@ from typing import Any
 import pytest
 from pydantic import TypeAdapter
 
+from polar.customer.repository import CustomerRepository
 from polar.customer.schemas.customer import CustomerResponse as Customer
 from polar.customer.schemas.state import CustomerState
 from polar.models import Organization
+from polar.models.customer import Customer as CustomerModel
+from polar.models.customer import CustomerType, _avatar_url_for_email
+from polar.models.member import MemberRole
+from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_customer
+from tests.fixtures.random_objects import create_customer, create_member
 
 _CustomerAdapter: TypeAdapter[Customer] = TypeAdapter(Customer)
 _CustomerStateAdapter: TypeAdapter[CustomerState] = TypeAdapter(CustomerState)
@@ -66,3 +71,51 @@ async def test_state_external_id(
         customer_state_json
     )
     assert customer_state_deserialized.external_id == "EXTERNAL_ID"
+
+
+@pytest.mark.asyncio
+async def test_avatar_url_team_falls_back_to_owner(
+    save_fixture: SaveFixture,
+    session: AsyncSession,
+    organization: Organization,
+) -> None:
+    customer = CustomerModel(
+        email=None, type=CustomerType.team, organization=organization
+    )
+    await save_fixture(customer)
+    await create_member(
+        save_fixture,
+        customer=customer,
+        organization=organization,
+        role=MemberRole.owner,
+        email="owner@example.com",
+    )
+
+    session.expunge_all()
+    loaded = await CustomerRepository.from_session(session).get_by_id(customer.id)
+    assert loaded is not None
+
+    customer_schema = _CustomerAdapter.validate_python(loaded, from_attributes=True)
+    assert customer_schema.avatar_url == _avatar_url_for_email("owner@example.com")
+
+
+@pytest.mark.asyncio
+async def test_avatar_url_serializes_null_without_email(
+    save_fixture: SaveFixture,
+    session: AsyncSession,
+    organization: Organization,
+) -> None:
+    customer = CustomerModel(
+        email=None, type=CustomerType.team, organization=organization
+    )
+    await save_fixture(customer)
+
+    session.expunge_all()
+    loaded = await CustomerRepository.from_session(session).get_by_id(customer.id)
+    assert loaded is not None
+
+    customer_schema = _CustomerAdapter.validate_python(loaded, from_attributes=True)
+    assert customer_schema.avatar_url is None
+
+    serialized = json.loads(customer_schema.model_dump_json())
+    assert serialized["avatar_url"] is None


### PR DESCRIPTION
Inspired by how Polar-for-Polar is set up, I'm annoyed how we're not showing any logo indicators for those customers even though the customer type `team` with no email is a recommended approach.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `avatar_url` on customers nullable and resolve it on the model using the customer's email, falling back to the owner's email for team customers; return `null` when no email is available. Also bind the owner on creation to avoid lazy-loading/DB roundtrips and bump the customer state cache version.

- **New Features**
  - Compute `avatar_url` on the model; prefer customer email, then owner email; otherwise `null`. Expose `avatar_url: string | null` in API schemas and the generated `clients/packages/client` `v1` types.

- **Bug Fixes**
  - Bind the created owner member to `customer.owner` in memory; set `owner=None` when no member is created to prevent MissingGreenlet and extra DB queries during serialization.
  - Bump customer state cache key to `v6` to invalidate stale cached responses after the schema change.

<sup>Written for commit c89801c994358ecd7f8a19ba76826473e6876b93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

