### PR TITLE
Upgrade to `team` type on one-time purchases too

### DIFF
--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -541,6 +541,26 @@ class CustomerService:
 
         return updated_customer
 
+    async def upgrade_to_team(
+        self, session: AsyncSession, customer: Customer
+    ) -> Customer:
+        """Upgrade a customer to the 'team' type for seat-based purchases.
+
+        One-way and idempotent: customers already on 'team' (or any non-individual
+        type) are left untouched. NULL type is treated as 'individual' (legacy
+        customers).
+        """
+        current_type = customer.type or CustomerType.individual
+        if current_type != CustomerType.individual:
+            return customer
+
+        repository = CustomerRepository.from_session(session)
+        return await repository.update(
+            customer,
+            update_dict={"type": CustomerType.team},
+            flush=True,
+        )
+
     async def delete(
         self,
         session: AsyncSession,

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -626,6 +626,9 @@ class OrderService:
                 product_id=product.id,
                 order_id=order.id,
             )
+        else:
+            # Auto-upgrade customer to 'team' type for seat-based purchases
+            await customer_service.upgrade_to_team(session, order.customer)
 
         # Trigger notifications
         organization = checkout.organization

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -100,7 +100,6 @@ from polar.payment_method.service import payment_method as payment_method_servic
 from polar.product.guard import (
     is_custom_price,
     is_fixed_price,
-    is_seat_price,
     is_static_price,
 )
 from polar.product.price_set import (
@@ -614,11 +613,11 @@ class OrderService:
             session, checkout, OrderBillingReasonInternal.purchase, payment
         )
 
-        # For seat-based orders, benefits are granted when seats are claimed
-        # For non-seat orders, grant benefits immediately
-        prices = checkout.prices[product.id]
-        has_seat_price = any(is_seat_price(price) for price in prices)
-        if not has_seat_price:
+        # Key the decision off the seats actually purchased on this order, not the
+        # product's price catalog: a product may compose a fixed price with a seat
+        # price, so only `order.seats` reflects whether seats were really bought.
+        if order.seats is None:
+            # Non-seat orders grant benefits immediately
             enqueue_job(
                 "benefit.enqueue_benefits_grants",
                 task="grant",
@@ -627,7 +626,9 @@ class OrderService:
                 order_id=order.id,
             )
         else:
-            # Auto-upgrade customer to 'team' type for seat-based purchases
+            # Seat-based orders grant benefits when seats are claimed; upgrade the
+            # buyer to a 'team' customer so they can manage and claim their seats
+            # (mirrors the subscription flow)
             await customer_service.upgrade_to_team(session, order.customer)
 
         # Trigger notifications

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -80,7 +80,6 @@ from polar.models import (
     User,
 )
 from polar.models.billing_entry import BillingEntryDirection, BillingEntryType
-from polar.models.customer import CustomerType
 from polar.models.order import OrderBillingReasonInternal
 from polar.models.product_price import ProductPrice, ProductPriceSeatUnit
 from polar.models.subscription import CustomerCancellationReason, SubscriptionStatus
@@ -578,7 +577,7 @@ class SubscriptionService:
 
         # Auto-upgrade customer to 'team' type when subscribing to a seat-based product
         if product.has_seat_based_price:
-            await self._maybe_upgrade_customer_to_team(session, customer)
+            await customer_service.upgrade_to_team(session, customer)
 
         await self._after_subscription_created(session, subscription)
         # ⚠️ Some users are relying on `subscription.updated` for everything
@@ -711,7 +710,7 @@ class SubscriptionService:
 
         # Auto-upgrade customer to 'team' type when subscribing to a seat-based product
         if product.has_seat_based_price:
-            await self._maybe_upgrade_customer_to_team(session, customer)
+            await customer_service.upgrade_to_team(session, customer)
 
         # Link potential discount redemption to the subscription
         if subscription.discount is not None:
@@ -926,19 +925,6 @@ class SubscriptionService:
                         },
                     ),
                 )
-
-    async def _maybe_upgrade_customer_to_team(
-        self, session: AsyncSession, customer: Customer
-    ) -> None:
-        customer_type = customer.type or CustomerType.individual
-        if customer_type != CustomerType.individual:
-            return
-        customer_repository = CustomerRepository.from_session(session)
-        await customer_repository.update(
-            customer,
-            update_dict={"type": CustomerType.team},
-            flush=True,
-        )
 
     async def _after_subscription_created(
         self, session: AsyncSession, subscription: Subscription
@@ -1327,7 +1313,7 @@ class SubscriptionService:
                 # the billing customer to a 'team' customer and claim a seat for
                 # them so they keep benefit access immediately after the switch.
                 if is_initial_seat_transition:
-                    await self._maybe_upgrade_customer_to_team(
+                    await customer_service.upgrade_to_team(
                         session, subscription.customer
                     )
                     await seat_service.assign_seat(

--- a/server/scripts/backfill_seat_customers_to_team.py
+++ b/server/scripts/backfill_seat_customers_to_team.py
@@ -1,0 +1,120 @@
+"""Upgrade individual customers who actually bought seats to 'team'.
+
+A purchase with ``seats IS NOT NULL`` — a one-time order (``order/service.py``) or
+a subscription (``subscription/service.py``) — means the customer really purchased
+seats, which should make them a 'team' customer. The runtime hooks that perform
+this upgrade were added after seat-based pricing shipped, so some existing buyers
+are stranded as 'individual'. This backfill catches them up.
+
+Limited to organizations that have migrated to the member model
+(``feature_settings.member_model_enabled``); pre-migration organizations are skipped.
+
+One-way and idempotent: only customers currently 'individual' (or NULL, treated as
+individual) are touched, mirroring ``CustomerService.upgrade_to_team``.
+
+Usage:
+    cd server
+    uv run python -m scripts.backfill_seat_customers_to_team
+    uv run python -m scripts.backfill_seat_customers_to_team --no-dry-run
+"""
+
+import uuid
+
+import typer
+from rich.console import Console
+from rich.table import Table
+from sqlalchemy import Select, or_, select, update
+
+from polar.kit.db.postgres import create_async_sessionmaker
+from polar.models import Customer, Order, Organization, Subscription
+from polar.models.customer import CustomerType
+from polar.postgres import create_async_engine
+from scripts.helper import configure_script_console_logging, typer_async
+
+cli = typer.Typer()
+console = Console()
+configure_script_console_logging()
+
+
+def _target_customer_ids() -> Select[tuple[uuid.UUID]]:
+    seat_order_customers = select(Order.customer_id).where(
+        Order.seats.is_not(None),
+        Order.deleted_at.is_(None),
+    )
+    seat_subscription_customers = select(Subscription.customer_id).where(
+        Subscription.seats.is_not(None),
+        Subscription.deleted_at.is_(None),
+    )
+    # Only organizations that have migrated to the member model; an absent flag
+    # evaluates to NULL and is excluded, skipping pre-migration organizations.
+    member_model_organizations = select(Organization.id).where(
+        Organization.feature_settings["member_model_enabled"].as_boolean().is_(True)
+    )
+    return select(Customer.id).where(
+        Customer.deleted_at.is_(None),
+        or_(
+            Customer._type.is_(None),
+            Customer._type == CustomerType.individual,
+        ),
+        Customer.organization_id.in_(member_model_organizations),
+        or_(
+            Customer.id.in_(seat_order_customers),
+            Customer.id.in_(seat_subscription_customers),
+        ),
+    )
+
+
+@cli.command()
+@typer_async
+async def backfill_seat_customers_to_team(
+    dry_run: bool = typer.Option(
+        True, help="Print what would be done without writing changes"
+    ),
+) -> None:
+    mode = "DRY-RUN" if dry_run else "EXECUTE"
+    console.rule(f"[bold]Upgrade seat customers to team — {mode}")
+
+    engine = create_async_engine("script")
+    sessionmaker = create_async_sessionmaker(engine)
+    try:
+        async with sessionmaker() as session:
+            customers = (
+                await session.execute(
+                    select(Customer.id, Customer.email, Customer._type).where(
+                        Customer.id.in_(_target_customer_ids())
+                    )
+                )
+            ).all()
+
+            verb = "Would upgrade" if dry_run else "Upgrading"
+            console.print(f"{verb} [bold]{len(customers)}[/bold] customer(s) to 'team'")
+
+            if customers:
+                table = Table()
+                table.add_column("Customer ID")
+                table.add_column("Email")
+                table.add_column("Current type")
+                for customer_id, email, customer_type in customers:
+                    table.add_row(
+                        str(customer_id),
+                        email or "—",
+                        customer_type or "individual (NULL)",
+                    )
+                console.print(table)
+
+            if customers and not dry_run:
+                await session.execute(
+                    update(Customer)
+                    .values({Customer._type: CustomerType.team})
+                    .where(Customer.id.in_([customer.id for customer in customers]))
+                )
+                await session.commit()
+                console.print(
+                    f"[green]✓ Upgraded {len(customers)} customer(s) to 'team'"
+                )
+    finally:
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -661,12 +661,13 @@ async def create_product_fixed_and_seat(
     tiers: list[dict[str, typing.Any]] | None = None,
     seat_tier_type: SeatTierType = SeatTierType.volume,
     currency: str = "usd",
-    recurring_interval: SubscriptionRecurringInterval = (
+    recurring_interval: SubscriptionRecurringInterval | None = (
         SubscriptionRecurringInterval.month
     ),
 ) -> Product:
-    """Create a recurring product composing one fixed price with one seat price.
+    """Create a product composing one fixed price with one seat price.
 
+    Recurring by default; pass ``recurring_interval=None`` for a one-time product.
     Bills ``fixed_amount + seat_price.calculate_amount(seats)``. Pass ``tiers``
     (with ``seat_tier_type=graduated``) for a graduated seat schedule.
     """

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -825,6 +825,45 @@ class TestCreateFromCheckoutOneTime:
         await session.refresh(customer)
         assert customer.type == CustomerType.individual
 
+    async def test_composed_fixed_and_seat_upgrades_customer_to_team(
+        self,
+        enqueue_job_mock: MagicMock,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        # A one-time product composing a fixed price with a seat price always
+        # bills both (fixed + per-seat), so the buyer really does purchase seats
+        # and must be upgraded to 'team'.
+        product = await create_product_fixed_and_seat(
+            save_fixture,
+            organization=organization,
+            recurring_interval=None,
+            fixed_amount=5000,
+            price_per_seat=1000,
+        )
+
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product],
+            status=CheckoutStatus.confirmed,
+            customer=customer,
+            seats=3,
+        )
+
+        order = await order_service.create_from_checkout_one_time(session, checkout)
+
+        assert order.seats == 3
+        assert len(order.items) == 2
+
+        await session.refresh(customer)
+        assert customer.type == CustomerType.team
+
+        # Seat-based orders defer benefit grants until seats are claimed
+        for c in enqueue_job_mock.call_args_list:
+            assert c.args[0] != "benefit.enqueue_benefits_grants"
+
 
 @pytest.mark.asyncio
 class TestCreateFromCheckoutSubscription:

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -59,6 +59,7 @@ from polar.models import (
 from polar.models.billing_entry import BillingEntryDirection, BillingEntryType
 from polar.models.checkout import CheckoutStatus
 from polar.models.custom_field import CustomFieldType
+from polar.models.customer import CustomerType
 from polar.models.discount import DiscountDuration, DiscountType
 from polar.models.order import OrderBillingReasonInternal, OrderStatus
 from polar.models.organization import Organization, OrganizationStatus
@@ -769,6 +770,60 @@ class TestCreateFromCheckoutOneTime:
         publish_checkout_event_mock.assert_awaited_once_with(
             checkout.client_secret, CheckoutEvent.order_created
         )
+
+    async def test_seat_based_upgrades_customer_to_team(
+        self,
+        enqueue_job_mock: MagicMock,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=None,
+            prices=[("seat", 1000, "usd")],
+        )
+
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product],
+            status=CheckoutStatus.confirmed,
+            customer=customer,
+            seats=5,
+        )
+
+        order = await order_service.create_from_checkout_one_time(session, checkout)
+
+        assert order.seats == 5
+        assert order.customer == checkout.customer
+
+        await session.refresh(customer)
+        assert customer.type == CustomerType.team
+
+        # Seat-based orders defer benefit grants until seats are claimed
+        for c in enqueue_job_mock.call_args_list:
+            assert c.args[0] != "benefit.enqueue_benefits_grants"
+
+    async def test_fixed_does_not_upgrade_customer_to_team(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product_one_time: Product,
+        customer: Customer,
+    ) -> None:
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product_one_time],
+            status=CheckoutStatus.confirmed,
+            customer=customer,
+        )
+
+        await order_service.create_from_checkout_one_time(session, checkout)
+
+        await session.refresh(customer)
+        assert customer.type == CustomerType.individual
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Automatically upgrades customers to the `team` type for seat-based one-time checkouts and defers benefits until seats are claimed, aligning with subscriptions. Uses `order.seats` to detect seat purchases (incl. composed fixed+seat products), centralizes the upgrade in `CustomerService.upgrade_to_team`, and adds a backfill script for existing seat buyers.

- **New Features**
  - Auto-upgrade to `team` on one-time orders with seats; idempotent.
  - Non-seat one-time orders grant benefits immediately.

- **Migration**
  - Added `scripts/backfill_seat_customers_to_team.py` to upgrade past seat buyers; dry-run by default and limited to orgs with `member_model_enabled` (run: `uv run python -m scripts.backfill_seat_customers_to_team`).

<sup>Written for commit 36dbe6b352d4b2c99eb59d8ca2e94d3ff41a2eb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

