### PR TITLE
refactor(backoffice): reorder org status tabs and unify terminal-state colors

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/list_view.py
+++ b/server/polar/backoffice/organizations_v2/views/list_view.py
@@ -390,6 +390,13 @@ class OrganizationListView:
                 ),
             ),
             Tab(
+                label="Active",
+                url=str(request.url_for("organizations:list")) + "?status=active",
+                active=status_filter == OrganizationStatus.ACTIVE,
+                count=status_counts.get(OrganizationStatus.ACTIVE, 0),
+                badge_variant="success",
+            ),
+            Tab(
                 label="Review",
                 url=str(request.url_for("organizations:list")) + "?status=review",
                 active=status_filter == OrganizationStatus.REVIEW,
@@ -404,11 +411,18 @@ class OrganizationListView:
                 badge_variant="warning",
             ),
             Tab(
-                label="Active",
-                url=str(request.url_for("organizations:list")) + "?status=active",
-                active=status_filter == OrganizationStatus.ACTIVE,
-                count=status_counts.get(OrganizationStatus.ACTIVE, 0),
-                badge_variant="success",
+                label="Offboarding",
+                url=str(request.url_for("organizations:list")) + "?status=offboarding",
+                active=status_filter == OrganizationStatus.OFFBOARDING,
+                count=status_counts.get(OrganizationStatus.OFFBOARDING, 0),
+                badge_variant="warning",
+            ),
+            Tab(
+                label="Offboarded",
+                url=str(request.url_for("organizations:list")) + "?status=offboarded",
+                active=status_filter == OrganizationStatus.OFFBOARDED,
+                count=status_counts.get(OrganizationStatus.OFFBOARDED, 0),
+                badge_variant="error",
             ),
             Tab(
                 label="Denied",
@@ -423,19 +437,6 @@ class OrganizationListView:
                 active=status_filter == OrganizationStatus.BLOCKED,
                 count=status_counts.get(OrganizationStatus.BLOCKED, 0),
                 badge_variant="error",
-            ),
-            Tab(
-                label="Offboarding",
-                url=str(request.url_for("organizations:list")) + "?status=offboarding",
-                active=status_filter == OrganizationStatus.OFFBOARDING,
-                count=status_counts.get(OrganizationStatus.OFFBOARDING, 0),
-                badge_variant="warning",
-            ),
-            Tab(
-                label="Offboarded",
-                url=str(request.url_for("organizations:list")) + "?status=offboarded",
-                active=status_filter == OrganizationStatus.OFFBOARDED,
-                count=status_counts.get(OrganizationStatus.OFFBOARDED, 0),
             ),
             # Pushed to the right — a separate dimension from the status tabs.
             Tab(


### PR DESCRIPTION
## Summary


- New tab order: **All · Active · Review · Snoozed · Offboarding · Offboarded · Denied · Blocked** … **Open cases**
- **Offboarded**, **Denied**, and **Blocked** now share the same `error` badge color


## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

