### PR TITLE
feat(cases): record prevented chargebacks as a dispute_prevented

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -31443,6 +31443,7 @@ export interface components {
       | 'dispute_under_review'
       | 'dispute_won'
       | 'dispute_lost'
+      | 'dispute_prevented'
     /** SupportCaseThread */
     SupportCaseThread: {
       case: components['schemas']['SupportCase']
@@ -59840,6 +59841,7 @@ export const supportCaseMessageTypeValues: ReadonlyArray<
   'dispute_under_review',
   'dispute_won',
   'dispute_lost',
+  'dispute_prevented',
 ]
 export const supportCaseTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SupportCaseType']

--- a/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
@@ -52,6 +52,11 @@ _OUTCOMES: dict[SupportCaseMessageType, tuple[str, str, str]] = {
     SupportCaseMessageType.appeal_denied: ("badge-error", "icon-x", "Appeal denied"),
     SupportCaseMessageType.dispute_won: ("badge-success", "icon-check", "Dispute won"),
     SupportCaseMessageType.dispute_lost: ("badge-error", "icon-x", "Dispute lost"),
+    SupportCaseMessageType.dispute_prevented: (
+        "badge-success",
+        "icon-shield-check",
+        "Dispute prevented",
+    ),
 }
 
 # Milestone events: title + (lucide icon, node circle classes). These render as
@@ -65,6 +70,7 @@ _EVENT_TITLES: dict[SupportCaseMessageType, str] = {
     SupportCaseMessageType.dispute_under_review: "Dispute under review",
     SupportCaseMessageType.dispute_won: "Dispute won",
     SupportCaseMessageType.dispute_lost: "Dispute lost",
+    SupportCaseMessageType.dispute_prevented: "Dispute prevented",
     SupportCaseMessageType.assigned: "Case assigned",
     SupportCaseMessageType.released: "Case unassigned",
 }
@@ -92,6 +98,10 @@ _EVENT_NODES: dict[SupportCaseMessageType, tuple[str, str]] = {
         "bg-success text-success-content",
     ),
     SupportCaseMessageType.dispute_lost: ("icon-x", "bg-error text-error-content"),
+    SupportCaseMessageType.dispute_prevented: (
+        "icon-shield-check",
+        "bg-success text-success-content",
+    ),
     SupportCaseMessageType.assigned: ("icon-user-check", _MUTED_NODE),
     SupportCaseMessageType.released: ("icon-user-x", _MUTED_NODE),
 }

--- a/server/polar/dispute/dispute_case.py
+++ b/server/polar/dispute/dispute_case.py
@@ -118,6 +118,22 @@ class DisputeCaseService:
         )
         return await self.close(session, case)
 
+    async def prevent(
+        self, session: AsyncSession, case: DisputeSupportCase
+    ) -> SupportCaseMessage:
+        """Record that the chargeback was prevented (refunded before it went
+        through), then close the case — the merchant outcome, kept on the
+        timeline instead of a silent close."""
+        await self._assert_open(session, case)
+        await support_case_service.post_message(
+            session,
+            case,
+            type=SupportCaseMessageType.dispute_prevented,
+            author_kind=SupportCaseMessageAuthorKind.system,
+            audience=[SupportCaseAudience.merchant],
+        )
+        return await self.close(session, case)
+
     async def close(
         self,
         session: AsyncSession,

--- a/server/polar/dispute/service.py
+++ b/server/polar/dispute/service.py
@@ -1,6 +1,7 @@
 import uuid
 from collections.abc import Sequence
 from datetime import UTC, datetime
+from typing import assert_never
 
 import stripe as stripe_lib
 from sqlalchemy.orm import joinedload
@@ -208,13 +209,15 @@ class DisputeService:
         """Reconcile the merchant support case with the dispute's status.
 
         Opens the case the first time the dispute needs a response, posts the
-        milestone updates (under review, won, lost) and closes it on resolution.
-        Idempotent: opening is guarded by the existing case, the closing
-        milestones by the case being open, and the (non-closing) under-review
-        milestone by an actual status change — so retried webhooks are no-ops.
+        milestone for each terminal status (under review, won, lost, prevented)
+        and closes it on resolution. Idempotent: opening is guarded by the
+        existing case, the terminal milestones by the case being open, and the
+        (non-closing) under-review milestone by an actual status change — so
+        retried webhooks are no-ops.
         """
         case = await dispute_case_service.get_case(session, dispute)
 
+        # Open (or reopen) the case the first time the dispute needs a response.
         if dispute.status == DisputeStatus.needs_response:
             if case is None:
                 await dispute_case_service.open_case(
@@ -226,18 +229,26 @@ class DisputeService:
                 await dispute_case_service.reopen(session, case)
             return
 
+        # Every other transition only acts on an already-open case.
         if case is None or not await dispute_case_service.is_open(session, case):
             return
 
-        if dispute.status == DisputeStatus.under_review:
-            if dispute.status != previous_status:
-                await dispute_case_service.mark_under_review(session, case)
-        elif dispute.status in (DisputeStatus.won, DisputeStatus.lost):
-            await dispute_case_service.resolve(
-                session, case, won=dispute.status == DisputeStatus.won
-            )
-        elif dispute.closed:  # prevented: silent close, the merchant never acted
-            await dispute_case_service.close(session, case)
+        match dispute.status:
+            case DisputeStatus.under_review:
+                # Skip the no-op repost when a retried webhook doesn't change it.
+                if dispute.status != previous_status:
+                    await dispute_case_service.mark_under_review(session, case)
+            case DisputeStatus.won | DisputeStatus.lost:
+                await dispute_case_service.resolve(
+                    session, case, won=dispute.status == DisputeStatus.won
+                )
+            case DisputeStatus.prevented:
+                await dispute_case_service.prevent(session, case)
+            case DisputeStatus.needs_response | DisputeStatus.early_warning:
+                # needs_response is handled above; early_warning never has a case.
+                pass
+            case _:
+                assert_never(dispute.status)
 
     async def upsert_from_chargeback_stop(
         self, session: AsyncSession, alert: ChargebackStopAlert

--- a/server/polar/models/support_case.py
+++ b/server/polar/models/support_case.py
@@ -80,6 +80,7 @@ class SupportCaseMessageType(StrEnum):
     dispute_under_review = "dispute_under_review"
     dispute_won = "dispute_won"
     dispute_lost = "dispute_lost"
+    dispute_prevented = "dispute_prevented"
 
 
 class SupportCase(RecordModel):

--- a/server/scripts/backfill_dispute_prevented_milestone.py
+++ b/server/scripts/backfill_dispute_prevented_milestone.py
@@ -1,0 +1,150 @@
+"""
+Backfill the ``dispute_prevented`` milestone onto dispute support cases that were
+silently closed before that lifecycle event existed.
+
+Prevented disputes (chargebacks refunded before they went through) used to close
+the case with a bare ``closed`` event — no record of *why*. Going forward the
+sync posts a ``dispute_prevented`` milestone; this adds it to the existing stock.
+
+A case qualifies when:
+  - it's a dispute case (``type = dispute``) whose dispute is ``prevented``,
+  - it has a ``closed`` event (it was actually closed), and
+  - it has no ``dispute_prevented`` message yet (so this is re-runnable).
+
+The milestone is inserted just before the ``closed`` event (system-authored,
+merchant audience, no body — same as the live path).
+
+Usage:
+    cd server
+
+    # Dry-run (default) — list the cases that would get the milestone:
+    uv run python -m scripts.backfill_dispute_prevented_milestone
+
+    # Apply:
+    uv run python -m scripts.backfill_dispute_prevented_milestone --execute
+"""
+
+from collections.abc import Sequence
+from datetime import timedelta
+from typing import Any
+
+import structlog
+import typer
+from rich.console import Console
+from rich.table import Table
+from sqlalchemy import Select, func, select
+
+from polar.kit.db.postgres import create_async_sessionmaker
+from polar.models import Dispute, Order, Organization
+from polar.models.dispute import DisputeStatus
+from polar.models.support_case import (
+    DisputeSupportCase,
+    SupportCase,
+    SupportCaseAudience,
+    SupportCaseMessage,
+    SupportCaseMessageAuthorKind,
+    SupportCaseMessageType,
+    SupportCaseType,
+)
+from polar.postgres import create_async_engine
+from scripts.helper import configure_script_console_logging, typer_async
+
+cli = typer.Typer()
+console = Console()
+configure_script_console_logging()
+log = structlog.get_logger()
+
+
+def _statement() -> Select[Any]:
+    closed_at = (
+        select(func.max(SupportCaseMessage.created_at))
+        .where(
+            SupportCaseMessage.case_id == SupportCase.id,
+            SupportCaseMessage.type == SupportCaseMessageType.closed,
+            SupportCaseMessage.deleted_at.is_(None),
+        )
+        .scalar_subquery()
+    )
+    has_prevented = (
+        select(SupportCaseMessage.id)
+        .where(
+            SupportCaseMessage.case_id == SupportCase.id,
+            SupportCaseMessage.type == SupportCaseMessageType.dispute_prevented,
+        )
+        .exists()
+    )
+    return (
+        select(
+            SupportCase.id.label("case_id"),
+            Organization.slug.label("org"),
+            closed_at.label("closed_at"),
+        )
+        .join(Dispute, DisputeSupportCase.dispute_id == Dispute.id)
+        .join(Order, Dispute.order_id == Order.id)
+        .join(Organization, Order.organization_id == Organization.id)
+        .where(
+            SupportCase.type == SupportCaseType.dispute,
+            SupportCase.deleted_at.is_(None),
+            Dispute.status == DisputeStatus.prevented,
+            closed_at.is_not(None),
+            ~has_prevented,
+        )
+        .order_by(closed_at)
+    )
+
+
+def _render(rows: Sequence[Any]) -> None:
+    table = Table(title=f"Prevented cases missing the milestone ({len(rows)})")
+    table.add_column("Case ID", style="dim")
+    table.add_column("Organization")
+    table.add_column("Closed at", style="yellow")
+    for row in rows:
+        table.add_row(str(row.case_id), row.org, str(row.closed_at))
+    console.print(table)
+
+
+@cli.command()
+@typer_async
+async def backfill_dispute_prevented_milestone(
+    execute: bool = typer.Option(
+        False, help="Actually insert the milestones (default: dry-run)"
+    ),
+) -> None:
+    engine = create_async_engine("script")
+    sessionmaker = create_async_sessionmaker(engine)
+    mode = "EXECUTE" if execute else "DRY-RUN"
+    console.rule(f"[bold]Backfill dispute_prevented milestone — {mode}")
+
+    try:
+        async with sessionmaker() as session:
+            rows = (await session.execute(_statement())).all()
+            _render(rows)
+
+            if not rows:
+                log.info("Nothing to do — every prevented case has the milestone")
+                return
+            if not execute:
+                log.info(
+                    "Dry-run only — re-run with --execute to insert", total=len(rows)
+                )
+                return
+
+            for row in rows:
+                session.add(
+                    SupportCaseMessage(
+                        case_id=row.case_id,
+                        type=SupportCaseMessageType.dispute_prevented,
+                        author_kind=SupportCaseMessageAuthorKind.system,
+                        audience=[SupportCaseAudience.merchant],
+                        # Sit just before the close so the timeline reads in order.
+                        created_at=row.closed_at - timedelta(microseconds=1),
+                    )
+                )
+            await session.commit()
+            log.info("Backfilled dispute_prevented milestones", total=len(rows))
+    finally:
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/tests/dispute/test_service.py
+++ b/server/tests/dispute/test_service.py
@@ -843,6 +843,54 @@ class TestUpsertFromStripeDisputeCase:
         types = await _message_types(session, case)
         assert types.count(SupportCaseMessageType.dispute_under_review) == 1
 
+    async def test_posts_prevented_message_on_prevented_close(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        organization: Organization,
+        dispute_transaction_service_mock: MagicMock,
+        refund_service_mock: MagicMock,
+    ) -> None:
+        order = await create_order(save_fixture, customer=customer)
+        charge_id = "STRIPE_CHARGE_ID"
+        await create_payment(
+            save_fixture, organization, order=order, processor_id=charge_id
+        )
+        needs_response = build_stripe_dispute(
+            status="needs_response",
+            charge_id=charge_id,
+            amount=order.subtotal_amount + order.tax_amount,
+            balance_transactions=[],
+        )
+        await dispute_service.upsert_from_stripe(session, needs_response)
+
+        # Rapid-resolution: Stripe reports "lost" with a zero-fee balance txn,
+        # which we treat as prevented and close the case.
+        prevented = build_stripe_dispute(
+            status="lost",
+            id=needs_response.id,
+            charge_id=charge_id,
+            amount=order.subtotal_amount + order.tax_amount,
+            balance_transactions=[
+                build_stripe_balance_transaction(
+                    amount=-order.due_amount, reporting_category="dispute", fee=0
+                )
+            ],
+        )
+        dispute = await dispute_service.upsert_from_stripe(session, prevented)
+        assert dispute.status == DisputeStatus.prevented
+
+        case = await dispute_case_service.get_case(session, dispute)
+        assert case is not None
+        assert not await dispute_case_service.is_open(session, case)
+        types = await _message_types(session, case)
+        # The prevented outcome is on the timeline, before the close.
+        assert types.count(SupportCaseMessageType.dispute_prevented) == 1
+        assert types.index(SupportCaseMessageType.dispute_prevented) < types.index(
+            SupportCaseMessageType.closed
+        )
+
     async def test_under_review_message_not_duplicated_on_retry(
         self,
         save_fixture: SaveFixture,


### PR DESCRIPTION
## Summary

Prevented chargebacks (refunded before they go through — e.g. via ChargebackStop or RDR) used to close their dispute support case **silently**, leaving no record of *why* it closed. This makes "prevented" a first-class lifecycle event on the case, symmetric with won/lost, and backfills the existing stock.
<!-- Brief description of what this PR does -->

## What

- New `SupportCaseMessageType.dispute_prevented` lifecycle milestone (string column — no migration).
- The dispute→case sync now posts `dispute_prevented` (then closes) instead of a bare `closed`, so the timeline records the outcome.
- Backoffice renders the milestone (timeline event "Dispute prevented" + header outcome badge).
- Refactored the terminal-status handling in `_sync_support_case` into an explicit, exhaustive `match`.
- One-off backfill script to add the milestone to dispute cases that were already silently closed.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record prevented chargebacks as a `dispute_prevented` milestone and show it in support cases instead of silently closing. Sync now posts the milestone, then closes; a script backfills old cases.

- **New Features**
  - Added `dispute_prevented` case milestone; sync posts it for prevented disputes and then closes the case, and the generated `v1` API client now includes this type.
  - Backoffice shows "Dispute prevented" in the timeline and as an outcome badge.
  - Refactored terminal status handling to an explicit match and added `prevent()` on dispute cases; tests cover the new path.

- **Migration**
  - Backfill historical cases: `uv run python -m scripts.backfill_dispute_prevented_milestone --execute` (dry-run by default).

<sup>Written for commit 7a79a4a281b5060b596e24e43a316648bfc2e8ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

