### PR TITLE
polar: mirror org owners/admins as billing_manager members

### DIFF
--- a/server/polar/integrations/polar/client.py
+++ b/server/polar/integrations/polar/client.py
@@ -48,6 +48,7 @@ from polar_sdk.models import (
     SubscriptionProrationBehavior,
     SubscriptionUpdateBase,
 )
+from polar_sdk.models.membercreate import Role as MemberCreateRole
 from polar_sdk.models.polarerror import PolarError
 
 from polar.config import settings
@@ -432,12 +433,19 @@ class PolarSelfClient:
             return contacts
 
     async def add_member(
-        self, *, customer_id: str, email: str, name: str, external_id: str
+        self,
+        *,
+        customer_id: str,
+        email: str,
+        name: str,
+        external_id: str,
+        role: str = MemberCreateRole.MEMBER.value,
     ) -> None:
         with logfire.span(
             "polar.add_member",
             customer_id=customer_id,
             external_id=external_id,
+            role=role,
         ) as span:
             try:
                 await self._sdk.members.create_member_async(
@@ -446,6 +454,7 @@ class PolarSelfClient:
                         email=email,
                         name=name,
                         external_id=external_id,
+                        role=MemberCreateRole(role),
                     )
                 )
             except PolarError as e:

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -27,7 +27,9 @@ from polar.email.schemas import (
 )
 from polar.email.sender import Attachment, enqueue_email_template
 from polar.integrations.plain.service import plain as plain_service
+from polar.models.member import MemberRole
 from polar.models.organization import SupportTier
+from polar.models.user_organization import OrganizationRole
 from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncReadSession, AsyncSession
 from polar.startup_program.service import (
@@ -79,6 +81,12 @@ BenefitGrantWebhookPayload = (
 )
 
 
+def billing_member_role(organization_role: OrganizationRole) -> MemberRole:
+    if organization_role in (OrganizationRole.owner, OrganizationRole.admin):
+        return MemberRole.billing_manager
+    return MemberRole.member
+
+
 class PolarSelfService:
     INITIAL_MEMBER_DELAY_MS = 1000
 
@@ -122,6 +130,7 @@ class PolarSelfService:
         email: str,
         name: str,
         external_id: str,
+        role: MemberRole = MemberRole.member,
         delay: int | None = None,
     ) -> None:
         if not self.is_configured:
@@ -133,6 +142,7 @@ class PolarSelfService:
             email=email,
             name=name,
             external_id=external_id,
+            role=role.value,
         )
 
     def enqueue_update_member(

--- a/server/polar/integrations/polar/tasks.py
+++ b/server/polar/integrations/polar/tasks.py
@@ -18,6 +18,7 @@ from polar.integrations.plain.service import plain as plain_service
 from polar.integrations.tinybird.service import count_user_events_by_organization
 from polar.kit.utils import utc_now
 from polar.models.external_event import ExternalEventSource
+from polar.models.member import MemberRole
 from polar.worker import (
     AsyncSessionMaker,
     CronTrigger,
@@ -66,7 +67,11 @@ async def create_customer(
 
 @actor(actor_name="polar_self.add_member", priority=TaskPriority.LOW)
 async def add_member(
-    external_customer_id: str, email: str, name: str, external_id: str
+    external_customer_id: str,
+    email: str,
+    name: str,
+    external_id: str,
+    role: str = MemberRole.member.value,
 ) -> None:
     from polar_sdk.models.polarerror import PolarError
 
@@ -83,6 +88,7 @@ async def add_member(
         email=email,
         name=name,
         external_id=external_id,
+        role=role,
     )
     await plain_service.upsert_customer(
         external_id=external_id,

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -24,6 +24,7 @@ from polar.exceptions import (
     PolarRequestValidationError,
     ValidationError,
 )
+from polar.integrations.polar.service import billing_member_role
 from polar.integrations.polar.service import polar_self as polar_self_service
 from polar.kit.anonymization import anonymize_email_for_deletion, anonymize_for_deletion
 from polar.kit.currency import PresentmentCurrency
@@ -884,6 +885,7 @@ class OrganizationService:
                     email=user.email,
                     name=user.full_name or user.email.split("@", 1)[0],
                     external_id=str(user.id),
+                    role=billing_member_role(role),
                     delay=polar_self_member_delay,
                 )
 

--- a/server/scripts/backfill_polar_self_member_roles.py
+++ b/server/scripts/backfill_polar_self_member_roles.py
@@ -1,0 +1,85 @@
+import uuid
+
+import typer
+from sqlalchemy import Select, String, and_, cast, select, update
+
+from polar.config import settings
+from polar.kit.db.postgres import create_async_sessionmaker
+from polar.models import Customer, UserOrganization
+from polar.models.member import Member, MemberRole
+from polar.models.user_organization import OrganizationRole
+from polar.postgres import AsyncSession, create_async_engine
+
+from .helper import configure_script_logging, typer_async
+
+cli = typer.Typer()
+
+
+def _members_to_upgrade_statement(self_org_id: uuid.UUID) -> Select[tuple[uuid.UUID]]:
+    return (
+        select(Member.id)
+        .join(Customer, Member.customer_id == Customer.id)
+        .join(
+            UserOrganization,
+            and_(
+                cast(UserOrganization.organization_id, String) == Customer.external_id,
+                cast(UserOrganization.user_id, String) == Member.external_id,
+            ),
+        )
+        .where(
+            Customer.organization_id == self_org_id,
+            Customer.deleted_at.is_(None),
+            Member.deleted_at.is_(None),
+            Member.external_id.is_not(None),
+            Member.role == MemberRole.member,
+            UserOrganization.deleted_at.is_(None),
+            UserOrganization.role.in_([OrganizationRole.owner, OrganizationRole.admin]),
+        )
+    )
+
+
+async def run_backfill(*, session: AsyncSession, dry_run: bool) -> int:
+    self_org_id = uuid.UUID(settings.POLAR_ORGANIZATION_ID)
+    statement = _members_to_upgrade_statement(self_org_id)
+    member_ids = [row[0] for row in (await session.execute(statement)).all()]
+
+    if member_ids and not dry_run:
+        await session.execute(
+            update(Member)
+            .where(Member.id.in_(member_ids))
+            .values(role=MemberRole.billing_manager)
+        )
+        await session.commit()
+
+    return len(member_ids)
+
+
+@cli.command()
+@typer_async
+async def backfill(
+    dry_run: bool = typer.Option(
+        True, help="Print what would be done without writing changes"
+    ),
+) -> None:
+    """Upgrade mirrored Polar self members for org owners/admins to billing_manager."""
+    configure_script_logging()
+
+    if not settings.POLAR_ORGANIZATION_ID:
+        typer.echo("POLAR_ORGANIZATION_ID is not configured, aborting.")
+        raise typer.Exit(1)
+
+    engine = create_async_engine("script")
+    sessionmaker = create_async_sessionmaker(engine)
+
+    try:
+        async with sessionmaker() as session:
+            count = await run_backfill(session=session, dry_run=dry_run)
+
+        verb = "Would upgrade" if dry_run else "Upgraded"
+        typer.echo(f"{verb} {count} members to billing_manager")
+    finally:
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/tests/integrations/polar/test_tasks.py
+++ b/server/tests/integrations/polar/test_tasks.py
@@ -118,6 +118,7 @@ class TestAddMember:
             email="user@example.com",
             name="User Example",
             external_id="user-123",
+            role="member",
         )
         plain_service_mock.add_customer_to_tenant.assert_awaited_once_with(
             customer_external_id="user-123",

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -21,6 +21,7 @@ from polar.kit.http import UrlReachability
 from polar.models import Customer, Organization, Product, User, UserOrganization
 from polar.models.account import Account
 from polar.models.benefit import BenefitType
+from polar.models.member import MemberRole
 from polar.models.organization import (
     STATUS_CAPABILITIES,
     InvalidStatusTransitionError,
@@ -4503,3 +4504,40 @@ class TestChangeOwnerRoleSwap:
         assert new is not None
         assert previous.role == OrganizationRole.member
         assert new.role == OrganizationRole.owner
+
+
+@pytest.mark.asyncio
+class TestAddUser:
+    @pytest.mark.parametrize(
+        ("organization_role", "expected_member_role"),
+        [
+            (OrganizationRole.owner, MemberRole.billing_manager),
+            (OrganizationRole.admin, MemberRole.billing_manager),
+            (OrganizationRole.member, MemberRole.member),
+        ],
+    )
+    async def test_mirrors_org_role_to_polar_self_member_role(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+        organization_role: OrganizationRole,
+        expected_member_role: MemberRole,
+    ) -> None:
+        add_member_mock = mocker.patch(
+            "polar.organization.service.polar_self_service.enqueue_add_member"
+        )
+
+        await organization_service.add_user(
+            session, organization, user, role=organization_role
+        )
+
+        add_member_mock.assert_called_once_with(
+            external_customer_id=str(organization.id),
+            email=user.email,
+            name=user.full_name or user.email.split("@", 1)[0],
+            external_id=str(user.id),
+            role=expected_member_role,
+            delay=None,
+        )


### PR DESCRIPTION
Org owners and admins hold `organization:manage` and may edit billing details, but they were mirrored into the Polar billing customer as plain `member`s. The customer portal billing authorizer only allows `owner` and `billing_manager` members, so any non-creator owner/admin hit a 403 when updating billing details, payment methods, etc. Only the org creator worked, since they become the team `owner` member.

Map the organization role to the mirrored member role on member creation (owner/admin -> billing_manager, member -> member) and add a backfill script to upgrade existing affected members. The team `owner` member keeps its role.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

