### PR TITLE
feat(worker): add DB-less broker entrypoint for DB-free queues

### DIFF
--- a/server/polar/worker/_broker.py
+++ b/server/polar/worker/_broker.py
@@ -175,7 +175,7 @@ class LogfireMiddleware(dramatiq.Middleware):
         return self.after_process_message(broker, message)
 
 
-def get_broker() -> dramatiq.Broker:
+def get_broker(*, database: bool = True) -> dramatiq.Broker:
     redis_pool = redis.ConnectionPool.from_url(
         settings.redis_url,
         client_name=f"{settings.ENV.value}.worker.dramatiq",
@@ -193,7 +193,7 @@ def get_broker() -> dramatiq.Broker:
         # Group completion callbacks for orchestrating task sequences
         GroupCallbacks(rate_limiter_backend),
         # Resource lifecycle (worker boot/shutdown)
-        SQLAlchemyMiddleware(),
+        *([SQLAlchemyMiddleware()] if database else []),
         RedisMiddleware(),
         HTTPXMiddleware(),
         HealthMiddleware(),

--- a/server/polar/worker/run_without_db.py
+++ b/server/polar/worker/run_without_db.py
@@ -1,0 +1,26 @@
+import dramatiq
+
+from polar.worker._broker import get_broker
+from polar.worker._encoder import JSONEncoder
+
+# Entrypoint for workers whose queues never touch PostgreSQL. Building the broker
+# without the SQLAlchemy middleware avoids creating a database engine/pool the
+# worker would never use. The broker must be set as the global broker before
+# `polar.tasks` is imported, so actors are declared against it rather than the
+# default (database-backed) broker created by `polar.worker`.
+broker = get_broker(database=False)
+dramatiq.set_broker(broker)
+dramatiq.set_encoder(JSONEncoder(broker))
+
+from polar import tasks  # noqa: E402
+from polar.logfire import configure_logfire  # noqa: E402
+from polar.logging import configure as configure_logging  # noqa: E402
+from polar.posthog import configure_posthog  # noqa: E402
+from polar.sentry import configure_sentry  # noqa: E402
+
+configure_sentry()
+configure_logfire("worker")
+configure_logging(logfire=True)
+configure_posthog()
+
+__all__ = ["broker", "tasks"]


### PR DESCRIPTION
## Summary

Add a worker runner explicitly not setting up any db connections, not even a lazy connection pool.
A follow-up PR will put it to use for tinybird workers.

This is a follow-up to the failed #12503 which broke because it's apparently not possible to ship the updated command in terraform in the same deployment