### PR TITLE
Add automated greeting + SSE for review appeal chat

### DIFF
--- a/clients/apps/web/src/components/Organization/HumanReviewCase/index.tsx
+++ b/clients/apps/web/src/components/Organization/HumanReviewCase/index.tsx
@@ -7,10 +7,12 @@ import {
   useReplyToAppealCase,
   useRequestHumanReview,
 } from '@/hooks/queries/org'
+import { useOrganizationSSE } from '@/hooks/sse'
 import { schemas } from '@polar-sh/client'
 import { Text } from '@polar-sh/orbit'
+import { useQueryClient } from '@tanstack/react-query'
 import { Loader2, MessageCircle } from 'lucide-react'
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   supportCaseUploader,
   toChatAttachments,
@@ -34,6 +36,19 @@ const HumanReviewCase = ({ organization }: Props) => {
   const requestReview = useRequestHumanReview(organization.id)
   const reply = useReplyToAppealCase(organization.id)
   useUnreadTitleBadge(organization.id, thread?.messages)
+
+  const queryClient = useQueryClient()
+  const eventEmitter = useOrganizationSSE(organization.id)
+  useEffect(() => {
+    const handler = () =>
+      queryClient.invalidateQueries({
+        queryKey: ['appealCase', organization.id],
+      })
+    eventEmitter.on('appeal_case.updated', handler)
+    return () => {
+      eventEmitter.off('appeal_case.updated', handler)
+    }
+  }, [eventEmitter, queryClient, organization.id])
 
   const messages = useMemo(() => thread?.messages ?? [], [thread])
   const messageById = useMemo(

--- a/clients/apps/web/src/hooks/queries/org.ts
+++ b/clients/apps/web/src/hooks/queries/org.ts
@@ -396,7 +396,7 @@ export const useRequestHumanReview = (id: string) =>
         params: { path: { id } },
         body: { reason },
       }),
-    onSuccess: async (result) => {
+    onSuccess: (result) => {
       if (result.error) return
       getQueryClient().invalidateQueries({ queryKey: ['appealCase', id] })
     },

--- a/server/polar/organization_review/appeal_case.py
+++ b/server/polar/organization_review/appeal_case.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 from uuid import UUID
 
+from polar.eventstream.service import publish as eventstream_publish
 from polar.exceptions import PolarError
 from polar.models import File, Organization, User
 from polar.models.organization_review import OrganizationReview
@@ -27,9 +28,16 @@ HUMAN_REVIEW_GREETING = (
     "you within 1–2 business days."
 )
 
-# The greeting is posted by a background job after this delay, so it lands a
-# beat after the merchant's message instead of in the same instant.
+# Add a small delay to the automated greeting message
+# so it doesn't appear instantly (which looks a bit wonky)
 HUMAN_REVIEW_GREETING_DELAY_MS = 1500
+APPEAL_CASE_UPDATED_EVENT = "appeal_case.updated"
+
+
+async def publish_appeal_update(organization_id: UUID) -> None:
+    await eventstream_publish(
+        APPEAL_CASE_UPDATED_EVENT, {}, organization_id=organization_id
+    )
 
 
 class AppealCaseError(PolarError): ...
@@ -98,6 +106,7 @@ class AppealCaseService:
             body=reason,
             audience=[SupportCaseAudience.merchant],
         )
+        await publish_appeal_update(organization.id)
         enqueue_job(
             "organization_review.post_appeal_greeting",
             case_id=case.id,
@@ -138,6 +147,7 @@ class AppealCaseService:
                 "support_case.notify_organization_of_new_message",
                 message_id=message.id,
             )
+            await publish_appeal_update(case.organization_id)
         return message
 
     async def record_decision(
@@ -174,6 +184,7 @@ class AppealCaseService:
         enqueue_job(
             "support_case.notify_organization_of_new_message", message_id=message.id
         )
+        await publish_appeal_update(case.organization_id)
         # This records the decision on the case only. The caller drives org
         # state: approve goes through organization.backoffice_approve, which
         # closes the case via approve_open_case; deny needs no org change, as

--- a/server/polar/organization_review/appeal_case.py
+++ b/server/polar/organization_review/appeal_case.py
@@ -22,6 +22,15 @@ from polar.support_case.repository import (
 from polar.support_case.service import support_case as support_case_service
 from polar.worker import enqueue_job
 
+HUMAN_REVIEW_GREETING = (
+    "Thanks for reaching out! Our team will review your appeal and get back to "
+    "you within 1–2 business days."
+)
+
+# The greeting is posted by a background job after this delay, so it lands a
+# beat after the merchant's message instead of in the same instant.
+HUMAN_REVIEW_GREETING_DELAY_MS = 1500
+
 
 class AppealCaseError(PolarError): ...
 
@@ -88,6 +97,11 @@ class AppealCaseService:
             author_user=requested_by_user,
             body=reason,
             audience=[SupportCaseAudience.merchant],
+        )
+        enqueue_job(
+            "organization_review.post_appeal_greeting",
+            case_id=case.id,
+            delay=HUMAN_REVIEW_GREETING_DELAY_MS,
         )
         return case
 

--- a/server/polar/organization_review/tasks.py
+++ b/server/polar/organization_review/tasks.py
@@ -8,6 +8,10 @@ from polar.exceptions import PolarTaskError
 from polar.integrations.polar.service import polar_self
 from polar.models.organization import Organization, OrganizationStatus
 from polar.models.organization_review import OrganizationReview
+from polar.models.support_case import (
+    SupportCaseAudience,
+    SupportCaseMessageAuthorKind,
+)
 from polar.organization.repository import (
     OrganizationRepository,
 )
@@ -16,9 +20,15 @@ from polar.organization.repository import (
 )
 from polar.organization.service import organization as organization_service
 from polar.postgres import AsyncSession
+from polar.support_case.repository import (
+    SupportCaseMessageRepository,
+    SupportCaseRepository,
+)
+from polar.support_case.service import support_case as support_case_service
 from polar.worker import AsyncSessionMaker, TaskPriority, actor
 
 from .agent import run_organization_review
+from .appeal_case import HUMAN_REVIEW_GREETING
 from .report import build_agent_report
 from .repository import OrganizationReviewRepository
 from .schemas import (
@@ -365,4 +375,34 @@ async def review_appeal(organization_id: uuid.UUID) -> None:
             review_context=ReviewContext.APPEAL,
             verdict=report.verdict,
             risk_score=report.overall_risk_score,
+        )
+
+
+@actor(
+    actor_name="organization_review.post_appeal_greeting",
+    priority=TaskPriority.LOW,
+)
+async def post_appeal_greeting(case_id: uuid.UUID) -> None:
+    """Post the automated greeting to a freshly opened human-review case."""
+    async with AsyncSessionMaker() as session:
+        case = await SupportCaseRepository.from_session(session).get_by_id(case_id)
+        if case is None:
+            return
+
+        message_repository = SupportCaseMessageRepository.from_session(session)
+        if not await message_repository.is_open(case_id):
+            return
+        existing = await message_repository.list_by_case(case_id, visible_to=None)
+        if any(
+            message.author_kind == SupportCaseMessageAuthorKind.platform
+            for message in existing
+        ):
+            return
+
+        await support_case_service.post_message(
+            session,
+            case,
+            author_kind=SupportCaseMessageAuthorKind.platform,
+            body=HUMAN_REVIEW_GREETING,
+            audience=[SupportCaseAudience.merchant],
         )

--- a/server/polar/organization_review/tasks.py
+++ b/server/polar/organization_review/tasks.py
@@ -28,7 +28,7 @@ from polar.support_case.service import support_case as support_case_service
 from polar.worker import AsyncSessionMaker, TaskPriority, actor
 
 from .agent import run_organization_review
-from .appeal_case import HUMAN_REVIEW_GREETING
+from .appeal_case import HUMAN_REVIEW_GREETING, publish_appeal_update
 from .report import build_agent_report
 from .repository import OrganizationReviewRepository
 from .schemas import (
@@ -406,3 +406,4 @@ async def post_appeal_greeting(case_id: uuid.UUID) -> None:
             body=HUMAN_REVIEW_GREETING,
             audience=[SupportCaseAudience.merchant],
         )
+        await publish_appeal_update(case.organization_id)

--- a/server/tests/organization_review/test_appeal_case.py
+++ b/server/tests/organization_review/test_appeal_case.py
@@ -1,3 +1,7 @@
+import contextlib
+from collections.abc import AsyncIterator
+from unittest.mock import patch
+
 import pytest
 import pytest_asyncio
 from pytest_mock import MockerFixture
@@ -14,18 +18,28 @@ from polar.models.support_case import (
 )
 from polar.models.user import User
 from polar.organization_review.appeal_case import (
+    HUMAN_REVIEW_GREETING,
+    HUMAN_REVIEW_GREETING_DELAY_MS,
     CaseAlreadyExistsError,
     CaseClosedError,
 )
 from polar.organization_review.appeal_case import (
     appeal_case as appeal_case_service,
 )
+from polar.organization_review.tasks import post_appeal_greeting
 from polar.postgres import AsyncSession
 from polar.support_case.repository import (
     SupportCaseMessageRepository,
     SupportCaseParticipantRepository,
 )
 from tests.fixtures.database import SaveFixture
+
+_post_appeal_greeting = post_appeal_greeting.__wrapped__  # type: ignore[attr-defined]
+
+
+@contextlib.asynccontextmanager
+async def _session_maker(session: AsyncSession) -> AsyncIterator[AsyncSession]:
+    yield session
 
 
 @pytest_asyncio.fixture
@@ -59,11 +73,16 @@ async def _participants(
 class TestRequestHumanReview:
     async def test_creates_linked_case(
         self,
+        mocker: MockerFixture,
         session: AsyncSession,
         denied_review: OrganizationReview,
         organization: Organization,
         user: User,
     ) -> None:
+        enqueue_job_mock = mocker.patch(
+            "polar.organization_review.appeal_case.enqueue_job"
+        )
+
         case = await appeal_case_service.request_human_review(
             session,
             denied_review,
@@ -85,10 +104,17 @@ class TestRequestHumanReview:
         messages = await message_repository.list_by_case(case.id)
         types = {m.type for m in messages}
         assert SupportCaseMessageType.opened in types
+        # Only the merchant's message is posted synchronously; the greeting is
+        # enqueued as a delayed job so it lands a beat later.
         chat = [m for m in messages if m.type == SupportCaseMessageType.chat]
         assert len(chat) == 1
         assert chat[0].body == "Please reconsider — here is the missing context."
         assert chat[0].author_kind == SupportCaseMessageAuthorKind.merchant
+        enqueue_job_mock.assert_called_once_with(
+            "organization_review.post_appeal_greeting",
+            case_id=case.id,
+            delay=HUMAN_REVIEW_GREETING_DELAY_MS,
+        )
 
         assert await message_repository.is_open(case.id) is True
 
@@ -216,6 +242,7 @@ class TestReplyNotifiesMerchant:
             requested_by_user=user,
             organization=organization,
         )
+        enqueue.reset_mock()  # ignore the greeting enqueue from case creation
         message = await appeal_case_service.add_reply(
             session,
             case,
@@ -243,6 +270,7 @@ class TestReplyNotifiesMerchant:
             requested_by_user=user,
             organization=organization,
         )
+        enqueue.reset_mock()  # ignore the greeting enqueue from case creation
         await appeal_case_service.add_reply(
             session,
             case,
@@ -269,9 +297,82 @@ class TestReplyNotifiesMerchant:
             requested_by_user=user,
             organization=organization,
         )
+        enqueue.reset_mock()  # ignore the greeting enqueue from case creation
         message = await appeal_case_service.record_decision(
             session, case, approved=False, staff_user=user, reason="denied again"
         )
         enqueue.assert_called_once_with(
             "support_case.notify_organization_of_new_message", message_id=message.id
         )
+
+
+@pytest.mark.asyncio
+class TestPostAppealGreeting:
+    async def test_posts_greeting(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        denied_review: OrganizationReview,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        mocker.patch("polar.organization_review.appeal_case.enqueue_job")
+        case = await appeal_case_service.request_human_review(
+            session,
+            denied_review,
+            reason="Please reconsider.",
+            requested_by_user=user,
+            organization=organization,
+        )
+
+        with patch(
+            "polar.organization_review.tasks.AsyncSessionMaker",
+            side_effect=lambda: _session_maker(session),
+        ):
+            await _post_appeal_greeting(case.id)
+        await session.flush()
+
+        message_repository = SupportCaseMessageRepository.from_session(session)
+        messages = await message_repository.list_by_case(case.id)
+        platform = [
+            message
+            for message in messages
+            if message.author_kind == SupportCaseMessageAuthorKind.platform
+            and message.type == SupportCaseMessageType.chat
+        ]
+        assert len(platform) == 1
+        assert platform[0].body == HUMAN_REVIEW_GREETING
+
+    async def test_idempotent(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        denied_review: OrganizationReview,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        mocker.patch("polar.organization_review.appeal_case.enqueue_job")
+        case = await appeal_case_service.request_human_review(
+            session,
+            denied_review,
+            reason="Please reconsider.",
+            requested_by_user=user,
+            organization=organization,
+        )
+
+        with patch(
+            "polar.organization_review.tasks.AsyncSessionMaker",
+            side_effect=lambda: _session_maker(session),
+        ):
+            await _post_appeal_greeting(case.id)
+            await _post_appeal_greeting(case.id)
+        await session.flush()
+
+        message_repository = SupportCaseMessageRepository.from_session(session)
+        messages = await message_repository.list_by_case(case.id)
+        platform = [
+            message
+            for message in messages
+            if message.author_kind == SupportCaseMessageAuthorKind.platform
+        ]
+        assert len(platform) == 1

--- a/server/tests/organization_review/test_appeal_case.py
+++ b/server/tests/organization_review/test_appeal_case.py
@@ -82,6 +82,9 @@ class TestRequestHumanReview:
         enqueue_job_mock = mocker.patch(
             "polar.organization_review.appeal_case.enqueue_job"
         )
+        publish_mock = mocker.patch(
+            "polar.organization_review.appeal_case.publish_appeal_update"
+        )
 
         case = await appeal_case_service.request_human_review(
             session,
@@ -115,6 +118,7 @@ class TestRequestHumanReview:
             case_id=case.id,
             delay=HUMAN_REVIEW_GREETING_DELAY_MS,
         )
+        publish_mock.assert_called_once_with(organization.id)
 
         assert await message_repository.is_open(case.id) is True
 
@@ -242,7 +246,10 @@ class TestReplyNotifiesMerchant:
             requested_by_user=user,
             organization=organization,
         )
-        enqueue.reset_mock()  # ignore the greeting enqueue from case creation
+        enqueue.reset_mock()
+        publish = mocker.patch(
+            "polar.organization_review.appeal_case.publish_appeal_update"
+        )
         message = await appeal_case_service.add_reply(
             session,
             case,
@@ -253,6 +260,7 @@ class TestReplyNotifiesMerchant:
         enqueue.assert_called_once_with(
             "support_case.notify_organization_of_new_message", message_id=message.id
         )
+        publish.assert_called_once_with(case.organization_id)
 
     async def test_internal_note_does_not_enqueue(
         self,
@@ -270,7 +278,10 @@ class TestReplyNotifiesMerchant:
             requested_by_user=user,
             organization=organization,
         )
-        enqueue.reset_mock()  # ignore the greeting enqueue from case creation
+        enqueue.reset_mock()
+        publish = mocker.patch(
+            "polar.organization_review.appeal_case.publish_appeal_update"
+        )
         await appeal_case_service.add_reply(
             session,
             case,
@@ -280,6 +291,7 @@ class TestReplyNotifiesMerchant:
             internal=True,
         )
         enqueue.assert_not_called()
+        publish.assert_not_called()
 
     async def test_decision_enqueues_email(
         self,
@@ -297,13 +309,17 @@ class TestReplyNotifiesMerchant:
             requested_by_user=user,
             organization=organization,
         )
-        enqueue.reset_mock()  # ignore the greeting enqueue from case creation
+        enqueue.reset_mock()
+        publish = mocker.patch(
+            "polar.organization_review.appeal_case.publish_appeal_update"
+        )
         message = await appeal_case_service.record_decision(
             session, case, approved=False, staff_user=user, reason="denied again"
         )
         enqueue.assert_called_once_with(
             "support_case.notify_organization_of_new_message", message_id=message.id
         )
+        publish.assert_called_once_with(case.organization_id)
 
 
 @pytest.mark.asyncio
@@ -317,6 +333,9 @@ class TestPostAppealGreeting:
         user: User,
     ) -> None:
         mocker.patch("polar.organization_review.appeal_case.enqueue_job")
+        publish_mock = mocker.patch(
+            "polar.organization_review.tasks.publish_appeal_update"
+        )
         case = await appeal_case_service.request_human_review(
             session,
             denied_review,
@@ -342,6 +361,7 @@ class TestPostAppealGreeting:
         ]
         assert len(platform) == 1
         assert platform[0].body == HUMAN_REVIEW_GREETING
+        publish_mock.assert_called_once_with(case.organization_id)
 
     async def test_idempotent(
         self,


### PR DESCRIPTION
## Summary

This PR will:

* Move the appeal chat from polling to SSE
* Add an automated greeting message, with a 1500ms delay

## Demo

https://github.com/user-attachments/assets/da28a510-704a-4f35-97c0-2075436e5da3




<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12567?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

