### PR TITLE
chore(terraform): run tinybird workers on the DB-less entrypoint [blocked on #12547]

### DIFF
--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -195,11 +195,11 @@ module "production" {
       dramatiq_prom_port = "10001"
       database_pool_size = "16"
     }
-    "worker-tinybird" = {
-      start_command      = "uv run dramatiq polar.worker.run -p 4 -t 32 --queues tinybird"
+    worker-tinybird = {
+      start_command      = "uv run dramatiq polar.worker.run_without_db -p 4 -t 32 --queues tinybird"
       dramatiq_prom_port = "10002"
     }
-    "worker-invoices-receipts" = {
+    worker-invoices-receipts = {
       start_command      = "uv run dramatiq polar.worker.run -p 1 -t 3 --queues invoices_and_receipts"
       plan               = "standard"
       dramatiq_prom_port = "10003"

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -120,7 +120,7 @@ module "sandbox" {
       database_pool_size = "16"
     }
     worker-sandbox-tinybird = {
-      start_command      = "uv run dramatiq polar.worker.run -p 1 -t 16 --queues tinybird"
+      start_command      = "uv run dramatiq polar.worker.run_without_db -p 1 -t 16 --queues tinybird"
       dramatiq_prom_port = "10002"
     }
     worker-sandbox-invoices-receipts = {


### PR DESCRIPTION
## Summary

**This is PR 2 of 2 — do not merge until #12547 is merged AND deployed.**

Points the production and sandbox tinybird worker services at `polar.worker.run_without_db` (added in #12547) so they boot without a PostgreSQL engine/connection pool. Also drops the stray quotes on the `worker-tinybird` / `worker-invoices-receipts` map keys (review feedback).

## ⚠️ Merge ordering

The worker image (built from `main`) and the `start_command` (Terraform Cloud) deploy independently. This PR changes only `terraform/**`, so merging it triggers a Terraform apply that redeploys the tinybird worker with the new `start_command`. That command references `polar.worker.run_without_db`, which only exists once #12547 is deployed.

**Sequence:**
1. Merge #12547 → wait for the backend image to build and deploy (the entrypoint is now in the running image).
2. Then merge this PR → Terraform flips the `start_command`; the redeploy lands on an image that already contains the module.

Merging this before #12547 is deployed reproduces the `ModuleNotFoundError` that broke the original combined PR (#12503).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

