### PR TITLE
feat: (customer-portal)allow editing member names in the customer portal

### DIFF
--- a/clients/apps/web/src/components/CustomerPortal/InlineEditTableRow.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/InlineEditTableRow.tsx
@@ -1,6 +1,4 @@
-import { Button } from '@polar-sh/orbit'
-import { Input } from '@polar-sh/orbit'
-import { Text } from '@polar-sh/orbit'
+import { Button, Input, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 
 interface InlineEditTableRowProps {
@@ -13,7 +11,6 @@ interface InlineEditTableRowProps {
   type?: 'text' | 'email'
   loading?: boolean
   error?: string
-  saveDisabled?: boolean
   colSpan?: number
 }
 
@@ -27,9 +24,9 @@ export const InlineEditTableRow = ({
   type = 'text',
   loading = false,
   error,
-  saveDisabled = false,
   colSpan = 3,
 }: InlineEditTableRowProps) => {
+  const saveDisabled = value.trim().length === 0
   return (
     <tr className="border-b transition-colors">
       <td colSpan={colSpan} className="p-0">

--- a/clients/apps/web/src/components/CustomerPortal/InlineEditTableRow.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/InlineEditTableRow.tsx
@@ -1,0 +1,74 @@
+import { Button } from '@polar-sh/orbit'
+import { Input } from '@polar-sh/orbit'
+import { Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+
+interface InlineEditTableRowProps {
+  value: string
+  onChange: (value: string) => void
+  onSave: () => void
+  onCancel: () => void
+  placeholder?: string
+  submitLabel?: string
+  type?: 'text' | 'email'
+  loading?: boolean
+  error?: string
+  saveDisabled?: boolean
+  colSpan?: number
+}
+
+export const InlineEditTableRow = ({
+  value,
+  onChange,
+  onSave,
+  onCancel,
+  placeholder,
+  submitLabel = 'Save',
+  type = 'text',
+  loading = false,
+  error,
+  saveDisabled = false,
+  colSpan = 3,
+}: InlineEditTableRowProps) => {
+  return (
+    <tr className="border-b transition-colors">
+      <td colSpan={colSpan} className="p-0">
+        <Box alignItems="start" gap="l" p="l">
+          <Box flexDirection="column" flex={1} gap="xs">
+            <Input
+              type={type}
+              value={value}
+              autoFocus
+              placeholder={placeholder}
+              disabled={loading}
+              onChange={(e) => onChange(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !saveDisabled) {
+                  onSave()
+                }
+                if (e.key === 'Escape') {
+                  onCancel()
+                }
+              }}
+            />
+            {error && (
+              <Text variant="caption" color="danger">
+                {error}
+              </Text>
+            )}
+          </Box>
+          <Button
+            onClick={onSave}
+            loading={loading}
+            disabled={loading || saveDisabled}
+          >
+            {submitLabel}
+          </Button>
+          <Button variant="ghost" onClick={onCancel} disabled={loading}>
+            Cancel
+          </Button>
+        </Box>
+      </td>
+    </tr>
+  )
+}

--- a/clients/apps/web/src/components/CustomerPortal/SeatManagementTable.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/SeatManagementTable.tsx
@@ -61,7 +61,6 @@ export const SeatManagementTable = ({
 
   const [email, setEmail] = useState('')
   const [error, setError] = useState<string>()
-  const [isSending, setIsSending] = useState(false)
   const [isInviting, setIsInviting] = useState(false)
   const [loadingSeats, setLoadingSeats] = useState<Set<string>>(new Set())
   const [editingSeatId, setEditingSeatId] = useState<string>()
@@ -82,7 +81,6 @@ export const SeatManagementTable = ({
       return
     }
 
-    setIsSending(true)
     setError(undefined)
 
     try {
@@ -105,8 +103,6 @@ export const SeatManagementTable = ({
       }
     } catch {
       setError('Failed to send invitation')
-    } finally {
-      setIsSending(false)
     }
   }
 
@@ -323,9 +319,8 @@ export const SeatManagementTable = ({
                     value={email}
                     placeholder="email@example.com"
                     submitLabel="Invite"
-                    loading={isSending}
+                    loading={assignSeat.isPending}
                     error={error}
-                    saveDisabled={!email.trim()}
                     onChange={(value) => {
                       setEmail(value)
                       setError(undefined)
@@ -340,20 +335,19 @@ export const SeatManagementTable = ({
                 ) : (
                   <tr className="border-b transition-colors">
                     <td colSpan={3} className="p-0">
-                      <button
-                        type="button"
-                        className="flex w-full items-center justify-between px-4 py-4 text-left transition-colors"
-                        onClick={() => setIsInviting(true)}
-                      >
-                        <span className="dark:text-polar-400 text-gray-500">
+                      <Box alignItems="center" justifyContent="between" p="l">
+                        <Text color="muted">
                           {availableSeats === 1
                             ? 'One more seat available'
                             : `${availableSeats} more seats available`}
-                        </span>
-                        <span className="dark:bg-polar-700 dark:hover:bg-polar-600 flex h-10 cursor-pointer items-center rounded-xl border border-black/4 bg-gray-100 px-3 text-sm font-medium text-black hover:bg-gray-200 dark:border-white/5 dark:text-white">
+                        </Text>
+                        <Button
+                          variant="secondary"
+                          onClick={() => setIsInviting(true)}
+                        >
                           Invite member
-                        </span>
-                      </button>
+                        </Button>
+                      </Box>
                     </td>
                   </tr>
                 ))}

--- a/clients/apps/web/src/components/CustomerPortal/SeatManagementTable.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/SeatManagementTable.tsx
@@ -5,6 +5,7 @@ import {
   useCustomerSeats,
   useResendSeatInvitation,
   useRevokeSeat,
+  useUpdateCustomerPortalMember,
 } from '@/hooks/queries/customerPortal'
 import { validateEmail } from '@/utils/validation'
 import MoreVertOutlined from '@mui/icons-material/MoreVertOutlined'
@@ -16,25 +17,16 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@polar-sh/ui/components/atoms/DropdownMenu'
-import { Input } from '@polar-sh/orbit'
 import { Status } from '@polar-sh/orbit'
+import { Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
 import { useState } from 'react'
 import { toast } from '../Toast/use-toast'
 import { seatStatusDisplayConfig } from '../Seats/seatStatus'
 import { CustomerSeatQuantityManager } from './CustomerSeatQuantityManager'
+import { InlineEditTableRow } from './InlineEditTableRow'
 
-interface CustomerSeat {
-  id: string
-  subscription_id?: string | null
-  order_id?: string | null
-  status: 'pending' | 'claimed' | 'revoked'
-  customer_id?: string | null
-  customer_email?: string | null
-  claimed_at?: string | null
-  revoked_at?: string | null
-  created_at: string
-  seat_metadata?: Record<string, unknown> | null
-}
+type CustomerSeat = schemas['CustomerSeat']
 
 type SeatBasedSubscription = { subscriptionId: string }
 type SeatBasedOrder = { orderId: string }
@@ -65,12 +57,16 @@ export const SeatManagementTable = ({
   const assignSeat = useAssignSeat(api)
   const revokeSeat = useRevokeSeat(api)
   const resendInvitation = useResendSeatInvitation(api)
+  const updateMember = useUpdateCustomerPortalMember(api)
 
   const [email, setEmail] = useState('')
   const [error, setError] = useState<string>()
   const [isSending, setIsSending] = useState(false)
   const [isInviting, setIsInviting] = useState(false)
   const [loadingSeats, setLoadingSeats] = useState<Set<string>>(new Set())
+  const [editingSeatId, setEditingSeatId] = useState<string>()
+  const [editName, setEditName] = useState('')
+  const [editError, setEditError] = useState<string>()
 
   const totalSeats = seatsData?.total_seats || 0
   const availableSeats = seatsData?.available_seats || 0
@@ -162,6 +158,41 @@ export const SeatManagementTable = ({
     }
   }
 
+  const startEditingName = (seat: CustomerSeat) => {
+    setEditingSeatId(seat.id)
+    setEditName(seat.member?.name ?? '')
+    setEditError(undefined)
+  }
+
+  const cancelEditingName = () => {
+    setEditingSeatId(undefined)
+    setEditName('')
+    setEditError(undefined)
+  }
+
+  const handleSaveName = async (seat: CustomerSeat) => {
+    if (!seat.member?.id) {
+      return
+    }
+
+    setEditError(undefined)
+    try {
+      await updateMember.mutateAsync({
+        id: seat.member.id,
+        body: { name: editName.trim() || null },
+      })
+      cancelEditingName()
+      toast({
+        title: 'Name updated',
+        description: "The member's name has been updated.",
+      })
+    } catch (error) {
+      setEditError(
+        error instanceof Error ? error.message : 'Failed to update name',
+      )
+    }
+  }
+
   const isSubscription = isSeatBasedSubscription(identifier)
 
   return (
@@ -186,7 +217,7 @@ export const SeatManagementTable = ({
             <thead className="[&_tr]:border-b">
               <tr className="dark:bg-polar-800 border-b bg-gray-50">
                 <th className="text-muted-foreground h-12 px-4 text-left align-middle font-medium">
-                  Email
+                  Member
                 </th>
                 <th className="text-muted-foreground h-12 px-4 text-left align-middle font-medium">
                   Status
@@ -204,12 +235,38 @@ export const SeatManagementTable = ({
                   const [label, color] = seatStatusDisplayConfig[seat.status]
                   const isSeatLoading = loadingSeats.has(seat.id)
 
+                  const isEditingName = editingSeatId === seat.id
+                  const memberName = seat.member?.name
+                  const memberEmail =
+                    seat.member?.email || seat.customer_email || '—'
+
+                  if (isEditingName) {
+                    return (
+                      <InlineEditTableRow
+                        key={seat.id}
+                        value={editName}
+                        placeholder="Member name"
+                        loading={updateMember.isPending}
+                        error={editError}
+                        onChange={(value) => {
+                          setEditName(value)
+                          setEditError(undefined)
+                        }}
+                        onSave={() => handleSaveName(seat)}
+                        onCancel={cancelEditingName}
+                      />
+                    )
+                  }
+
                   return (
                     <tr key={seat.id} className="border-b transition-colors">
                       <td className="p-4 align-middle">
-                        <span className="text-sm">
-                          {seat.customer_email || '—'}
-                        </span>
+                        <Box flexDirection="column">
+                          {memberName && <Text>{memberName}</Text>}
+                          <Text color={memberName ? 'muted' : undefined}>
+                            {memberEmail}
+                          </Text>
+                        </Box>
                       </td>
                       <td className="p-4 align-middle">
                         <Status color={color} status={label} />
@@ -227,6 +284,14 @@ export const SeatManagementTable = ({
                                 </Button>
                               </DropdownMenuTrigger>
                               <DropdownMenuContent align="end">
+                                {seat.member?.id && (
+                                  <DropdownMenuItem
+                                    onClick={() => startEditingName(seat)}
+                                    disabled={isSeatLoading}
+                                  >
+                                    Edit name
+                                  </DropdownMenuItem>
+                                )}
                                 {seat.status === 'pending' && (
                                   <DropdownMenuItem
                                     onClick={() =>
@@ -251,58 +316,30 @@ export const SeatManagementTable = ({
                     </tr>
                   )
                 })}
-              {availableSeats > 0 && (
-                <tr className="border-b transition-colors">
-                  <td colSpan={3} className="p-0">
-                    {isInviting ? (
-                      <div className="flex items-start gap-4 p-4">
-                        <div className="flex-1">
-                          <Input
-                            type="email"
-                            placeholder="email@example.com"
-                            value={email}
-                            autoFocus
-                            onChange={(e) => {
-                              setEmail(e.target.value)
-                              setError(undefined)
-                            }}
-                            disabled={isSending}
-                            onKeyDown={(e) => {
-                              if (e.key === 'Enter') {
-                                handleAssignSeat()
-                              }
-                              if (e.key === 'Escape') {
-                                setIsInviting(false)
-                                setEmail('')
-                                setError(undefined)
-                              }
-                            }}
-                          />
-                          {error && (
-                            <p className="dark:text-polar-400 mt-1 text-xs text-gray-500">
-                              {error}
-                            </p>
-                          )}
-                        </div>
-                        <Button
-                          onClick={handleAssignSeat}
-                          disabled={!email.trim() || isSending}
-                          loading={isSending}
-                        >
-                          Invite
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          onClick={() => {
-                            setIsInviting(false)
-                            setEmail('')
-                            setError(undefined)
-                          }}
-                        >
-                          Cancel
-                        </Button>
-                      </div>
-                    ) : (
+              {availableSeats > 0 &&
+                (isInviting ? (
+                  <InlineEditTableRow
+                    type="email"
+                    value={email}
+                    placeholder="email@example.com"
+                    submitLabel="Invite"
+                    loading={isSending}
+                    error={error}
+                    saveDisabled={!email.trim()}
+                    onChange={(value) => {
+                      setEmail(value)
+                      setError(undefined)
+                    }}
+                    onSave={handleAssignSeat}
+                    onCancel={() => {
+                      setIsInviting(false)
+                      setEmail('')
+                      setError(undefined)
+                    }}
+                  />
+                ) : (
+                  <tr className="border-b transition-colors">
+                    <td colSpan={3} className="p-0">
                       <button
                         type="button"
                         className="flex w-full items-center justify-between px-4 py-4 text-left transition-colors"
@@ -317,10 +354,9 @@ export const SeatManagementTable = ({
                           Invite member
                         </span>
                       </button>
-                    )}
-                  </td>
-                </tr>
-              )}
+                    </td>
+                  </tr>
+                ))}
             </tbody>
           </table>
         </div>

--- a/clients/apps/web/src/hooks/queries/customerPortal.ts
+++ b/clients/apps/web/src/hooks/queries/customerPortal.ts
@@ -574,8 +574,12 @@ export const useUpdateCustomerPortalMember = (api: Client) =>
       return result
     },
     onSuccess: async () => {
-      getQueryClient().invalidateQueries({
+      const queryClient = getQueryClient()
+      queryClient.invalidateQueries({
         queryKey: ['customer_portal_members'],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ['customer_seats'],
       })
     },
   })

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -4250,7 +4250,7 @@ export interface paths {
     head?: never
     /**
      * Update Member
-     * @description Update a member's role.
+     * @description Update a member's name or role.
      *
      *     Only available to owners and billing managers of team customers.
      *
@@ -16663,9 +16663,14 @@ export interface components {
     }
     /**
      * CustomerPortalMemberUpdate
-     * @description Schema for updating a member's role in the customer portal.
+     * @description Schema for updating a member in the customer portal.
      */
     CustomerPortalMemberUpdate: {
+      /**
+       * Name
+       * @description The new name for the member.
+       */
+      name?: string | null
       /**
        * @description The new role for the member.
        * @example billing_manager

--- a/server/polar/customer_portal/endpoints/member.py
+++ b/server/polar/customer_portal/endpoints/member.py
@@ -168,8 +168,13 @@ async def update_member(
     if member is None:
         raise ResourceNotFound("Member not found")
 
-    # Prevent changing your own role (self-demotion). Name changes are allowed.
-    if member_update.role is not None and member.id == actor_member.id:
+    # Prevent changing your own role (self-demotion). A no-op role value and
+    # name changes are allowed.
+    if (
+        member_update.role is not None
+        and member_update.role != member.role
+        and member.id == actor_member.id
+    ):
         raise PolarRequestValidationError(
             [
                 {

--- a/server/polar/customer_portal/endpoints/member.py
+++ b/server/polar/customer_portal/endpoints/member.py
@@ -151,7 +151,7 @@ async def update_member(
     session: AsyncSession = Depends(get_db_session),
 ) -> Member:
     """
-    Update a member's role.
+    Update a member's name or role.
 
     Only available to owners and billing managers of team customers.
 
@@ -168,12 +168,8 @@ async def update_member(
     if member is None:
         raise ResourceNotFound("Member not found")
 
-    # If no role provided, return member unchanged
-    if member_update.role is None:
-        return member
-
-    # Prevent self-modification
-    if member.id == actor_member.id:
+    # Prevent changing your own role (self-demotion). Name changes are allowed.
+    if member_update.role is not None and member.id == actor_member.id:
         raise PolarRequestValidationError(
             [
                 {
@@ -186,7 +182,11 @@ async def update_member(
         )
 
     return await member_service.update(
-        session, member, role=member_update.role, caller_member=actor_member
+        session,
+        member,
+        name=member_update.name,
+        role=member_update.role,
+        caller_member=actor_member,
     )
 
 

--- a/server/polar/customer_portal/schemas/member.py
+++ b/server/polar/customer_portal/schemas/member.py
@@ -2,6 +2,7 @@ from pydantic import Field
 
 from polar.kit.email import EmailStrDNS
 from polar.kit.schemas import IDSchema, Schema, TimestampedSchema
+from polar.member.schemas import MemberNameInput
 from polar.models.member import MemberRole
 
 
@@ -29,8 +30,12 @@ class CustomerPortalMemberCreate(Schema):
 
 
 class CustomerPortalMemberUpdate(Schema):
-    """Schema for updating a member's role in the customer portal."""
+    """Schema for updating a member in the customer portal."""
 
+    name: MemberNameInput | None = Field(
+        default=None,
+        description="The new name for the member.",
+    )
     role: MemberRole | None = Field(
         default=None,
         description="The new role for the member.",

--- a/server/polar/member/service.py
+++ b/server/polar/member/service.py
@@ -783,7 +783,7 @@ class MemberService:
         update_dict = {}
         if name is not None:
             update_dict["name"] = name
-        if role is not None and not transferred:
+        if role is not None and role != member.role and not transferred:
             update_dict["role"] = role
         if new_email is not None:
             update_dict["email"] = new_email

--- a/server/tests/customer_portal/endpoints/test_member.py
+++ b/server/tests/customer_portal/endpoints/test_member.py
@@ -386,6 +386,62 @@ class TestUpdateMember:
 
     @pytest.mark.auth(MEMBER_OWNER_AUTH_SUBJECT)
     @pytest.mark.keep_session_state
+    async def test_owner_can_update_member_name(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        member_owner: Member,
+    ) -> None:
+        """Owner can update another member's name without touching the role."""
+        customer.type = CustomerType.team
+        await save_fixture(customer)
+
+        member2 = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="member@example.com",
+            name="Regular Member",
+            role=MemberRole.member,
+        )
+        await save_fixture(member2)
+
+        response = await client.patch(
+            f"/v1/customer-portal/members/{member2.id}",
+            json={"name": "Renamed Member"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "Renamed Member"
+        assert data["role"] == "member"
+
+    @pytest.mark.auth(MEMBER_OWNER_AUTH_SUBJECT)
+    @pytest.mark.keep_session_state
+    async def test_can_update_own_name(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        member_owner: Member,
+    ) -> None:
+        """Editing your own name is allowed (unlike role)."""
+        customer.type = CustomerType.team
+        await save_fixture(customer)
+
+        response = await client.patch(
+            f"/v1/customer-portal/members/{member_owner.id}",
+            json={"name": "My New Name"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "My New Name"
+
+    @pytest.mark.auth(MEMBER_OWNER_AUTH_SUBJECT)
+    @pytest.mark.keep_session_state
     async def test_owner_can_transfer_ownership(
         self,
         client: AsyncClient,


### PR DESCRIPTION
---
## Summary

Customers can now edit a team member's name directly from the seat management table in the customer portal. Previously only roles could be updated.

**Backend**

The update_member endpoint and CustomerPortalMemberUpdate schema now accept an optional name. The self-modification guard was narrowed to role changes only, so a member can rename themselves but still can't change their own role. Added tests covering name updates for both other members and oneself.

**Frontend**

Introduced a reusable InlineEditTableRow component for inline edit/save/cancel rows (with Enter/Escape support), now used for both inviting members and editing names. The seat table was refactored to show member name + email, add an "Edit name" action, use the generated CustomerSeat type, and migrate legacy Tailwind markup to Orbit primitives.


| Edit Member Form Seats | 
|---|
| <img width="790" height="513" alt="Screenshot 2026-06-18 at 10 58 03" src="https://github.com/user-attachments/assets/303aac53-70b2-4712-bf3f-4d77dfe3336c" /> |


## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [X] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [X] The diff is reasonably sized and easy to review
- [X] New functionality is covered by tests
- [X] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [X] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow editing a team member’s name directly from the customer portal seat table. Adds API support for name updates and a reusable inline edit row for a smoother invite/edit flow.

- **New Features**
  - Edit a member’s name inline from the seat table (Enter/Escape, save/cancel); member column shows name + email and adds an “Edit name” action.
  - API now accepts optional `name` for member updates; no-op role updates are allowed and don’t write to the DB; self role changes are still blocked; tests added.
  - On successful updates, invalidate `customer_portal_members` and `customer_seats` queries.

- **Refactors**
  - Introduced `InlineEditTableRow` and reused it for invites and name edits.
  - Seat table migrated to `@polar-sh/orbit` primitives and now uses the generated `CustomerSeat` type.

<sup>Written for commit 1b27cb2f88028e84c2d5369e52fffb20227f0bdb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

