### PR TITLE
feat(worker): make health middleware db-aware

### DIFF
--- a/server/polar/worker/_broker.py
+++ b/server/polar/worker/_broker.py
@@ -196,7 +196,7 @@ def get_broker(*, database: bool = True) -> dramatiq.Broker:
         *([SQLAlchemyMiddleware()] if database else []),
         RedisMiddleware(),
         HTTPXMiddleware(),
-        HealthMiddleware(),
+        HealthMiddleware(database=database),
         scheduler_middleware,
         # Observability (outer layer for message processing)
         LogContextMiddleware(),

--- a/server/polar/worker/_health.py
+++ b/server/polar/worker/_health.py
@@ -10,20 +10,21 @@ import structlog
 import uvicorn
 from dramatiq.middleware import Middleware
 from redis import RedisError
+from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
 from starlette.applications import Starlette
 from starlette.exceptions import HTTPException
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Route
 
-from polar.config import settings
 from polar.external_event.repository import ExternalEventRepository
 from polar.kit.db.postgres import AsyncSessionMaker, create_async_sessionmaker
 from polar.kit.utils import utc_now
 from polar.logfire import configure_logfire
 from polar.logging import Logger
 from polar.logging import configure as configure_logging
-from polar.postgres import AsyncEngine, create_async_engine, create_async_read_engine
+from polar.postgres import AsyncEngine, create_async_engine
 from polar.redis import Redis, create_redis
 from polar.webhook.repository import WebhookEventRepository
 
@@ -57,6 +58,18 @@ async def health(request: Request) -> JSONResponse:
         await redis.ping()
     except RedisError as e:
         raise HTTPException(status_code=503, detail="Redis is not available") from e
+
+    async_sessionmaker: AsyncSessionMaker | None = getattr(
+        request.state, "async_sessionmaker", None
+    )
+    if async_sessionmaker is not None:
+        try:
+            async with async_sessionmaker() as session:
+                await session.execute(text("SELECT 1"))
+        except SQLAlchemyError as e:
+            raise HTTPException(
+                status_code=503, detail="Database is not available"
+            ) from e
 
     if _heartbeat_checker is not None and not _heartbeat_checker():
         raise HTTPException(status_code=503, detail="Scheduler heartbeat is stale")
@@ -121,10 +134,7 @@ def _create_lifespan(
 
         async_engine: AsyncEngine | None = None
         if database:
-            if settings.is_read_replica_configured():
-                async_engine = create_async_read_engine("worker")
-            else:
-                async_engine = create_async_engine("worker")
+            async_engine = create_async_engine("worker")
             state["async_sessionmaker"] = create_async_sessionmaker(async_engine)
 
         yield state

--- a/server/polar/worker/_health.py
+++ b/server/polar/worker/_health.py
@@ -23,7 +23,7 @@ from polar.kit.utils import utc_now
 from polar.logfire import configure_logfire
 from polar.logging import Logger
 from polar.logging import configure as configure_logging
-from polar.postgres import create_async_engine, create_async_read_engine
+from polar.postgres import AsyncEngine, create_async_engine, create_async_read_engine
 from polar.redis import Redis, create_redis
 from polar.webhook.repository import WebhookEventRepository
 
@@ -41,9 +41,14 @@ def set_heartbeat_checker(checker: Callable[[], bool]) -> None:
 
 
 class HealthMiddleware(Middleware):
+    def __init__(self, *, database: bool = True) -> None:
+        self._database = database
+
     @property
     def forks(self) -> list[Callable[[], int]]:
-        return [_run_exposition_server]
+        if self._database:
+            return [_run_exposition_server]
+        return [_run_exposition_server_without_db]
 
 
 async def health(request: Request) -> JSONResponse:
@@ -106,22 +111,29 @@ async def external_events(request: Request) -> JSONResponse:
     return JSONResponse({"status": "ok"})
 
 
-@contextlib.asynccontextmanager
-async def lifespan(app: Starlette) -> AsyncGenerator[Mapping[str, Any]]:
-    if settings.is_read_replica_configured():
-        async_engine = create_async_read_engine("worker")
-    else:
-        async_engine = create_async_engine("worker")
-    async_sessionmaker = create_async_sessionmaker(async_engine)
-    redis = create_redis("worker")
+def _create_lifespan(
+    *, database: bool
+) -> Callable[[Starlette], contextlib.AbstractAsyncContextManager[Mapping[str, Any]]]:
+    @contextlib.asynccontextmanager
+    async def lifespan(app: Starlette) -> AsyncGenerator[Mapping[str, Any]]:
+        redis = create_redis("worker")
+        state: dict[str, Any] = {"redis": redis}
 
-    yield {
-        "redis": redis,
-        "async_sessionmaker": async_sessionmaker,
-    }
+        async_engine: AsyncEngine | None = None
+        if database:
+            if settings.is_read_replica_configured():
+                async_engine = create_async_read_engine("worker")
+            else:
+                async_engine = create_async_engine("worker")
+            state["async_sessionmaker"] = create_async_sessionmaker(async_engine)
 
-    await redis.close()
-    await async_engine.dispose()
+        yield state
+
+        await redis.close()
+        if async_engine is not None:
+            await async_engine.dispose()
+
+    return lifespan
 
 
 async def handle_server_error(request: Request, exc: Exception) -> JSONResponse:
@@ -129,24 +141,27 @@ async def handle_server_error(request: Request, exc: Exception) -> JSONResponse:
     return JSONResponse({"status": "error"}, status_code=500)
 
 
-def create_app() -> Starlette:
-    routes = [
-        Route("/", health, methods=["GET"]),
-        Route("/webhooks", webhooks, methods=["GET"]),
-        Route("/unhandled-external-events", external_events, methods=["GET"]),
-    ]
+def create_app(*, database: bool = True) -> Starlette:
+    routes = [Route("/", health, methods=["GET"])]
+    # The webhooks and external-events probes query PostgreSQL; only expose them
+    # when the worker has a database.
+    if database:
+        routes += [
+            Route("/webhooks", webhooks, methods=["GET"]),
+            Route("/unhandled-external-events", external_events, methods=["GET"]),
+        ]
     return Starlette(
         routes=routes,
-        lifespan=lifespan,
+        lifespan=_create_lifespan(database=database),
         exception_handlers={Exception: handle_server_error},
     )
 
 
-def _run_exposition_server() -> int:
+def _run_server(*, database: bool) -> int:
     log.debug("Starting exposition server...")
     configure_logfire("worker")
     configure_logging(logfire=True)
-    app = create_app()
+    app = create_app(database=database)
     config = uvicorn.Config(
         app, host=HTTP_HOST, port=HTTP_PORT, log_level="error", access_log=False
     )
@@ -157,3 +172,11 @@ def _run_exposition_server() -> int:
         pass
 
     return 0
+
+
+def _run_exposition_server() -> int:
+    return _run_server(database=True)
+
+
+def _run_exposition_server_without_db() -> int:
+    return _run_server(database=False)

--- a/server/tests/worker/test_health.py
+++ b/server/tests/worker/test_health.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+from pytest_mock import MockerFixture
 from redis import RedisError
 from starlette.applications import Starlette
 from starlette.exceptions import HTTPException
@@ -14,6 +15,11 @@ from starlette.routing import Route
 
 import polar.worker._health as health_module
 from polar.worker._health import (
+    HealthMiddleware,
+    _create_lifespan,
+    _run_exposition_server,
+    _run_exposition_server_without_db,
+    create_app,
     handle_server_error,
     health,
 )
@@ -187,3 +193,70 @@ class TestSchedulerHealthIntegration:
                 assert response.status_code == 200
         finally:
             health_module._heartbeat_checker = original
+
+
+class TestHealthMiddlewareForks:
+    def test_database_uses_db_exposition_server(self) -> None:
+        assert HealthMiddleware(database=True).forks == [_run_exposition_server]
+
+    def test_no_database_uses_dbless_exposition_server(self) -> None:
+        assert HealthMiddleware(database=False).forks == [
+            _run_exposition_server_without_db
+        ]
+
+    def test_defaults_to_database(self) -> None:
+        assert HealthMiddleware().forks == [_run_exposition_server]
+
+
+class TestCreateApp:
+    def test_database_exposes_db_routes(self) -> None:
+        paths = {route.path for route in create_app(database=True).routes}
+        assert paths == {"/", "/webhooks", "/unhandled-external-events"}
+
+    def test_no_database_exposes_only_liveness(self) -> None:
+        paths = {route.path for route in create_app(database=False).routes}
+        assert paths == {"/"}
+
+
+@pytest.mark.asyncio
+class TestLifespan:
+    async def test_no_database_does_not_create_engine(
+        self, mocker: MockerFixture
+    ) -> None:
+        create_engine = mocker.patch.object(health_module, "create_async_engine")
+        create_read_engine = mocker.patch.object(
+            health_module, "create_async_read_engine"
+        )
+        mocker.patch.object(
+            health_module, "create_redis", return_value=MagicMock(close=AsyncMock())
+        )
+
+        async with _create_lifespan(database=False)(MagicMock()) as state:
+            assert "redis" in state
+            assert "async_sessionmaker" not in state
+
+        create_engine.assert_not_called()
+        create_read_engine.assert_not_called()
+
+    async def test_database_creates_engine_and_sessionmaker(
+        self, mocker: MockerFixture
+    ) -> None:
+        engine = MagicMock(dispose=AsyncMock())
+        create_engine = mocker.patch.object(
+            health_module, "create_async_engine", return_value=engine
+        )
+        mocker.patch.object(
+            health_module, "create_async_sessionmaker", return_value="sessionmaker"
+        )
+        mocker.patch.object(
+            health_module.settings, "is_read_replica_configured", return_value=False
+        )
+        mocker.patch.object(
+            health_module, "create_redis", return_value=MagicMock(close=AsyncMock())
+        )
+
+        async with _create_lifespan(database=True)(MagicMock()) as state:
+            assert state["async_sessionmaker"] == "sessionmaker"
+
+        create_engine.assert_called_once()
+        engine.dispose.assert_awaited_once()

--- a/server/tests/worker/test_health.py
+++ b/server/tests/worker/test_health.py
@@ -1,3 +1,4 @@
+import contextlib
 import time
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -6,6 +7,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 from pytest_mock import MockerFixture
 from redis import RedisError
+from sqlalchemy.exc import SQLAlchemyError
 from starlette.applications import Starlette
 from starlette.exceptions import HTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -36,7 +38,16 @@ def mock_redis() -> AsyncMock:
 def mock_request(mock_redis: AsyncMock) -> MagicMock:
     req = MagicMock()
     req.state.redis = mock_redis
+    req.state.async_sessionmaker = None
     return req
+
+
+def _sessionmaker_for(session: Any) -> MagicMock:
+    @contextlib.asynccontextmanager
+    async def maker() -> Any:
+        yield session
+
+    return MagicMock(side_effect=maker)
 
 
 @pytest.mark.asyncio
@@ -87,6 +98,39 @@ class TestHealth:
 
         assert exc_info.value.status_code == 503
         assert "Redis" in str(exc_info.value.detail)
+
+    async def test_database_accessible_in_db_mode(
+        self, mock_request: MagicMock, mock_redis: AsyncMock
+    ) -> None:
+        session = AsyncMock()
+        mock_request.state.async_sessionmaker = _sessionmaker_for(session)
+
+        response = await health(mock_request)
+
+        assert response.status_code == 200
+        session.execute.assert_awaited_once()
+
+    async def test_database_unavailable_in_db_mode(
+        self, mock_request: MagicMock, mock_redis: AsyncMock
+    ) -> None:
+        session = AsyncMock()
+        session.execute.side_effect = SQLAlchemyError("Connection refused")
+        mock_request.state.async_sessionmaker = _sessionmaker_for(session)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await health(mock_request)
+
+        assert exc_info.value.status_code == 503
+        assert "Database" in str(exc_info.value.detail)
+
+    async def test_database_not_checked_in_db_less_mode(
+        self, mock_request: MagicMock, mock_redis: AsyncMock
+    ) -> None:
+        mock_request.state.async_sessionmaker = None
+
+        response = await health(mock_request)
+
+        assert response.status_code == 200
 
 
 class TestIsSchedulerHealthy:
@@ -224,9 +268,6 @@ class TestLifespan:
         self, mocker: MockerFixture
     ) -> None:
         create_engine = mocker.patch.object(health_module, "create_async_engine")
-        create_read_engine = mocker.patch.object(
-            health_module, "create_async_read_engine"
-        )
         mocker.patch.object(
             health_module, "create_redis", return_value=MagicMock(close=AsyncMock())
         )
@@ -236,7 +277,6 @@ class TestLifespan:
             assert "async_sessionmaker" not in state
 
         create_engine.assert_not_called()
-        create_read_engine.assert_not_called()
 
     async def test_database_creates_engine_and_sessionmaker(
         self, mocker: MockerFixture
@@ -247,9 +287,6 @@ class TestLifespan:
         )
         mocker.patch.object(
             health_module, "create_async_sessionmaker", return_value="sessionmaker"
-        )
-        mocker.patch.object(
-            health_module.settings, "is_read_replica_configured", return_value=False
         )
         mocker.patch.object(
             health_module, "create_redis", return_value=MagicMock(close=AsyncMock())

--- a/server/tests/worker/test_health.py
+++ b/server/tests/worker/test_health.py
@@ -254,11 +254,19 @@ class TestHealthMiddlewareForks:
 
 class TestCreateApp:
     def test_database_exposes_db_routes(self) -> None:
-        paths = {route.path for route in create_app(database=True).routes}
+        paths = {
+            route.path
+            for route in create_app(database=True).routes
+            if isinstance(route, Route)
+        }
         assert paths == {"/", "/webhooks", "/unhandled-external-events"}
 
     def test_no_database_exposes_only_liveness(self) -> None:
-        paths = {route.path for route in create_app(database=False).routes}
+        paths = {
+            route.path
+            for route in create_app(database=False).routes
+            if isinstance(route, Route)
+        }
         assert paths == {"/"}
 
 


### PR DESCRIPTION
- Make `HealthMiddleware` in workers aware of if running with or without db access
- Stop connecting to the read replica in the server running the health checks. We should connect to the same db instance that the workers themselves connect to
- `/`: Also check DB availability if running in db mode
- `/webhooks`: only expose if running in db mode
- `/unhandled-external-events`: only expose if running in db mode

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

