### PR TITLE
Read from `Subscription.net_amount` for metrics

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/metrics/[metric]/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/metrics/[metric]/page.tsx
@@ -1,6 +1,5 @@
 import ClientPage from '@/components/Metrics/dashboards/ClientPage'
 import DashboardDetailClientPage from '@/components/Metrics/dashboards/DashboardDetailClientPage'
-import { shouldShowSubscriptionMetricsTaxAlert } from '@/components/Metrics/SubscriptionMetricsTaxAlert'
 import { getServerSideAPI } from '@/utils/client/serverside'
 import { fromISODate, METRIC_GROUPS, toISODate } from '@/utils/metrics'
 import { getOrganizationBySlugOrNotFound } from '@/utils/organization'
@@ -140,13 +139,5 @@ export default async function Page(props: {
     redirect(`${redirectPath}?${urlSearchParams}`, RedirectType.replace)
   }
 
-  return (
-    <ClientPage
-      metric={metric}
-      organizationId={organization.id}
-      showSubscriptionMetricsTaxAlert={shouldShowSubscriptionMetricsTaxAlert(
-        organization,
-      )}
-    />
-  )
+  return <ClientPage metric={metric} organization={organization} />
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/metrics/[metric]/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/metrics/[metric]/page.tsx
@@ -1,5 +1,6 @@
 import ClientPage from '@/components/Metrics/dashboards/ClientPage'
 import DashboardDetailClientPage from '@/components/Metrics/dashboards/DashboardDetailClientPage'
+import { shouldShowSubscriptionMetricsTaxAlert } from '@/components/Metrics/SubscriptionMetricsTaxAlert'
 import { getServerSideAPI } from '@/utils/client/serverside'
 import { fromISODate, METRIC_GROUPS, toISODate } from '@/utils/metrics'
 import { getOrganizationBySlugOrNotFound } from '@/utils/organization'
@@ -139,5 +140,13 @@ export default async function Page(props: {
     redirect(`${redirectPath}?${urlSearchParams}`, RedirectType.replace)
   }
 
-  return <ClientPage metric={metric} organizationId={organization.id} />
+  return (
+    <ClientPage
+      metric={metric}
+      organizationId={organization.id}
+      showSubscriptionMetricsTaxAlert={shouldShowSubscriptionMetricsTaxAlert(
+        organization,
+      )}
+    />
+  )
 }

--- a/clients/apps/web/src/components/DashboardOverview/OverviewSection.tsx
+++ b/clients/apps/web/src/components/DashboardOverview/OverviewSection.tsx
@@ -1,6 +1,10 @@
 'use client'
 
 import { MetricGroup } from '@/components/Metrics/dashboards/MetricGroup'
+import {
+  shouldShowSubscriptionMetricsTaxAlert,
+  SubscriptionMetricsTaxAlert,
+} from '@/components/Metrics/SubscriptionMetricsTaxAlert'
 import { Modal } from '@polar-sh/orbit'
 import { useMetrics } from '@/hooks/queries'
 import { useChartRange } from '@/hooks/useChartRange'
@@ -82,6 +86,9 @@ export function OverviewSection({ organization }: OverviewSectionProps) {
           </Button>
         </div>
       </div>
+      {shouldShowSubscriptionMetricsTaxAlert(organization) && (
+        <SubscriptionMetricsTaxAlert />
+      )}
       <MetricGroup
         data={data}
         metricKeys={activeMetrics}

--- a/clients/apps/web/src/components/DashboardOverview/OverviewSection.tsx
+++ b/clients/apps/web/src/components/DashboardOverview/OverviewSection.tsx
@@ -1,10 +1,7 @@
 'use client'
 
 import { MetricGroup } from '@/components/Metrics/dashboards/MetricGroup'
-import {
-  shouldShowSubscriptionMetricsTaxAlert,
-  SubscriptionMetricsTaxAlert,
-} from '@/components/Metrics/SubscriptionMetricsTaxAlert'
+import { SubscriptionMetricsTaxAlert } from '@/components/Metrics/SubscriptionMetricsTaxAlert'
 import { Modal } from '@polar-sh/orbit'
 import { useMetrics } from '@/hooks/queries'
 import { useChartRange } from '@/hooks/useChartRange'
@@ -86,9 +83,7 @@ export function OverviewSection({ organization }: OverviewSectionProps) {
           </Button>
         </div>
       </div>
-      {shouldShowSubscriptionMetricsTaxAlert(organization) && (
-        <SubscriptionMetricsTaxAlert />
-      )}
+      <SubscriptionMetricsTaxAlert organization={organization} />
       <MetricGroup
         data={data}
         metricKeys={activeMetrics}

--- a/clients/apps/web/src/components/Metrics/SubscriptionMetricsTaxAlert.tsx
+++ b/clients/apps/web/src/components/Metrics/SubscriptionMetricsTaxAlert.tsx
@@ -1,0 +1,40 @@
+import { schemas } from '@polar-sh/client'
+import { Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+
+const AFFECTED_TAX_BEHAVIORS = new Set<schemas['TaxBehaviorOption']>([
+  'location',
+  'inclusive',
+])
+
+interface OrganizationWithTaxBehavior {
+  organization: Pick<schemas['Organization'], 'default_tax_behavior'>
+}
+
+export const shouldShowSubscriptionMetricsTaxAlert = ({
+  default_tax_behavior,
+}: OrganizationWithTaxBehavior['organization']) => {
+  return AFFECTED_TAX_BEHAVIORS.has(default_tax_behavior)
+}
+
+export const SubscriptionMetricsTaxAlert = () => {
+  return (
+    <Box
+      flexDirection={'column'}
+      rowGap="xs"
+      borderRadius="l"
+      backgroundColor="background-card"
+      padding="l"
+    >
+      <Text as="strong">Subscription metrics now exclude tax</Text>
+      <Box>
+        <Text color="muted">
+          We corrected subscription metrics to be tax-exclusive, matching your
+          revenue metrics. Because your organization uses location-based or
+          inclusive tax behavior, these subscription metrics may be a bit lower
+          than before.
+        </Text>
+      </Box>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/components/Metrics/SubscriptionMetricsTaxAlert.tsx
+++ b/clients/apps/web/src/components/Metrics/SubscriptionMetricsTaxAlert.tsx
@@ -1,40 +1,30 @@
-import { schemas } from '@polar-sh/client'
-import { Text } from '@polar-sh/orbit'
-import { Box } from '@polar-sh/orbit/Box'
+import type { schemas } from '@polar-sh/client'
+import { SubscriptionMetricsTaxAlertClient } from './SubscriptionMetricsTaxAlertClient'
 
 const AFFECTED_TAX_BEHAVIORS = new Set<schemas['TaxBehaviorOption']>([
   'location',
   'inclusive',
 ])
 
-interface OrganizationWithTaxBehavior {
-  organization: Pick<schemas['Organization'], 'default_tax_behavior'>
+const SUBSCRIPTION_METRICS_TAX_CHANGE_TIMESTAMP = Date.parse(
+  '2026-06-23T07:47:00.000Z',
+)
+
+interface SubscriptionMetricsTaxAlertProps {
+  organization: schemas['Organization']
 }
 
-export const shouldShowSubscriptionMetricsTaxAlert = ({
-  default_tax_behavior,
-}: OrganizationWithTaxBehavior['organization']) => {
-  return AFFECTED_TAX_BEHAVIORS.has(default_tax_behavior)
-}
+export const SubscriptionMetricsTaxAlert = ({
+  organization,
+}: SubscriptionMetricsTaxAlertProps) => {
+  const shouldShow =
+    Date.parse(organization.created_at) <
+      SUBSCRIPTION_METRICS_TAX_CHANGE_TIMESTAMP &&
+    AFFECTED_TAX_BEHAVIORS.has(organization.default_tax_behavior)
 
-export const SubscriptionMetricsTaxAlert = () => {
-  return (
-    <Box
-      flexDirection={'column'}
-      rowGap="xs"
-      borderRadius="l"
-      backgroundColor="background-card"
-      padding="l"
-    >
-      <Text as="strong">Subscription metrics now exclude tax</Text>
-      <Box>
-        <Text color="muted">
-          We corrected subscription metrics to be tax-exclusive, matching your
-          revenue metrics. Because your organization uses location-based or
-          inclusive tax behavior, these subscription metrics may be a bit lower
-          than before.
-        </Text>
-      </Box>
-    </Box>
-  )
+  if (!shouldShow) {
+    return null
+  }
+
+  return <SubscriptionMetricsTaxAlertClient organizationId={organization.id} />
 }

--- a/clients/apps/web/src/components/Metrics/SubscriptionMetricsTaxAlertClient.tsx
+++ b/clients/apps/web/src/components/Metrics/SubscriptionMetricsTaxAlertClient.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { useDismissed } from '@/hooks/useDismissed'
+import { Alert } from '@polar-sh/orbit'
+
+interface SubscriptionMetricsTaxAlertClientProps {
+  organizationId: string
+}
+
+export const SubscriptionMetricsTaxAlertClient = ({
+  organizationId,
+}: SubscriptionMetricsTaxAlertClientProps) => {
+  const { isDismissed, dismiss } = useDismissed(
+    `subscription_metrics_tax_alert:${organizationId}`,
+  )
+
+  if (isDismissed) {
+    return null
+  }
+
+  return (
+    <Alert
+      variant="info"
+      title="Subscription metrics now exclude tax"
+      description="We corrected subscription metrics to be tax-exclusive, matching your revenue metrics. Because your organization uses location-based or inclusive tax behavior, these subscription metrics may be a bit lower than before."
+      onDismiss={dismiss}
+    />
+  )
+}

--- a/clients/apps/web/src/components/Metrics/dashboards/ClientPage.tsx
+++ b/clients/apps/web/src/components/Metrics/dashboards/ClientPage.tsx
@@ -3,7 +3,7 @@
 import { SubscriptionMetricsTaxAlert } from '@/components/Metrics/SubscriptionMetricsTaxAlert'
 import { useMetrics } from '@/hooks/queries'
 import { fromISODate, METRIC_GROUPS, toISODate } from '@/utils/metrics'
-import { getMetricsRangeDates } from '@polar-sh/client'
+import { getMetricsRangeDates, type schemas } from '@polar-sh/client'
 import { Box } from '@polar-sh/orbit/Box'
 import {
   createParser,
@@ -30,15 +30,12 @@ const parseAsISODate = createParser({
 
 interface ClientPageProps {
   metric: string
-  organizationId: string
-  showSubscriptionMetricsTaxAlert: boolean
+  organization: schemas['Organization']
 }
 
-export default function ClientPage({
-  metric,
-  organizationId,
-  showSubscriptionMetricsTaxAlert,
-}: ClientPageProps) {
+export default function ClientPage({ metric, organization }: ClientPageProps) {
+  const organizationId = organization.id
+
   const [defaultStartDate, defaultEndDate] = useMemo(
     () => getMetricsRangeDates('30d'),
     [],
@@ -83,8 +80,8 @@ export default function ClientPage({
 
   return (
     <Box flexDirection="column" rowGap="3xl">
-      {metric === 'subscriptions' && showSubscriptionMetricsTaxAlert && (
-        <SubscriptionMetricsTaxAlert />
+      {metric === 'subscriptions' && (
+        <SubscriptionMetricsTaxAlert organization={organization} />
       )}
       {metric === 'cancellations' ? (
         <CancellationsContent

--- a/clients/apps/web/src/components/Metrics/dashboards/ClientPage.tsx
+++ b/clients/apps/web/src/components/Metrics/dashboards/ClientPage.tsx
@@ -1,8 +1,10 @@
 'use client'
 
+import { SubscriptionMetricsTaxAlert } from '@/components/Metrics/SubscriptionMetricsTaxAlert'
 import { useMetrics } from '@/hooks/queries'
 import { fromISODate, METRIC_GROUPS, toISODate } from '@/utils/metrics'
 import { getMetricsRangeDates } from '@polar-sh/client'
+import { Box } from '@polar-sh/orbit/Box'
 import {
   createParser,
   parseAsArrayOf,
@@ -29,11 +31,13 @@ const parseAsISODate = createParser({
 interface ClientPageProps {
   metric: string
   organizationId: string
+  showSubscriptionMetricsTaxAlert: boolean
 }
 
 export default function ClientPage({
   metric,
   organizationId,
+  showSubscriptionMetricsTaxAlert,
 }: ClientPageProps) {
   const [defaultStartDate, defaultEndDate] = useMemo(
     () => getMetricsRangeDates('30d'),
@@ -78,7 +82,10 @@ export default function ClientPage({
   }
 
   return (
-    <div className="flex flex-col gap-12">
+    <Box flexDirection="column" rowGap="3xl">
+      {metric === 'subscriptions' && showSubscriptionMetricsTaxAlert && (
+        <SubscriptionMetricsTaxAlert />
+      )}
       {metric === 'cancellations' ? (
         <CancellationsContent
           data={data}
@@ -93,6 +100,6 @@ export default function ClientPage({
       ) : (
         <MetricGroup metricKeys={metrics} data={data} interval={interval} />
       )}
-    </div>
+    </Box>
   )
 }

--- a/server/polar/metrics/queries.py
+++ b/server/polar/metrics/queries.py
@@ -240,10 +240,10 @@ def get_active_subscriptions_cte(
     converted_amount = case(
         (
             func.lower(Subscription.currency) == "usd",
-            Subscription.amount,
+            Subscription.net_amount,
         ),
         else_=func.round(
-            Subscription.amount
+            Subscription.net_amount
             * func.coalesce(
                 bucketed_fx_rate,
                 closest_global_fx_rate,


### PR DESCRIPTION
Switch subscription-based metrics to use `net_amount` instead.

<img width="987" height="852" alt="image" src="https://github.com/user-attachments/assets/214f99bb-dedb-412e-8df8-eab7ade9cbeb" />

Related to polarsource/feedback#179



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Subscription metrics now use `Subscription.net_amount` (tax‑exclusive) for USD and FX conversions. Adds a dismissible notice on the subscriptions analytics view and the overview to explain the change for affected orgs.

- **New Features**
  - Server: read `net_amount` in metrics queries, aligning subscription metrics with revenue; values may drop where tax was previously included.
  - UI: show an `@polar-sh/orbit` dismissible Alert for orgs with location-based or inclusive tax created before the change; persists dismissal per org.
  - Analytics: pass `organization` to `ClientPage` and display the notice only for the subscriptions metric.

<sup>Written for commit 05d06cce5a7c328825edc3e4b2bfb36e168daaf8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

