### PR TITLE
refactor: drop Playwright from org-review scraping, use Firecrawl only

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -33,11 +33,6 @@ on:
         required: false
         type: boolean
         default: false
-      render-playwright-worker-service-ids:
-        description: "Comma-separated list of Render playwright worker service IDs"
-        required: false
-        type: string
-        default: ""
     secrets:
       RENDER_API_TOKEN:
         required: true
@@ -104,9 +99,7 @@ jobs:
             "$TAG" \
             "${{ inputs.has-migrations }}" \
             "${{ inputs.render-api-service-id }}" \
-            "${{ inputs.render-worker-service-ids }}" \
-            "$TAG" \
-            "${{ inputs.render-playwright-worker-service-ids }}"
+            "${{ inputs.render-worker-service-ids }}"
         env:
           RENDER_API_TOKEN: ${{ secrets.RENDER_API_TOKEN }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -226,28 +226,6 @@ jobs:
           secrets: |
             IPINFO_ACCESS_TOKEN=${{ secrets.IPINFO_ACCESS_TOKEN }}
 
-      - name: Docker meta (Playwright)
-        id: meta-playwright
-        uses: docker/metadata-action@v6
-        with:
-          images: ghcr.io/polarsource/polar-playwright
-          tags: |
-            type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - uses: useblacksmith/build-push-action@v2
-        id: push-playwright
-        with:
-          push: true
-          tags: ${{ steps.meta-playwright.outputs.tags }}
-          context: ./server
-          target: playwright
-          platforms: linux/amd64
-          build-args: |
-            RELEASE_VERSION=${{ github.sha }}
-          secrets: |
-            IPINFO_ACCESS_TOKEN=${{ secrets.IPINFO_ACCESS_TOKEN }}
-
   build-lambda-worker:
     name: "Build Lambda Worker Image (ECR) λ"
     needs: changes
@@ -355,8 +333,7 @@ jobs:
     with:
       environment: sandbox
       render-api-service-id: "srv-crkocgbtq21c73ddsdbg"
-      render-worker-service-ids: "srv-d62q7vh4tr6s73fk44ng,srv-d733cp15pdvs73f6vqng,srv-d7unnjhj2pic73c2vr60"
-      render-playwright-worker-service-ids: "srv-d089jj7diees73934kgg"
+      render-worker-service-ids: "srv-d62q7vh4tr6s73fk44ng,srv-d733cp15pdvs73f6vqng,srv-d7unnjhj2pic73c2vr60,srv-d089jj7diees73934kgg"
       has-migrations: ${{ needs.changes.outputs.migrations-sandbox == 'true' || github.event_name == 'workflow_dispatch' }}
       skip-backend: ${{ needs.changes.outputs.backend-sandbox != 'true' && github.event_name != 'workflow_dispatch' }}
       skip-frontend: ${{ needs.changes.outputs.frontend-sandbox != 'true' && github.event_name != 'workflow_dispatch' }}
@@ -376,8 +353,7 @@ jobs:
     with:
       environment: production
       render-api-service-id: "srv-ci4r87h8g3ne0dmvvl60"
-      render-worker-service-ids: "srv-d4k62svpm1nc73af5e3g,srv-d3hrh1j3fgac73a1t4r0,srv-d4uto5ili9vc73dd37tg,srv-d5l0oekhg0os73clofm0,srv-d733djuuk2gs73e98h1g,srv-d7us9je7r5hc73be5ieg"
-      render-playwright-worker-service-ids: "srv-d4k6otfgi27c73cicnpg"
+      render-worker-service-ids: "srv-d4k62svpm1nc73af5e3g,srv-d3hrh1j3fgac73a1t4r0,srv-d4uto5ili9vc73dd37tg,srv-d5l0oekhg0os73clofm0,srv-d733djuuk2gs73e98h1g,srv-d7us9je7r5hc73be5ieg,srv-d4k6otfgi27c73cicnpg"
       has-migrations: ${{ needs.changes.outputs.migrations-production == 'true' || github.event_name == 'workflow_dispatch' }}
       skip-backend: ${{ needs.changes.outputs.backend-production != 'true' && github.event_name != 'workflow_dispatch' }}
       skip-frontend: ${{ needs.changes.outputs.frontend-production != 'true' && github.event_name != 'workflow_dispatch' }}

--- a/.github/workflows/deploy_server.sh
+++ b/.github/workflows/deploy_server.sh
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-# Usage: ./deploy_server.sh <docker_tag> <has_migrations> <api_service_id> <worker_service_ids> [playwright_tag] [playwright_worker_service_ids]
+# Usage: ./deploy_server.sh <docker_tag> <has_migrations> <api_service_id> <worker_service_ids>
 if [ $# -lt 4 ]; then
-  echo "Usage: $0 <docker_tag> <has_migrations> <api_service_id> <worker_service_ids> [playwright_tag] [playwright_worker_service_ids]"
-  echo "Example: $0 sha-abc1234 true srv-123 srv-456,srv-789 sha-def5678 srv-999"
+  echo "Usage: $0 <docker_tag> <has_migrations> <api_service_id> <worker_service_ids>"
+  echo "Example: $0 sha-abc1234 true srv-123 srv-456,srv-789"
   exit 1
 fi
 
@@ -126,16 +126,6 @@ deploy_servers() {
   echo "✅ ${services} deployments completed successfully!"
 }
 
-# Parse playwright configuration
-PLAYWRIGHT_TAG="${5:-}"
-PLAYWRIGHT_WORKER_IDS="${6:-}"
-PLAYWRIGHT_SERVERS=()
-PLAYWRIGHT_IMG=""
-if [[ -n "$PLAYWRIGHT_TAG" && -n "$PLAYWRIGHT_WORKER_IDS" ]]; then
-  PLAYWRIGHT_IMG="ghcr.io/polarsource/polar-playwright:${PLAYWRIGHT_TAG}"
-  IFS=',' read -ra PLAYWRIGHT_SERVERS <<< "$PLAYWRIGHT_WORKER_IDS"
-fi
-
 # Deploy based on migration status
 if [ "$HAS_MIGRATIONS" = "true" ]; then
   echo "📋 Deploying API first (migrations detected), then workers in parallel"
@@ -144,16 +134,11 @@ if [ "$HAS_MIGRATIONS" = "true" ]; then
   api_server=("$API_SERVICE_ID")
   deploy_servers api_server "API" "environment"
 
-  # Deploy workers and playwright workers in parallel
+  # Deploy workers
   pids=()
 
   if [ ${#WORKER_SERVERS[@]} -gt 0 ]; then
     deploy_servers WORKER_SERVERS "workers" "environment" &
-    pids+=($!)
-  fi
-
-  if [ ${#PLAYWRIGHT_SERVERS[@]} -gt 0 ]; then
-    deploy_servers PLAYWRIGHT_SERVERS "playwright-workers" "environment" "$PLAYWRIGHT_IMG" &
     pids+=($!)
   fi
 
@@ -173,11 +158,6 @@ else
   pids=()
   deploy_servers all_servers "All" "environment" &
   pids+=($!)
-
-  if [ ${#PLAYWRIGHT_SERVERS[@]} -gt 0 ]; then
-    deploy_servers PLAYWRIGHT_SERVERS "playwright-workers" "environment" "$PLAYWRIGHT_IMG" &
-    pids+=($!)
-  fi
 
   for pid in "${pids[@]}"; do
     wait "$pid" || exit 1

--- a/dev/docker/scripts/startup.sh
+++ b/dev/docker/scripts/startup.sh
@@ -210,17 +210,6 @@ print(count)
     fi
 fi
 
-# Install Playwright browsers for worker (needed for website scraping)
-PLAYWRIGHT_MARKER="/root/.cache/ms-playwright/.installed"
-if [[ "${1:-api}" == "worker" ]] && [[ ! -f "$PLAYWRIGHT_MARKER" ]]; then
-    echo "Installing Playwright browsers..."
-    uv run playwright install --with-deps chromium
-    touch "$PLAYWRIGHT_MARKER"
-    echo "Playwright browsers installed"
-elif [[ "${1:-api}" == "worker" ]]; then
-    echo "Playwright browsers already installed"
-fi
-
 # Start the requested service
 case "${1:-api}" in
     api)

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -124,12 +124,7 @@ ENV RELEASE_VERSION=${RELEASE_VERSION}
 
 CMD ["uv", "run", "uvicorn", "polar.app:app", "--host", "0.0.0.0", "--port", "10000", "--limit-max-requests", "50000", "--limit-max-requests-jitter", "10000", "--timeout-graceful-shutdown", "30"]
 
-# Stage 6: Playwright image (for browser automation workers)
-FROM production AS playwright
-
-RUN uv run playwright install --with-deps chromium
-
-# Stage 7: AWS Lambda image (SQS-driven background tasks, POC)
+# Stage 6: AWS Lambda image (SQS-driven background tasks, POC)
 FROM public.ecr.aws/lambda/python:3.14 AS lambda-build
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -238,15 +238,10 @@ class Settings(BaseSettings):
     PYDANTIC_AI_GATEWAY_API_KEY: str = "DummyKey"
     PYDANTIC_AI_GATEWAY_MODEL: str = "openai:gpt-5.5"
 
-    # Organization review website scraping
+    # Organization review website scraping. Firecrawl Cloud backs the JS-render
+    # path of the collector: it renders JavaScript, follows redirects, and
+    # egresses from Firecrawl's network rather than ours.
     FIRECRAWL_API_KEY: str | None = None
-    # Which scraper backs the JS-render path of the organization-review website
-    # collector. "playwright" uses the in-house headless browser, "firecrawl"
-    # uses Firecrawl Cloud, and "shadow" runs Firecrawl alongside Playwright to
-    # log a comparison while still using Playwright's result for the live verdict.
-    ORGANIZATION_REVIEW_SCRAPER: Literal["playwright", "firecrawl", "shadow"] = (
-        "firecrawl"
-    )
 
     # How long an organization stays in `offboarding` before it automatically
     # transitions to the terminal `offboarded` state. Measured from the last paid

--- a/server/polar/organization_review/collectors/firecrawl_client.py
+++ b/server/polar/organization_review/collectors/firecrawl_client.py
@@ -1,9 +1,8 @@
 """Thin wrapper around the Firecrawl Cloud `/scrape` endpoint.
 
 Firecrawl renders JavaScript, evades bot/Cloudflare blocks, and uses proxies
-server-side, so it replaces the in-house headless Chromium (Playwright) used by
-the organization-review website collector. The browser egress is now Firecrawl's
-network rather than ours.
+server-side. It backs the JS-render path of the organization-review website
+collector; the browser egress is Firecrawl's network rather than ours.
 """
 
 from __future__ import annotations
@@ -43,9 +42,9 @@ class ScrapeResult:
 def _get_client() -> AsyncFirecrawl:
     """Lazily build a singleton Firecrawl client.
 
-    Imported lazily (and cached) so that importing this module — or running the
-    collector with the Playwright scraper selected — never requires the
-    Firecrawl SDK to be configured. Mirrors the `_get_website_agent` pattern.
+    Imported lazily (and cached) so that importing this module never requires
+    the Firecrawl SDK to be installed until a scrape actually happens. Mirrors
+    the `_get_website_agent` pattern.
     """
     from firecrawl import AsyncFirecrawl
 

--- a/server/polar/organization_review/collectors/setup.py
+++ b/server/polar/organization_review/collectors/setup.py
@@ -3,9 +3,7 @@ from urllib.parse import urlparse
 
 import httpx
 import structlog
-from playwright.async_api import async_playwright
 
-from polar.config import settings
 from polar.kit.http import SSRFBlockedError, resolve_and_validate_ip
 from polar.models.checkout_link import CheckoutLink
 from polar.models.webhook_endpoint import WebhookEndpoint
@@ -31,8 +29,6 @@ _REDIRECT_TIMEOUT = 5.0
 _MAX_URLS_TO_RESOLVE = 20
 # Maximum concurrent redirect resolutions
 _MAX_CONCURRENT = 5
-# Timeout for Playwright page navigation (ms)
-_BROWSER_PAGE_TIMEOUT_MS = 10_000
 
 
 def _extract_domain(url: str) -> str | None:
@@ -157,110 +153,11 @@ def _pick_one_per_hostname(urls: list[str]) -> list[str]:
 
 
 async def _resolve_redirect_with_browser(url: str) -> UrlRedirectInfo:
-    """Detect client-side redirects (meta refresh, JS) for a single URL.
-
-    Dispatches to the configured scraper: the in-house Playwright browser,
-    Firecrawl Cloud, or (in shadow mode) both — logging a comparison while
-    returning Playwright's result for the live verdict.
-    """
-    scraper = settings.ORGANIZATION_REVIEW_SCRAPER
-    if scraper == "firecrawl":
-        return await _resolve_redirect_firecrawl(url)
-    if scraper == "shadow":
-        return await _resolve_redirect_shadow(url)
-    return await _resolve_redirect_playwright(url)
-
-
-async def _resolve_redirect_playwright(url: str) -> UrlRedirectInfo:
-    """Use a headless browser to detect client-side redirects (meta refresh, JS).
-
-    Launches a fresh Playwright browser, navigates to the URL, waits for
-    any client-side redirects to settle, then compares the final domain.
-    """
-    try:
-        _validate_url_scheme(url)
-        await _validate_url_host(url)
-    except (ValueError, SSRFBlockedError):
-        return UrlRedirectInfo(original_url=url, error="blocked")
-
-    pw = None
-    browser = None
-    try:
-        pw = await async_playwright().start()
-        browser = await pw.chromium.launch(headless=True)
-        context = await browser.new_context(
-            user_agent=(
-                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-                "AppleWebKit/537.36 (KHTML, like Gecko) "
-                "Chrome/131.0.0.0 Safari/537.36"
-            ),
-            java_script_enabled=True,
-        )
-        page = await context.new_page()
-
-        # Install SSRF-only interceptor (allow cross-origin — we want to detect it)
-        async def _ssrf_handler(route):  # type: ignore[no-untyped-def]
-            parsed = urlparse(route.request.url)
-            if parsed.scheme in ("data", "blob"):
-                await route.continue_()
-                return
-            hostname = parsed.hostname
-            if hostname:
-                try:
-                    await resolve_and_validate_ip(hostname)
-                except SSRFBlockedError:
-                    await route.abort("blockedbyclient")
-                    return
-            await route.continue_()
-
-        await page.route("**/*", _ssrf_handler)
-
-        await page.goto(
-            url,
-            timeout=_BROWSER_PAGE_TIMEOUT_MS,
-            wait_until="domcontentloaded",
-        )
-        # Wait for JS / meta-refresh redirects to settle
-        try:
-            await page.wait_for_load_state("networkidle", timeout=5_000)
-        except Exception:
-            pass  # best-effort
-        await page.wait_for_timeout(1_000)
-
-        final_url = page.url
-        final_domain = _extract_domain(final_url)
-        original_domain = _extract_domain(url)
-        redirected = _is_cross_domain(original_domain, final_domain)
-
-        return UrlRedirectInfo(
-            original_url=url,
-            final_url=final_url,
-            final_domain=final_domain,
-            redirected=redirected,
-        )
-    except Exception:
-        log.warning("setup_collector.browser_redirect_error", url=url, exc_info=True)
-        return UrlRedirectInfo(original_url=url, error="browser_error")
-    finally:
-        if browser:
-            try:
-                await browser.close()
-            except Exception:
-                pass
-        if pw:
-            try:
-                await pw.stop()
-            except Exception:
-                pass
-
-
-async def _resolve_redirect_firecrawl(url: str) -> UrlRedirectInfo:
-    """Use Firecrawl Cloud to detect client-side redirects (meta refresh, JS).
+    """Detect client-side redirects (meta refresh, JS) via Firecrawl Cloud.
 
     Firecrawl follows HTTP/JS/meta-refresh redirects server-side and reports the
     final URL; we compare its domain against the original. Egress is Firecrawl's
-    network, so the per-hop SSRF interceptor is dropped — the scheme/host
-    pre-flight remains.
+    network rather than ours, so only the scheme/host pre-flight applies.
     """
     try:
         _validate_url_scheme(url)
@@ -284,29 +181,6 @@ async def _resolve_redirect_firecrawl(url: str) -> UrlRedirectInfo:
         final_domain=final_domain,
         redirected=redirected,
     )
-
-
-async def _resolve_redirect_shadow(url: str) -> UrlRedirectInfo:
-    """Run Firecrawl alongside Playwright, log a comparison, return Playwright's.
-
-    The two resolvers run concurrently so the observational Firecrawl scrape
-    doesn't add its latency on top of Playwright's for every URL.
-    """
-    firecrawl_result, playwright_result = await asyncio.gather(
-        _resolve_redirect_firecrawl(url),
-        _resolve_redirect_playwright(url),
-    )
-    log.info(
-        "setup_collector.shadow_compare",
-        url=url,
-        playwright_redirected=playwright_result.redirected,
-        playwright_final_url=playwright_result.final_url,
-        playwright_error=playwright_result.error,
-        firecrawl_redirected=firecrawl_result.redirected,
-        firecrawl_final_url=firecrawl_result.final_url,
-        firecrawl_error=firecrawl_result.error,
-    )
-    return playwright_result
 
 
 async def resolve_url_redirects(urls: list[str]) -> list[UrlRedirectInfo]:

--- a/server/polar/organization_review/collectors/website.py
+++ b/server/polar/organization_review/collectors/website.py
@@ -3,15 +3,12 @@ from __future__ import annotations
 import asyncio
 import functools
 import re
-import time
 from dataclasses import dataclass, field
-from typing import Any
 from urllib.parse import urljoin, urlparse
 
 import httpx
 import structlog
 import trafilatura
-from playwright.async_api import Browser, Page, Playwright, Route, async_playwright
 from pydantic_ai import Agent, RunContext
 
 from polar.config import settings
@@ -35,45 +32,6 @@ _USER_AGENT = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
     "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
 )
-
-# JS: extract internal links from navigation areas, CTAs, and main content.
-_EXTRACT_LINKS_JS = """
-() => {
-    const results = [];
-    const seen = new Set();
-
-    function addLink(a) {
-        const href = a.href;
-        const text = (a.textContent || '').trim().substring(0, 80);
-        if (href && !seen.has(href) && text && !href.startsWith('javascript:')) {
-            seen.add(href);
-            results.push(text + ' -> ' + href);
-        }
-    }
-
-    // Nav, header, footer, sidebar, ARIA navigation
-    const navSelectors = [
-        'nav a', 'header a', 'footer a', 'aside a',
-        '[role="navigation"] a', '[role="menu"] a', '[role="menubar"] a',
-    ];
-    for (const sel of navSelectors) {
-        for (const a of document.querySelectorAll(sel)) addLink(a);
-    }
-
-    // CTA-style links in main content
-    for (const a of document.querySelectorAll('main a, [role="main"] a, #content a, .content a')) {
-        addLink(a);
-    }
-
-    // Remaining top-level links
-    for (const a of document.querySelectorAll('a[href]')) {
-        if (results.length >= 40) break;
-        addLink(a);
-    }
-
-    return results.slice(0, 40);
-}
-"""
 
 SYSTEM_PROMPT = """\
 You are a website analyst for a business compliance review. Your job is to explore \
@@ -116,90 +74,12 @@ Keep it factual and under 500 words. Skip sections with no relevant info.
 
 @dataclass
 class WebsiteDeps:
-    """Shared dependencies — HTTP client always available, browser lazy-initialized."""
+    """Shared dependencies for the website agent's page-visiting tools."""
 
     client: httpx.AsyncClient
     allowed_domain: str
     pages_visited: list[WebsitePage] = field(default_factory=list)
     pages_navigated: int = 0
-
-    # Playwright state — initialized on first `browse_page` call
-    _playwright: Playwright | None = field(default=None, repr=False)
-    _browser: Browser | None = field(default=None, repr=False)
-    _browser_page: Page | None = field(default=None, repr=False)
-
-    async def get_browser_page(self) -> Page:
-        """Lazily launch a headless browser and return its page."""
-        if self._browser_page is None:
-            self._playwright = await async_playwright().start()
-            self._browser = await self._playwright.chromium.launch(headless=True)
-            context = await self._browser.new_context(
-                user_agent=_USER_AGENT,
-                java_script_enabled=True,
-                viewport={"width": 1280, "height": 720},
-                locale="en-US",
-            )
-            self._browser_page = await context.new_page()
-            await self._install_request_interceptor(self._browser_page)
-        return self._browser_page
-
-    async def _install_request_interceptor(self, page: Page) -> None:
-        """Install a route handler that blocks off-origin navigations and SSRF."""
-        allowed_domain = self.allowed_domain
-
-        async def _handler(route: Route) -> None:
-            request = route.request
-            url = request.url
-            parsed = urlparse(url)
-
-            # Allow data: and blob: URLs (inline resources)
-            if parsed.scheme in ("data", "blob"):
-                await route.continue_()
-                return
-
-            resource_type = request.resource_type
-
-            # Origin check: only for document/fetch/xhr (allows CDN subresources)
-            if resource_type in ("document", "fetch", "xhr"):
-                if not _is_allowed_origin(url, allowed_domain):
-                    log.info(
-                        "website_collector.playwright_blocked_origin",
-                        url=url,
-                        resource_type=resource_type,
-                    )
-                    await route.abort("blockedbyclient")
-                    return
-
-            # SSRF check: for all requests with a hostname
-            hostname = parsed.hostname
-            if hostname:
-                try:
-                    await resolve_and_validate_ip(hostname)
-                except SSRFBlockedError:
-                    log.info(
-                        "website_collector.playwright_blocked_ssrf",
-                        url=url,
-                        resource_type=resource_type,
-                    )
-                    await route.abort("blockedbyclient")
-                    return
-
-            await route.continue_()
-
-        await page.route("**/*", _handler)
-
-    async def cleanup(self) -> None:
-        """Close browser resources if they were initialized."""
-        try:
-            if self._browser:
-                await self._browser.close()
-        except Exception:
-            log.warning("website_collector.browser_close_failed", exc_info=True)
-        try:
-            if self._playwright:
-                await self._playwright.stop()
-        except Exception:
-            log.warning("website_collector.playwright_stop_failed", exc_info=True)
 
 
 # ---------------------------------------------------------------------------
@@ -389,6 +269,10 @@ with server-side rendering. Use this by default."""
 async def browse_page(ctx: RunContext[WebsiteDeps], url: str) -> str:
     """Open a URL in a headless browser with full JavaScript rendering. \
 Slower but handles SPAs and JS-heavy sites. Use when fetch_page returns empty content."""
+    # Rendering runs on Firecrawl Cloud, which executes JavaScript and follows
+    # redirects server-side and egresses from Firecrawl's network rather than
+    # ours. The per-hop SSRF interceptor is therefore not needed — the cheap
+    # origin pre-flight plus the origin-lock on the returned final URL remain.
     deps = ctx.deps
     if deps.pages_navigated >= MAX_PAGES:
         return "Page limit reached. Produce your summary now."
@@ -396,97 +280,6 @@ Slower but handles SPAs and JS-heavy sites. Use when fetch_page returns empty co
     if not _is_allowed_origin(url, deps.allowed_domain):
         return f"Error: URL is off-origin (only {deps.allowed_domain} is allowed)"
 
-    scraper = settings.ORGANIZATION_REVIEW_SCRAPER
-    if scraper == "firecrawl":
-        return await _browse_page_firecrawl(deps, url)
-    if scraper == "shadow":
-        return await _browse_page_shadow(deps, url)
-    return await _browse_page_playwright(deps, url)
-
-
-async def _browse_page_playwright(deps: WebsiteDeps, url: str) -> str:
-    """Render a page with the in-house headless browser (Playwright)."""
-    # SSRF pre-check (defense-in-depth — interceptor also blocks)
-    initial_host = urlparse(url).hostname
-    if initial_host:
-        try:
-            await resolve_and_validate_ip(initial_host)
-        except SSRFBlockedError as e:
-            return f"Error: {e}"
-
-    deps.pages_navigated += 1
-    page = await deps.get_browser_page()
-
-    try:
-        response = await page.goto(
-            url, timeout=PAGE_TIMEOUT_MS, wait_until="domcontentloaded"
-        )
-        if response and response.status >= 400:
-            return f"Error: HTTP {response.status} for {url}"
-    except Exception as e:
-        return f"Error navigating to {url}: {str(e)[:100]}"
-
-    # Wait for JS rendering / SPA hydration
-    try:
-        await page.wait_for_load_state("networkidle", timeout=5_000)
-    except Exception:
-        pass  # Best-effort; don't fail if network stays busy
-    await page.wait_for_timeout(1_000)
-
-    # Post-navigation origin check — catch JS-driven redirects
-    current_url = page.url
-    if not _is_allowed_origin(current_url, deps.allowed_domain):
-        return (
-            f"Error: page redirected to off-origin URL {current_url} "
-            f"(only {deps.allowed_domain} is allowed)"
-        )
-
-    # Extract content via trafilatura
-    try:
-        html = await page.content()
-        content = trafilatura.extract(html, output_format="markdown") or ""
-    except Exception:
-        content = ""
-
-    title = await page.title() or None
-
-    truncated = len(content) > MAX_CHARS_PER_PAGE
-    if truncated:
-        content = content[:MAX_CHARS_PER_PAGE]
-
-    deps.pages_visited.append(
-        WebsitePage(
-            url=current_url,
-            title=title,
-            content=content,
-            content_truncated=truncated,
-            method="browser",
-        )
-    )
-
-    # Extract links for the agent to choose from
-    try:
-        links = await page.evaluate(_EXTRACT_LINKS_JS)
-    except Exception:
-        links = []
-
-    return _build_tool_response(
-        title=title,
-        current_url=current_url,
-        pages_navigated=deps.pages_navigated,
-        content=content,
-        truncated=truncated,
-        links=links,
-    )
-
-
-async def _browse_page_firecrawl(deps: WebsiteDeps, url: str) -> str:
-    """Render a page via Firecrawl Cloud.
-
-    Firecrawl's browser egress is external, so the per-hop SSRF interceptor is
-    dropped — the cheap origin pre-flight (already done by the caller) plus the
-    origin-lock on the returned final URL remain.
-    """
     deps.pages_navigated += 1
 
     try:
@@ -530,63 +323,6 @@ async def _browse_page_firecrawl(deps: WebsiteDeps, url: str) -> str:
         truncated=truncated,
         links=[],
     )
-
-
-async def _browse_page_shadow(deps: WebsiteDeps, url: str) -> str:
-    """Run Firecrawl alongside Playwright, log a comparison, return Playwright's.
-
-    Observational: the Firecrawl scrape never raises and never touches
-    `pages_navigated` / `pages_visited` — only Playwright's result is used. The
-    two run concurrently so the shadow scrape never adds to the live verdict's
-    latency (which is bounded by `OVERALL_TIMEOUT_S`).
-    """
-    pages_before = len(deps.pages_visited)
-    observation, response = await asyncio.gather(
-        _firecrawl_observe(url),
-        _browse_page_playwright(deps, url),
-    )
-
-    # Only attribute a page to this call if Playwright actually appended one;
-    # otherwise pages_visited[-1] would be a stale page from an earlier call.
-    playwright_page = (
-        deps.pages_visited[-1] if len(deps.pages_visited) > pages_before else None
-    )
-    log.info(
-        "website_collector.shadow_compare",
-        url=url,
-        playwright_markdown_length=(
-            len(playwright_page.content) if playwright_page else 0
-        ),
-        playwright_final_url=playwright_page.url if playwright_page else None,
-        **observation,
-    )
-    return response
-
-
-async def _firecrawl_observe(url: str) -> dict[str, Any]:
-    """Scrape via Firecrawl for shadow comparison. Never raises; returns log fields.
-
-    Success and failure return the same set of keys so the `shadow_compare` log
-    event has a stable schema for downstream comparison queries.
-    """
-    start = time.monotonic()
-    try:
-        result = await scrape_markdown(url)
-    except Exception as e:
-        return {
-            "firecrawl_markdown_length": 0,
-            "firecrawl_final_url": None,
-            "firecrawl_status_code": None,
-            "firecrawl_latency_ms": int((time.monotonic() - start) * 1000),
-            "firecrawl_error": str(e)[:200],
-        }
-    return {
-        "firecrawl_markdown_length": len(result.markdown),
-        "firecrawl_final_url": result.url,
-        "firecrawl_status_code": result.status_code,
-        "firecrawl_latency_ms": int((time.monotonic() - start) * 1000),
-        "firecrawl_error": None,
-    }
 
 
 # ---------------------------------------------------------------------------
@@ -658,27 +394,24 @@ async def _run_website_agent(
         headers={"User-Agent": _USER_AGENT},
     ) as client:
         deps = WebsiteDeps(client=client, allowed_domain=allowed_domain)
-        try:
-            with organization_baggage(
-                organization_id=organization_id,
-                organization_slug=organization_slug,
-            ):
-                result = await agent.run(
-                    f"Analyze the website at: {base_url}",
-                    deps=deps,
-                )
-
-            return WebsiteData(
-                base_url=base_url,
-                pages=deps.pages_visited,
-                summary=result.output,
-                total_pages_attempted=max(deps.pages_navigated, 1),
-                total_pages_succeeded=len(
-                    [p for p in deps.pages_visited if p.content.strip()]
-                ),
-                usage=UsageInfo.from_agent_usage(
-                    result.usage(), model_provider, model_name
-                ),
+        with organization_baggage(
+            organization_id=organization_id,
+            organization_slug=organization_slug,
+        ):
+            result = await agent.run(
+                f"Analyze the website at: {base_url}",
+                deps=deps,
             )
-        finally:
-            await deps.cleanup()
+
+        return WebsiteData(
+            base_url=base_url,
+            pages=deps.pages_visited,
+            summary=result.output,
+            total_pages_attempted=max(deps.pages_navigated, 1),
+            total_pages_succeeded=len(
+                [p for p in deps.pages_visited if p.content.strip()]
+            ),
+            usage=UsageInfo.from_agent_usage(
+                result.usage(), model_provider, model_name
+            ),
+        )

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -59,7 +59,6 @@ dependencies = [
   "aiocsv>=1.4.1",
   "alembic-utils>=0.8.8",
   "clickhouse-connect[async]>=1.2.0",
-  "playwright>=1.60.0",
   "trafilatura>=2.1.0",
   "firecrawl-py>=4.28.2",
   "polar-sdk==0.31.7",

--- a/server/tests/organization_review/collectors/test_setup.py
+++ b/server/tests/organization_review/collectors/test_setup.py
@@ -3,7 +3,6 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from pytest_mock import MockerFixture
 
-from polar.config import settings
 from polar.organization_review.collectors.firecrawl_client import ScrapeResult
 from polar.organization_review.collectors.setup import (
     _extract_domain,
@@ -579,107 +578,8 @@ class TestResolveUrlRedirects:
         assert results[0].redirected is False
 
 
-class TestResolveRedirectWithBrowserDispatch:
-    """The redirect resolver dispatches to the configured scraper."""
-
-    @pytest.mark.asyncio
-    async def test_defaults_to_firecrawl(self, mocker: MockerFixture) -> None:
-        firecrawl = mocker.patch(
-            "polar.organization_review.collectors.setup._resolve_redirect_firecrawl",
-            new_callable=AsyncMock,
-            return_value=UrlRedirectInfo(original_url="https://example.com/"),
-        )
-        playwright = mocker.patch(
-            "polar.organization_review.collectors.setup._resolve_redirect_playwright",
-            new_callable=AsyncMock,
-        )
-
-        await _resolve_redirect_with_browser("https://example.com/")
-
-        firecrawl.assert_called_once_with("https://example.com/")
-        playwright.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_playwright_toggle_uses_playwright(
-        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr(settings, "ORGANIZATION_REVIEW_SCRAPER", "playwright")
-        playwright = mocker.patch(
-            "polar.organization_review.collectors.setup._resolve_redirect_playwright",
-            new_callable=AsyncMock,
-            return_value=UrlRedirectInfo(original_url="https://example.com/"),
-        )
-        firecrawl = mocker.patch(
-            "polar.organization_review.collectors.setup._resolve_redirect_firecrawl",
-            new_callable=AsyncMock,
-        )
-
-        await _resolve_redirect_with_browser("https://example.com/")
-
-        playwright.assert_called_once_with("https://example.com/")
-        firecrawl.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_firecrawl_toggle_uses_firecrawl(
-        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr(settings, "ORGANIZATION_REVIEW_SCRAPER", "firecrawl")
-        playwright = mocker.patch(
-            "polar.organization_review.collectors.setup._resolve_redirect_playwright",
-            new_callable=AsyncMock,
-        )
-        firecrawl = mocker.patch(
-            "polar.organization_review.collectors.setup._resolve_redirect_firecrawl",
-            new_callable=AsyncMock,
-            return_value=UrlRedirectInfo(original_url="https://example.com/"),
-        )
-
-        await _resolve_redirect_with_browser("https://example.com/")
-
-        firecrawl.assert_called_once_with("https://example.com/")
-        playwright.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_shadow_returns_playwright_runs_both(
-        self, mocker: MockerFixture, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        monkeypatch.setattr(settings, "ORGANIZATION_REVIEW_SCRAPER", "shadow")
-        playwright_result = UrlRedirectInfo(
-            original_url="https://example.com/",
-            final_url="https://example.com/",
-            final_domain="example.com",
-            redirected=False,
-        )
-        firecrawl_result = UrlRedirectInfo(
-            original_url="https://example.com/",
-            final_url="https://scam.com/",
-            final_domain="scam.com",
-            redirected=True,
-        )
-        playwright = mocker.patch(
-            "polar.organization_review.collectors.setup._resolve_redirect_playwright",
-            new_callable=AsyncMock,
-            return_value=playwright_result,
-        )
-        firecrawl = mocker.patch(
-            "polar.organization_review.collectors.setup._resolve_redirect_firecrawl",
-            new_callable=AsyncMock,
-            return_value=firecrawl_result,
-        )
-
-        result = await _resolve_redirect_with_browser("https://example.com/")
-
-        assert result is playwright_result
-        playwright.assert_called_once()
-        firecrawl.assert_called_once()
-
-
 class TestResolveRedirectFirecrawl:
     """The Firecrawl redirect path compares the post-redirect final domain."""
-
-    @pytest.fixture(autouse=True)
-    def _use_firecrawl(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(settings, "ORGANIZATION_REVIEW_SCRAPER", "firecrawl")
 
     @pytest.mark.asyncio
     async def test_cross_domain_redirect(self, mocker: MockerFixture) -> None:

--- a/server/tests/organization_review/collectors/test_website.py
+++ b/server/tests/organization_review/collectors/test_website.py
@@ -1,12 +1,10 @@
 import asyncio
-from collections.abc import Awaitable, Callable
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 
-from polar.config import settings
 from polar.kit.http import SSRFBlockedError
 from polar.organization_review.collectors.firecrawl_client import ScrapeResult
 from polar.organization_review.collectors.website import (
@@ -416,53 +414,6 @@ class TestCollectWebsiteData:
 
 
 # ---------------------------------------------------------------------------
-# WebsiteDeps cleanup
-# ---------------------------------------------------------------------------
-
-
-class TestWebsiteDepsCleanup:
-    @pytest.mark.asyncio
-    async def test_cleanup_when_browser_not_initialized(self) -> None:
-        """Cleanup should be a no-op when browser was never started."""
-        client = AsyncMock(spec=httpx.AsyncClient)
-        deps = WebsiteDeps(client=client, allowed_domain="example.com")
-
-        # Should not raise
-        await deps.cleanup()
-
-    @pytest.mark.asyncio
-    async def test_cleanup_closes_browser_and_playwright(self) -> None:
-        client = AsyncMock(spec=httpx.AsyncClient)
-        deps = WebsiteDeps(client=client, allowed_domain="example.com")
-
-        mock_browser = AsyncMock()
-        mock_playwright = AsyncMock()
-        deps._browser = mock_browser
-        deps._playwright = mock_playwright
-
-        await deps.cleanup()
-
-        mock_browser.close.assert_called_once()
-        mock_playwright.stop.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_cleanup_handles_browser_close_error(self) -> None:
-        """Playwright stop should still be called even if browser.close fails."""
-        client = AsyncMock(spec=httpx.AsyncClient)
-        deps = WebsiteDeps(client=client, allowed_domain="example.com")
-
-        mock_browser = AsyncMock()
-        mock_browser.close.side_effect = RuntimeError("close failed")
-        mock_playwright = AsyncMock()
-        deps._browser = mock_browser
-        deps._playwright = mock_playwright
-
-        await deps.cleanup()
-
-        mock_playwright.stop.assert_called_once()
-
-
-# ---------------------------------------------------------------------------
 # fetch_page — SSRF & redirect tests
 # ---------------------------------------------------------------------------
 
@@ -626,174 +577,7 @@ class TestFetchPageSSRF:
 
 
 # ---------------------------------------------------------------------------
-# browse_page — SSRF tests
-# ---------------------------------------------------------------------------
-
-
-class TestBrowsePageSSRF:
-    @pytest.fixture(autouse=True)
-    def _use_playwright(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(settings, "ORGANIZATION_REVIEW_SCRAPER", "playwright")
-
-    @pytest.mark.asyncio
-    async def test_blocks_initial_ssrf(self) -> None:
-        """browse_page should block a URL that resolves to a private IP."""
-        client = AsyncMock(spec=httpx.AsyncClient)
-        deps = WebsiteDeps(client=client, allowed_domain="example.com")
-        ctx = MagicMock()
-        ctx.deps = deps
-
-        with patch(
-            "polar.organization_review.collectors.website.resolve_and_validate_ip",
-            new_callable=AsyncMock,
-            side_effect=SSRFBlockedError("resolves to private IP 10.0.0.1"),
-        ):
-            result = await browse_page(ctx, "https://example.com/")
-
-        assert "private IP" in result
-        assert deps.pages_navigated == 0
-
-    @pytest.mark.asyncio
-    async def test_detects_post_navigation_off_origin_redirect(self) -> None:
-        """browse_page should detect when the browser ended up on a different domain."""
-        mock_page = AsyncMock()
-        mock_page.goto = AsyncMock(return_value=MagicMock(status=200))
-        mock_page.wait_for_load_state = AsyncMock()
-        mock_page.wait_for_timeout = AsyncMock()
-        mock_page.url = "https://evil.com/phished"  # JS redirect happened
-
-        client = AsyncMock(spec=httpx.AsyncClient)
-        deps = WebsiteDeps(client=client, allowed_domain="example.com")
-        deps._browser_page = mock_page
-        ctx = MagicMock()
-        ctx.deps = deps
-
-        with _PATCH_SSRF:
-            result = await browse_page(ctx, "https://example.com/")
-
-        assert "off-origin" in result
-        assert "evil.com" in result
-
-
-# ---------------------------------------------------------------------------
-# Playwright route interceptor
-# ---------------------------------------------------------------------------
-
-
-class TestPlaywrightRouteInterceptor:
-    @pytest.mark.asyncio
-    async def test_route_installed_on_page(self) -> None:
-        """get_browser_page should install the route handler."""
-        mock_page = AsyncMock()
-        mock_context = AsyncMock()
-        mock_context.new_page.return_value = mock_page
-        mock_browser = AsyncMock()
-        mock_browser.new_context.return_value = mock_context
-        mock_pw = AsyncMock()
-        mock_pw.chromium.launch.return_value = mock_browser
-
-        with patch(
-            "polar.organization_review.collectors.website.async_playwright"
-        ) as mock_apw:
-            mock_apw.return_value.start = AsyncMock(return_value=mock_pw)
-
-            client = AsyncMock(spec=httpx.AsyncClient)
-            deps = WebsiteDeps(client=client, allowed_domain="example.com")
-            page = await deps.get_browser_page()
-
-        assert page is mock_page
-        mock_page.route.assert_called_once()
-        call_args = mock_page.route.call_args[0]
-        assert call_args[0] == "**/*"
-        assert callable(call_args[1])
-
-    @pytest.mark.asyncio
-    async def test_blocks_off_origin_document_request(self) -> None:
-        """Route handler should block document requests to different domains."""
-        client = AsyncMock(spec=httpx.AsyncClient)
-        deps = WebsiteDeps(client=client, allowed_domain="example.com")
-
-        # Capture the handler
-        mock_page = AsyncMock()
-        handler: dict[str, Callable[[Any], Awaitable[Any]]] = {}
-
-        async def capture_route(
-            pattern: str, h: Callable[[Any], Awaitable[Any]]
-        ) -> None:
-            handler["handler"] = h
-
-        mock_page.route = capture_route
-        await deps._install_request_interceptor(mock_page)
-
-        route = AsyncMock()
-        route.request.url = "https://evil.com/page"
-        route.request.resource_type = "document"
-
-        with _PATCH_SSRF:
-            await handler["handler"](route)
-
-        route.abort.assert_called_once_with("blockedbyclient")
-
-    @pytest.mark.asyncio
-    async def test_allows_cdn_subresources(self) -> None:
-        """Route handler should allow image/script/stylesheet from CDN domains."""
-        client = AsyncMock(spec=httpx.AsyncClient)
-        deps = WebsiteDeps(client=client, allowed_domain="example.com")
-
-        mock_page = AsyncMock()
-        handler: dict[str, Callable[[Any], Awaitable[Any]]] = {}
-
-        async def capture_route(
-            pattern: str, h: Callable[[Any], Awaitable[Any]]
-        ) -> None:
-            handler["handler"] = h
-
-        mock_page.route = capture_route
-        await deps._install_request_interceptor(mock_page)
-
-        route = AsyncMock()
-        route.request.url = "https://cdn.jsdelivr.net/some-lib.js"
-        route.request.resource_type = "script"
-
-        with _PATCH_SSRF:
-            await handler["handler"](route)
-
-        route.continue_.assert_called_once()
-        route.abort.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_blocks_ssrf_on_any_resource_type(self) -> None:
-        """Route handler should block any request resolving to a private IP."""
-        client = AsyncMock(spec=httpx.AsyncClient)
-        deps = WebsiteDeps(client=client, allowed_domain="example.com")
-
-        mock_page = AsyncMock()
-        handler: dict[str, Callable[[Any], Awaitable[Any]]] = {}
-
-        async def capture_route(
-            pattern: str, h: Callable[[Any], Awaitable[Any]]
-        ) -> None:
-            handler["handler"] = h
-
-        mock_page.route = capture_route
-        await deps._install_request_interceptor(mock_page)
-
-        route = AsyncMock()
-        route.request.url = "https://example.com/api/data"
-        route.request.resource_type = "image"
-
-        with patch(
-            "polar.organization_review.collectors.website.resolve_and_validate_ip",
-            new_callable=AsyncMock,
-            side_effect=SSRFBlockedError("private IP"),
-        ):
-            await handler["handler"](route)
-
-        route.abort.assert_called_once_with("blockedbyclient")
-
-
-# ---------------------------------------------------------------------------
-# browse_page — Firecrawl branch
+# browse_page — Firecrawl rendering
 # ---------------------------------------------------------------------------
 
 
@@ -813,10 +597,6 @@ def _patch_scrape_markdown(result: ScrapeResult | Exception) -> Any:
 
 
 class TestBrowsePageFirecrawl:
-    @pytest.fixture(autouse=True)
-    def _use_firecrawl(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setattr(settings, "ORGANIZATION_REVIEW_SCRAPER", "firecrawl")
-
     @pytest.mark.asyncio
     async def test_successful_scrape(self) -> None:
         client = AsyncMock(spec=httpx.AsyncClient)
@@ -946,90 +726,3 @@ class TestBrowsePageFirecrawl:
         assert deps.pages_visited[0].content_truncated is True
         assert len(deps.pages_visited[0].content) <= MAX_CHARS_PER_PAGE
         assert "(content truncated)" in response
-
-
-# ---------------------------------------------------------------------------
-# browse_page — shadow mode
-# ---------------------------------------------------------------------------
-
-
-class TestBrowsePageShadow:
-    @pytest.mark.asyncio
-    async def test_uses_playwright_result_and_runs_firecrawl(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Shadow mode returns Playwright's result but still invokes Firecrawl."""
-        monkeypatch.setattr(settings, "ORGANIZATION_REVIEW_SCRAPER", "shadow")
-
-        mock_page = AsyncMock()
-        mock_page.goto = AsyncMock(return_value=MagicMock(status=200))
-        mock_page.wait_for_load_state = AsyncMock()
-        mock_page.wait_for_timeout = AsyncMock()
-        mock_page.url = "https://example.com/"
-        mock_page.content = AsyncMock(
-            return_value=(
-                "<html><head><title>PW Title</title></head>"
-                "<body><p>Playwright content here</p></body></html>"
-            )
-        )
-        mock_page.title = AsyncMock(return_value="PW Title")
-        mock_page.evaluate = AsyncMock(return_value=[])
-
-        client = AsyncMock(spec=httpx.AsyncClient)
-        deps = WebsiteDeps(client=client, allowed_domain="example.com")
-        deps._browser_page = mock_page
-        ctx = MagicMock()
-        ctx.deps = deps
-
-        firecrawl_result = ScrapeResult(
-            markdown="firecrawl content",
-            url="https://example.com/",
-            status_code=200,
-            title="FC Title",
-        )
-        with (
-            _patch_scrape_markdown(firecrawl_result) as mock_scrape,
-            _PATCH_SSRF,
-        ):
-            response = await browse_page(ctx, "https://example.com/")
-
-        # Playwright's result is the live one
-        assert "Page: PW Title" in response
-        assert deps.pages_navigated == 1
-        assert len(deps.pages_visited) == 1
-        assert deps.pages_visited[0].title == "PW Title"
-        # Firecrawl was still run for comparison
-        mock_scrape.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_firecrawl_failure_does_not_break_playwright(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """A Firecrawl error in shadow mode must not affect the Playwright result."""
-        monkeypatch.setattr(settings, "ORGANIZATION_REVIEW_SCRAPER", "shadow")
-
-        mock_page = AsyncMock()
-        mock_page.goto = AsyncMock(return_value=MagicMock(status=200))
-        mock_page.wait_for_load_state = AsyncMock()
-        mock_page.wait_for_timeout = AsyncMock()
-        mock_page.url = "https://example.com/"
-        mock_page.content = AsyncMock(
-            return_value="<html><head><title>PW</title></head><body><p>ok</p></body></html>"
-        )
-        mock_page.title = AsyncMock(return_value="PW")
-        mock_page.evaluate = AsyncMock(return_value=[])
-
-        client = AsyncMock(spec=httpx.AsyncClient)
-        deps = WebsiteDeps(client=client, allowed_domain="example.com")
-        deps._browser_page = mock_page
-        ctx = MagicMock()
-        ctx.deps = deps
-
-        with (
-            _patch_scrape_markdown(RuntimeError("firecrawl exploded")),
-            _PATCH_SSRF,
-        ):
-            response = await browse_page(ctx, "https://example.com/")
-
-        assert "Page: PW" in response
-        assert deps.pages_navigated == 1

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-15T15:30:35.004792Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -2370,25 +2370,6 @@ wheels = [
 ]
 
 [[package]]
-name = "playwright"
-version = "1.60.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "greenlet" },
-    { name = "pyee" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/f0/832bd9677194908da118064eef20082f2791e3d18215cc6d9391ee2c5a67/playwright-1.60.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:6a8cd0fec171fb3089e95e898c8bc8a6f35dea0b78b399e12fcc19427e91b1d7", size = 43474635, upload-time = "2026-05-18T12:00:31.969Z" },
-    { url = "https://files.pythonhosted.org/packages/59/7b/e1d32ae8a3ed937ec2be3721c5f728b13d731a0b7c6442e0b3bec5094ac0/playwright-1.60.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:39b5420ba6145045b69ced4c5c47d4d9fe5bddfc8ff816c518913afcb25ec7a5", size = 42261327, upload-time = "2026-05-18T12:00:35.638Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/bc/23de499ded6411c188a20c5a0dea6f0cd4ed5d2b3cc6042a5dbd3ed609aa/playwright-1.60.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:2581d0e6a3392c71f91b27460c7fd093356818dc430f48153896c8aeeaef7705", size = 43474636, upload-time = "2026-05-18T12:00:39.294Z" },
-    { url = "https://files.pythonhosted.org/packages/22/7b/1d679f4fced4ea94efadd17103856d8c565384f68382a1681264e46f5925/playwright-1.60.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:1c2bfae7884fb3fb05b853290eab8f343d524e5016f2f1def702acbbdf14c93e", size = 47467220, upload-time = "2026-05-18T12:00:43.179Z" },
-    { url = "https://files.pythonhosted.org/packages/84/c2/1528d267d4442bd2c6b8eaeab819dd52c2030bf80e89293f0ba1f687473b/playwright-1.60.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:43e66564125ee31b07a58cefb21e256d62d67d8d1713e6858df7a3019d8ed353", size = 47154856, upload-time = "2026-05-18T12:00:46.715Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/4e/b008b6440a7a1624378041da94829956d4b8f7ab9ef5aad22d0dc3f2e26d/playwright-1.60.0-py3-none-win32.whl", hash = "sha256:ec94e416ea320711e0ad4bf185dcbf41833672961e90773e1885255d7db7b7e7", size = 37902157, upload-time = "2026-05-18T12:00:50.374Z" },
-    { url = "https://files.pythonhosted.org/packages/55/f0/0541524133104f9cc20bf900870ff4a736b76a23483f3a55295ddfa58409/playwright-1.60.0-py3-none-win_amd64.whl", hash = "sha256:9566821ce6030a1f9e7146a24e19355ab0d98805fd0f9be50bb3d8fef1750c02", size = 37902159, upload-time = "2026-05-18T12:00:53.728Z" },
-    { url = "https://files.pythonhosted.org/packages/80/c8/210f282d278e4709cdd71b12a31af45a30a22ab3207b387e29b37e478713/playwright-1.60.0-py3-none-win_arm64.whl", hash = "sha256:6e4f6700a4c2250efff8e690a81d66e3855754fb587b6b87cf5c784014f91537", size = 34037981, upload-time = "2026-05-18T12:00:57.584Z" },
-]
-
-[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2432,7 +2413,6 @@ dependencies = [
     { name = "makefun" },
     { name = "markdown-it-py" },
     { name = "plain-client" },
-    { name = "playwright" },
     { name = "polar-sdk" },
     { name = "posthog" },
     { name = "prometheus-client" },
@@ -2528,7 +2508,6 @@ requires-dist = [
     { name = "makefun", specifier = ">=1.15.6" },
     { name = "markdown-it-py", specifier = ">=4.2.0" },
     { name = "plain-client", specifier = ">=0.0.3" },
-    { name = "playwright", specifier = ">=1.60.0" },
     { name = "polar-sdk", url = "https://files.pythonhosted.org/packages/dc/e0/a88026b9432c7e2c0c096911ddc97cb06f483036a00a8afd5254efe1c16a/polar_sdk-0.31.7-py3-none-any.whl" },
     { name = "posthog", specifier = ">=7.18.0" },
     { name = "prometheus-client", specifier = ">=0.25.0" },
@@ -2915,18 +2894,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
-]
-
-[[package]]
-name = "pyee"
-version = "13.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Drop playwright and keep firecrawl

## What

- Collapse `browse_page` and client-side redirect resolution onto Firecraw
- Remove the `playwright` dependency (relock).
- Remove the Playwright Docker stage and its CI build/push, and the local chromium install from the dev worker startup.
- The dedicated "playwright worker" Render services no longer need the chromium image, so they're folded into the regular worker deploy list (kept, not decommissioned they run core `low_priority` queues).
- Prune the Playwright/shadow collector tests.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

