### PR TITLE
fix(lint): ban UserOrganization expansion outright, bless the helper

### DIFF
--- a/server/polar/authz/repository.py
+++ b/server/polar/authz/repository.py
@@ -26,7 +26,9 @@ def select_user_org_ids(
     grants that permission.
     """
     stmt = (
-        select(UserOrganization.organization_id)
+        # The one blessed place that expands user memberships into org ids;
+        # every other caller must go through this helper.
+        select(UserOrganization.organization_id)  # noqa: org-scope
         .join(Organization, UserOrganization.organization_id == Organization.id)
         .where(
             UserOrganization.user_id == user_id,

--- a/server/scripts/lint_org_scope.py
+++ b/server/scripts/lint_org_scope.py
@@ -29,6 +29,7 @@ import ast
 import re
 import sys
 from pathlib import Path
+from typing import TypeGuard
 
 NOQA_MARKER = "org-scope"
 MODEL_NAME = "UserOrganization"
@@ -39,7 +40,7 @@ SUBJECT_NAME = "auth_subject"
 _NOQA_RE = re.compile(r"#\s*noqa(?::\s*(?P<codes>[^#]*))?", re.IGNORECASE)
 
 
-def _is_model_attr(node: ast.AST) -> bool:
+def _is_model_attr(node: ast.AST) -> TypeGuard[ast.Attribute]:
     """True for `UserOrganization.<attr>`, including a module-qualified base
     (e.g. `UserOrganization.user_id` or `models.UserOrganization.user_id`)."""
     if not isinstance(node, ast.Attribute):

--- a/server/scripts/lint_org_scope.py
+++ b/server/scripts/lint_org_scope.py
@@ -1,21 +1,24 @@
-"""Flag inline `UserOrganization` membership filters keyed on the auth subject.
+"""Flag hand-rolled `UserOrganization` membership expansion.
 
 Resolving "which organizations can this subject access?" must go through the
 canonical helpers so a single definition stays enforceable — `select_user_org_ids`
 (`polar.authz.repository`) for subquery use, or `get_accessible_org_ids`
 (`polar.authz.service`). This matters ahead of session/token organization
 scoping: those helpers are the one place the down-scope restriction is applied,
-so an inline subquery silently bypasses it.
+so a hand-rolled subquery silently bypasses it.
 
-Rule:
+Rules:
+- Flag `select(UserOrganization.organization_id)` — building the
+  user→accessible-orgs subquery by hand. The canonical helper is the sole
+  blessed exception and marks itself with `# noqa: org-scope`.
 - Flag a comparison where one operand is `UserOrganization.<col>` and another
-  operand references `auth_subject` — e.g.
-  `UserOrganization.user_id == auth_subject.subject.id`. That is the read-
-  expansion bypass.
+  references `auth_subject` (e.g. `UserOrganization.user_id ==
+  auth_subject.subject.id`) — the join-form bypass that doesn't project
+  `organization_id` directly.
 - Membership *management* code (filtering by a plain `user_id`/`user.id`
-  parameter, not `auth_subject`) is NOT flagged — it doesn't reference the
-  auth subject, so it never matches.
-- `# noqa: org-scope` on the comparison line is an explicit escape.
+  parameter, not `auth_subject`, and not projecting `organization_id`) is NOT
+  flagged.
+- `# noqa: org-scope` on the offending line is an explicit escape.
 
 Exits 1 on any violation.
 """
@@ -57,6 +60,24 @@ def _references_subject(node: ast.AST) -> bool:
     )
 
 
+def _is_membership_expansion(node: ast.AST) -> bool:
+    """True for `select(UserOrganization.organization_id)` — hand-building the
+    user→accessible-orgs subquery instead of calling the helper."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    is_select = (isinstance(func, ast.Name) and func.id == "select") or (
+        isinstance(func, ast.Attribute) and func.attr == "select"
+    )
+    if not is_select:
+        return False
+    return any(
+        _is_model_attr(arg) and arg.attr == "organization_id"
+        for arg in node.args
+        if isinstance(arg, ast.Attribute)
+    )
+
+
 def _line_has_noqa(source_lines: list[str], lineno: int) -> bool:
     idx = lineno - 1
     if not (0 <= idx < len(source_lines)):
@@ -82,13 +103,16 @@ def check_file(path: Path) -> list[tuple[Path, int, str]]:
     violations: list[tuple[Path, int, str]] = []
 
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Compare):
-            continue
-
-        operands = [node.left, *node.comparators]
-        if not any(_is_model_attr(op) for op in operands):
-            continue
-        if not any(_references_subject(op) for op in operands):
+        if isinstance(node, ast.Call):
+            if not _is_membership_expansion(node):
+                continue
+        elif isinstance(node, ast.Compare):
+            operands = [node.left, *node.comparators]
+            if not any(_is_model_attr(op) for op in operands):
+                continue
+            if not any(_references_subject(op) for op in operands):
+                continue
+        else:
             continue
 
         if _line_has_noqa(source_lines, node.lineno):
@@ -98,7 +122,7 @@ def check_file(path: Path) -> list[tuple[Path, int, str]]:
             (
                 path,
                 node.lineno,
-                "inline UserOrganization filter keyed on auth_subject bypasses "
+                "hand-rolled UserOrganization membership expansion bypasses "
                 "org-scope enforcement. Use select_user_org_ids("
                 "auth_subject.subject.id) from polar.authz.repository (or "
                 "get_accessible_org_ids). Escape with `# noqa: org-scope` if "

--- a/server/scripts/lint_org_scope.py
+++ b/server/scripts/lint_org_scope.py
@@ -61,8 +61,11 @@ def _references_subject(node: ast.AST) -> bool:
 
 
 def _is_membership_expansion(node: ast.AST) -> bool:
-    """True for `select(UserOrganization.organization_id)` — hand-building the
-    user→accessible-orgs subquery instead of calling the helper."""
+    """True for a `select(...)` projecting `UserOrganization.organization_id` —
+    hand-building the user→accessible-orgs subquery instead of calling the helper.
+    Catches wrapped/unpacked forms too (e.g. `select(distinct(...))` or
+    `select(UserOrganization.organization_id.label(...))`) by scanning each
+    projected argument's subtree."""
     if not isinstance(node, ast.Call):
         return False
     func = node.func
@@ -72,9 +75,9 @@ def _is_membership_expansion(node: ast.AST) -> bool:
     if not is_select:
         return False
     return any(
-        _is_model_attr(arg) and arg.attr == "organization_id"
+        _is_model_attr(descendant) and descendant.attr == "organization_id"
         for arg in node.args
-        if isinstance(arg, ast.Attribute)
+        for descendant in ast.walk(arg)
     )
 
 
@@ -101,6 +104,7 @@ def check_file(path: Path) -> list[tuple[Path, int, str]]:
 
     source_lines = source.splitlines()
     violations: list[tuple[Path, int, str]] = []
+    seen_lines: set[int] = set()
 
     for node in ast.walk(tree):
         if isinstance(node, ast.Call):
@@ -117,6 +121,10 @@ def check_file(path: Path) -> list[tuple[Path, int, str]]:
 
         if _line_has_noqa(source_lines, node.lineno):
             continue
+
+        if node.lineno in seen_lines:  # one query can match both branches
+            continue
+        seen_lines.add(node.lineno)
 
         violations.append(
             (


### PR DESCRIPTION
It's even safer this way

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stricter org-scope linting: ban hand-built expansion of `UserOrganization` into org IDs; only the `select_user_org_ids` helper is allowed. This closes bypass paths and keeps down-scope rules enforceable.

- **Bug Fixes**
  - Linter bans membership expansion: flags `select(UserOrganization.organization_id)` anywhere (including wrapped via `distinct(...)` or `.label(...)`) and comparisons keyed on `auth_subject`; skips membership management code that doesn’t reference `auth_subject`; dedupes per line.
  - `select_user_org_ids` in `polar.authz.repository` is the only allowed expansion and is marked `# noqa: org-scope`; error text/docs updated; typing narrowed with a `TypeGuard` in `_is_model_attr` so mypy accepts `.attr`.

<sup>Written for commit 22fc7a9cec8e2afb43d91303b10e9744353b597d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

