### PR TITLE
ci: Disable index images for lambdas

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -288,6 +288,8 @@ jobs:
           context: ./server
           target: lambda
           platforms: linux/amd64
+          provenance: false
+          sbom: false
           build-args: |
             RELEASE_VERSION=${{ github.sha }}
           secrets: |


### PR DESCRIPTION
They are not supported yet. We get: The image manifest, config or layer media type for the source image [...]:latest is not supported.

See https://github.com/aws/aws-lambda-roadmap/issues/82


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable provenance and SBOM in the Docker build for Lambda images to avoid OCI index/attestation media types that AWS Lambda does not support. This fixes the “image manifest, config or layer media type … is not supported” error and unblocks deploys.

<sup>Written for commit 786136b9cb0e3a765f6e38b13fee9c138c2e207e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

