### PR TITLE
feat(support_case): populate organization_id on case creation

### DIFF
--- a/server/polar/dispute/dispute_case.py
+++ b/server/polar/dispute/dispute_case.py
@@ -54,7 +54,7 @@ class DisputeCaseService:
 
         case = await support_case_service.create(
             session,
-            DisputeSupportCase(dispute_id=dispute.id),
+            DisputeSupportCase(dispute_id=dispute.id, organization=organization),
             author_kind=SupportCaseMessageAuthorKind.system,
             audience=[SupportCaseAudience.merchant],
         )

--- a/server/polar/dispute/dispute_case.py
+++ b/server/polar/dispute/dispute_case.py
@@ -54,7 +54,7 @@ class DisputeCaseService:
 
         case = await support_case_service.create(
             session,
-            DisputeSupportCase(dispute_id=dispute.id, organization=organization),
+            DisputeSupportCase(dispute=dispute, organization=organization),
             author_kind=SupportCaseMessageAuthorKind.system,
             audience=[SupportCaseAudience.merchant],
         )

--- a/server/polar/organization_review/appeal_case.py
+++ b/server/polar/organization_review/appeal_case.py
@@ -69,7 +69,7 @@ class AppealCaseService:
         case = await support_case_service.create(
             session,
             ReviewAppealSupportCase(
-                organization_review_id=review.id, organization=organization
+                organization_review=review, organization=organization
             ),
             author_kind=SupportCaseMessageAuthorKind.merchant,
             author_user=requested_by_user,

--- a/server/polar/organization_review/appeal_case.py
+++ b/server/polar/organization_review/appeal_case.py
@@ -68,7 +68,9 @@ class AppealCaseService:
 
         case = await support_case_service.create(
             session,
-            ReviewAppealSupportCase(organization_review_id=review.id),
+            ReviewAppealSupportCase(
+                organization_review_id=review.id, organization=organization
+            ),
             author_kind=SupportCaseMessageAuthorKind.merchant,
             author_user=requested_by_user,
             audience=[SupportCaseAudience.merchant],

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -3174,6 +3174,7 @@ class TestSoftDeleteOrganization:
         case = await dispute_case_service.open_case(
             session, dispute, organization=organization
         )
+        assert case.organization_id == organization.id
 
         await organization_service.soft_delete_organization(session, organization)
 

--- a/server/tests/organization_review/test_appeal_case_endpoints.py
+++ b/server/tests/organization_review/test_appeal_case_endpoints.py
@@ -206,6 +206,7 @@ class TestGetAppealCase:
             requested_by_user=user,
             organization=organization,
         )
+        assert case.organization_id == organization.id
         await appeal_case_service.add_reply(
             session,
             case,


### PR DESCRIPTION
Set the denormalized organization on the appeal and dispute case creation paths, both of which already have the owning organization in scope. The column stays nullable until existing rows are backfilled.

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populate organization_id on creation of dispute and appeal support cases, and set related objects (dispute and organization_review) directly instead of IDs. This links new cases to their organization for easier querying; tests assert it, and the column remains nullable until existing rows are backfilled.

<sup>Written for commit a8730d78b509a8087c4a77665315c70de68fa737. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

