### PR TITLE
fix(dashboard): avoid ?query=null on View Customer link when email is missing

### DIFF
--- a/clients/apps/web/src/components/Customer/CustomerContextView.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerContextView.tsx
@@ -2,6 +2,7 @@
 
 import { StatisticCard } from '@/components/Shared/StatisticCard'
 import { useMetrics } from '@/hooks/queries/metrics'
+import { buildCustomerDashboardPath } from '@/utils/customer'
 import { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
 import { Avatar } from '@polar-sh/orbit'
@@ -75,7 +76,7 @@ export const CustomerContextView = ({
           </StatisticCard>
         </div>
         <Link
-          href={`/dashboard/${organization.slug}/customers/${customer.id}?query=${customer.email}`}
+          href={buildCustomerDashboardPath(organization.slug, customer)}
           className="flex flex-row items-center gap-4"
         >
           <Button className="w-full" size="lg" variant="secondary">

--- a/clients/apps/web/src/components/Events/EventCustomer.tsx
+++ b/clients/apps/web/src/components/Events/EventCustomer.tsx
@@ -1,5 +1,6 @@
 import { OrganizationContext } from '@/providers/maintainerOrganization'
 import { getAnonymousCustomerName } from '@/utils/anonymous-customer'
+import { buildCustomerDashboardPath } from '@/utils/customer'
 import { schemas } from '@polar-sh/client'
 import { Avatar } from '@polar-sh/orbit'
 import { Button } from '@polar-sh/orbit'
@@ -111,7 +112,10 @@ export const EventCustomer = ({ event }: { event: schemas['Event'] }) => {
           </div>
           <div className="">
             <Link
-              href={`/dashboard/${organization.slug}/customers/${event.customer.id}?query=${event.customer.email}`}
+              href={buildCustomerDashboardPath(
+                organization.slug,
+                event.customer,
+              )}
             >
               <Button fullWidth variant="secondary" size="sm">
                 View Customer

--- a/clients/apps/web/src/components/Events/EventRow.tsx
+++ b/clients/apps/web/src/components/Events/EventRow.tsx
@@ -1,4 +1,5 @@
 import { useInfiniteEvents } from '@/hooks/queries/events'
+import { buildCustomerDashboardPath } from '@/utils/customer'
 import KeyboardArrowDownOutlined from '@mui/icons-material/KeyboardArrowDownOutlined'
 import KeyboardArrowRightOutlined from '@mui/icons-material/KeyboardArrowRightOutlined'
 import { schemas } from '@polar-sh/client'
@@ -178,7 +179,10 @@ export const EventRow = ({
               <Tooltip>
                 <TooltipTrigger>
                   <Link
-                    href={`/dashboard/${organization.slug}/customers/${event.customer?.id}?query=${event.customer?.email}`}
+                    href={buildCustomerDashboardPath(
+                      organization.slug,
+                      event.customer,
+                    )}
                     className="flex items-center gap-x-3"
                     onClick={(e) => {
                       e.stopPropagation()

--- a/clients/apps/web/src/utils/customer.ts
+++ b/clients/apps/web/src/utils/customer.ts
@@ -1,0 +1,8 @@
+export const buildCustomerDashboardPath = (
+  organizationSlug: string,
+  customer: { id: string; email?: string | null; name?: string | null },
+): string => {
+  const search = customer.email ?? customer.name
+  const params = search ? `?${new URLSearchParams({ query: search })}` : ''
+  return `/dashboard/${organizationSlug}/customers/${customer.id}${params}`
+}


### PR DESCRIPTION
## Summary
Fixes "View Customer" links that appended ?query=null when a customer had no email. Template literals turn null into the string "null", which filled the customer sidebar search incorrectly.

Added a util function to build customer dashboard URLs and only include a query param when the customer has an email or name, so that the query is based on the name instead of email when no email exists. Updates code in three places with the broken pattern: CustomerContextView, EventCustomer, and EventRow.

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [X] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [X] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [X] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [X] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

