### PR TITLE
fix(case): polymorphic load inline

### DIFF
--- a/server/polar/models/support_case.py
+++ b/server/polar/models/support_case.py
@@ -157,7 +157,10 @@ class SupportCase(RecordModel):
 class ReviewAppealSupportCase(SupportCase):
     """A support case handling an organization review appeal."""
 
-    __mapper_args__ = {"polymorphic_identity": SupportCaseType.review_appeal}
+    __mapper_args__ = {
+        "polymorphic_identity": SupportCaseType.review_appeal,
+        "polymorphic_load": "inline",
+    }
 
     organization_review_id: Mapped[UUID] = mapped_column(
         Uuid,
@@ -183,7 +186,10 @@ Index(
 class DisputeSupportCase(SupportCase):
     """A support case handling a payment dispute (chargeback)."""
 
-    __mapper_args__ = {"polymorphic_identity": SupportCaseType.dispute}
+    __mapper_args__ = {
+        "polymorphic_identity": SupportCaseType.dispute,
+        "polymorphic_load": "inline",
+    }
 
     dispute_id: Mapped[UUID] = mapped_column(
         Uuid,

--- a/server/tests/support_case/test_repository.py
+++ b/server/tests/support_case/test_repository.py
@@ -1,0 +1,88 @@
+"""Loading a polymorphic support case through the base-class repository must
+populate the concrete subclass's own columns inline. Otherwise reading them
+emits a second, lazy query — which fails under async as a greenlet IO error.
+"""
+
+import pytest
+
+from polar.models import Customer, Organization, OrganizationReview, Product
+from polar.models.support_case import (
+    DisputeSupportCase,
+    ReviewAppealSupportCase,
+)
+from polar.postgres import AsyncSession
+from polar.support_case.repository import SupportCaseRepository
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import (
+    create_dispute,
+    create_order,
+    create_payment,
+)
+
+
+async def _dispute_case(
+    save_fixture: SaveFixture,
+    organization: Organization,
+    customer: Customer,
+    product: Product,
+) -> DisputeSupportCase:
+    order = await create_order(save_fixture, customer=customer, product=product)
+    payment = await create_payment(save_fixture, organization, order=order)
+    dispute = await create_dispute(save_fixture, order, payment)
+    case = DisputeSupportCase(dispute=dispute, organization=organization)
+    await save_fixture(case)
+    return case
+
+
+async def _appeal_case(
+    save_fixture: SaveFixture, organization: Organization
+) -> ReviewAppealSupportCase:
+    review = OrganizationReview(
+        organization_id=organization.id,
+        verdict=OrganizationReview.Verdict.FAIL,
+        risk_score=90.0,
+        violated_sections=[],
+        reason="denied",
+        model_used="test",
+    )
+    await save_fixture(review)
+    case = ReviewAppealSupportCase(
+        organization_review=review, organization=organization
+    )
+    await save_fixture(case)
+    return case
+
+
+@pytest.mark.asyncio
+class TestGetById:
+    async def test_loads_dispute_subclass_column(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        case = await _dispute_case(save_fixture, organization, customer, product)
+        dispute_id = case.dispute_id
+        session.expunge_all()
+
+        loaded = await SupportCaseRepository.from_session(session).get_by_id(case.id)
+
+        assert isinstance(loaded, DisputeSupportCase)
+        assert loaded.dispute_id == dispute_id
+
+    async def test_loads_appeal_subclass_column(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        case = await _appeal_case(save_fixture, organization)
+        organization_review_id = case.organization_review_id
+        session.expunge_all()
+
+        loaded = await SupportCaseRepository.from_session(session).get_by_id(case.id)
+
+        assert isinstance(loaded, ReviewAppealSupportCase)
+        assert loaded.organization_review_id == organization_review_id


### PR DESCRIPTION
## Summary

Fix [sentry#7567199765](https://polar-sh.sentry.io/issues/7567199765/?alert_rule_id=16426328&alert_type=issue&notification_uuid=36974a01-81a7-41a5-be48-48ec51bb0da2&project=-1&referrer=slack)



## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eager-load subclass columns for polymorphic support cases to prevent async lazy-load errors (greenlet IO). Fixes Sentry issue 7567199765.

- **Bug Fixes**
  - Set `polymorphic_load="inline"` on `ReviewAppealSupportCase` and `DisputeSupportCase` so subclass columns load with the base query.
  - Added tests (`server/tests/support_case/test_repository.py`) to verify `SupportCaseRepository.get_by_id` returns the correct subclass with populated fields.

<sup>Written for commit 212eb557ee9a369f0ccf2ff92e97d5acabac4afd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

