### PR TITLE
Update upcoming charge preview with prorations

### DIFF
--- a/clients/apps/web/src/components/CustomerPortal/CurrentPeriodOverview.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CurrentPeriodOverview.tsx
@@ -40,14 +40,17 @@ export const CurrentPeriodOverview = ({
   }
 
   const hasMeters = subscription.meters.length > 0
+  const hasProrations =
+    subscriptionPreview && subscriptionPreview.prorations.length > 0
   const hasTaxes = subscriptionPreview && subscriptionPreview.tax_amount > 0
   const hasDiscount =
     subscriptionPreview && subscriptionPreview.discount_amount > 0
 
   const isFreeProduct = subscription.prices.some(isFreePrice)
 
-  // For subscriptions set to cancel, only show if there are meters
-  if (isCancelingAtPeriodEnd && !hasMeters) {
+  // For subscriptions set to cancel, only show if there's still something to
+  // bill: metered usage or pending prorations.
+  if (isCancelingAtPeriodEnd && !hasMeters && !hasProrations) {
     return null
   }
 
@@ -101,6 +104,26 @@ export const CurrentPeriodOverview = ({
             )}
           </span>
         </div>
+      )}
+
+      {hasProrations && (
+        <>
+          <span className="font-medium">Prorations</span>
+
+          {subscriptionPreview.prorations.map((proration, index) => (
+            <div key={index} className="flex items-center justify-between">
+              <span className="dark:text-polar-400 text-gray-600">
+                {proration.label}
+              </span>
+              <span className="font-medium">
+                {formatCurrency('compact')(
+                  proration.amount,
+                  subscription.currency,
+                )}
+              </span>
+            </div>
+          ))}
+        </>
       )}
 
       {hasMeters && (

--- a/clients/apps/web/src/components/Subscriptions/UpcomingChargeCard.tsx
+++ b/clients/apps/web/src/components/Subscriptions/UpcomingChargeCard.tsx
@@ -38,6 +38,7 @@ const UpcomingChargeCard = ({
   const isFreeProduct = subscription.prices.some(isFreePrice)
 
   const hasMeters = subscription.meters.length > 0
+  const hasProrations = chargePreview && chargePreview.prorations.length > 0
   const hasTaxes = chargePreview && chargePreview.tax_amount > 0
   const hasDiscount = chargePreview && chargePreview.discount_amount > 0
 
@@ -93,6 +94,25 @@ const UpcomingChargeCard = ({
                 )
               }
             />
+          )}
+
+          {hasProrations && (
+            <>
+              <div className="mt-2">
+                <span className="font-medium">Prorations</span>
+              </div>
+
+              {chargePreview.prorations.map((proration, index) => (
+                <DetailRow
+                  key={index}
+                  label={proration.label}
+                  value={formatCurrency('compact')(
+                    proration.amount,
+                    subscription.currency,
+                  )}
+                />
+              ))}
+            </>
           )}
 
           {hasMeters && (

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -29955,8 +29955,18 @@ export interface components {
        */
       metered_amount: number
       /**
+       * Proration Amount
+       * @description Net pending proration adjustments in cents from mid-period changes (seat or product changes), to be billed on the next invoice.
+       */
+      proration_amount: number
+      /**
+       * Prorations
+       * @description Itemized pending proration adjustments to be billed on the next invoice.
+       */
+      prorations: components['schemas']['SubscriptionChargePreviewProration'][]
+      /**
        * Subtotal Amount
-       * @description Subtotal amount in cents (base + metered, before discount and tax)
+       * @description Subtotal amount in cents (base + metered + prorations, before discount and tax)
        */
       subtotal_amount: number
       /**
@@ -29979,6 +29989,22 @@ export interface components {
        * @description Total amount in cents (final charge amount)
        */
       total_amount: number
+    }
+    /**
+     * SubscriptionChargePreviewProration
+     * @description A pending proration adjustment to be billed on the next invoice.
+     */
+    SubscriptionChargePreviewProration: {
+      /**
+       * Label
+       * @description Human-readable description of the proration.
+       */
+      label: string
+      /**
+       * Amount
+       * @description Signed amount in cents: positive to charge, negative to credit.
+       */
+      amount: number
     }
     /**
      * SubscriptionCreateCustomer

--- a/server/polar/subscription/schemas.py
+++ b/server/polar/subscription/schemas.py
@@ -436,6 +436,15 @@ SubscriptionUpdate = Annotated[
 ]
 
 
+class SubscriptionChargePreviewProration(Schema):
+    """A pending proration adjustment to be billed on the next invoice."""
+
+    label: str = Field(description="Human-readable description of the proration.")
+    amount: int = Field(
+        description=("Signed amount in cents: positive to charge, negative to credit.")
+    )
+
+
 class SubscriptionChargePreview(Schema):
     """Preview of the next charge for a subscription."""
 
@@ -445,8 +454,17 @@ class SubscriptionChargePreview(Schema):
     metered_amount: int = Field(
         description="Total metered usage charges in cents (sum of all meter charges)"
     )
+    proration_amount: int = Field(
+        description=(
+            "Net pending proration adjustments in cents from mid-period changes "
+            "(seat or product changes), to be billed on the next invoice."
+        )
+    )
+    prorations: list[SubscriptionChargePreviewProration] = Field(
+        description="Itemized pending proration adjustments to be billed on the next invoice."
+    )
     subtotal_amount: int = Field(
-        description="Subtotal amount in cents (base + metered, before discount and tax)"
+        description="Subtotal amount in cents (base + metered + prorations, before discount and tax)"
     )
     discount_amount: int = Field(description="Discount amount in cents")
     net_amount: int = Field(description="Net amount in cents before taxes")

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -110,6 +110,7 @@ from .repository import SubscriptionRepository, SubscriptionUpdateRepository
 from .schemas import (
     SubscriptionCancel,
     SubscriptionChargePreview,
+    SubscriptionChargePreviewProration,
     SubscriptionCreate,
     SubscriptionCreateCustomer,
     SubscriptionRevoke,
@@ -1944,7 +1945,27 @@ class SubscriptionService:
 
         metered_amount = sum(meter.amount for meter in subscription.meters)
 
-        subtotal_amount = base_price + metered_amount
+        # Pending mid-period prorations (seat/product changes) already exist as
+        # billing entries; surface them so the preview matches the next invoice.
+        prorations: list[SubscriptionChargePreviewProration] = []
+        proration_amount = 0
+        async for (
+            line_item,
+            _,
+        ) in billing_entry_service.compute_pending_subscription_line_items(
+            session, subscription
+        ):
+            if not line_item.proration:
+                continue
+            prorations.append(
+                SubscriptionChargePreviewProration(
+                    label=line_item.label, amount=line_item.amount
+                )
+            )
+            proration_amount += line_item.amount
+
+        recurring_amount = base_price + metered_amount
+        subtotal_amount = recurring_amount + proration_amount
 
         discount_amount = 0
 
@@ -1964,8 +1985,10 @@ class SubscriptionService:
                 applicable_discount = subscription.discount
 
         if applicable_discount is not None:
+            # Discount applies to the recurring charge only; prorations are billed
+            # net of their own proration at entry-creation time.
             discount_amount = applicable_discount.get_discount_amount(
-                subtotal_amount, subscription.currency
+                recurring_amount, subscription.currency
             )
 
         net_amount = subtotal_amount - discount_amount
@@ -2011,6 +2034,8 @@ class SubscriptionService:
         return SubscriptionChargePreview(
             base_amount=base_price,
             metered_amount=metered_amount,
+            proration_amount=proration_amount,
+            prorations=prorations,
             subtotal_amount=subtotal_amount,
             discount_amount=discount_amount,
             net_amount=net_amount,


### PR DESCRIPTION
Two seat changes didn't show on this component at all, now they do. I'll look into updating the line item label once more in a separate PR.

**Merchant dashboard**

<img width="840" height="413" alt="image" src="https://github.com/user-attachments/assets/ed113025-a017-42ac-b04b-6858936428a0" />

**Customer portal**

<img width="762" height="385" alt="image" src="https://github.com/user-attachments/assets/273d64c0-b67e-4f1f-a4dc-fdf33096fb47" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show prorations from mid-period seat/product changes in the upcoming charge preview across the Merchant dashboard and Customer portal. The API now returns itemized prorations, and the UI displays them so users see what will be billed next.

- **New Features**
  - Added `proration_amount` and `prorations[]` to `SubscriptionChargePreview` (server and client types), plus `SubscriptionChargePreviewProration`.
  - Compute prorations from pending billing entries; include them in `subtotal_amount` and apply discounts only to the recurring amount (base + metered).
  - UI: Added a “Prorations” section to `UpcomingChargeCard` and Customer Portal `CurrentPeriodOverview`, showing each proration’s label and amount; still show when canceling if prorations exist.

- **Bug Fixes**
  - Seat change prorations now appear in the upcoming charge preview (previously missing).

<sup>Written for commit be23c0799a2b5a16e9a0c0604d4b6f947d4b91f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

