### PR TITLE
Show number of seats in upcoming charge preview

### DIFF
--- a/clients/apps/web/src/components/CustomerPortal/CurrentPeriodOverview.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CurrentPeriodOverview.tsx
@@ -1,5 +1,5 @@
 import { useCustomerSubscriptionChargePreview } from '@/hooks/queries/customerPortal'
-import { isFreePrice } from '@/utils/product'
+import { isFreePrice, isSeatBasedPrice } from '@/utils/product'
 import { Client, schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
 import { useMemo } from 'react'
@@ -29,6 +29,18 @@ export const CurrentPeriodOverview = ({
   }, [subscription])
   const product = products.find((product) => product.id === productId)
 
+  // For seat-based subscriptions, surface the number of seats we'll charge for
+  // next, preferring a pending update if one is scheduled.
+  const seats = useMemo(() => {
+    if (
+      subscription.pending_update &&
+      subscription.pending_update.seats != null
+    ) {
+      return subscription.pending_update.seats
+    }
+    return subscription.seats
+  }, [subscription])
+
   const isTrialing = subscription.status === 'trialing'
   const isActive = subscription.status === 'active'
   const isCancelingAtPeriodEnd =
@@ -47,6 +59,11 @@ export const CurrentPeriodOverview = ({
     subscriptionPreview && subscriptionPreview.discount_amount > 0
 
   const isFreeProduct = subscription.prices.some(isFreePrice)
+
+  const isSeatBasedProduct = product?.prices.some(
+    (price) =>
+      price.price_currency === subscription.currency && isSeatBasedPrice(price),
+  )
 
   // For subscriptions set to cancel, only show if there's still something to
   // bill: metered usage or pending prorations.
@@ -89,7 +106,9 @@ export const CurrentPeriodOverview = ({
       {product && subscriptionPreview && (
         <div className="flex items-center justify-between">
           <span className="dark:text-polar-400 text-gray-600">
-            {product.name}
+            {isSeatBasedProduct && seats != null
+              ? `${product.name} (${seats} ${seats === 1 ? 'seat' : 'seats'})`
+              : product.name}
           </span>
           <span
             className={isCancelingAtPeriodEnd ? 'text-gray-500' : 'font-medium'}

--- a/clients/apps/web/src/components/Subscriptions/UpcomingChargeCard.tsx
+++ b/clients/apps/web/src/components/Subscriptions/UpcomingChargeCard.tsx
@@ -3,7 +3,7 @@
 import { DetailRow } from '@/components/Shared/DetailRow'
 import { useProduct } from '@/hooks/queries'
 import { useSubscriptionChargePreview } from '@/hooks/queries/subscriptions'
-import { isFreePrice } from '@/utils/product'
+import { isFreePrice, isSeatBasedPrice } from '@/utils/product'
 import { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
 import ShadowBox from '@polar-sh/ui/components/atoms/ShadowBox'
@@ -25,6 +25,18 @@ const UpcomingChargeCard = ({
   }, [subscription])
   const { data: product } = useProduct(productId)
 
+  // For seat-based subscriptions, surface the number of seats we'll charge for
+  // next, preferring a pending update if one is scheduled.
+  const seats = useMemo(() => {
+    if (
+      subscription.pending_update &&
+      subscription.pending_update.seats != null
+    ) {
+      return subscription.pending_update.seats
+    }
+    return subscription.seats
+  }, [subscription])
+
   const isTrialing = subscription.status === 'trialing'
   const isActive = subscription.status === 'active'
   const isCancelingAtPeriodEnd =
@@ -41,6 +53,11 @@ const UpcomingChargeCard = ({
   const hasProrations = chargePreview && chargePreview.prorations.length > 0
   const hasTaxes = chargePreview && chargePreview.tax_amount > 0
   const hasDiscount = chargePreview && chargePreview.discount_amount > 0
+
+  const isSeatBasedProduct = product?.prices.some(
+    (price) =>
+      price.price_currency === subscription.currency && isSeatBasedPrice(price),
+  )
 
   const chargeDate = isTrialing
     ? subscription.trial_end
@@ -82,7 +99,11 @@ const UpcomingChargeCard = ({
         <div className="flex flex-col gap-2">
           {product && chargePreview && (
             <DetailRow
-              label={product?.name || ''}
+              label={
+                isSeatBasedProduct && seats != null
+                  ? `${product.name} (${seats} ${seats === 1 ? 'seat' : 'seats'})`
+                  : product.name
+              }
               value={
                 isCancelingAtPeriodEnd ? (
                   <span className="text-gray-500">Canceled</span>


### PR DESCRIPTION
<img width="439" height="102" alt="image" src="https://github.com/user-attachments/assets/2c8c2c7b-4cc5-4a89-9ebc-2ed8aacf5f4b" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the number of seats in upcoming charge previews for seat-based subscriptions, using pending seat updates when scheduled. This clarifies the next invoice in the Customer Portal and Subscriptions views.

- **New Features**
  - Show "(X seat[s])" next to the product name in UpcomingChargeCard and CurrentPeriodOverview.
  - Seat count uses `pending_update.seats` when set, otherwise `subscription.seats`; only applies to seat-based prices.

<sup>Written for commit 56b15c8cc472d41f0fa0895f8bba6df7b0b7ecd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

