### PR TITLE
server: set a connection limit to Redis client

### DIFF
--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -184,6 +184,7 @@ class Settings(BaseSettings):
     REDIS_HOST: str = "127.0.0.1"
     REDIS_PORT: int = 6379
     REDIS_DB: int = 0
+    REDIS_MAX_CONNECTIONS: int = 50
 
     # Emails
     EMAIL_RENDERER_BINARY_PATH: Annotated[

--- a/server/polar/redis.py
+++ b/server/polar/redis.py
@@ -29,6 +29,7 @@ def create_redis(process_name: ProcessName) -> Redis:
         retry_on_error=REDIS_RETRY_ON_ERRROR,
         retry=REDIS_RETRY,
         client_name=f"{settings.ENV.value}.{process_name}",
+        max_connections=settings.REDIS_MAX_CONNECTIONS,
     )
 
 

--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -341,12 +341,13 @@ resource "render_web_service" "api" {
   custom_domains = var.api_service_config.custom_domains
 
   env_vars = {
-    SERVICE_NAME             = { value = "api${local.env_suffix}" }
-    WEB_CONCURRENCY          = { value = var.api_service_config.web_concurrency }
-    FORWARDED_ALLOW_IPS      = { value = var.api_service_config.forwarded_allow_ips }
-    POLAR_ALLOWED_HOSTS      = { value = var.api_service_config.allowed_hosts }
-    POLAR_CORS_ORIGINS       = { value = var.api_service_config.cors_origins }
-    POLAR_DATABASE_POOL_SIZE = { value = var.api_service_config.database_pool_size }
+    SERVICE_NAME                = { value = "api${local.env_suffix}" }
+    WEB_CONCURRENCY             = { value = var.api_service_config.web_concurrency }
+    FORWARDED_ALLOW_IPS         = { value = var.api_service_config.forwarded_allow_ips }
+    POLAR_ALLOWED_HOSTS         = { value = var.api_service_config.allowed_hosts }
+    POLAR_CORS_ORIGINS          = { value = var.api_service_config.cors_origins }
+    POLAR_DATABASE_POOL_SIZE    = { value = var.api_service_config.database_pool_size }
+    POLAR_REDIS_MAX_CONNECTIONS = { value = var.api_service_config.redis_max_connections }
   }
 }
 
@@ -379,9 +380,10 @@ resource "render_web_service" "worker" {
   custom_domains = length(each.value.custom_domains) > 0 ? each.value.custom_domains : null
 
   env_vars = {
-    SERVICE_NAME             = { value = each.key }
-    dramatiq_prom_port       = { value = each.value.dramatiq_prom_port }
-    POLAR_DATABASE_POOL_SIZE = { value = each.value.database_pool_size }
+    SERVICE_NAME                = { value = each.key }
+    dramatiq_prom_port          = { value = each.value.dramatiq_prom_port }
+    POLAR_DATABASE_POOL_SIZE    = { value = each.value.database_pool_size }
+    POLAR_REDIS_MAX_CONNECTIONS = { value = each.value.redis_max_connections }
   }
 }
 
@@ -409,10 +411,11 @@ resource "render_cron_job" "cron" {
   # and write it to a temp file in the start command. POLAR_JWKS is set here
   # to override the env group value (/etc/secrets/jwks.json) which doesn't exist.
   env_vars = {
-    SERVICE_NAME             = { value = each.key }
-    POLAR_DATABASE_POOL_SIZE = { value = each.value.database_pool_size }
-    POLAR_JWKS               = { value = "/tmp/jwks.json" }
-    POLAR_JWKS_CONTENT       = { value = var.backend_secrets.jwks }
+    SERVICE_NAME                = { value = each.key }
+    POLAR_DATABASE_POOL_SIZE    = { value = each.value.database_pool_size }
+    POLAR_REDIS_MAX_CONNECTIONS = { value = each.value.redis_max_connections }
+    POLAR_JWKS                  = { value = "/tmp/jwks.json" }
+    POLAR_JWKS_CONTENT          = { value = var.backend_secrets.jwks }
   }
 }
 

--- a/terraform/modules/render_service/variables.tf
+++ b/terraform/modules/render_service/variables.tf
@@ -35,6 +35,7 @@ variable "api_service_config" {
     postgres_database      = optional(string, "polar_cpit")
     postgres_read_database = optional(string, "polar_cpit")
     redis_db               = optional(string, "0")
+    redis_max_connections  = optional(string, "50")
     plan                   = optional(string, "standard")
   })
 }
@@ -42,13 +43,14 @@ variable "api_service_config" {
 variable "workers" {
   description = "Map of worker configurations"
   type = map(object({
-    start_command      = string
-    image_url          = optional(string, "ghcr.io/polarsource/polar")
-    custom_domains     = optional(list(object({ name = string })), [])
-    dramatiq_prom_port = optional(string, "10000")
-    plan               = optional(string, "pro")
-    num_instances      = optional(number, 1)
-    database_pool_size = optional(string, "5")
+    start_command         = string
+    image_url             = optional(string, "ghcr.io/polarsource/polar")
+    custom_domains        = optional(list(object({ name = string })), [])
+    dramatiq_prom_port    = optional(string, "10000")
+    plan                  = optional(string, "pro")
+    num_instances         = optional(number, 1)
+    database_pool_size    = optional(string, "5")
+    redis_max_connections = optional(string, "10")
   }))
 }
 
@@ -293,11 +295,12 @@ variable "polar_self_config" {
 variable "cron_jobs" {
   description = "Map of cron job configurations. image_url defaults to the API service image. Uses 'latest' tag so Render pulls the newest image before each run."
   type = map(object({
-    schedule           = string
-    start_command      = string
-    image_url          = optional(string)
-    plan               = optional(string, "starter")
-    database_pool_size = optional(string, "5")
+    schedule              = string
+    start_command         = string
+    image_url             = optional(string)
+    plan                  = optional(string, "starter")
+    database_pool_size    = optional(string, "5")
+    redis_max_connections = optional(string, "10")
   }))
   default = {}
 }

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -147,6 +147,7 @@ module "production" {
     custom_domains         = [{ name = "api.polar.sh" }, { name = "api-alt.polar.sh" }, { name = "buy.polar.sh" }, { name = "backoffice.polar.sh" }]
     plan                   = "pro_plus"
     web_concurrency        = "6"
+    redis_max_connections  = "50"
   }
 
   postgres_config = {
@@ -173,36 +174,43 @@ module "production" {
 
   workers = {
     "scheduler" = {
-      start_command      = "uv run python -m polar.worker.scheduler"
-      plan               = "standard"
-      dramatiq_prom_port = "10000"
+      start_command         = "uv run python -m polar.worker.scheduler"
+      plan                  = "standard"
+      dramatiq_prom_port    = "10000"
+      redis_max_connections = "10"
     }
     "worker" = {
-      start_command      = "uv run dramatiq polar.worker.run -p 2 -t 8 --queues low_priority"
-      custom_domains     = [{ name = "worker.polar.sh" }]
-      dramatiq_prom_port = "10000"
+      start_command         = "uv run dramatiq polar.worker.run -p 2 -t 8 --queues low_priority"
+      custom_domains        = [{ name = "worker.polar.sh" }]
+      dramatiq_prom_port    = "10000"
+      redis_max_connections = "10"
     }
     "worker-medium-priority" = {
-      start_command      = "uv run dramatiq polar.worker.run -p 2 -t 4 --queues medium_priority"
-      dramatiq_prom_port = "10001"
+      start_command         = "uv run dramatiq polar.worker.run -p 2 -t 4 --queues medium_priority"
+      dramatiq_prom_port    = "10001"
+      redis_max_connections = "10"
     }
     "worker-high-priority" = {
-      start_command      = "uv run dramatiq polar.worker.run -p 2 -t 4 --queues high_priority"
-      dramatiq_prom_port = "10001"
+      start_command         = "uv run dramatiq polar.worker.run -p 2 -t 4 --queues high_priority"
+      dramatiq_prom_port    = "10001"
+      redis_max_connections = "10"
     }
     "worker-webhook" = {
-      start_command      = "uv run dramatiq polar.worker.run -p 1 -t 16 --queues webhooks"
-      dramatiq_prom_port = "10001"
-      database_pool_size = "16"
+      start_command         = "uv run dramatiq polar.worker.run -p 1 -t 16 --queues webhooks"
+      dramatiq_prom_port    = "10001"
+      database_pool_size    = "16"
+      redis_max_connections = "10"
     }
     "worker-tinybird" = {
-      start_command      = "uv run dramatiq polar.worker.run -p 4 -t 32 --queues tinybird"
-      dramatiq_prom_port = "10002"
+      start_command         = "uv run dramatiq polar.worker.run -p 4 -t 32 --queues tinybird"
+      dramatiq_prom_port    = "10002"
+      redis_max_connections = "10"
     }
     "worker-invoices-receipts" = {
-      start_command      = "uv run dramatiq polar.worker.run -p 1 -t 3 --queues invoices_and_receipts"
-      plan               = "standard"
-      dramatiq_prom_port = "10003"
+      start_command         = "uv run dramatiq polar.worker.run -p 1 -t 3 --queues invoices_and_receipts"
+      plan                  = "standard"
+      dramatiq_prom_port    = "10003"
+      redis_max_connections = "10"
     }
   }
 

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -107,27 +107,32 @@ module "sandbox" {
     postgres_database      = "polar_sandbox"
     postgres_read_database = "polar_sandbox"
     redis_db               = "1"
+    redis_max_connections  = "50"
     plan                   = "pro"
   }
 
   workers = {
     worker-sandbox = {
-      start_command      = "uv run dramatiq polar.worker.run -p 4 -t 8 -f polar.worker.scheduler:start --queues high_priority medium_priority low_priority"
-      dramatiq_prom_port = "10000"
+      start_command         = "uv run dramatiq polar.worker.run -p 4 -t 8 -f polar.worker.scheduler:start --queues high_priority medium_priority low_priority"
+      dramatiq_prom_port    = "10000"
+      redis_max_connections = "10"
     }
     worker-sandbox-webhook = {
-      start_command      = "uv run dramatiq polar.worker.run -p 1 -t 16 --queues webhooks"
-      dramatiq_prom_port = "10001"
-      database_pool_size = "16"
+      start_command         = "uv run dramatiq polar.worker.run -p 1 -t 16 --queues webhooks"
+      dramatiq_prom_port    = "10001"
+      database_pool_size    = "16"
+      redis_max_connections = "10"
     }
     worker-sandbox-tinybird = {
-      start_command      = "uv run dramatiq polar.worker.run -p 1 -t 16 --queues tinybird"
-      dramatiq_prom_port = "10002"
+      start_command         = "uv run dramatiq polar.worker.run -p 1 -t 16 --queues tinybird"
+      dramatiq_prom_port    = "10002"
+      redis_max_connections = "10"
     }
     worker-sandbox-invoices-receipts = {
-      start_command      = "uv run dramatiq polar.worker.run -p 1 -t 3 --queues invoices_and_receipts"
-      plan               = "standard"
-      dramatiq_prom_port = "10003"
+      start_command         = "uv run dramatiq polar.worker.run -p 1 -t 3 --queues invoices_and_receipts"
+      plan                  = "standard"
+      dramatiq_prom_port    = "10003"
+      redis_max_connections = "10"
     }
   }
 

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -138,13 +138,15 @@ module "test" {
     postgres_database      = local.db_name
     postgres_read_database = local.db_name
     redis_db               = "0"
+    redis_max_connections  = "50"
     plan                   = "pro"
   }
 
   workers = {
     worker-test = {
-      start_command      = "uv run dramatiq -p 2 -t 4 -f polar.worker.scheduler:start polar.worker.run"
-      dramatiq_prom_port = "10000"
+      start_command         = "uv run dramatiq -p 2 -t 4 -f polar.worker.scheduler:start polar.worker.run"
+      dramatiq_prom_port    = "10000"
+      redis_max_connections = "10"
     }
   }
 


### PR DESCRIPTION

Introduce an environment variable to control the maximum number of connections to the Redis client. This is useful for managing resource usage and preventing connection exhaustion in high-load scenarios.

Decided values:

- API: 50 connections — a quite high limit to be able to serve the eventstream requests
- Worker: 10 connections — a lower limit, but since the Redis client has a retry strategy, it seems fine to restrict it a bit more.

Note: the underlying Dramatiq Redis connection is not concerned by this limit.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

