### PR TITLE
Properly clear cache with Next.js 16 caching profiles

### DIFF
--- a/clients/apps/web/src/hooks/queries/org.ts
+++ b/clients/apps/web/src/hooks/queries/org.ts
@@ -133,8 +133,8 @@ export const useUpdateOrganization = () =>
       getQueryClient().invalidateQueries({
         queryKey: ['organizations', data.id],
       })
-      await revalidate(`organizations:${data.id}`)
-      await revalidate(`organizations:${data.slug}`)
+      await revalidate(`organizations:${data.id}`, { expire: 0 })
+      await revalidate(`organizations:${data.slug}`, { expire: 0 })
 
       if (variables.userId) {
         await revalidate(`users:${variables.userId}:organizations`, {

--- a/clients/apps/web/src/hooks/queries/org.ts
+++ b/clients/apps/web/src/hooks/queries/org.ts
@@ -108,8 +108,8 @@ export const useCreateOrganization = () =>
       getQueryClient().invalidateQueries({
         queryKey: ['organizations', data.id],
       })
-      await revalidate(`organizations:${data.id}`)
-      await revalidate(`organizations:${data.slug}`)
+      await revalidate(`organizations:${data.id}`, { expire: 0 })
+      await revalidate(`organizations:${data.slug}`, { expire: 0 })
     },
   })
 
@@ -158,8 +158,8 @@ export const useEnableOrganizationPreviewAccess = (organizationId: string) =>
       getQueryClient().invalidateQueries({
         queryKey: ['organizations', data.id],
       })
-      await revalidate(`organizations:${data.id}`)
-      await revalidate(`organizations:${data.slug}`)
+      await revalidate(`organizations:${data.id}`, { expire: 0 })
+      await revalidate(`organizations:${data.slug}`, { expire: 0 })
     },
   })
 
@@ -365,7 +365,7 @@ export const useSubmitOrganizationReview = (id: string) =>
       getQueryClient().invalidateQueries({
         queryKey: ['organizationReviewStatus', id],
       })
-      await revalidate(`organizations:${id}`)
+      await revalidate(`organizations:${id}`, { expire: 0 })
     },
   })
 


### PR DESCRIPTION
Since Next.js, we weren't properly clearing these caches by leaving out the second argument, which falls back to a `default` `cacheLife` profile, or something.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force-clear organization caches with Next.js 16 caching profiles by passing { expire: 0 } to all relevant revalidate calls. This fixes stale org data after settings or review updates.

- **Bug Fixes**
  - Added { expire: 0 } to revalidate for keys `organizations:{id}` and `organizations:{slug}` in create, update, preview-access enable, and review submit flows.
  - Prevents fallback to the default caching profile and ensures both server cache and React Query caches are properly invalidated.

<sup>Written for commit d0655a9b8ab4c825fbf08edd646610ffe27de537. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

