### PR TITLE
Make Organization Access Tokens endpoints web only

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -5040,15 +5040,10 @@ export interface paths {
     /**
      * List
      * @description List organization access tokens.
-     *
-     *     **Scopes**: `organization_access_tokens:read` `organization_access_tokens:write`
      */
     get: operations['organization_access_tokens:list']
     put?: never
-    /**
-     * Create
-     * @description **Scopes**: `organization_access_tokens:write`
-     */
+    /** Create */
     post: operations['organization_access_tokens:create']
     delete?: never
     options?: never
@@ -5066,17 +5061,11 @@ export interface paths {
     get?: never
     put?: never
     post?: never
-    /**
-     * Delete
-     * @description **Scopes**: `organization_access_tokens:write`
-     */
+    /** Delete */
     delete: operations['organization_access_tokens:delete']
     options?: never
     head?: never
-    /**
-     * Update
-     * @description **Scopes**: `organization_access_tokens:write`
-     */
+    /** Update */
     patch: operations['organization_access_tokens:update']
     trace?: never
   }
@@ -7270,8 +7259,6 @@ export interface components {
       | 'notifications:write'
       | 'notification_recipients:read'
       | 'notification_recipients:write'
-      | 'organization_access_tokens:read'
-      | 'organization_access_tokens:write'
     /** BackupCodesEnrollment */
     BackupCodesEnrollment: {
       /** Codes */
@@ -22607,7 +22594,7 @@ export interface components {
       response_types: 'code'[]
       /**
        * Scope
-       * @default openid profile email user:read user:write organizations:read organizations:write custom_fields:read custom_fields:write discounts:read discounts:write checkout_links:read checkout_links:write checkouts:read checkouts:write transactions:read transactions:write payouts:read payouts:write products:read products:write benefits:read benefits:write events:read events:write meters:read meters:write files:read files:write subscriptions:read subscriptions:write customers:read customers:write members:read members:write wallets:read wallets:write disputes:read customer_meters:read customer_sessions:write member_sessions:write customer_seats:read customer_seats:write orders:read orders:write refunds:read refunds:write payments:read metrics:read metrics:write webhooks:read webhooks:write license_keys:read license_keys:write customer_portal:read customer_portal:write notifications:read notifications:write notification_recipients:read notification_recipients:write organization_access_tokens:read organization_access_tokens:write
+       * @default openid profile email user:read user:write organizations:read organizations:write custom_fields:read custom_fields:write discounts:read discounts:write checkout_links:read checkout_links:write checkouts:read checkouts:write transactions:read transactions:write payouts:read payouts:write products:read products:write benefits:read benefits:write events:read events:write meters:read meters:write files:read files:write subscriptions:read subscriptions:write customers:read customers:write members:read members:write wallets:read wallets:write disputes:read customer_meters:read customer_sessions:write member_sessions:write customer_seats:read customer_seats:write orders:read orders:write refunds:read refunds:write payments:read metrics:read metrics:write webhooks:read webhooks:write license_keys:read license_keys:write customer_portal:read customer_portal:write notifications:read notifications:write notification_recipients:read notification_recipients:write
        */
       scope: string
       /** Client Name */
@@ -22672,7 +22659,7 @@ export interface components {
       response_types: 'code'[]
       /**
        * Scope
-       * @default openid profile email user:read user:write organizations:read organizations:write custom_fields:read custom_fields:write discounts:read discounts:write checkout_links:read checkout_links:write checkouts:read checkouts:write transactions:read transactions:write payouts:read payouts:write products:read products:write benefits:read benefits:write events:read events:write meters:read meters:write files:read files:write subscriptions:read subscriptions:write customers:read customers:write members:read members:write wallets:read wallets:write disputes:read customer_meters:read customer_sessions:write member_sessions:write customer_seats:read customer_seats:write orders:read orders:write refunds:read refunds:write payments:read metrics:read metrics:write webhooks:read webhooks:write license_keys:read license_keys:write customer_portal:read customer_portal:write notifications:read notifications:write notification_recipients:read notification_recipients:write organization_access_tokens:read organization_access_tokens:write
+       * @default openid profile email user:read user:write organizations:read organizations:write custom_fields:read custom_fields:write discounts:read discounts:write checkout_links:read checkout_links:write checkouts:read checkouts:write transactions:read transactions:write payouts:read payouts:write products:read products:write benefits:read benefits:write events:read events:write meters:read meters:write files:read files:write subscriptions:read subscriptions:write customers:read customers:write members:read members:write wallets:read wallets:write disputes:read customer_meters:read customer_sessions:write member_sessions:write customer_seats:read customer_seats:write orders:read orders:write refunds:read refunds:write payments:read metrics:read metrics:write webhooks:read webhooks:write license_keys:read license_keys:write customer_portal:read customer_portal:write notifications:read notifications:write notification_recipients:read notification_recipients:write
        */
       scope: string
       /** Client Name */
@@ -22718,7 +22705,7 @@ export interface components {
       response_types: 'code'[]
       /**
        * Scope
-       * @default openid profile email user:read user:write organizations:read organizations:write custom_fields:read custom_fields:write discounts:read discounts:write checkout_links:read checkout_links:write checkouts:read checkouts:write transactions:read transactions:write payouts:read payouts:write products:read products:write benefits:read benefits:write events:read events:write meters:read meters:write files:read files:write subscriptions:read subscriptions:write customers:read customers:write members:read members:write wallets:read wallets:write disputes:read customer_meters:read customer_sessions:write member_sessions:write customer_seats:read customer_seats:write orders:read orders:write refunds:read refunds:write payments:read metrics:read metrics:write webhooks:read webhooks:write license_keys:read license_keys:write customer_portal:read customer_portal:write notifications:read notifications:write notification_recipients:read notification_recipients:write organization_access_tokens:read organization_access_tokens:write
+       * @default openid profile email user:read user:write organizations:read organizations:write custom_fields:read custom_fields:write discounts:read discounts:write checkout_links:read checkout_links:write checkouts:read checkouts:write transactions:read transactions:write payouts:read payouts:write products:read products:write benefits:read benefits:write events:read events:write meters:read meters:write files:read files:write subscriptions:read subscriptions:write customers:read customers:write members:read members:write wallets:read wallets:write disputes:read customer_meters:read customer_sessions:write member_sessions:write customer_seats:read customer_seats:write orders:read orders:write refunds:read refunds:write payments:read metrics:read metrics:write webhooks:read webhooks:write license_keys:read license_keys:write customer_portal:read customer_portal:write notifications:read notifications:write notification_recipients:read notification_recipients:write
        */
       scope: string
       /** Client Name */
@@ -56766,8 +56753,6 @@ export const availableScopeValues: ReadonlyArray<
   'notifications:write',
   'notification_recipients:read',
   'notification_recipients:write',
-  'organization_access_tokens:read',
-  'organization_access_tokens:write',
 ]
 export const balanceCreditOrderEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['BalanceCreditOrderEvent']['name']

--- a/server/polar/auth/scope.py
+++ b/server/polar/auth/scope.py
@@ -144,7 +144,15 @@ READ_ONLY_SCOPES: set[Scope] = {
     Scope.organization_access_tokens_read,
 }
 
-SCOPES_SUPPORTED = [s.value for s in Scope]
+SCOPES_SUPPORTED = [
+    s.value
+    for s in Scope
+    if s
+    not in {
+        Scope.organization_access_tokens_read,
+        Scope.organization_access_tokens_write,
+    }
+]
 SCOPES_SUPPORTED_DISPLAY_NAMES: dict[Scope, str] = {
     Scope.openid: "OpenID",
     Scope.profile: "Read your profile",

--- a/server/polar/organization_access_token/auth.py
+++ b/server/polar/organization_access_token/auth.py
@@ -2,27 +2,25 @@ from typing import Annotated
 
 from fastapi import Depends
 
-from polar.auth.dependencies import Authenticator
-from polar.auth.models import AuthSubject, Organization, User
+from polar.auth.models import AuthSubject, User
 from polar.auth.scope import Scope
+from polar.authz.dependencies import WebUserAuthorizer
 
-_OrganizationAccessTokensRead = Authenticator(
+_OrganizationAccessTokensRead = WebUserAuthorizer(
     required_scopes={
         Scope.organization_access_tokens_read,
         Scope.organization_access_tokens_write,
-    },
-    allowed_subjects={User, Organization},
+    }
 )
 OrganizationAccessTokensRead = Annotated[
-    AuthSubject[User | Organization], Depends(_OrganizationAccessTokensRead)
+    AuthSubject[User], Depends(_OrganizationAccessTokensRead)
 ]
 
-_OrganizationAccessTokensWrite = Authenticator(
+_OrganizationAccessTokensWrite = WebUserAuthorizer(
     required_scopes={
         Scope.organization_access_tokens_write,
-    },
-    allowed_subjects={User, Organization},
+    }
 )
 OrganizationAccessTokensWrite = Annotated[
-    AuthSubject[User | Organization], Depends(_OrganizationAccessTokensWrite)
+    AuthSubject[User], Depends(_OrganizationAccessTokensWrite)
 ]

--- a/server/polar/organization_access_token/endpoints.py
+++ b/server/polar/organization_access_token/endpoints.py
@@ -24,7 +24,7 @@ from .service import organization_access_token as organization_access_token_serv
 
 router = APIRouter(
     prefix="/organization-access-tokens",
-    tags=["organization_access_tokens", APITag.public],
+    tags=["organization_access_tokens", APITag.private],
 )
 
 

--- a/server/tests/organization_access_token/test_endpoints.py
+++ b/server/tests/organization_access_token/test_endpoints.py
@@ -65,7 +65,7 @@ class TestCreateOrganizationAccessToken:
             },
         )
     )
-    async def test_oat_caller_cannot_mint_broader_scope(
+    async def test_oat_caller_cannot_mint(
         self,
         client: AsyncClient,
     ) -> None:
@@ -77,34 +77,7 @@ class TestCreateOrganizationAccessToken:
             },
         )
 
-        assert response.status_code == 422
-        body = response.json()
-        assert any(
-            err.get("loc") == ["body", "scopes"] for err in body.get("detail", [])
-        )
-
-    @pytest.mark.auth(
-        AuthSubjectFixture(
-            subject="organization",
-            scopes={
-                Scope.organization_access_tokens_write,
-                Scope.metrics_read,
-            },
-        )
-    )
-    async def test_oat_caller_within_scope_ok(
-        self,
-        client: AsyncClient,
-    ) -> None:
-        response = await client.post(
-            "/v1/organization-access-tokens/",
-            json={
-                "comment": "within scope",
-                "scopes": ["metrics:read"],
-            },
-        )
-
-        assert response.status_code == 201
+        assert response.status_code == 401
 
 
 @pytest.mark.asyncio
@@ -117,7 +90,7 @@ class TestUpdateOrganizationAccessToken:
             },
         )
     )
-    async def test_oat_caller_cannot_elevate_scopes(
+    async def test_oat_caller_cannot_update(
         self,
         client: AsyncClient,
         save_fixture: SaveFixture,
@@ -132,33 +105,4 @@ class TestUpdateOrganizationAccessToken:
             json={"scopes": ["orders:write"]},
         )
 
-        assert response.status_code == 422
-
-    @pytest.mark.auth(
-        AuthSubjectFixture(
-            subject="organization",
-            scopes={
-                Scope.organization_access_tokens_write,
-                Scope.metrics_read,
-            },
-        )
-    )
-    async def test_oat_caller_within_scope_ok(
-        self,
-        client: AsyncClient,
-        save_fixture: SaveFixture,
-        organization: Organization,
-    ) -> None:
-        existing: OrganizationAccessToken = await _build_oat(
-            save_fixture,
-            organization,
-            scopes={Scope.metrics_read},
-            comment="update_within_scope",
-        )
-
-        response = await client.patch(
-            f"/v1/organization-access-tokens/{existing.id}",
-            json={"scopes": ["metrics:read"]},
-        )
-
-        assert response.status_code == 200
+        assert response.status_code == 401


### PR DESCRIPTION

Allowing to mint tokens from the API doesn't really make sense and will always be a security risk. This PR forces the endpoints to be web only, and hides the corresponding scope from the API.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

