### PR TITLE
fix: require only read scope to list customer seats

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -4572,7 +4572,7 @@ export interface paths {
     }
     /**
      * List Seats
-     * @description **Scopes**: `customer_seats:write`
+     * @description **Scopes**: `customer_seats:read`
      */
     get: operations['customer-seats:list_seats']
     put?: never

--- a/server/polar/customer_seat/endpoints.py
+++ b/server/polar/customer_seat/endpoints.py
@@ -18,7 +18,7 @@ from polar.redis import Redis, get_redis
 from polar.routing import APIRouter
 from polar.subscription.repository import SubscriptionRepository
 
-from .auth import SeatWrite
+from .auth import SeatRead, SeatWrite
 from .repository import CustomerSeatRepository
 from .schemas import CustomerSeat as CustomerSeatSchema
 from .schemas import (
@@ -113,7 +113,7 @@ async def assign_seat(
     },
 )
 async def list_seats(
-    auth_subject: SeatWrite,
+    auth_subject: SeatRead,
     session: AsyncSession = Depends(get_db_session),
     subscription_id: Annotated[UUID4 | None, Query()] = None,
     order_id: Annotated[UUID4 | None, Query()] = None,

--- a/server/tests/customer_seat/test_endpoints.py
+++ b/server/tests/customer_seat/test_endpoints.py
@@ -90,6 +90,23 @@ class TestListSeats:
 
         assert response.status_code == 403
 
+    @pytest.mark.auth(
+        AuthSubjectFixture(scopes={Scope.customer_seats_read}),
+    )
+    async def test_list_seats_read_scope_only(
+        self,
+        client: AsyncClient,
+        subscription_with_seats: Subscription,
+        customer_seat_pending: CustomerSeat,
+        user_organization_seat_enabled: UserOrganization,
+    ) -> None:
+        response = await client.get(
+            "/v1/customer-seats",
+            params={"subscription_id": str(subscription_with_seats.id)},
+        )
+
+        assert response.status_code == 200
+
     async def test_list_seats_unauthorized(
         self,
         client: AsyncClient,


### PR DESCRIPTION
## Summary

`GET /v1/customer-seats` wrongly required the `customer_seats:write` 


## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

