### PR TITLE
tf/aws: Set up dummy lambda

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -280,12 +280,11 @@ jobs:
         id: push-lambda-worker
         with:
           push: true
-          # Sandbox/prod repos — add into the tags block once they exist:
-          #   ${{ steps.login-ecr.outputs.registry }}/polar-sandbox-lambda-worker:sha-${{ github.sha }}
+          # Prod repo — add into the tags block once it exists:
           #   ${{ steps.login-ecr.outputs.registry }}/polar-production-lambda-worker:sha-${{ github.sha }}
           tags: |
-            ${{ steps.login-ecr.outputs.registry }}/polar-test-lambda-worker:sha-${{ github.sha }}
-            ${{ steps.login-ecr.outputs.registry }}/polar-test-lambda-worker:latest
+            ${{ steps.login-ecr.outputs.registry }}/polar-sandbox-lambda-worker:sha-${{ github.sha }}
+            ${{ steps.login-ecr.outputs.registry }}/polar-sandbox-lambda-worker:latest
           context: ./server
           target: lambda
           platforms: linux/amd64

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -130,9 +130,86 @@ FROM production AS playwright
 RUN uv run playwright install --with-deps chromium
 
 # Stage 7: AWS Lambda image (SQS-driven background tasks, POC)
-FROM production AS lambda
+FROM public.ecr.aws/lambda/python:3.14 AS lambda-build
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-RUN uv pip install awslambdaric
+ENV PYTHONUNBUFFERED=1
+ENV UV_COMPILE_BYTECODE=1
+ENV UV_LINK_MODE=copy
+ENV UV_NO_CACHE=1
+ENV UV_NO_SYNC=1
 
-ENTRYPOINT ["uv", "run", "python", "-m", "awslambdaric"]
+WORKDIR /app/server
+
+RUN --mount=type=bind,source=uv.lock,target=uv.lock \
+  --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+  dnf install -y gcc gcc-c++ git make \
+  && uv sync --no-group dev --frozen \
+  && dnf clean all
+
+ADD . /app/server/
+
+COPY --from=build-emails-bin /app/bin/react-email-pkg /app/server/
+ENV POLAR_EMAIL_RENDERER_BINARY_PATH=/app/server/react-email-pkg
+
+COPY --from=build-backoffice /app/static /app/server/polar/backoffice/static
+COPY --from=download-ipinfo /data /data
+COPY --from=download-cjk-fonts /fonts/ /app/server/polar/invoice/fonts/
+
+ARG RELEASE_VERSION
+ENV RELEASE_VERSION=${RELEASE_VERSION}
+
+FROM public.ecr.aws/lambda/python:3.14 AS lambda
+
+ARG RELEASE_VERSION
+ENV RELEASE_VERSION=${RELEASE_VERSION}
+
+COPY --from=lambda-build /app /app
+COPY --from=lambda-build /data /data
+COPY --from=docker.io/tailscale/tailscale:stable /usr/local/bin/tailscaled /var/runtime/tailscaled
+COPY --from=docker.io/tailscale/tailscale:stable /usr/local/bin/tailscale /var/runtime/tailscale
+
+ENV LAMBDA_TASK_ROOT=/app/server
+ENV PATH="/app/server/.venv/bin:$PATH"
+ENV PYTHONPATH="/app/server/.venv/lib/python3.14/site-packages:/app/server"
+ENV POLAR_EMAIL_RENDERER_BINARY_PATH=/app/server/react-email-pkg
+ENV POLAR_IP_GEOLOCATION_DATABASE_DIRECTORY_PATH=/data
+ENV POLAR_IP_GEOLOCATION_DATABASE_NAME=country_asn.mmdb
+
+WORKDIR /app/server
+
+RUN mkdir -p /var/run /var/cache /var/lib /var/task \
+  && rm -rf /var/run/tailscale /var/cache/tailscale /var/lib/tailscale /var/task/tailscale \
+  && ln -s /tmp/tailscale /var/run/tailscale \
+  && ln -s /tmp/tailscale /var/cache/tailscale \
+  && ln -s /tmp/tailscale /var/lib/tailscale \
+  && ln -s /tmp/tailscale /var/task/tailscale
+
+RUN <<'EOF'
+cat > /var/runtime/polar-bootstrap <<'BOOTSTRAP'
+#!/bin/sh
+set -eu
+
+if [ -n "${POLAR_JWKS_CONTENT:-}" ] && [ -n "${POLAR_JWKS:-}" ]; then
+  mkdir -p "$(dirname "$POLAR_JWKS")"
+  printf "%s" "$POLAR_JWKS_CONTENT" > "$POLAR_JWKS"
+fi
+
+if [ -n "${TAILSCALE_AUTHKEY:-}" ]; then
+  mkdir -p /tmp/tailscale
+  /var/runtime/tailscaled --tun=userspace-networking --socks5-server=localhost:1055 &
+  tailscale_hostname="${TAILSCALE_HOSTNAME:-polar-${POLAR_ENV:-unknown}-worker-lambda}"
+  tailscale_tags="tag:${POLAR_ENV:-unknown},tag:worker-lambda,tag:aws"
+  until /var/runtime/tailscale up --authkey="${TAILSCALE_AUTHKEY}?ephemeral=true&preauthorized=true" --hostname="${tailscale_hostname}" --advertise-tags="${tailscale_tags}"; do
+    sleep 0.1
+  done
+  export ALL_PROXY="${ALL_PROXY:-socks5://localhost:1055/}"
+fi
+
+exec /lambda-entrypoint.sh "$@"
+BOOTSTRAP
+chmod +x /var/runtime/polar-bootstrap
+EOF
+
+ENTRYPOINT ["/var/runtime/polar-bootstrap"]
 CMD ["polar.worker.aws_lambda.handler"]

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -167,6 +167,7 @@ class Settings(BaseSettings):
     POSTGRES_HOST: str = "127.0.0.1"
     POSTGRES_PORT: int = 5432
     POSTGRES_DATABASE: str = "polar"
+    POSTGRES_SSL: bool = False
     DATABASE_POOL_SIZE: int = 5
     DATABASE_SYNC_POOL_SIZE: int = 1  # Specific pool size for sync connection: since we only use it in OAuth2 router, don't waste resources.
     DATABASE_POOL_RECYCLE_SECONDS: int = 600  # 10 minutes

--- a/server/polar/kit/db/postgres.py
+++ b/server/polar/kit/db/postgres.py
@@ -84,12 +84,15 @@ def create_sync_engine(
     pool_recycle: int | None = None,
     command_timeout: float | None = None,
     debug: bool = False,
+    sslmode: str | None = None,
 ) -> Engine:
     connect_args: dict[str, Any] = {}
     if application_name is not None:
         connect_args["application_name"] = application_name
     if command_timeout is not None:
         connect_args["options"] = f"-c statement_timeout={int(command_timeout * 1000)}"
+    if sslmode is not None:
+        connect_args["sslmode"] = sslmode
     return _create_engine(
         dsn,
         echo=debug,

--- a/server/polar/kit/db/postgres.py
+++ b/server/polar/kit/db/postgres.py
@@ -53,12 +53,15 @@ def create_async_engine(
     pool_recycle: int | None = None,
     command_timeout: float | None = None,
     debug: bool = False,
+    ssl: str | None = None,
 ) -> AsyncEngine:
     connect_args: dict[str, Any] = {"prepared_statement_cache_size": 0}
     if application_name is not None:
         connect_args["server_settings"] = {"application_name": application_name}
     if command_timeout is not None:
         connect_args["command_timeout"] = command_timeout
+    if ssl is not None:
+        connect_args["ssl"] = ssl
 
     return _create_async_engine(
         dsn,

--- a/server/polar/postgres.py
+++ b/server/polar/postgres.py
@@ -57,6 +57,7 @@ def create_sync_engine(process_name: ProcessName) -> Engine:
         pool_size=settings.DATABASE_SYNC_POOL_SIZE,
         pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
         command_timeout=settings.DATABASE_COMMAND_TIMEOUT_SECONDS,
+        sslmode="require" if settings.POSTGRES_SSL else None,
     )
 
 

--- a/server/polar/postgres.py
+++ b/server/polar/postgres.py
@@ -31,6 +31,7 @@ def create_async_engine(
         pool_size=settings.DATABASE_POOL_SIZE,
         pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
         command_timeout=settings.DATABASE_COMMAND_TIMEOUT_SECONDS,
+        ssl="require" if settings.POSTGRES_SSL else None,
     )
 
 
@@ -43,6 +44,7 @@ def create_async_read_engine(process_name: ProcessName) -> AsyncEngine:
         pool_size=settings.DATABASE_POOL_SIZE,
         pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
         command_timeout=settings.DATABASE_COMMAND_TIMEOUT_SECONDS,
+        ssl="require" if settings.POSTGRES_SSL else None,
     )
 
 

--- a/terraform/global/production.tf
+++ b/terraform/global/production.tf
@@ -435,6 +435,14 @@ resource "tfe_variable" "tailscale_advertise_routes_production" {
   variable_set_id = tfe_variable_set.production.id
 }
 
+resource "tfe_variable" "lambda_worker_tailscale_token_production" {
+  key             = "lambda_worker_tailscale_token"
+  category        = "terraform"
+  description     = "Tailscale auth token for production Lambda workers"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.production.id
+}
+
 resource "tfe_variable" "plain_default_tier_external_id_production" {
   key             = "plain_default_tier_external_id"
   category        = "terraform"

--- a/terraform/global/sandbox.tf
+++ b/terraform/global/sandbox.tf
@@ -132,6 +132,14 @@ resource "tfe_variable" "backend_jwks_sandbox" {
   variable_set_id = tfe_variable_set.sandbox.id
 }
 
+resource "tfe_variable" "lambda_worker_tailscale_token_sandbox" {
+  key             = "lambda_worker_tailscale_token"
+  category        = "terraform"
+  description     = "Tailscale auth token for sandbox Lambda workers"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.sandbox.id
+}
+
 resource "tfe_variable" "aws_access_key_id_sandbox" {
   key             = "aws_access_key_id_sandbox"
   category        = "terraform"

--- a/terraform/global/test.tf
+++ b/terraform/global/test.tf
@@ -124,6 +124,14 @@ resource "tfe_variable" "backend_jwks_test" {
   variable_set_id = tfe_variable_set.test.id
 }
 
+resource "tfe_variable" "lambda_worker_tailscale_token_test" {
+  key             = "lambda_worker_tailscale_token"
+  category        = "terraform"
+  description     = "Tailscale auth token for test Lambda workers"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.test.id
+}
+
 resource "tfe_variable" "aws_access_key_id_test" {
   key             = "aws_access_key_id"
   category        = "terraform"

--- a/terraform/modules/static_egress_ip/main.tf
+++ b/terraform/modules/static_egress_ip/main.tf
@@ -1,0 +1,5 @@
+resource "aws_eip" "this" {
+  domain = "vpc"
+
+  tags = merge(var.tags, { Name = var.name })
+}

--- a/terraform/modules/static_egress_ip/outputs.tf
+++ b/terraform/modules/static_egress_ip/outputs.tf
@@ -1,9 +1,9 @@
 output "allocation_id" {
-  description = "Allocation ID of the Elastic IP, consumed by a NAT gateway."
+  description = "Allocation ID of the Elastic IP."
   value       = aws_eip.this.allocation_id
 }
 
 output "public_ip" {
-  description = "The static public IP. Add this (as a /32) to the database IP allow list."
+  description = "The static public IP address."
   value       = aws_eip.this.public_ip
 }

--- a/terraform/modules/static_egress_ip/outputs.tf
+++ b/terraform/modules/static_egress_ip/outputs.tf
@@ -1,0 +1,9 @@
+output "allocation_id" {
+  description = "Allocation ID of the Elastic IP, consumed by a NAT gateway."
+  value       = aws_eip.this.allocation_id
+}
+
+output "public_ip" {
+  description = "The static public IP. Add this (as a /32) to the database IP allow list."
+  value       = aws_eip.this.public_ip
+}

--- a/terraform/modules/static_egress_ip/terraform.tf
+++ b/terraform/modules/static_egress_ip/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/terraform/modules/static_egress_ip/variables.tf
+++ b/terraform/modules/static_egress_ip/variables.tf
@@ -1,0 +1,10 @@
+variable "name" {
+  description = "Name tag for the Elastic IP."
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags applied to the Elastic IP."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -14,7 +14,7 @@ resource "aws_internet_gateway" "this" {
 
 resource "aws_subnet" "public" {
   vpc_id            = aws_vpc.this.id
-  cidr_block        = cidrsubnet(var.cidr_block, 8, 0)
+  cidr_block        = cidrsubnet(var.cidr_block, 4, 0)
   availability_zone = var.availability_zones[0]
 
   tags = merge(var.tags, { Name = "${var.name}-public" })
@@ -24,7 +24,7 @@ resource "aws_subnet" "private" {
   count = length(var.availability_zones)
 
   vpc_id            = aws_vpc.this.id
-  cidr_block        = cidrsubnet(var.cidr_block, 8, count.index + 1)
+  cidr_block        = cidrsubnet(var.cidr_block, 4, count.index + 1)
   availability_zone = var.availability_zones[count.index]
 
   tags = merge(var.tags, { Name = "${var.name}-private-${var.availability_zones[count.index]}" })

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -1,0 +1,76 @@
+resource "aws_vpc" "this" {
+  cidr_block           = var.cidr_block
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = merge(var.tags, { Name = var.name })
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.tags, { Name = var.name })
+}
+
+resource "aws_subnet" "public" {
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = cidrsubnet(var.cidr_block, 8, 0)
+  availability_zone = var.availability_zones[0]
+
+  tags = merge(var.tags, { Name = "${var.name}-public" })
+}
+
+resource "aws_subnet" "private" {
+  count = length(var.availability_zones)
+
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = cidrsubnet(var.cidr_block, 8, count.index + 1)
+  availability_zone = var.availability_zones[count.index]
+
+  tags = merge(var.tags, { Name = "${var.name}-private-${var.availability_zones[count.index]}" })
+}
+
+resource "aws_nat_gateway" "this" {
+  allocation_id = var.eip_allocation_id
+  subnet_id     = aws_subnet.public.id
+
+  tags = merge(var.tags, { Name = var.name })
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.tags, { Name = "${var.name}-public" })
+}
+
+resource "aws_route" "public_internet" {
+  route_table_id         = aws_route_table.public.id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.this.id
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.tags, { Name = "${var.name}-private" })
+}
+
+resource "aws_route" "private_nat" {
+  route_table_id         = aws_route_table.private.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.this.id
+}
+
+resource "aws_route_table_association" "private" {
+  count = length(aws_subnet.private)
+
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -4,11 +4,11 @@ output "vpc_id" {
 }
 
 output "private_subnet_ids" {
-  description = "IDs of the private subnets (route egress through the NAT gateway)."
+  description = "IDs of the private subnets."
   value       = aws_subnet.private[*].id
 }
 
 output "public_subnet_id" {
-  description = "ID of the public subnet hosting the NAT gateway."
+  description = "ID of the public subnet."
   value       = aws_subnet.public.id
 }

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -1,0 +1,14 @@
+output "vpc_id" {
+  description = "ID of the VPC."
+  value       = aws_vpc.this.id
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets (route egress through the NAT gateway)."
+  value       = aws_subnet.private[*].id
+}
+
+output "public_subnet_id" {
+  description = "ID of the public subnet hosting the NAT gateway."
+  value       = aws_subnet.public.id
+}

--- a/terraform/modules/vpc/terraform.tf
+++ b/terraform/modules/vpc/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -12,6 +12,11 @@ variable "cidr_block" {
 variable "availability_zones" {
   description = "Availability zones for the private subnets. The first also hosts the NAT gateway's public subnet."
   type        = list(string)
+
+  validation {
+    condition     = length(var.availability_zones) > 0
+    error_message = "availability_zones must contain at least one availability zone."
+  }
 }
 
 variable "eip_allocation_id" {

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -1,0 +1,26 @@
+variable "name" {
+  description = "Name prefix applied to the VPC and its resources."
+  type        = string
+}
+
+variable "cidr_block" {
+  description = "CIDR block for the VPC."
+  type        = string
+  default     = "10.20.0.0/16"
+}
+
+variable "availability_zones" {
+  description = "Availability zones for the private subnets. The first also hosts the NAT gateway's public subnet."
+  type        = list(string)
+}
+
+variable "eip_allocation_id" {
+  description = "Allocation ID of the Elastic IP attached to the NAT gateway."
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags applied to all created resources."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/production/aws.tf
+++ b/terraform/production/aws.tf
@@ -210,9 +210,9 @@ data "aws_iam_policy_document" "lambda_worker_deploy" {
       "lambda:UpdateFunctionCode",
     ]
     resources = [
-      "arn:aws:lambda:us-east-2:${data.aws_caller_identity.current.account_id}:function:polar-test-lambda-worker*",
-      "arn:aws:lambda:us-east-2:${data.aws_caller_identity.current.account_id}:function:polar-sandbox-lambda-worker*",
-      "arn:aws:lambda:us-east-2:${data.aws_caller_identity.current.account_id}:function:polar-production-lambda-worker*",
+      "arn:aws:lambda:us-east-2:${data.aws_caller_identity.current.account_id}:function:polar-test-worker-*",
+      "arn:aws:lambda:us-east-2:${data.aws_caller_identity.current.account_id}:function:polar-sandbox-worker-*",
+      "arn:aws:lambda:us-east-2:${data.aws_caller_identity.current.account_id}:function:polar-production-worker-*",
     ]
   }
 }

--- a/terraform/production/aws.tf
+++ b/terraform/production/aws.tf
@@ -189,6 +189,7 @@ data "aws_iam_policy_document" "lambda_worker_ecr_push" {
       "ecr:UploadLayerPart",
     ]
     resources = [
+      "arn:aws:ecr:us-east-2:${data.aws_caller_identity.current.account_id}:repository/polar-sandbox-lambda-worker",
       "arn:aws:ecr:us-east-2:${data.aws_caller_identity.current.account_id}:repository/polar-test-lambda-worker",
     ]
   }

--- a/terraform/production/aws.tf
+++ b/terraform/production/aws.tf
@@ -181,6 +181,7 @@ data "aws_iam_policy_document" "lambda_worker_ecr_push" {
     sid = "PushLambdaWorkerImage"
     actions = [
       "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
       "ecr:CompleteLayerUpload",
       "ecr:DescribeImages",
       "ecr:DescribeRepositories",

--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -404,6 +404,12 @@ variable "tailscale_advertise_routes" {
   type        = string
 }
 
+# variable "lambda_worker_tailscale_token" {
+#   description = "Tailscale auth token for production Lambda workers"
+#   type        = string
+#   sensitive   = true
+# }
+
 variable "plain_default_tier_external_id" {
   description = "Default Plain tier external ID used as a fallback for the polar-self support benefit"
   type        = string

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -27,33 +27,6 @@ module "lambda_worker_ecr" {
   name = "polar-sandbox-lambda-worker"
 }
 
-module "egress_ip" {
-  source = "../modules/static_egress_ip"
-
-  name = "polar-sandbox-egress"
-}
-
-module "vpc" {
-  source = "../modules/vpc"
-
-  name               = "polar-sandbox"
-  availability_zones = ["us-east-2a", "us-east-2b"]
-  eip_allocation_id  = module.egress_ip.allocation_id
-}
-
-resource "aws_security_group" "dummy_lambda_worker" {
-  name        = "polar-sandbox-worker-dummy"
-  description = "Egress for the sandbox dummy Lambda worker."
-  vpc_id      = module.vpc.vpc_id
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-
 module "dummy_lambda_worker" {
   source = "../modules/aws_task_worker"
 
@@ -62,8 +35,8 @@ module "dummy_lambda_worker" {
   queue_name         = "polar-sandbox-tasks-dummy"
   image_uri          = "${module.lambda_worker_ecr.repository_url}:latest"
   enabled            = false
-  subnet_ids         = module.vpc.private_subnet_ids
-  security_group_ids = [aws_security_group.dummy_lambda_worker.id]
+  subnet_ids         = local.lambda_subnet_ids
+  security_group_ids = local.lambda_security_group_ids
 
   environment_variables = {
     POLAR_ENV                     = "sandbox"

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -68,6 +68,7 @@ module "dummy_lambda_worker" {
     POLAR_POSTGRES_READ_PWD = local.db_password
     POLAR_SECRET            = var.backend_secret_sandbox
     POLAR_SENTRY_DSN        = var.backend_sentry_dsn_sandbox
+    TAILSCALE_AUTHKEY       = var.lambda_worker_tailscale_token
   }
 }
 

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -74,13 +74,10 @@ module "dummy_lambda_worker" {
     POLAR_LOG_LEVEL               = "INFO"
     POLAR_TESTING                 = "0"
     POLAR_POSTGRES_DATABASE       = "polar_sandbox"
-    POLAR_POSTGRES_HOST           = local.db_internal_host
+    POLAR_POSTGRES_HOST           = local.db_external_host
     POLAR_POSTGRES_PORT           = local.db_port
     POLAR_POSTGRES_USER           = local.db_user
-    POLAR_POSTGRES_READ_DATABASE  = "polar_sandbox"
-    POLAR_POSTGRES_READ_HOST      = local.read_replica.id
-    POLAR_POSTGRES_READ_PORT      = local.db_port
-    POLAR_POSTGRES_READ_USER      = local.db_user
+    POLAR_POSTGRES_SSL            = "true"
     POLAR_REDIS_HOST              = local.redis_host
     POLAR_REDIS_PORT              = local.redis_port
     POLAR_REDIS_DB                = "1"
@@ -90,14 +87,13 @@ module "dummy_lambda_worker" {
   }
 
   secret_environment_variables = {
-    POLAR_CURRENT_JWK_KID   = var.backend_current_jwk_kid_sandbox
-    POLAR_JWKS_CONTENT      = var.backend_jwks_sandbox
-    POLAR_LOGFIRE_TOKEN     = var.logfire_token
-    POLAR_POSTGRES_PWD      = local.db_password
-    POLAR_POSTGRES_READ_PWD = local.db_password
-    POLAR_SECRET            = var.backend_secret_sandbox
-    POLAR_SENTRY_DSN        = var.backend_sentry_dsn_sandbox
-    TAILSCALE_AUTHKEY       = var.lambda_worker_tailscale_token
+    POLAR_CURRENT_JWK_KID = var.backend_current_jwk_kid_sandbox
+    POLAR_JWKS_CONTENT    = var.backend_jwks_sandbox
+    POLAR_LOGFIRE_TOKEN   = var.logfire_token
+    POLAR_POSTGRES_PWD    = local.db_password
+    POLAR_SECRET          = var.backend_secret_sandbox
+    POLAR_SENTRY_DSN      = var.backend_sentry_dsn_sandbox
+    TAILSCALE_AUTHKEY     = var.lambda_worker_tailscale_token
   }
 }
 

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -21,6 +21,56 @@ import {
   id = "polar-sandbox-files"
 }
 
+module "lambda_worker_ecr" {
+  source = "../modules/ecr_repository"
+
+  name = "polar-sandbox-lambda-worker"
+}
+
+module "dummy_lambda_worker" {
+  source = "../modules/aws_task_worker"
+
+  environment = "sandbox"
+  name        = "dummy"
+  queue_name  = "polar-sandbox-tasks-dummy"
+  image_uri   = "${module.lambda_worker_ecr.repository_url}:latest"
+  enabled     = false
+
+  environment_variables = {
+    POLAR_ENV                     = "sandbox"
+    POLAR_BASE_URL                = "https://sandbox-api.polar.sh"
+    POLAR_FRONTEND_BASE_URL       = "https://sandbox.polar.sh"
+    POLAR_CHECKOUT_BASE_URL       = "https://sandbox-api.polar.sh/v1/checkout-links/{client_secret}/redirect"
+    POLAR_JWKS                    = "/tmp/jwks.json"
+    POLAR_LOG_LEVEL               = "INFO"
+    POLAR_TESTING                 = "0"
+    POLAR_POSTGRES_DATABASE       = "polar_sandbox"
+    POLAR_POSTGRES_HOST           = local.db_internal_host
+    POLAR_POSTGRES_PORT           = local.db_port
+    POLAR_POSTGRES_USER           = local.db_user
+    POLAR_POSTGRES_READ_DATABASE  = "polar_sandbox"
+    POLAR_POSTGRES_READ_HOST      = local.read_replica.id
+    POLAR_POSTGRES_READ_PORT      = local.db_port
+    POLAR_POSTGRES_READ_USER      = local.db_user
+    POLAR_REDIS_HOST              = local.redis_host
+    POLAR_REDIS_PORT              = local.redis_port
+    POLAR_REDIS_DB                = "1"
+    POLAR_AWS_REGION              = "us-east-2"
+    POLAR_WORKER_SQS_ENABLED      = "true"
+    POLAR_WORKER_SQS_QUEUE_PREFIX = "polar-sandbox-tasks"
+  }
+
+  secret_environment_variables = {
+    POLAR_CURRENT_JWK_KID   = var.backend_current_jwk_kid_sandbox
+    POLAR_JWKS_CONTENT      = var.backend_jwks_sandbox
+    POLAR_LOGFIRE_TOKEN     = var.logfire_token
+    POLAR_POSTGRES_PWD      = local.db_password
+    POLAR_POSTGRES_READ_PWD = local.db_password
+    POLAR_SECRET            = var.backend_secret_sandbox
+    POLAR_SENTRY_DSN        = var.backend_sentry_dsn_sandbox
+  }
+}
+
 # =============================================================================
 # Image Resizer Lambda@Edge
 # =============================================================================

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -27,14 +27,43 @@ module "lambda_worker_ecr" {
   name = "polar-sandbox-lambda-worker"
 }
 
+module "egress_ip" {
+  source = "../modules/static_egress_ip"
+
+  name = "polar-sandbox-egress"
+}
+
+module "vpc" {
+  source = "../modules/vpc"
+
+  name               = "polar-sandbox"
+  availability_zones = ["us-east-2a", "us-east-2b"]
+  eip_allocation_id  = module.egress_ip.allocation_id
+}
+
+resource "aws_security_group" "dummy_lambda_worker" {
+  name        = "polar-sandbox-worker-dummy"
+  description = "Egress for the sandbox dummy Lambda worker."
+  vpc_id      = module.vpc.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
 module "dummy_lambda_worker" {
   source = "../modules/aws_task_worker"
 
-  environment = "sandbox"
-  name        = "dummy"
-  queue_name  = "polar-sandbox-tasks-dummy"
-  image_uri   = "${module.lambda_worker_ecr.repository_url}:latest"
-  enabled     = false
+  environment        = "sandbox"
+  name               = "dummy"
+  queue_name         = "polar-sandbox-tasks-dummy"
+  image_uri          = "${module.lambda_worker_ecr.repository_url}:latest"
+  enabled            = false
+  subnet_ids         = module.vpc.private_subnet_ids
+  security_group_ids = [aws_security_group.dummy_lambda_worker.id]
 
   environment_variables = {
     POLAR_ENV                     = "sandbox"

--- a/terraform/sandbox/network.tf
+++ b/terraform/sandbox/network.tf
@@ -1,0 +1,35 @@
+# =============================================================================
+# Shared Lambda networking
+# =============================================================================
+
+module "egress_ip" {
+  source = "../modules/static_egress_ip"
+
+  name = "polar-sandbox-egress"
+}
+
+module "vpc" {
+  source = "../modules/vpc"
+
+  name               = "polar-sandbox"
+  availability_zones = ["us-east-2a", "us-east-2b", "us-east-2c"]
+  eip_allocation_id  = module.egress_ip.allocation_id
+}
+
+resource "aws_security_group" "lambda" {
+  name        = "polar-sandbox-lambda"
+  description = "Shared egress security group for sandbox Lambdas."
+  vpc_id      = module.vpc.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+locals {
+  lambda_subnet_ids         = module.vpc.private_subnet_ids
+  lambda_security_group_ids = [aws_security_group.lambda.id]
+}

--- a/terraform/sandbox/outputs.tf
+++ b/terraform/sandbox/outputs.tf
@@ -12,3 +12,8 @@ output "dummy_lambda_worker_queue_url" {
   description = "Sandbox dummy Lambda worker SQS queue URL."
   value       = module.dummy_lambda_worker.queue_url
 }
+
+output "egress_ip" {
+  description = "Static NAT egress IP for the sandbox VPC. Add this (as a /32) to the database IP allow list."
+  value       = module.egress_ip.public_ip
+}

--- a/terraform/sandbox/outputs.tf
+++ b/terraform/sandbox/outputs.tf
@@ -1,0 +1,14 @@
+output "lambda_worker_ecr_repository_url" {
+  description = "ECR repository URL for the sandbox Lambda worker image."
+  value       = module.lambda_worker_ecr.repository_url
+}
+
+output "dummy_lambda_worker_function_name" {
+  description = "Sandbox dummy Lambda worker function name."
+  value       = module.dummy_lambda_worker.function_name
+}
+
+output "dummy_lambda_worker_queue_url" {
+  description = "Sandbox dummy Lambda worker SQS queue URL."
+  value       = module.dummy_lambda_worker.queue_url
+}

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -35,6 +35,7 @@ locals {
   # Database connection info (derived from postgres resource)
   # db_host          = render_postgres.db.id
   db_internal_host = data.render_postgres.db.id
+  db_external_host = nonsensitive(regex("@([^/:]+)", data.render_postgres.db.connection_info.external_connection_string))
   db_port          = "5432"
   # db_name          = data.render_postgres.db.database_name
   db_user     = data.render_postgres.db.database_user

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -35,7 +35,7 @@ locals {
   # Database connection info (derived from postgres resource)
   # db_host          = render_postgres.db.id
   db_internal_host = data.render_postgres.db.id
-  db_external_host = nonsensitive(regex("@([^/:]+)", data.render_postgres.db.connection_info.external_connection_string))
+  db_external_host = nonsensitive(regex("@([^/:]+)", data.render_postgres.db.connection_info.external_connection_string)[0])
   db_port          = "5432"
   # db_name          = data.render_postgres.db.database_name
   db_user     = data.render_postgres.db.database_user

--- a/terraform/sandbox/variables.tf
+++ b/terraform/sandbox/variables.tf
@@ -106,6 +106,12 @@ variable "backend_jwks_sandbox" {
   sensitive   = true
 }
 
+variable "lambda_worker_tailscale_token" {
+  description = "Tailscale auth token for sandbox Lambda workers"
+  type        = string
+  sensitive   = true
+}
+
 # AWS S3 - Sandbox
 variable "aws_access_key_id_sandbox" {
   description = "AWS Access Key ID for sandbox"

--- a/terraform/test/variables.tf
+++ b/terraform/test/variables.tf
@@ -100,6 +100,12 @@ variable "backend_jwks" {
   sensitive   = true
 }
 
+# variable "lambda_worker_tailscale_token" {
+#   description = "Tailscale auth token for test Lambda workers"
+#   type        = string
+#   sensitive   = true
+# }
+
 # AWS S3
 variable "aws_access_key_id" {
   description = "AWS Access Key ID for production"


### PR DESCRIPTION
This is the first worker lambda that we have running. We'll use it as testing grounds

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set up a sandbox dummy worker Lambda using a Lambda-ready Docker image with Tailscale, running inside a sandbox VPC with a static NAT egress IP for end-to-end testing. Enabled Postgres TLS and connected the worker to the Render external DB host; CI and IAM updated so images push and deploy to sandbox.

- **New Features**
  - Provisions ECR repo `polar-sandbox-lambda-worker` and a `dummy` worker bound to `polar-sandbox-tasks-dummy`; configures env/secret vars (incl. `TAILSCALE_AUTHKEY`); disabled by default.
  - Adds a sandbox VPC with private subnets, NAT gateway, and a static egress IP; creates a shared Lambda security group; passes subnet/SG IDs to the worker and outputs the egress IP for DB allow lists.
  - Updates the Lambda image to `public.ecr.aws/lambda/python:3.14` with a Tailscale bootstrap and handler `polar.worker.aws_lambda.handler`; adds Postgres TLS support (`POSTGRES_SSL`) and points the worker to the public DB host.

- **Bug Fixes**
  - Grants `ecr:BatchGetImage`, includes the sandbox repo in ECR push permissions, updates Lambda deploy policy ARNs to `polar-*-worker-*`, adds AZ validation to the VPC module, and fixes parsing of the Render external DB host via regex.

<sup>Written for commit 2e82fce7703550a36b3a82b3ed570253efafe05b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

