### PR TITLE
tf/lambda: Remove reserved concurrency for dummy task

### DIFF
--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -30,13 +30,14 @@ module "lambda_worker_ecr" {
 module "dummy_lambda_worker" {
   source = "../modules/aws_task_worker"
 
-  environment        = "sandbox"
-  name               = "dummy"
-  queue_name         = "polar-sandbox-tasks-dummy"
-  image_uri          = "${module.lambda_worker_ecr.repository_url}:latest"
-  enabled            = false
-  subnet_ids         = local.lambda_subnet_ids
-  security_group_ids = local.lambda_security_group_ids
+  environment          = "sandbox"
+  name                 = "dummy"
+  queue_name           = "polar-sandbox-tasks-dummy"
+  image_uri            = "${module.lambda_worker_ecr.repository_url}:latest"
+  enabled              = false
+  reserved_concurrency = null
+  subnet_ids           = local.lambda_subnet_ids
+  security_group_ids   = local.lambda_security_group_ids
 
   environment_variables = {
     POLAR_ENV                     = "sandbox"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Remove reserved concurrency for the sandbox dummy Lambda worker by setting `reserved_concurrency = null`. This frees account concurrency and avoids unintended throttling for a disabled task.

<sup>Written for commit 03a259a6a72f6cad6af7b05a58f145c70d707a1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

