### PR TITLE
server/user: lock user when generating an identity verification to prevent TOCTOU

### DIFF
--- a/server/polar/checkout/endpoints.py
+++ b/server/polar/checkout/endpoints.py
@@ -187,7 +187,9 @@ async def update(
     session: AsyncSession = Depends(get_db_session),
 ) -> Checkout:
     """Update a checkout session."""
-    checkout = await checkout_service.get_by_id(session, auth_subject, id)
+    checkout = await checkout_service.get_by_id(
+        session, auth_subject, id, for_update=True
+    )
 
     if checkout is None:
         raise ResourceNotFound()
@@ -233,7 +235,9 @@ async def client_update(
     session: AsyncSession = Depends(get_db_session),
 ) -> Checkout:
     """Update a checkout session by client secret."""
-    checkout = await checkout_service.get_by_client_secret(session, client_secret)
+    checkout = await checkout_service.get_by_client_secret(
+        session, client_secret, for_update=True
+    )
 
     return await checkout_service.update(
         session, checkout, checkout_update, ip_geolocation_client
@@ -263,7 +267,9 @@ async def client_confirm(
 
     Orders and subscriptions will be processed.
     """
-    checkout = await checkout_service.get_by_client_secret(session, client_secret)
+    checkout = await checkout_service.get_by_client_secret(
+        session, client_secret, for_update=True
+    )
 
     return await checkout_service.confirm(
         session, auth_subject, checkout, checkout_confirm

--- a/server/polar/checkout/repository.py
+++ b/server/polar/checkout/repository.py
@@ -1,3 +1,4 @@
+import typing
 from uuid import UUID
 
 from sqlalchemy import Select, update
@@ -32,14 +33,41 @@ class CheckoutRepository(
 ):
     model = Checkout
 
+    @typing.overload
     async def get_by_client_secret(
-        self, client_secret: str, *, options: Options = ()
+        self,
+        client_secret: str,
+        *,
+        options: Options = (),
+        for_update: typing.Literal[False] = False,
+    ) -> Checkout: ...
+
+    @typing.overload
+    async def get_by_client_secret(
+        self,
+        client_secret: str,
+        *,
+        options: Options = (),
+        for_update: typing.Literal[True],
+        nowait: bool = False,
+    ) -> Checkout | None: ...
+
+    async def get_by_client_secret(
+        self,
+        client_secret: str,
+        *,
+        options: Options = (),
+        for_update: bool = False,
+        nowait: bool = False,
     ) -> Checkout | None:
         statement = (
             self.get_base_statement()
             .where(Checkout.client_secret == client_secret)
             .options(*options)
         )
+        if for_update:
+            statement = statement.with_for_update(of=Checkout, nowait=nowait)
+
         return await self.get_one_or_none(statement)
 
     async def expire_open_checkouts(self) -> list[UUID]:
@@ -65,7 +93,7 @@ class CheckoutRepository(
         return (
             joinedload(Checkout.organization).joinedload(Organization.account),
             joinedload(Checkout.customer),
-            joinedload(Checkout.product).options(
+            selectinload(Checkout.product).options(
                 selectinload(Product.product_medias),
                 selectinload(Product.attached_custom_fields),
             ),

--- a/server/polar/checkout/repository.py
+++ b/server/polar/checkout/repository.py
@@ -42,25 +42,6 @@ class CheckoutRepository(
         )
         return await self.get_one_or_none(statement)
 
-    async def get_by_id_for_update(
-        self, checkout_id: UUID, *, nowait: bool = True, options: Options = ()
-    ) -> Checkout | None:
-        """
-        Get checkout by ID with FOR UPDATE lock.
-
-        Uses FOR UPDATE OF checkouts to lock only the checkout row, allowing
-        LEFT OUTER JOINs for eager loading of relationships.
-
-        See: https://www.postgresql.org/docs/current/explicit-locking.html
-        """
-        statement = (
-            self.get_base_statement()
-            .where(Checkout.id == checkout_id)
-            .options(*options)
-            .with_for_update(nowait=nowait, of=Checkout)
-        )
-        return await self.get_one_or_none(statement)
-
     async def expire_open_checkouts(self) -> list[UUID]:
         statement = (
             update(Checkout)

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -1,7 +1,7 @@
 import contextlib
 import typing
 import uuid
-from collections.abc import AsyncGenerator, AsyncIterator, Sequence
+from collections.abc import AsyncGenerator, Sequence
 
 import sentry_sdk
 import stripe as stripe_lib
@@ -216,8 +216,20 @@ class TrialAlreadyRedeemed(CheckoutError):
 class CheckoutLocked(CheckoutError):
     """Raised when checkout is locked by another transaction."""
 
-    def __init__(self, checkout_id: uuid.UUID) -> None:
+    @typing.overload
+    def __init__(self, *, checkout_id: uuid.UUID) -> None: ...
+
+    @typing.overload
+    def __init__(self, *, checkout_secret: str) -> None: ...
+
+    def __init__(
+        self,
+        *,
+        checkout_id: uuid.UUID | None = None,
+        checkout_secret: str | None = None,
+    ) -> None:
         self.checkout_id = checkout_id
+        self.checkout_secret = checkout_secret
         message = "Checkout is currently being processed. Please try again."
         super().__init__(message, 409)
 
@@ -297,6 +309,8 @@ class CheckoutService:
         session: AsyncReadSession,
         auth_subject: AuthSubject[User | Organization],
         id: uuid.UUID,
+        *,
+        for_update: bool = False,
     ) -> Checkout | None:
         repository = CheckoutRepository.from_session(session)
         org_ids = await get_accessible_org_ids(
@@ -307,7 +321,15 @@ class CheckoutService:
             .where(Checkout.id == id)
             .options(*repository.get_eager_options())
         )
-        checkout = await repository.get_one_or_none(statement)
+        if for_update:
+            statement = statement.with_for_update(of=Checkout, nowait=True)
+
+        try:
+            checkout = await repository.get_one_or_none(statement)
+        except DBAPIError as e:
+            if is_lock_not_available_error(e):
+                raise CheckoutLocked(checkout_id=id) from e
+            raise
 
         if checkout is None:
             return None
@@ -900,27 +922,26 @@ class CheckoutService:
         checkout_update: CheckoutUpdate | CheckoutUpdatePublic,
         ip_geolocation_client: ip_geolocation.IPGeolocationClient | None = None,
     ) -> Checkout:
-        async with self._lock_checkout_update(session, checkout) as checkout:
-            checkout = await self._update_checkout(
-                session, checkout, checkout_update, ip_geolocation_client
-            )
-            try:
-                checkout = await self._update_checkout_tax(session, checkout)
-            # Swallow incomplete tax calculation error: require it only on confirm
-            except TaxCalculationLogicalError:
-                pass
+        checkout = await self._update_checkout(
+            session, checkout, checkout_update, ip_geolocation_client
+        )
+        try:
+            checkout = await self._update_checkout_tax(session, checkout)
+        # Swallow incomplete tax calculation error: require it only on confirm
+        except TaxCalculationLogicalError:
+            pass
 
-            # Reset is_business_customer if payment form is no longer required
-            # This handles the case where a 100% discount is applied and the
-            # billing address section disappears from the frontend
-            if (
-                not checkout.is_payment_form_required
-                and not checkout.require_billing_address
-            ):
-                checkout.is_business_customer = False
+        # Reset is_business_customer if payment form is no longer required
+        # This handles the case where a 100% discount is applied and the
+        # billing address section disappears from the frontend
+        if (
+            not checkout.is_payment_form_required
+            and not checkout.require_billing_address
+        ):
+            checkout.is_business_customer = False
 
-            await self._after_checkout_updated(session, checkout)
-            return checkout
+        await self._after_checkout_updated(session, checkout)
+        return checkout
 
     async def confirm(
         self,
@@ -929,33 +950,32 @@ class CheckoutService:
         checkout: Checkout,
         checkout_confirm: CheckoutConfirm,
     ) -> Checkout:
-        async with self._lock_checkout_update(session, checkout) as checkout:
-            checkout = await self._update_checkout(session, checkout, checkout_confirm)
-            # When redeeming a discount, we need to lock the discount to prevent concurrent redemptions
-            if checkout.discount is not None:
-                try:
-                    async with discount_service.redeem_discount(
-                        session, checkout.discount
-                    ) as discount_redemption:
-                        discount_redemption.checkout = checkout
-                        return await self._confirm_inner(
-                            session, auth_subject, checkout, checkout_confirm
-                        )
-                except DiscountNotRedeemableError as e:
-                    raise PolarRequestValidationError(
-                        [
-                            {
-                                "type": "value_error",
-                                "loc": ("body", "discount_id"),
-                                "msg": "Discount is no longer redeemable.",
-                                "input": checkout.discount.id,
-                            }
-                        ]
-                    ) from e
+        checkout = await self._update_checkout(session, checkout, checkout_confirm)
+        # When redeeming a discount, we need to lock the discount to prevent concurrent redemptions
+        if checkout.discount is not None:
+            try:
+                async with discount_service.redeem_discount(
+                    session, checkout.discount
+                ) as discount_redemption:
+                    discount_redemption.checkout = checkout
+                    return await self._confirm_inner(
+                        session, auth_subject, checkout, checkout_confirm
+                    )
+            except DiscountNotRedeemableError as e:
+                raise PolarRequestValidationError(
+                    [
+                        {
+                            "type": "value_error",
+                            "loc": ("body", "discount_id"),
+                            "msg": "Discount is no longer redeemable.",
+                            "input": checkout.discount.id,
+                        }
+                    ]
+                ) from e
 
-            return await self._confirm_inner(
-                session, auth_subject, checkout, checkout_confirm
-            )
+        return await self._confirm_inner(
+            session, auth_subject, checkout, checkout_confirm
+        )
 
     async def _confirm_inner(
         self,
@@ -1433,12 +1453,25 @@ class CheckoutService:
         return checkout
 
     async def get_by_client_secret(
-        self, session: AsyncSession, client_secret: str
+        self, session: AsyncSession, client_secret: str, *, for_update: bool = False
     ) -> Checkout:
         repository = CheckoutRepository.from_session(session)
-        checkout = await repository.get_by_client_secret(
-            client_secret, options=repository.get_eager_options()
-        )
+        if for_update:
+            try:
+                checkout = await repository.get_by_client_secret(
+                    client_secret,
+                    options=repository.get_eager_options(),
+                    for_update=True,
+                    nowait=True,
+                )
+            except DBAPIError as e:
+                if is_lock_not_available_error(e):
+                    raise CheckoutLocked(checkout_secret=client_secret) from e
+                raise
+        else:
+            checkout = await repository.get_by_client_secret(
+                client_secret, options=repository.get_eager_options()
+            )
         if checkout is None:
             raise ResourceNotFound()
 
@@ -1869,42 +1902,6 @@ class CheckoutService:
                 )
 
         return subscription, subscription.customer
-
-    @contextlib.asynccontextmanager
-    async def _lock_checkout_update(
-        self, session: AsyncSession, checkout: Checkout
-    ) -> AsyncIterator[Checkout]:
-        """
-        Lock checkout with FOR UPDATE NOWAIT and reload fresh from database.
-
-        Uses PostgreSQL row-level locking instead of Redis distributed locks.
-        If another transaction holds the lock, immediately raises CheckoutLocked
-        instead of waiting (NOWAIT behavior).
-
-        Uses FOR UPDATE OF checkouts to lock only the checkout row while still
-        allowing eager loading of relationships via LEFT OUTER JOINs.
-
-        See: https://www.postgresql.org/docs/current/explicit-locking.html
-        """
-        repository = CheckoutRepository.from_session(session)
-        checkout_id = checkout.id
-
-        try:
-            locked_checkout = await repository.get_by_id(
-                checkout_id,
-                options=repository.get_eager_options(),
-                for_update=True,
-                nowait=True,
-            )
-        except DBAPIError as e:
-            if is_lock_not_available_error(e):
-                raise CheckoutLocked(checkout_id) from e
-            raise
-
-        if locked_checkout is None:
-            raise ResourceNotFound()
-
-        yield locked_checkout
 
     async def _update_checkout(
         self,

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -1890,10 +1890,11 @@ class CheckoutService:
         checkout_id = checkout.id
 
         try:
-            locked_checkout = await repository.get_by_id_for_update(
+            locked_checkout = await repository.get_by_id(
                 checkout_id,
-                nowait=True,
                 options=repository.get_eager_options(),
+                for_update=True,
+                nowait=True,
             )
         except DBAPIError as e:
             if is_lock_not_available_error(e):

--- a/server/polar/discount/repository.py
+++ b/server/polar/discount/repository.py
@@ -10,18 +10,6 @@ from polar.models import Discount, DiscountRedemption
 class DiscountRepository(RepositoryBase[Discount], RepositoryIDMixin[Discount, UUID]):
     model = Discount
 
-    async def get_by_id_for_update(
-        self, discount_id: UUID, *, nowait: bool = True
-    ) -> Discount | None:
-        """Get discount by ID with FOR UPDATE lock."""
-        statement = (
-            select(Discount)
-            .where(Discount.id == discount_id, Discount.is_deleted.is_(False))
-            .with_for_update(nowait=nowait)
-            .options(raiseload(Discount.organization))
-        )
-        return await self.get_one_or_none(statement)
-
     async def get_by_code_and_organization_for_update(
         self,
         code: str,

--- a/server/polar/discount/service.py
+++ b/server/polar/discount/service.py
@@ -440,7 +440,7 @@ class DiscountService(ResourceServiceReader[Discount]):
 
         # Acquire FOR UPDATE lock (we're already inside checkout's transaction)
         try:
-            await repository.get_by_id_for_update(discount.id, nowait=True)
+            await repository.get_by_id(discount.id, for_update=True, nowait=True)
         except DBAPIError as e:
             if is_lock_not_available_error(e):
                 raise DiscountNotRedeemableError(discount) from e

--- a/server/polar/kit/repository/base.py
+++ b/server/polar/kit/repository/base.py
@@ -208,7 +208,7 @@ class RepositoryIDMixin[MODEL_ID: ModelIDProtocol, ID_TYPE]:  # type: ignore[typ
         *,
         options: Options = (),
         for_update: Literal[False] = False,
-    ) -> MODEL_ID: ...
+    ) -> MODEL_ID | None: ...
 
     @overload
     async def get_by_id(
@@ -218,7 +218,7 @@ class RepositoryIDMixin[MODEL_ID: ModelIDProtocol, ID_TYPE]:  # type: ignore[typ
         options: Options = (),
         for_update: Literal[True],
         nowait: bool = False,
-    ) -> MODEL_ID: ...
+    ) -> MODEL_ID | None: ...
 
     async def get_by_id(
         self: RepositoryProtocol[MODEL_ID],
@@ -233,6 +233,10 @@ class RepositoryIDMixin[MODEL_ID: ModelIDProtocol, ID_TYPE]:  # type: ignore[typ
         )
         if for_update:
             statement = statement.with_for_update(of=self.model, nowait=nowait)
+            # Avoid stale data when using for_update:
+            # the object might have been loaded without the lock earlier
+            # in the same transaction
+            statement = statement.execution_options(populate_existing=True)
         return await self.get_one_or_none(statement)
 
 
@@ -277,6 +281,10 @@ class RepositorySoftDeletionIDMixin[
         )
         if for_update:
             statement = statement.with_for_update(of=self.model, nowait=nowait)
+            # Avoid stale data when using for_update:
+            # the object might have been loaded without the lock earlier
+            # in the same transaction
+            statement = statement.execution_options(populate_existing=True)
         return await self.get_one_or_none(statement)
 
 

--- a/server/polar/kit/repository/base.py
+++ b/server/polar/kit/repository/base.py
@@ -233,10 +233,6 @@ class RepositoryIDMixin[MODEL_ID: ModelIDProtocol, ID_TYPE]:  # type: ignore[typ
         )
         if for_update:
             statement = statement.with_for_update(of=self.model, nowait=nowait)
-            # Avoid stale data when using for_update:
-            # the object might have been loaded without the lock earlier
-            # in the same transaction
-            statement = statement.execution_options(populate_existing=True)
         return await self.get_one_or_none(statement)
 
 
@@ -281,10 +277,6 @@ class RepositorySoftDeletionIDMixin[
         )
         if for_update:
             statement = statement.with_for_update(of=self.model, nowait=nowait)
-            # Avoid stale data when using for_update:
-            # the object might have been loaded without the lock earlier
-            # in the same transaction
-            statement = statement.execution_options(populate_existing=True)
         return await self.get_one_or_none(statement)
 
 

--- a/server/polar/kit/repository/base.py
+++ b/server/polar/kit/repository/base.py
@@ -1,7 +1,7 @@
 from collections.abc import AsyncGenerator, Sequence
 from datetime import datetime
 from enum import StrEnum
-from typing import Any, Protocol, Self
+from typing import Any, Literal, Protocol, Self, overload
 
 from sqlalchemy import Select, UnaryExpression, asc, desc, func, select
 from sqlalchemy.orm import Mapped
@@ -201,15 +201,38 @@ class RepositorySoftDeletionMixin[MODEL_DELETED_AT: ModelDeletedAtProtocol]:
 
 
 class RepositoryIDMixin[MODEL_ID: ModelIDProtocol, ID_TYPE]:  # type: ignore[type-arg]
+    @overload
     async def get_by_id(
         self: RepositoryProtocol[MODEL_ID],
         id: ID_TYPE,
         *,
         options: Options = (),
+        for_update: Literal[False] = False,
+    ) -> MODEL_ID: ...
+
+    @overload
+    async def get_by_id(
+        self: RepositoryProtocol[MODEL_ID],
+        id: ID_TYPE,
+        *,
+        options: Options = (),
+        for_update: Literal[True],
+        nowait: bool = False,
+    ) -> MODEL_ID: ...
+
+    async def get_by_id(
+        self: RepositoryProtocol[MODEL_ID],
+        id: ID_TYPE,
+        *,
+        options: Options = (),
+        for_update: bool = False,
+        nowait: bool = False,
     ) -> MODEL_ID | None:
         statement = (
             self.get_base_statement().where(self.model.id == id).options(*options)
         )
+        if for_update:
+            statement = statement.with_for_update(of=self.model, nowait=nowait)
         return await self.get_one_or_none(statement)
 
 
@@ -217,18 +240,43 @@ class RepositorySoftDeletionIDMixin[
     MODEL_DELETED_AT_ID: ModelDeletedAtIDProtocol,  # type: ignore[type-arg]
     ID_TYPE,
 ]:
+    @overload
     async def get_by_id(
         self: RepositorySoftDeletionProtocol[MODEL_DELETED_AT_ID],
         id: ID_TYPE,
         *,
         options: Options = (),
         include_deleted: bool = False,
+        for_update: Literal[False] = False,
+    ) -> MODEL_DELETED_AT_ID | None: ...
+
+    @overload
+    async def get_by_id(
+        self: RepositorySoftDeletionProtocol[MODEL_DELETED_AT_ID],
+        id: ID_TYPE,
+        *,
+        options: Options = (),
+        include_deleted: bool = False,
+        for_update: Literal[True],
+        nowait: bool = False,
+    ) -> MODEL_DELETED_AT_ID | None: ...
+
+    async def get_by_id(
+        self: RepositorySoftDeletionProtocol[MODEL_DELETED_AT_ID],
+        id: ID_TYPE,
+        *,
+        options: Options = (),
+        include_deleted: bool = False,
+        for_update: bool = False,
+        nowait: bool = False,
     ) -> MODEL_DELETED_AT_ID | None:
         statement = (
             self.get_base_statement(include_deleted=include_deleted)
             .where(self.model.id == id)
             .options(*options)
         )
+        if for_update:
+            statement = statement.with_for_update(of=self.model, nowait=nowait)
         return await self.get_one_or_none(statement)
 
 

--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -98,6 +98,10 @@ class OrganizationRepository(
 
         if for_update:
             statement = statement.with_for_update(of=self.model, nowait=nowait)
+            # Avoid stale data when using for_update:
+            # the object might have been loaded without the lock earlier
+            # in the same transaction
+            statement = statement.execution_options(populate_existing=True)
 
         return await self.get_one_or_none(statement)
 

--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -1,3 +1,4 @@
+import typing
 from collections.abc import Sequence
 from datetime import datetime
 from uuid import UUID
@@ -53,6 +54,7 @@ class OrganizationRepository(
 ):
     model = Organization
 
+    @typing.overload
     async def get_by_id(
         self,
         id: UUID,
@@ -60,6 +62,30 @@ class OrganizationRepository(
         options: Options = (),
         include_deleted: bool = False,
         include_blocked: bool = False,
+        for_update: typing.Literal[False] = False,
+    ) -> Organization | None: ...
+
+    @typing.overload
+    async def get_by_id(
+        self,
+        id: UUID,
+        *,
+        options: Options = (),
+        include_deleted: bool = False,
+        include_blocked: bool = False,
+        for_update: typing.Literal[True],
+        nowait: bool = False,
+    ) -> Organization | None: ...
+
+    async def get_by_id(
+        self,
+        id: UUID,
+        *,
+        options: Options = (),
+        include_deleted: bool = False,
+        include_blocked: bool = False,
+        for_update: bool = False,
+        nowait: bool = False,
     ) -> Organization | None:
         statement = (
             self.get_base_statement(include_deleted=include_deleted)
@@ -69,6 +95,9 @@ class OrganizationRepository(
 
         if not include_blocked:
             statement = statement.where(self.model.status != OrganizationStatus.BLOCKED)
+
+        if for_update:
+            statement = statement.with_for_update(of=self.model, nowait=nowait)
 
         return await self.get_one_or_none(statement)
 

--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -98,10 +98,6 @@ class OrganizationRepository(
 
         if for_update:
             statement = statement.with_for_update(of=self.model, nowait=nowait)
-            # Avoid stale data when using for_update:
-            # the object might have been loaded without the lock earlier
-            # in the same transaction
-            statement = statement.execution_options(populate_existing=True)
 
         return await self.get_one_or_none(statement)
 

--- a/server/polar/payout/repository.py
+++ b/server/polar/payout/repository.py
@@ -88,23 +88,6 @@ class PayoutRepository(
         )
         return await self.get_one_or_none(statement)
 
-    async def get_by_id_for_update(
-        self, id: UUID, *, options: Options = ()
-    ) -> Payout | None:
-        """Get a payout by ID with a FOR UPDATE lock on the payout row.
-
-        Locks only the payout row (``OF payouts``) so eager-loading joins don't
-        try to lock the joined rows. Blocks until any concurrent holder (e.g.
-        cancel()) releases, so the transfer serializes against cancellation.
-        """
-        statement = (
-            self.get_base_statement()
-            .where(Payout.id == id)
-            .options(*options)
-            .with_for_update(of=Payout)
-        )
-        return await self.get_one_or_none(statement)
-
     async def count_pending_by_payout_account(self, payout_account_id: UUID) -> int:
         statement = self.get_base_statement().where(
             Payout.payout_account_id == payout_account_id,

--- a/server/polar/payout/tasks.py
+++ b/server/polar/payout/tasks.py
@@ -46,8 +46,8 @@ async def payout_transfer(payout_id: uuid.UUID) -> None:
         # (deny/block/backoffice) and would otherwise pay out a payout the ledger
         # already reversed. FOR UPDATE serializes with cancel(), which locks the
         # same row.
-        payout = await repository.get_by_id_for_update(
-            payout_id, options=repository.get_eager_options()
+        payout = await repository.get_by_id(
+            payout_id, options=repository.get_eager_options(), for_update=True
         )
         if payout is None:
             raise PayoutDoesNotExist(payout_id)

--- a/server/polar/user/service.py
+++ b/server/polar/user/service.py
@@ -142,6 +142,11 @@ class UserService:
     async def create_identity_verification(
         self, session: AsyncSession, user: User
     ) -> UserIdentityVerification:
+        repository = UserRepository.from_session(session)
+        user_update = await repository.get_by_id(user.id, for_update=True)
+        assert user_update is not None
+        user = user_update
+
         if user.identity_verified:
             raise IdentityAlreadyVerified(user.id)
 
@@ -162,7 +167,6 @@ class UserService:
                 user
             )
 
-        repository = UserRepository.from_session(session)
         await repository.update(
             user, update_dict={"identity_verification_id": verification_session.id}
         )

--- a/server/tests/checkout/test_repository.py
+++ b/server/tests/checkout/test_repository.py
@@ -4,11 +4,12 @@ import pytest
 
 from polar.checkout.repository import CheckoutRepository
 from polar.kit.utils import utc_now
-from polar.models import Product
+from polar.models import Organization, Product
 from polar.models.checkout import CheckoutStatus
+from polar.models.discount import DiscountDuration, DiscountType
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_checkout
+from tests.fixtures.random_objects import create_checkout, create_discount
 
 
 @pytest.mark.asyncio
@@ -54,3 +55,41 @@ class TestExpireOpenCheckouts:
         updated_successful_checkout = await repository.get_by_id(successful_checkout.id)
         assert updated_successful_checkout is not None
         assert updated_successful_checkout.status == CheckoutStatus.succeeded
+
+
+@pytest.mark.asyncio
+async def test_for_update_eager_loading(
+    save_fixture: SaveFixture,
+    session: AsyncSession,
+    product: Product,
+    organization: Organization,
+) -> None:
+    discount = await create_discount(
+        save_fixture,
+        type=DiscountType.percentage,
+        basis_points=5_000,
+        duration=DiscountDuration.once,
+        organization=organization,
+        code="TESTCODE",
+        products=[product],
+    )
+    checkout = await create_checkout(
+        save_fixture, products=[product], discount=discount
+    )
+    assert checkout.product is not None
+
+    repository = CheckoutRepository.from_session(session)
+
+    # Fetch the checkout with for_update and eager loading
+    fetched_checkout = await repository.get_by_client_secret(
+        checkout.client_secret, for_update=True, options=repository.get_eager_options()
+    )
+
+    assert fetched_checkout is not None
+    assert fetched_checkout.id == checkout.id
+    assert fetched_checkout.product is not None
+    assert fetched_checkout.product.attached_custom_fields == []
+    for product in fetched_checkout.products:
+        assert product.product_medias == []
+    assert fetched_checkout.discount is not None
+    assert fetched_checkout.discount.products == [product]

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -3103,7 +3103,7 @@ class TestUpdate:
             prices=[(4242, "usd")],
         )
         checkout_recurring_fixed.checkout_products.append(
-            CheckoutProduct(product=new_product, order=1)
+            CheckoutProduct(product=new_product, order=1, ad_hoc_prices=[])
         )
         await save_fixture(checkout_recurring_fixed)
 
@@ -3149,7 +3149,7 @@ class TestUpdate:
         )
 
         checkout_recurring_fixed.checkout_products.append(
-            CheckoutProduct(product=new_product, order=1)
+            CheckoutProduct(product=new_product, order=1, ad_hoc_prices=[])
         )
         checkout_recurring_fixed.discount = discount
         await save_fixture(checkout_recurring_fixed)
@@ -3193,7 +3193,7 @@ class TestUpdate:
         )
 
         checkout_recurring_fixed.checkout_products.append(
-            CheckoutProduct(product=new_product, order=1)
+            CheckoutProduct(product=new_product, order=1, ad_hoc_prices=[])
         )
         checkout_recurring_fixed.discount = discount
         await save_fixture(checkout_recurring_fixed)

--- a/server/tests/payout/test_repository.py
+++ b/server/tests/payout/test_repository.py
@@ -4,6 +4,7 @@ from polar.enums import PayoutAccountType
 from polar.kit.utils import utc_now
 from polar.models import Organization, User
 from polar.models.payout import PayoutStatus
+from polar.models.transaction import TransactionType
 from polar.payout.repository import PayoutRepository
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
@@ -12,6 +13,7 @@ from tests.fixtures.random_objects import (
     create_payout,
     create_payout_account,
 )
+from tests.transaction.conftest import create_transaction
 
 
 @pytest.mark.asyncio
@@ -112,3 +114,43 @@ class TestGetHeldCountsByAccounts:
 
         # Only the live held payout counts; the soft-deleted one is excluded.
         assert counts == {account.id: 1}
+
+
+@pytest.mark.asyncio
+class TestGetById:
+    async def test_for_update(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        # FOR UPDATE OF payouts must lock only the payout row so the eager-load
+        # joins (account, payout_account, transactions) don't trip the
+        # nullable-outer-join lock error. Exercises the real SQL on Postgres.
+        account = await create_account(save_fixture, user)
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        payout = await create_payout(
+            save_fixture, account=account, payout_account=payout_account
+        )
+        await create_transaction(
+            save_fixture,
+            account=account,
+            type=TransactionType.payout,
+            amount=-payout.amount,
+            account_currency=account.currency,
+            payout=payout,
+        )
+
+        repository = PayoutRepository.from_session(session)
+        locked = await repository.get_by_id(
+            payout.id, options=repository.get_eager_options(), for_update=True
+        )
+
+        assert locked is not None
+        assert locked.id == payout.id
+        # Relationships resolve without a lazy load, confirming eager loading.
+        assert locked.account.id == account.id
+        assert locked.payout_account.id == payout_account.id

--- a/server/tests/payout/test_service.py
+++ b/server/tests/payout/test_service.py
@@ -601,46 +601,6 @@ class TestTriggerStripePayouts:
 
 
 @pytest.mark.asyncio
-class TestGetByIdForUpdate:
-    async def test_locks_and_eager_loads(
-        self,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        organization: Organization,
-        user: User,
-    ) -> None:
-        # FOR UPDATE OF payouts must lock only the payout row so the eager-load
-        # joins (account, payout_account, transactions) don't trip the
-        # nullable-outer-join lock error. Exercises the real SQL on Postgres.
-        account = await create_account(save_fixture, user)
-        payout_account = await create_payout_account(
-            save_fixture, organization, user, type=PayoutAccountType.stripe
-        )
-        payout = await create_payout(
-            save_fixture, account=account, payout_account=payout_account
-        )
-        await create_transaction(
-            save_fixture,
-            account=account,
-            type=TransactionType.payout,
-            amount=-payout.amount,
-            account_currency=account.currency,
-            payout=payout,
-        )
-
-        repository = PayoutRepository.from_session(session)
-        locked = await repository.get_by_id_for_update(
-            payout.id, options=repository.get_eager_options()
-        )
-
-        assert locked is not None
-        assert locked.id == payout.id
-        # Relationships resolve without a lazy load, confirming eager loading.
-        assert locked.account.id == account.id
-        assert locked.payout_account.id == payout_account.id
-
-
-@pytest.mark.asyncio
 class TestTransferStripe:
     @pytest.mark.parametrize(
         "status",


### PR DESCRIPTION
- server/user: lock user when generating an identity verification to prevent TOCTOU
- server: add for_update capabilities to base repository

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

