### PR TITLE
Select and Combobox color fix

### DIFF
--- a/clients/apps/web/src/components/Shared/EmptyState.tsx
+++ b/clients/apps/web/src/components/Shared/EmptyState.tsx
@@ -1,4 +1,5 @@
-import { Button } from '@polar-sh/orbit'
+import { Button, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
 import { ButtonProps } from '@polar-sh/orbit/ui/button'
 import { ReactNode } from 'react'
 
@@ -16,19 +17,31 @@ export const EmptyState = ({
   actions,
 }: EmptyStateProps) => {
   return (
-    <div className="dark:border-polar-700 flex flex-col items-center justify-center gap-2 rounded-xl border border-gray-200 p-12">
+    <Box
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      gap="s"
+      borderRadius="m"
+      borderWidth={1}
+      borderStyle="solid"
+      borderColor="border-primary"
+      padding="3xl"
+    >
       <div className="dark:text-polar-500 text-5xl text-gray-500">{icon}</div>
-      <div className="flex flex-col items-center text-center">
-        <h3 className="dark:text-polar-50 text-lg text-gray-900">{title}</h3>
-        <p className="dark:text-polar-500 text-gray-500">{description}</p>
-      </div>
+      <Box flexDirection="column" alignItems="center" textAlign="center">
+        <Text variant="heading-xxs" as="h3">
+          {title}
+        </Text>
+        <Text color="muted">{description}</Text>
+      </Box>
       {(actions?.length ?? 0) > 0 ? (
-        <div className="mt-4 flex flex-row gap-x-4">
+        <Box marginTop="l" columnGap="l">
           {actions?.map((action, index) => (
             <Button key={index} {...action} />
           ))}
-        </div>
+        </Box>
       ) : null}
-    </div>
+    </Box>
   )
 }

--- a/clients/packages/orbit/src/components/Select.tsx
+++ b/clients/packages/orbit/src/components/Select.tsx
@@ -35,7 +35,7 @@ const SelectTrigger = ({
   <SelectTriggerPrimitive
     ref={ref}
     className={twMerge(
-      'dark:bg-polar-800 dark:hover:bg-polar-700 dark:hover:border-polar-700 dark:border-polar-700 flex cursor-pointer flex-row gap-x-2 rounded-xl border border-gray-200 bg-white px-3 shadow-xs transition-colors hover:border-gray-300 dark:text-white! text-black!',
+      'dark:bg-polar-800 dark:hover:bg-polar-700 dark:hover:border-polar-700 dark:border-polar-700 flex cursor-pointer flex-row gap-x-2 rounded-xl border border-gray-200 bg-white px-3 shadow-xs transition-colors hover:border-gray-300 dark:text-white text-black',
       className,
     )}
     {...props}

--- a/clients/packages/orbit/src/components/Select.tsx
+++ b/clients/packages/orbit/src/components/Select.tsx
@@ -35,7 +35,7 @@ const SelectTrigger = ({
   <SelectTriggerPrimitive
     ref={ref}
     className={twMerge(
-      'dark:bg-polar-800 dark:hover:bg-polar-700 dark:hover:border-polar-700 dark:border-polar-700 flex cursor-pointer flex-row gap-x-2 rounded-xl border border-gray-200 bg-white px-3 shadow-xs transition-colors hover:border-gray-300',
+      'dark:bg-polar-800 dark:hover:bg-polar-700 dark:hover:border-polar-700 dark:border-polar-700 flex cursor-pointer flex-row gap-x-2 rounded-xl border border-gray-200 bg-white px-3 shadow-xs transition-colors hover:border-gray-300 dark:text-white! text-black!',
       className,
     )}
     {...props}

--- a/clients/packages/ui/src/components/atoms/Combobox.tsx
+++ b/clients/packages/ui/src/components/atoms/Combobox.tsx
@@ -102,10 +102,7 @@ export function Combobox<T>({
             aria-expanded={open}
             disabled={disabled}
             className={cn(
-              'dark:bg-polar-800 dark:hover:bg-polar-700 dark:hover:border-polar-700 dark:border-polar-700 flex w-full flex-row justify-between gap-x-2 rounded-xl border border-gray-200 bg-white px-3 font-normal shadow-xs transition-colors hover:border-gray-300 hover:bg-white',
-              selectedItem
-                ? 'text-foreground hover:text-foreground'
-                : 'text-foreground/50 hover:text-foreground/50 dark:text-polar-400 dark:hover:text-polar-300',
+              'dark:bg-polar-800 dark:hover:bg-polar-700 dark:hover:border-polar-700 dark:border-polar-700 flex w-full flex-row justify-between gap-x-2 rounded-lg border border-gray-200 bg-white px-3 font-normal shadow-xs transition-colors hover:bg-gray-50 hover:text-black dark:hover:text-white',
               className,
             )}
           >
@@ -147,7 +144,7 @@ export function Combobox<T>({
                       key={itemValue}
                       value={itemValue}
                       onSelect={handleSelect}
-                      className="rounded-md"
+                      className="rounded-md text-black dark:text-white"
                     >
                       {renderItem ? renderItem(item) : itemLabel}
                       <Check


### PR DESCRIPTION
Fix Select and Combobox colors. Also updated EmptyState to use Box.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes color and hover styles in `Select` and `Combobox` for better readability in light and dark themes, and updates `EmptyState` to use `Box`/`Text` for consistent styling.

- **Bug Fixes**
  - `Select` (`@polar-sh/orbit`): set explicit trigger text colors (light: black, dark: white).
  - `Combobox` (`@polar-sh/ui`): align rounding to `rounded-lg`, improve hover background/text colors, ensure option text is readable in both themes, and remove a stray `!important`.

- **Refactors**
  - `EmptyState`: replaced custom divs with `Box` and `Text`, using design tokens for spacing, borders, and typography; actions now use `Box` for layout.

<sup>Written for commit 5d1559864a94b6d94e4e88bee05688003fe3abe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



