### PR TITLE
chore(auth): add plan for enterprise sso

### DIFF
--- a/enterprise-sso-plan-v2.md
+++ b/enterprise-sso-plan-v2.md
@@ -1,0 +1,253 @@
+# Plan v2: Enterprise SSO with single-organization session scope
+
+> Revised after @frankie567's review of #12591. The core change: org-slug-prefixed
+> auth routes replace the "inject a dynamic factor into the global `get_factors`
+> set" mechanism. That dissolves the fragile FastAPI-dependency-caching trick from
+> v1 and naturally scopes everything to one organization.
+
+## Context
+
+Enterprise customers want their team to sign in through their own OIDC identity
+provider and land **scoped to that one organization** — a contractor who also
+belongs to other orgs must not be able to act on them from an SSO session.
+
+The **read-path groundwork already shipped**: a `UserSession` can be down-scoped
+via `user_session_organizations` rows; the auth middleware
+(`polar/auth/middlewares.py:178`) turns those rows into
+`AuthSubject.organization_ids`; every org-scoped query enforces it through
+`select_user_org_ids(scoped_to=...)` (`polar/authz/repository.py:12`). **Nothing
+writes scope rows yet.**
+
+This plan is the **producer**: an OIDC SSO login that authenticates a user against
+the org's IdP and mints a `UserSession` scoped to exactly that one org.
+
+## What changed from v1 (review resolutions)
+
+| v1 design | v2 resolution | Source |
+| --- | --- | --- |
+| Inject per-connection factor into static `get_factors` via FastAPI per-request dependency-identity caching | **Org-slug-prefixed routes** `/v1/auth/{slug}/...`; a dedicated `AuthenticationSessionService` is built per-org with that org's factors | review #1; lines 38, 163, 195 |
+| `get_optional_sso_factor` for non-SSO requests | **Deleted.** On a slug route the context is always present | line 163 |
+| Flat OIDC columns (`oidc_issuer`, `client_id`, `client_secret`) | Generic `type` enum (`oidc` only for now) + typed JSONB `configuration` | line 106 |
+| One connection per org (unique FK) | **Multiple connections per org** — no unique constraint; each is its own factor | line 55 |
+| `client_secret` plain column, only auth method | `auth_method` in `configuration`: `client_secret` **and** `private_key_jwt` (Okta pilot). `private_key_jwt` support added **upstream in reauth by @frankie567** | lines 23, 153 |
+| Static factor `identifier = "sso"` | `identifier = {connection_id}` (dynamic; required for multiple-per-org) | line 149 |
+| JIT provisioning (Phase 5) | **Cut from v1.** Out of scope; separate spec. v1 contract: user **must already be a member** — reject otherwise | review #2; line 110 |
+| Domain table + DNS TXT verification + email-domain discovery (`POST /auth/sso`) | **Cut from v1.** Existed to power discovery + gate JIT, both gone. Entry point is the per-org slug URL | line 185 |
+| `context` not persisted in `update()` | **Independent bug fix**, not part of this spec | line 44 |
+
+**Identity binding (v1 contract, confirmed with Maxime):** an SSO-authenticated
+user who is **not** a member of the org is **rejected**. JIT will ship before SSO
+is advertised, so the "must pre-exist as a member" window never reaches GA.
+
+## Flow
+
+```mermaid
+flowchart TD
+    A["User opens /{slug} SSO login"] --> B["GET /v1/auth/{slug}/sso/{connection_id}/authorize"]
+    B -->|"org-scoped AuthenticationSessionService<br/>reauth OIDCFactor.start"| C["IdP authorize"]
+    C --> D["GET /v1/auth/{slug}/sso/{connection_id}/callback"]
+    D -->|"factor.callback -> id_token claims"| E{"email_verified true?"}
+    E -- no --> X["reject"]
+    E -- yes --> F{"user is member of org?"}
+    F -- no --> X
+    F -- yes --> G["set context.sso_organization_id<br/>then advance"]
+    G --> H["GET /v1/auth/{slug}/complete"]
+    H -->|"complete enforce_factors=False"| I["get_login_response<br/>organization_ids={org}"]
+    I --> J[("user_sessions +<br/>1x user_session_organizations row")]
+```
+
+The org slug in the URL is the single source of org context across every request
+(authorize → IdP → callback → complete), so nothing needs to be "remembered"
+between the redirect hops.
+
+---
+
+## Phase 0 — Independent prerequisite (separate PR)
+
+Persist `context` in `AuthenticationSessionService.update()`
+(`polar/auth/authentication_session.py:78`) — add `context=authentication_session.context`
+to `.values(...)`. @frankie567 flagged the v1 omission as a standalone bug; it ships
+on its own so the SSO flow can carry `sso_organization_id` across the redirect.
+
+**Blocked-on-upstream:** `private_key_jwt` auth method in `reauth` (@frankie567).
+Phase 3's factor reads `auth_method` from `configuration` and delegates to reauth;
+the `client_secret` path can ship without waiting, `private_key_jwt` lands when
+reauth does.
+
+## Phase 1 — Data model (migration-only PR, ships first)
+
+Per repo convention, the migration lands before consuming code.
+
+- **`polar/models/organization_sso_connection.py`** — `OrganizationSSOConnection(RecordModel)`:
+  - `organization_id` (FK → `organizations.id`, **not unique**), `relationship(Organization)`.
+  - `type: OrganizationSSOConnectionType` — enum, `oidc` only for now.
+  - `configuration: <typed JSONB>` — Pydantic-validated, discriminated on `type`.
+    For `oidc`: `issuer`, `client_id`, `auth_method` (`client_secret` | `private_key_jwt`),
+    and `client_secret` **only when** `auth_method == client_secret` (plain string,
+    per decision; encryption is a follow-up). `private_key_jwt` stores no secret —
+    signing uses Polar's existing JWKS.
+  - `enabled: bool`.
+- Register in `polar/models/__init__.py` (import + `__all__`, mirroring
+  `UserSessionOrganization` at lines 101/212).
+- Autogenerate: `uv run alembic revision --autogenerate -m "add organization SSO connection"`,
+  review, `uv run alembic upgrade head`. **No code reads this model yet.**
+
+No `OrganizationSSODomain`, no `SSOAccount` — both were JIT/discovery scaffolding,
+cut from v1.
+
+## Phase 2 — Connection config CRUD (`polar/sso/`)
+
+New module following the repository/service/endpoints/schemas pattern
+(`server/AGENTS.md`).
+
+- **`repository.py`** — `OrganizationSSOConnectionRepository`:
+  `list_by_organization`, `get_by_id`, `get_enabled_by_id` (for the login path).
+- **`service.py`** — singleton `organization_sso_connection`: CRUD over connections.
+  Validate `configuration` against the `type` on write. Never `session.commit()`.
+- **`endpoints.py`** — routes under the **org id** path param so `AuthorizeOrgManage`
+  (`polar/authz/dependencies.py:152`) applies directly:
+  - `GET /v1/organizations/{id}/sso-connections` (list)
+  - `POST /v1/organizations/{id}/sso-connections` (**User-only** write — `AuthorizeOrgManageUser`)
+  - `GET|PATCH|DELETE /v1/organizations/{id}/sso-connections/{connection_id}`
+  - Return ORM models via `response_model`; **never echo `client_secret`** (exclude
+    from the read schema).
+- **`schemas.py`** — create/update/read; typed `configuration` per `type`; read
+  schema omits `client_secret`.
+- Mount the router alongside the other org routers.
+- **Feature gate** is implicit: SSO is reachable only if an `enabled` connection
+  row exists for the org. No separate flag for v1.
+
+## Phase 3 — Generic OIDC factor + org-scoped session service + login routes
+
+### Factor
+
+- **`polar/auth/oauth2/sso.py`** — `SSOFactor(OIDCFactorBase)`:
+  - `identifier = str(connection.id)` (**dynamic**, per connection — lets one org
+    carry several SSO factors and lets `advance` match by identity).
+  - `__init__(self, session, state_service, connection)`: store `connection`; set
+    `self.DISCOVERY_ENDPOINT = f"{connection.configuration.issuer}/.well-known/openid-configuration"`;
+    `super().__init__(identifier=str(connection.id), client_id=connection.configuration.client_id, state_service=...)`.
+  - Auth method dispatch from `connection.configuration.auth_method`:
+    `client_secret` → `get_client_secret()` returns the stored secret;
+    `private_key_jwt` → delegate to reauth's upstream asymmetric signing (Polar JWKS).
+  - `get_profile` defers to the inherited OIDC userinfo impl.
+  - **No storage/enrollment abstracts** (those backed `sso_account`, cut with JIT).
+
+### Org-scoped factor set + session service
+
+This is the heart of the v2 change. Fork the two static dependencies into
+slug-scoped variants:
+
+- **`get_org_factors(slug, ...)`** — resolve the org from `{slug}`; build the factor
+  set = the existing static factors (`email_otp`, `totp`, `backup_codes`, `apple`,
+  `github`, `google`) **∪** one `SSOFactor` per **enabled** connection on that org.
+  Mirrors `get_factors` (`polar/auth/factors.py:277`) but org-aware.
+- **`get_org_authentication_session_service(slug, session, factors=Depends(get_org_factors))`**
+  — `return AuthenticationSessionService(session, factors)`. `__init__` already
+  takes `factors` (`authentication_session.py:38`), so no reauth change needed — the
+  service simply knows the org's SSO factors because we fed them in.
+
+That's what makes `advance` accept the SSO factor natively: it's a real member of
+the service's `factors` set, no per-request-identity caching trick.
+
+### Login router (slug-prefixed)
+
+New module modeled on `get_oauth_login_router` (`router.py`), mounted under
+`/v1/auth/{slug}/`:
+
+- `GET /v1/auth/{slug}/sso/{connection_id}/authorize` — load the enabled connection
+  (404 via `ResourceNotFound` if missing/disabled/not on this org), build `SSOFactor`,
+  `factor.start(...)` with state/PKCE/nonce (`OAuth2StateService`), set state cookie,
+  redirect to the IdP.
+- `GET /v1/auth/{slug}/sso/{connection_id}/callback` — `factor.callback(...)`; decode
+  via `factor.get_id_token_claims(id_token)`:
+  - require `email_verified is True`, else `PolarAuthRedirectionError`;
+  - resolve the user by asserted email (`user_service.get_by_email`); if the user
+    doesn't exist **or is not a member** of the org → **reject** (no JIT in v1);
+  - set `context.sso_organization_id` then `advance` (Phase 4).
+- Add `"sso"` to the `Factor` literal in `polar/auth/schemas.py:13` (used for the
+  `polar_last_login_method` cookie in `complete`).
+- Mount the SSO login router in `polar/auth/endpoints.py`.
+
+> Note: `complete` must also resolve under the slug (`/v1/auth/{slug}/complete`) so
+> it uses `get_org_authentication_session_service`. Either add a slug-scoped
+> `complete` route or have the existing `complete` accept the slug — decide during
+> implementation; the constraint is that `complete` sees the org's factor set.
+
+## Phase 4 — Scoped session minting
+
+- **`polar/auth/authentication_session.py`** — override `complete` to accept
+  `enforce_factors: bool = True`; when `False`, skip the `get_available_factors` /
+  `FactorsRemainingException` check (still require `identity_id`, still `delete`).
+  Implements "SSO alone completes login" even for TOTP-enrolled users.
+  (`context` persistence handled in Phase 0.)
+- **SSO callback**, before `advance`:
+  `authentication_session.context = {**(authentication_session.context or {}),
+  "sso_organization_id": str(connection.organization_id)}`, then
+  `advance(authentication_session, identity_id, factor)`.
+- **`polar/auth/service.py`** — extend `_create_user_session` and
+  `get_login_response` with `organization_ids: frozenset[UUID] | None = None`; when
+  provided, create one `UserSessionOrganization` per id via
+  `UserSession.organization_scopes`. Email/social logins pass nothing → unrestricted
+  (unchanged).
+- **`complete`** — read `context.get("sso_organization_id")`; when present, call
+  `complete(..., enforce_factors=False)` and
+  `get_login_response(..., organization_ids=frozenset({UUID(org_id)}))`. Assert
+  exactly one scope row.
+
+---
+
+## Files
+
+**Add:** `polar/models/organization_sso_connection.py`;
+`polar/sso/{repository,service,endpoints,schemas}.py`; `polar/auth/oauth2/sso.py`;
+the slug-prefixed SSO login router; Phase-1 Alembic revision.
+
+**Modify:** `polar/models/__init__.py` (register model); `polar/auth/factors.py`
+(`get_org_factors`); `polar/auth/authentication_session.py`
+(`get_org_authentication_session_service`; `complete` `enforce_factors` flag);
+`polar/auth/service.py` (`organization_ids` on session minting);
+`polar/auth/endpoints.py` (mount router; slug-scoped `complete`);
+`polar/auth/schemas.py` (`"sso"` in `Factor`).
+
+**Independent PR (Phase 0):** `polar/auth/authentication_session.py` `update()`
+persists `context`.
+
+**Reuse as-is:** `OIDCFactor`/`OIDCFactorBase` (reauth), `OAuth2StateService`
+(`polar/auth/oauth2/state.py`), `user_service.get_by_email`,
+`AuthorizeOrgManage(User)`, the `user_session_organizations` read-path groundwork.
+
+**Upstream dependency:** `private_key_jwt` auth method in `reauth` (@frankie567).
+
+## Security
+
+- Reject any SSO login where the user is not already a member (no JIT in v1).
+- Require `email_verified` on the asserted identity.
+- Reuse reauth state/nonce/PKCE replay protection (`OAuth2StateService`).
+- Minted session scoped to exactly the connection's org (assert single scope row).
+- `client_secret` plain column per decision; `private_key_jwt` stores no secret
+  (encryption of secrets = follow-up).
+
+## Non-goals (explicit follow-ups)
+
+JIT provisioning, domain verification + email-domain discovery, `sso_enforced`
+(making an org unreachable from non-SSO sessions), SAML, SCIM, multi-org SSO
+sessions, the admin frontend, `client_secret` encryption, a "remember last org"
+discovery mechanism.
+
+## Verification
+
+- **Unit** (`tests/sso/`): connection CRUD; `configuration` validation per `type`;
+  `SSOFactor` discovery-URL construction + `id_token` validation against a **mock
+  OIDC IdP** (local JWKS, signed `id_token` fixtures) for both `client_secret` and
+  (once reauth lands) `private_key_jwt`.
+- **Integration** (`tests/auth/`): full `/v1/auth/{slug}/sso/{connection_id}/authorize`
+  → callback → `/v1/auth/{slug}/complete` against the mock IdP. Assert the resulting
+  `UserSession` has **exactly one** `organization_scopes` row, and a second org the
+  user belongs to is **not** accessible (extend `tests/auth/test_middlewares.py`).
+  Assert a TOTP-enrolled member still completes via SSO alone (`enforce_factors=False`).
+- **Negative:** non-member identity → rejected; `email_verified=false` → rejected;
+  disabled/missing connection → 404; connection from a different org under this slug
+  → 404.
+- `uv run task test`, `uv run task lint && uv run task lint_types`,
+  `uv run task lint_org_scope`.

--- a/enterprisessoplan.md
+++ b/enterprisessoplan.md
@@ -1,0 +1,273 @@
+# Plan: Enterprise SSO with single-organization session scope
+
+## Context
+
+Enterprise customers want their team to sign in to Polar through their own
+OIDC identity provider and land **scoped to that one organization** — a
+contractor who also belongs to other orgs must not be able to act on them from
+an SSO session.
+
+The **read-path groundwork already shipped**: a `UserSession` can be down-scoped
+via `user_session_organizations` rows; the auth middleware
+(`polar/auth/middlewares.py:178`) turns those rows into
+`AuthSubject.organization_ids`; and every org-scoped query enforces it through
+`select_user_org_ids(scoped_to=...)` (`polar/authz/repository.py:12`). **Nothing
+writes scope rows yet** — every session is currently unrestricted.
+
+This plan is the **producer**: an OIDC SSO login that authenticates a user
+against the org's IdP and mints a `UserSession` scoped to exactly that one org
+(one `user_session_organizations` row).
+
+## Key findings from exploration (these de-risk the design)
+
+1. **`reauth` already ships a generic OIDC factor.** `reauth.factors.oauth2.oidc`
+   provides `OIDCFactor` (and `OIDCFactorBase`): full discovery-doc + JWKS +
+   `id_token` validation, parametrized only by `client_id`, `client_secret`, and
+   `DISCOVERY_ENDPOINT`. `GoogleOAuth2Factor` is just `OIDCFactor` with a
+   hardcoded discovery URL. **We do not build OIDC primitives** — we subclass
+   `OIDCFactorBase`/`OIDCFactor` and feed it the connection's issuer.
+
+2. **The "dynamic factor in a static set" problem is solvable without touching
+   reauth.** `reauth`'s `advance()` (`reauth/authentication_session.py`) checks
+   `factor in self.factors` by **object identity** (no `__eq__` on `FactorBase`),
+   and `self.factors` comes from Polar's `get_factors` dependency
+   (`polar/auth/factors.py:277`). FastAPI **caches dependency results per
+   request**, so if both `get_factors` and the SSO router resolve the *same*
+   `get_sso_factor` dependency, they share one instance and `advance` accepts it.
+   We key the SSO factor off a `{connection_id}` path param so `get_factors` can
+   conditionally include it (see Phase 3).
+
+3. **One real groundwork gap:** Polar's `AuthenticationSessionService.update()`
+   (`polar/auth/authentication_session.py:78`) does **not** persist `context`.
+   We must add `context` to its `.values(...)` so we can carry
+   `sso_organization_id` across the redirect to `GET /auth/complete` (which runs
+   in a separate request and reloads the session from the DB).
+
+4. **No at-rest encryption helper exists.** `slack_app.client_secret` and
+   `oauth2_client.client_secret` are plain `String` columns.
+
+## Decisions (confirmed with Maxime)
+
+- **client_secret storage:** plain `String` column, matching existing precedent.
+  Encryption is a hardening follow-up.
+- **2FA interaction:** **SSO alone completes login** — after the SSO factor we
+  bypass remaining-factor enforcement (see Phase 4), even if the user has TOTP.
+- **Connections per org:** **one** — unique FK on `organization_id`, managed as a
+  singleton at `/organizations/{id}/sso-connection`.
+- **Identity binding:** match by IdP-asserted verified email, **plus** a small
+  `sso_account` link table (`connection_id`, `idp_sub` → `user_id`) for stable
+  binding + audit (reauth's enrollment path supports this naturally).
+- **JIT role:** `member`.
+
+## Flow & dependency shape
+
+```mermaid
+flowchart TD
+    subgraph Config["Phase 1+2 (org admin)"]
+      A[OrganizationSSOConnection<br/>+ verified domains] -->|AuthorizeOrgManage| B[CRUD + domain verify]
+    end
+
+    subgraph Login["Phase 3 login (per request)"]
+      C[POST /auth/sso<br/>email -> resolve conn by domain] --> D[/auth/sso/&#123;conn&#125;/authorize/]
+      D -->|reauth OIDCFactor.start| E[IdP authorize]
+      E --> F[/auth/sso/&#123;conn&#125;/callback/]
+      F -->|factor.callback -> id_token| G{email in verified domain?}
+      G -- no --> X[reject]
+      G -- yes --> H[JIT: get_by_email_or_create<br/>+ add_user role=member<br/>+ upsert sso_account]
+      H -->|set context.sso_organization_id<br/>then advance| I[(authentication_sessions)]
+    end
+
+    subgraph Complete["Phase 4 mint scoped session"]
+      I --> J[GET /auth/complete]
+      J -->|complete enforce_factors=False| K[get_login_response<br/>organization_ids=&#123;org&#125;]
+      K --> L[(user_sessions +<br/>1x user_session_organizations row)]
+    end
+
+    M[get_sso_factor dep<br/>reads &#123;conn&#125; path param] -.shared cached instance.-> D
+    M -.included in.-> N[get_factors set]
+    N -.-> F
+```
+
+`get_sso_factor` is the single dependency shared (via FastAPI per-request caching)
+between `get_factors` and the SSO router — this is what makes `advance` accept the
+per-connection factor.
+
+---
+
+## Phase 1 — Data model (migration-only PR, ships first)
+
+Per repo convention, the migration lands before consuming code.
+
+- **`polar/models/organization_sso_connection.py`** — `OrganizationSSOConnection(RecordModel)`:
+  - `organization_id` (FK → `organizations.id`, **unique**, one per org),
+    `relationship(Organization)`.
+  - `oidc_issuer: str` (discovery built as `{issuer}/.well-known/openid-configuration`),
+    `client_id: str`, `client_secret: str` (plain `String`, per decision),
+    `enabled: bool`.
+- **`polar/models/organization_sso_domain.py`** — `OrganizationSSODomain(Model)`:
+  `(sso_connection_id, domain)` PK, `verification_token: str`,
+  `verified_at: datetime | None`. A domain is usable for JIT only when
+  `verified_at` is set.
+- **`polar/models/sso_account.py`** — `SSOAccount(RecordModel)`:
+  `sso_connection_id` (FK), `account_id: str` (IdP `sub`), `user_id` (FK),
+  unique `(sso_connection_id, account_id)`. Stable identity binding + audit.
+- Register all three in `polar/models/__init__.py` (import + `__all__`, mirroring
+  `UserSessionOrganization` at lines 101/212).
+- Autogenerate: `uv run alembic revision --autogenerate -m "add organization SSO models"`,
+  review, `uv run alembic upgrade head`. **No code reads these models yet.**
+
+## Phase 2 — Connection config + domain verification (`polar/sso/`)
+
+New module following the repository/service/endpoints/schemas pattern
+(`server/AGENTS.md`).
+
+- **`repository.py`** — `OrganizationSSOConnectionRepository` (`get_by_organization`,
+  `get_by_verified_domain(domain)` joining verified `OrganizationSSODomain`),
+  `SSOAccountRepository` (`get_by_connection_and_account_id`, upsert).
+- **`service.py`** — singleton `organization_sso_connection`: CRUD; domain add
+  (issue `verification_token`), `verify_domain` (DNS TXT lookup → set
+  `verified_at`). Use `enqueue_job` for any async work; never `session.commit()`.
+- **`endpoints.py`** — singleton routes under the **org id** path param so
+  `AuthorizeOrgManage` (`polar/authz/dependencies.py:152`, resolves `{id}`,
+  enforces `org_policy.can_manage` = admin-only) applies directly:
+  - `GET /v1/organizations/{id}/sso-connection`
+  - `PUT /v1/organizations/{id}/sso-connection` (upsert; **User-only** write —
+    use `AuthorizeOrgManageUser`)
+  - `DELETE /v1/organizations/{id}/sso-connection`
+  - `POST /v1/organizations/{id}/sso-connection/domains` + verify endpoint.
+  Return ORM models via `response_model`; never echo `client_secret` back
+  (exclude from the read schema).
+- **`schemas.py`** — create/update/read schemas; read schema omits `client_secret`.
+- Mount the router where other API routers are registered (alongside
+  `polar/organization/endpoints.py` registration).
+- **Feature gate** is implicit: SSO is reachable only if a connection row exists
+  and is `enabled`; no separate flag needed for v1.
+
+## Phase 3 — Generic OIDC factor + login endpoints
+
+- **`polar/auth/oauth2/sso.py`** — `SSOFactor(OIDCFactorBase)`:
+  - `identifier = "sso"`, inherits `AMR = OAUTH2`, `step = 0`.
+  - `__init__(self, session, state_service, connection)`: store `connection`; set
+    instance attr `self.DISCOVERY_ENDPOINT = f"{connection.oidc_issuer}/.well-known/openid-configuration"`;
+    `super().__init__(identifier="sso", client_id=connection.client_id, state_service=...)`.
+  - `get_client_secret()` → `self.connection.client_secret`.
+  - Implement the storage abstracts against `sso_account` keyed by
+    `self.connection.id` (mirror `OAuth2FactorMixin` in `factor.py`, but use
+    `SSOAccount`/connection_id instead of `OAuthAccount`/platform enum):
+    `get_enrollment`, `insert`, `update`, `get_enrollment_by_provider_and_account`.
+    `get_profile` may defer to the inherited OIDC userinfo impl.
+  - `get_sso_factor(request, session, state_service)` dependency: read
+    `request.path_params["connection_id"]`, load the enabled connection (404 via
+    `ResourceNotFound` if missing/disabled), construct `SSOFactor`. Add an
+    `get_optional_sso_factor` variant returning `None` when no `connection_id` in
+    `path_params`.
+- **`polar/auth/factors.py`** — add `sso_factor: SSOFactor | None =
+  Depends(get_optional_sso_factor)` to `get_factors` and include it in the set
+  when not `None`. (On non-SSO requests `path_params` has no `connection_id` →
+  `None` → set unchanged.)
+- **New SSO router** (own module, modeled on `get_oauth_login_router` in
+  `router.py`, but with `{connection_id}` in the authorize/callback paths so the
+  shared factor instance resolves):
+  - `POST /auth/sso` — body `{email}`: resolve connection by verified email
+    domain (`get_by_verified_domain`); 404 if none; redirect (303) to
+    `/auth/sso/{connection_id}/authorize`. (Discovery-by-domain = the one-click UX.)
+  - `GET /auth/sso/{connection_id}/authorize` — `_check_factor` + `factor.start(...)`
+    with state/PKCE/nonce (reuse `OAuth2StateService`), set state cookie, redirect.
+  - `GET /auth/sso/{connection_id}/callback` — `factor.callback(...)`; on the
+    signup branch decode claims via `factor.get_id_token_claims(id_token)`:
+    - require `email_verified is True`;
+    - require the email's domain is **verified** for this connection — else
+      `PolarAuthRedirectionError` (no JIT, no link);
+    - resolve user: `sso_account` by `sub` → else
+      `user_service.get_by_email_or_create`;
+    - **JIT (Phase 5)**, then set context + `advance` (below).
+- Add `"sso"` to the `Factor` literal in `polar/auth/schemas.py:13` (used for the
+  `polar_last_login_method` cookie value in `complete`).
+- Mount the SSO login router in `polar/auth/endpoints.py` next to the existing
+  `get_oauth_login_router(...)` includes.
+
+## Phase 4 — Scoped session minting
+
+- **`polar/auth/authentication_session.py`** — add `context=...` to the
+  `.values(...)` in `update()` (line ~78) so context survives `advance`. Override
+  `complete` to accept `enforce_factors: bool = True`; when `False`, skip the
+  `get_available_factors` / `FactorsRemainingException` check (still require
+  `identity_id`, still `delete`). This implements "SSO alone completes login".
+- **In the SSO callback**, before `advance`, set
+  `authentication_session.context = {**(authentication_session.context or {}),
+  "sso_organization_id": str(connection.organization_id)}`, then
+  `authentication_session_service.advance(authentication_session, identity_id, factor)`.
+  (`advance` calls `get_available_factors` while `identity_id` is still `None`, so
+  no enrollment check runs and the shared SSO factor is present — verified against
+  reauth source.)
+- **`polar/auth/service.py`** — extend `_create_user_session` and
+  `get_login_response` with `organization_ids: frozenset[UUID] | None = None`;
+  when provided, create one `UserSessionOrganization` per id via
+  `UserSession.organization_scopes` (the existing relationship,
+  `polar/models/user_session.py`). Email/social logins pass nothing → unrestricted
+  (unchanged).
+- **`polar/auth/endpoints.py` `complete`** — read
+  `context.get("sso_organization_id")`; when present, call
+  `complete(..., enforce_factors=False)` and
+  `get_login_response(..., organization_ids=frozenset({UUID(org_id)}))`. Assert
+  exactly one scope row.
+
+## Phase 5 — JIT provisioning
+
+In the SSO callback, after the domain check and user resolution:
+- `user.email_verified = True` (IdP asserted a verified email).
+- If not already a member, `organization_service.add_user(session, organization,
+  user, role=OrganizationRole.member)` (`polar/organization/service.py:833`).
+- Upsert the `sso_account` link (`connection_id`, `sub`, `user_id`) so subsequent
+  logins resolve by `sub`.
+
+---
+
+## Files
+
+**Add:** `polar/models/organization_sso_connection.py`,
+`polar/models/organization_sso_domain.py`, `polar/models/sso_account.py`;
+`polar/sso/{repository,service,endpoints,schemas}.py`;
+`polar/auth/oauth2/sso.py`; the SSO login router; Phase-1 Alembic revision.
+
+**Modify:** `polar/models/__init__.py` (register models);
+`polar/auth/factors.py` (optional SSO factor in `get_factors`);
+`polar/auth/authentication_session.py` (persist `context`; `complete` flag);
+`polar/auth/service.py` (`organization_ids` on session minting);
+`polar/auth/endpoints.py` (mount router; scoped `complete`);
+`polar/auth/schemas.py` (`"sso"` in `Factor`).
+
+**Reuse as-is:** `OIDCFactor`/`OIDCFactorBase` (reauth), `OAuth2StateService`
+(`polar/auth/oauth2/state.py`), `user_service.get_by_email_or_create`,
+`organization_service.add_user`, `AuthorizeOrgManage(User)`, the
+`user_session_organizations` read-path groundwork.
+
+## Security
+
+- JIT/link only when `email_verified` **and** the email domain is verified for the
+  connection; otherwise reject (prevents IdP-asserted account takeover).
+- Reuse reauth state/nonce/PKCE replay protection (`OAuth2StateService`).
+- Minted session scoped to exactly the connection's org (assert single row).
+- `client_secret` plain column per decision (encryption = follow-up).
+
+## Non-goals (explicit follow-ups)
+
+`sso_enforced` (making an org unreachable from non-SSO sessions — a separate
+*enforcement* change), SAML, SCIM, multi-org SSO sessions, multiple connections
+per org, the admin frontend, and `client_secret` encryption.
+
+## Verification
+
+- **Unit** (`tests/sso/`): connection CRUD + domain verification; `SSOFactor`
+  discovery-URL construction + `id_token` validation against a **mock OIDC IdP**
+  (local JWKS, signed `id_token` fixtures).
+- **Integration** (`tests/auth/`): full `POST /auth/sso` → authorize → callback →
+  `GET /auth/complete` against the mock IdP. Assert the resulting `UserSession`
+  has **exactly one** `organization_scopes` row for the connection's org, and that
+  a second org the user belongs to is **not** accessible (extend the scoped-session
+  assertions in `tests/auth/test_middlewares.py`). Assert TOTP-enrolled user still
+  completes via SSO alone (`enforce_factors=False`).
+- **Negative:** email outside verified domain → rejected; `email_verified=false`
+  → rejected; disabled/missing connection → 404.
+- `uv run task test`, `uv run task lint && uv run task lint_types`,
+  `uv run task lint_org_scope`.


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- issue number -->

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->

## Why

<!-- Explain why this change is needed -->

## How

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds design docs for Enterprise SSO (OIDC) that sign in via an org’s IdP and mint sessions scoped to that org. The v2 plan uses org‑slug–prefixed auth routes and an org‑scoped factor set with per‑connection OIDC factors (`client_secret` or `private_key_jwt`), supports multiple connections per org, defers JIT and domain verification, rejects non‑members, and notes persisting auth session `context` plus an upstream `reauth` update for `private_key_jwt`.

<sup>Written for commit 18b268415e6e581296cb164d16301eea205d5d18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

