### PR TITLE
feat: default organization-review website scraper to Firecrawl

### DIFF
--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -244,7 +244,7 @@ class Settings(BaseSettings):
     # uses Firecrawl Cloud, and "shadow" runs Firecrawl alongside Playwright to
     # log a comparison while still using Playwright's result for the live verdict.
     ORGANIZATION_REVIEW_SCRAPER: Literal["playwright", "firecrawl", "shadow"] = (
-        "playwright"
+        "firecrawl"
     )
 
     # Stripe

--- a/server/tests/organization_review/collectors/test_setup.py
+++ b/server/tests/organization_review/collectors/test_setup.py
@@ -583,7 +583,27 @@ class TestResolveRedirectWithBrowserDispatch:
     """The redirect resolver dispatches to the configured scraper."""
 
     @pytest.mark.asyncio
-    async def test_defaults_to_playwright(self, mocker: MockerFixture) -> None:
+    async def test_defaults_to_firecrawl(self, mocker: MockerFixture) -> None:
+        firecrawl = mocker.patch(
+            "polar.organization_review.collectors.setup._resolve_redirect_firecrawl",
+            new_callable=AsyncMock,
+            return_value=UrlRedirectInfo(original_url="https://example.com/"),
+        )
+        playwright = mocker.patch(
+            "polar.organization_review.collectors.setup._resolve_redirect_playwright",
+            new_callable=AsyncMock,
+        )
+
+        await _resolve_redirect_with_browser("https://example.com/")
+
+        firecrawl.assert_called_once_with("https://example.com/")
+        playwright.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_playwright_toggle_uses_playwright(
+        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings, "ORGANIZATION_REVIEW_SCRAPER", "playwright")
         playwright = mocker.patch(
             "polar.organization_review.collectors.setup._resolve_redirect_playwright",
             new_callable=AsyncMock,

--- a/server/tests/organization_review/collectors/test_website.py
+++ b/server/tests/organization_review/collectors/test_website.py
@@ -631,6 +631,10 @@ class TestFetchPageSSRF:
 
 
 class TestBrowsePageSSRF:
+    @pytest.fixture(autouse=True)
+    def _use_playwright(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings, "ORGANIZATION_REVIEW_SCRAPER", "playwright")
+
     @pytest.mark.asyncio
     async def test_blocks_initial_ssrf(self) -> None:
         """browse_page should block a URL that resolves to a private IP."""


### PR DESCRIPTION
## Summary

Make Firecrawl Cloud the default backend for JS rendering.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

