### PR TITLE
Include seat transition in proration line items

### DIFF
--- a/server/polar/billing_entry/repository.py
+++ b/server/polar/billing_entry/repository.py
@@ -4,7 +4,7 @@ from itertools import batched
 from uuid import UUID
 
 from sqlalchemy import Select, func, select, update
-from sqlalchemy.orm.strategy_options import contains_eager
+from sqlalchemy.orm.strategy_options import contains_eager, joinedload
 
 from polar.config import settings
 from polar.kit.repository import (
@@ -61,7 +61,10 @@ class BillingEntryRepository(
             self.get_pending_by_subscription_statement(subscription_id)
             .join(BillingEntry.product_price)
             .where(ProductPrice.is_static.is_(True))
-            .options(contains_eager(BillingEntry.product_price))
+            .options(
+                contains_eager(BillingEntry.product_price),
+                joinedload(BillingEntry.event),
+            )
         )
         async for result in self.stream(statement):
             yield result

--- a/server/polar/billing_entry/service.py
+++ b/server/polar/billing_entry/service.py
@@ -200,20 +200,24 @@ class BillingEntryService:
         end = format_date(entry.end_timestamp.date(), locale="en_US")
         amount = entry.amount
 
-        # Appending the current total seat count implies an amount that doesn't
-        # reconcile with the charge, so omit it for those types to avoid confusion
-        seats_for_label = (
-            None
-            if entry.type
-            in (
-                BillingEntryType.subscription_seats_increase,
-                BillingEntryType.subscription_seats_decrease,
-            )
-            else seats
+        is_seat_change = entry.type in (
+            BillingEntryType.subscription_seats_increase,
+            BillingEntryType.subscription_seats_decrease,
         )
-        price_label = OrderItem.format_price_label(
-            product, price, seats=seats_for_label
-        )
+
+        if is_seat_change:
+            old_seats = entry.event.user_metadata.get("old_seats")
+            new_seats = entry.event.user_metadata.get("new_seats")
+
+            if old_seats is not None and new_seats is not None:
+                seat_transition = f"{old_seats} → {new_seats} seats"
+                price_label = f"{product.name} ({seat_transition})"
+            else:
+                # This shouldn't happen, but if it does, don't include the full
+                # seat count if we can't show a delta to avoid confusion
+                price_label = OrderItem.format_price_label(product, price, seats=None)
+        else:
+            price_label = OrderItem.format_price_label(product, price, seats=seats)
 
         match entry.direction:
             case BillingEntryDirection.credit:

--- a/server/tests/billing_entry/test_service.py
+++ b/server/tests/billing_entry/test_service.py
@@ -443,10 +443,10 @@ class TestCreateOrderItemsFromPending:
             assert entry.order_item_id == order_item_current_price.id
 
     @pytest.mark.parametrize(
-        "entry_type",
+        ("entry_type", "new_seats", "expected_transition"),
         [
-            BillingEntryType.subscription_seats_increase,
-            BillingEntryType.subscription_seats_decrease,
+            (BillingEntryType.subscription_seats_increase, 14, "10 → 14 seats"),
+            (BillingEntryType.subscription_seats_decrease, 6, "10 → 6 seats"),
         ],
     )
     async def test_proration_seat_items(
@@ -456,6 +456,8 @@ class TestCreateOrderItemsFromPending:
         customer: Customer,
         organization: Organization,
         entry_type: BillingEntryType,
+        new_seats: int,
+        expected_transition: str,
     ) -> None:
         product = await create_product(
             save_fixture,
@@ -476,6 +478,7 @@ class TestCreateOrderItemsFromPending:
             price=price,
             subscription=subscription,
             amount=50_00,
+            new_seats=new_seats,
         )
 
         async with billing_entry_service.create_order_items_from_pending(
@@ -487,10 +490,12 @@ class TestCreateOrderItemsFromPending:
             assert order_item.amount == 50_00
             assert order_item.proration is True
 
-            # Seat-change prorations charge a delta, not the full seat amount,
-            # so the label must not imply a total seat count (which wouldn't
-            # reconcile with the prorated amount).
-            assert "seat" not in order_item.label
+            # Seat-change prorations charge a delta, not the full seat amount.
+            # The label shows the seat transition (old → new), read from the
+            # event metadata, so the prorated amount is explained rather than a
+            # single total seat count that wouldn't reconcile with it.
+            assert product.name in order_item.label
+            assert expected_transition in order_item.label
 
             await create_order(
                 save_fixture,


### PR DESCRIPTION
Render `Product name (X → Y seats)` as the line item for seat change prorations.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show seat transitions on proration line items for seat increases/decreases to clarify delta-based charges. Labels now read like "Product (10 → 14 seats)" instead of implying a full seat count.

- **Bug Fixes**
  - Include "old → new seats" in labels using `event.user_metadata`.
  - Prevent labels from implying a total seat count when charging a delta.
  - Eager-load `BillingEntry.event` via `joinedload` to read metadata without extra queries.
  - Update tests to assert product name and seat transition in the label.

<sup>Written for commit 6dde3694c79ef23efe6f099f67bb48490c022c5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

