### PR TITLE
Add member id to the table in backoffice

### DIFF
--- a/server/polar/backoffice/customers/endpoints.py
+++ b/server/polar/backoffice/customers/endpoints.py
@@ -372,6 +372,7 @@ async def get(
                             text("Generate Portal Link")
 
                 with datatable.Datatable[Member, Any](
+                    datatable.DatatableAttrColumn("id", "ID", clipboard=True),
                     datatable.DatatableAttrColumn("email", "Email", clipboard=True),
                     datatable.DatatableAttrColumn("name", "Name"),
                     datatable.DatatableAttrColumn("role", "Role"),


### PR DESCRIPTION
You need the member ID to be able to queue a benefit grant retry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Member ID column to the Backoffice customers table to make it easy to queue a benefit grant retry. The column is labeled "ID" and supports copy-to-clipboard.

<sup>Written for commit 579c07be8165ee3a6da22c12a694cf8e6136b684. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

