### PR TITLE
feat(bo): appeal case links to org page

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
@@ -223,10 +223,18 @@ class SupportCaseSection:
                                 text("Awaiting decision")
                         if is_open:
                             self._render_assignment_chip(case)
-            # Assignment is advisory and available on any open case; the
-            # approve/deny decision is appeal-only (disputes are bank-decided).
-            if is_open:
-                self._render_actions(request, case, is_appeal=is_appeal)
+            # Right-side controls: a link to the org overview (appeals) plus the
+            # actions while the case is open. Assignment is advisory on any open
+            # case; the approve/deny decision is appeal-only (disputes are
+            # bank-decided).
+            if is_appeal or is_open:
+                with tag.div(classes="flex-none flex items-center gap-2"):
+                    if is_appeal:
+                        self._render_org_link(request)
+                    if is_open:
+                        self._render_assignment_button(request, case)
+                        if is_appeal:
+                            self._render_appeal_decision_buttons(request)
 
     def _render_assignment_chip(self, case: SupportCase) -> None:
         assignee_id = case.assigned_user_id
@@ -254,13 +262,14 @@ class SupportCaseSection:
         release_url = f"{request.url_for('support_cases:release', case_id=case.id)}?{urlencode({'return_to': detail_path})}"
         return take_url, release_url
 
-    def _render_actions(
-        self, request: Request, case: SupportCase, *, is_appeal: bool
-    ) -> None:
-        with tag.div(classes="flex-none flex items-center gap-2"):
-            self._render_assignment_button(request, case)
-            if is_appeal:
-                self._render_appeal_decision_buttons(request)
+    def _render_org_link(self, request: Request) -> None:
+        url = str(request.url_for("organizations:detail", organization_id=self.org.id))
+        with tag.a(href=url, classes="btn btn-sm btn-outline gap-1"):
+            attr("target", "_blank")
+            attr("rel", "noopener noreferrer")
+            text("View organization")
+            with tag.div(classes="icon-external-link"):
+                pass
 
     def _render_assignment_button(self, request: Request, case: SupportCase) -> None:
         take_url, release_url = self._assignment_urls(request, case)


### PR DESCRIPTION
## Summary

Adds a button to navigate to the org page from an appeal support case. As requested by the team.

<img width="1658" height="200" alt="Screenshot 2026-06-19 at 10 02 47" src="https://github.com/user-attachments/assets/2f25d2d6-4270-40c3-a93b-ca059f80b7d5" />


## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a "View organization" button to appeal support case headers that opens the org overview in a new tab for quick navigation. Assignment remains available on open cases, and appeal decision buttons show on open appeals.

<sup>Written for commit 02b5d8c5f31d3ad0cd9c1bad5389089b3a967c8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

