### PR TITLE
Add git protection to OTA script

### DIFF
--- a/clients/apps/app/README.md
+++ b/clients/apps/app/README.md
@@ -79,6 +79,9 @@ Publish through `pnpm ota`, **not** raw `eas update`. It runs a preflight guard
 reach devices then forwards to `eas update` for you:
 
 ```bash
+# Make sure you are on the main branch first
+git checkout main
+
 # Test on preview first if it's a larger change
 pnpm ota --channel preview --message "Description of changes"
 

--- a/clients/apps/app/tooling/ota-preflight/index.js
+++ b/clients/apps/app/tooling/ota-preflight/index.js
@@ -23,6 +23,7 @@ const { diffFingerprints, stripPnpmPeerHashes } = require('./fingerprint-diff')
 const APP_DIR = path.resolve(__dirname, '../..')
 const PLATFORMS = ['ios', 'android']
 const OWN_FLAGS = new Set(['--check-only'])
+const OTA_BRANCH = 'main'
 
 const REASON_LABELS = {
   expoAutolinkingIos: 'native module (iOS autolinking)',
@@ -60,6 +61,39 @@ function readOption(argv, name) {
   }
   const inline = argv.find((arg) => arg.startsWith(`${name}=`))
   return inline ? inline.slice(name.length + 1) : undefined
+}
+
+function git(args) {
+  return execFileSync('git', args, {
+    cwd: APP_DIR,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+}
+
+function checkGitState() {
+  const branch = git(['rev-parse', '--abbrev-ref', 'HEAD'])
+  if (branch !== OTA_BRANCH) {
+    return (
+      `On branch "${branch}", but OTAs must ship from "${OTA_BRANCH}". ` +
+      `Switch branches before publishing.`
+    )
+  }
+
+  const dirty = git(['status', '--porcelain'])
+  if (dirty) {
+    const files = dirty
+      .split('\n')
+      .map((line) => `      ${line}`)
+      .join('\n')
+    return (
+      'Working tree has uncommitted changes — the OTA bundle is built from the ' +
+      'working tree, so commit or stash them to avoid shipping unintended code:\n' +
+      files
+    )
+  }
+
+  return undefined
 }
 
 function resolveRuntimeVersion() {
@@ -230,6 +264,17 @@ function main(argv) {
       (runtime ? `, runtime "${runtime}" (appVersion policy)` : '') +
       '\n',
   )
+
+  if (!checkOnly) {
+    const gitIssue = checkGitState()
+    if (gitIssue) {
+      console.error('──────────────────────────────────────────────')
+      console.error('OTA preflight blocked by git state:\n')
+      console.error(`  • ${gitIssue}\n`)
+      return 1
+    }
+    console.log(`   ${'git'.padEnd(8)} on ${OTA_BRANCH}, working tree clean`)
+  }
 
   const eas = createEasClient()
   const results = PLATFORMS.map((platform) =>


### PR DESCRIPTION
We can push OTA updates to our app from any branch, in whatever state. This means we can mistakenly push from a branch that is not on `main` and has a dirty diff. Meaning the code that is pushed hasn't been reviewed, or pushed by mistake.

This PR adds some guardrails in our OTA script:

* You have to be on the `main` branch to push an OTA
* Your local git diff must be clean, all changes need to be committed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

