### PR TITLE
refactor(support_case): read organization_id directly, drop resolver

### DIFF
--- a/server/polar/backoffice/support_cases/endpoints.py
+++ b/server/polar/backoffice/support_cases/endpoints.py
@@ -22,7 +22,6 @@ from polar.models.support_case import (
     SupportCaseType,
 )
 from polar.models.user_session import UserSession
-from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncSession, get_db_read_session, get_db_session
 from polar.support_case.repository import (
     SupportCaseAttachmentRepository,
@@ -211,17 +210,14 @@ def _detail_redirect(
 async def _load_case_and_organization(
     session: AsyncSession, case_id: uuid.UUID
 ) -> tuple[SupportCase, Organization]:
-    """Load a case and the organization it belongs to, or raise 404."""
-    case = await SupportCaseRepository.from_session(session).get_by_id(case_id)
+    """Load a case and its organization (incl. soft-deleted/blocked), or raise 404."""
+    case = await SupportCaseRepository.from_session(session).get_by_id(
+        case_id, options=(joinedload(SupportCase.organization),)
+    )
     if case is None:
         raise HTTPException(status_code=404, detail="Support case not found")
-    # Soft-deleted orgs keep their cases viewable, matching the org detail pages.
-    organization = await OrganizationRepository.from_session(session).get_by_id(
-        case.organization_id, include_deleted=True, include_blocked=True
-    )
-    if organization is None:
-        raise HTTPException(status_code=404, detail="Organization not found")
-    return case, organization
+
+    return case, case.organization
 
 
 @router.post("/{case_id}/take", name="support_cases:take", response_model=None)

--- a/server/polar/backoffice/support_cases/endpoints.py
+++ b/server/polar/backoffice/support_cases/endpoints.py
@@ -215,14 +215,10 @@ async def _load_case_and_organization(
     case = await SupportCaseRepository.from_session(session).get_by_id(case_id)
     if case is None:
         raise HTTPException(status_code=404, detail="Support case not found")
-    organization_id = await support_case_service.get_organization_id(session, case)
-    organization = None
-    if organization_id is not None:
-        # Soft-deleted orgs keep their cases viewable, matching the
-        # org detail pages
-        organization = await OrganizationRepository.from_session(session).get_by_id(
-            organization_id, include_deleted=True, include_blocked=True
-        )
+    # Soft-deleted orgs keep their cases viewable, matching the org detail pages.
+    organization = await OrganizationRepository.from_session(session).get_by_id(
+        case.organization_id, include_deleted=True, include_blocked=True
+    )
     if organization is None:
         raise HTTPException(status_code=404, detail="Organization not found")
     return case, organization

--- a/server/polar/support_case/service.py
+++ b/server/polar/support_case/service.py
@@ -1,12 +1,7 @@
 from collections.abc import Sequence
-from uuid import UUID
 
-from sqlalchemy.orm import joinedload
-
-from polar.models import Customer, Dispute, File, Organization, User
+from polar.models import Customer, File, Organization, User
 from polar.models.support_case import (
-    DisputeSupportCase,
-    ReviewAppealSupportCase,
     SupportCase,
     SupportCaseAttachment,
     SupportCaseAudience,
@@ -15,13 +10,10 @@ from polar.models.support_case import (
     SupportCaseMessageType,
     SupportCaseParticipant,
     SupportCaseParticipantKind,
-    SupportCaseType,
 )
-from polar.postgres import AsyncReadSession, AsyncSession
+from polar.postgres import AsyncSession
 
 from .repository import (
-    DisputeSupportCaseRepository,
-    ReviewAppealSupportCaseRepository,
     SupportCaseAttachmentRepository,
     SupportCaseMessageRepository,
     SupportCaseParticipantRepository,
@@ -51,30 +43,6 @@ class SupportCaseService:
             audience=audience,
         )
         return case
-
-    async def get_organization_id(
-        self, session: AsyncSession | AsyncReadSession, case: SupportCase
-    ) -> UUID | None:
-        """The organization that owns a case, resolved through its domain object."""
-        if case.type == SupportCaseType.review_appeal:
-            appeal = await ReviewAppealSupportCaseRepository.from_session(
-                session
-            ).get_by_id(
-                case.id,
-                options=(joinedload(ReviewAppealSupportCase.organization_review),),
-            )
-            return appeal.organization_review.organization_id if appeal else None
-        if case.type == SupportCaseType.dispute:
-            dispute_case = await DisputeSupportCaseRepository.from_session(
-                session
-            ).get_by_id(
-                case.id,
-                options=(
-                    joinedload(DisputeSupportCase.dispute).joinedload(Dispute.order),
-                ),
-            )
-            return dispute_case.dispute.order.organization_id if dispute_case else None
-        return None
 
     async def add_participant(
         self,

--- a/server/polar/support_case/tasks.py
+++ b/server/polar/support_case/tasks.py
@@ -14,7 +14,6 @@ from polar.support_case.repository import (
     SupportCaseMessageRepository,
     SupportCaseRepository,
 )
-from polar.support_case.service import support_case as support_case_service
 from polar.user_organization.service import (
     user_organization as user_organization_service,
 )
@@ -58,11 +57,9 @@ async def notify_organization_of_new_message(message_id: UUID) -> None:
         # when the merchant dispute view ships.
         if case.type == SupportCaseType.dispute:
             return
-        organization_id = await support_case_service.get_organization_id(session, case)
-        if organization_id is None:
-            return
-
-        members = await user_organization_service.list_by_org(session, organization_id)
+        members = await user_organization_service.list_by_org(
+            session, case.organization_id
+        )
         if not members:
             return
         organization = members[0].organization


### PR DESCRIPTION
Now that organization_id is denormalized and NOT NULL, read it straight off the case at both call sites (the new-message task and the backoffice case view) and remove SupportCaseService.get_organization_id along with the polymorphic per-type domain-object lookup it did.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Read `organization_id` directly from `SupportCase` and remove the resolver. This simplifies the code and reduces queries in the backoffice view and new-message notification task.

- **Refactors**
  - Replace resolver with direct `case.organization_id` usage in tasks.
  - Load organization via `joinedload(SupportCase.organization)` in backoffice detail; includes soft-deleted/blocked.
  - Remove `SupportCaseService.get_organization_id` and per-type lookups.
  - Fewer DB hits and less branching in support case flows.

<sup>Written for commit b72036b60071e7383e43cae9a3fb1c2b4f96e2a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

