### PR TITLE
refactor(enums): introduce RecurringInterval as the canonical interval type

### DIFF
--- a/clients/apps/app/components/Products/AmountLabel.tsx
+++ b/clients/apps/app/components/Products/AmountLabel.tsx
@@ -7,7 +7,7 @@ import { Text } from '../Shared/Text'
 interface AmountLabelProps {
   amount: number
   currency: string
-  interval?: schemas['SubscriptionRecurringInterval']
+  interval?: schemas['RecurringInterval']
   loading?: boolean
 }
 

--- a/clients/apps/app/components/Products/ProductRow.tsx
+++ b/clients/apps/app/components/Products/ProductRow.tsx
@@ -15,7 +15,7 @@ export interface ProductRowProps {
   product: schemas['Product']
   currency: string
   amount?: number
-  interval?: schemas['SubscriptionRecurringInterval']
+  interval?: schemas['RecurringInterval']
 }
 
 export const ProductRow = ({

--- a/clients/apps/web/src/components/Customer/CustomerContextView.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerContextView.tsx
@@ -182,18 +182,22 @@ const STATUS_ORDER: Record<schemas['SubscriptionStatus'], number> = {
   incomplete_expired: 6,
 }
 
-const INTERVAL_LABELS: Record<
-  schemas['SubscriptionRecurringInterval'],
-  string
-> = { day: 'Daily', week: 'Weekly', month: 'Monthly', year: 'Yearly' }
+const INTERVAL_LABELS: Record<schemas['RecurringInterval'], string> = {
+  day: 'Daily',
+  week: 'Weekly',
+  month: 'Monthly',
+  year: 'Yearly',
+}
 
-const INTERVAL_PLURAL: Record<
-  schemas['SubscriptionRecurringInterval'],
-  string
-> = { day: 'days', week: 'weeks', month: 'months', year: 'years' }
+const INTERVAL_PLURAL: Record<schemas['RecurringInterval'], string> = {
+  day: 'days',
+  week: 'weeks',
+  month: 'months',
+  year: 'years',
+}
 
 const formatInterval = (
-  interval: schemas['SubscriptionRecurringInterval'],
+  interval: schemas['RecurringInterval'],
   count: number,
 ): string =>
   count === 1

--- a/clients/apps/web/src/components/Shared/AmountLabel.tsx
+++ b/clients/apps/web/src/components/Shared/AmountLabel.tsx
@@ -5,7 +5,7 @@ import { useMemo } from 'react'
 interface AmountLabelProps {
   amount: number
   currency: string
-  interval?: schemas['SubscriptionRecurringInterval']
+  interval?: schemas['RecurringInterval']
   intervalCount?: number | null
 }
 

--- a/clients/apps/web/src/components/Subscriptions/SubscriptionDetails.tsx
+++ b/clients/apps/web/src/components/Subscriptions/SubscriptionDetails.tsx
@@ -15,7 +15,7 @@ import { SubscriptionStatus } from './SubscriptionStatus'
 import { twMerge } from 'tailwind-merge'
 
 const formatRecurringSchedule = (
-  interval: schemas['SubscriptionRecurringInterval'],
+  interval: schemas['RecurringInterval'],
   intervalCount: number | null,
 ): string => {
   const count = intervalCount && intervalCount > 1 ? intervalCount : null

--- a/clients/packages/checkout/src/components/AmountLabel.tsx
+++ b/clients/packages/checkout/src/components/AmountLabel.tsx
@@ -9,7 +9,7 @@ interface AmountLabelProps {
   amount: number
   currency: string
   mode: 'compact' | 'standard'
-  interval?: schemas['SubscriptionRecurringInterval'] | null
+  interval?: schemas['RecurringInterval'] | null
   intervalCount?: number | null
   locale?: AcceptedLocale
 }

--- a/clients/packages/checkout/src/components/CheckoutProductSwitcher.tsx
+++ b/clients/packages/checkout/src/components/CheckoutProductSwitcher.tsx
@@ -149,7 +149,7 @@ const FromPrice = ({
 }: {
   amount: number
   currency: string
-  interval?: schemas['SubscriptionRecurringInterval'] | null
+  interval?: schemas['RecurringInterval'] | null
   intervalCount?: number | null
   locale?: AcceptedLocale
 }) => {

--- a/clients/packages/checkout/src/components/SeatDetailRow.tsx
+++ b/clients/packages/checkout/src/components/SeatDetailRow.tsx
@@ -8,7 +8,7 @@ import DetailRow from './DetailRow'
 interface SeatDetailRowProps {
   row: SeatRow
   currency: string
-  interval?: schemas['SubscriptionRecurringInterval'] | null
+  interval?: schemas['RecurringInterval'] | null
   intervalCount?: number | null
   locale: AcceptedLocale
 }

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -12183,9 +12183,7 @@ export interface components {
       /** @description The visibility of the product. */
       visibility: components['schemas']['ProductVisibility']
       /** @description The recurring interval of the product. If `None`, the product is a one-time purchase. */
-      recurring_interval:
-        | components['schemas']['SubscriptionRecurringInterval']
-        | null
+      recurring_interval: components['schemas']['RecurringInterval'] | null
       /**
        * Recurring Interval Count
        * @description Number of interval units of the subscription. If this is set to 1 the charge will happen every interval (e.g. every month), if set to 2 it will be every other month, and so on. None for one-time products.
@@ -12544,9 +12542,7 @@ export interface components {
       /** @description The visibility of the product. */
       visibility: components['schemas']['ProductVisibility']
       /** @description The recurring interval of the product. If `None`, the product is a one-time purchase. */
-      recurring_interval:
-        | components['schemas']['SubscriptionRecurringInterval']
-        | null
+      recurring_interval: components['schemas']['RecurringInterval'] | null
       /**
        * Recurring Interval Count
        * @description Number of interval units of the subscription. If this is set to 1 the charge will happen every interval (e.g. every month), if set to 2 it will be every other month, and so on. None for one-time products.
@@ -16221,9 +16217,7 @@ export interface components {
       /** @description The visibility of the product. */
       visibility: components['schemas']['ProductVisibility']
       /** @description The recurring interval of the product. If `None`, the product is a one-time purchase. */
-      recurring_interval:
-        | components['schemas']['SubscriptionRecurringInterval']
-        | null
+      recurring_interval: components['schemas']['RecurringInterval'] | null
       /**
        * Recurring Interval Count
        * @description Number of interval units of the subscription. If this is set to 1 the charge will happen every interval (e.g. every month), if set to 2 it will be every other month, and so on. None for one-time products.
@@ -16326,7 +16320,7 @@ export interface components {
        * @description The interval at which the subscription recurs.
        * @example month
        */
-      recurring_interval: components['schemas']['SubscriptionRecurringInterval']
+      recurring_interval: components['schemas']['RecurringInterval']
       /**
        * Recurring Interval Count
        * @description Number of interval units of the subscription. If this is set to 1 the charge will happen every interval (e.g. every month), if set to 2 it will be every other month, and so on.
@@ -16806,9 +16800,7 @@ export interface components {
       /** @description The visibility of the product. */
       visibility: components['schemas']['ProductVisibility']
       /** @description The recurring interval of the product. If `None`, the product is a one-time purchase. */
-      recurring_interval:
-        | components['schemas']['SubscriptionRecurringInterval']
-        | null
+      recurring_interval: components['schemas']['RecurringInterval'] | null
       /**
        * Recurring Interval Count
        * @description Number of interval units of the subscription. If this is set to 1 the charge will happen every interval (e.g. every month), if set to 2 it will be every other month, and so on. None for one-time products.
@@ -17488,7 +17480,7 @@ export interface components {
        */
       currency: string
       /** @description The interval at which the subscription recurs. */
-      recurring_interval: components['schemas']['SubscriptionRecurringInterval']
+      recurring_interval: components['schemas']['RecurringInterval']
       /**
        * Current Period Start
        * Format: date-time
@@ -17747,7 +17739,7 @@ export interface components {
        * @description The interval at which the subscription recurs.
        * @example month
        */
-      recurring_interval: components['schemas']['SubscriptionRecurringInterval']
+      recurring_interval: components['schemas']['RecurringInterval']
       /**
        * Recurring Interval Count
        * @description Number of interval units of the subscription. If this is set to 1 the charge will happen every interval (e.g. every month), if set to 2 it will be every other month, and so on.
@@ -17991,9 +17983,7 @@ export interface components {
       /** @description The visibility of the product. */
       visibility: components['schemas']['ProductVisibility']
       /** @description The recurring interval of the product. If `None`, the product is a one-time purchase. */
-      recurring_interval:
-        | components['schemas']['SubscriptionRecurringInterval']
-        | null
+      recurring_interval: components['schemas']['RecurringInterval'] | null
       /**
        * Recurring Interval Count
        * @description Number of interval units of the subscription. If this is set to 1 the charge will happen every interval (e.g. every month), if set to 2 it will be every other month, and so on. None for one-time products.
@@ -19331,9 +19321,7 @@ export interface components {
       /** @description The visibility of the product. */
       visibility: components['schemas']['ProductVisibility']
       /** @description The recurring interval of the product. If `None`, the product is a one-time purchase. */
-      recurring_interval:
-        | components['schemas']['SubscriptionRecurringInterval']
-        | null
+      recurring_interval: components['schemas']['RecurringInterval'] | null
       /**
        * Recurring Interval Count
        * @description Number of interval units of the subscription. If this is set to 1 the charge will happen every interval (e.g. every month), if set to 2 it will be every other month, and so on. None for one-time products.
@@ -20587,7 +20575,7 @@ export interface components {
        */
       type: 'recurring'
       /** @description The recurring interval of the price. */
-      recurring_interval: components['schemas']['SubscriptionRecurringInterval']
+      recurring_interval: components['schemas']['RecurringInterval']
       /**
        * Minimum Amount
        * @description The minimum amount the customer can pay. If 0, the price is 'free or pay what you want'.
@@ -20665,7 +20653,7 @@ export interface components {
        */
       type: 'recurring'
       /** @description The recurring interval of the price. */
-      recurring_interval: components['schemas']['SubscriptionRecurringInterval']
+      recurring_interval: components['schemas']['RecurringInterval']
       /**
        * Price Amount
        * @description The price in cents.
@@ -23453,9 +23441,7 @@ export interface components {
       /** @description The visibility of the product. */
       visibility: components['schemas']['ProductVisibility']
       /** @description The recurring interval of the product. If `None`, the product is a one-time purchase. */
-      recurring_interval:
-        | components['schemas']['SubscriptionRecurringInterval']
-        | null
+      recurring_interval: components['schemas']['RecurringInterval'] | null
       /**
        * Recurring Interval Count
        * @description Number of interval units of the subscription. If this is set to 1 the charge will happen every interval (e.g. every month), if set to 2 it will be every other month, and so on. None for one-time products.
@@ -23643,7 +23629,7 @@ export interface components {
        * @description The interval at which the subscription recurs.
        * @example month
        */
-      recurring_interval: components['schemas']['SubscriptionRecurringInterval']
+      recurring_interval: components['schemas']['RecurringInterval']
       /**
        * Recurring Interval Count
        * @description Number of interval units of the subscription. If this is set to 1 the charge will happen every interval (e.g. every month), if set to 2 it will be every other month, and so on.
@@ -27418,9 +27404,7 @@ export interface components {
       /** @description The visibility of the product. */
       visibility: components['schemas']['ProductVisibility']
       /** @description The recurring interval of the product. If `None`, the product is a one-time purchase. */
-      recurring_interval:
-        | components['schemas']['SubscriptionRecurringInterval']
-        | null
+      recurring_interval: components['schemas']['RecurringInterval'] | null
       /**
        * Recurring Interval Count
        * @description Number of interval units of the subscription. If this is set to 1 the charge will happen every interval (e.g. every month), if set to 2 it will be every other month, and so on. None for one-time products.
@@ -27623,7 +27607,7 @@ export interface components {
        */
       trial_interval_count?: number | null
       /** @description The recurring interval of the product. */
-      recurring_interval: components['schemas']['SubscriptionRecurringInterval']
+      recurring_interval: components['schemas']['RecurringInterval']
       /**
        * Recurring Interval Count
        * @description Number of interval units of the subscription. If this is set to 1 the charge will happen every interval (e.g. every month), if set to 2 it will be every other month, and so on.
@@ -28620,9 +28604,7 @@ export interface components {
        */
       description?: string | null
       /** @description The recurring interval of the product. If `None`, the product is a one-time purchase. **Can only be set on legacy recurring products. Once set, it can't be changed.** */
-      recurring_interval?:
-        | components['schemas']['SubscriptionRecurringInterval']
-        | null
+      recurring_interval?: components['schemas']['RecurringInterval'] | null
       /**
        * Recurring Interval Count
        * @description Number of interval units of the subscription. If this is set to 1 the charge will happen every interval (e.g. every month), if set to 2 it will be every other month, and so on. Once set, it can't be changed.**
@@ -28703,6 +28685,11 @@ export interface components {
         [key: string]: string
       }
     }
+    /**
+     * RecurringInterval
+     * @enum {string}
+     */
+    RecurringInterval: 'day' | 'week' | 'month' | 'year'
     /** Refund */
     Refund: {
       /**
@@ -29658,7 +29645,7 @@ export interface components {
        * @description The interval at which the subscription recurs.
        * @example month
        */
-      recurring_interval: components['schemas']['SubscriptionRecurringInterval']
+      recurring_interval: components['schemas']['RecurringInterval']
       /**
        * Recurring Interval Count
        * @description Number of interval units of the subscription. If this is set to 1 the charge will happen every interval (e.g. every month), if set to 2 it will be every other month, and so on.
@@ -30750,11 +30737,6 @@ export interface components {
       /** Recurring Interval Count */
       recurring_interval_count?: number
     }
-    /**
-     * SubscriptionRecurringInterval
-     * @enum {string}
-     */
-    SubscriptionRecurringInterval: 'day' | 'week' | 'month' | 'year'
     /** SubscriptionRevoke */
     SubscriptionRevoke: {
       /**
@@ -32054,9 +32036,7 @@ export interface components {
       id: string
       /** Name */
       name: string
-      recurring_interval:
-        | components['schemas']['SubscriptionRecurringInterval']
-        | null
+      recurring_interval: components['schemas']['RecurringInterval'] | null
       /** Organization Id */
       organization_id: string | null
       organization: components['schemas']['TransactionOrganization'] | null
@@ -59782,6 +59762,9 @@ export const productVisibilityValues: ReadonlyArray<
 export const propertyAggregationFuncValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['PropertyAggregation']['func']
 > = ['avg', 'max', 'min', 'sum']
+export const recurringIntervalValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['RecurringInterval']
+> = ['day', 'week', 'month', 'year']
 export const refundReasonValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['RefundReason']
 > = [
@@ -60033,9 +60016,6 @@ export const subscriptionProrationBehaviorValues: ReadonlyArray<
 export const subscriptionReactivatedEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SubscriptionReactivatedEvent']['name']
 > = ['subscription.reactivated']
-export const subscriptionRecurringIntervalValues: ReadonlyArray<
-  FlattenedDeepRequired<components>['schemas']['SubscriptionRecurringInterval']
-> = ['day', 'week', 'month', 'year']
 export const subscriptionRevokedEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SubscriptionRevokedEvent']['name']
 > = ['subscription.revoked']

--- a/server/polar/enums.py
+++ b/server/polar/enums.py
@@ -55,7 +55,7 @@ class PayoutAccountType(StrEnum):
         }[self]
 
 
-class SubscriptionRecurringInterval(StrEnum):
+class RecurringInterval(StrEnum):
     day = "day"
     week = "week"
     month = "month"
@@ -66,22 +66,32 @@ class SubscriptionRecurringInterval(StrEnum):
 
     def get_next_period(self, d: datetime, anchor_day: int, leap: int = 1) -> datetime:
         match self:
-            case SubscriptionRecurringInterval.day:
+            case RecurringInterval.day:
                 return d + relativedelta(days=leap)
-            case SubscriptionRecurringInterval.week:
+            case RecurringInterval.week:
                 return d + relativedelta(weeks=leap)
-            case SubscriptionRecurringInterval.month:
+            case RecurringInterval.month:
                 next = d + relativedelta(months=leap)
                 if next.day != anchor_day:
                     _, max_month_day = calendar.monthrange(next.year, next.month)
                     next = next.replace(day=min(anchor_day, max_month_day))
                 return next
-            case SubscriptionRecurringInterval.year:
+            case RecurringInterval.year:
                 next = d + relativedelta(years=leap)
                 if next.day != anchor_day:
                     _, max_month_day = calendar.monthrange(next.year, next.month)
                     next = next.replace(day=min(anchor_day, max_month_day))
                 return next
+
+
+# `RecurringInterval` is the canonical interval-unit enum (day/week/month/year),
+# shared by the billing interval and the meter interval.
+#
+# Backwards-compatible alias: the historical name stays valid for existing imports.
+SubscriptionRecurringInterval = RecurringInterval
+# Semantic alias for the product/subscription meter cycle. Same underlying values;
+# the distinct name documents intent at call sites.
+MeterInterval = RecurringInterval
 
 
 class SubscriptionProrationBehavior(StrEnum):


### PR DESCRIPTION
Part 1 of 3 of the **decouple meter cycle from billing cycle** stack (polarsource/feedback#154).

## What

- Rename enum `SubscriptionRecurringInterval` to the more general `RecurringInterval`
- Add alias `SubscriptionRecurringInterval` => `RecurringInterval`
- Add alias `MeterInterval` => `RecurringInterval`

## Why

A preparation for introducing a "meter cycle" for subsciptions, where meters (and meter credits) are benefits connected to a subscription that need to cycle on a different cadence than the subscription billing.

## Stack

1. **→ this PR** - `recurring-interval-rename` (base: `main`)
2.  #12509 - product/subscription `meter_interval` fields + divisibility validator
3. #12510 - two-clock scheduler + carried-overage meter-cycle settlement
