### PR TITLE
tf/lambda: Set up specific Redis instance for AWS workers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -295,29 +295,29 @@ jobs:
           secrets: |
             IPINFO_ACCESS_TOKEN=${{ secrets.IPINFO_ACCESS_TOKEN }}
 
-  # deploy-lambda-sandbox:
-  #   name: "Deploy Lambda Worker to Sandbox 🧪"
-  #   needs: [changes, build-lambda-worker]
-  #   if: always() && !failure() && !cancelled() && needs.build-lambda-worker.result == 'success' && (needs.changes.outputs.backend-sandbox == 'true' || github.event_name == 'workflow_dispatch')
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: read
-  #     id-token: write
-  #   steps:
-  #     - name: Configure AWS credentials
-  #       uses: aws-actions/configure-aws-credentials@v6.2.0
-  #       with:
-  #         role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-  #         aws-region: us-east-2
-  #     - name: Log in to Amazon ECR
-  #       id: login-ecr
-  #       uses: aws-actions/amazon-ecr-login@v2
-  #     - name: Update sandbox Lambda function code
-  #       run: |
-  #         aws lambda update-function-code \
-  #           --function-name polar-sandbox-lambda-worker \
-  #           --image-uri "${{ steps.login-ecr.outputs.registry }}/polar-sandbox-lambda-worker:sha-${{ github.sha }}" \
-  #           --publish
+  deploy-lambda-sandbox:
+    name: "Deploy Lambda Worker to Sandbox 🧪"
+    needs: [changes, build-lambda-worker]
+    if: always() && !failure() && !cancelled() && needs.build-lambda-worker.result == 'success' && (needs.changes.outputs.backend-sandbox == 'true' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6.2.0
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-2
+      - name: Log in to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+      - name: Update sandbox Lambda function code
+        run: |
+          aws lambda update-function-code \
+            --function-name polar-sandbox-worker-dummy \
+            --image-uri "${{ steps.login-ecr.outputs.registry }}/polar-sandbox-lambda-worker:sha-${{ github.sha }}" \
+            --publish
 
   # deploy-lambda-production:
   #   name: "Deploy Lambda Worker to Production 🚀"

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -337,6 +337,8 @@ class Settings(BaseSettings):
     WORKER_SQS_QUEUE_PREFIX: str = "polar-tasks"
     # Override to http://127.0.0.1:4566 in .env to target LocalStack
     SQS_ENDPOINT_URL: str | None = None
+    WORKER_SQS_AWS_ACCESS_KEY_ID: str | None = None
+    WORKER_SQS_AWS_SECRET_ACCESS_KEY: str | None = None
 
     # Downloadable files
     S3_FILES_BUCKET_NAME: str = "polar-s3"

--- a/server/polar/worker/_sqs.py
+++ b/server/polar/worker/_sqs.py
@@ -39,8 +39,12 @@ def get_sqs_client() -> "SQSClient":
     return boto3.client(
         "sqs",
         endpoint_url=settings.SQS_ENDPOINT_URL,
-        aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+        aws_access_key_id=(
+            settings.WORKER_SQS_AWS_ACCESS_KEY_ID or settings.AWS_ACCESS_KEY_ID
+        ),
+        aws_secret_access_key=(
+            settings.WORKER_SQS_AWS_SECRET_ACCESS_KEY or settings.AWS_SECRET_ACCESS_KEY
+        ),
         config=Config(
             region_name=settings.AWS_REGION,
             signature_version=settings.AWS_SIGNATURE_VERSION,

--- a/terraform/modules/aws_redis/main.tf
+++ b/terraform/modules/aws_redis/main.tf
@@ -1,0 +1,33 @@
+resource "aws_elasticache_subnet_group" "this" {
+  name       = var.name
+  subnet_ids = var.subnet_ids
+  tags       = var.tags
+}
+
+resource "aws_security_group" "this" {
+  name        = "${var.name}-cache"
+  description = "Ingress to ${var.name} Redis from allowed security groups."
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_vpc_security_group_ingress_rule" "redis" {
+  for_each                     = toset(var.ingress_security_group_ids)
+  security_group_id            = aws_security_group.this.id
+  referenced_security_group_id = each.value
+  from_port                    = var.port
+  to_port                      = var.port
+  ip_protocol                  = "tcp"
+}
+
+resource "aws_elasticache_cluster" "this" {
+  cluster_id         = var.name
+  engine             = "redis"
+  engine_version     = var.engine_version
+  node_type          = var.node_type
+  num_cache_nodes    = 1
+  port               = var.port
+  subnet_group_name  = aws_elasticache_subnet_group.this.name
+  security_group_ids = [aws_security_group.this.id]
+  tags               = var.tags
+}

--- a/terraform/modules/aws_redis/outputs.tf
+++ b/terraform/modules/aws_redis/outputs.tf
@@ -1,0 +1,14 @@
+output "host" {
+  description = "Primary endpoint host for the Redis node."
+  value       = aws_elasticache_cluster.this.cache_nodes[0].address
+}
+
+output "port" {
+  description = "Redis port."
+  value       = aws_elasticache_cluster.this.port
+}
+
+output "security_group_id" {
+  description = "Security group attached to the cache."
+  value       = aws_security_group.this.id
+}

--- a/terraform/modules/aws_redis/terraform.tf
+++ b/terraform/modules/aws_redis/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/terraform/modules/aws_redis/variables.tf
+++ b/terraform/modules/aws_redis/variables.tf
@@ -1,0 +1,43 @@
+variable "name" {
+  description = "Name used for the ElastiCache cluster, subnet group, and security group."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC the cache and its security group live in."
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Private subnets for the cache subnet group."
+  type        = list(string)
+}
+
+variable "ingress_security_group_ids" {
+  description = "Security groups allowed to reach Redis on the cache port."
+  type        = list(string)
+}
+
+variable "node_type" {
+  description = "ElastiCache node type."
+  type        = string
+  default     = "cache.t4g.micro"
+}
+
+variable "engine_version" {
+  description = "Redis engine version."
+  type        = string
+  default     = "7.1"
+}
+
+variable "port" {
+  description = "Redis port."
+  type        = number
+  default     = 6379
+}
+
+variable "tags" {
+  description = "Tags applied to all created resources."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -127,6 +127,19 @@ resource "render_env_group" "aws_s3" {
   }
 }
 
+resource "render_env_group" "worker_sqs" {
+  count          = var.worker_sqs_config != null ? 1 : 0
+  environment_id = var.render_environment_id
+  name           = "worker-sqs-${var.environment}"
+  env_vars = {
+    POLAR_WORKER_SQS_ENABLED               = { value = var.worker_sqs_config.enabled }
+    POLAR_WORKER_SQS_ACTORS                = { value = var.worker_sqs_config.actors }
+    POLAR_WORKER_SQS_QUEUE_PREFIX          = { value = var.worker_sqs_config.queue_prefix }
+    POLAR_WORKER_SQS_AWS_ACCESS_KEY_ID     = { value = var.worker_sqs_config.aws_access_key_id }
+    POLAR_WORKER_SQS_AWS_SECRET_ACCESS_KEY = { value = var.worker_sqs_config.aws_secret_access_key }
+  }
+}
+
 resource "render_env_group" "github" {
   environment_id = var.render_environment_id
   name           = "github-${var.environment}"
@@ -423,6 +436,12 @@ resource "render_env_group_link" "redis" {
 
 resource "render_env_group_link" "aws_s3" {
   env_group_id = render_env_group.aws_s3.id
+  service_ids  = local.all_service_ids
+}
+
+resource "render_env_group_link" "worker_sqs" {
+  count        = var.worker_sqs_config != null ? 1 : 0
+  env_group_id = render_env_group.worker_sqs[0].id
   service_ids  = local.all_service_ids
 }
 

--- a/terraform/modules/render_service/variables.tf
+++ b/terraform/modules/render_service/variables.tf
@@ -188,6 +188,19 @@ variable "aws_s3_secrets" {
   sensitive = true
 }
 
+variable "worker_sqs_config" {
+  description = "Worker SQS execution engine config and producer credentials (optional). null skips the env group."
+  type = object({
+    enabled               = string
+    actors                = string
+    queue_prefix          = string
+    aws_access_key_id     = string
+    aws_secret_access_key = string
+  })
+  default   = null
+  sensitive = true
+}
+
 variable "github_secrets" {
   description = "GitHub secrets (sensitive)"
   type = object({

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -34,7 +34,7 @@ module "dummy_lambda_worker" {
   name                 = "dummy"
   queue_name           = "polar-sandbox-tasks-dummy"
   image_uri            = "${module.lambda_worker_ecr.repository_url}:latest"
-  enabled              = false
+  enabled              = true
   reserved_concurrency = null
   subnet_ids           = local.lambda_subnet_ids
   security_group_ids   = local.lambda_security_group_ids

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -27,6 +27,15 @@ module "lambda_worker_ecr" {
   name = "polar-sandbox-lambda-worker"
 }
 
+module "redis" {
+  source = "../modules/aws_redis"
+
+  name                       = "polar-sandbox-worker"
+  vpc_id                     = module.vpc.vpc_id
+  subnet_ids                 = module.vpc.private_subnet_ids
+  ingress_security_group_ids = [aws_security_group.lambda.id]
+}
+
 module "dummy_lambda_worker" {
   source = "../modules/aws_task_worker"
 
@@ -52,8 +61,8 @@ module "dummy_lambda_worker" {
     POLAR_POSTGRES_PORT           = local.db_port
     POLAR_POSTGRES_USER           = local.db_user
     POLAR_POSTGRES_SSL            = "true"
-    POLAR_REDIS_HOST              = local.redis_host
-    POLAR_REDIS_PORT              = local.redis_port
+    POLAR_REDIS_HOST              = module.redis.host
+    POLAR_REDIS_PORT              = tostring(module.redis.port)
     POLAR_REDIS_DB                = "1"
     POLAR_AWS_REGION              = "us-east-2"
     POLAR_WORKER_SQS_ENABLED      = "true"

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -72,6 +72,35 @@ module "dummy_lambda_worker" {
 }
 
 # =============================================================================
+# Task producer IAM user (SQS send-only, used by the Render backend)
+# =============================================================================
+
+resource "aws_iam_user" "tasks_producer" {
+  name = "polar-sandbox-tasks-producer"
+}
+
+resource "aws_iam_access_key" "tasks_producer" {
+  user = aws_iam_user.tasks_producer.name
+}
+
+data "aws_iam_policy_document" "tasks_producer" {
+  statement {
+    sid = "SendTasks"
+    actions = [
+      "sqs:SendMessage",
+      "sqs:GetQueueUrl",
+    ]
+    resources = [module.dummy_lambda_worker.queue_arn]
+  }
+}
+
+resource "aws_iam_user_policy" "tasks_producer" {
+  name   = "polar-sandbox-tasks-producer"
+  user   = aws_iam_user.tasks_producer.name
+  policy = data.aws_iam_policy_document.tasks_producer.json
+}
+
+# =============================================================================
 # Image Resizer Lambda@Edge
 # =============================================================================
 

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -202,6 +202,14 @@ module "sandbox" {
     files_download_secret = var.s3_files_download_secret_sandbox
   }
 
+  worker_sqs_config = {
+    enabled               = "true"
+    actors                = jsonencode(["dummy"])
+    queue_prefix          = "polar-sandbox-tasks"
+    aws_access_key_id     = aws_iam_access_key.tasks_producer.id
+    aws_secret_access_key = aws_iam_access_key.tasks_producer.secret
+  }
+
   github_secrets = {
     client_id                           = var.github_client_id_sandbox
     client_secret                       = var.github_client_secret_sandbox


### PR DESCRIPTION
Instead of opening up and making the Redis on Render available to the lambda workers, we set up a specific one for the lambda workers. This ensures that we don't run out of connections due to an bump in concurrency, and that the two paralell infrastructures cant impact each other.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

