### PR TITLE
Manage subscription.net_amount from order or checkout

### DIFF
--- a/server/polar/models/subscription.py
+++ b/server/polar/models/subscription.py
@@ -46,6 +46,7 @@ if TYPE_CHECKING:
         CustomerSeat,
         Discount,
         Meter,
+        Order,
         Organization,
         PaymentMethod,
         Product,
@@ -414,8 +415,38 @@ class Subscription(CustomFieldDataMixin, MetadataMixin, RecordModel):
         amount = sum(price.amount for price in prices)
         if discount is not None:
             amount -= discount.get_discount_amount(amount, self.currency)
+
+        # Preserve the tax ratio implied by the current amount/net_amount pair:
+        # the tax rate for the same customer and product is unchanged, so reapply
+        # the previous fraction to the new amount. With no prior ratio (creation,
+        # or a free subscription becoming paid) we fall back to gross, and the
+        # next order derives the real net.
+        previous_amount = self.amount
+        previous_net_amount = self.net_amount
         self.amount = amount
-        self.net_amount = amount  # Same as amount while tax-exclusive
+        if previous_amount:
+            self.net_amount = round(amount * previous_net_amount / previous_amount)
+        else:
+            self.net_amount = amount
+
+    def update_net_amount_from(self, charge: "Order | Checkout") -> None:
+        """
+        Derive net_amount from the tax treatment of a charge (an order or checkout).
+
+        net_amount is the recurring amount net of inclusive tax. The fraction the
+        charge applied is uniform across its recurring, proration and metered line
+        items, so we reapply it to the subscription's own amount: tax-inclusive
+        charges back the tax out, tax-exclusive charges leave net_amount equal to
+        amount. Charges with no usable tax treatment ($0/credit, or a failed tax
+        calculation) are skipped so they can't overwrite a previously derived value.
+        """
+        taxable_total = charge.net_amount + (charge.tax_amount or 0)
+        if charge.tax_behavior is None or taxable_total <= 0:
+            return
+        if charge.tax_behavior == TaxBehavior.inclusive:
+            self.net_amount = round(self.amount * charge.net_amount / taxable_total)
+        else:
+            self.net_amount = self.amount
 
     def update_meters(self, prices: Sequence["SubscriptionProductPrice"]) -> None:
         subscription_meters = self.meters or []

--- a/server/polar/models/subscription.py
+++ b/server/polar/models/subscription.py
@@ -416,11 +416,14 @@ class Subscription(CustomFieldDataMixin, MetadataMixin, RecordModel):
         if discount is not None:
             amount -= discount.get_discount_amount(amount, self.currency)
 
-        # Preserve the tax ratio implied by the current amount/net_amount pair:
-        # the tax rate for the same customer and product is unchanged, so reapply
-        # the previous fraction to the new amount. With no prior ratio (creation,
-        # or a free subscription becoming paid) we fall back to gross, and the
-        # next order derives the real net.
+        # Preserve the net/gross ratio across the amount change. The customer's
+        # effective tax rate is fixed (single tax code, stable address) and recurring
+        # orders bill against subscription.tax_behavior, which is pinned at creation —
+        # so the ratio the first charge established stays valid even across plan
+        # changes. Cold start (creation, or free becoming paid) has no ratio: fall
+        # back to gross and let the next order derive the real net.
+        # TODO: once a plan change can move subscription.tax_behavior, reset to gross
+        # when the new behavior isn't inclusive instead of carrying the old ratio.
         previous_amount = self.amount
         previous_net_amount = self.net_amount
         self.amount = amount

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -821,6 +821,9 @@ class OrderService:
             flush=True,
         )
 
+        if subscription is not None:
+            subscription.update_net_amount_from(checkout)
+
         # Link payment and balance transaction to the order
         if payment is not None:
             payment_repository = PaymentRepository.from_session(session)
@@ -1406,6 +1409,8 @@ class OrderService:
                 flush=True,
             )
 
+            subscription.update_net_amount_from(order)
+
             # Impact customer's balance
             if balance_change != 0:
                 await wallet_service.create_balance_transaction(
@@ -1531,6 +1536,9 @@ class OrderService:
             ),
             flush=True,
         )
+
+        if checkout is not None:
+            subscription.update_net_amount_from(checkout)
 
         await self._on_order_created(session, order)
 

--- a/server/scripts/backfill_subscription_net_amount_inclusive_tax.py
+++ b/server/scripts/backfill_subscription_net_amount_inclusive_tax.py
@@ -1,0 +1,177 @@
+import asyncio
+from typing import Any, cast
+
+import typer
+from rich.progress import (
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeElapsedColumn,
+)
+from sqlalchemy import (
+    BigInteger,
+    ColumnElement,
+    CursorResult,
+    Numeric,
+    func,
+    select,
+    update,
+)
+
+from polar.config import settings
+from polar.enums import TaxBehavior
+from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
+from polar.kit.db.postgres import create_async_engine as _create_async_engine
+from polar.models import Order, Subscription
+
+from .helper import configure_script_logging, typer_async
+
+cli = typer.Typer()
+
+
+def _computed_net_amount() -> ColumnElement[int]:
+    """
+    Net amount derived from the subscription's latest inclusive-tax order.
+
+    The subscription row doesn't store a tax rate, so we back inclusive tax out of
+    `amount` using the net/gross ratio of the latest order that actually carried a
+    usable tax treatment. Subscriptions with no such order coalesce to their current
+    `net_amount`, which makes them invisible to the update predicate (idempotent, and
+    never writes NULL into the NOT NULL column).
+    """
+    order_taxable_total = Order.net_amount + Order.tax_amount
+    latest_order_net = (
+        select(
+            func.cast(
+                func.round(
+                    func.cast(Subscription.amount, Numeric)
+                    * Order.net_amount
+                    / func.cast(order_taxable_total, Numeric)
+                ),
+                BigInteger,
+            )
+        )
+        .where(
+            Order.subscription_id == Subscription.id,
+            Order.tax_behavior == TaxBehavior.inclusive,
+            order_taxable_total > 0,
+        )
+        .order_by(Order.created_at.desc(), Order.id.desc())
+        .limit(1)
+        .correlate(Subscription)
+        .scalar_subquery()
+    )
+    return func.coalesce(latest_order_net, Subscription.net_amount)
+
+
+async def run_backfill(
+    batch_size: int = 5000,
+    sleep_seconds: float = 0.1,
+    session: AsyncSession | None = None,
+) -> int:
+    """
+    Recompute `net_amount` for inclusive-tax subscriptions.
+
+    Before subscriptions tracked inclusive tax, `net_amount` was always set equal to
+    `amount`. This corrects every subscription with `tax_behavior == inclusive` by
+    backing the inclusive tax out, using the ratio from its latest qualifying order.
+
+    Set-based and batched: each batch updates up to `batch_size` rows whose stored
+    `net_amount` differs from the freshly computed value, so already-correct rows
+    (and rows with no qualifying order) drop out of the predicate. This gives the loop
+    its termination condition and makes the whole script safe to rerun.
+    """
+    engine = None
+    own_session = False
+
+    if session is None:
+        engine = _create_async_engine(
+            dsn=str(settings.get_postgres_dsn("asyncpg")),
+            application_name=f"{settings.ENV.value}.script",
+            debug=False,
+            pool_size=settings.DATABASE_POOL_SIZE,
+            pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
+            command_timeout=settings.DATABASE_COMMAND_TIMEOUT_SECONDS,
+        )
+        sessionmaker = create_async_sessionmaker(engine)
+        session = sessionmaker()
+        own_session = True
+
+    total_updated = 0
+    batch_number = 0
+
+    try:
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            TimeElapsedColumn(),
+            transient=False,
+        ) as progress:
+            task = progress.add_task("[cyan]Batch 0: 0 rows updated", total=None)
+
+            while True:
+                batch = (
+                    select(Subscription.id)
+                    .where(
+                        Subscription.tax_behavior == TaxBehavior.inclusive,
+                        Subscription.net_amount.is_distinct_from(
+                            _computed_net_amount()
+                        ),
+                    )
+                    .limit(batch_size)
+                )
+                result = await session.execute(
+                    update(Subscription)
+                    .where(Subscription.id.in_(batch))
+                    .values(net_amount=_computed_net_amount())
+                    .execution_options(synchronize_session=False)
+                )
+                await session.commit()
+
+                rows_updated = cast(CursorResult[Any], result).rowcount
+                if rows_updated == 0:
+                    progress.update(
+                        task,
+                        description=(
+                            f"[green]✓ Complete: {total_updated} rows updated"
+                        ),
+                    )
+                    break
+
+                batch_number += 1
+                total_updated += rows_updated
+                progress.update(
+                    task,
+                    description=(
+                        f"[cyan]Batch {batch_number}: {total_updated} rows updated"
+                    ),
+                )
+
+                if sleep_seconds > 0:
+                    await asyncio.sleep(sleep_seconds)
+
+        return total_updated
+
+    finally:
+        if own_session:
+            await session.close()
+        if engine is not None:
+            await engine.dispose()
+
+
+@cli.command()
+@typer_async
+async def backfill(
+    batch_size: int = typer.Option(5000, help="Number of rows to process per batch"),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+) -> None:
+    """Backfill net_amount for inclusive-tax subscriptions."""
+    configure_script_logging()
+    total_updated = await run_backfill(
+        batch_size=batch_size, sleep_seconds=sleep_seconds
+    )
+    typer.echo(f"Updated {total_updated} subscriptions")
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/tests/models/test_subscription.py
+++ b/server/tests/models/test_subscription.py
@@ -1,0 +1,76 @@
+import pytest
+
+from polar.enums import TaxBehavior
+from polar.models import Order, Subscription
+from polar.models.subscription_product_price import SubscriptionProductPrice
+
+
+def _prices(*amounts: int) -> list[SubscriptionProductPrice]:
+    return [SubscriptionProductPrice(amount=amount) for amount in amounts]
+
+
+def _charge(
+    tax_behavior: TaxBehavior | None, net_amount: int, tax_amount: int | None
+) -> Order:
+    return Order(
+        tax_behavior=tax_behavior, net_amount=net_amount, tax_amount=tax_amount
+    )
+
+
+class TestUpdateNetAmountFrom:
+    def test_exclusive_charge_sets_net_to_amount(self) -> None:
+        subscription = Subscription(amount=1000, net_amount=800)
+        subscription.update_net_amount_from(_charge(TaxBehavior.exclusive, 1000, 200))
+        assert subscription.net_amount == 1000
+
+    @pytest.mark.parametrize(
+        ("net_amount", "tax_amount", "amount", "expected_net"),
+        [
+            (800, 200, 1000, 800),
+            (826, 174, 1000, 826),
+            # The fraction spans recurring + metered + proration, but is uniform,
+            # so the recurring net is still derived correctly.
+            (4132, 868, 1000, 826),
+        ],
+    )
+    def test_inclusive_charge_backs_out_tax(
+        self, net_amount: int, tax_amount: int, amount: int, expected_net: int
+    ) -> None:
+        subscription = Subscription(amount=amount, net_amount=amount)
+        subscription.update_net_amount_from(
+            _charge(TaxBehavior.inclusive, net_amount, tax_amount)
+        )
+        assert subscription.net_amount == expected_net
+
+    @pytest.mark.parametrize(
+        "charge",
+        [
+            _charge(None, 1000, None),  # failed tax calculation
+            _charge(TaxBehavior.inclusive, 0, 0),  # $0 charge
+            _charge(TaxBehavior.inclusive, -500, -100),  # credit
+        ],
+    )
+    def test_unusable_charge_leaves_net_unchanged(self, charge: Order) -> None:
+        subscription = Subscription(amount=1000, net_amount=826)
+        subscription.update_net_amount_from(charge)
+        assert subscription.net_amount == 826
+
+
+class TestUpdateAmountAndCurrency:
+    def test_cold_start_falls_back_to_gross(self) -> None:
+        subscription = Subscription(currency="usd")
+        subscription.update_amount_and_currency(_prices(1000), None)
+        assert subscription.amount == 1000
+        assert subscription.net_amount == 1000
+
+    def test_preserves_inclusive_ratio_across_amount_change(self) -> None:
+        subscription = Subscription(currency="usd", amount=1000, net_amount=800)
+        subscription.update_amount_and_currency(_prices(1500, 500), None)
+        assert subscription.amount == 2000
+        assert subscription.net_amount == 1600
+
+    def test_exclusive_stays_equal(self) -> None:
+        subscription = Subscription(currency="usd", amount=1000, net_amount=1000)
+        subscription.update_amount_and_currency(_prices(3000), None)
+        assert subscription.amount == 3000
+        assert subscription.net_amount == 3000

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -1047,6 +1047,15 @@ class TestCreateSubscriptionOrder:
         assert order.billing_reason == OrderBillingReasonInternal.subscription_cycle
         assert order.subscription == subscription
 
+        if tax_behavior == TaxBehavior.inclusive:
+            assert subscription.net_amount == round(
+                subscription.amount
+                * order.net_amount
+                / (order.net_amount + order.tax_amount)
+            )
+        else:
+            assert subscription.net_amount == subscription.amount
+
         calculate_tax_mock.assert_called_once_with(
             str(order.id),
             subscription.currency,

--- a/server/tests/scripts/test_backfill_subscription_net_amount_inclusive_tax.py
+++ b/server/tests/scripts/test_backfill_subscription_net_amount_inclusive_tax.py
@@ -1,0 +1,206 @@
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import select
+
+from polar.enums import TaxBehavior
+from polar.kit.db.postgres import AsyncSession
+from polar.models import Organization, Product, Subscription
+from polar.models.subscription import SubscriptionStatus
+from scripts.backfill_subscription_net_amount_inclusive_tax import run_backfill
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import (
+    create_customer,
+    create_order,
+    create_subscription,
+)
+
+
+async def _set_amounts(
+    save_fixture: SaveFixture,
+    subscription: Subscription,
+    *,
+    amount: int,
+    net_amount: int,
+) -> None:
+    subscription.amount = amount
+    subscription.net_amount = net_amount
+    await save_fixture(subscription)
+
+
+async def _get_net_amount(session: AsyncSession, subscription: Subscription) -> int:
+    result = await session.execute(
+        select(Subscription.net_amount).where(Subscription.id == subscription.id)
+    )
+    return result.scalar_one()
+
+
+@pytest.mark.asyncio
+class TestBackfillSubscriptionNetAmountInclusiveTax:
+    async def test_backs_inclusive_tax_out_of_net_amount(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        organization: Organization,
+    ) -> None:
+        customer = await create_customer(save_fixture, organization=organization)
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.active,
+            tax_behavior=TaxBehavior.inclusive,
+        )
+        await _set_amounts(save_fixture, subscription, amount=10000, net_amount=10000)
+
+        await create_order(
+            save_fixture,
+            customer=customer,
+            subscription=subscription,
+            tax_behavior=TaxBehavior.inclusive,
+            subtotal_amount=10000,
+            tax_amount=2000,
+        )
+
+        updated = await run_backfill(batch_size=10, session=session)
+
+        assert updated == 1
+        assert await _get_net_amount(session, subscription) == 8000
+
+    async def test_uses_latest_qualifying_order(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        organization: Organization,
+    ) -> None:
+        customer = await create_customer(save_fixture, organization=organization)
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.active,
+            tax_behavior=TaxBehavior.inclusive,
+        )
+        await _set_amounts(save_fixture, subscription, amount=10000, net_amount=10000)
+
+        await create_order(
+            save_fixture,
+            customer=customer,
+            subscription=subscription,
+            tax_behavior=TaxBehavior.inclusive,
+            subtotal_amount=10000,
+            tax_amount=1000,
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        await create_order(
+            save_fixture,
+            customer=customer,
+            subscription=subscription,
+            tax_behavior=TaxBehavior.inclusive,
+            subtotal_amount=10000,
+            tax_amount=2000,
+            created_at=datetime(2026, 2, 1, tzinfo=UTC),
+        )
+
+        updated = await run_backfill(batch_size=10, session=session)
+
+        assert updated == 1
+        assert await _get_net_amount(session, subscription) == 8000
+
+    async def test_skips_subscription_without_qualifying_order(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        organization: Organization,
+    ) -> None:
+        customer = await create_customer(save_fixture, organization=organization)
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.active,
+            tax_behavior=TaxBehavior.inclusive,
+        )
+        await _set_amounts(save_fixture, subscription, amount=10000, net_amount=10000)
+
+        # $0 order has no usable tax treatment and must not overwrite net_amount.
+        await create_order(
+            save_fixture,
+            customer=customer,
+            subscription=subscription,
+            tax_behavior=TaxBehavior.inclusive,
+            subtotal_amount=0,
+            tax_amount=0,
+        )
+
+        updated = await run_backfill(batch_size=10, session=session)
+
+        assert updated == 0
+        assert await _get_net_amount(session, subscription) == 10000
+
+    async def test_leaves_exclusive_subscription_untouched(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        organization: Organization,
+    ) -> None:
+        customer = await create_customer(save_fixture, organization=organization)
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.active,
+            tax_behavior=TaxBehavior.exclusive,
+        )
+        await _set_amounts(save_fixture, subscription, amount=10000, net_amount=10000)
+
+        await create_order(
+            save_fixture,
+            customer=customer,
+            subscription=subscription,
+            tax_behavior=TaxBehavior.exclusive,
+            subtotal_amount=10000,
+            tax_amount=2000,
+        )
+
+        updated = await run_backfill(batch_size=10, session=session)
+
+        assert updated == 0
+        assert await _get_net_amount(session, subscription) == 10000
+
+    async def test_is_idempotent(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        organization: Organization,
+    ) -> None:
+        customer = await create_customer(save_fixture, organization=organization)
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.active,
+            tax_behavior=TaxBehavior.inclusive,
+        )
+        await _set_amounts(save_fixture, subscription, amount=10000, net_amount=10000)
+
+        await create_order(
+            save_fixture,
+            customer=customer,
+            subscription=subscription,
+            tax_behavior=TaxBehavior.inclusive,
+            subtotal_amount=10000,
+            tax_amount=2000,
+        )
+
+        first_run = await run_backfill(batch_size=10, session=session)
+        second_run = await run_backfill(batch_size=10, session=session)
+
+        assert first_run == 1
+        assert second_run == 0
+        assert await _get_net_amount(session, subscription) == 8000


### PR DESCRIPTION
This is a weird PR, but exploring a fix to polarsource/feedback#179.

The reason we also have to look at a checkout is that that's the only place where we have tax information for a trial subscription (the order `amount` for a starting trial is `0`), otherwise we could've worked from an order only.

I don't really like how this is a side-effect that has to be called from the three order creation paths.

Other than that, it's pretty straight-forward, we calculate the tax rate (either from the order's net_amount vs taxable base), or we re-apply the same tax rate on `subscription.amount` vs `subscription.net_amount` when a subscription is updated to keep the same tax rate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives `subscription.net_amount` from the tax behavior of the originating order/checkout and keeps the effective tax ratio when amounts change. Adds a backfill script to fix existing tax-inclusive subscriptions.

- **Bug Fixes**
  - Added `Subscription.update_net_amount_from(charge)` to apply the charge’s tax behavior: back out tax for inclusive; keep gross for exclusive; ignore $0/credits/failed tax.
  - `update_amount_and_currency` preserves the previous amount/net_amount ratio; falls back to gross when no prior ratio exists; TODO to reset when a plan change modifies `tax_behavior`.
  - Applied in checkout, subscription order, and trial order flows so `net_amount` is correct from day one.

- **Migration**
  - Added `server/scripts/backfill_subscription_net_amount_inclusive_tax.py` to recompute `net_amount` for inclusive-tax subscriptions using the latest qualifying order; batched and idempotent. Run after deploy to correct existing data.

<sup>Written for commit 3ed4abf9eb667024e8dfd5c2027032de3f2bcd06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

