### PR TITLE
feat(worker): run tinybird worker on a DB-less broker

### DIFF
--- a/server/polar/worker/_broker.py
+++ b/server/polar/worker/_broker.py
@@ -175,7 +175,7 @@ class LogfireMiddleware(dramatiq.Middleware):
         return self.after_process_message(broker, message)
 
 
-def get_broker() -> dramatiq.Broker:
+def get_broker(*, database: bool = True) -> dramatiq.Broker:
     redis_pool = redis.ConnectionPool.from_url(
         settings.redis_url,
         client_name=f"{settings.ENV.value}.worker.dramatiq",
@@ -193,7 +193,7 @@ def get_broker() -> dramatiq.Broker:
         # Group completion callbacks for orchestrating task sequences
         GroupCallbacks(rate_limiter_backend),
         # Resource lifecycle (worker boot/shutdown)
-        SQLAlchemyMiddleware(),
+        *([SQLAlchemyMiddleware()] if database else []),
         RedisMiddleware(),
         HTTPXMiddleware(),
         HealthMiddleware(),

--- a/server/polar/worker/run_without_db.py
+++ b/server/polar/worker/run_without_db.py
@@ -1,0 +1,26 @@
+import dramatiq
+
+from polar.worker._broker import get_broker
+from polar.worker._encoder import JSONEncoder
+
+# Entrypoint for workers whose queues never touch PostgreSQL. Building the broker
+# without the SQLAlchemy middleware avoids creating a database engine/pool the
+# worker would never use. The broker must be set as the global broker before
+# `polar.tasks` is imported, so actors are declared against it rather than the
+# default (database-backed) broker created by `polar.worker`.
+broker = get_broker(database=False)
+dramatiq.set_broker(broker)
+dramatiq.set_encoder(JSONEncoder(broker))
+
+from polar import tasks  # noqa: E402
+from polar.logfire import configure_logfire  # noqa: E402
+from polar.logging import configure as configure_logging  # noqa: E402
+from polar.posthog import configure_posthog  # noqa: E402
+from polar.sentry import configure_sentry  # noqa: E402
+
+configure_sentry()
+configure_logfire("worker")
+configure_logging(logfire=True)
+configure_posthog()
+
+__all__ = ["broker", "tasks"]

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -195,11 +195,11 @@ module "production" {
       dramatiq_prom_port = "10001"
       database_pool_size = "16"
     }
-    "worker-tinybird" = {
-      start_command      = "uv run dramatiq polar.worker.run -p 4 -t 32 --queues tinybird"
+    worker-tinybird = {
+      start_command      = "uv run dramatiq polar.worker.run_without_db -p 4 -t 32 --queues tinybird"
       dramatiq_prom_port = "10002"
     }
-    "worker-invoices-receipts" = {
+    worker-invoices-receipts = {
       start_command      = "uv run dramatiq polar.worker.run -p 1 -t 3 --queues invoices_and_receipts"
       plan               = "standard"
       dramatiq_prom_port = "10003"

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -120,7 +120,7 @@ module "sandbox" {
       database_pool_size = "16"
     }
     worker-sandbox-tinybird = {
-      start_command      = "uv run dramatiq polar.worker.run -p 1 -t 16 --queues tinybird"
+      start_command      = "uv run dramatiq polar.worker.run_without_db -p 1 -t 16 --queues tinybird"
       dramatiq_prom_port = "10002"
     }
     worker-sandbox-invoices-receipts = {


### PR DESCRIPTION
The tinybird worker (i.e. the tasks scheduled on the queue it consumes) never use the db, so we shouldn't set up an idle db connection pool for it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the Tinybird worker on a DB‑less `dramatiq` broker to avoid creating a Postgres engine/pool. Other workers keep using the default DB-backed broker.

- **Refactors**
  - `get_broker(*, database: bool = True)` now conditionally adds `SQLAlchemyMiddleware`.
  - Added `polar.worker.run_without_db` that sets a DB‑less broker before importing `polar.tasks`.
  - Updated production and sandbox Terraform to start the Tinybird worker with `polar.worker.run_without_db` (queues/flags unchanged).

<sup>Written for commit 3a737453451f19cd1f2a780a916a28cc114d249a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

