### PR TITLE
feat(auth): enforce UserSession organization down-scope

### DIFF
--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -290,6 +290,12 @@ class TestCreate:
         enqueue_job_mock.assert_called_once()
 ```
 
+Get an `AuthSubject` from the `@pytest.mark.auth` marker + the `auth_subject` fixture — never
+hand-roll one with a local helper like `AuthSubject(user, set(), None)`. Use `@pytest.mark.auth`
+(default `user`) or `@pytest.mark.auth(AuthSubjectFixture(subject="user_second"))`, take
+`auth_subject: AuthSubject[User]`, and pass it straight to the service. Keep an explicit `user`
+fixture param only when the body still needs it (e.g. `user.id`).
+
 ### API Tests (Integration)
 
 ```python

--- a/server/polar/auth/middlewares.py
+++ b/server/polar/auth/middlewares.py
@@ -175,7 +175,18 @@ async def get_auth_subject(
 
     user_session = await get_user_session(request, session)
     if user_session is not None:
-        return AuthSubject(user_session.user, set(user_session.scopes), user_session)
+        organization_ids = (
+            frozenset(
+                scope.organization_id for scope in user_session.organization_scopes
+            )
+            or None
+        )
+        return AuthSubject(
+            user_session.user,
+            set(user_session.scopes),
+            user_session,
+            organization_ids,
+        )
 
     return AuthSubject(Anonymous(), set(), None)
 

--- a/server/polar/auth/models.py
+++ b/server/polar/auth/models.py
@@ -1,5 +1,6 @@
 from functools import cached_property
 from typing import Any, Generic, TypeGuard, TypeVar
+from uuid import UUID
 
 from polar.enums import RateLimitGroup
 from polar.models import (
@@ -42,11 +43,23 @@ class AuthSubject(Generic[S]):  # noqa: UP046 # Don't use the new syntax as it a
     subject: S
     scopes: set[Scope]
     session: Session | None
+    # Organizations this credential is down-scoped to. ``None`` means
+    # unrestricted (all the subject's organizations, resolved live); a set
+    # restricts access to those organizations, always intersected with the
+    # subject's current membership.
+    organization_ids: frozenset[UUID] | None
 
-    def __init__(self, subject: S, scopes: set[Scope], session: Session | None) -> None:
+    def __init__(
+        self,
+        subject: S,
+        scopes: set[Scope],
+        session: Session | None,
+        organization_ids: frozenset[UUID] | None = None,
+    ) -> None:
         self.subject = subject
         self.scopes = scopes
         self.session = session
+        self.organization_ids = organization_ids
 
     @cached_property
     def rate_limit_key(self) -> tuple[str, RateLimitGroup]:

--- a/server/polar/authz/repository.py
+++ b/server/polar/authz/repository.py
@@ -13,6 +13,7 @@ def select_user_org_ids(
     user_id: UUID,
     *,
     permission: OrganizationPermission | None = None,
+    scoped_to: frozenset[UUID] | None,
 ) -> Select[tuple[UUID]]:
     """SQL `SELECT` of organization IDs the user is a member of.
 
@@ -24,6 +25,12 @@ def select_user_org_ids(
     when building auth-aware repository statements. When ``permission`` is
     provided, results are restricted to organizations where the user's role
     grants that permission.
+
+    ``scoped_to`` is the session/token down-scope (``AuthSubject.organization_ids``)
+    and is **required** — a caller must consciously forward the subject's scope,
+    or pass ``None`` to opt out (unrestricted). When a set is given, results are
+    intersected with it. Making it required keeps the filter fail-closed: a
+    forgotten argument is a type error, not a silent all-orgs leak.
     """
     stmt = (
         select(UserOrganization.organization_id)
@@ -36,6 +43,8 @@ def select_user_org_ids(
     )
     if permission is not None:
         stmt = stmt.where(UserOrganization.role.in_(roles_with_permission(permission)))
+    if scoped_to is not None:
+        stmt = stmt.where(UserOrganization.organization_id.in_(scoped_to))
     return stmt
 
 
@@ -52,14 +61,17 @@ class AuthzRepository:
         user_id: UUID,
         *,
         permission: OrganizationPermission | None = None,
+        scoped_to: frozenset[UUID] | None,
     ) -> set[UUID]:
         """Get accessible organization IDs a user is a member of.
 
         When ``permission`` is provided, results are further restricted to
-        organizations where the user's role grants that permission.
+        organizations where the user's role grants that permission. ``scoped_to``
+        is the required session/token down-scope (pass ``None`` to opt out);
+        results are intersected with it when a set is given.
         """
         result = await self.session.scalars(
-            select_user_org_ids(user_id, permission=permission)
+            select_user_org_ids(user_id, permission=permission, scoped_to=scoped_to)
         )
         return set(result.all())
 
@@ -80,7 +92,12 @@ class AuthzRepository:
 
         if is_user(auth_subject):
             stmt = stmt.where(
-                Organization.id.in_(select_user_org_ids(auth_subject.subject.id))
+                Organization.id.in_(
+                    select_user_org_ids(
+                        auth_subject.subject.id,
+                        scoped_to=auth_subject.organization_ids,
+                    )
+                )
             )
         elif is_organization(auth_subject):
             stmt = stmt.where(Organization.id == auth_subject.subject.id)

--- a/server/polar/authz/repository.py
+++ b/server/polar/authz/repository.py
@@ -9,28 +9,20 @@ from polar.models import Organization, UserOrganization
 from polar.postgres import AsyncReadSession
 
 
-def select_user_org_ids(
+def select_user_org_ids_by_id(
     user_id: UUID,
     *,
     permission: OrganizationPermission | None = None,
-    scoped_to: frozenset[UUID] | None,
 ) -> Select[tuple[UUID]]:
-    """SQL `SELECT` of organization IDs the user is a member of.
+    """SQL `SELECT` of organization IDs a specific user is a member of.
 
-    Joins ``Organization`` so soft-deleted orgs and orgs without
-    ``api_access`` are excluded — matching the parity expected of the
-    sibling ``AuthzRepository.get_user_org_ids`` helper.
+    Joins ``Organization`` so soft-deleted orgs and orgs without ``api_access``
+    are excluded. When ``permission`` is provided, results are restricted to
+    organizations where the user's role grants that permission.
 
-    Intended for use as a subquery inside `Resource.organization_id.in_(...)`
-    when building auth-aware repository statements. When ``permission`` is
-    provided, results are restricted to organizations where the user's role
-    grants that permission.
-
-    ``scoped_to`` is the session/token down-scope (``AuthSubject.organization_ids``)
-    and is **required** — a caller must consciously forward the subject's scope,
-    or pass ``None`` to opt out (unrestricted). When a set is given, results are
-    intersected with it. Making it required keeps the filter fail-closed: a
-    forgotten argument is a type error, not a silent all-orgs leak.
+    Takes a raw ``user_id`` and applies **no** session down-scope. Use it for
+    flows that check a particular user's membership (e.g. OAuth consent), not the
+    caller's accessible resources — for the latter use ``select_user_org_ids``.
     """
     stmt = (
         select(UserOrganization.organization_id)
@@ -43,8 +35,29 @@ def select_user_org_ids(
     )
     if permission is not None:
         stmt = stmt.where(UserOrganization.role.in_(roles_with_permission(permission)))
-    if scoped_to is not None:
-        stmt = stmt.where(UserOrganization.organization_id.in_(scoped_to))
+    return stmt
+
+
+def select_user_org_ids(
+    auth_subject: AuthSubject[User],
+    *,
+    permission: OrganizationPermission | None = None,
+) -> Select[tuple[UUID]]:
+    """SQL `SELECT` of organization IDs the subject can access.
+
+    Intended as a subquery inside ``Resource.organization_id.in_(...)`` when
+    building auth-aware statements. Takes the full ``AuthSubject`` so the
+    session/token down-scope (``organization_ids``) travels with the subject and
+    can't be forgotten or mismatched with a stray ``user_id``: results are the
+    user's memberships (optionally narrowed by ``permission``) intersected with
+    that scope. An unscoped subject (``organization_ids is None``) is not
+    narrowed.
+    """
+    stmt = select_user_org_ids_by_id(auth_subject.subject.id, permission=permission)
+    if auth_subject.organization_ids is not None:
+        stmt = stmt.where(
+            UserOrganization.organization_id.in_(auth_subject.organization_ids)
+        )
     return stmt
 
 
@@ -58,20 +71,18 @@ class AuthzRepository:
 
     async def get_user_org_ids(
         self,
-        user_id: UUID,
+        auth_subject: AuthSubject[User],
         *,
         permission: OrganizationPermission | None = None,
-        scoped_to: frozenset[UUID] | None,
     ) -> set[UUID]:
-        """Get accessible organization IDs a user is a member of.
+        """Get accessible organization IDs for the subject.
 
-        When ``permission`` is provided, results are further restricted to
-        organizations where the user's role grants that permission. ``scoped_to``
-        is the required session/token down-scope (pass ``None`` to opt out);
-        results are intersected with it when a set is given.
+        When ``permission`` is provided, results are restricted to organizations
+        where the user's role grants that permission. The subject's session
+        down-scope (``organization_ids``) is applied intrinsically.
         """
         result = await self.session.scalars(
-            select_user_org_ids(user_id, permission=permission, scoped_to=scoped_to)
+            select_user_org_ids(auth_subject, permission=permission)
         )
         return set(result.all())
 
@@ -91,14 +102,7 @@ class AuthzRepository:
         )
 
         if is_user(auth_subject):
-            stmt = stmt.where(
-                Organization.id.in_(
-                    select_user_org_ids(
-                        auth_subject.subject.id,
-                        scoped_to=auth_subject.organization_ids,
-                    )
-                )
-            )
+            stmt = stmt.where(Organization.id.in_(select_user_org_ids(auth_subject)))
         elif is_organization(auth_subject):
             stmt = stmt.where(Organization.id == auth_subject.subject.id)
         else:

--- a/server/polar/authz/repository.py
+++ b/server/polar/authz/repository.py
@@ -9,20 +9,21 @@ from polar.models import Organization, UserOrganization
 from polar.postgres import AsyncReadSession
 
 
-def select_user_org_ids_by_id(
+def select_user_org_ids(
     user_id: UUID,
     *,
     permission: OrganizationPermission | None = None,
 ) -> Select[tuple[UUID]]:
-    """SQL `SELECT` of organization IDs a specific user is a member of.
+    """SQL `SELECT` of organization IDs a user is a member of.
 
     Joins ``Organization`` so soft-deleted orgs and orgs without ``api_access``
     are excluded. When ``permission`` is provided, results are restricted to
     organizations where the user's role grants that permission.
 
-    Takes a raw ``user_id`` and applies **no** session down-scope. Use it for
-    flows that check a particular user's membership (e.g. OAuth consent), not the
-    caller's accessible resources — for the latter use ``select_user_org_ids``.
+    Takes a raw ``user_id`` and applies **no** session down-scope — it answers
+    "which orgs does this user belong to?". Use it for flows that check a
+    particular user's membership (e.g. OAuth consent), not the caller's
+    accessible resources — for the latter use ``select_accessible_org_ids``.
     """
     stmt = (
         select(UserOrganization.organization_id)
@@ -38,22 +39,22 @@ def select_user_org_ids_by_id(
     return stmt
 
 
-def select_user_org_ids(
+def select_accessible_org_ids(
     auth_subject: AuthSubject[User],
     *,
     permission: OrganizationPermission | None = None,
 ) -> Select[tuple[UUID]]:
     """SQL `SELECT` of organization IDs the subject can access.
 
-    Intended as a subquery inside ``Resource.organization_id.in_(...)`` when
-    building auth-aware statements. Takes the full ``AuthSubject`` so the
-    session/token down-scope (``organization_ids``) travels with the subject and
-    can't be forgotten or mismatched with a stray ``user_id``: results are the
-    user's memberships (optionally narrowed by ``permission``) intersected with
-    that scope. An unscoped subject (``organization_ids is None``) is not
-    narrowed.
+    The SQL-subquery sibling of ``get_accessible_org_ids``: use it inside
+    ``Resource.organization_id.in_(...)`` when building auth-aware statements.
+    Takes the full ``AuthSubject`` so the session/token down-scope
+    (``organization_ids``) travels with the subject and can't be forgotten or
+    mismatched with a stray ``user_id``: results are the user's memberships
+    (optionally narrowed by ``permission``) intersected with that scope. An
+    unscoped subject (``organization_ids is None``) is not narrowed.
     """
-    stmt = select_user_org_ids_by_id(auth_subject.subject.id, permission=permission)
+    stmt = select_user_org_ids(auth_subject.subject.id, permission=permission)
     if auth_subject.organization_ids is not None:
         stmt = stmt.where(
             UserOrganization.organization_id.in_(auth_subject.organization_ids)
@@ -82,7 +83,7 @@ class AuthzRepository:
         down-scope (``organization_ids``) is applied intrinsically.
         """
         result = await self.session.scalars(
-            select_user_org_ids(auth_subject, permission=permission)
+            select_accessible_org_ids(auth_subject, permission=permission)
         )
         return set(result.all())
 
@@ -102,7 +103,9 @@ class AuthzRepository:
         )
 
         if is_user(auth_subject):
-            stmt = stmt.where(Organization.id.in_(select_user_org_ids(auth_subject)))
+            stmt = stmt.where(
+                Organization.id.in_(select_accessible_org_ids(auth_subject))
+            )
         elif is_organization(auth_subject):
             stmt = stmt.where(Organization.id == auth_subject.subject.id)
         else:

--- a/server/polar/authz/service.py
+++ b/server/polar/authz/service.py
@@ -32,11 +32,7 @@ async def get_accessible_org_ids(
         return {AccessibleOrganizationID(auth_subject.subject.id)}
     if is_user(auth_subject):
         repository = AuthzRepository.from_session(session)
-        raw_ids = await repository.get_user_org_ids(
-            auth_subject.subject.id,
-            permission=permission,
-            scoped_to=auth_subject.organization_ids,
-        )
+        raw_ids = await repository.get_user_org_ids(auth_subject, permission=permission)
         return {AccessibleOrganizationID(uid) for uid in raw_ids}
     return set()
 

--- a/server/polar/authz/service.py
+++ b/server/polar/authz/service.py
@@ -33,7 +33,9 @@ async def get_accessible_org_ids(
     if is_user(auth_subject):
         repository = AuthzRepository.from_session(session)
         raw_ids = await repository.get_user_org_ids(
-            auth_subject.subject.id, permission=permission
+            auth_subject.subject.id,
+            permission=permission,
+            scoped_to=auth_subject.organization_ids,
         )
         return {AccessibleOrganizationID(uid) for uid in raw_ids}
     return set()

--- a/server/polar/custom_field/service.py
+++ b/server/polar/custom_field/service.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import contains_eager
 
 from polar.auth.models import AuthSubject, is_organization, is_user
 from polar.auth.permission import OrganizationPermission
-from polar.authz.repository import select_user_org_ids
+from polar.authz.repository import select_accessible_org_ids
 from polar.authz.service import (
     assert_organization_permission,
     assert_resource_permission,
@@ -275,7 +275,7 @@ class CustomFieldService(ResourceServiceReader[CustomField]):
         if is_user(auth_subject):
             statement = statement.where(
                 CustomField.organization_id.in_(
-                    select_user_org_ids(
+                    select_accessible_org_ids(
                         auth_subject,
                         permission=OrganizationPermission.custom_fields_read,
                     )

--- a/server/polar/custom_field/service.py
+++ b/server/polar/custom_field/service.py
@@ -278,6 +278,7 @@ class CustomFieldService(ResourceServiceReader[CustomField]):
                     select_user_org_ids(
                         auth_subject.subject.id,
                         permission=OrganizationPermission.custom_fields_read,
+                        scoped_to=auth_subject.organization_ids,
                     )
                 )
             )

--- a/server/polar/custom_field/service.py
+++ b/server/polar/custom_field/service.py
@@ -276,9 +276,8 @@ class CustomFieldService(ResourceServiceReader[CustomField]):
             statement = statement.where(
                 CustomField.organization_id.in_(
                     select_user_org_ids(
-                        auth_subject.subject.id,
+                        auth_subject,
                         permission=OrganizationPermission.custom_fields_read,
-                        scoped_to=auth_subject.organization_ids,
                     )
                 )
             )

--- a/server/polar/discount/service.py
+++ b/server/polar/discount/service.py
@@ -474,9 +474,7 @@ class DiscountService(ResourceServiceReader[Discount]):
             statement = statement.where(
                 Discount.organization_id.in_(
                     select_user_org_ids(
-                        auth_subject.subject.id,
-                        permission=OrganizationPermission.products_read,
-                        scoped_to=auth_subject.organization_ids,
+                        auth_subject, permission=OrganizationPermission.products_read
                     )
                 )
             )

--- a/server/polar/discount/service.py
+++ b/server/polar/discount/service.py
@@ -476,6 +476,7 @@ class DiscountService(ResourceServiceReader[Discount]):
                     select_user_org_ids(
                         auth_subject.subject.id,
                         permission=OrganizationPermission.products_read,
+                        scoped_to=auth_subject.organization_ids,
                     )
                 )
             )

--- a/server/polar/discount/service.py
+++ b/server/polar/discount/service.py
@@ -9,7 +9,7 @@ from sqlalchemy.exc import DBAPIError
 
 from polar.auth.models import AuthSubject, is_organization, is_user
 from polar.auth.permission import OrganizationPermission
-from polar.authz.repository import select_user_org_ids
+from polar.authz.repository import select_accessible_org_ids
 from polar.authz.service import (
     assert_organization_permission,
     assert_resource_permission,
@@ -473,7 +473,7 @@ class DiscountService(ResourceServiceReader[Discount]):
         if is_user(auth_subject):
             statement = statement.where(
                 Discount.organization_id.in_(
-                    select_user_org_ids(
+                    select_accessible_org_ids(
                         auth_subject, permission=OrganizationPermission.products_read
                     )
                 )

--- a/server/polar/event/service.py
+++ b/server/polar/event/service.py
@@ -1221,12 +1221,7 @@ class EventService:
             )
             if is_user(auth_subject):
                 statement = statement.where(
-                    Customer.organization_id.in_(
-                        select_user_org_ids(
-                            auth_subject.subject.id,
-                            scoped_to=auth_subject.organization_ids,
-                        )
-                    )
+                    Customer.organization_id.in_(select_user_org_ids(auth_subject))
                 )
             else:
                 statement = statement.where(
@@ -1267,12 +1262,7 @@ class EventService:
             )
             if is_user(auth_subject):
                 statement = statement.where(
-                    Member.organization_id.in_(
-                        select_user_org_ids(
-                            auth_subject.subject.id,
-                            scoped_to=auth_subject.organization_ids,
-                        )
-                    )
+                    Member.organization_id.in_(select_user_org_ids(auth_subject))
                 )
             else:
                 statement = statement.where(

--- a/server/polar/event/service.py
+++ b/server/polar/event/service.py
@@ -1222,7 +1222,10 @@ class EventService:
             if is_user(auth_subject):
                 statement = statement.where(
                     Customer.organization_id.in_(
-                        select_user_org_ids(auth_subject.subject.id)
+                        select_user_org_ids(
+                            auth_subject.subject.id,
+                            scoped_to=auth_subject.organization_ids,
+                        )
                     )
                 )
             else:
@@ -1265,7 +1268,10 @@ class EventService:
             if is_user(auth_subject):
                 statement = statement.where(
                     Member.organization_id.in_(
-                        select_user_org_ids(auth_subject.subject.id)
+                        select_user_org_ids(
+                            auth_subject.subject.id,
+                            scoped_to=auth_subject.organization_ids,
+                        )
                     )
                 )
             else:

--- a/server/polar/event/service.py
+++ b/server/polar/event/service.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import contains_eager
 
 from polar.auth.models import AuthSubject, is_organization, is_user
 from polar.auth.permission import OrganizationPermission
-from polar.authz.repository import select_user_org_ids
+from polar.authz.repository import select_accessible_org_ids
 from polar.authz.service import get_accessible_org_ids
 from polar.authz.types import AccessibleOrganizationID
 from polar.customer.repository import CustomerRepository
@@ -1221,7 +1221,9 @@ class EventService:
             )
             if is_user(auth_subject):
                 statement = statement.where(
-                    Customer.organization_id.in_(select_user_org_ids(auth_subject))
+                    Customer.organization_id.in_(
+                        select_accessible_org_ids(auth_subject)
+                    )
                 )
             else:
                 statement = statement.where(
@@ -1262,7 +1264,7 @@ class EventService:
             )
             if is_user(auth_subject):
                 statement = statement.where(
-                    Member.organization_id.in_(select_user_org_ids(auth_subject))
+                    Member.organization_id.in_(select_accessible_org_ids(auth_subject))
                 )
             else:
                 statement = statement.where(

--- a/server/polar/metrics/queries.py
+++ b/server/polar/metrics/queries.py
@@ -23,7 +23,7 @@ from sqlalchemy.dialects.postgresql import TIMESTAMP
 
 from polar.auth.models import AuthSubject, is_organization, is_user
 from polar.auth.permission import OrganizationPermission
-from polar.authz.repository import select_user_org_ids
+from polar.authz.repository import select_accessible_org_ids
 from polar.config import settings
 from polar.enums import SubscriptionRecurringInterval
 from polar.kit.time_queries import TimeInterval
@@ -106,7 +106,7 @@ def _get_readable_orders_statement(
     if is_user(auth_subject):
         statement = statement.where(
             Product.organization_id.in_(
-                select_user_org_ids(
+                select_accessible_org_ids(
                     auth_subject, permission=OrganizationPermission.analytics_read
                 )
             )
@@ -360,7 +360,7 @@ def _get_readable_subscriptions_statement(
     if is_user(auth_subject):
         statement = statement.where(
             Product.organization_id.in_(
-                select_user_org_ids(
+                select_accessible_org_ids(
                     auth_subject, permission=OrganizationPermission.analytics_read
                 )
             )
@@ -448,7 +448,7 @@ def get_checkouts_cte(
     if is_user(auth_subject):
         readable_checkouts_statement = readable_checkouts_statement.where(
             Product.organization_id.in_(
-                select_user_org_ids(
+                select_accessible_org_ids(
                     auth_subject, permission=OrganizationPermission.analytics_read
                 )
             )
@@ -703,7 +703,7 @@ def _get_readable_seats_statement(
     if is_user(auth_subject):
         statement = statement.where(
             Product.organization_id.in_(
-                select_user_org_ids(
+                select_accessible_org_ids(
                     auth_subject, permission=OrganizationPermission.analytics_read
                 )
             )

--- a/server/polar/metrics/queries.py
+++ b/server/polar/metrics/queries.py
@@ -109,6 +109,7 @@ def _get_readable_orders_statement(
                 select_user_org_ids(
                     auth_subject.subject.id,
                     permission=OrganizationPermission.analytics_read,
+                    scoped_to=auth_subject.organization_ids,
                 )
             )
         )
@@ -364,6 +365,7 @@ def _get_readable_subscriptions_statement(
                 select_user_org_ids(
                     auth_subject.subject.id,
                     permission=OrganizationPermission.analytics_read,
+                    scoped_to=auth_subject.organization_ids,
                 )
             )
         )
@@ -453,6 +455,7 @@ def get_checkouts_cte(
                 select_user_org_ids(
                     auth_subject.subject.id,
                     permission=OrganizationPermission.analytics_read,
+                    scoped_to=auth_subject.organization_ids,
                 )
             )
         )
@@ -709,6 +712,7 @@ def _get_readable_seats_statement(
                 select_user_org_ids(
                     auth_subject.subject.id,
                     permission=OrganizationPermission.analytics_read,
+                    scoped_to=auth_subject.organization_ids,
                 )
             )
         )

--- a/server/polar/metrics/queries.py
+++ b/server/polar/metrics/queries.py
@@ -107,9 +107,7 @@ def _get_readable_orders_statement(
         statement = statement.where(
             Product.organization_id.in_(
                 select_user_org_ids(
-                    auth_subject.subject.id,
-                    permission=OrganizationPermission.analytics_read,
-                    scoped_to=auth_subject.organization_ids,
+                    auth_subject, permission=OrganizationPermission.analytics_read
                 )
             )
         )
@@ -363,9 +361,7 @@ def _get_readable_subscriptions_statement(
         statement = statement.where(
             Product.organization_id.in_(
                 select_user_org_ids(
-                    auth_subject.subject.id,
-                    permission=OrganizationPermission.analytics_read,
-                    scoped_to=auth_subject.organization_ids,
+                    auth_subject, permission=OrganizationPermission.analytics_read
                 )
             )
         )
@@ -453,9 +449,7 @@ def get_checkouts_cte(
         readable_checkouts_statement = readable_checkouts_statement.where(
             Product.organization_id.in_(
                 select_user_org_ids(
-                    auth_subject.subject.id,
-                    permission=OrganizationPermission.analytics_read,
-                    scoped_to=auth_subject.organization_ids,
+                    auth_subject, permission=OrganizationPermission.analytics_read
                 )
             )
         )
@@ -710,9 +704,7 @@ def _get_readable_seats_statement(
         statement = statement.where(
             Product.organization_id.in_(
                 select_user_org_ids(
-                    auth_subject.subject.id,
-                    permission=OrganizationPermission.analytics_read,
-                    scoped_to=auth_subject.organization_ids,
+                    auth_subject, permission=OrganizationPermission.analytics_read
                 )
             )
         )

--- a/server/polar/models/user_session.py
+++ b/server/polar/models/user_session.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from sqlalchemy import CHAR, TIMESTAMP, ForeignKey, Text, Uuid
@@ -11,6 +12,9 @@ from polar.kit.db.models.base import RecordModel
 from polar.kit.extensions.sqlalchemy import StringEnum
 from polar.kit.utils import utc_now
 from polar.models.user import User
+
+if TYPE_CHECKING:
+    from polar.models.user_session_organization import UserSessionOrganization
 
 
 def get_expires_at() -> datetime:
@@ -36,3 +40,14 @@ class UserSession(RecordModel):
     @declared_attr
     def user(cls) -> Mapped[User]:
         return relationship(User, lazy="joined")
+
+    @declared_attr
+    def organization_scopes(cls) -> Mapped[list["UserSessionOrganization"]]:
+        # Down-scope links (M2M). Eager-loaded so the auth middleware can read
+        # the scope on every request without a lazy load. No rows means the
+        # session is unrestricted.
+        return relationship(
+            "UserSessionOrganization",
+            lazy="selectin",
+            cascade="all, delete-orphan",
+        )

--- a/server/polar/oauth2/grants/authorization_code.py
+++ b/server/polar/oauth2/grants/authorization_code.py
@@ -18,7 +18,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from polar.auth.permission import OrganizationPermission
-from polar.authz.repository import select_user_org_ids_by_id
+from polar.authz.repository import select_user_org_ids
 from polar.config import settings
 from polar.kit.crypto import generate_token, get_token_hash
 from polar.models import (
@@ -315,7 +315,7 @@ class ValidateSubAndPrompt:
         statement = select(Organization).where(
             Organization.id == organization_id,
             Organization.id.in_(
-                select_user_org_ids_by_id(
+                select_user_org_ids(
                     user.id,
                     permission=OrganizationPermission.organization_manage,
                 )

--- a/server/polar/oauth2/grants/authorization_code.py
+++ b/server/polar/oauth2/grants/authorization_code.py
@@ -318,6 +318,7 @@ class ValidateSubAndPrompt:
                 select_user_org_ids(
                     user.id,
                     permission=OrganizationPermission.organization_manage,
+                    scoped_to=None,
                 )
             ),
         )

--- a/server/polar/oauth2/grants/authorization_code.py
+++ b/server/polar/oauth2/grants/authorization_code.py
@@ -18,7 +18,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from polar.auth.permission import OrganizationPermission
-from polar.authz.repository import select_user_org_ids
+from polar.authz.repository import select_user_org_ids_by_id
 from polar.config import settings
 from polar.kit.crypto import generate_token, get_token_hash
 from polar.models import (
@@ -315,10 +315,9 @@ class ValidateSubAndPrompt:
         statement = select(Organization).where(
             Organization.id == organization_id,
             Organization.id.in_(
-                select_user_org_ids(
+                select_user_org_ids_by_id(
                     user.id,
                     permission=OrganizationPermission.organization_manage,
-                    scoped_to=None,
                 )
             ),
         )

--- a/server/polar/oauth2/grants/web.py
+++ b/server/polar/oauth2/grants/web.py
@@ -117,6 +117,7 @@ class WebGrant(BaseGrant, TokenEndpointMixin):
                 select_user_org_ids(
                     user.id,
                     permission=OrganizationPermission.organization_manage,
+                    scoped_to=None,
                 )
             ),
         )

--- a/server/polar/oauth2/grants/web.py
+++ b/server/polar/oauth2/grants/web.py
@@ -13,7 +13,7 @@ from authlib.oauth2.rfc6749.hooks import hooked
 from sqlalchemy import select
 
 from polar.auth.permission import OrganizationPermission
-from polar.authz.repository import select_user_org_ids_by_id
+from polar.authz.repository import select_user_org_ids
 from polar.config import settings
 from polar.kit.crypto import get_token_hash
 from polar.kit.utils import utc_now
@@ -114,7 +114,7 @@ class WebGrant(BaseGrant, TokenEndpointMixin):
         statement = select(Organization).where(
             Organization.id == organization_id,
             Organization.id.in_(
-                select_user_org_ids_by_id(
+                select_user_org_ids(
                     user.id,
                     permission=OrganizationPermission.organization_manage,
                 )

--- a/server/polar/oauth2/grants/web.py
+++ b/server/polar/oauth2/grants/web.py
@@ -13,7 +13,7 @@ from authlib.oauth2.rfc6749.hooks import hooked
 from sqlalchemy import select
 
 from polar.auth.permission import OrganizationPermission
-from polar.authz.repository import select_user_org_ids
+from polar.authz.repository import select_user_org_ids_by_id
 from polar.config import settings
 from polar.kit.crypto import get_token_hash
 from polar.kit.utils import utc_now
@@ -114,10 +114,9 @@ class WebGrant(BaseGrant, TokenEndpointMixin):
         statement = select(Organization).where(
             Organization.id == organization_id,
             Organization.id.in_(
-                select_user_org_ids(
+                select_user_org_ids_by_id(
                     user.id,
                     permission=OrganizationPermission.organization_manage,
-                    scoped_to=None,
                 )
             ),
         )

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -288,6 +288,7 @@ class OrderRepository(
                     select_user_org_ids(
                         auth_subject.subject.id,
                         permission=OrganizationPermission.sales_read,
+                        scoped_to=auth_subject.organization_ids,
                     )
                 )
             )

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -15,7 +15,7 @@ from polar.auth.models import (
     is_user,
 )
 from polar.auth.permission import OrganizationPermission
-from polar.authz.repository import select_user_org_ids
+from polar.authz.repository import select_accessible_org_ids
 from polar.authz.types import AccessibleOrganizationID
 from polar.kit.repository import (
     Options,
@@ -285,7 +285,7 @@ class OrderRepository(
         if is_user(auth_subject):
             statement = statement.where(
                 Order.organization_id.in_(
-                    select_user_org_ids(
+                    select_accessible_org_ids(
                         auth_subject, permission=OrganizationPermission.sales_read
                     )
                 )

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -286,9 +286,7 @@ class OrderRepository(
             statement = statement.where(
                 Order.organization_id.in_(
                     select_user_org_ids(
-                        auth_subject.subject.id,
-                        permission=OrganizationPermission.sales_read,
-                        scoped_to=auth_subject.organization_ids,
+                        auth_subject, permission=OrganizationPermission.sales_read
                     )
                 )
             )

--- a/server/polar/search/service.py
+++ b/server/polar/search/service.py
@@ -15,7 +15,7 @@ from sqlalchemy import (
 
 from polar.auth.models import AuthSubject, User
 from polar.auth.scope import Scope
-from polar.authz.repository import select_user_org_ids
+from polar.authz.repository import select_accessible_org_ids
 from polar.kit.db.postgres import AsyncReadSession
 from polar.models import (
     Customer,
@@ -69,7 +69,7 @@ class SearchService:
 
         organization_subquery = select(Organization.id).where(
             Organization.id == organization_id,
-            Organization.id.in_(select_user_org_ids(auth_subject)),
+            Organization.id.in_(select_accessible_org_ids(auth_subject)),
         )
 
         subqueries: list[Select[Any]] = []

--- a/server/polar/search/service.py
+++ b/server/polar/search/service.py
@@ -69,7 +69,11 @@ class SearchService:
 
         organization_subquery = select(Organization.id).where(
             Organization.id == organization_id,
-            Organization.id.in_(select_user_org_ids(auth_subject.subject.id)),
+            Organization.id.in_(
+                select_user_org_ids(
+                    auth_subject.subject.id, scoped_to=auth_subject.organization_ids
+                )
+            ),
         )
 
         subqueries: list[Select[Any]] = []

--- a/server/polar/search/service.py
+++ b/server/polar/search/service.py
@@ -69,11 +69,7 @@ class SearchService:
 
         organization_subquery = select(Organization.id).where(
             Organization.id == organization_id,
-            Organization.id.in_(
-                select_user_org_ids(
-                    auth_subject.subject.id, scoped_to=auth_subject.organization_ids
-                )
-            ),
+            Organization.id.in_(select_user_org_ids(auth_subject)),
         )
 
         subqueries: list[Select[Any]] = []

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -23,7 +23,7 @@ from polar.auth.models import (
     Customer as AuthCustomer,
 )
 from polar.auth.permission import OrganizationPermission
-from polar.authz.repository import select_user_org_ids
+from polar.authz.repository import select_accessible_org_ids
 from polar.enums import SubscriptionRecurringInterval
 from polar.kit.repository import (
     Options,
@@ -191,7 +191,7 @@ class SubscriptionRepository(
         if is_user(auth_subject):
             statement = statement.where(
                 Subscription.organization_id.in_(
-                    select_user_org_ids(
+                    select_accessible_org_ids(
                         auth_subject, permission=OrganizationPermission.sales_read
                     )
                 )

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -194,6 +194,7 @@ class SubscriptionRepository(
                     select_user_org_ids(
                         auth_subject.subject.id,
                         permission=OrganizationPermission.sales_read,
+                        scoped_to=auth_subject.organization_ids,
                     )
                 )
             )

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -192,9 +192,7 @@ class SubscriptionRepository(
             statement = statement.where(
                 Subscription.organization_id.in_(
                     select_user_org_ids(
-                        auth_subject.subject.id,
-                        permission=OrganizationPermission.sales_read,
-                        scoped_to=auth_subject.organization_ids,
+                        auth_subject, permission=OrganizationPermission.sales_read
                     )
                 )
             )

--- a/server/polar/transaction/endpoints.py
+++ b/server/polar/transaction/endpoints.py
@@ -44,8 +44,7 @@ async def search_transactions(
 ) -> ListResource[Transaction]:
     results, count = await transaction_service.search(
         session,
-        auth_subject.subject,
-        organization_ids=auth_subject.organization_ids,
+        auth_subject,
         type=type,
         account_id=account_id,
         payment_customer_id=payment_customer_id,

--- a/server/polar/transaction/endpoints.py
+++ b/server/polar/transaction/endpoints.py
@@ -45,6 +45,7 @@ async def search_transactions(
     results, count = await transaction_service.search(
         session,
         auth_subject.subject,
+        organization_ids=auth_subject.organization_ids,
         type=type,
         account_id=account_id,
         payment_customer_id=payment_customer_id,

--- a/server/polar/transaction/service/transaction.py
+++ b/server/polar/transaction/service/transaction.py
@@ -41,7 +41,7 @@ class TransactionService(BaseTransactionService):
         session: AsyncReadSession,
         user: User,
         *,
-        organization_ids: frozenset[uuid.UUID] | None = None,
+        organization_ids: frozenset[uuid.UUID] | None,
         type: TransactionType | None = None,
         account_id: uuid.UUID | None = None,
         payment_customer_id: uuid.UUID | None = None,
@@ -108,7 +108,7 @@ class TransactionService(BaseTransactionService):
         id: uuid.UUID,
         user: User,
         *,
-        organization_ids: frozenset[uuid.UUID] | None = None,
+        organization_ids: frozenset[uuid.UUID] | None,
     ) -> Transaction:
         statement = (
             self._get_readable_transactions_statement(
@@ -283,7 +283,7 @@ class TransactionService(BaseTransactionService):
         return int(result.scalar_one())
 
     def _get_readable_transactions_statement(
-        self, user: User, *, organization_ids: frozenset[uuid.UUID] | None = None
+        self, user: User, *, organization_ids: frozenset[uuid.UUID] | None
     ) -> Select[Any]:
         readable_org_ids = select_user_org_ids(
             user.id,

--- a/server/polar/transaction/service/transaction.py
+++ b/server/polar/transaction/service/transaction.py
@@ -41,6 +41,7 @@ class TransactionService(BaseTransactionService):
         session: AsyncReadSession,
         user: User,
         *,
+        organization_ids: frozenset[uuid.UUID] | None = None,
         type: TransactionType | None = None,
         account_id: uuid.UUID | None = None,
         payment_customer_id: uuid.UUID | None = None,
@@ -52,7 +53,9 @@ class TransactionService(BaseTransactionService):
             (TransactionSortProperty.created_at, True)
         ],
     ) -> tuple[Sequence[Transaction], int]:
-        statement = self._get_readable_transactions_statement(user)
+        statement = self._get_readable_transactions_statement(
+            user, organization_ids=organization_ids
+        )
 
         statement = statement.options(
             # Incurred transactions
@@ -100,10 +103,17 @@ class TransactionService(BaseTransactionService):
         return results, count
 
     async def lookup(
-        self, session: AsyncReadSession, id: uuid.UUID, user: User
+        self,
+        session: AsyncReadSession,
+        id: uuid.UUID,
+        user: User,
+        *,
+        organization_ids: frozenset[uuid.UUID] | None = None,
     ) -> Transaction:
         statement = (
-            self._get_readable_transactions_statement(user)
+            self._get_readable_transactions_statement(
+                user, organization_ids=organization_ids
+            )
             .options(
                 # Incurred transactions
                 subqueryload(Transaction.account_incurred_transactions),
@@ -272,9 +282,13 @@ class TransactionService(BaseTransactionService):
         result = await session.execute(statement)
         return int(result.scalar_one())
 
-    def _get_readable_transactions_statement(self, user: User) -> Select[Any]:
+    def _get_readable_transactions_statement(
+        self, user: User, *, organization_ids: frozenset[uuid.UUID] | None = None
+    ) -> Select[Any]:
         readable_org_ids = select_user_org_ids(
-            user.id, permission=OrganizationPermission.finance_read
+            user.id,
+            permission=OrganizationPermission.finance_read,
+            scoped_to=organization_ids,
         )
         statement = (
             select(Transaction)

--- a/server/polar/transaction/service/transaction.py
+++ b/server/polar/transaction/service/transaction.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import joinedload, subqueryload
 
 from polar.auth.models import AuthSubject
 from polar.auth.permission import OrganizationPermission
-from polar.authz.repository import select_user_org_ids
+from polar.authz.repository import select_accessible_org_ids
 from polar.exceptions import ResourceNotFound
 from polar.kit.pagination import PaginationParams, paginate
 from polar.kit.sorting import Sorting
@@ -279,7 +279,7 @@ class TransactionService(BaseTransactionService):
     def _get_readable_transactions_statement(
         self, auth_subject: AuthSubject[User]
     ) -> Select[Any]:
-        readable_org_ids = select_user_org_ids(
+        readable_org_ids = select_accessible_org_ids(
             auth_subject, permission=OrganizationPermission.finance_read
         )
         statement = (

--- a/server/polar/transaction/service/transaction.py
+++ b/server/polar/transaction/service/transaction.py
@@ -7,6 +7,7 @@ from sqlalchemy import Select, UnaryExpression, asc, desc, func, or_, select
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import joinedload, subqueryload
 
+from polar.auth.models import AuthSubject
 from polar.auth.permission import OrganizationPermission
 from polar.authz.repository import select_user_org_ids
 from polar.exceptions import ResourceNotFound
@@ -39,9 +40,8 @@ class TransactionService(BaseTransactionService):
     async def search(
         self,
         session: AsyncReadSession,
-        user: User,
+        auth_subject: AuthSubject[User],
         *,
-        organization_ids: frozenset[uuid.UUID] | None,
         type: TransactionType | None = None,
         account_id: uuid.UUID | None = None,
         payment_customer_id: uuid.UUID | None = None,
@@ -53,9 +53,7 @@ class TransactionService(BaseTransactionService):
             (TransactionSortProperty.created_at, True)
         ],
     ) -> tuple[Sequence[Transaction], int]:
-        statement = self._get_readable_transactions_statement(
-            user, organization_ids=organization_ids
-        )
+        statement = self._get_readable_transactions_statement(auth_subject)
 
         statement = statement.options(
             # Incurred transactions
@@ -106,14 +104,10 @@ class TransactionService(BaseTransactionService):
         self,
         session: AsyncReadSession,
         id: uuid.UUID,
-        user: User,
-        *,
-        organization_ids: frozenset[uuid.UUID] | None,
+        auth_subject: AuthSubject[User],
     ) -> Transaction:
         statement = (
-            self._get_readable_transactions_statement(
-                user, organization_ids=organization_ids
-            )
+            self._get_readable_transactions_statement(auth_subject)
             .options(
                 # Incurred transactions
                 subqueryload(Transaction.account_incurred_transactions),
@@ -283,12 +277,10 @@ class TransactionService(BaseTransactionService):
         return int(result.scalar_one())
 
     def _get_readable_transactions_statement(
-        self, user: User, *, organization_ids: frozenset[uuid.UUID] | None
+        self, auth_subject: AuthSubject[User]
     ) -> Select[Any]:
         readable_org_ids = select_user_org_ids(
-            user.id,
-            permission=OrganizationPermission.finance_read,
-            scoped_to=organization_ids,
+            auth_subject, permission=OrganizationPermission.finance_read
         )
         statement = (
             select(Transaction)
@@ -301,9 +293,9 @@ class TransactionService(BaseTransactionService):
             .join(User, onclause=User.account_id == Account.id, isouter=True)
             .where(
                 or_(
-                    User.id == user.id,
+                    User.id == auth_subject.subject.id,
                     Organization.id.in_(readable_org_ids),
-                    Transaction.payment_user_id == user.id,
+                    Transaction.payment_user_id == auth_subject.subject.id,
                     Transaction.payment_organization_id.in_(readable_org_ids),
                 )
             )

--- a/server/tests/auth/test_middlewares.py
+++ b/server/tests/auth/test_middlewares.py
@@ -1,0 +1,58 @@
+import pytest
+from starlette.requests import Request
+
+from polar.auth.middlewares import get_auth_subject
+from polar.auth.service import auth as auth_service
+from polar.config import settings
+from polar.models import Organization, User, UserOrganization
+from polar.models.user_session_organization import UserSessionOrganization
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+
+
+def _request_with_session_cookie(token: str) -> Request:
+    cookie = f"{settings.USER_SESSION_COOKIE_KEY}={token}".encode()
+    return Request({"type": "http", "headers": [(b"cookie", cookie)]})
+
+
+@pytest.mark.asyncio
+class TestGetAuthSubjectUserSessionScope:
+    async def test_unscoped_session_is_unrestricted(
+        self,
+        session: AsyncSession,
+        user: User,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        token, _ = await auth_service._create_user_session(
+            session, user, user_agent="test", scopes=[]
+        )
+
+        auth_subject = await get_auth_subject(
+            _request_with_session_cookie(token), session
+        )
+
+        assert auth_subject.subject == user
+        assert auth_subject.organization_ids is None
+
+    async def test_scoped_session_populates_organization_ids(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        token, user_session = await auth_service._create_user_session(
+            session, user, user_agent="test", scopes=[]
+        )
+        await save_fixture(
+            UserSessionOrganization(
+                user_session_id=user_session.id, organization_id=organization.id
+            )
+        )
+        auth_subject = await get_auth_subject(
+            _request_with_session_cookie(token), session
+        )
+
+        assert auth_subject.organization_ids == frozenset({organization.id})

--- a/server/tests/authz/test_service.py
+++ b/server/tests/authz/test_service.py
@@ -9,6 +9,7 @@ from polar.models.organization import OrganizationStatus
 from polar.models.user_organization import UserOrganization
 from polar.postgres import AsyncSession
 from tests.fixtures.auth import AuthSubjectFixture
+from tests.fixtures.database import SaveFixture
 
 NONEXISTENT_ORG_ID = UUID("00000000-0000-0000-0000-000000000000")
 
@@ -127,3 +128,108 @@ class TestGetAccessibleOrgIds:
 
         result = await get_accessible_org_ids(session, auth_subject)
         assert result == set()
+
+
+@pytest.mark.asyncio
+class TestGetAccessibleOrgIdsScopedTo:
+    """`AuthSubject.organization_ids` down-scopes the accessible set."""
+
+    @pytest.mark.auth
+    async def test_none_is_unrestricted(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user: User,
+        organization: Organization,
+        organization_second: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await save_fixture(
+            UserOrganization(user=user, organization=organization_second)
+        )
+        auth_subject.organization_ids = None
+
+        result = await get_accessible_org_ids(session, auth_subject)
+        assert result == {organization.id, organization_second.id}
+
+    @pytest.mark.auth
+    async def test_scopes_to_subset(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user: User,
+        organization: Organization,
+        organization_second: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await save_fixture(
+            UserOrganization(user=user, organization=organization_second)
+        )
+        auth_subject.organization_ids = frozenset({organization.id})
+
+        result = await get_accessible_org_ids(session, auth_subject)
+        assert result == {organization.id}
+
+    @pytest.mark.auth
+    async def test_intersects_with_membership(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        # Scoped to an org the user is not a member of: membership is the floor.
+        auth_subject.organization_ids = frozenset({NONEXISTENT_ORG_ID})
+
+        result = await get_accessible_org_ids(session, auth_subject)
+        assert result == set()
+
+    @pytest.mark.auth
+    async def test_empty_scope_grants_nothing(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        # An explicit empty set restricts to nothing (distinct from None).
+        auth_subject.organization_ids = frozenset()
+
+        result = await get_accessible_org_ids(session, auth_subject)
+        assert result == set()
+
+
+@pytest.mark.asyncio
+class TestGetAccessibleOrganizationScopedTo:
+    @pytest.mark.auth
+    async def test_returned_when_in_scope(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        auth_subject.organization_ids = frozenset({organization.id})
+
+        result = await get_accessible_organization(
+            session, auth_subject, organization.id
+        )
+        assert result is not None
+        assert result.id == organization.id
+
+    @pytest.mark.auth
+    async def test_excluded_when_out_of_scope(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        auth_subject.organization_ids = frozenset({NONEXISTENT_ORG_ID})
+
+        result = await get_accessible_organization(
+            session, auth_subject, organization.id
+        )
+        assert result is None

--- a/server/tests/order/test_endpoints.py
+++ b/server/tests/order/test_endpoints.py
@@ -7,8 +7,9 @@ import pytest_asyncio
 from httpx import AsyncClient
 from pytest_mock import MockerFixture
 
+from polar.auth.models import AuthSubject
 from polar.auth.scope import Scope
-from polar.models import Customer, Order, Organization, Product, UserOrganization
+from polar.models import Customer, Order, Organization, Product, User, UserOrganization
 from polar.models.order import OrderStatus
 from polar.order.service import PaymentFailed, PaymentFailedReason
 from tests.fixtures.auth import AuthSubjectFixture
@@ -105,6 +106,37 @@ class TestListOrders:
         assert response.status_code == 200
         json = response.json()
         assert json["pagination"]["total_count"] == 2
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.orders_read}))
+    async def test_organization_scoped_session(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        auth_subject: AuthSubject[User],
+        user: User,
+        organization: Organization,
+        organization_second: Organization,
+        user_organization: UserOrganization,
+        orders: list[Order],
+        order_organization_second: Order,
+    ) -> None:
+        # Member of both organizations.
+        await save_fixture(
+            UserOrganization(user=user, organization=organization_second)
+        )
+
+        # Unscoped session sees orders from both organizations.
+        response = await client.get("/v1/orders/")
+        assert response.status_code == 200
+        assert response.json()["pagination"]["total_count"] == len(orders) + 1
+
+        # Down-scoping the session to one org hides the other org's orders.
+        auth_subject.organization_ids = frozenset({organization.id})
+        response = await client.get("/v1/orders/")
+        assert response.status_code == 200
+        returned_ids = {item["id"] for item in response.json()["items"]}
+        assert returned_ids == {str(order.id) for order in orders}
+        assert str(order_organization_second.id) not in returned_ids
 
 
 @pytest.mark.asyncio

--- a/server/tests/transaction/service/test_blocked_org_access.py
+++ b/server/tests/transaction/service/test_blocked_org_access.py
@@ -36,7 +36,7 @@ class TestBlockedOrganizationTransactionAccess:
         await save_fixture(organization)
 
         results, count = await transaction_service.search(
-            session, user, pagination=PaginationParams(1, 10)
+            session, user, organization_ids=None, pagination=PaginationParams(1, 10)
         )
 
         result_ids = [t.id for t in results]
@@ -61,7 +61,7 @@ class TestBlockedOrganizationTransactionAccess:
         await save_fixture(organization)
 
         results, count = await transaction_service.search(
-            session, user, pagination=PaginationParams(1, 10)
+            session, user, organization_ids=None, pagination=PaginationParams(1, 10)
         )
 
         result_ids = [t.id for t in results]
@@ -86,7 +86,7 @@ class TestBlockedOrganizationTransactionAccess:
         await save_fixture(organization)
 
         results, count = await transaction_service.search(
-            session, user, pagination=PaginationParams(1, 10)
+            session, user, organization_ids=None, pagination=PaginationParams(1, 10)
         )
 
         result_ids = [t.id for t in results]

--- a/server/tests/transaction/service/test_blocked_org_access.py
+++ b/server/tests/transaction/service/test_blocked_org_access.py
@@ -1,5 +1,6 @@
 import pytest
 
+from polar.auth.models import AuthSubject
 from polar.kit.pagination import PaginationParams
 from polar.models import (
     Account,
@@ -13,6 +14,10 @@ from polar.postgres import AsyncSession
 from polar.transaction.service.transaction import transaction as transaction_service
 from tests.fixtures.database import SaveFixture
 from tests.transaction.conftest import create_transaction
+
+
+def _auth(user: User) -> AuthSubject[User]:
+    return AuthSubject(user, set(), None)
 
 
 @pytest.mark.asyncio
@@ -36,7 +41,7 @@ class TestBlockedOrganizationTransactionAccess:
         await save_fixture(organization)
 
         results, count = await transaction_service.search(
-            session, user, organization_ids=None, pagination=PaginationParams(1, 10)
+            session, _auth(user), pagination=PaginationParams(1, 10)
         )
 
         result_ids = [t.id for t in results]
@@ -61,7 +66,7 @@ class TestBlockedOrganizationTransactionAccess:
         await save_fixture(organization)
 
         results, count = await transaction_service.search(
-            session, user, organization_ids=None, pagination=PaginationParams(1, 10)
+            session, _auth(user), pagination=PaginationParams(1, 10)
         )
 
         result_ids = [t.id for t in results]
@@ -86,7 +91,7 @@ class TestBlockedOrganizationTransactionAccess:
         await save_fixture(organization)
 
         results, count = await transaction_service.search(
-            session, user, organization_ids=None, pagination=PaginationParams(1, 10)
+            session, _auth(user), pagination=PaginationParams(1, 10)
         )
 
         result_ids = [t.id for t in results]

--- a/server/tests/transaction/service/test_blocked_org_access.py
+++ b/server/tests/transaction/service/test_blocked_org_access.py
@@ -16,17 +16,14 @@ from tests.fixtures.database import SaveFixture
 from tests.transaction.conftest import create_transaction
 
 
-def _auth(user: User) -> AuthSubject[User]:
-    return AuthSubject(user, set(), None)
-
-
 @pytest.mark.asyncio
 class TestBlockedOrganizationTransactionAccess:
+    @pytest.mark.auth
     async def test_blocked_org_account_transactions_hidden(
         self,
         session: AsyncSession,
+        auth_subject: AuthSubject[User],
         save_fixture: SaveFixture,
-        user: User,
         organization: Organization,
         user_organization: UserOrganization,
         account: Account,
@@ -41,18 +38,19 @@ class TestBlockedOrganizationTransactionAccess:
         await save_fixture(organization)
 
         results, count = await transaction_service.search(
-            session, _auth(user), pagination=PaginationParams(1, 10)
+            session, auth_subject, pagination=PaginationParams(1, 10)
         )
 
         result_ids = [t.id for t in results]
         assert transaction.id not in result_ids
         assert count == 0
 
+    @pytest.mark.auth
     async def test_blocked_org_payment_transactions_hidden(
         self,
         session: AsyncSession,
+        auth_subject: AuthSubject[User],
         save_fixture: SaveFixture,
-        user: User,
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
@@ -66,16 +64,18 @@ class TestBlockedOrganizationTransactionAccess:
         await save_fixture(organization)
 
         results, count = await transaction_service.search(
-            session, _auth(user), pagination=PaginationParams(1, 10)
+            session, auth_subject, pagination=PaginationParams(1, 10)
         )
 
         result_ids = [t.id for t in results]
         assert transaction.id not in result_ids
         assert count == 0
 
+    @pytest.mark.auth
     async def test_direct_payment_transactions_visible_after_org_blocked(
         self,
         session: AsyncSession,
+        auth_subject: AuthSubject[User],
         save_fixture: SaveFixture,
         user: User,
         organization: Organization,
@@ -91,7 +91,7 @@ class TestBlockedOrganizationTransactionAccess:
         await save_fixture(organization)
 
         results, count = await transaction_service.search(
-            session, _auth(user), pagination=PaginationParams(1, 10)
+            session, auth_subject, pagination=PaginationParams(1, 10)
         )
 
         result_ids = [t.id for t in results]

--- a/server/tests/transaction/service/test_transaction.py
+++ b/server/tests/transaction/service/test_transaction.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 import pytest
 
+from polar.auth.models import AuthSubject
 from polar.exceptions import ResourceNotFound
 from polar.kit.pagination import PaginationParams
 from polar.kit.utils import utc_now
@@ -14,6 +15,10 @@ from tests.fixtures.database import SaveFixture
 from tests.transaction.conftest import create_transaction
 
 
+def _auth(user: User) -> AuthSubject[User]:
+    return AuthSubject(user, set(), None)
+
+
 @pytest.mark.asyncio
 class TestSearch:
     async def test_no_access(
@@ -23,10 +28,7 @@ class TestSearch:
         all_transactions: list[Transaction],
     ) -> None:
         results, count = await transaction_service.search(
-            session,
-            user_second,
-            organization_ids=None,
-            pagination=PaginationParams(1, 10),
+            session, _auth(user_second), pagination=PaginationParams(1, 10)
         )
 
         assert count == 0
@@ -41,7 +43,7 @@ class TestSearch:
         all_transactions: list[Transaction],
     ) -> None:
         results, count = await transaction_service.search(
-            session, user, organization_ids=None, pagination=PaginationParams(1, 10)
+            session, _auth(user), pagination=PaginationParams(1, 10)
         )
 
         assert count == len(readable_user_transactions)
@@ -71,8 +73,7 @@ class TestSearch:
 
         results, count = await transaction_service.search(
             session,
-            user,
-            organization_ids=None,
+            _auth(user),
             type=TransactionType.payout,
             pagination=PaginationParams(1, 10),
         )
@@ -101,8 +102,7 @@ class TestSearch:
 
         results, count = await transaction_service.search(
             session,
-            user,
-            organization_ids=None,
+            _auth(user),
             account_id=account.id,
             pagination=PaginationParams(1, 10),
         )
@@ -128,8 +128,7 @@ class TestSearch:
 
         results, count = await transaction_service.search(
             session,
-            user,
-            organization_ids=None,
+            _auth(user),
             payment_user_id=user.id,
             pagination=PaginationParams(1, 10),
         )
@@ -156,8 +155,7 @@ class TestSearch:
 
         results, count = await transaction_service.search(
             session,
-            user,
-            organization_ids=None,
+            _auth(user),
             payment_organization_id=organization.id,
             pagination=PaginationParams(1, 10),
         )
@@ -263,9 +261,7 @@ class TestLookup:
         session.expunge_all()
 
         with pytest.raises(ResourceNotFound):
-            await transaction_service.lookup(
-                session, uuid.uuid4(), user_second, organization_ids=None
-            )
+            await transaction_service.lookup(session, uuid.uuid4(), _auth(user_second))
 
     async def test_user_not_accessible(
         self,
@@ -279,10 +275,7 @@ class TestLookup:
 
         with pytest.raises(ResourceNotFound):
             await transaction_service.lookup(
-                session,
-                readable_user_transactions[0].id,
-                user_second,
-                organization_ids=None,
+                session, readable_user_transactions[0].id, _auth(user_second)
             )
 
     async def test_valid(
@@ -297,7 +290,7 @@ class TestLookup:
         session.expunge_all()
 
         transaction = await transaction_service.lookup(
-            session, readable_user_transactions[0].id, user, organization_ids=None
+            session, readable_user_transactions[0].id, _auth(user)
         )
 
         assert transaction.id == readable_user_transactions[0].id

--- a/server/tests/transaction/service/test_transaction.py
+++ b/server/tests/transaction/service/test_transaction.py
@@ -23,7 +23,10 @@ class TestSearch:
         all_transactions: list[Transaction],
     ) -> None:
         results, count = await transaction_service.search(
-            session, user_second, pagination=PaginationParams(1, 10)
+            session,
+            user_second,
+            organization_ids=None,
+            pagination=PaginationParams(1, 10),
         )
 
         assert count == 0
@@ -38,7 +41,7 @@ class TestSearch:
         all_transactions: list[Transaction],
     ) -> None:
         results, count = await transaction_service.search(
-            session, user, pagination=PaginationParams(1, 10)
+            session, user, organization_ids=None, pagination=PaginationParams(1, 10)
         )
 
         assert count == len(readable_user_transactions)
@@ -69,6 +72,7 @@ class TestSearch:
         results, count = await transaction_service.search(
             session,
             user,
+            organization_ids=None,
             type=TransactionType.payout,
             pagination=PaginationParams(1, 10),
         )
@@ -96,7 +100,11 @@ class TestSearch:
         session.expunge_all()
 
         results, count = await transaction_service.search(
-            session, user, account_id=account.id, pagination=PaginationParams(1, 10)
+            session,
+            user,
+            organization_ids=None,
+            account_id=account.id,
+            pagination=PaginationParams(1, 10),
         )
 
         assert count == len(account_transactions)
@@ -121,6 +129,7 @@ class TestSearch:
         results, count = await transaction_service.search(
             session,
             user,
+            organization_ids=None,
             payment_user_id=user.id,
             pagination=PaginationParams(1, 10),
         )
@@ -148,6 +157,7 @@ class TestSearch:
         results, count = await transaction_service.search(
             session,
             user,
+            organization_ids=None,
             payment_organization_id=organization.id,
             pagination=PaginationParams(1, 10),
         )
@@ -253,7 +263,9 @@ class TestLookup:
         session.expunge_all()
 
         with pytest.raises(ResourceNotFound):
-            await transaction_service.lookup(session, uuid.uuid4(), user_second)
+            await transaction_service.lookup(
+                session, uuid.uuid4(), user_second, organization_ids=None
+            )
 
     async def test_user_not_accessible(
         self,
@@ -267,7 +279,10 @@ class TestLookup:
 
         with pytest.raises(ResourceNotFound):
             await transaction_service.lookup(
-                session, readable_user_transactions[0].id, user_second
+                session,
+                readable_user_transactions[0].id,
+                user_second,
+                organization_ids=None,
             )
 
     async def test_valid(
@@ -282,7 +297,7 @@ class TestLookup:
         session.expunge_all()
 
         transaction = await transaction_service.lookup(
-            session, readable_user_transactions[0].id, user
+            session, readable_user_transactions[0].id, user, organization_ids=None
         )
 
         assert transaction.id == readable_user_transactions[0].id

--- a/server/tests/transaction/service/test_transaction.py
+++ b/server/tests/transaction/service/test_transaction.py
@@ -11,39 +11,38 @@ from polar.models import Account, Organization, Transaction, User, UserOrganizat
 from polar.models.transaction import PlatformFeeType, TransactionType
 from polar.postgres import AsyncSession
 from polar.transaction.service.transaction import transaction as transaction_service
+from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 from tests.transaction.conftest import create_transaction
 
 
-def _auth(user: User) -> AuthSubject[User]:
-    return AuthSubject(user, set(), None)
-
-
 @pytest.mark.asyncio
 class TestSearch:
+    @pytest.mark.auth(AuthSubjectFixture(subject="user_second"))
     async def test_no_access(
         self,
         session: AsyncSession,
-        user_second: User,
+        auth_subject: AuthSubject[User],
         all_transactions: list[Transaction],
     ) -> None:
         results, count = await transaction_service.search(
-            session, _auth(user_second), pagination=PaginationParams(1, 10)
+            session, auth_subject, pagination=PaginationParams(1, 10)
         )
 
         assert count == 0
         assert len(results) == 0
 
+    @pytest.mark.auth
     async def test_no_filter(
         self,
         session: AsyncSession,
-        user: User,
+        auth_subject: AuthSubject[User],
         user_organization: UserOrganization,
         readable_user_transactions: list[Transaction],
         all_transactions: list[Transaction],
     ) -> None:
         results, count = await transaction_service.search(
-            session, _auth(user), pagination=PaginationParams(1, 10)
+            session, auth_subject, pagination=PaginationParams(1, 10)
         )
 
         assert count == len(readable_user_transactions)
@@ -59,11 +58,12 @@ class TestSearch:
             if result.order is not None:
                 result.order.product
 
+    @pytest.mark.auth
     async def test_filter_type(
         self,
         session: AsyncSession,
+        auth_subject: AuthSubject[User],
         account: Account,
-        user: User,
         user_organization: UserOrganization,
         readable_user_transactions: list[Transaction],
         all_transactions: list[Transaction],
@@ -73,7 +73,7 @@ class TestSearch:
 
         results, count = await transaction_service.search(
             session,
-            _auth(user),
+            auth_subject,
             type=TransactionType.payout,
             pagination=PaginationParams(1, 10),
         )
@@ -88,10 +88,11 @@ class TestSearch:
         for result in results:
             assert result.id in payout_transactions_id
 
+    @pytest.mark.auth
     async def test_filter_account(
         self,
         session: AsyncSession,
-        user: User,
+        auth_subject: AuthSubject[User],
         account: Account,
         user_organization: UserOrganization,
         account_transactions: list[Transaction],
@@ -102,7 +103,7 @@ class TestSearch:
 
         results, count = await transaction_service.search(
             session,
-            _auth(user),
+            auth_subject,
             account_id=account.id,
             pagination=PaginationParams(1, 10),
         )
@@ -115,9 +116,11 @@ class TestSearch:
         for result in results:
             assert result.id in account_transactions_id
 
+    @pytest.mark.auth
     async def test_filter_payment_user(
         self,
         session: AsyncSession,
+        auth_subject: AuthSubject[User],
         user: User,
         user_organization: UserOrganization,
         user_transactions: list[Transaction],
@@ -128,7 +131,7 @@ class TestSearch:
 
         results, count = await transaction_service.search(
             session,
-            _auth(user),
+            auth_subject,
             payment_user_id=user.id,
             pagination=PaginationParams(1, 10),
         )
@@ -141,10 +144,11 @@ class TestSearch:
         for result in results:
             assert result.id in user_transactions_id
 
+    @pytest.mark.auth
     async def test_filter_payment_organization(
         self,
         session: AsyncSession,
-        user: User,
+        auth_subject: AuthSubject[User],
         organization: Organization,
         user_organization: UserOrganization,
         organization_transactions: list[Transaction],
@@ -155,7 +159,7 @@ class TestSearch:
 
         results, count = await transaction_service.search(
             session,
-            _auth(user),
+            auth_subject,
             payment_organization_id=organization.id,
             pagination=PaginationParams(1, 10),
         )
@@ -256,17 +260,21 @@ class TestGetSummary:
 
 @pytest.mark.asyncio
 class TestLookup:
-    async def test_not_existing(self, session: AsyncSession, user_second: User) -> None:
+    @pytest.mark.auth(AuthSubjectFixture(subject="user_second"))
+    async def test_not_existing(
+        self, session: AsyncSession, auth_subject: AuthSubject[User]
+    ) -> None:
         # then
         session.expunge_all()
 
         with pytest.raises(ResourceNotFound):
-            await transaction_service.lookup(session, uuid.uuid4(), _auth(user_second))
+            await transaction_service.lookup(session, uuid.uuid4(), auth_subject)
 
+    @pytest.mark.auth(AuthSubjectFixture(subject="user_second"))
     async def test_user_not_accessible(
         self,
         session: AsyncSession,
-        user_second: User,
+        auth_subject: AuthSubject[User],
         readable_user_transactions: list[Transaction],
         all_transactions: list[Transaction],
     ) -> None:
@@ -275,13 +283,14 @@ class TestLookup:
 
         with pytest.raises(ResourceNotFound):
             await transaction_service.lookup(
-                session, readable_user_transactions[0].id, _auth(user_second)
+                session, readable_user_transactions[0].id, auth_subject
             )
 
+    @pytest.mark.auth
     async def test_valid(
         self,
         session: AsyncSession,
-        user: User,
+        auth_subject: AuthSubject[User],
         user_organization: UserOrganization,
         readable_user_transactions: list[Transaction],
         all_transactions: list[Transaction],
@@ -290,7 +299,7 @@ class TestLookup:
         session.expunge_all()
 
         transaction = await transaction_service.lookup(
-            session, readable_user_transactions[0].id, _auth(user)
+            session, readable_user_transactions[0].id, auth_subject
         )
 
         assert transaction.id == readable_user_transactions[0].id

--- a/server/tests/transaction/test_endpoints.py
+++ b/server/tests/transaction/test_endpoints.py
@@ -3,10 +3,12 @@ import uuid
 import pytest
 from httpx import AsyncClient
 
-from polar.models import Account, Transaction, UserOrganization
+from polar.auth.models import AuthSubject
+from polar.models import Account, Organization, Transaction, User, UserOrganization
 from polar.models.user_organization import OrganizationRole
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
+from tests.transaction.conftest import create_transaction
 
 
 @pytest.mark.asyncio
@@ -31,6 +33,46 @@ class TestSearchTransactions:
 
         json = response.json()
         assert json["pagination"]["total_count"] == len(readable_user_transactions)
+
+    @pytest.mark.auth
+    async def test_organization_scoped_session(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        auth_subject: AuthSubject[User],
+        user: User,
+        organization: Organization,
+        organization_second: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        # Member (admin → finance:read) of the second org too.
+        await save_fixture(
+            UserOrganization(
+                user=user,
+                organization=organization_second,
+                role=OrganizationRole.admin,
+            )
+        )
+        transaction = await create_transaction(
+            save_fixture, payment_organization=organization
+        )
+        transaction_second = await create_transaction(
+            save_fixture, payment_organization=organization_second
+        )
+
+        # Unscoped session sees both organizations' transactions.
+        response = await client.get("/v1/transactions/search")
+        assert response.status_code == 200
+        ids = {item["id"] for item in response.json()["items"]}
+        assert {str(transaction.id), str(transaction_second.id)} <= ids
+
+        # Down-scoping the session to one org hides the other org's transactions.
+        auth_subject.organization_ids = frozenset({organization.id})
+        response = await client.get("/v1/transactions/search")
+        assert response.status_code == 200
+        ids = {item["id"] for item in response.json()["items"]}
+        assert str(transaction.id) in ids
+        assert str(transaction_second.id) not in ids
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Until we implement SSO, nothing is writing in the `UserSessionOrganization` table so this is transparent as every callers explicitly pass `auth_subject.organization_ids = None`

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces organization down-scope on user sessions across auth-aware queries and reads. Down-scoped sessions only see data for scoped organizations; unscoped sessions behave as before.

- **New Features**
  - Add `organization_ids` to `AuthSubject`, populated from `UserSession.organization_scopes` (selectin-loaded). `None` = unrestricted; empty set = no access; always intersected with membership.
  - Introduce `select_accessible_org_ids(auth_subject, permission=...)` for scope-aware org filtering; keep `select_user_org_ids(user_id, ...)` for membership-only checks. `AuthzRepository.get_user_org_ids` now takes `AuthSubject[User]` and applies down-scope.
  - Apply scoping in metrics, search, orders, subscriptions, discounts, custom fields, events (customer/member checks), and transactions. Transaction endpoints and service now accept `AuthSubject`.

- **Migration**
  - Use `select_accessible_org_ids(auth_subject, ...)` in auth-aware statements instead of `select_user_org_ids(user_id, ...)`.
  - Update `AuthzRepository.get_user_org_ids(...)` to pass the `AuthSubject[User]`.
  - Update `TransactionService.search/lookup(...)` and endpoints to pass the `AuthSubject` rather than a `User`.

<sup>Written for commit cbb14a76ff15d17dc023494d2fbe8ac0bc9fe735. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





