### PR TITLE
refactor(authz): route membership reads through select_user_org_ids

### DIFF
--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -59,9 +59,7 @@ class ResourceRepository(
         if is_user(auth_subject):
             statement = statement.where(
                 Resource.organization_id.in_(
-                    select(UserOrganization.organization_id).where(
-                        UserOrganization.user_id == auth_subject.subject.id
-                    )
+                    select_user_org_ids(auth_subject.subject.id)
                 )
             )
         elif is_organization(auth_subject):
@@ -75,6 +73,13 @@ class ResourceRepository(
         statement = self.get_base_statement().where(Resource.slug == slug)
         return await self.get_one_or_none(statement)
 ```
+
+**Always resolve a user's organizations via `select_user_org_ids(auth_subject.subject.id)`**
+(`polar.authz.repository`) for subqueries, or `get_accessible_org_ids(...)`
+(`polar.authz.service`) at the service layer. Never inline a
+`UserOrganization.user_id == auth_subject...` filter — those helpers are the
+single point where session/token org-scoping is enforced, so an inline subquery
+silently bypasses it. Enforced by `uv run task lint_org_scope`.
 
 **Key methods from base:**
 - `get_base_statement()` - Returns `select(self.model)`

--- a/server/polar/event/service.py
+++ b/server/polar/event/service.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import contains_eager
 
 from polar.auth.models import AuthSubject, is_organization, is_user
 from polar.auth.permission import OrganizationPermission
+from polar.authz.repository import select_user_org_ids
 from polar.authz.service import get_accessible_org_ids
 from polar.authz.types import AccessibleOrganizationID
 from polar.customer.repository import CustomerRepository
@@ -43,7 +44,6 @@ from polar.models import (
     MeterEvent,
     Organization,
     User,
-    UserOrganization,
 )
 from polar.models.event import EventSource
 from polar.postgres import AsyncSession
@@ -1222,10 +1222,7 @@ class EventService:
             if is_user(auth_subject):
                 statement = statement.where(
                     Customer.organization_id.in_(
-                        select(UserOrganization.organization_id).where(
-                            UserOrganization.user_id == auth_subject.subject.id,
-                            UserOrganization.is_deleted.is_(False),
-                        )
+                        select_user_org_ids(auth_subject.subject.id)
                     )
                 )
             else:
@@ -1268,10 +1265,7 @@ class EventService:
             if is_user(auth_subject):
                 statement = statement.where(
                     Member.organization_id.in_(
-                        select(UserOrganization.organization_id).where(
-                            UserOrganization.user_id == auth_subject.subject.id,
-                            UserOrganization.is_deleted.is_(False),
-                        )
+                        select_user_org_ids(auth_subject.subject.id)
                     )
                 )
             else:

--- a/server/polar/metrics/queries.py
+++ b/server/polar/metrics/queries.py
@@ -22,6 +22,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import TIMESTAMP
 
 from polar.auth.models import AuthSubject, is_organization, is_user
+from polar.authz.repository import select_user_org_ids
 from polar.config import settings
 from polar.enums import SubscriptionRecurringInterval
 from polar.kit.time_queries import TimeInterval
@@ -36,7 +37,6 @@ from polar.models import (
     Subscription,
     Transaction,
     User,
-    UserOrganization,
 )
 from polar.models.product import ProductBillingType
 from polar.models.transaction import TransactionType
@@ -104,12 +104,7 @@ def _get_readable_orders_statement(
 
     if is_user(auth_subject):
         statement = statement.where(
-            Product.organization_id.in_(
-                select(UserOrganization.organization_id).where(
-                    UserOrganization.user_id == auth_subject.subject.id,
-                    UserOrganization.is_deleted.is_(False),
-                )
-            )
+            Product.organization_id.in_(select_user_org_ids(auth_subject.subject.id))
         )
     elif is_organization(auth_subject):
         statement = statement.where(Product.organization_id == auth_subject.subject.id)
@@ -359,12 +354,7 @@ def _get_readable_subscriptions_statement(
 
     if is_user(auth_subject):
         statement = statement.where(
-            Product.organization_id.in_(
-                select(UserOrganization.organization_id).where(
-                    UserOrganization.user_id == auth_subject.subject.id,
-                    UserOrganization.is_deleted.is_(False),
-                )
-            )
+            Product.organization_id.in_(select_user_org_ids(auth_subject.subject.id))
         )
     elif is_organization(auth_subject):
         statement = statement.where(Product.organization_id == auth_subject.subject.id)
@@ -448,12 +438,7 @@ def get_checkouts_cte(
 
     if is_user(auth_subject):
         readable_checkouts_statement = readable_checkouts_statement.where(
-            Product.organization_id.in_(
-                select(UserOrganization.organization_id).where(
-                    UserOrganization.user_id == auth_subject.subject.id,
-                    UserOrganization.is_deleted.is_(False),
-                )
-            )
+            Product.organization_id.in_(select_user_org_ids(auth_subject.subject.id))
         )
     elif is_organization(auth_subject):
         readable_checkouts_statement = readable_checkouts_statement.where(
@@ -704,12 +689,7 @@ def _get_readable_seats_statement(
 
     if is_user(auth_subject):
         statement = statement.where(
-            Product.organization_id.in_(
-                select(UserOrganization.organization_id).where(
-                    UserOrganization.user_id == auth_subject.subject.id,
-                    UserOrganization.is_deleted.is_(False),
-                )
-            )
+            Product.organization_id.in_(select_user_org_ids(auth_subject.subject.id))
         )
     elif is_organization(auth_subject):
         statement = statement.where(Product.organization_id == auth_subject.subject.id)

--- a/server/polar/search/service.py
+++ b/server/polar/search/service.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
 
 from polar.auth.models import AuthSubject, User
 from polar.auth.scope import Scope
+from polar.authz.repository import select_user_org_ids
 from polar.kit.db.postgres import AsyncReadSession
 from polar.models import (
     Customer,
@@ -22,7 +23,6 @@ from polar.models import (
     Organization,
     Product,
     Subscription,
-    UserOrganization,
 )
 
 from .schemas import (
@@ -67,14 +67,9 @@ class SearchService:
         ts_query_english = func.websearch_to_tsquery("english", query)
         ilike_term = f"%{query}%"
 
-        organization_subquery = (
-            select(Organization.id)
-            .join(UserOrganization, Organization.id == UserOrganization.organization_id)
-            .where(
-                Organization.id == organization_id,
-                UserOrganization.user_id == auth_subject.subject.id,
-                UserOrganization.is_deleted.is_(False),
-            )
+        organization_subquery = select(Organization.id).where(
+            Organization.id == organization_id,
+            Organization.id.in_(select_user_org_ids(auth_subject.subject.id)),
         )
 
         subqueries: list[Select[Any]] = []

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -110,9 +110,10 @@ worker = { cmd = "dramatiq -p 1 -t 1 --watch polar -f polar.worker.scheduler:sta
 test = { cmd = "POLAR_ENV=testing python -m pytest --cov polar/ --cov-report=term-missing", help = "run all tests" }
 test_fast = { cmd = "POLAR_ENV=testing python -m pytest -n auto -p no:sugar --no-cov", help = "run all tests, but fast" }
 loadtest = { cmd = "locust -f load_tests/locustfile.py --host=http://127.0.0.1:8000", help = "run load tests (interactive)" }
-lint = { cmd = "ruff format . && ruff check --fix . && task lint_subquery", help = "run linters with autofix" }
-lint_check = { cmd = "ruff format --check . && ruff check . && task lint_subquery", help = "run ruff linter" }
+lint = { cmd = "ruff format . && ruff check --fix . && task lint_subquery && task lint_org_scope", help = "run linters with autofix" }
+lint_check = { cmd = "ruff format --check . && ruff check . && task lint_subquery && task lint_org_scope", help = "run ruff linter" }
 lint_subquery = { cmd = "python scripts/lint_subquery.py", help = "flag .subquery() calls that don't narrow columns" }
+lint_org_scope = { cmd = "python scripts/lint_org_scope.py", help = "flag inline UserOrganization filters that bypass select_user_org_ids" }
 lint_types = { cmd = "mypy --num-workers 2 polar scripts tests", help = "run mypy type verify" }
 db_migrate = { cmd = "python -m scripts.db upgrade", help = "run alembic upgrade" }
 db_recreate = { cmd = "python -m scripts.db recreate", help = "drop and recreate database" }

--- a/server/scripts/lint_org_scope.py
+++ b/server/scripts/lint_org_scope.py
@@ -1,0 +1,124 @@
+"""Flag inline `UserOrganization` membership filters keyed on the auth subject.
+
+Resolving "which organizations can this subject access?" must go through the
+canonical helpers so a single definition stays enforceable — `select_user_org_ids`
+(`polar.authz.repository`) for subquery use, or `get_accessible_org_ids`
+(`polar.authz.service`). This matters ahead of session/token organization
+scoping: those helpers are the one place the down-scope restriction is applied,
+so an inline subquery silently bypasses it.
+
+Rule:
+- Flag a comparison where one operand is `UserOrganization.<col>` and another
+  operand references `auth_subject` — e.g.
+  `UserOrganization.user_id == auth_subject.subject.id`. That is the read-
+  expansion bypass.
+- Membership *management* code (filtering by a plain `user_id`/`user.id`
+  parameter, not `auth_subject`) is NOT flagged — it doesn't reference the
+  auth subject, so it never matches.
+- `# noqa: org-scope` on the comparison line is an explicit escape.
+
+Exits 1 on any violation.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+NOQA_MARKER = "org-scope"
+MODEL_NAME = "UserOrganization"
+SUBJECT_NAME = "auth_subject"
+
+
+def _is_model_attr(node: ast.AST) -> bool:
+    """True for `UserOrganization.<attr>` (e.g. `UserOrganization.user_id`)."""
+    return (
+        isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == MODEL_NAME
+    )
+
+
+def _references_subject(node: ast.AST) -> bool:
+    """True if the subtree mentions the `auth_subject` name anywhere."""
+    return any(
+        isinstance(child, ast.Name) and child.id == SUBJECT_NAME
+        for child in ast.walk(node)
+    )
+
+
+def _line_has_noqa(source_lines: list[str], lineno: int) -> bool:
+    idx = lineno - 1
+    return 0 <= idx < len(source_lines) and NOQA_MARKER in source_lines[idx]
+
+
+def check_file(path: Path) -> list[tuple[Path, int, str]]:
+    """Return a list of (path, lineno, message) violations."""
+    source = path.read_text()
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        return [(path, exc.lineno or 0, f"syntax error: {exc.msg}")]
+
+    source_lines = source.splitlines()
+    violations: list[tuple[Path, int, str]] = []
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Compare):
+            continue
+
+        operands = [node.left, *node.comparators]
+        if not any(_is_model_attr(op) for op in operands):
+            continue
+        if not any(_references_subject(op) for op in operands):
+            continue
+
+        if _line_has_noqa(source_lines, node.lineno):
+            continue
+
+        violations.append(
+            (
+                path,
+                node.lineno,
+                "inline UserOrganization filter keyed on auth_subject bypasses "
+                "org-scope enforcement. Use select_user_org_ids("
+                "auth_subject.subject.id) from polar.authz.repository (or "
+                "get_accessible_org_ids). Escape with `# noqa: org-scope` if "
+                "intentional.",
+            )
+        )
+
+    return violations
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent / "polar"
+    if not root.exists():
+        print(f"error: {root} not found", file=sys.stderr)
+        return 2
+
+    checked = 0
+    violations: list[tuple[Path, int, str]] = []
+    for path in sorted(root.rglob("*.py")):
+        if "migrations" in path.parts:
+            continue
+        checked += 1
+        violations.extend(check_file(path))
+
+    if violations:
+        for path, lineno, message in violations:
+            try:
+                rel = path.relative_to(Path.cwd())
+            except ValueError:
+                rel = path
+            print(f"{rel}:{lineno}: {message}")
+        print(f"\n{len(violations)} violation(s) across {checked} file(s).")
+        return 1
+
+    print(f"OK: {checked} file(s) checked, no org-scope violations.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server/scripts/lint_org_scope.py
+++ b/server/scripts/lint_org_scope.py
@@ -23,6 +23,7 @@ Exits 1 on any violation.
 from __future__ import annotations
 
 import ast
+import re
 import sys
 from pathlib import Path
 
@@ -30,14 +31,22 @@ NOQA_MARKER = "org-scope"
 MODEL_NAME = "UserOrganization"
 SUBJECT_NAME = "auth_subject"
 
+# Matches `# noqa` optionally followed by `: code1, code2`. A bare `# noqa`
+# suppresses everything; a coded form only suppresses the listed codes.
+_NOQA_RE = re.compile(r"#\s*noqa(?::\s*(?P<codes>[^#]*))?", re.IGNORECASE)
+
 
 def _is_model_attr(node: ast.AST) -> bool:
-    """True for `UserOrganization.<attr>` (e.g. `UserOrganization.user_id`)."""
-    return (
-        isinstance(node, ast.Attribute)
-        and isinstance(node.value, ast.Name)
-        and node.value.id == MODEL_NAME
-    )
+    """True for `UserOrganization.<attr>`, including a module-qualified base
+    (e.g. `UserOrganization.user_id` or `models.UserOrganization.user_id`)."""
+    if not isinstance(node, ast.Attribute):
+        return False
+    base = node.value
+    if isinstance(base, ast.Name):
+        return base.id == MODEL_NAME
+    if isinstance(base, ast.Attribute):
+        return base.attr == MODEL_NAME
+    return False
 
 
 def _references_subject(node: ast.AST) -> bool:
@@ -50,7 +59,15 @@ def _references_subject(node: ast.AST) -> bool:
 
 def _line_has_noqa(source_lines: list[str], lineno: int) -> bool:
     idx = lineno - 1
-    return 0 <= idx < len(source_lines) and NOQA_MARKER in source_lines[idx]
+    if not (0 <= idx < len(source_lines)):
+        return False
+    match = _NOQA_RE.search(source_lines[idx])
+    if match is None:
+        return False
+    codes = match.group("codes")
+    if codes is None:  # bare `# noqa` suppresses everything
+        return True
+    return NOQA_MARKER in {code.strip() for code in codes.split(",")}
 
 
 def check_file(path: Path) -> list[tuple[Path, int, str]]:


### PR DESCRIPTION
## Summary

Groundwork for down-scoping sessions/tokens to specific organizations.

Normalize all "which orgs can this user access?" reads onto the canonical `select_user_org_ids` helper, and add a lint to keep them there.

⚠️ Previously these 7 reads filtered out deleted memberships but not the org's `api_access` capability. Using the helper also filters on `Organization.can_authenticate`, so it's stricter than before, these reads now additionally exclude soft-deleted and blocked (no api_access) organizations, matching the (~50 others) main-path reads.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

