### PR TITLE
feat: add offboarded merchant status

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OffboardedBanner.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OffboardedBanner.tsx
@@ -1,0 +1,38 @@
+import { schemas } from '@polar-sh/client'
+import { Button, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { AlertTriangleIcon } from 'lucide-react'
+import Link from 'next/link'
+
+interface OffboardedBannerProps {
+  organization: schemas['Organization']
+}
+
+export const OffboardedBanner = ({ organization }: OffboardedBannerProps) => {
+  return (
+    <Box
+      flexDirection={{ base: 'column', md: 'row' }}
+      justifyContent="between"
+      gap="l"
+      borderRadius="l"
+      backgroundColor="background-card"
+      padding={{ base: 'l', md: 'xl' }}
+    >
+      <Box flexDirection="column" rowGap="s">
+        <Box alignItems="center" columnGap="s">
+          <AlertTriangleIcon className="h-4 w-4 shrink-0" />
+          <Text as="strong">Your organization has been offboarded</Text>
+        </Box>
+        <Box maxWidth="45rem">
+          <Text color="muted">
+            New payments are disabled. Your remaining balance is available to
+            withdraw from your account page.
+          </Text>
+        </Box>
+      </Box>
+      <Link href={`/dashboard/${organization.slug}/finance/account`}>
+        <Button variant="secondary">Withdraw balance</Button>
+      </Link>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OrganizationStatusBanner.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OrganizationStatusBanner.tsx
@@ -2,6 +2,7 @@ import { useOrganizationPaymentStatus } from '@/hooks/queries'
 import { CONFIG } from '@/utils/config'
 import { schemas } from '@polar-sh/client'
 import { DeniedBanner } from './DeniedBanner'
+import { OffboardedBanner } from './OffboardedBanner'
 import { OffboardingBanner } from './OffboardingBanner'
 import { OnboardingChecklistCard } from './OnboardingChecklistCard'
 
@@ -26,6 +27,10 @@ export const OrganizationStatusBanner = ({
 
   if (paymentStatus?.organization_status === 'offboarding') {
     return <OffboardingBanner organization={organization} />
+  }
+
+  if (paymentStatus?.organization_status === 'offboarded') {
+    return <OffboardedBanner organization={organization} />
   }
 
   if (paymentStatus?.organization_status === 'created') {

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPageRouter.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPageRouter.tsx
@@ -42,22 +42,25 @@ export const AccountPageRouter = ({
     reviewStatus?.verdict === 'PASS' &&
     reviewStatus?.reason === 'Grandfathered organization'
   const isDenied = organization.status === 'denied'
-  // `offboarded` is terminal but must keep payout access so the merchant can
-  // withdraw their remaining balance.
-  const isActive = ['active', 'review', 'snoozed', 'offboarded'].includes(
-    organization.status,
-  )
+  // Statuses that retain payout/account access. Includes the terminal
+  // `offboarded` state, where the merchant withdraws their remaining balance.
+  const hasAccountAccess = [
+    'active',
+    'review',
+    'snoozed',
+    'offboarded',
+  ].includes(organization.status)
   const hasSubmittedDetails = !!organization.details_submitted_at
 
   const requireDetails =
     !hasSubmittedDetails &&
-    (!isGrandfathered || (isGrandfathered && !isActive && !isDenied))
+    (!isGrandfathered || (isGrandfathered && !hasAccountAccess && !isDenied))
 
   const isApproved = isDenied
     ? false
     : reviewStatus?.verdict === 'PASS' ||
       reviewStatus?.appeal_decision === 'approved' ||
-      isActive
+      hasAccountAccess
 
   if (requireDetails) {
     return <AccountPageDetailsRequired organization={organization} />

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPageRouter.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPageRouter.tsx
@@ -42,7 +42,11 @@ export const AccountPageRouter = ({
     reviewStatus?.verdict === 'PASS' &&
     reviewStatus?.reason === 'Grandfathered organization'
   const isDenied = organization.status === 'denied'
-  const isActive = ['active', 'review', 'snoozed'].includes(organization.status)
+  // `offboarded` is terminal but must keep payout access so the merchant can
+  // withdraw their remaining balance.
+  const isActive = ['active', 'review', 'snoozed', 'offboarded'].includes(
+    organization.status,
+  )
   const hasSubmittedDetails = !!organization.details_submitted_at
 
   const requireDetails =

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -25807,6 +25807,7 @@ export interface components {
       | 'active'
       | 'blocked'
       | 'offboarding'
+      | 'offboarded'
     /** OrganizationSubscription */
     OrganizationSubscription: {
       /**
@@ -58771,6 +58772,7 @@ export const organizationStatusValues: ReadonlyArray<
   'active',
   'blocked',
   'offboarding',
+  'offboarded',
 ]
 export const organizationSubscriptionSettingsProration_behaviorValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['OrganizationSubscriptionSettings']['proration_behavior']

--- a/server/emails/src/emails/index.ts
+++ b/server/emails/src/emails/index.ts
@@ -13,6 +13,7 @@ import { OrderConfirmation } from './order_confirmation'
 import { OrganizationAccessTokenLeaked } from './organization_access_token_leaked'
 import { OrganizationAccountUnlink } from './organization_account_unlink'
 import { OrganizationInvite } from './organization_invite'
+import { OrganizationOffboarded } from './organization_offboarded'
 import { PersonalAccessTokenLeaked } from './personal_access_token_leaked'
 import { PolarSelfStartupProgramWelcome } from './polar_self_startup_program_welcome'
 import { PolarSelfSubscriptionConfirmation } from './polar_self_subscription_confirmation'
@@ -44,6 +45,7 @@ const TEMPLATES: Record<string, React.FC<never>> = {
   organization_access_token_leaked: OrganizationAccessTokenLeaked,
   organization_account_unlink: OrganizationAccountUnlink,
   organization_invite: OrganizationInvite,
+  organization_offboarded: OrganizationOffboarded,
   personal_access_token_leaked: PersonalAccessTokenLeaked,
   seat_invitation: SeatInvitation,
   subscription_cancellation: SubscriptionCancellation,

--- a/server/emails/src/emails/organization_offboarded.tsx
+++ b/server/emails/src/emails/organization_offboarded.tsx
@@ -1,0 +1,47 @@
+import {
+  Button,
+  Footer,
+  Intro,
+  Text,
+  WrapperPolar,
+} from '../components/foundation'
+import type { schemas } from '../types'
+
+export function OrganizationOffboarded({
+  email,
+  organization_name,
+  account_url,
+}: schemas['OrganizationOffboardedProps']) {
+  return (
+    <WrapperPolar
+      preview={`${organization_name} has been offboarded from Polar`}
+    >
+      <Intro headline={`${organization_name} has been offboarded`}>
+        Your organization{' '}
+        <Text as="span" weight="bold">
+          {organization_name}
+        </Text>{' '}
+        has been offboarded from Polar. New payments, including checkouts and
+        subscription renewals, are now disabled.
+      </Intro>
+      <Text>
+        Your remaining balance is available to withdraw. You can request a
+        payout from your dashboard at any time.
+      </Text>
+      <Button href={account_url}>Withdraw your balance</Button>
+      <Text>
+        If you have any questions, just reply to this email and our team will
+        help.
+      </Text>
+      <Footer email={email} />
+    </WrapperPolar>
+  )
+}
+
+OrganizationOffboarded.PreviewProps = {
+  email: 'admin@example.com',
+  organization_name: 'Acme Inc.',
+  account_url: 'https://polar.sh/dashboard/acme-inc/finance/account',
+}
+
+export default OrganizationOffboarded

--- a/server/emails/src/types/openapi.ts
+++ b/server/emails/src/types/openapi.ts
@@ -2094,6 +2094,25 @@ export interface components {
       /** Invite Url */
       invite_url: string
     }
+    /** OrganizationOffboardedEmail */
+    OrganizationOffboardedEmail: {
+      /**
+       * Template
+       * @default organization_offboarded
+       * @constant
+       */
+      template: 'organization_offboarded'
+      props: components['schemas']['OrganizationOffboardedProps']
+    }
+    /** OrganizationOffboardedProps */
+    OrganizationOffboardedProps: {
+      /** Email */
+      email: string
+      /** Organization Name */
+      organization_name: string
+      /** Account Url */
+      account_url: string
+    }
     /** OrganizationSocialLink */
     OrganizationSocialLink: {
       /** @description The social platform of the URL */
@@ -2132,6 +2151,7 @@ export interface components {
       | 'active'
       | 'blocked'
       | 'offboarding'
+      | 'offboarded'
     /** OrganizationSubscriptionSettings */
     OrganizationSubscriptionSettings: {
       /** Allow Multiple Subscriptions */

--- a/server/polar/backoffice/components/_status_badge.py
+++ b/server/polar/backoffice/components/_status_badge.py
@@ -19,7 +19,7 @@ def status_badge(
     Generates a badge element with appropriate styling based on organization status.
     Uses DaisyUI badge classes with semantic color mapping:
     - REVIEW, OFFBOARDING: warning (yellow)
-    - ACTIVE, SNOOZED, DENIED, CREATED: ghost (gray)
+    - ACTIVE, SNOOZED, DENIED, CREATED, OFFBOARDED: ghost (gray)
 
     Args:
         status: The organization status to display.
@@ -62,6 +62,10 @@ def status_badge(
         OrganizationStatus.OFFBOARDING: {
             "class": "badge-warning",
             "aria": "offboarding status",
+        },
+        OrganizationStatus.OFFBOARDED: {
+            "class": "badge-ghost border border-base-300",
+            "aria": "offboarded status",
         },
     }
 

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -438,6 +438,8 @@ async def list_organizations(
         status_filter = OrganizationStatus.CREATED
     elif status == "offboarding":
         status_filter = OrganizationStatus.OFFBOARDING
+    elif status == "offboarded":
+        status_filter = OrganizationStatus.OFFBOARDED
     elif status == "review":
         status_filter = OrganizationStatus.REVIEW
     elif status == "snoozed":
@@ -467,12 +469,14 @@ async def list_organizations(
         # typically live on denied organizations.
         stmt = stmt.where(Organization.id.in_(open_case_organization_ids()))
     elif not q:
-        # By default, exclude denied and blocked organizations (but not when searching)
+        # By default, exclude denied, blocked, and offboarded organizations
+        # (terminal states with their own tabs) — but not when searching.
         stmt = stmt.where(
             Organization.status.notin_(
                 [
                     OrganizationStatus.DENIED,
                     OrganizationStatus.BLOCKED,
+                    OrganizationStatus.OFFBOARDED,
                 ]
             )
         )

--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -717,6 +717,17 @@ class OrganizationDetailView:
                             ):
                                 text("Deny")
 
+                    elif self.org.status == OrganizationStatus.OFFBOARDED:
+                        with tag.div(
+                            classes="bg-base-200 border border-base-300 p-3 rounded-lg text-xs"
+                        ):
+                            with tag.p(classes="text-base-content/70"):
+                                text(
+                                    "Terminal state. New payments are blocked and "
+                                    "payouts are released so the merchant can "
+                                    "withdraw their remaining balance."
+                                )
+
                     # Always available actions
                     with tag.div(classes="divider my-2"):
                         pass

--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -375,13 +375,18 @@ class OrganizationListView:
                 label="All",
                 url=str(request.url_for("organizations:list")),
                 active=status_filter is None and not selected_open_cases,
-                # Mirror the default list, which hides denied/blocked orgs (they
-                # have their own tabs) — otherwise the count overstates the rows.
+                # Mirror the default list, which hides denied/blocked/offboarded
+                # orgs (they have their own tabs) — otherwise the count overstates
+                # the rows.
                 count=sum(
                     count
                     for status, count in status_counts.items()
                     if status
-                    not in (OrganizationStatus.DENIED, OrganizationStatus.BLOCKED)
+                    not in (
+                        OrganizationStatus.DENIED,
+                        OrganizationStatus.BLOCKED,
+                        OrganizationStatus.OFFBOARDED,
+                    )
                 ),
             ),
             Tab(
@@ -425,6 +430,12 @@ class OrganizationListView:
                 active=status_filter == OrganizationStatus.OFFBOARDING,
                 count=status_counts.get(OrganizationStatus.OFFBOARDING, 0),
                 badge_variant="warning",
+            ),
+            Tab(
+                label="Offboarded",
+                url=str(request.url_for("organizations:list")) + "?status=offboarded",
+                active=status_filter == OrganizationStatus.OFFBOARDED,
+                count=status_counts.get(OrganizationStatus.OFFBOARDED, 0),
             ),
             # Pushed to the right — a separate dimension from the status tabs.
             Tab(

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -247,6 +247,11 @@ class Settings(BaseSettings):
         "playwright"
     )
 
+    # How long an organization stays in `offboarding` before it automatically
+    # transitions to the terminal `offboarded` state. Measured from the last paid
+    # (not fully refunded) order, i.e. the post-chargeback-risk wind-down window.
+    ORGANIZATION_OFFBOARDING_PERIOD: timedelta = timedelta(days=120)
+
     # Stripe
     STRIPE_SECRET_KEY: str = ""
     STRIPE_PUBLISHABLE_KEY: str = ""

--- a/server/polar/email/schemas.py
+++ b/server/polar/email/schemas.py
@@ -37,6 +37,7 @@ class EmailTemplate(StrEnum):
     organization_access_token_leaked = "organization_access_token_leaked"
     organization_invite = "organization_invite"
     organization_account_unlink = "organization_account_unlink"
+    organization_offboarded = "organization_offboarded"
     support_case_organization_new_message = "support_case_organization_new_message"
     personal_access_token_leaked = "personal_access_token_leaked"
     seat_invitation = "seat_invitation"
@@ -480,6 +481,18 @@ class OrganizationAccountUnlinkEmail(BaseModel):
     props: OrganizationAccountUnlinkProps
 
 
+class OrganizationOffboardedProps(EmailProps):
+    organization_name: str
+    account_url: str
+
+
+class OrganizationOffboardedEmail(BaseModel):
+    template: Literal[EmailTemplate.organization_offboarded] = (
+        EmailTemplate.organization_offboarded
+    )
+    props: OrganizationOffboardedProps
+
+
 Email = Annotated[
     LoginCodeEmail
     | CustomerEmailChangedNotificationEmail
@@ -492,6 +505,7 @@ Email = Annotated[
     | OrganizationAccessTokenLeakedEmail
     | OrganizationInviteEmail
     | OrganizationAccountUnlinkEmail
+    | OrganizationOffboardedEmail
     | SupportCaseOrganizationNewMessageEmail
     | PersonalAccessTokenLeakedEmail
     | SeatInvitationEmail

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -198,6 +198,7 @@ class OrganizationStatus(StrEnum):
     ACTIVE = "active"
     BLOCKED = "blocked"
     OFFBOARDING = "offboarding"
+    OFFBOARDED = "offboarded"
 
     def get_display_name(self) -> str:
         return {
@@ -208,6 +209,7 @@ class OrganizationStatus(StrEnum):
             OrganizationStatus.ACTIVE: "Active",
             OrganizationStatus.BLOCKED: "Blocked",
             OrganizationStatus.OFFBOARDING: "Offboarding",
+            OrganizationStatus.OFFBOARDED: "Offboarded",
         }[self]
 
     @classmethod
@@ -333,6 +335,16 @@ STATUS_CAPABILITIES: dict[OrganizationStatus, OrganizationCapabilities] = {
         "api_access": True,
         "dashboard_access": True,
     },
+    # Terminal wind-down: new payments are blocked, but payouts are released so
+    # the merchant can withdraw their remaining balance (auto-processed, not held).
+    OrganizationStatus.OFFBOARDED: {
+        "checkout_payments": False,
+        "subscription_renewals": False,
+        "payouts": True,
+        "refunds": False,
+        "api_access": True,
+        "dashboard_access": True,
+    },
     OrganizationStatus.BLOCKED: {
         "checkout_payments": False,
         "subscription_renewals": False,
@@ -420,6 +432,13 @@ ALLOWED_STATUS_TRANSITIONS: dict[OrganizationStatus, frozenset[OrganizationStatu
         {
             OrganizationStatus.REVIEW,
             OrganizationStatus.DENIED,
+            OrganizationStatus.BLOCKED,
+            OrganizationStatus.OFFBOARDED,
+        }
+    ),
+    # Terminal state: only a block escape hatch remains.
+    OrganizationStatus.OFFBOARDED: frozenset(
+        {
             OrganizationStatus.BLOCKED,
         }
     ),

--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -191,13 +191,18 @@ class OrganizationRepository(
     ) -> Sequence[Organization]:
         """Offboarding orgs whose offboarding period has elapsed.
 
-        The period is measured from the most recent paid order that hasn't been
-        fully refunded (the post-chargeback-risk window). Orgs without such an
-        order fall back to when they entered offboarding (``status_updated_at``).
+        Anchor = the later of (a) the most recent paid order that hasn't been
+        fully refunded — the post-chargeback-risk window, and (b) when the org
+        entered offboarding (``status_updated_at``) — the merchant wind-down
+        floor. Both gates must clear, so a merchant freshly put into
+        offboarding always gets the full wind-down period even if their last
+        payment is already past the chargeback window. Orgs with no paid
+        orders use ``status_updated_at`` alone (PostgreSQL ``GREATEST`` skips
+        NULLs).
 
         ``FOR UPDATE`` on the org row: a concurrent admin status change either
-        commits before our SELECT (and the row falls out of the WHERE clause) or
-        waits behind our lock — eliminating the read/transition race.
+        commits before our SELECT (and the row falls out of the WHERE clause)
+        or waits behind our lock — eliminating the read/transition race.
         """
         last_paid_order_at = (
             select(func.max(Order.created_at))
@@ -209,7 +214,7 @@ class OrganizationRepository(
             .correlate(Organization)
             .scalar_subquery()
         )
-        anchor = func.coalesce(last_paid_order_at, Organization.status_updated_at)
+        anchor = func.greatest(last_paid_order_at, Organization.status_updated_at)
         statement = (
             self.get_base_statement()
             .where(

--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -29,6 +29,7 @@ from polar.models.discount import (
     DiscountPercentage,
     DiscountType,
 )
+from polar.models.order import OrderStatus
 from polar.models.organization import (
     OrganizationCapabilities,
     OrganizationStatus,
@@ -43,6 +44,9 @@ from .sorting import OrganizationSortProperty
 # Maximum orgs the unsnooze cron processes per run. Bounds worst-case
 # transaction size when many time-based snoozes expire in the same window.
 UNSNOOZE_EXPIRED_BATCH_SIZE = 500
+
+# Maximum orgs the auto-offboard cron processes per run.
+OFFBOARD_EXPIRED_BATCH_SIZE = 500
 
 
 class OrganizationRepository(
@@ -178,6 +182,37 @@ class OrganizationRepository(
                 Organization.snoozed_until <= now,
             )
             .order_by(Organization.snoozed_until.asc())
+            .limit(limit)
+        )
+        return await self.get_all(statement)
+
+    async def get_offboarding_past_period(
+        self, cutoff: datetime, *, limit: int = OFFBOARD_EXPIRED_BATCH_SIZE
+    ) -> Sequence[Organization]:
+        """Offboarding orgs whose offboarding period has elapsed.
+
+        The period is measured from the most recent paid order that hasn't been
+        fully refunded (the post-chargeback-risk window). Orgs without such an
+        order fall back to when they entered offboarding (``status_updated_at``).
+        """
+        last_paid_order_at = (
+            select(func.max(Order.created_at))
+            .where(
+                Order.organization_id == Organization.id,
+                Order.status.in_((OrderStatus.paid, OrderStatus.partially_refunded)),
+                Order.deleted_at.is_(None),
+            )
+            .correlate(Organization)
+            .scalar_subquery()
+        )
+        anchor = func.coalesce(last_paid_order_at, Organization.status_updated_at)
+        statement = (
+            self.get_base_statement()
+            .where(
+                Organization.status == OrganizationStatus.OFFBOARDING,
+                anchor <= cutoff,
+            )
+            .order_by(anchor.asc())
             .limit(limit)
         )
         return await self.get_all(statement)

--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -194,6 +194,10 @@ class OrganizationRepository(
         The period is measured from the most recent paid order that hasn't been
         fully refunded (the post-chargeback-risk window). Orgs without such an
         order fall back to when they entered offboarding (``status_updated_at``).
+
+        ``FOR UPDATE`` on the org row: a concurrent admin status change either
+        commits before our SELECT (and the row falls out of the WHERE clause) or
+        waits behind our lock — eliminating the read/transition race.
         """
         last_paid_order_at = (
             select(func.max(Order.created_at))
@@ -214,6 +218,7 @@ class OrganizationRepository(
             )
             .order_by(anchor.asc())
             .limit(limit)
+            .with_for_update(of=Organization)
         )
         return await self.get_all(statement)
 

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -370,6 +370,7 @@ class LegacyOrganizationStatus(StrEnum):
             OrganizationStatus.ACTIVE: LegacyOrganizationStatus.ACTIVE,
             OrganizationStatus.BLOCKED: LegacyOrganizationStatus.DENIED,
             OrganizationStatus.OFFBOARDING: LegacyOrganizationStatus.ACTIVE,
+            OrganizationStatus.OFFBOARDED: LegacyOrganizationStatus.DENIED,
         }
         try:
             return mapping[status]

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1423,7 +1423,9 @@ class OrganizationService:
         """Auto-transition offboarding orgs to the terminal offboarded state.
 
         Run periodically by a worker once the offboarding period has elapsed
-        since the org's last paid order. Returns the orgs transitioned.
+        since both the org's last paid order (chargeback safety) and its
+        entry into offboarding (merchant wind-down floor). Returns the orgs
+        transitioned.
         """
         repository = OrganizationRepository.from_session(session)
         cutoff = datetime.now(UTC) - settings.ORGANIZATION_OFFBOARDING_PERIOD

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1417,6 +1417,34 @@ class OrganizationService:
             transitioned.append(organization)
         return transitioned
 
+    async def offboard_expired_organizations(
+        self, session: AsyncSession
+    ) -> Sequence[Organization]:
+        """Auto-transition offboarding orgs to the terminal offboarded state.
+
+        Run periodically by a worker once the offboarding period has elapsed
+        since the org's last paid order. Returns the orgs transitioned.
+        """
+        repository = OrganizationRepository.from_session(session)
+        cutoff = datetime.now(UTC) - settings.ORGANIZATION_OFFBOARDING_PERIOD
+        candidates = await repository.get_offboarding_past_period(cutoff)
+        transitioned: list[Organization] = []
+        for organization in candidates:
+            # Skip if a concurrent admin action already moved the org out of
+            # OFFBOARDING — set_status would raise InvalidStatusTransitionError
+            # and abort the whole batch otherwise.
+            if organization.status != OrganizationStatus.OFFBOARDING:
+                continue
+            organization.set_status(OrganizationStatus.OFFBOARDED)
+            _append_internal_note(
+                organization,
+                "Automatically offboarded after the offboarding period elapsed.",
+            )
+            session.add(organization)
+            enqueue_job("organization.offboarded", organization_id=organization.id)
+            transitioned.append(organization)
+        return transitioned
+
     async def _exit_snooze_to_review(
         self, session: AsyncSession, organization: Organization
     ) -> None:

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1430,9 +1430,12 @@ class OrganizationService:
         candidates = await repository.get_offboarding_past_period(cutoff)
         transitioned: list[Organization] = []
         for organization in candidates:
-            # Skip if a concurrent admin action already moved the org out of
-            # OFFBOARDING — set_status would raise InvalidStatusTransitionError
-            # and abort the whole batch otherwise.
+            # Lock the row and re-read status so a concurrent admin action that
+            # moved the org out of OFFBOARDING between the candidate query and
+            # here isn't clobbered with the terminal OFFBOARDED state.
+            await session.refresh(
+                organization, attribute_names=["status"], with_for_update=True
+            )
             if organization.status != OrganizationStatus.OFFBOARDING:
                 continue
             organization.set_status(OrganizationStatus.OFFBOARDED)

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1427,17 +1427,12 @@ class OrganizationService:
         """
         repository = OrganizationRepository.from_session(session)
         cutoff = datetime.now(UTC) - settings.ORGANIZATION_OFFBOARDING_PERIOD
+        # The candidate query takes FOR UPDATE on each org row, so a concurrent
+        # admin status change either falls out of the WHERE clause or waits
+        # behind our lock — no per-row re-check needed.
         candidates = await repository.get_offboarding_past_period(cutoff)
         transitioned: list[Organization] = []
         for organization in candidates:
-            # Lock the row and re-read status so a concurrent admin action that
-            # moved the org out of OFFBOARDING between the candidate query and
-            # here isn't clobbered with the terminal OFFBOARDED state.
-            await session.refresh(
-                organization, attribute_names=["status"], with_for_update=True
-            )
-            if organization.status != OrganizationStatus.OFFBOARDING:
-                continue
             organization.set_status(OrganizationStatus.OFFBOARDED)
             _append_internal_note(
                 organization,

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -5,6 +5,11 @@ from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
 from polar.customer.repository import CustomerRepository
+from polar.email.schemas import (
+    OrganizationOffboardedEmail,
+    OrganizationOffboardedProps,
+)
+from polar.email.sender import enqueue_email_template
 from polar.exceptions import PolarTaskError
 from polar.integrations.plain.service import plain as plain_service
 from polar.member.repository import MemberRepository
@@ -16,6 +21,9 @@ from polar.models.member import Member, MemberRole
 from polar.models.organization import OrganizationStatus
 from polar.postgres import AsyncSession
 from polar.user.repository import UserRepository
+from polar.user_organization.service import (
+    user_organization as user_organization_service,
+)
 from polar.worker import (
     AsyncSessionMaker,
     CronTrigger,
@@ -75,6 +83,45 @@ async def organization_unsnooze_expired() -> None:
     """Auto-unsnooze TIME_BASED snoozed orgs whose deadline has passed."""
     async with AsyncSessionMaker() as session:
         await organization_service.unsnooze_expired_organizations(session)
+
+
+@actor(
+    actor_name="organization.offboard_expired",
+    cron_trigger=CronTrigger.from_crontab("0 4 * * *"),
+    priority=TaskPriority.LOW,
+    max_retries=0,
+)
+async def organization_offboard_expired() -> None:
+    """Auto-transition offboarding orgs to offboarded once the period elapses."""
+    async with AsyncSessionMaker() as session:
+        await organization_service.offboard_expired_organizations(session)
+
+
+@actor(actor_name="organization.offboarded", priority=TaskPriority.LOW)
+async def organization_offboarded(organization_id: uuid.UUID) -> None:
+    """Notify an organization's members that it has been offboarded."""
+    async with AsyncSessionMaker() as session:
+        repository = OrganizationRepository.from_session(session)
+        organization = await repository.get_by_id(organization_id)
+        if organization is None:
+            raise OrganizationDoesNotExist(organization_id)
+
+        members = await user_organization_service.list_by_org(session, organization.id)
+        for member in members:
+            email = member.user.email
+            if not email:
+                continue
+            enqueue_email_template(
+                OrganizationOffboardedEmail(
+                    props=OrganizationOffboardedProps(
+                        email=email,
+                        organization_name=organization.name,
+                        account_url=organization.account_url,
+                    )
+                ),
+                to_email_addr=email,
+                subject=f"{organization.name} has been offboarded from Polar",
+            )
 
 
 def _check_threshold_debounce_key(account_id: uuid.UUID) -> str:

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -102,7 +102,9 @@ async def organization_offboarded(organization_id: uuid.UUID) -> None:
     """Notify an organization's members that it has been offboarded."""
     async with AsyncSessionMaker() as session:
         repository = OrganizationRepository.from_session(session)
-        organization = await repository.get_by_id(organization_id)
+        # include_blocked: an admin may block the org between the offboard
+        # transition and this task running; we still want to send the email.
+        organization = await repository.get_by_id(organization_id, include_blocked=True)
         if organization is None:
             raise OrganizationDoesNotExist(organization_id)
 

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -22,6 +22,7 @@ from polar.models import Customer, Organization, Product, User, UserOrganization
 from polar.models.account import Account
 from polar.models.benefit import BenefitType
 from polar.models.member import MemberRole
+from polar.models.order import OrderStatus
 from polar.models.organization import (
     STATUS_CAPABILITIES,
     InvalidStatusTransitionError,
@@ -38,6 +39,7 @@ from polar.models.user import IdentityVerificationStatus
 from polar.models.user_organization import OrganizationRole
 from polar.organization.repository import OrganizationRepository
 from polar.organization.schemas import (
+    LegacyOrganizationStatus,
     OrganizationCreate,
     OrganizationDetails,
     OrganizationFeatureSettingsUpdate,
@@ -3905,6 +3907,176 @@ class TestUnsnoozeExpiredOrganizations:
 
 
 @pytest.mark.asyncio
+class TestOffboardExpiredOrganizations:
+    async def _make_offboarding(
+        self,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        *,
+        status_updated_days_ago: int,
+    ) -> None:
+        organization.status = OrganizationStatus.OFFBOARDING
+        organization.status_updated_at = datetime.now(UTC) - timedelta(
+            days=status_updated_days_ago
+        )
+        await save_fixture(organization)
+
+    async def test_old_paid_order_transitions(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        await self._make_offboarding(
+            save_fixture, organization, status_updated_days_ago=10
+        )
+        await create_order(
+            save_fixture,
+            customer=customer,
+            status=OrderStatus.paid,
+            created_at=datetime.now(UTC) - timedelta(days=121),
+        )
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        result = await organization_service.offboard_expired_organizations(session)
+
+        assert len(result) == 1
+        assert result[0].id == organization.id
+        assert result[0].status == OrganizationStatus.OFFBOARDED
+        enqueue_job_mock.assert_called_once_with(
+            "organization.offboarded", organization_id=organization.id
+        )
+
+    async def test_recent_paid_order_skipped(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        # Old offboarding date, but a recent paid order anchors the window.
+        await self._make_offboarding(
+            save_fixture, organization, status_updated_days_ago=200
+        )
+        await create_order(
+            save_fixture,
+            customer=customer,
+            status=OrderStatus.paid,
+            created_at=datetime.now(UTC) - timedelta(days=10),
+        )
+
+        result = await organization_service.offboard_expired_organizations(session)
+
+        assert result == []
+        assert organization.status == OrganizationStatus.OFFBOARDING
+
+    async def test_partially_refunded_recent_order_skipped(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        # Partially refunded orders still count as paid-and-not-fully-refunded.
+        await self._make_offboarding(
+            save_fixture, organization, status_updated_days_ago=200
+        )
+        await create_order(
+            save_fixture,
+            customer=customer,
+            status=OrderStatus.partially_refunded,
+            created_at=datetime.now(UTC) - timedelta(days=10),
+        )
+
+        result = await organization_service.offboard_expired_organizations(session)
+
+        assert result == []
+        assert organization.status == OrganizationStatus.OFFBOARDING
+
+    async def test_fully_refunded_order_falls_back_to_status_updated_at(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        # A fully refunded order is ignored, so the window falls back to the
+        # offboarding-entry date, which is old enough here.
+        await self._make_offboarding(
+            save_fixture, organization, status_updated_days_ago=121
+        )
+        await create_order(
+            save_fixture,
+            customer=customer,
+            status=OrderStatus.refunded,
+            created_at=datetime.now(UTC) - timedelta(days=1),
+        )
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        result = await organization_service.offboard_expired_organizations(session)
+
+        assert len(result) == 1
+        assert result[0].status == OrganizationStatus.OFFBOARDED
+        enqueue_job_mock.assert_called_once_with(
+            "organization.offboarded", organization_id=organization.id
+        )
+
+    async def test_no_orders_uses_status_updated_at(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        await self._make_offboarding(
+            save_fixture, organization, status_updated_days_ago=121
+        )
+
+        result = await organization_service.offboard_expired_organizations(session)
+
+        assert len(result) == 1
+        assert result[0].status == OrganizationStatus.OFFBOARDED
+
+    async def test_recent_offboarding_no_orders_skipped(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        await self._make_offboarding(
+            save_fixture, organization, status_updated_days_ago=10
+        )
+
+        result = await organization_service.offboard_expired_organizations(session)
+
+        assert result == []
+        assert organization.status == OrganizationStatus.OFFBOARDING
+
+    async def test_status_changed_concurrently_is_skipped(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        # The candidate query returned an org whose status has since flipped.
+        organization.status = OrganizationStatus.ACTIVE
+        mocker.patch.object(
+            OrganizationRepository,
+            "get_offboarding_past_period",
+            return_value=[organization],
+        )
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        result = await organization_service.offboard_expired_organizations(session)
+
+        assert result == []
+        assert organization.status == OrganizationStatus.ACTIVE
+        enqueue_job_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
 class TestSetPayoutAccount:
     @pytest.mark.auth
     async def test_set_payout_account_on_organization(
@@ -4035,6 +4207,22 @@ class TestSetPayoutAccount:
         assert cancel_calls == []
 
 
+class TestLegacyOrganizationStatus:
+    @pytest.mark.parametrize("status", list(OrganizationStatus))
+    def test_from_status_covers_every_status(self, status: OrganizationStatus) -> None:
+        # Every status must map to a legacy value — a missing entry would 500
+        # when serializing the org through the public schema.
+        assert isinstance(
+            LegacyOrganizationStatus.from_status(status), LegacyOrganizationStatus
+        )
+
+    def test_offboarded_maps_to_denied(self) -> None:
+        assert (
+            LegacyOrganizationStatus.from_status(OrganizationStatus.OFFBOARDED)
+            == LegacyOrganizationStatus.DENIED
+        )
+
+
 @pytest.mark.asyncio
 class TestStatusTransitions:
     """Tests for the organization status transition rules enforced in
@@ -4049,6 +4237,7 @@ class TestStatusTransitions:
             OrganizationStatus.ACTIVE,
             OrganizationStatus.DENIED,
             OrganizationStatus.OFFBOARDING,
+            OrganizationStatus.OFFBOARDED,
         ],
     )
     async def test_every_status_can_go_to_blocked(
@@ -4059,6 +4248,47 @@ class TestStatusTransitions:
         organization.status = current
         organization.set_status(OrganizationStatus.BLOCKED)
         assert organization.status == OrganizationStatus.BLOCKED
+
+    async def test_offboarding_can_go_to_offboarded(
+        self,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.OFFBOARDING
+        organization.set_status(OrganizationStatus.OFFBOARDED)
+        assert organization.status == OrganizationStatus.OFFBOARDED
+        assert (
+            organization.capabilities
+            == STATUS_CAPABILITIES[OrganizationStatus.OFFBOARDED]
+        )
+
+    async def test_offboarded_enables_payout_blocks_payments(
+        self,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.OFFBOARDING
+        organization.set_status(OrganizationStatus.OFFBOARDED)
+        assert organization.can_payout is True
+        assert organization.can_accept_payments is False
+        assert organization.can_renew_subscriptions is False
+        assert organization.can_refund is False
+
+    @pytest.mark.parametrize(
+        "target",
+        [
+            OrganizationStatus.ACTIVE,
+            OrganizationStatus.REVIEW,
+            OrganizationStatus.DENIED,
+            OrganizationStatus.OFFBOARDING,
+        ],
+    )
+    async def test_offboarded_is_terminal_except_blocked(
+        self,
+        target: OrganizationStatus,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.OFFBOARDED
+        with pytest.raises(InvalidStatusTransitionError):
+            organization.set_status(target)
 
     async def test_review_can_go_to_offboarding(
         self,

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -4026,6 +4026,7 @@ class TestOffboardExpiredOrganizations:
 
     async def test_no_orders_uses_status_updated_at(
         self,
+        mocker: MockerFixture,
         session: AsyncSession,
         save_fixture: SaveFixture,
         organization: Organization,
@@ -4033,11 +4034,15 @@ class TestOffboardExpiredOrganizations:
         await self._make_offboarding(
             save_fixture, organization, status_updated_days_ago=121
         )
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
 
         result = await organization_service.offboard_expired_organizations(session)
 
         assert len(result) == 1
         assert result[0].status == OrganizationStatus.OFFBOARDED
+        enqueue_job_mock.assert_called_once_with(
+            "organization.offboarded", organization_id=organization.id
+        )
 
     async def test_recent_offboarding_no_orders_skipped(
         self,

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -3921,7 +3921,7 @@ class TestOffboardExpiredOrganizations:
         )
         await save_fixture(organization)
 
-    async def test_old_paid_order_transitions(
+    async def test_both_anchors_old_transitions(
         self,
         mocker: MockerFixture,
         session: AsyncSession,
@@ -3929,8 +3929,10 @@ class TestOffboardExpiredOrganizations:
         organization: Organization,
         customer: Customer,
     ) -> None:
+        # Both gates clear: chargeback window expired and merchant has had
+        # their wind-down period in offboarding.
         await self._make_offboarding(
-            save_fixture, organization, status_updated_days_ago=10
+            save_fixture, organization, status_updated_days_ago=121
         )
         await create_order(
             save_fixture,
@@ -3948,6 +3950,31 @@ class TestOffboardExpiredOrganizations:
         enqueue_job_mock.assert_called_once_with(
             "organization.offboarded", organization_id=organization.id
         )
+
+    async def test_old_paid_order_but_recent_offboarding_skipped(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        # Regression: an org freshly put into offboarding must still get its
+        # full wind-down period even if its last payment is already past the
+        # chargeback window. Anchor = MAX(last_paid, status_updated_at).
+        await self._make_offboarding(
+            save_fixture, organization, status_updated_days_ago=4
+        )
+        await create_order(
+            save_fixture,
+            customer=customer,
+            status=OrderStatus.paid,
+            created_at=datetime.now(UTC) - timedelta(days=149),
+        )
+
+        result = await organization_service.offboard_expired_organizations(session)
+
+        assert result == []
+        assert organization.status == OrganizationStatus.OFFBOARDING
 
     async def test_recent_paid_order_skipped(
         self,
@@ -4052,6 +4079,31 @@ class TestOffboardExpiredOrganizations:
     ) -> None:
         await self._make_offboarding(
             save_fixture, organization, status_updated_days_ago=10
+        )
+
+        result = await organization_service.offboard_expired_organizations(session)
+
+        assert result == []
+        assert organization.status == OrganizationStatus.OFFBOARDING
+
+    async def test_old_offboarding_recent_paid_order_skipped(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        # Mirror of the resumeset case: chargeback gate clears (offboarding is
+        # ancient) but the merchant just took a payment, so we must wait
+        # another 120 days from that payment before the terminal transition.
+        await self._make_offboarding(
+            save_fixture, organization, status_updated_days_ago=200
+        )
+        await create_order(
+            save_fixture,
+            customer=customer,
+            status=OrderStatus.paid,
+            created_at=datetime.now(UTC) - timedelta(days=4),
         )
 
         result = await organization_service.offboard_expired_organizations(session)

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -4059,27 +4059,6 @@ class TestOffboardExpiredOrganizations:
         assert result == []
         assert organization.status == OrganizationStatus.OFFBOARDING
 
-    async def test_status_changed_concurrently_is_skipped(
-        self,
-        mocker: MockerFixture,
-        session: AsyncSession,
-        organization: Organization,
-    ) -> None:
-        # The candidate query returned an org whose status has since flipped.
-        organization.status = OrganizationStatus.ACTIVE
-        mocker.patch.object(
-            OrganizationRepository,
-            "get_offboarding_past_period",
-            return_value=[organization],
-        )
-        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
-
-        result = await organization_service.offboard_expired_organizations(session)
-
-        assert result == []
-        assert organization.status == OrganizationStatus.ACTIVE
-        enqueue_job_mock.assert_not_called()
-
 
 @pytest.mark.asyncio
 class TestSetPayoutAccount:

--- a/server/tests/organization/test_tasks.py
+++ b/server/tests/organization/test_tasks.py
@@ -115,6 +115,8 @@ class TestOrganizationOffboarded:
         await organization_offboarded(organization.id)
 
         enqueue_email_mock.assert_called_once()
-        _, kwargs = enqueue_email_mock.call_args
+        args, kwargs = enqueue_email_mock.call_args
         assert kwargs["to_email_addr"] == user.email
         assert organization.name in kwargs["subject"]
+        email = args[0]
+        assert email.props.account_url == organization.account_url

--- a/server/tests/organization/test_tasks.py
+++ b/server/tests/organization/test_tasks.py
@@ -4,11 +4,12 @@ import pytest
 from pytest_mock import MockerFixture
 
 from polar.kit.db.postgres import AsyncSession
-from polar.models import Organization, User
+from polar.models import Organization, User, UserOrganization
 from polar.models.organization import OrganizationStatus
 from polar.organization.tasks import (
     OrganizationDoesNotExist,
     organization_created,
+    organization_offboarded,
     organization_under_review,
 )
 from tests.fixtures.database import SaveFixture
@@ -87,3 +88,33 @@ class TestOrganizationUnderReview:
             organization_id=organization.id,
             auto_approve_eligible=False,
         )
+
+
+@pytest.mark.asyncio
+class TestOrganizationOffboarded:
+    async def test_not_existing_organization(self, session: AsyncSession) -> None:
+        session.expunge_all()
+
+        with pytest.raises(OrganizationDoesNotExist):
+            await organization_offboarded(uuid.uuid4())
+
+    async def test_emails_each_member(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+        user_organization: UserOrganization,
+    ) -> None:
+        session.expunge_all()
+
+        enqueue_email_mock = mocker.patch(
+            "polar.organization.tasks.enqueue_email_template"
+        )
+
+        await organization_offboarded(organization.id)
+
+        enqueue_email_mock.assert_called_once()
+        _, kwargs = enqueue_email_mock.call_args
+        assert kwargs["to_email_addr"] == user.email
+        assert organization.name in kwargs["subject"]

--- a/server/tests/payout/test_service.py
+++ b/server/tests/payout/test_service.py
@@ -262,6 +262,43 @@ class TestCreate:
         enqueue_job_mock.assert_any_call("payout.created", payout_id=payout.id)
         enqueue_job_mock.assert_any_call("payout.transfer", payout_id=payout.id)
 
+    async def test_offboarded_enqueues_created_and_transfer(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        locker: Locker,
+        organization: Organization,
+        account: Account,
+        user: User,
+        payout_transaction_service_mock: MagicMock,
+    ) -> None:
+        # An offboarded org's payout is auto-processed (pending, not held): both
+        # the created event and the Stripe transfer are enqueued.
+        enqueue_job_mock = mocker.patch("polar.payout.service.enqueue_job")
+
+        organization.status = OrganizationStatus.OFFBOARDING
+        organization.set_status(OrganizationStatus.OFFBOARDED)
+        await save_fixture(organization)
+
+        await create_payout_account(save_fixture, organization, user)
+
+        payment_transaction_1 = await create_payment_transaction(
+            save_fixture, charge_id="CHARGE_1"
+        )
+        await create_balance_transaction(
+            save_fixture, account=account, payment_transaction=payment_transaction_1
+        )
+
+        payout_transaction_service_mock.create.return_value = Transaction()
+
+        payout = await payout_service.create(session, locker, organization)
+
+        assert payout.status == PayoutStatus.pending
+        assert enqueue_job_mock.call_count == 2
+        enqueue_job_mock.assert_any_call("payout.created", payout_id=payout.id)
+        enqueue_job_mock.assert_any_call("payout.transfer", payout_id=payout.id)
+
     async def test_valid(
         self,
         save_fixture: SaveFixture,


### PR DESCRIPTION
## Summary

Introduce a terminal `offboarded` organization status. An org automatically transitions from `offboarding` to `offboarded` 120 days after its last paid order (or when the org moved to offboarding state if there is none).

## What
- New `OFFBOARDED` status with withdraw capabilities
- Daily cron transitions eligible offboarding orgs; the 120-day window is anchored on the most recent paid (not fully refunded) order.
- Merchant email on transition
- Backoffice changes
- Terminal state: only a `blocked` escape transition is allowed.

## Why

`offboarding` had no defined end state. This will allow us to have a clean state

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

