### PR TITLE
refactor(metrics): scope SQL metric reads by analytics_read permission

### DIFF
--- a/server/polar/metrics/queries.py
+++ b/server/polar/metrics/queries.py
@@ -22,6 +22,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import TIMESTAMP
 
 from polar.auth.models import AuthSubject, is_organization, is_user
+from polar.auth.permission import OrganizationPermission
 from polar.authz.repository import select_user_org_ids
 from polar.config import settings
 from polar.enums import SubscriptionRecurringInterval
@@ -104,7 +105,12 @@ def _get_readable_orders_statement(
 
     if is_user(auth_subject):
         statement = statement.where(
-            Product.organization_id.in_(select_user_org_ids(auth_subject.subject.id))
+            Product.organization_id.in_(
+                select_user_org_ids(
+                    auth_subject.subject.id,
+                    permission=OrganizationPermission.analytics_read,
+                )
+            )
         )
     elif is_organization(auth_subject):
         statement = statement.where(Product.organization_id == auth_subject.subject.id)
@@ -354,7 +360,12 @@ def _get_readable_subscriptions_statement(
 
     if is_user(auth_subject):
         statement = statement.where(
-            Product.organization_id.in_(select_user_org_ids(auth_subject.subject.id))
+            Product.organization_id.in_(
+                select_user_org_ids(
+                    auth_subject.subject.id,
+                    permission=OrganizationPermission.analytics_read,
+                )
+            )
         )
     elif is_organization(auth_subject):
         statement = statement.where(Product.organization_id == auth_subject.subject.id)
@@ -438,7 +449,12 @@ def get_checkouts_cte(
 
     if is_user(auth_subject):
         readable_checkouts_statement = readable_checkouts_statement.where(
-            Product.organization_id.in_(select_user_org_ids(auth_subject.subject.id))
+            Product.organization_id.in_(
+                select_user_org_ids(
+                    auth_subject.subject.id,
+                    permission=OrganizationPermission.analytics_read,
+                )
+            )
         )
     elif is_organization(auth_subject):
         readable_checkouts_statement = readable_checkouts_statement.where(
@@ -689,7 +705,12 @@ def _get_readable_seats_statement(
 
     if is_user(auth_subject):
         statement = statement.where(
-            Product.organization_id.in_(select_user_org_ids(auth_subject.subject.id))
+            Product.organization_id.in_(
+                select_user_org_ids(
+                    auth_subject.subject.id,
+                    permission=OrganizationPermission.analytics_read,
+                )
+            )
         )
     elif is_organization(auth_subject):
         statement = statement.where(Product.organization_id == auth_subject.subject.id)


### PR DESCRIPTION
## Summary

Align the SQL metrics backend with the Tinybird one: both now resolve a user's accessible organizations through `OrganizationPermission.analytics_read`.

## What

`polar/metrics/queries.py` — pass `permission=analytics_read` to `select_user_org_ids` in the orders / subscriptions / checkouts / seats readable statements (1 import + 4 call sites).

## Why

The Tinybird path (`metrics/service.py`) already filters orgs by `analytics_read` via `get_accessible_org_ids`; the SQL path did not.

## How

Functional no-op today — `analytics_read` is a `_MEMBER_PERMISSIONS` entry, so every role (member/admin/owner) grants it and the added `role IN (...)` clause matches every membership. The value is future-proofing: if `analytics_read` is ever moved to admin-only or a finer role model lands, the SQL backend tightens in lockstep with Tinybird instead of silently leaking metrics.

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included
