### PR TITLE
chore(server): remove unused APITag.mcp and SpeakeasyMCPAPIRoute

### DIFF
--- a/server/polar/customer/endpoints.py
+++ b/server/polar/customer/endpoints.py
@@ -49,7 +49,7 @@ _CustomerAdapter: TypeAdapter[CustomerSchema] = TypeAdapter(CustomerSchema)
 
 router = APIRouter(
     prefix="/customers",
-    tags=["customers", APITag.public, APITag.mcp],
+    tags=["customers", APITag.public],
 )
 
 

--- a/server/polar/customer_meter/endpoints.py
+++ b/server/polar/customer_meter/endpoints.py
@@ -18,7 +18,7 @@ from .service import customer_meter as customer_meter_service
 
 router = APIRouter(
     prefix="/customer-meters",
-    tags=["customer_meters", APITag.public, APITag.mcp],
+    tags=["customer_meters", APITag.public],
 )
 
 

--- a/server/polar/kit/routing.py
+++ b/server/polar/kit/routing.py
@@ -149,35 +149,6 @@ class SpeakeasyPaginationAPIRoute(APIRoute):
             }
 
 
-class SpeakeasyMCPAPIRoute(APIRoute):
-    """
-    A subclass of `APIRoute` that automatically adds `x-speakeasy-mcp` property
-    to the OpenAPI schema.
-    """
-
-    def __init__(self, path: str, endpoint: Callable[..., Any], **kwargs: Any) -> None:
-        super().__init__(path, endpoint, **kwargs)
-        openapi_extra = self.openapi_extra or {}
-        if APITag.mcp in self.tags:
-            safe_method = all(
-                method in {"GET", "HEAD", "OPTIONS"} for method in self.methods
-            )
-            scopes = [
-                "read" if safe_method else "write",
-            ]
-            non_generic_tags = [str(tag) for tag in self.tags if tag not in APITag]
-            if len(non_generic_tags) > 0:
-                scopes.append(".".join(non_generic_tags))
-
-            openapi_extra = {
-                **openapi_extra,
-                "x-speakeasy-mcp": {"disabled": False, "scopes": scopes},
-            }
-        else:
-            openapi_extra = {**openapi_extra, "x-speakeasy-mcp": {"disabled": True}}
-        self.openapi_extra = openapi_extra
-
-
 def _inherit_signature_from[**P, T](
     _to: Callable[P, T],
 ) -> Callable[[Callable[..., T]], Callable[P, T]]:
@@ -203,7 +174,6 @@ __all__ = [
     "IncludedInSchemaAPIRoute",
     "SpeakeasyGroupAPIRoute",
     "SpeakeasyIgnoreAPIRoute",
-    "SpeakeasyMCPAPIRoute",
     "SpeakeasyNameOverrideAPIRoute",
     "SpeakeasyPaginationAPIRoute",
     "get_api_router_class",

--- a/server/polar/member/endpoints.py
+++ b/server/polar/member/endpoints.py
@@ -21,7 +21,7 @@ from .service import member_service
 
 router = APIRouter(
     prefix="/members",
-    tags=["members", APITag.public, APITag.mcp],
+    tags=["members", APITag.public],
 )
 
 MemberNotFound = {

--- a/server/polar/metrics/endpoints.py
+++ b/server/polar/metrics/endpoints.py
@@ -45,7 +45,7 @@ from .service import metrics as metrics_service
 
 VALID_METRIC_SLUGS = {m.slug for m in METRICS}
 
-router = APIRouter(prefix="/metrics", tags=["metrics", APITag.public, APITag.mcp])
+router = APIRouter(prefix="/metrics", tags=["metrics", APITag.public])
 
 MetricDashboardID = Annotated[UUID4, Path(description="The metric dashboard ID.")]
 

--- a/server/polar/openapi.py
+++ b/server/polar/openapi.py
@@ -36,7 +36,6 @@ class APITag(StrEnum):
 
     public = "public"
     private = "private"
-    mcp = "mcp"
 
     @classmethod
     def metadata(cls) -> list[OpenAPITag]:
@@ -54,10 +53,6 @@ class APITag(StrEnum):
                     "Endpoints that should appear in the schema only "
                     "in development to generate our internal JS SDK."
                 ),
-            },
-            {
-                "name": cls.mcp,
-                "description": "Endpoints enabled in the MCP server.",
             },
         ]
 

--- a/server/polar/order/endpoints.py
+++ b/server/polar/order/endpoints.py
@@ -52,7 +52,7 @@ from .service import (
 )
 from .service import order as order_service
 
-router = APIRouter(prefix="/orders", tags=["orders", APITag.public, APITag.mcp])
+router = APIRouter(prefix="/orders", tags=["orders", APITag.public])
 
 
 @router.get(

--- a/server/polar/organization_access_token/endpoints.py
+++ b/server/polar/organization_access_token/endpoints.py
@@ -24,7 +24,7 @@ from .service import organization_access_token as organization_access_token_serv
 
 router = APIRouter(
     prefix="/organization-access-tokens",
-    tags=["organization_access_tokens", APITag.public, APITag.mcp],
+    tags=["organization_access_tokens", APITag.public],
 )
 
 

--- a/server/polar/payment/endpoints.py
+++ b/server/polar/payment/endpoints.py
@@ -17,7 +17,7 @@ from .schemas import Payment as PaymentSchema
 from .schemas import PaymentAdapter, PaymentID
 from .service import payment as payment_service
 
-router = APIRouter(prefix="/payments", tags=["payments", APITag.public, APITag.mcp])
+router = APIRouter(prefix="/payments", tags=["payments", APITag.public])
 
 
 PaymentNotFound = {

--- a/server/polar/product/endpoints.py
+++ b/server/polar/product/endpoints.py
@@ -29,7 +29,7 @@ from .sorting import ProductSortProperty
 
 router = APIRouter(
     prefix="/products",
-    tags=["products", APITag.public, APITag.mcp],
+    tags=["products", APITag.public],
 )
 
 ProductNotFound = {

--- a/server/polar/routing.py
+++ b/server/polar/routing.py
@@ -4,7 +4,6 @@ from polar.kit.routing import (
     IncludedInSchemaAPIRoute,
     SpeakeasyGroupAPIRoute,
     SpeakeasyIgnoreAPIRoute,
-    SpeakeasyMCPAPIRoute,
     SpeakeasyNameOverrideAPIRoute,
     SpeakeasyPaginationAPIRoute,
     get_api_router_class,
@@ -18,7 +17,6 @@ class APIRoute(
     SpeakeasyIgnoreAPIRoute,
     SpeakeasyNameOverrideAPIRoute,
     SpeakeasyGroupAPIRoute,
-    SpeakeasyMCPAPIRoute,
     SpeakeasyPaginationAPIRoute,
 ):
     pass

--- a/server/polar/subscription/endpoints.py
+++ b/server/polar/subscription/endpoints.py
@@ -44,9 +44,7 @@ from .service import subscription as subscription_service
 
 log = structlog.get_logger()
 
-router = APIRouter(
-    prefix="/subscriptions", tags=["subscriptions", APITag.public, APITag.mcp]
-)
+router = APIRouter(prefix="/subscriptions", tags=["subscriptions", APITag.public])
 
 SubscriptionNotFound = {
     "description": "Subscription not found.",


### PR DESCRIPTION
`APITag.mcp` is no longer consumed by anyone as the tools exposed in our MCP is selected outside of this codebase, so this removes it along with `SpeakeasyMCPAPIRoute`.

Follow-up to the discussion in #12446.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused `APITag.mcp` and the `SpeakeasyMCPAPIRoute` that added the `x-speakeasy-mcp` OpenAPI extension, and cleaned `mcp` tags from affected routers. Pure cleanup with no API behavior change and no diff in the generated TypeScript client.

<sup>Written for commit 24eaec29c48e60cb271997d0e8ceb1ecd2ebff62. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

