### PR TITLE
Improve UX of Benefit page

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/benefits/[benefitId]/BenefitPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/benefits/[benefitId]/BenefitPage.tsx
@@ -10,7 +10,8 @@ import {
 } from '@/components/Benefit/utils'
 import { MasterDetailLayoutContent } from '@/components/Layout/MasterDetailLayout'
 import { ConfirmModal } from '@/components/Modal/ConfirmModal'
-import { Button, InlineModal, Status } from '@polar-sh/orbit'
+import { Button, InlineModal, Status, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
 import { useModal } from '@/components/Modal/useModal'
 import { useToast } from '@/components/Toast/use-toast'
 import { useDeleteBenefit } from '@/hooks/queries'
@@ -129,17 +130,26 @@ const ClientPage: React.FC<ClientPageProps> = ({
     <MasterDetailLayoutContent
       header={
         <>
-          <div className="flex flex-row items-center gap-6">
-            <span className="dark:bg-polar-700 flex h-12 w-12 shrink-0 flex-row items-center justify-center rounded-full bg-gray-200 text-2xl text-black dark:text-white">
+          <Box alignItems="center" gap="xl">
+            <Box
+              width={48}
+              height={48}
+              flexShrink={0}
+              alignItems="center"
+              justifyContent="center"
+              borderRadius="full"
+              backgroundColor="background-card"
+              color="text-primary"
+            >
               {resolveBenefitIcon(benefit.type, 'h-4 w-4')}
-            </span>
-            <div className="flex flex-col">
-              <div className="flex min-w-0 flex-row items-center gap-4">
-                <p className="truncate text-lg">
+            </Box>
+            <Box flexDirection="column">
+              <Box minWidth={0} alignItems="center" gap="l">
+                <Text variant="heading-xxs" as="p" truncate>
                   {(benefit.description?.length ?? 0) > 0
                     ? benefit.description
                     : '—'}
-                </p>
+                </Text>
                 <Status
                   color="gray"
                   status={
@@ -148,14 +158,12 @@ const ClientPage: React.FC<ClientPageProps> = ({
                       : 'Hidden from customers'
                   }
                 />
-              </div>
-              <div className="dark:text-polar-500 flex flex-row items-center gap-2 text-gray-500">
-                <span>{benefitsDisplayNames[benefit.type]}</span>
-              </div>
-            </div>
-          </div>
+              </Box>
+              <Text color="muted">{benefitsDisplayNames[benefit.type]}</Text>
+            </Box>
+          </Box>
 
-          <div className="flex flex-row items-center gap-4">
+          <Box alignItems="center" gap="l">
             <Button onClick={toggleEdit}>Edit Benefit</Button>
             <DropdownMenu>
               <DropdownMenuTrigger className="focus:outline-none" asChild>
@@ -180,20 +188,20 @@ const ClientPage: React.FC<ClientPageProps> = ({
                 )}
               </DropdownMenuContent>
             </DropdownMenu>
-          </div>
+          </Box>
         </>
       }
     >
-      <div className="flex h-full w-full flex-col">
-        <div className="flex w-full flex-col gap-8 pb-8">
+      <Box flexDirection="column" width="100%" height="100%">
+        <Box flexDirection="column" width="100%" gap="2xl" paddingBottom="2xl">
           <BenefitProducts benefit={benefit} organization={organization} />
           {benefit.type === 'license_keys' ? (
             <LicenseKeysPage organization={organization} benefit={benefit} />
           ) : (
             <BenefitPage benefit={benefit} organization={organization} />
           )}
-        </div>
-      </div>
+        </Box>
+      </Box>
 
       <InlineModal
         isShown={isEditShown}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/benefits/[benefitId]/BenefitPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/benefits/[benefitId]/BenefitPage.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { BenefitPage } from '@/components/Benefit/BenefitPage'
+import { BenefitProducts } from '@/components/Benefit/BenefitProducts'
 import { LicenseKeysPage } from '@/components/Benefit/LicenseKeysPage'
 import UpdateBenefitModalContent from '@/components/Benefit/UpdateBenefitModalContent'
 import {
@@ -148,7 +149,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
                   }
                 />
               </div>
-              <div className="dark:text-polar-500 flex flex-row items-center gap-2 font-mono text-sm text-gray-500">
+              <div className="dark:text-polar-500 flex flex-row items-center gap-2 text-gray-500">
                 <span>{benefitsDisplayNames[benefit.type]}</span>
               </div>
             </div>
@@ -185,6 +186,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
     >
       <div className="flex h-full w-full flex-col">
         <div className="flex w-full flex-col gap-8 pb-8">
+          <BenefitProducts benefit={benefit} organization={organization} />
           {benefit.type === 'license_keys' ? (
             <LicenseKeysPage organization={organization} benefit={benefit} />
           ) : (

--- a/clients/apps/web/src/components/Benefit/BenefitPage.tsx
+++ b/clients/apps/web/src/components/Benefit/BenefitPage.tsx
@@ -10,6 +10,8 @@ import { schemas } from '@polar-sh/client'
 import { Avatar } from '@polar-sh/orbit'
 import { Button } from '@polar-sh/orbit'
 import { DataTable } from '@polar-sh/orbit'
+import { Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import { ColumnDef } from '@tanstack/react-table'
 import { ExternalLink } from 'lucide-react'
@@ -119,21 +121,19 @@ export const BenefitPage = ({ benefit, organization }: BenefitPageProps) => {
           <Link
             href={`/dashboard/${organization.slug}/customers/${grant.customer.id}`}
           >
-            <div className="flex items-center gap-3">
+            <Box alignItems="center" gap="m">
               <Avatar
                 className="h-10 w-10"
                 avatar_url={grant.customer.avatar_url}
                 name={grant.customer.email ?? grant.customer.name ?? '—'}
               />
-              <div className="flex min-w-0 flex-col">
-                <div className="w-full truncate text-sm">
-                  {grant.customer.name ?? '—'}
-                </div>
-                <div className="dark:text-polar-500 w-full truncate text-xs text-gray-500">
+              <Box minWidth={0} flexDirection="column">
+                <Text truncate>{grant.customer.name ?? '—'}</Text>
+                <Text variant="caption" color="muted" truncate>
                   {grant.customer.email ?? '—'}
-                </div>
-              </div>
-            </div>
+                </Text>
+              </Box>
+            </Box>
           </Link>
         ),
       },
@@ -187,7 +187,7 @@ export const BenefitPage = ({ benefit, organization }: BenefitPageProps) => {
           }
 
           return (
-            <div className="flex gap-2">
+            <Box gap="s">
               {hasOrder && (
                 <Link
                   href={`/dashboard/${organization.slug}/sales/${grant.order_id}`}
@@ -206,7 +206,7 @@ export const BenefitPage = ({ benefit, organization }: BenefitPageProps) => {
                   </Button>
                 </Link>
               )}
-            </div>
+            </Box>
           )
         },
       },
@@ -216,17 +216,19 @@ export const BenefitPage = ({ benefit, organization }: BenefitPageProps) => {
   }, [benefit.type, memberColumnEnabled, organization.slug])
 
   return (
-    <div className="flex flex-col gap-6">
-      <div className="flex flex-row items-center justify-between gap-4">
-        <h2 className="text-xl">Benefit Grants</h2>
-        <div className="w-auto">
+    <Box flexDirection="column" gap="xl">
+      <Box alignItems="center" justifyContent="between" gap="l">
+        <Text variant="heading-xxs" as="h2">
+          Benefit Grants
+        </Text>
+        <Box width="auto">
           <BenefitGrantStatusSelect
             statuses={['granted', 'revoked']}
             value={grantStatus}
             onChange={setGrantStatus}
           />
-        </div>
-      </div>
+        </Box>
+      </Box>
       <DataTable
         data={benefitGrants?.items || []}
         isLoading={isLoading}
@@ -238,7 +240,7 @@ export const BenefitPage = ({ benefit, organization }: BenefitPageProps) => {
         onPaginationChange={setPagination}
         columns={columns}
       />
-    </div>
+    </Box>
   )
 }
 
@@ -254,16 +256,16 @@ const SlackGrantDetails = ({ grant }: { grant: schemas['BenefitGrant'] }) => {
         : 'Waiting for email'
 
   return (
-    <div className="flex min-w-0 flex-col gap-2">
-      <div className="flex min-w-0 flex-col">
-        <span className="truncate font-mono text-sm">
+    <Box minWidth={0} flexDirection="column" gap="s">
+      <Box minWidth={0} flexDirection="column">
+        <Text monospace truncate>
           {properties.channel_name ? `#${properties.channel_name}` : '—'}
-        </span>
-        <span className="dark:text-polar-500 truncate text-xs text-gray-500">
+        </Text>
+        <Text variant="caption" color="muted" truncate>
           {status}
           {properties.invited_email ? ` · ${properties.invited_email}` : ''}
-        </span>
-      </div>
+        </Text>
+      </Box>
       {properties.invite_url && (
         <a
           href={properties.invite_url}
@@ -277,6 +279,6 @@ const SlackGrantDetails = ({ grant }: { grant: schemas['BenefitGrant'] }) => {
           </Button>
         </a>
       )}
-    </div>
+    </Box>
   )
 }

--- a/clients/apps/web/src/components/Benefit/BenefitProducts.tsx
+++ b/clients/apps/web/src/components/Benefit/BenefitProducts.tsx
@@ -1,12 +1,17 @@
+import { Pagination } from '@/components/Products/Benefits/components/Pagination'
 import LegacyRecurringProductPrices from '@/components/Products/LegacyRecurringProductPrices'
 import ProductPriceLabel from '@/components/Products/ProductPriceLabel'
 import { EmptyState } from '@/components/Shared/EmptyState'
 import { useProducts } from '@/hooks/queries/products'
 import { hasLegacyRecurringPrices } from '@/utils/product'
 import { schemas } from '@polar-sh/client'
-import { List, ListItem, Pill, Status } from '@polar-sh/orbit'
+import { List, ListItem, Pill, Status, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
 import { Package } from 'lucide-react'
 import Link from 'next/link'
+import { useState } from 'react'
+
+const PAGE_SIZE = 10
 
 export interface BenefitProductsProps {
   benefit: schemas['Benefit']
@@ -17,32 +22,35 @@ export const BenefitProducts = ({
   benefit,
   organization,
 }: BenefitProductsProps) => {
+  const [page, setPage] = useState(1)
+
   const { data: products, isLoading } = useProducts(organization.id, {
     benefit_id: benefit.id,
     is_archived: null,
     sorting: ['name'],
-    limit: 100,
+    page,
+    limit: PAGE_SIZE,
   })
 
   const items = products?.items ?? []
+  const totalPages = products?.pagination.max_page ?? 1
 
   return (
-    <div className="flex flex-col gap-6">
-      <div className="flex flex-row items-center justify-between gap-4">
-        <div className="flex flex-col gap-2">
-          <h2 className="text-xl">Products</h2>
-          <p className="dark:text-polar-500 text-gray-500">
+    <Box flexDirection="column" gap="xl">
+      <Box alignItems="center" justifyContent="between" gap="l">
+        <Box flexDirection="column" gap="s">
+          <Text variant="heading-xxs" as="h2">
+            Products
+          </Text>
+          <Text color="muted">
             Products where this benefit currently is enabled
-          </p>
-        </div>
-        {items.length > 0 && (
-          <span className="dark:text-polar-500 text-sm text-gray-500">
-            {items.length} {items.length === 1 ? 'product' : 'products'}
-          </span>
-        )}
-      </div>
+          </Text>
+        </Box>
+      </Box>
       {isLoading ? (
-        <div className="dark:bg-polar-800 h-24 animate-pulse rounded-2xl bg-gray-100" />
+        <div className="animate-pulse">
+          <Box height={96} borderRadius="l" backgroundColor="background-card" />
+        </div>
       ) : items.length === 0 ? (
         <EmptyState
           icon={<Package />}
@@ -50,39 +58,58 @@ export const BenefitProducts = ({
           description="This benefit is not attached to any product yet"
         />
       ) : (
-        <List size="small">
-          {items.map((product) => (
-            <Link
-              key={product.id}
-              href={`/dashboard/${organization.slug}/products/${product.id}`}
-            >
-              <ListItem size="small" className="px-6 py-4">
-                <div className="flex min-w-0 grow flex-row items-center gap-x-2 text-sm">
-                  <span className="truncate">{product.name}</span>
-                  {product.visibility === 'private' && (
-                    <Pill color="gray" className="shrink-0 px-2 py-0.5 text-xs">
-                      Private
-                    </Pill>
-                  )}
-                  {product.is_archived && (
-                    <Status color="red" status="Archived" />
-                  )}
-                </div>
-                <span className="shrink-0 text-sm leading-snug">
-                  {hasLegacyRecurringPrices(product) ? (
-                    <LegacyRecurringProductPrices product={product} />
-                  ) : (
-                    <ProductPriceLabel
-                      product={product}
-                      currency={organization.default_presentment_currency}
-                    />
-                  )}
-                </span>
-              </ListItem>
-            </Link>
-          ))}
-        </List>
+        <Box flexDirection="column" gap="l">
+          <List size="small">
+            {items.map((product) => (
+              <Link
+                key={product.id}
+                href={`/dashboard/${organization.slug}/products/${product.id}`}
+              >
+                <ListItem size="small" className="px-6 py-4">
+                  <Box
+                    minWidth={0}
+                    flexGrow={1}
+                    alignItems="center"
+                    columnGap="s"
+                  >
+                    <Text truncate>{product.name}</Text>
+                    {product.visibility === 'private' && (
+                      <Pill
+                        color="gray"
+                        className="shrink-0 px-2 py-0.5 text-xs"
+                      >
+                        Private
+                      </Pill>
+                    )}
+                    {product.is_archived && (
+                      <Status color="red" status="Archived" />
+                    )}
+                  </Box>
+                  <div className="shrink-0 text-sm leading-snug">
+                    {hasLegacyRecurringPrices(product) ? (
+                      <LegacyRecurringProductPrices product={product} />
+                    ) : (
+                      <ProductPriceLabel
+                        product={product}
+                        currency={organization.default_presentment_currency}
+                      />
+                    )}
+                  </div>
+                </ListItem>
+              </Link>
+            ))}
+          </List>
+          {totalPages > 1 && (
+            <Box justifyContent="end">
+              <Pagination
+                page={page}
+                totalPages={totalPages}
+                onPageChange={setPage}
+              />
+            </Box>
+          )}
+        </Box>
       )}
-    </div>
+    </Box>
   )
 }

--- a/clients/apps/web/src/components/Benefit/BenefitProducts.tsx
+++ b/clients/apps/web/src/components/Benefit/BenefitProducts.tsx
@@ -1,0 +1,88 @@
+import LegacyRecurringProductPrices from '@/components/Products/LegacyRecurringProductPrices'
+import ProductPriceLabel from '@/components/Products/ProductPriceLabel'
+import { EmptyState } from '@/components/Shared/EmptyState'
+import { useProducts } from '@/hooks/queries/products'
+import { hasLegacyRecurringPrices } from '@/utils/product'
+import { schemas } from '@polar-sh/client'
+import { List, ListItem, Pill, Status } from '@polar-sh/orbit'
+import { Package } from 'lucide-react'
+import Link from 'next/link'
+
+export interface BenefitProductsProps {
+  benefit: schemas['Benefit']
+  organization: schemas['Organization']
+}
+
+export const BenefitProducts = ({
+  benefit,
+  organization,
+}: BenefitProductsProps) => {
+  const { data: products, isLoading } = useProducts(organization.id, {
+    benefit_id: benefit.id,
+    is_archived: null,
+    sorting: ['name'],
+    limit: 100,
+  })
+
+  const items = products?.items ?? []
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-row items-center justify-between gap-4">
+        <div className="flex flex-col gap-2">
+          <h2 className="text-xl">Products</h2>
+          <p className="dark:text-polar-500 text-gray-500">
+            Products where this benefit currently is enabled
+          </p>
+        </div>
+        {items.length > 0 && (
+          <span className="dark:text-polar-500 text-sm text-gray-500">
+            {items.length} {items.length === 1 ? 'product' : 'products'}
+          </span>
+        )}
+      </div>
+      {isLoading ? (
+        <div className="dark:bg-polar-800 h-24 animate-pulse rounded-2xl bg-gray-100" />
+      ) : items.length === 0 ? (
+        <EmptyState
+          icon={<Package />}
+          title="No products yet"
+          description="This benefit is not attached to any product yet"
+        />
+      ) : (
+        <List size="small">
+          {items.map((product) => (
+            <Link
+              key={product.id}
+              href={`/dashboard/${organization.slug}/products/${product.id}`}
+            >
+              <ListItem size="small" className="px-6 py-4">
+                <div className="flex min-w-0 grow flex-row items-center gap-x-2 text-sm">
+                  <span className="truncate">{product.name}</span>
+                  {product.visibility === 'private' && (
+                    <Pill color="gray" className="shrink-0 px-2 py-0.5 text-xs">
+                      Private
+                    </Pill>
+                  )}
+                  {product.is_archived && (
+                    <Status color="red" status="Archived" />
+                  )}
+                </div>
+                <span className="shrink-0 text-sm leading-snug">
+                  {hasLegacyRecurringPrices(product) ? (
+                    <LegacyRecurringProductPrices product={product} />
+                  ) : (
+                    <ProductPriceLabel
+                      product={product}
+                      currency={organization.default_presentment_currency}
+                    />
+                  )}
+                </span>
+              </ListItem>
+            </Link>
+          ))}
+        </List>
+      )}
+    </div>
+  )
+}

--- a/clients/apps/web/src/components/Benefit/LicenseKeysPage.tsx
+++ b/clients/apps/web/src/components/Benefit/LicenseKeysPage.tsx
@@ -20,6 +20,8 @@ import {
 import { schemas } from '@polar-sh/client'
 import { Avatar } from '@polar-sh/orbit'
 import { Button } from '@polar-sh/orbit'
+import { Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
 import CopyToClipboardInput from '@polar-sh/ui/components/atoms/CopyToClipboardInput'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@polar-sh/orbit'
 import { RowSelectionState } from '@tanstack/react-table'
@@ -191,9 +193,11 @@ export const LicenseKeysPage = ({
   )
 
   const LicenseKeyContextView = selectedLicenseKey ? (
-    <div className="flex flex-col gap-y-8 p-8">
-      <h1 className="text-xl">License Key</h1>
-      <div className="flex flex-row items-center gap-x-3">
+    <Box flexDirection="column" rowGap="2xl" padding="2xl">
+      <Text variant="heading-xxs" as="h1">
+        License Key
+      </Text>
+      <Box alignItems="center" columnGap="m">
         <Avatar
           className="h-10 w-10"
           avatar_url={selectedLicenseKey.customer.avatar_url}
@@ -203,11 +207,11 @@ export const LicenseKeysPage = ({
             '—'
           }
         />
-        <div className="flex flex-col">
-          <span>{selectedLicenseKey.customer.email ?? '—'}</span>
-        </div>
-      </div>
-      <div className="flex flex-col gap-y-6">
+        <Box flexDirection="column">
+          <Text>{selectedLicenseKey.customer.email ?? '—'}</Text>
+        </Box>
+      </Box>
+      <Box flexDirection="column" rowGap="xl">
         <CopyToClipboardInput
           value={selectedLicenseKey.key}
           onCopy={() => {
@@ -218,8 +222,8 @@ export const LicenseKeysPage = ({
           }}
         />
         <LicenseKeyDetails licenseKey={selectedLicenseKey} />
-      </div>
-      <div className="flex flex-row gap-x-4">
+      </Box>
+      <Box columnGap="l">
         {['disabled', 'revoked'].includes(selectedLicenseKey.status) && (
           <Button
             onClick={() => handleToggleLicenseKeyStatus('granted')}
@@ -246,8 +250,8 @@ export const LicenseKeysPage = ({
             Revoke
           </Button>
         )}
-      </div>
-    </div>
+      </Box>
+    </Box>
   ) : undefined
 
   return (
@@ -257,17 +261,19 @@ export const LicenseKeysPage = ({
         <TabsTrigger value="grants">Grants</TabsTrigger>
       </TabsList>
       <TabsContent value="license-keys">
-        <div className="flex flex-col gap-y-6">
-          <div className="flex flex-row items-center justify-between gap-4">
-            <h2 className="text-xl">License Keys</h2>
-            <div className="w-auto">
+        <Box flexDirection="column" rowGap="xl">
+          <Box alignItems="center" justifyContent="between" gap="l">
+            <Text variant="heading-xxs" as="h2">
+              License Keys
+            </Text>
+            <Box width="auto">
               <LicenseKeyStatusSelect
                 statuses={['granted', 'disabled', 'revoked']}
                 value={status}
                 onChange={setStatus}
               />
-            </div>
-          </div>
+            </Box>
+          </Box>
           <LicenseKeysList
             isLoading={isLoading}
             rowCount={licenseKeys?.pagination.total_count ?? 0}
@@ -300,7 +306,7 @@ export const LicenseKeysPage = ({
               setDeepLinkParam(null)
             }}
           />
-        </div>
+        </Box>
       </TabsContent>
       <TabsContent value="grants">
         <BenefitPage benefit={benefit} organization={organization} />

--- a/clients/apps/web/src/components/Shared/EmptyState.tsx
+++ b/clients/apps/web/src/components/Shared/EmptyState.tsx
@@ -22,11 +22,13 @@ export const EmptyState = ({
         <h3 className="dark:text-polar-50 text-lg text-gray-900">{title}</h3>
         <p className="dark:text-polar-500 text-gray-500">{description}</p>
       </div>
-      <div className="mt-4 flex flex-row gap-x-4">
-        {actions?.map((action, index) => (
-          <Button key={index} {...action} />
-        ))}
-      </div>
+      {(actions?.length ?? 0) > 0 ? (
+        <div className="mt-4 flex flex-row gap-x-4">
+          {actions?.map((action, index) => (
+            <Button key={index} {...action} />
+          ))}
+        </div>
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
- **benefits: add product list**
- **benefits: improve ux of benefit page**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Products section to the Benefit page that lists products using the benefit, and polishes the Benefit and License Keys pages for clearer headers and spacing.

- **New Features**
  - Product list on the Benefit page with pagination (10/page), name sorting, price display, and private/archived badges.
  - Each item links to the product detail page.

- **Refactors**
  - Reworked Benefit and License Keys pages with Orbit layout components for consistent spacing and truncation.
  - Unified heading styles and status selectors.
  - `EmptyState` now renders action buttons only when provided to avoid empty gaps.

<sup>Written for commit 08756cfa2ecb21cd078dce67417aae5e0a1a3ace. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

