### PR TITLE
Re-review active orgs when products change

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
@@ -58,6 +58,7 @@ class OverviewSection(ChecklistMixin):
         "setup_complete": "Setup Complete",
         "threshold": "Threshold",
         "manual": "Manual",
+        "product_created": "Product Created",
     }
 
     def _render_review_context_badge(self, review_type: str | None) -> None:

--- a/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
@@ -58,7 +58,7 @@ class OverviewSection(ChecklistMixin):
         "setup_complete": "Setup Complete",
         "threshold": "Threshold",
         "manual": "Manual",
-        "product_created": "Product Created",
+        "product_changed": "Product Changed",
     }
 
     def _render_review_context_badge(self, review_type: str | None) -> None:

--- a/server/polar/organization_review/agent.py
+++ b/server/polar/organization_review/agent.py
@@ -133,7 +133,7 @@ async def _collect_setup(organization_id: UUID, context: ReviewContext) -> Setup
     if context not in (
         ReviewContext.THRESHOLD,
         ReviewContext.MANUAL,
-        ReviewContext.PRODUCT_CREATED,
+        ReviewContext.PRODUCT_CHANGED,
     ):
         return SetupData()
 
@@ -180,7 +180,7 @@ async def _collect_metrics(
     if context not in (
         ReviewContext.THRESHOLD,
         ReviewContext.MANUAL,
-        ReviewContext.PRODUCT_CREATED,
+        ReviewContext.PRODUCT_CHANGED,
     ):
         return PaymentMetrics()
 

--- a/server/polar/organization_review/agent.py
+++ b/server/polar/organization_review/agent.py
@@ -130,7 +130,11 @@ async def _collect_products(
 
 
 async def _collect_setup(organization_id: UUID, context: ReviewContext) -> SetupData:
-    if context not in (ReviewContext.THRESHOLD, ReviewContext.MANUAL):
+    if context not in (
+        ReviewContext.THRESHOLD,
+        ReviewContext.MANUAL,
+        ReviewContext.PRODUCT_CREATED,
+    ):
         return SetupData()
 
     async with AsyncReadSessionMaker() as session:
@@ -173,7 +177,11 @@ async def _collect_setup(organization_id: UUID, context: ReviewContext) -> Setup
 async def _collect_metrics(
     organization_id: UUID, context: ReviewContext
 ) -> PaymentMetrics:
-    if context not in (ReviewContext.THRESHOLD, ReviewContext.MANUAL):
+    if context not in (
+        ReviewContext.THRESHOLD,
+        ReviewContext.MANUAL,
+        ReviewContext.PRODUCT_CREATED,
+    ):
         return PaymentMetrics()
 
     async with AsyncReadSessionMaker() as session:

--- a/server/polar/organization_review/analyzer.py
+++ b/server/polar/organization_review/analyzer.py
@@ -680,6 +680,9 @@ class ReviewAnalyzer:
             ReviewContext.THRESHOLD: THRESHOLD_PREAMBLE,
             ReviewContext.MANUAL: MANUAL_PREAMBLE,
             ReviewContext.APPEAL: APPEAL_PREAMBLE,
+            # A product-created review is a comprehensive re-review of an
+            # active org, same as a threshold review.
+            ReviewContext.PRODUCT_CREATED: THRESHOLD_PREAMBLE,
         }.get(context)
 
         policy_block = f"## Acceptable Use Policy\n\n{policy_content}"
@@ -783,9 +786,13 @@ class ReviewAnalyzer:
                     f"(overriding the catalog price): {products.adhoc_prices_count}"
                 )
 
-        # Setup & Integration Signals (only for threshold/manual reviews)
+        # Setup & Integration Signals (only for threshold/manual/product-created reviews)
         setup = snapshot.setup
-        if snapshot.context in (ReviewContext.THRESHOLD, ReviewContext.MANUAL):
+        if snapshot.context in (
+            ReviewContext.THRESHOLD,
+            ReviewContext.MANUAL,
+            ReviewContext.PRODUCT_CREATED,
+        ):
             parts.append("\n## Setup & Integration Signals")
 
             if setup.checkout_success_urls.unique_urls:

--- a/server/polar/organization_review/analyzer.py
+++ b/server/polar/organization_review/analyzer.py
@@ -680,9 +680,9 @@ class ReviewAnalyzer:
             ReviewContext.THRESHOLD: THRESHOLD_PREAMBLE,
             ReviewContext.MANUAL: MANUAL_PREAMBLE,
             ReviewContext.APPEAL: APPEAL_PREAMBLE,
-            # A product-created review is a comprehensive re-review of an
+            # A product-change review is a comprehensive re-review of an
             # active org, same as a threshold review.
-            ReviewContext.PRODUCT_CREATED: THRESHOLD_PREAMBLE,
+            ReviewContext.PRODUCT_CHANGED: THRESHOLD_PREAMBLE,
         }.get(context)
 
         policy_block = f"## Acceptable Use Policy\n\n{policy_content}"
@@ -786,12 +786,12 @@ class ReviewAnalyzer:
                     f"(overriding the catalog price): {products.adhoc_prices_count}"
                 )
 
-        # Setup & Integration Signals (only for threshold/manual/product-created reviews)
+        # Setup & Integration Signals (only for threshold/manual/product-changed reviews)
         setup = snapshot.setup
         if snapshot.context in (
             ReviewContext.THRESHOLD,
             ReviewContext.MANUAL,
-            ReviewContext.PRODUCT_CREATED,
+            ReviewContext.PRODUCT_CHANGED,
         ):
             parts.append("\n## Setup & Integration Signals")
 

--- a/server/polar/organization_review/eval/task.py
+++ b/server/polar/organization_review/eval/task.py
@@ -21,6 +21,7 @@ CONTEXT_MAP = {
     "setup_complete": ReviewContext.SETUP_COMPLETE,
     "threshold": ReviewContext.THRESHOLD,
     "manual": ReviewContext.MANUAL,
+    "product_created": ReviewContext.PRODUCT_CREATED,
     "unknown": ReviewContext.THRESHOLD,
 }
 

--- a/server/polar/organization_review/eval/task.py
+++ b/server/polar/organization_review/eval/task.py
@@ -21,7 +21,7 @@ CONTEXT_MAP = {
     "setup_complete": ReviewContext.SETUP_COMPLETE,
     "threshold": ReviewContext.THRESHOLD,
     "manual": ReviewContext.MANUAL,
-    "product_created": ReviewContext.PRODUCT_CREATED,
+    "product_changed": ReviewContext.PRODUCT_CHANGED,
     "unknown": ReviewContext.THRESHOLD,
 }
 

--- a/server/polar/organization_review/schemas.py
+++ b/server/polar/organization_review/schemas.py
@@ -33,7 +33,9 @@ class ReviewContext(StrEnum):
     THRESHOLD = "threshold"  # Following reviews when payment threshold hit
     MANUAL = "manual"  # Full manual review triggered from backoffice
     APPEAL = "appeal"  # Appeal of a previous denial
-    PRODUCT_CREATED = "product_created"  # Review when an active org creates a product
+    PRODUCT_CHANGED = (
+        "product_changed"  # Review when an active org creates/updates a product
+    )
 
 
 # --- Shared utility schemas ---

--- a/server/polar/organization_review/schemas.py
+++ b/server/polar/organization_review/schemas.py
@@ -33,6 +33,7 @@ class ReviewContext(StrEnum):
     THRESHOLD = "threshold"  # Following reviews when payment threshold hit
     MANUAL = "manual"  # Full manual review triggered from backoffice
     APPEAL = "appeal"  # Appeal of a previous denial
+    PRODUCT_CREATED = "product_created"  # Review when an active org creates a product
 
 
 # --- Shared utility schemas ---

--- a/server/polar/organization_review/tasks.py
+++ b/server/polar/organization_review/tasks.py
@@ -55,16 +55,18 @@ def _run_agent_debounce_key(
     auto_approve_eligible: bool = False,
     plain_thread_id: str | None = None,
 ) -> str | None:
-    """Debounce only PRODUCT_CREATED reviews, per organization.
+    """Debounce only PRODUCT_CHANGED reviews, per organization.
 
-    A merchant may create many products in quick succession (or in bulk via
-    the API); without debouncing each one would spawn a full agent review.
-    Other contexts (submission, threshold, manual, appeal) must never be
-    collapsed, so the factory returns ``None`` for them — which disables
-    debouncing for that message.
+    A merchant may create or edit many products in quick succession (or in
+    bulk via the API); without debouncing each change would spawn a full
+    agent review. A single per-organization key also collapses a create
+    immediately followed by edits into one review. Other contexts
+    (submission, threshold, manual, appeal) must never be collapsed, so the
+    factory returns ``None`` for them — which disables debouncing for that
+    message.
     """
-    if context == ReviewContext.PRODUCT_CREATED:
-        return f"organization_review.product_created:{organization_id}"
+    if context == ReviewContext.PRODUCT_CHANGED:
+        return f"organization_review.product_changed:{organization_id}"
     return None
 
 
@@ -127,7 +129,7 @@ async def run_review_agent(
 
     For SUBMISSION context: creates an OrganizationReview record and auto-denies on DENY.
     For THRESHOLD context: log-only, persists to OrganizationAgentReview table.
-    For PRODUCT_CREATED context: pulls an active org back into REVIEW on a bad verdict.
+    For PRODUCT_CHANGED context: pulls an active org back into REVIEW on a bad verdict.
     """
     if settings.ENV == Environment.sandbox:
         return
@@ -140,16 +142,16 @@ async def run_review_agent(
         if organization is None:
             raise OrganizationDoesNotExist(organization_id)
 
-        # A product-created review only makes sense for active orgs: it exists
+        # A product-change review only makes sense for active orgs: it exists
         # to pull them back into review. Status may have changed between enqueue
         # and execution (debounce delay), so re-check here before spending an
         # agent run.
         if (
-            review_context == ReviewContext.PRODUCT_CREATED
+            review_context == ReviewContext.PRODUCT_CHANGED
             and organization.status != OrganizationStatus.ACTIVE
         ):
             log.info(
-                "organization_review.product_created.skip_non_active",
+                "organization_review.product_changed.skip_non_active",
                 organization_id=str(organization_id),
                 slug=organization.slug,
                 status=organization.status,
@@ -269,10 +271,10 @@ async def run_review_agent(
             elif report.verdict == ReviewVerdict.APPROVE:
                 await organization_service.maybe_activate(session, organization)
 
-        # For PRODUCT_CREATED context: a bad verdict pulls the active org back
+        # For PRODUCT_CHANGED context: a bad verdict pulls the active org back
         # into REVIEW for a human to look at. A clean APPROVE is a no-op — the
         # org keeps operating. We never auto-deny here, only escalate.
-        if review_context == ReviewContext.PRODUCT_CREATED:
+        if review_context == ReviewContext.PRODUCT_CHANGED:
             if report.verdict != ReviewVerdict.APPROVE:
                 organization.set_status(OrganizationStatus.REVIEW)
                 session.add(organization)
@@ -281,13 +283,13 @@ async def run_review_agent(
                     organization_id=organization_id,
                     agent_review_id=agent_review_id,
                     decision=DecisionType.ESCALATE,
-                    review_context=ReviewContext.PRODUCT_CREATED,
+                    review_context=ReviewContext.PRODUCT_CHANGED,
                     verdict=report.verdict,
                     risk_score=report.overall_risk_score,
                 )
 
                 log.info(
-                    "organization_review.product_created.escalated_to_review",
+                    "organization_review.product_changed.escalated_to_review",
                     organization_id=str(organization_id),
                     slug=organization.slug,
                     verdict=report.verdict.value,

--- a/server/polar/organization_review/tasks.py
+++ b/server/polar/organization_review/tasks.py
@@ -49,6 +49,25 @@ _VERDICT_MAP: dict[ReviewVerdict, OrganizationReview.Verdict] = {
 }
 
 
+def _run_agent_debounce_key(
+    organization_id: uuid.UUID,
+    context: str = ReviewContext.THRESHOLD,
+    auto_approve_eligible: bool = False,
+    plain_thread_id: str | None = None,
+) -> str | None:
+    """Debounce only PRODUCT_CREATED reviews, per organization.
+
+    A merchant may create many products in quick succession (or in bulk via
+    the API); without debouncing each one would spawn a full agent review.
+    Other contexts (submission, threshold, manual, appeal) must never be
+    collapsed, so the factory returns ``None`` for them — which disables
+    debouncing for that message.
+    """
+    if context == ReviewContext.PRODUCT_CREATED:
+        return f"organization_review.product_created:{organization_id}"
+    return None
+
+
 async def _persist_agent_result(
     session: AsyncSession,
     organization: Organization,
@@ -96,6 +115,7 @@ async def _persist_agent_result(
     time_limit=180_000,  # 3 min timeout
     max_retries=4,
     min_backoff=30_000,
+    debounce_key=_run_agent_debounce_key,
 )
 async def run_review_agent(
     organization_id: uuid.UUID,
@@ -107,6 +127,7 @@ async def run_review_agent(
 
     For SUBMISSION context: creates an OrganizationReview record and auto-denies on DENY.
     For THRESHOLD context: log-only, persists to OrganizationAgentReview table.
+    For PRODUCT_CREATED context: pulls an active org back into REVIEW on a bad verdict.
     """
     if settings.ENV == Environment.sandbox:
         return
@@ -118,6 +139,22 @@ async def run_review_agent(
         organization = await repository.get_by_id(organization_id, include_blocked=True)
         if organization is None:
             raise OrganizationDoesNotExist(organization_id)
+
+        # A product-created review only makes sense for active orgs: it exists
+        # to pull them back into review. Status may have changed between enqueue
+        # and execution (debounce delay), so re-check here before spending an
+        # agent run.
+        if (
+            review_context == ReviewContext.PRODUCT_CREATED
+            and organization.status != OrganizationStatus.ACTIVE
+        ):
+            log.info(
+                "organization_review.product_created.skip_non_active",
+                organization_id=str(organization_id),
+                slug=organization.slug,
+                status=organization.status,
+            )
+            return
 
         result = await run_organization_review(
             session, organization, context=review_context
@@ -231,6 +268,30 @@ async def run_review_agent(
                 )
             elif report.verdict == ReviewVerdict.APPROVE:
                 await organization_service.maybe_activate(session, organization)
+
+        # For PRODUCT_CREATED context: a bad verdict pulls the active org back
+        # into REVIEW for a human to look at. A clean APPROVE is a no-op — the
+        # org keeps operating. We never auto-deny here, only escalate.
+        if review_context == ReviewContext.PRODUCT_CREATED:
+            if report.verdict != ReviewVerdict.APPROVE:
+                organization.set_status(OrganizationStatus.REVIEW)
+                session.add(organization)
+
+                await review_repository.record_agent_decision(
+                    organization_id=organization_id,
+                    agent_review_id=agent_review_id,
+                    decision=DecisionType.ESCALATE,
+                    review_context=ReviewContext.PRODUCT_CREATED,
+                    verdict=report.verdict,
+                    risk_score=report.overall_risk_score,
+                )
+
+                log.info(
+                    "organization_review.product_created.escalated_to_review",
+                    organization_id=str(organization_id),
+                    slug=organization.slug,
+                    verdict=report.verdict.value,
+                )
 
 
 @actor(

--- a/server/polar/organization_review/tasks.py
+++ b/server/polar/organization_review/tasks.py
@@ -118,6 +118,7 @@ async def _persist_agent_result(
     max_retries=4,
     min_backoff=30_000,
     debounce_key=_run_agent_debounce_key,
+    debounce_min_threshold=300,
 )
 async def run_review_agent(
     organization_id: uuid.UUID,

--- a/server/polar/product/service.py
+++ b/server/polar/product/service.py
@@ -38,11 +38,13 @@ from polar.models import (
     ProductVisibility,
     User,
 )
+from polar.models.organization import OrganizationStatus
 from polar.models.product_custom_field import ProductCustomField
 from polar.models.product_price import ProductPriceSource
 from polar.models.webhook_endpoint import WebhookEventType
 from polar.organization.repository import OrganizationRepository
 from polar.organization.resolver import get_payload_organization
+from polar.organization_review.schemas import ReviewContext
 from polar.product.guard import (
     is_custom_price,
     is_fixed_price,
@@ -773,6 +775,18 @@ class ProductService:
         product: Product,
     ) -> None:
         await self._send_webhook(session, product, WebhookEventType.product_created)
+
+        # Re-review active organizations when they add a product: a new product
+        # can change the merchant's risk profile. The review is debounced
+        # per-organization and only pulls the org back into review on a bad
+        # verdict (see organization_review.tasks). Non-active orgs (e.g. still
+        # onboarding) are skipped — there is nothing to pull back into review.
+        if product.organization.status == OrganizationStatus.ACTIVE:
+            enqueue_job(
+                "organization_review.run_agent",
+                organization_id=product.organization_id,
+                context=ReviewContext.PRODUCT_CREATED,
+            )
 
     async def _after_product_updated(
         self, session: AsyncSession, product: Product

--- a/server/polar/product/service.py
+++ b/server/polar/product/service.py
@@ -438,6 +438,7 @@ class ProductService:
         await session.refresh(product, {"prices", "all_prices"})
 
         await self._after_product_updated(session, product)
+        self._enqueue_organization_review(product)
 
         return product
 
@@ -529,6 +530,9 @@ class ProductService:
             )
             enqueue_job("order.update_product_benefits_grants", product.id)
             enqueue_job("customer_seat.update_product_benefits_grants", product.id)
+            # A pure reorder (no added/deleted benefits) does not change the
+            # risk profile, so it does not warrant a review.
+            self._enqueue_organization_review(product)
 
         await self._after_product_updated(session, product)
 
@@ -775,23 +779,28 @@ class ProductService:
         product: Product,
     ) -> None:
         await self._send_webhook(session, product, WebhookEventType.product_created)
-
-        # Re-review active organizations when they add a product: a new product
-        # can change the merchant's risk profile. The review is debounced
-        # per-organization and only pulls the org back into review on a bad
-        # verdict (see organization_review.tasks). Non-active orgs (e.g. still
-        # onboarding) are skipped — there is nothing to pull back into review.
-        if product.organization.status == OrganizationStatus.ACTIVE:
-            enqueue_job(
-                "organization_review.run_agent",
-                organization_id=product.organization_id,
-                context=ReviewContext.PRODUCT_CREATED,
-            )
+        self._enqueue_organization_review(product)
 
     async def _after_product_updated(
         self, session: AsyncSession, product: Product
     ) -> None:
         await self._send_webhook(session, product, WebhookEventType.product_updated)
+
+    def _enqueue_organization_review(self, product: Product) -> None:
+        """Re-review an active organization when one of its products changes.
+
+        Creating or meaningfully editing a product can change the merchant's
+        risk profile, so we re-run the review agent. It is debounced
+        per-organization and only pulls the org back into review on a bad
+        verdict (see organization_review.tasks). Non-active orgs (e.g. still
+        onboarding) are skipped — there is nothing to pull back into review.
+        """
+        if product.organization.status == OrganizationStatus.ACTIVE:
+            enqueue_job(
+                "organization_review.run_agent",
+                organization_id=product.organization_id,
+                context=ReviewContext.PRODUCT_CHANGED,
+            )
 
     async def _send_webhook(
         self,

--- a/server/tests/organization_review/test_tasks.py
+++ b/server/tests/organization_review/test_tasks.py
@@ -1,6 +1,8 @@
-"""Tests for organization_review.tasks – SUBMISSION re-run + appeal review paths."""
+"""Tests for organization_review.tasks – SUBMISSION re-run, PRODUCT_CREATED
+escalation, and appeal review paths."""
 
 import contextlib
+import uuid
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
@@ -12,9 +14,14 @@ from polar.models.organization_review import OrganizationReview
 from polar.organization.repository import (
     OrganizationReviewRepository as OrgReviewRepository,
 )
+from polar.organization_review.repository import (
+    OrganizationReviewRepository as AgentReviewRepository,
+)
 from polar.organization_review.schemas import (
+    ActorType,
     AgentReviewResult,
     DataSnapshot,
+    DecisionType,
     DimensionAssessment,
     HistoryData,
     IdentityData,
@@ -29,7 +36,11 @@ from polar.organization_review.schemas import (
     RiskLevel,
     UsageInfo,
 )
-from polar.organization_review.tasks import review_appeal, run_review_agent
+from polar.organization_review.tasks import (
+    _run_agent_debounce_key,
+    review_appeal,
+    run_review_agent,
+)
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
 
@@ -573,3 +584,139 @@ class TestReviewAppeal:
             await _review_appeal(organization.id)
 
         run_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+class TestRunReviewAgentProductCreated:
+    """PRODUCT_CREATED re-reviews an active org when it adds a product. A bad
+    verdict pulls it back into REVIEW for a human; a clean APPROVE is a no-op.
+    It never auto-denies."""
+
+    async def test_deny_pulls_active_org_into_review(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        # The `organization` fixture is ACTIVE by default.
+        agent_result = _make_agent_result(
+            verdict=ReviewVerdict.DENY,
+            risk_level=RiskLevel.HIGH,
+            merchant_summary="New product looks prohibited",
+            violated_sections=["Prohibited Products"],
+        )
+
+        with (
+            patch(
+                "polar.organization_review.tasks.AsyncSessionMaker",
+                return_value=_mock_session_maker(session),
+            ),
+            patch(
+                "polar.organization_review.tasks.run_organization_review",
+                new_callable=AsyncMock,
+                return_value=agent_result,
+            ),
+        ):
+            await _run_review_agent(
+                organization.id,
+                context=ReviewContext.PRODUCT_CREATED,
+            )
+
+        await session.flush()
+        await session.refresh(organization)
+        assert organization.status == OrganizationStatus.REVIEW
+
+        agent_review_repo = AgentReviewRepository.from_session(session)
+        decision = await agent_review_repo.get_current_decision(organization.id)
+        assert decision is not None
+        assert decision.actor_type == ActorType.AGENT
+        assert decision.decision == DecisionType.ESCALATE
+        assert decision.review_context == ReviewContext.PRODUCT_CREATED
+
+    async def test_approve_keeps_org_active(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        assert organization.status == OrganizationStatus.ACTIVE
+
+        agent_result = _make_agent_result(verdict=ReviewVerdict.APPROVE)
+
+        with (
+            patch(
+                "polar.organization_review.tasks.AsyncSessionMaker",
+                return_value=_mock_session_maker(session),
+            ),
+            patch(
+                "polar.organization_review.tasks.run_organization_review",
+                new_callable=AsyncMock,
+                return_value=agent_result,
+            ),
+        ):
+            await _run_review_agent(
+                organization.id,
+                context=ReviewContext.PRODUCT_CREATED,
+            )
+
+        await session.flush()
+        await session.refresh(organization)
+        assert organization.status == OrganizationStatus.ACTIVE
+
+        agent_review_repo = AgentReviewRepository.from_session(session)
+        decision = await agent_review_repo.get_current_decision(organization.id)
+        assert decision is None
+
+    async def test_non_active_org_is_skipped(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        # The org was pulled into REVIEW (e.g. by the threshold flow) between
+        # the product-created enqueue and the debounced execution. There is
+        # nothing to escalate, so the agent must not even run.
+        organization.set_status(OrganizationStatus.REVIEW)
+        await save_fixture(organization)
+
+        run_review_mock = AsyncMock()
+        with (
+            patch(
+                "polar.organization_review.tasks.AsyncSessionMaker",
+                return_value=_mock_session_maker(session),
+            ),
+            patch(
+                "polar.organization_review.tasks.run_organization_review",
+                run_review_mock,
+            ),
+        ):
+            await _run_review_agent(
+                organization.id,
+                context=ReviewContext.PRODUCT_CREATED,
+            )
+
+        run_review_mock.assert_not_awaited()
+        await session.refresh(organization)
+        assert organization.status == OrganizationStatus.REVIEW
+
+
+class TestRunAgentDebounceKey:
+    """Only PRODUCT_CREATED reviews are debounced (per organization)."""
+
+    def test_product_created_returns_per_org_key(self) -> None:
+        organization_id = uuid.uuid4()
+        key = _run_agent_debounce_key(
+            organization_id, context=ReviewContext.PRODUCT_CREATED
+        )
+        assert key == f"organization_review.product_created:{organization_id}"
+
+    def test_other_contexts_are_not_debounced(self) -> None:
+        organization_id = uuid.uuid4()
+        assert (
+            _run_agent_debounce_key(organization_id, context=ReviewContext.THRESHOLD)
+            is None
+        )
+        assert (
+            _run_agent_debounce_key(organization_id, context=ReviewContext.SUBMISSION)
+            is None
+        )
+        # Default context is THRESHOLD — also not debounced.
+        assert _run_agent_debounce_key(organization_id) is None

--- a/server/tests/organization_review/test_tasks.py
+++ b/server/tests/organization_review/test_tasks.py
@@ -1,4 +1,4 @@
-"""Tests for organization_review.tasks – SUBMISSION re-run, PRODUCT_CREATED
+"""Tests for organization_review.tasks – SUBMISSION re-run, PRODUCT_CHANGED
 escalation, and appeal review paths."""
 
 import contextlib
@@ -587,10 +587,10 @@ class TestReviewAppeal:
 
 
 @pytest.mark.asyncio
-class TestRunReviewAgentProductCreated:
-    """PRODUCT_CREATED re-reviews an active org when it adds a product. A bad
-    verdict pulls it back into REVIEW for a human; a clean APPROVE is a no-op.
-    It never auto-denies."""
+class TestRunReviewAgentProductChanged:
+    """PRODUCT_CHANGED re-reviews an active org when it creates or edits a
+    product. A bad verdict pulls it back into REVIEW for a human; a clean
+    APPROVE is a no-op. It never auto-denies."""
 
     async def test_deny_pulls_active_org_into_review(
         self,
@@ -618,7 +618,7 @@ class TestRunReviewAgentProductCreated:
         ):
             await _run_review_agent(
                 organization.id,
-                context=ReviewContext.PRODUCT_CREATED,
+                context=ReviewContext.PRODUCT_CHANGED,
             )
 
         await session.flush()
@@ -630,7 +630,7 @@ class TestRunReviewAgentProductCreated:
         assert decision is not None
         assert decision.actor_type == ActorType.AGENT
         assert decision.decision == DecisionType.ESCALATE
-        assert decision.review_context == ReviewContext.PRODUCT_CREATED
+        assert decision.review_context == ReviewContext.PRODUCT_CHANGED
 
     async def test_approve_keeps_org_active(
         self,
@@ -654,7 +654,7 @@ class TestRunReviewAgentProductCreated:
         ):
             await _run_review_agent(
                 organization.id,
-                context=ReviewContext.PRODUCT_CREATED,
+                context=ReviewContext.PRODUCT_CHANGED,
             )
 
         await session.flush()
@@ -672,7 +672,7 @@ class TestRunReviewAgentProductCreated:
         organization: Organization,
     ) -> None:
         # The org was pulled into REVIEW (e.g. by the threshold flow) between
-        # the product-created enqueue and the debounced execution. There is
+        # the product-changed enqueue and the debounced execution. There is
         # nothing to escalate, so the agent must not even run.
         organization.set_status(OrganizationStatus.REVIEW)
         await save_fixture(organization)
@@ -690,7 +690,7 @@ class TestRunReviewAgentProductCreated:
         ):
             await _run_review_agent(
                 organization.id,
-                context=ReviewContext.PRODUCT_CREATED,
+                context=ReviewContext.PRODUCT_CHANGED,
             )
 
         run_review_mock.assert_not_awaited()
@@ -699,14 +699,14 @@ class TestRunReviewAgentProductCreated:
 
 
 class TestRunAgentDebounceKey:
-    """Only PRODUCT_CREATED reviews are debounced (per organization)."""
+    """Only PRODUCT_CHANGED reviews are debounced (per organization)."""
 
-    def test_product_created_returns_per_org_key(self) -> None:
+    def test_product_changed_returns_per_org_key(self) -> None:
         organization_id = uuid.uuid4()
         key = _run_agent_debounce_key(
-            organization_id, context=ReviewContext.PRODUCT_CREATED
+            organization_id, context=ReviewContext.PRODUCT_CHANGED
         )
-        assert key == f"organization_review.product_created:{organization_id}"
+        assert key == f"organization_review.product_changed:{organization_id}"
 
     def test_other_contexts_are_not_debounced(self) -> None:
         organization_id = uuid.uuid4()

--- a/server/tests/product/test_service.py
+++ b/server/tests/product/test_service.py
@@ -24,10 +24,12 @@ from polar.models import (
 )
 from polar.models.benefit import BenefitType
 from polar.models.file import FileServiceTypes, ProductMediaFile
+from polar.models.organization import OrganizationStatus
 from polar.models.product_price import (
     ProductPriceAmountType,
     ProductPriceFixed,
 )
+from polar.organization_review.schemas import ReviewContext
 from polar.postgres import AsyncSession
 from polar.product.guard import (
     is_fixed_price,
@@ -405,6 +407,73 @@ class TestCreate:
         assert len(product.prices) == 1
         price = product.prices[0]
         assert is_static_price(price)
+
+    @pytest.mark.auth
+    async def test_active_organization_enqueues_review(
+        self,
+        session: AsyncSession,
+        enqueue_job_mock: AsyncMock,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        assert organization.status == OrganizationStatus.ACTIVE
+
+        create_schema = ProductCreateRecurring(
+            name="Product",
+            organization_id=organization.id,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[
+                ProductPriceFixedCreate(
+                    amount_type=ProductPriceAmountType.fixed,
+                    price_amount=1000,
+                    price_currency=PresentmentCurrency.usd,
+                )
+            ],
+        )
+
+        await product_service.create(session, create_schema, auth_subject)
+
+        enqueue_job_mock.assert_any_call(
+            "organization_review.run_agent",
+            organization_id=organization.id,
+            context=ReviewContext.PRODUCT_CREATED,
+        )
+
+    @pytest.mark.auth
+    async def test_non_active_organization_does_not_enqueue_review(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        enqueue_job_mock: AsyncMock,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        organization.set_status(OrganizationStatus.REVIEW)
+        await save_fixture(organization)
+
+        create_schema = ProductCreateRecurring(
+            name="Product",
+            organization_id=organization.id,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[
+                ProductPriceFixedCreate(
+                    amount_type=ProductPriceAmountType.fixed,
+                    price_amount=1000,
+                    price_currency=PresentmentCurrency.usd,
+                )
+            ],
+        )
+
+        await product_service.create(session, create_schema, auth_subject)
+
+        review_calls = [
+            c
+            for c in enqueue_job_mock.call_args_list
+            if c.args and c.args[0] == "organization_review.run_agent"
+        ]
+        assert review_calls == []
 
     @pytest.mark.auth
     async def test_user_empty_description(

--- a/server/tests/product/test_service.py
+++ b/server/tests/product/test_service.py
@@ -437,7 +437,7 @@ class TestCreate:
         enqueue_job_mock.assert_any_call(
             "organization_review.run_agent",
             organization_id=organization.id,
-            context=ReviewContext.PRODUCT_CREATED,
+            context=ReviewContext.PRODUCT_CHANGED,
         )
 
     @pytest.mark.auth
@@ -1483,6 +1483,65 @@ class TestUpdate:
         AuthSubjectFixture(subject="user"),
         AuthSubjectFixture(subject="organization"),
     )
+    async def test_active_organization_enqueues_review(
+        self,
+        session: AsyncSession,
+        enqueue_job_mock: AsyncMock,
+        auth_subject: AuthSubject[User | Organization],
+        product: Product,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        assert organization.status == OrganizationStatus.ACTIVE
+
+        await product_service.update(
+            session,
+            product,
+            ProductUpdate(name="Product Update"),
+            auth_subject,
+        )
+
+        enqueue_job_mock.assert_any_call(
+            "organization_review.run_agent",
+            organization_id=product.organization_id,
+            context=ReviewContext.PRODUCT_CHANGED,
+        )
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="user"),
+        AuthSubjectFixture(subject="organization"),
+    )
+    async def test_non_active_organization_does_not_enqueue_review(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        enqueue_job_mock: AsyncMock,
+        auth_subject: AuthSubject[User | Organization],
+        product: Product,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        organization.set_status(OrganizationStatus.REVIEW)
+        await save_fixture(organization)
+
+        await product_service.update(
+            session,
+            product,
+            ProductUpdate(name="Product Update"),
+            auth_subject,
+        )
+
+        review_calls = [
+            c
+            for c in enqueue_job_mock.call_args_list
+            if c.args and c.args[0] == "organization_review.run_agent"
+        ]
+        assert review_calls == []
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="user"),
+        AuthSubjectFixture(subject="organization"),
+    )
     async def test_valid_description_change(
         self,
         session: AsyncSession,
@@ -2230,6 +2289,37 @@ class TestUpdateBenefits:
 
         # Reordering the same set of benefits should not trigger grants update
         enqueue_job_mock.assert_not_called()
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="user"),
+        AuthSubjectFixture(subject="organization"),
+    )
+    async def test_changed_benefits_enqueue_review(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        enqueue_job_mock: AsyncMock,
+        auth_subject: AuthSubject[User | Organization],
+        user_organization: UserOrganization,
+        product: Product,
+        organization: Organization,
+        benefits: list[Benefit],
+    ) -> None:
+        assert organization.status == OrganizationStatus.ACTIVE
+        await set_product_benefits(save_fixture, product=product, benefits=[])
+
+        await product_service.update_benefits(
+            session,
+            product,
+            [benefit.id for benefit in benefits],
+            auth_subject,
+        )
+
+        enqueue_job_mock.assert_any_call(
+            "organization_review.run_agent",
+            organization_id=product.organization_id,
+            context=ReviewContext.PRODUCT_CHANGED,
+        )
 
     @pytest.mark.auth(
         AuthSubjectFixture(subject="user"),


### PR DESCRIPTION
## Summary

**Related Issue**: <!-- issue number -->

Add automatic re-review of active organizations when their products are created or modified. This allows the review agent to detect risk profile changes from product additions/edits and escalate organizations back into review if needed.

## What

- Added `PRODUCT_CHANGED` review context to trigger organization re-reviews when products are created, updated, or have benefits modified
- Implemented debouncing for product-changed reviews (per-organization) to avoid spawning multiple agent runs for bulk product operations
- Product-changed reviews only affect active organizations; non-active orgs are skipped
- Bad verdicts escalate active orgs back into `REVIEW` status; clean approvals are no-ops
- Updated review agent to include product-changed context in setup/metrics collection and prompt generation
- Added comprehensive test coverage for both product service and organization review task flows

## Why

Creating or editing products can materially change a merchant's risk profile (e.g., adding prohibited items, changing pricing structure). The review system should continuously monitor for these changes in active organizations rather than only reviewing at submission or when thresholds are hit. This provides better fraud/compliance detection without blocking merchant operations.

## How

1. **Product Service**: When a product is created, updated, or has benefits changed, `_enqueue_organization_review()` checks if the organization is active and enqueues a `organization_review.run_agent` job with `PRODUCT_CHANGED` context
2. **Review Tasks**: Added `_run_agent_debounce_key()` to debounce product-changed reviews per organization (collapses rapid creates/edits into one review). The task skips non-active orgs and escalates active ones on bad verdicts
3. **Review Agent**: Extended setup/metrics collection and prompt generation to handle `PRODUCT_CHANGED` context (treated like threshold reviews for data gathering)
4. **Tests**: Added test cases covering:
   - Active org enqueues review on product create/update/benefits change
   - Non-active org skips review enqueue
   - Bad verdict pulls active org into review
   - Clean approval keeps org active
   - Non-active org is skipped during execution

## Checklist

- [x] This PR addresses a single concern (product-triggered org re-review)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests (8 new test cases added)
- [x] Linting and type checking pass
- [x] No unrelated changes included

https://claude.ai/code/session_016TXKq2gBx3fJpF454kf9t5

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

