### PR TITLE
Remove 1000 seat upper limit from checkout schemas

### DIFF
--- a/server/polar/checkout/schemas.py
+++ b/server/polar/checkout/schemas.py
@@ -199,16 +199,19 @@ class CheckoutCreateBase(
     seats: int | None = Field(
         default=None,
         ge=1,
+        le=10000,
         description="Predefined number of seats (works with seat-based pricing only)",
     )
     min_seats: int | None = Field(
         default=None,
         ge=1,
+        le=10000,
         description=("Minimum number of seats (works with seat-based pricing only)"),
     )
     max_seats: int | None = Field(
         default=None,
         ge=1,
+        le=10000,
         description=("Maximum number of seats (works with seat-based pricing only)"),
     )
 
@@ -361,6 +364,7 @@ class CheckoutUpdateBase(CustomFieldDataInputMixin, Schema):
     seats: int | None = Field(
         default=None,
         ge=1,
+        le=10000,
         description="Number of seats for seat-based pricing.",
     )
     is_business_customer: bool | None = None

--- a/server/polar/checkout/schemas.py
+++ b/server/polar/checkout/schemas.py
@@ -199,19 +199,16 @@ class CheckoutCreateBase(
     seats: int | None = Field(
         default=None,
         ge=1,
-        le=1000,
         description="Predefined number of seats (works with seat-based pricing only)",
     )
     min_seats: int | None = Field(
         default=None,
         ge=1,
-        le=1000,
         description=("Minimum number of seats (works with seat-based pricing only)"),
     )
     max_seats: int | None = Field(
         default=None,
         ge=1,
-        le=1000,
         description=("Maximum number of seats (works with seat-based pricing only)"),
     )
 
@@ -364,7 +361,6 @@ class CheckoutUpdateBase(CustomFieldDataInputMixin, Schema):
     seats: int | None = Field(
         default=None,
         ge=1,
-        le=1000,
         description="Number of seats for seat-based pricing.",
     )
     is_business_customer: bool | None = None

--- a/server/polar/checkout_link/schemas.py
+++ b/server/polar/checkout_link/schemas.py
@@ -92,9 +92,7 @@ class CheckoutLinkCreateBase(TrialConfigurationInputMixin, MetadataInputMixin, S
     discount_id: UUID4 | None = Field(
         default=None, description=_discount_id_description
     )
-    seats: int | None = Field(
-        default=None, ge=1, le=1000, description=_seats_description
-    )
+    seats: int | None = Field(default=None, ge=1, description=_seats_description)
     success_url: SuccessURL = None
     return_url: ReturnURL = None
 
@@ -154,9 +152,7 @@ class CheckoutLinkUpdate(MetadataInputMixin, TrialConfigurationInputMixin):
     discount_id: UUID4 | None = Field(
         default=None, description=_discount_id_description
     )
-    seats: int | None = Field(
-        default=None, ge=1, le=1000, description=_seats_description
-    )
+    seats: int | None = Field(default=None, ge=1, description=_seats_description)
     success_url: SuccessURL = None
     return_url: ReturnURL = None
 

--- a/server/polar/checkout_link/schemas.py
+++ b/server/polar/checkout_link/schemas.py
@@ -92,7 +92,9 @@ class CheckoutLinkCreateBase(TrialConfigurationInputMixin, MetadataInputMixin, S
     discount_id: UUID4 | None = Field(
         default=None, description=_discount_id_description
     )
-    seats: int | None = Field(default=None, ge=1, description=_seats_description)
+    seats: int | None = Field(
+        default=None, ge=1, le=10000, description=_seats_description
+    )
     success_url: SuccessURL = None
     return_url: ReturnURL = None
 
@@ -152,7 +154,9 @@ class CheckoutLinkUpdate(MetadataInputMixin, TrialConfigurationInputMixin):
     discount_id: UUID4 | None = Field(
         default=None, description=_discount_id_description
     )
-    seats: int | None = Field(default=None, ge=1, description=_seats_description)
+    seats: int | None = Field(
+        default=None, ge=1, le=10000, description=_seats_description
+    )
     success_url: SuccessURL = None
     return_url: ReturnURL = None
 


### PR DESCRIPTION
Customer request 😁 

## Summary

Removes the `le=1000` (less than or equal to 1000) upper limit constraint from seat-related fields in checkout and checkout link schemas.

## What

Removed the `le=1000` maximum value constraint from the following fields:
- `CheckoutLinkCreateBase.seats`
- `CheckoutLinkUpdate.seats`
- `CheckoutCreateBase.seats`
- `CheckoutCreateBase.min_seats`
- `CheckoutCreateBase.max_seats`
- `CheckoutUpdateBase.seats`

The minimum value constraint (`ge=1`) is retained to ensure seats must be at least 1.

## Why

The 1000 seat upper limit appears to be an arbitrary constraint that may not align with business requirements. Removing this limit allows customers to configure seat-based pricing for larger organizations without artificial restrictions.

## How

Updated the Pydantic Field definitions to remove the `le=1000` parameter while keeping the `ge=1` minimum constraint intact.

## Checklist

- [x] This PR addresses a single concern (removing an arbitrary constraint)
- [x] The diff is reasonably sized and easy to review
- [x] No new functionality requiring tests
- [x] Schema validation changes only (no logic changes)

https://claude.ai/code/session_014QTk6YWM6bWeaEjxhw7vyq


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised the seat cap from 1000 to 10000 in checkout and checkout link schemas to support larger seat-based purchases. Minimum of 1 seat is still enforced; no logic changes.

- **Refactors**
  - Replaced `le=1000` with `le=10000` on `CheckoutCreateBase.seats`, `CheckoutCreateBase.min_seats`, `CheckoutCreateBase.max_seats`, and `CheckoutUpdateBase.seats`.
  - Replaced `le=1000` with `le=10000` on `CheckoutLinkCreateBase.seats` and `CheckoutLinkUpdate.seats`.

<sup>Written for commit 1b640c249794b7c6f45aa62d851b1a2bb66e26eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



