### PR TITLE
feat(disputes): chargebackstop can't de escalate an open dispute

### DIFF
--- a/server/polar/dispute/service.py
+++ b/server/polar/dispute/service.py
@@ -294,6 +294,7 @@ class DisputeService:
                     payment_processor_id=None,  # We don't know the dispute ID yet
                     order=order,
                     payment=payment,
+                    status=DisputeStatus.early_warning,
                 )
             )
 
@@ -303,9 +304,6 @@ class DisputeService:
         # We refunded the transaction before the dispute could be escalated
         if alert["transaction_refund_outcome"] == "REFUNDED":
             dispute.status = DisputeStatus.prevented
-        # We didn't take action: the dispute will be escalated, we'll get news from Stripe later
-        elif not dispute.closed:
-            dispute.status = DisputeStatus.early_warning
 
         return await repository.update(dispute)
 

--- a/server/tests/dispute/test_service.py
+++ b/server/tests/dispute/test_service.py
@@ -1029,6 +1029,65 @@ class TestUpsertFromChargebackStop:
         with pytest.raises(DisputePaymentNotFoundError):
             await dispute_service.upsert_from_chargeback_stop(session, alert)
 
+    async def test_late_alert_does_not_downgrade_escalated_dispute(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        organization: Organization,
+        mocker: MockerFixture,
+    ) -> None:
+        """A ChargebackStop alert that lags behind Stripe must not de-escalate a
+        dispute Stripe has already opened: it's no longer an early warning."""
+        order = await create_order(
+            save_fixture, customer=customer, subtotal_amount=1000, tax_amount=200
+        )
+        charge_id = "STRIPE_CHARGE_ID"
+        payment_intent_id = "STRIPE_PAYMENT_INTENT_ID"
+        payment = await create_payment(
+            save_fixture, organization, amount=1200, order=order, processor_id=charge_id
+        )
+        # Stripe already opened the dispute, so it carries a processor id and a
+        # live (non-early) status before the alert arrives.
+        dispute = await create_dispute(
+            save_fixture,
+            order,
+            payment,
+            status=DisputeStatus.needs_response,
+            amount=1000,
+            tax_amount=200,
+            currency="usd",
+            payment_processor_id="STRIPE_DISPUTE_ID",
+        )
+        payment_intent = build_stripe_payment_intent(
+            id=payment_intent_id, latest_charge=charge_id
+        )
+        mocker.patch(
+            "polar.dispute.service.stripe_service.get_payment_intent",
+            return_value=payment_intent,
+        )
+
+        alert = build_chargeback_stop_alert(
+            integration_transaction_id=payment_intent_id,
+            transaction_refund_outcome="NOT_REFUNDED",
+            transaction_amount_in_cents=1200,
+            transaction_currency_code="usd",
+        )
+
+        updated_dispute = await dispute_service.upsert_from_chargeback_stop(
+            session, alert
+        )
+
+        assert updated_dispute.id == dispute.id
+        assert updated_dispute.status == DisputeStatus.needs_response
+        assert updated_dispute.payment_processor_id == "STRIPE_DISPUTE_ID"
+        # The alert is still recorded against the existing dispute.
+        assert (
+            updated_dispute.dispute_alert_processor
+            == DisputeAlertProcessor.chargeback_stop
+        )
+        assert updated_dispute.dispute_alert_processor_id == alert["id"]
+
     async def test_new_not_refunded(
         self,
         save_fixture: SaveFixture,


### PR DESCRIPTION
https://polar-sh.sentry.io/issues/7561825136/?alert_rule_id=16426328&alert_type=issue&frontend_events=%7B%22event_name%22%3A%22Sign%20Up%22%2C%22event_label%22%3A%22google%22%7D&notification_uuid=8eb0f8c2-033d-4fb2-8082-150e12349bec&project=-1&referrer=slack

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop ChargebackStop alerts from de-escalating active disputes. We now set `early_warning` only when creating a new dispute and never overwrite an already opened dispute (e.g., `needs_response`).

- **Bug Fixes**
  - Initialize newly created disputes from ChargebackStop with `early_warning`; removed code that reset existing disputes to `early_warning` when not refunded.
  - Added a test to ensure a lagging alert keeps an opened dispute at `needs_response` while recording alert metadata.

<sup>Written for commit 2910a6e50e7584c33e685bcc4c58637fc2e6b603. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

