### PR TITLE
Simplify MoR Pipeline section on Landing page

### DIFF
--- a/clients/apps/web/src/components/Landing/Pipeline.tsx
+++ b/clients/apps/web/src/components/Landing/Pipeline.tsx
@@ -3,23 +3,6 @@
 import { Avatar, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import Link from 'next/link'
-import { useState } from 'react'
-
-const ArrowRight = () => (
-  <svg
-    width="14"
-    height="14"
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={2}
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <line x1="5" y1="12" x2="19" y2="12" />
-    <polyline points="12 5 19 12 12 19" />
-  </svg>
-)
 
 interface Aspect {
   title: string
@@ -148,30 +131,7 @@ const ArrowDown = () => (
   </Box>
 )
 
-const Chevron = ({ open }: { open: boolean }) => (
-  <Box color="text-tertiary" flexShrink={0}>
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth={2}
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      style={{
-        transform: open ? 'rotate(180deg)' : 'rotate(0deg)',
-        transition: 'transform 150ms ease',
-      }}
-    >
-      <polyline points="6 9 12 15 18 9" />
-    </svg>
-  </Box>
-)
-
 export const Pipeline = () => {
-  const [active, setActive] = useState(0)
-
   return (
     <Box
       position="relative"
@@ -194,61 +154,35 @@ export const Pipeline = () => {
             </Text>
           </Box>
 
-          <Box display={{ base: 'none', md: 'flex' }} flexDirection="column">
-            {ASPECTS.map((aspect, index) => {
-              const open = index === active
+          <Box
+            display={{ base: 'none', md: 'flex' }}
+            rowGap="xl"
+            flexDirection="column"
+          >
+            {ASPECTS.map((aspect) => {
               return (
-                <Box
-                  as="li"
-                  key={aspect.title}
-                  borderBottomWidth={1}
-                  borderStyle="solid"
-                  borderColor="border-secondary"
-                  paddingVertical="xl"
-                  display="flex"
-                  flexDirection="column"
-                  rowGap="l"
-                >
+                <Link href={aspect.href} key={aspect.title}>
                   <Box
-                    alignItems="center"
-                    justifyContent="between"
-                    columnGap="l"
-                    cursor="pointer"
-                    onClick={() => setActive(index)}
+                    as="li"
+                    display="flex"
+                    flexDirection="column"
+                    rowGap="s"
+                    borderLeftWidth={4}
+                    borderStyle="solid"
+                    paddingLeft="xl"
                   >
-                    <Box flexDirection="row" columnGap="s">
-                      <Text
-                        variant="heading-xxs"
-                        color={open ? undefined : 'muted'}
-                      >
-                        {aspect.title}
-                      </Text>
+                    <Box alignItems="center" justifyContent="between">
+                      <Box flexDirection="row" columnGap="s">
+                        <Text variant="heading-xxs">{aspect.title}</Text>
+                      </Box>
                     </Box>
-                    <Chevron open={open} />
-                  </Box>
-                  {open && (
-                    <Box paddingBottom="l" flexDirection="column" rowGap="m">
+                    <Box flexDirection="column" rowGap="m">
                       <Text variant="body" color="muted">
                         {aspect.desc}
                       </Text>
-                      <Link href={aspect.href}>
-                        <Box
-                          alignItems="center"
-                          columnGap="m"
-                          width="fit-content"
-                          color={{
-                            base: 'text-primary',
-                            hover: 'text-secondary',
-                          }}
-                          cursor="pointer"
-                        >
-                          <Text variant="body">Learn more</Text>
-                          <ArrowRight />
-                        </Box>
-                      </Link>
                     </Box>
-                  )}
-                </Box>
+                  </Box>
+                </Link>
               )
             })}
           </Box>
@@ -303,8 +237,6 @@ export const Pipeline = () => {
                 padding="s"
               >
                 {group.map((aspect) => {
-                  const globalIndex = ASPECTS.indexOf(aspect)
-                  const isActive = globalIndex === active
                   return (
                     <Box
                       key={aspect.title}
@@ -313,15 +245,9 @@ export const Pipeline = () => {
                       paddingVertical="s"
                       paddingHorizontal="s"
                       cursor="pointer"
-                      onClick={() => setActive(globalIndex)}
                     >
-                      <CheckIcon active={isActive} />
-                      <Text
-                        variant="body"
-                        color={isActive ? undefined : 'muted'}
-                      >
-                        {aspect.title}
-                      </Text>
+                      <CheckIcon active={true} />
+                      <Text variant="body">{aspect.title}</Text>
                     </Box>
                   )
                 })}

--- a/clients/apps/web/src/components/Landing/Pipeline.tsx
+++ b/clients/apps/web/src/components/Landing/Pipeline.tsx
@@ -147,7 +147,7 @@ export const Pipeline = () => {
         alignItems="start"
       >
         {/* Accordion */}
-        <Box as="ul" flexDirection="column" rowGap="2xl">
+        <Box flexDirection="column" rowGap="2xl">
           <Box flexDirection="column" rowGap="2xl">
             <Text variant="heading-l" as="h2" wrap="balance">
               Everything between usage & revenue
@@ -155,34 +155,41 @@ export const Pipeline = () => {
           </Box>
 
           <Box
+            as="ul"
             display={{ base: 'none', md: 'flex' }}
             rowGap="xl"
             flexDirection="column"
           >
             {ASPECTS.map((aspect) => {
               return (
-                <Link href={aspect.href} key={aspect.title}>
-                  <Box
-                    as="li"
-                    display="flex"
-                    flexDirection="column"
-                    rowGap="s"
-                    borderLeftWidth={4}
-                    borderStyle="solid"
-                    paddingLeft="xl"
-                  >
-                    <Box alignItems="center" justifyContent="between">
-                      <Box flexDirection="row" columnGap="s">
-                        <Text variant="heading-xxs">{aspect.title}</Text>
+                <Box
+                  as="li"
+                  key={aspect.title}
+                  display="flex"
+                  flexDirection="column"
+                >
+                  <Link href={aspect.href}>
+                    <Box
+                      display="flex"
+                      flexDirection="column"
+                      rowGap="s"
+                      borderLeftWidth={4}
+                      borderStyle="solid"
+                      paddingLeft="xl"
+                    >
+                      <Box alignItems="center" justifyContent="between">
+                        <Box flexDirection="row" columnGap="s">
+                          <Text variant="heading-xxs">{aspect.title}</Text>
+                        </Box>
+                      </Box>
+                      <Box flexDirection="column" rowGap="m">
+                        <Text variant="body" color="muted">
+                          {aspect.desc}
+                        </Text>
                       </Box>
                     </Box>
-                    <Box flexDirection="column" rowGap="m">
-                      <Text variant="body" color="muted">
-                        {aspect.desc}
-                      </Text>
-                    </Box>
-                  </Box>
-                </Link>
+                  </Link>
+                </Box>
               )
             })}
           </Box>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Simplified the Landing Pipeline by removing expand/collapse and making each item a direct link. The section is now static, semantic, and easier to scan.

- **Refactors**
  - Removed local state and toggle UI (`useState`, chevron, arrow icons).
  - Desktop: aspect list uses `ul/li`; each item shows title + description and is a `Link` with a left-border accent.
  - Mobile: chips are non-interactive; `CheckIcon` is always active and text is no longer muted.

<sup>Written for commit 7ec40ac2ffdf98db15d84780fa9cb76da78d07cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

