### PR TITLE
feat: add backoffice button to complete offboarding

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -8,6 +8,7 @@ This module provides a modern, three-column layout with:
 - Keyboard shortcuts and accessibility improvements
 """
 
+import math
 import uuid
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
@@ -2606,6 +2607,137 @@ async def offboard_dialog(
                         text("Cancel")
                 with button(variant="warning", type="submit"):
                     text("Set Offboarding")
+
+    return None
+
+
+@router.api_route(
+    "/{organization_id}/offboarded-dialog",
+    name="organizations:offboarded_dialog",
+    methods=["GET", "POST"],
+    response_model=None,
+    dependencies=[Depends(get_admin)],
+)
+async def offboarded_dialog(
+    request: Request,
+    organization_id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+) -> HXRedirectResponse | None:
+    """Manually complete offboarding: move the org to the terminal offboarded state."""
+    repository = OrganizationRepository(session)
+
+    organization = await repository.get_by_id(organization_id, include_blocked=True)
+    if not organization:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    if request.method == "POST":
+        try:
+            await organization_service.set_organization_offboarded(
+                session, organization
+            )
+        except OrganizationError as e:
+            await add_toast(request, e.message, "error")
+        else:
+            await add_toast(request, "Organization offboarded", "success")
+        return HXRedirectResponse(
+            request,
+            str(
+                request.url_for("organizations:detail", organization_id=organization_id)
+            ),
+            303,
+        )
+
+    # Surface how much of the wind-down period remains. The auto-offboard cron
+    # anchors on the later of the last paid order (chargeback risk) and the
+    # offboarding-entry date (merchant wind-down floor); mirror that here so the
+    # admin sees whether they're completing offboarding early.
+    now = datetime.now(UTC)
+    last_paid_order_at = await repository.get_last_paid_order_at(organization_id)
+    offboarding_since = organization.status_updated_at
+    anchors = [d for d in (last_paid_order_at, offboarding_since) if d is not None]
+    anchor = max(anchors) if anchors else None
+    completes_at = (
+        anchor + settings.ORGANIZATION_OFFBOARDING_PERIOD
+        if anchor is not None
+        else None
+    )
+    period_elapsed = completes_at is not None and now >= completes_at
+    remaining_days = (
+        math.ceil((completes_at - now) / timedelta(days=1))
+        if completes_at is not None and not period_elapsed
+        else None
+    )
+
+    def date_row(label: str, value: datetime | None) -> None:
+        with tag.div(classes="flex justify-between gap-4 text-sm"):
+            with tag.span(classes="text-base-content/70"):
+                text(label)
+            with tag.span(classes="font-medium"):
+                text(value.strftime("%Y-%m-%d") if value is not None else "—")
+
+    with modal("Complete Offboarding", open=True):
+        with tag.form(
+            hx_post=str(
+                request.url_for(
+                    "organizations:offboarded_dialog",
+                    organization_id=organization_id,
+                )
+            ),
+            classes="flex flex-col gap-4",
+        ):
+            with tag.p(classes="font-semibold"):
+                text("Set Organization to Offboarded")
+
+            with tag.div(classes="bg-base-200 border border-base-300 p-4 rounded-lg"):
+                with tag.p(classes="font-semibold mb-2"):
+                    text("This action will:")
+                with tag.ul(classes="list-disc list-inside space-y-1 text-sm"):
+                    with tag.li():
+                        text(
+                            "Email all organization members that the organization "
+                            "has been offboarded."
+                        )
+                    with tag.li():
+                        text(
+                            "Move the organization to Offboarded (terminal). New "
+                            "payments stay blocked and payouts are released so the "
+                            "merchant can withdraw their remaining balance."
+                        )
+
+            with tag.div(
+                classes="bg-base-200 border border-base-300 p-4 rounded-lg space-y-1"
+            ):
+                date_row("Last paid order", last_paid_order_at)
+                date_row("Offboarding since", offboarding_since)
+                date_row("Offboarding period completes", completes_at)
+
+            if not period_elapsed:
+                with tag.div(
+                    classes="bg-warning/10 border border-warning/20 p-4 rounded-lg"
+                ):
+                    with tag.p(classes="font-semibold text-warning mb-1"):
+                        text("Offboarding period has not fully elapsed")
+                    with tag.p(classes="text-sm"):
+                        if remaining_days is not None:
+                            text(
+                                f"{remaining_days} day(s) remain since the latest of "
+                                "the offboarding date and the last paid order. "
+                                "Completing now skips the rest of the wind-down "
+                                "period (chargeback and withdrawal window)."
+                            )
+                        else:
+                            text(
+                                "The offboarding date is unknown, so the wind-down "
+                                "period can't be verified. Completing now skips any "
+                                "remaining chargeback and withdrawal window."
+                            )
+
+            with tag.div(classes="modal-action pt-6 border-t border-base-200"):
+                with tag.form(method="dialog"):
+                    with button(ghost=True):
+                        text("Cancel")
+                with button(variant="warning", type="submit"):
+                    text("Complete Offboarding")
 
     return None
 

--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -670,7 +670,8 @@ class OrganizationDetailView:
                                 text("Deny")
 
                     elif self.org.status == OrganizationStatus.OFFBOARDING:
-                        # Offboarding can be reverted to review or denied
+                        # Offboarding can be reverted to review, denied, or
+                        # completed (moved to the terminal offboarded state).
                         with tag.div(classes="w-full"):
                             with button(
                                 variant="secondary",
@@ -685,6 +686,21 @@ class OrganizationDetailView:
                                 hx_target="#modal",
                             ):
                                 text("Set Under Review")
+
+                        with tag.div(classes="w-full"):
+                            with button(
+                                variant="secondary",
+                                size="sm",
+                                outline=True,
+                                hx_get=str(
+                                    request.url_for(
+                                        "organizations:offboarded_dialog",
+                                        organization_id=self.org.id,
+                                    )
+                                ),
+                                hx_target="#modal",
+                            ):
+                                text("Complete Offboarding")
 
                         with tag.div(classes="w-full"):
                             with button(

--- a/server/polar/models/order.py
+++ b/server/polar/models/order.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 from uuid import UUID
 
 from alembic_utils.pg_function import PGFunction
@@ -73,6 +73,11 @@ class OrderStatus(StrEnum):
     refunded = "refunded"
     partially_refunded = "partially_refunded"
     void = "void"
+
+    @classmethod
+    def paid_statuses(cls) -> set[Self]:
+        """Orders that count as a completed, not fully refunded, payment."""
+        return {cls.paid, cls.partially_refunded}  # pyright: ignore
 
 
 class OrderError(PolarError): ...

--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -48,11 +48,6 @@ UNSNOOZE_EXPIRED_BATCH_SIZE = 500
 # Maximum orgs the auto-offboard cron processes per run.
 OFFBOARD_EXPIRED_BATCH_SIZE = 500
 
-# Order statuses that count as a completed (not fully refunded) payment when
-# anchoring the offboarding chargeback-risk window. Shared so the auto-offboard
-# cron and the backoffice "remaining period" display can't drift.
-PAID_ORDER_STATUSES = (OrderStatus.paid, OrderStatus.partially_refunded)
-
 
 class OrganizationRepository(
     RepositorySortingMixin[Organization, OrganizationSortProperty],
@@ -213,7 +208,7 @@ class OrganizationRepository(
             select(func.max(Order.created_at))
             .where(
                 Order.organization_id == Organization.id,
-                Order.status.in_(PAID_ORDER_STATUSES),
+                Order.status.in_(OrderStatus.paid_statuses()),
                 Order.deleted_at.is_(None),
             )
             .correlate(Organization)
@@ -241,7 +236,7 @@ class OrganizationRepository(
         """
         statement = select(func.max(Order.created_at)).where(
             Order.organization_id == organization_id,
-            Order.status.in_(PAID_ORDER_STATUSES),
+            Order.status.in_(OrderStatus.paid_statuses()),
             Order.deleted_at.is_(None),
         )
         result = await self.session.execute(statement)

--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -48,6 +48,11 @@ UNSNOOZE_EXPIRED_BATCH_SIZE = 500
 # Maximum orgs the auto-offboard cron processes per run.
 OFFBOARD_EXPIRED_BATCH_SIZE = 500
 
+# Order statuses that count as a completed (not fully refunded) payment when
+# anchoring the offboarding chargeback-risk window. Shared so the auto-offboard
+# cron and the backoffice "remaining period" display can't drift.
+PAID_ORDER_STATUSES = (OrderStatus.paid, OrderStatus.partially_refunded)
+
 
 class OrganizationRepository(
     RepositorySortingMixin[Organization, OrganizationSortProperty],
@@ -208,7 +213,7 @@ class OrganizationRepository(
             select(func.max(Order.created_at))
             .where(
                 Order.organization_id == Organization.id,
-                Order.status.in_((OrderStatus.paid, OrderStatus.partially_refunded)),
+                Order.status.in_(PAID_ORDER_STATUSES),
                 Order.deleted_at.is_(None),
             )
             .correlate(Organization)
@@ -226,6 +231,21 @@ class OrganizationRepository(
             .with_for_update(of=Organization)
         )
         return await self.get_all(statement)
+
+    async def get_last_paid_order_at(self, organization_id: UUID) -> datetime | None:
+        """Most recent paid (not fully refunded) order date for an org.
+
+        Same chargeback-risk anchor as ``get_offboarding_past_period``, but for
+        a single organization — lets the backoffice surface how much of the
+        offboarding wind-down period remains before an auto-offboard.
+        """
+        statement = select(func.max(Order.created_at)).where(
+            Order.organization_id == organization_id,
+            Order.status.in_(PAID_ORDER_STATUSES),
+            Order.deleted_at.is_(None),
+        )
+        result = await self.session.execute(statement)
+        return result.scalar_one_or_none()
 
     def get_sorting_clause(self, property: OrganizationSortProperty) -> SortingClause:
         match property:

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1435,15 +1435,40 @@ class OrganizationService:
         candidates = await repository.get_offboarding_past_period(cutoff)
         transitioned: list[Organization] = []
         for organization in candidates:
-            organization.set_status(OrganizationStatus.OFFBOARDED)
-            _append_internal_note(
+            self._transition_to_offboarded(
+                session,
                 organization,
                 "Automatically offboarded after the offboarding period elapsed.",
             )
-            session.add(organization)
-            enqueue_job("organization.offboarded", organization_id=organization.id)
             transitioned.append(organization)
         return transitioned
+
+    async def set_organization_offboarded(
+        self, session: AsyncSession, organization: Organization
+    ) -> Organization:
+        """Manually transition an offboarding org to the terminal offboarded state.
+
+        Same effect as the auto-offboard cron, but triggered from the
+        backoffice — used to complete offboarding before the wind-down period
+        has fully elapsed.
+        """
+        if organization.status != OrganizationStatus.OFFBOARDING:
+            raise OrganizationError(
+                "Only organizations that are offboarding can be set to offboarded.",
+                403,
+            )
+        self._transition_to_offboarded(
+            session, organization, "Manually offboarded from the backoffice."
+        )
+        return organization
+
+    def _transition_to_offboarded(
+        self, session: AsyncSession, organization: Organization, note: str
+    ) -> None:
+        organization.set_status(OrganizationStatus.OFFBOARDED)
+        _append_internal_note(organization, note)
+        session.add(organization)
+        enqueue_job("organization.offboarded", organization_id=organization.id)
 
     async def _exit_snooze_to_review(
         self, session: AsyncSession, organization: Organization

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -3674,6 +3674,54 @@ class TestSetOrganizationOffboarding:
 
 
 @pytest.mark.asyncio
+class TestSetOrganizationOffboarded:
+    async def test_from_offboarding(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.OFFBOARDING
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        result = await organization_service.set_organization_offboarded(
+            session, organization
+        )
+
+        assert result.status == OrganizationStatus.OFFBOARDED
+        assert result.status_updated_at is not None
+        assert result.internal_notes is not None
+        assert "Manually offboarded" in result.internal_notes
+        enqueue_job_mock.assert_called_once_with(
+            "organization.offboarded", organization_id=organization.id
+        )
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            OrganizationStatus.REVIEW,
+            OrganizationStatus.SNOOZED,
+            OrganizationStatus.ACTIVE,
+            OrganizationStatus.DENIED,
+            OrganizationStatus.CREATED,
+            OrganizationStatus.OFFBOARDED,
+        ],
+    )
+    async def test_from_non_offboarding_raises(
+        self,
+        status: OrganizationStatus,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = status
+
+        with pytest.raises(Exception, match="Only organizations that are offboarding"):
+            await organization_service.set_organization_offboarded(
+                session, organization
+            )
+
+
+@pytest.mark.asyncio
 class TestSnoozeOrganization:
     async def test_from_review(
         self,


### PR DESCRIPTION
## Summary

Adds a **Complete Offboarding** action on the backoffice organization detail page 

## What

- New `organizations:offboarded_dialog` backoffice endpoint + a button in the offboarding action group.
- The confirmation modal warns that organization members will be emailed and shows the wind-down anchor data: last paid order, offboarding-since date, computed completion date, and days remaining (rounded up).
- New `OrganizationService.set_organization_offboarded` (guards that status is `offboarding`) and a shared `_transition_to_offboarded` helper now used by both the manual path and the auto-offboard cron.
- Repository helper `get_last_paid_order_at` plus a shared `PAID_ORDER_STATUSES` constant so the cron and the modal's anchor logic can't drift.

## Why

The auto-offboard cron only completes offboarding after the full wind-down period. Admins need a way to complete it on demand, with clear visibility into whether they are doing so early.


## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

