### PR TITLE
server/subscription: replace Redis lock by SQL lock when cycling

### DIFF
--- a/server/polar/subscription/tasks.py
+++ b/server/polar/subscription/tasks.py
@@ -6,7 +6,6 @@ from sqlalchemy.orm import selectinload
 
 from polar.exceptions import PolarTaskError
 from polar.kit.utils import utc_now
-from polar.locker import Locker
 from polar.logging import Logger
 from polar.models import Subscription, SubscriptionMeter
 from polar.product.repository import ProductRepository
@@ -14,7 +13,6 @@ from polar.subscription.repository import SubscriptionRepository
 from polar.worker import (
     AsyncSessionMaker,
     CronTrigger,
-    RedisMiddleware,
     TaskPriority,
     actor,
     enqueue_job,
@@ -47,44 +45,34 @@ class SubscriptionTierDoesNotExist(SubscriptionTaskError):
 
 @actor(actor_name="subscription.cycle", priority=TaskPriority.LOW)
 async def subscription_cycle(subscription_id: uuid.UUID, force: bool = False) -> None:
-    redis = RedisMiddleware.get()
-    locker = Locker(redis)
-    lock_name = f"subscription:cycle:{subscription_id}"
-
-    if await locker.is_locked(lock_name):
-        log.info(
-            "Subscription is already being cycled by another worker",
-            subscription_id=subscription_id,
+    async with AsyncSessionMaker() as session:
+        repository = SubscriptionRepository.from_session(session)
+        subscription = await repository.get_by_id(
+            subscription_id,
+            options=repository.get_eager_options(),
+            for_update=True,
         )
-        return
+        if subscription is None:
+            raise SubscriptionDoesNotExist(subscription_id)
 
-    async with locker.lock(lock_name, timeout=1.0, blocking_timeout=0.1):
-        async with AsyncSessionMaker() as session:
-            repository = SubscriptionRepository.from_session(session)
-            subscription = await repository.get_by_id(
-                subscription_id, options=repository.get_eager_options()
+        if not subscription.active or (
+            not force
+            and subscription.current_period_end
+            and subscription.current_period_end > utc_now()
+        ):
+            log.info(
+                "Subscription has already been cycled",
+                subscription_id=subscription_id,
             )
-            if subscription is None:
-                raise SubscriptionDoesNotExist(subscription_id)
+            subscription = await repository.update(
+                subscription, update_dict={"scheduler_locked_at": None}
+            )
+            return
 
-            if not subscription.active or (
-                not force
-                and subscription.current_period_end
-                and subscription.current_period_end > utc_now()
-            ):
-                log.info(
-                    "Subscription has already been cycled",
-                    subscription_id=subscription_id,
-                )
-                subscription = await repository.update(
-                    subscription, update_dict={"scheduler_locked_at": None}
-                )
-                return
-
-            async with SubscriptionUpdateContext(
-                session, subscription, subscription_service
-            ) as ctx:
-                await subscription_service.cycle(session, ctx, subscription)
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.cycle(session, ctx, subscription)
 
 
 @actor(


### PR DESCRIPTION

We had an incident on Saturday where a burst of subscription cycles caused an overflow of Redis connections. This PR replaces the Redis lock with a SQL `FOR UPDATE` lock to ease the load on Redis, while bringing a more robust locking mechanism to the subscription cycle process.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

