### PR TITLE
fix(web): disambiguate currency symbols in Latest Orders widget

### DIFF
--- a/clients/apps/web/src/components/Widgets/OrdersWidget.tsx
+++ b/clients/apps/web/src/components/Widgets/OrdersWidget.tsx
@@ -61,7 +61,7 @@ const OrderCard = ({ className, order }: OrderCardProps) => {
       <div className="flex flex-row justify-between gap-x-4">
         <h3 className="min-w-0 truncate">{order.description}</h3>
         <span>
-          {formatCurrency('compact')(order.net_amount, order.currency)}
+          {formatCurrency('standard')(order.net_amount, order.currency)}
         </span>
       </div>
     </Card>


### PR DESCRIPTION
The Latest Orders widget used formatCurrency('compact'), which renders amounts with 'narrowSymbol'. That strips the disambiguating prefix, so AUD displayed as "$" instead of "A$".

Switch to 'standard' mode (currencyDisplay: 'symbol') to match the order detail page, so USD shows as "$" and AUD as "A$". Both modes scrub trailing ".00", so the compact appearance is preserved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changed the Latest Orders widget to use `formatCurrency('standard')` so currency symbols are unambiguous (USD "$", AUD "A$"). This matches the order detail page and keeps the compact look by still stripping trailing ".00".

<sup>Written for commit d8557ba77a10cb6536a526b8227de98f733cfd48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

