### PR TITLE
Resolve tax behavior when changing subscription product

### DIFF
--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -34,6 +34,7 @@ from polar.enums import (
     SubscriptionProrationBehavior,
     SubscriptionRecurringInterval,
     TaxBehavior,
+    TaxBehaviorOption,
 )
 from polar.event.service import event as event_service
 from polar.event.system import (
@@ -101,7 +102,10 @@ from polar.product.guard import (
 from polar.product.price_set import NoPricesForCurrencies, PriceSet
 from polar.product.repository import ProductRepository
 from polar.product.service import product as product_service
-from polar.tax.calculation import TaxCalculationLogicalError
+from polar.tax.calculation import (
+    TaxCalculationLogicalError,
+    get_tax_behavior_from_option,
+)
 from polar.tax.calculation import tax_calculation as tax_calculation_service
 from polar.webhook.service import webhook as webhook_service
 from polar.worker import enqueue_job, make_bulk_job_delay_calculator
@@ -226,6 +230,43 @@ def _from_timestamp(t: int | None) -> datetime | None:
     if t is None:
         return None
     return datetime.fromtimestamp(t, UTC)
+
+
+def resolve_subscription_tax_behavior(
+    subscription: Subscription,
+) -> TaxBehavior | None:
+    """Resolve the tax behavior for a subscription from its current product.
+
+    The tax behavior is stored on the subscription so it stays consistent across
+    organization-default and product-config changes. When the product itself
+    changes, though, it must be recomputed from the new product's price (falling
+    back to the organization default), mirroring what the checkout does. Otherwise
+    a cross-tax_behavior product change keeps a stale behavior and the recurring
+    tax is computed wrong.
+
+    Requires `subscription.prices`, `subscription.customer` and
+    `subscription.organization` to be loaded.
+    """
+    tax_behavior_option = subscription.organization.default_tax_behavior
+    # All prices share the same tax behavior for a given currency, so the first
+    # explicitly set one wins; a missing one falls back to the organization default.
+    for price in subscription.prices:
+        if price.tax_behavior is not None:
+            tax_behavior_option = price.tax_behavior
+            break
+
+    billing_address = subscription.customer.billing_address
+    if billing_address is not None:
+        return get_tax_behavior_from_option(tax_behavior_option, billing_address)
+
+    # Without a billing address, location-based resolution can't run, so we defer
+    # it to order time (where it falls back to the organization default). Explicit
+    # behaviors don't depend on the address and can be resolved right away.
+    if tax_behavior_option == TaxBehaviorOption.inclusive:
+        return TaxBehavior.inclusive
+    if tax_behavior_option == TaxBehaviorOption.exclusive:
+        return TaxBehavior.exclusive
+    return None
 
 
 class SubscriptionUpdateContext:
@@ -790,6 +831,12 @@ class SubscriptionService:
                 # Check before apply_update() changes subscription.product
                 pending_update_changed_interval = pending_update.is_interval_changed()
                 pending_update.apply_update()
+                if pending_update.product_id is not None:
+                    # The product changed, so recompute the stored tax behavior from
+                    # the new product; keeping a stale one would tax this new cycle wrong.
+                    subscription.tax_behavior = resolve_subscription_tax_behavior(
+                        subscription
+                    )
                 subscription_update_repository = (
                     SubscriptionUpdateRepository.from_session(session)
                 )
@@ -1300,6 +1347,11 @@ class SubscriptionService:
 
                 interval_changed = subscription_update.is_interval_changed()
                 subscription = subscription_update.apply_update()
+                # The product changed, so recompute the stored tax behavior from
+                # the new product to avoid charging recurring tax with a stale one.
+                subscription.tax_behavior = resolve_subscription_tax_behavior(
+                    subscription
+                )
                 if was_trialing:
                     if ends_trial:
                         # End the trial immediately - cycle() below will transition
@@ -1935,6 +1987,12 @@ class SubscriptionService:
             else:
                 pending_update.discount = None
             pending_update.apply_update()
+            if pending_update.product_id is not None:
+                # The product changed, so recompute the stored tax behavior from
+                # the new product to preview the recurring tax correctly.
+                subscription.tax_behavior = resolve_subscription_tax_behavior(
+                    subscription
+                )
 
         # If subscription is set to cancel at period end, there's no base charge
         # Only metered charges accumulated during the period will be billed

--- a/server/polar/tax/calculation/__init__.py
+++ b/server/polar/tax/calculation/__init__.py
@@ -216,5 +216,6 @@ __all__ = [
     "TaxCode",
     "TaxRevertError",
     "TaxabilityReason",
+    "get_tax_behavior_from_option",
     "tax_calculation",
 ]

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -23,6 +23,7 @@ from polar.enums import (
     SubscriptionProrationBehavior,
     SubscriptionRecurringInterval,
     TaxBehavior,
+    TaxBehaviorOption,
 )
 from polar.event.repository import EventRepository
 from polar.event.system import SystemEvent
@@ -31,6 +32,7 @@ from polar.exceptions import (
     PolarRequestValidationError,
     ResourceUnavailable,
 )
+from polar.kit.address import Address, CountryAlpha2
 from polar.kit.currency import PresentmentCurrency
 from polar.kit.pagination import PaginationParams
 from polar.kit.trial import TrialInterval
@@ -1686,6 +1688,63 @@ class TestCycle:
         )
         assert updated_subscription_update is not None
         assert updated_subscription_update.applied_at is not None
+
+    async def test_pending_update_product_updates_tax_behavior(
+        self,
+        session: AsyncSession,
+        enqueue_job_mock: MagicMock,
+        enqueue_email_mock: MagicMock,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        customer.billing_address = Address(country=CountryAlpha2("FR"))
+        await save_fixture(customer)
+
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+        )
+        product.prices[0].tax_behavior = TaxBehaviorOption.exclusive
+        await save_fixture(product.prices[0])
+
+        new_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+        )
+        new_product.prices[0].tax_behavior = TaxBehaviorOption.inclusive
+        await save_fixture(new_product.prices[0])
+
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            tax_behavior=TaxBehavior.exclusive,
+            scheduler_locked_at=utc_now(),
+        )
+        subscription_update, _ = generate_subscription_update(
+            subscription,
+            SubscriptionProrationBehavior.next_period,
+            product=new_product,
+        )
+        await save_fixture(subscription_update)
+        subscription.pending_update = subscription_update
+        await save_fixture(subscription)
+
+        # The scheduled change hasn't been applied yet.
+        assert subscription.tax_behavior == TaxBehavior.exclusive
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.cycle(
+                session, ctx, subscription
+            )
+
+        assert updated_subscription.product == new_product
+        assert updated_subscription.tax_behavior == TaxBehavior.inclusive
 
     async def test_pending_update_seats(
         self,
@@ -4198,6 +4257,135 @@ class TestUpdateProduct:
             and "next_period" in error["msg"]
             for error in errors
         )
+
+    async def test_cross_tax_behavior_product_change_updates_tax_behavior(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        customer.billing_address = Address(country=CountryAlpha2("FR"))
+        await save_fixture(customer)
+
+        product.prices[0].tax_behavior = TaxBehaviorOption.exclusive
+        await save_fixture(product.prices[0])
+
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            tax_behavior=TaxBehavior.exclusive,
+        )
+
+        new_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+        )
+        new_product.prices[0].tax_behavior = TaxBehaviorOption.inclusive
+        await save_fixture(new_product.prices[0])
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=new_product.id,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
+
+        assert updated.product == new_product
+        assert updated.tax_behavior == TaxBehavior.inclusive
+
+    async def test_cross_tax_behavior_product_change_inclusive_to_exclusive(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        customer.billing_address = Address(country=CountryAlpha2("FR"))
+        await save_fixture(customer)
+
+        product.prices[0].tax_behavior = TaxBehaviorOption.inclusive
+        await save_fixture(product.prices[0])
+
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            tax_behavior=TaxBehavior.inclusive,
+        )
+
+        new_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+        )
+        new_product.prices[0].tax_behavior = TaxBehaviorOption.exclusive
+        await save_fixture(new_product.prices[0])
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=new_product.id,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
+
+        assert updated.product == new_product
+        assert updated.tax_behavior == TaxBehavior.exclusive
+
+    async def test_product_change_resolves_location_based_tax_behavior(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        # The organization default is location-based and the products don't
+        # override it, so the behavior must be resolved from the billing address.
+        assert organization.default_tax_behavior == TaxBehaviorOption.location
+        customer.billing_address = Address(country=CountryAlpha2("US"))
+        await save_fixture(customer)
+
+        # Stale behavior, as if it had been resolved under a tax-inclusive address.
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            tax_behavior=TaxBehavior.inclusive,
+        )
+
+        new_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+        )
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=new_product.id,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
+
+        assert updated.product == new_product
+        # The US is a tax-exclusive country, so location resolves to exclusive.
+        assert updated.tax_behavior == TaxBehavior.exclusive
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

**Related Issue**: <!-- issue number -->

When a subscription's product changes, the stored tax behavior must be recomputed from the new product's price configuration to ensure recurring charges are calculated correctly. Previously, the tax behavior remained stale after a product change, causing incorrect tax calculations.

## What

- Added `resolve_subscription_tax_behavior()` function to compute the correct tax behavior for a subscription based on its current product, organization defaults, and customer billing address
- Updated `cycle()` to recompute tax behavior when applying a pending product change
- Updated `update_product()` to recompute tax behavior after changing the product
- Updated `calculate_charge_preview()` to recompute tax behavior when previewing charges with a pending product change
- Exported `get_tax_behavior_from_option()` from tax calculation module for use in resolution logic
- Added comprehensive test coverage for tax behavior updates across product changes

## Why

When a subscription's product changes (either immediately or via a pending update), the new product may have different tax behavior configuration. The subscription's stored `tax_behavior` field must be updated to reflect this, otherwise:
1. Recurring charges are calculated with stale tax behavior
2. Charge previews show incorrect tax amounts
3. The behavior diverges from what the checkout would have set for a new subscription

This mirrors the checkout's behavior of resolving tax behavior from the product configuration at subscription creation time.

## How

The solution introduces a `resolve_subscription_tax_behavior()` function that:
1. Checks the new product's price for an explicit tax behavior override
2. Falls back to the organization's default tax behavior
3. Resolves location-based behavior using the customer's billing address (if available)
4. Returns the appropriate `TaxBehavior` enum value

This function is called in three places where product changes occur:
- When cycling and applying a pending product update
- When immediately updating the product
- When previewing charges with a pending product update

## Checklist

- [x] This PR addresses a single concern (fixing tax behavior staleness on product changes)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests (3 new test cases added)
- [x] No unrelated changes or drive-by fixes are included

https://claude.ai/code/session_01M26ovQDegfCrHLev22EErp

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12554?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

