### PR TITLE
Add support for running Polar on Vercel

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,4 @@
+.env
+server/emails/bin/
+server/emails/dist/
+.jwks.json

--- a/clients/apps/web/next.config.mjs
+++ b/clients/apps/web/next.config.mjs
@@ -23,9 +23,22 @@ const POLAR_AUTH_COOKIE_KEY =
 const ENVIRONMENT =
   process.env.VERCEL_ENV || process.env.NEXT_PUBLIC_VERCEL_ENV || 'development'
 
-const defaultFrontendHostname = process.env.NEXT_PUBLIC_FRONTEND_BASE_URL
-  ? new URL(process.env.NEXT_PUBLIC_FRONTEND_BASE_URL).hostname
-  : 'polar.sh'
+const resolveFrontendHostname = () => {
+  // Under `vc dev` everything is same-origin through the dev proxy.
+  if (process.env.VERCEL && process.env.VERCEL_ENV === 'development') {
+    return 'localhost'
+  }
+  // FRONTEND_URL is injected by Vercel as the absolute deployment URL.
+  if (process.env.FRONTEND_URL) {
+    return new URL(process.env.FRONTEND_URL).hostname
+  }
+  if (process.env.NEXT_PUBLIC_FRONTEND_BASE_URL) {
+    return new URL(process.env.NEXT_PUBLIC_FRONTEND_BASE_URL).hostname
+  }
+  return 'polar.sh'
+}
+
+const defaultFrontendHostname = resolveFrontendHostname()
 
 const S3_PUBLIC_IMAGES_BUCKET_ORIGIN = process.env
   .S3_PUBLIC_IMAGES_BUCKET_HOSTNAME
@@ -250,17 +263,23 @@ const nextConfig = {
             type: 'cookie',
             key: POLAR_AUTH_COOKIE_KEY,
           },
-          {
-            type: 'host',
-            value: defaultFrontendHostname,
-          },
+          // On Vercel everything is same origin
+          ...(process.env.VERCEL
+            ? []
+            : [
+                {
+                  type: 'host',
+                  value: defaultFrontendHostname,
+                },
+              ]),
         ],
         permanent: false,
       },
 
       // Redirect /dashboard to correct domain if on a different domain name
       // Skip in preview builds — preview env uses a single domain via Caddy proxy
-      ...(!previewBasePath
+      // and under Vercel services deployment
+      ...(!(previewBasePath || process.env.VERCEL)
         ? [
             {
               source: '/dashboard/:path*',

--- a/clients/apps/web/src/app/(main)/auth/backup-codes/VerifyPage.tsx
+++ b/clients/apps/web/src/app/(main)/auth/backup-codes/VerifyPage.tsx
@@ -2,6 +2,7 @@
 
 import { useBackupCodesVerify } from '@/hooks'
 import { setValidationErrors } from '@/utils/api/errors'
+import { isApiSameOrigin } from '@/utils/auth'
 import { CONFIG } from '@/utils/config'
 import { isValidationError } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
@@ -36,7 +37,12 @@ const VerifyPage = () => {
         }
         return
       }
-      router.push('/auth')
+      // Same-origin needs a hard navigation
+      if (isApiSameOrigin()) {
+        window.location.assign('/auth')
+      } else {
+        router.push('/auth')
+      }
     } catch {
       setError('code', {
         message: 'An unexpected error occurred. Please try again.',

--- a/clients/apps/web/src/app/(main)/auth/email-otp/VerifyPage.tsx
+++ b/clients/apps/web/src/app/(main)/auth/email-otp/VerifyPage.tsx
@@ -2,6 +2,7 @@
 
 import { useEmailOTPVerify } from '@/hooks'
 import { setValidationErrors } from '@/utils/api/errors'
+import { isApiSameOrigin } from '@/utils/auth'
 import { CONFIG } from '@/utils/config'
 import { isValidationError } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
@@ -43,7 +44,12 @@ const VerifyPage = ({ intent = 'login' }: { intent?: 'login' | 'signup' }) => {
         }
         return
       }
-      router.push('/auth')
+      // Same-origin needs a hard navigation
+      if (isApiSameOrigin()) {
+        window.location.assign('/auth')
+      } else {
+        router.push('/auth')
+      }
     } catch {
       setError('code', {
         message: 'An unexpected error occurred. Please try again.',

--- a/clients/apps/web/src/app/(main)/auth/totp/VerifyPage.tsx
+++ b/clients/apps/web/src/app/(main)/auth/totp/VerifyPage.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { useTOTPVerify } from '@/hooks'
 import { setValidationErrors } from '@/utils/api/errors'
+import { isApiSameOrigin } from '@/utils/auth'
 import { CONFIG } from '@/utils/config'
 import { isValidationError } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
@@ -44,7 +45,12 @@ const VerifyPage = () => {
         }
         return
       }
-      router.push('/auth')
+      // Same-origin needs a hard navigation
+      if (isApiSameOrigin()) {
+        window.location.assign('/auth')
+      } else {
+        router.push('/auth')
+      }
     } catch {
       setError('code', {
         message: 'An unexpected error occurred. Please try again.',

--- a/clients/apps/web/src/utils/auth.ts
+++ b/clients/apps/web/src/utils/auth.ts
@@ -1,6 +1,26 @@
 import { getPublicServerURL } from '@/utils/api'
+import { CONFIG } from '@/utils/config'
 import { Client, operations, schemas } from '@polar-sh/client'
 import { redirect } from 'next/navigation'
+
+/**
+ * True when the API shares the frontend's origin.
+ *
+ * In that case the `/v1/auth/complete` route must be reached
+ * via a hard browser navigation rather than Next's client-side router, because
+ * `/v1/auth/complete` is a one-time GET.
+ */
+export const isApiSameOrigin = (): boolean => {
+  if (typeof window === 'undefined') return false
+  try {
+    return (
+      new URL(CONFIG.BASE_URL, window.location.origin).origin ===
+      window.location.origin
+    )
+  } catch {
+    return false
+  }
+}
 
 export const getGitHubAuthorizeLoginURL = (): string => {
   return `${getPublicServerURL()}/v1/auth/github/authorize`

--- a/clients/apps/web/src/utils/client/index.ts
+++ b/clients/apps/web/src/utils/client/index.ts
@@ -73,10 +73,12 @@ export const createServerSideAPI = async (
     }
   }
 
-  // Use POLAR_API_URL for server-side requests (e.g., in Docker containers)
+  // Use POLAR_API_URL or API_URL (injected by Vercel) for server-side requests (e.g., in Docker containers)
   // Fall back to NEXT_PUBLIC_API_URL for local development
   const apiUrl =
-    process.env.POLAR_API_URL || (process.env.NEXT_PUBLIC_API_URL as string)
+    process.env.POLAR_API_URL ||
+    process.env.API_URL ||
+    (process.env.NEXT_PUBLIC_API_URL as string)
 
   const client = baseCreateClient(apiUrl, token, apiHeaders)
 

--- a/clients/turbo.json
+++ b/clients/turbo.json
@@ -3,6 +3,7 @@
   "globalDependencies": ["**/.env.*local"],
   "globalEnv": [
     "POLAR_API_URL",
+    "API_URL",
     "EXPO_PUBLIC_POLAR_SERVER_URL",
     "NODE_ENV",
     "NEXT_PHASE",
@@ -15,6 +16,7 @@
     "POLAR_PREVIEW_ACCESS_TOKEN",
     "POLAR_PREVIEW_BUILD",
     "POLAR_PREVIEW_BACKEND_HOST",
+    "VERCEL",
     "VERCEL_ENV",
     "VERCEL_GIT_PULL_REQUEST_ID",
     "VERCEL_URL",

--- a/clients/turbo.json
+++ b/clients/turbo.json
@@ -4,6 +4,7 @@
   "globalEnv": [
     "POLAR_API_URL",
     "API_URL",
+    "FRONTEND_URL",
     "EXPO_PUBLIC_POLAR_SERVER_URL",
     "NODE_ENV",
     "NEXT_PHASE",

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -4,11 +4,17 @@ import tempfile
 from datetime import timedelta
 from enum import StrEnum
 from pathlib import Path
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 from urllib.parse import urlparse
 
 from annotated_types import Ge
-from pydantic import AfterValidator, DirectoryPath, Field, PostgresDsn
+from pydantic import (
+    AfterValidator,
+    DirectoryPath,
+    Field,
+    PostgresDsn,
+    model_validator,
+)
 from pydantic_ai.models import Model, infer_model, parse_model_id
 from pydantic_ai.providers.gateway import gateway_provider
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -26,7 +32,20 @@ class Environment(StrEnum):
     test = "test"  # Used for the test environment in Render
 
 
+# Vercel services are used for development and test environment only
+_VERCEL_ENV_TO_ENVIRONMENT: dict[str, Environment] = {
+    "development": Environment.development,  # vc dev
+    "preview": Environment.test,
+    "production": Environment.test,
+}
+
+
 def _validate_email_renderer_binary_path(value: Path) -> Path:
+    # On Vercel the email renderer lives in a separate service, so the binary
+    # isn't present in every service's bundle
+    if os.getenv("VERCEL"):
+        return value
+
     if not value.exists() and not value.is_file():
         raise ValueError(
             f"""
@@ -352,6 +371,9 @@ class Settings(BaseSettings):
     MINIO_USER: str = "polar"
     MINIO_PWD: str = "polarpolar"
 
+    # Vercel
+    VERCEL_ENV: str | None = None
+
     # Chargeback Stop
     CHARGEBACK_STOP_WEBHOOK_SECRET: str = ""
 
@@ -531,6 +553,34 @@ class Settings(BaseSettings):
     TAX_PROCESSORS: list[TaxProcessor] = [TaxProcessor.stripe]
     TAX_RECORD_PROCESSOR: TaxProcessor = TaxProcessor.stripe
 
+    @model_validator(mode="before")
+    @classmethod
+    def _map_vercel_env_vars(cls, values: dict[str, Any]) -> dict[str, Any]:
+        vercel_env = os.getenv("VERCEL_ENV")
+        if not vercel_env:
+            return values
+
+        values["VERCEL_ENV"] = vercel_env
+
+        # On Vercel the proxy unifies all services under one origin, so the
+        # Vercel-injected URLs take precedence over .env values
+        if api_url := os.getenv("API_URL"):
+            values["BASE_URL"] = api_url
+            values["CHECKOUT_BASE_URL"] = (
+                f"{api_url}/v1/checkout-links/{{client_secret}}/redirect"
+            )
+
+        if frontend_url := os.getenv("FRONTEND_URL"):
+            values["FRONTEND_BASE_URL"] = frontend_url
+
+            hostname = urlparse(frontend_url).hostname
+            if hostname:
+                values["USER_SESSION_COOKIE_DOMAIN"] = hostname
+                values["AUTHENTICATION_SESSION_COOKIE_DOMAIN"] = hostname
+                values["OAUTH2_SESSION_STATE_COOKIE_DOMAIN"] = hostname
+
+        return values
+
     model_config = SettingsConfigDict(
         env_prefix="polar_",
         env_file_encoding="utf-8",
@@ -538,6 +588,9 @@ class Settings(BaseSettings):
         env_file=env_file,
         extra="allow",
     )
+
+    def is_vercel(self) -> bool:
+        return self.VERCEL_ENV is not None
 
     @property
     def redis_url(self) -> str:
@@ -584,7 +637,11 @@ class Settings(BaseSettings):
         )
 
     def is_environment(self, environments: set[Environment]) -> bool:
-        return self.ENV in environments
+        env = self.ENV
+        if self.VERCEL_ENV is not None:
+            env = _VERCEL_ENV_TO_ENVIRONMENT.get(self.VERCEL_ENV, env)
+
+        return env in environments
 
     def is_development(self) -> bool:
         return self.is_environment({Environment.development})

--- a/server/polar/logging.py
+++ b/server/polar/logging.py
@@ -1,5 +1,7 @@
 import contextvars
+import logging
 import logging.config
+import sys
 import typing
 import uuid
 from typing import Any
@@ -10,6 +12,26 @@ from logfire.integrations.structlog import LogfireProcessor
 from polar.config import settings
 
 Logger = structlog.stdlib.BoundLogger
+
+
+class VercelLoggingHandler(logging.Handler):
+    """Route WARNING+ to stderr, everything else to stdout"""
+
+    def __init__(self, level: int = logging.NOTSET) -> None:
+        super().__init__(level)
+        self._stdout = logging.StreamHandler(sys.stdout)
+        self._stderr = logging.StreamHandler(sys.stderr)
+
+    def setFormatter(self, fmt: logging.Formatter | None) -> None:
+        super().setFormatter(fmt)
+        self._stdout.setFormatter(fmt)
+        self._stderr.setFormatter(fmt)
+
+    def emit(self, record: logging.LogRecord) -> None:
+        if record.levelno >= logging.WARNING:
+            self._stderr.emit(record)
+        else:
+            self._stdout.emit(record)
 
 
 def _map_critical_to_fatal(
@@ -59,6 +81,13 @@ class Logging[RendererType]:
     @classmethod
     def configure_stdlib(cls, *, logfire: bool) -> None:
         level = cls.get_level()
+        # On Vercel route info/debug to stdout and warnings/errors to stderr so
+        # only the latter show as [error] in the dashboard.
+        handler_class = (
+            "polar.logging.VercelLoggingHandler"
+            if settings.is_vercel()
+            else "logging.StreamHandler"
+        )
         logging.config.dictConfig(
             {
                 "version": 1,
@@ -90,7 +119,7 @@ class Logging[RendererType]:
                 "handlers": {
                     "default": {
                         "level": level,
-                        "class": "logging.StreamHandler",
+                        "class": handler_class,
                         "formatter": "polar",
                     },
                 },

--- a/server/polar/subscription/tasks.py
+++ b/server/polar/subscription/tasks.py
@@ -2,14 +2,17 @@ import uuid
 from datetime import timedelta
 
 import structlog
+from sqlalchemy import update
 from sqlalchemy.orm import selectinload
 
+from polar.config import settings
 from polar.exceptions import PolarTaskError
 from polar.kit.utils import utc_now
 from polar.logging import Logger
 from polar.models import Subscription, SubscriptionMeter
 from polar.product.repository import ProductRepository
 from polar.subscription.repository import SubscriptionRepository
+from polar.subscription.scheduler import SubscriptionJobStore
 from polar.worker import (
     AsyncSessionMaker,
     CronTrigger,
@@ -208,4 +211,46 @@ async def send_trial_conversion_reminder(subscription_id: uuid.UUID) -> None:
 
         await subscription_service.send_trial_conversion_reminder_email(
             session, subscription
+        )
+
+
+# Vercel replacement for SubscriptionJobStore using cron jobs,
+# because there's no primitive yet for long-running tasks that
+# can do background work without triggers
+@actor(
+    actor_name="subscription.cycle_due",
+    priority=TaskPriority.LOW,
+    cron_trigger=CronTrigger() if settings.is_vercel() else None,
+)
+async def subscription_cycle_due() -> None:
+    async with AsyncSessionMaker() as session:
+        statement = (
+            SubscriptionJobStore.scheduling_statement()
+            .where(Subscription.current_period_end <= utc_now())
+            .with_only_columns(Subscription.id)
+        )
+        result = await session.execute(statement)
+        subscription_ids = result.scalars().all()
+
+        locked_ids: set[uuid.UUID] = set()
+        if subscription_ids:
+            lock_result = await session.execute(
+                update(Subscription)
+                .where(
+                    Subscription.id.in_(subscription_ids),
+                    Subscription.scheduler_locked_at.is_(None),
+                )
+                .values(scheduler_locked_at=utc_now())
+                .returning(Subscription.id)
+            )
+            locked_ids = set(lock_result.scalars().all())
+
+    enqueued = [sid for sid in subscription_ids if sid in locked_ids]
+    for sid in enqueued:
+        enqueue_job("subscription.cycle", subscription_id=sid)
+
+    if enqueued:
+        log.info(
+            "subscription.cycle_due.enqueued",
+            count=len(enqueued),
         )

--- a/server/polar/worker/_broker.py
+++ b/server/polar/worker/_broker.py
@@ -15,6 +15,7 @@ from dramatiq.middleware.group_callbacks import GroupCallbacks
 from dramatiq.rate_limits.backends import RedisBackend as RateLimiterBackend
 from dramatiq.results import Results
 from dramatiq.results.backends import RedisBackend as ResultsBackend
+from vercel.workers.dramatiq import VercelQueuesBroker
 
 from polar.config import settings
 from polar.logfire import instrument_httpx
@@ -216,13 +217,14 @@ def get_broker(*, database: bool = True) -> dramatiq.Broker:
         middleware.CurrentMessage(),
     ]
 
-    broker = RedisBroker(
+    if settings.is_vercel():
+        return VercelQueuesBroker(middleware=middleware_list)
+
+    return RedisBroker(
         connection_pool=redis_pool,
         middleware=middleware_list,
         dead_message_ttl=3600 * 1000,  # 1 hour in milliseconds
     )
-
-    return broker
 
 
 __all__ = [

--- a/server/polar/worker/_enqueue.py
+++ b/server/polar/worker/_enqueue.py
@@ -93,6 +93,11 @@ class JobQueueManager:
         queue_messages = defaultdict[str, list[tuple[str, Any]]](list)
         all_messages: list[tuple[str, Any]] = []
 
+        # On Vercel, VercelQueuesBroker.enqueue applies delays natively (via eta
+        # on the original queue), so we carry the delay through to enqueue rather
+        # than rewriting to a ".DQ" delay queue
+        vercel_messages: list[tuple[dramatiq.Message[Any], int | None]] = []
+
         for actor_name, args, kwargs, delay in redis_jobs:
             fn: dramatiq.Actor[Any, Any] = broker.get_actor(actor_name)
             redis_message_id = str(uuid.uuid4())
@@ -119,6 +124,12 @@ class JobQueueManager:
                 else:
                     delay = debounce_delay
 
+            if settings.is_vercel():
+                # don't use dq_name with Vercel Queues, because it has no ".DQ" queues
+                vercel_messages.append((message, delay))
+                all_messages.append((fn.actor_name, message.encode()))
+                continue
+
             # Handle delay: convert to eta and use delayed queue
             # See https://github.com/Bogdanp/dramatiq/blob/aa91cdfcfa6d8ad957ca0afe900266617f2661f8/dramatiq/brokers/stub.py#L107-L116
             if delay is not None and delay > 0:
@@ -135,12 +146,19 @@ class JobQueueManager:
             )
             all_messages.append((fn.actor_name, message.encode()))
 
-        for queue_name, messages in queue_messages.items():
-            for batch in itertools.batched(messages, FLUSH_BATCH_SIZE):
-                await self._batch_hset_messages(redis, queue_name, batch)
-                await self._batch_rpush_queue(
-                    redis, queue_name, (message_id for message_id, _ in batch)
-                )
+        if settings.is_vercel():
+            for message, delay in vercel_messages:
+                if delay is not None and delay > 0:
+                    broker.enqueue(message, delay=delay)
+                else:
+                    broker.enqueue(message)
+        else:
+            for queue_name, messages in queue_messages.items():
+                for batch in itertools.batched(messages, FLUSH_BATCH_SIZE):
+                    await self._batch_hset_messages(redis, queue_name, batch)
+                    await self._batch_rpush_queue(
+                        redis, queue_name, (message_id for message_id, _ in batch)
+                    )
 
         for actor_name, encoded_message in all_messages:
             log.debug(

--- a/server/polar/worker/_queues.py
+++ b/server/polar/worker/_queues.py
@@ -1,5 +1,7 @@
 from enum import IntEnum, StrEnum
 
+from polar.config import settings
+
 
 class TaskPriority(IntEnum):
     HIGH = 0
@@ -7,13 +9,18 @@ class TaskPriority(IntEnum):
     LOW = 100
 
 
+def _queue_name(name: str) -> str:
+    # Vercel Queues topics must not contain underscores, so hyphenate here
+    return name.replace("_", "-") if settings.is_vercel() else name
+
+
 class TaskQueue(StrEnum):
-    HIGH_PRIORITY = "high_priority"
-    MEDIUM_PRIORITY = "medium_priority"
-    LOW_PRIORITY = "low_priority"
-    WEBHOOKS = "webhooks"
-    TINYBIRD = "tinybird"
-    INVOICES_AND_RECEIPTS = "invoices_and_receipts"
+    HIGH_PRIORITY = _queue_name("high_priority")
+    MEDIUM_PRIORITY = _queue_name("medium_priority")
+    LOW_PRIORITY = _queue_name("low_priority")
+    WEBHOOKS = _queue_name("webhooks")
+    TINYBIRD = _queue_name("tinybird")
+    INVOICES_AND_RECEIPTS = _queue_name("invoices_and_receipts")
 
 
 __all__ = [

--- a/server/polar/worker/cron.py
+++ b/server/polar/worker/cron.py
@@ -1,0 +1,84 @@
+# transform APScheduler cron jobs into Vercel crons format
+
+import sys
+from collections.abc import Callable
+from typing import Any
+
+from apscheduler.triggers.cron import CronTrigger
+from apscheduler.triggers.cron.fields import BaseField
+
+from polar import tasks  # noqa: F401 - ensure all actors are registered
+
+from ._broker import scheduler_middleware
+
+_CRONTAB_FIELDS = ("minute", "hour", "day", "month", "day_of_week")
+
+
+def _expr_to_str(expr: Any, remap: Callable[[int], int] | None = None) -> str:
+    if not hasattr(expr, "first"):
+        s = "*"
+    else:
+        first = remap(expr.first) if remap else expr.first
+        last = remap(expr.last) if remap else expr.last
+        if last != first:
+            s = f"{first}-{last}"
+        else:
+            s = str(first)
+    if expr.step:
+        s += f"/{expr.step}"
+    return s
+
+
+def _field_to_str(field: BaseField, remap: Callable[[int], int] | None = None) -> str:
+    return ",".join(_expr_to_str(e, remap) for e in field.expressions)
+
+
+def _apscheduler_dow_to_posix(n: int) -> int:
+    """APScheduler: mon=0..sun=6 -> POSIX: sun=0..sat=6"""
+    return (n + 1) % 7
+
+
+def trigger_to_crontab(trigger: CronTrigger) -> str:
+    fields = {f.name: f for f in trigger.fields}
+    parts = []
+    for name in _CRONTAB_FIELDS:
+        remap = _apscheduler_dow_to_posix if name == "day_of_week" else None
+        parts.append(_field_to_str(fields[name], remap))
+    return " ".join(parts)
+
+
+_THIS_MODULE = sys.modules[__name__]
+
+
+def _send_attr_name(actor_name: str) -> str:
+    return "send_" + actor_name.replace(".", "_").replace("-", "_")
+
+
+# Expose each cron actor's bound `send` method as a module-level attribute so
+# the Vercel cron service can invoke it directly
+for _send_fn, _ in scheduler_middleware.cron_triggers:
+    _actor = _send_fn.__self__  # type: ignore[attr-defined]
+    setattr(_THIS_MODULE, _send_attr_name(_actor.actor_name), _send_fn)
+
+
+class CronTab:
+    def get_crons(self) -> list[tuple[str, str]]:
+        result = []
+        for send_fn, trigger in scheduler_middleware.cron_triggers:
+            actor = send_fn.__self__  # type: ignore[attr-defined]
+            schedule = trigger_to_crontab(trigger)
+            result.append(
+                (
+                    f"{__spec__.name}:{_send_attr_name(actor.actor_name)}",
+                    schedule,
+                )
+            )
+        return result
+
+
+crontab = CronTab()
+
+
+if __name__ == "__main__":
+    for name, sched in crontab.get_crons():
+        print(f"{name:70s} {sched}")  # noqa: T201

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -67,6 +67,9 @@ dependencies = [
   "markdown-it-py>=4.2.0",
   "tzdata>=2026.2",
   "reauth==0.1.8",
+  # Vercel-specific
+  "vercel-workers[dramatiq]==0.0.25",
+  "vercel==0.5.9",
 ]
 
 [dependency-groups]
@@ -188,7 +191,7 @@ warn_untyped_fields = true
 
 [tool.uv]
 exclude-newer = "1 week"
-exclude-newer-package = { reauth = false } # Reauth is brand new, but remember to remove this exclusion when stabilized
+exclude-newer-package = { reauth = false, vercel-workers = false } # Reauth is brand new, but remember to remove this exclusion when stabilized
 
 [tool.uv.sources]
 dramatiq = { git = "https://github.com/frankie567/dramatiq", rev = "memory-leak-asyncio-ter" }

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -12,6 +12,7 @@ exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
 reauth = false
+vercel-workers = false
 
 [[package]]
 name = "aiocsv"
@@ -488,6 +489,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/73/3183c9e41ca755713bdf2cc1d0810df742c09484e2e1ddd693bee53877c1/brotli-1.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d2d085ded05278d1c7f65560aae97b3160aeb2ea2c0b3e26204856beccb60888", size = 1488164, upload-time = "2025-11-05T18:38:53.079Z" },
     { url = "https://files.pythonhosted.org/packages/64/6a/0c78d8f3a582859236482fd9fa86a65a60328a00983006bcf6d83b7b2253/brotli-1.2.0-cp314-cp314-win32.whl", hash = "sha256:832c115a020e463c2f67664560449a7bea26b0c1fdd690352addad6d0a08714d", size = 339280, upload-time = "2025-11-05T18:38:54.02Z" },
     { url = "https://files.pythonhosted.org/packages/f5/10/56978295c14794b2c12007b07f3e41ba26acda9257457d7085b0bb3bb90c/brotli-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:e7c0af964e0b4e3412a0ebf341ea26ec767fa0b4cf81abb5e897c9338b5ad6a3", size = 375639, upload-time = "2025-11-05T18:38:55.67Z" },
+]
+
+[[package]]
+name = "cbor2"
+version = "5.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/cb/09939728be094d155b5d4ac262e39877875f5f7e36eea66beb359f647bd0/cbor2-5.9.0.tar.gz", hash = "sha256:85c7a46279ac8f226e1059275221e6b3d0e370d2bb6bd0500f9780781615bcea", size = 111231, upload-time = "2026-03-22T15:56:50.638Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/7d/9ccc36d10ef96e6038e48046ebe1ce35a1e7814da0e1e204d09e6ef09b8d/cbor2-5.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23606d31ba1368bd1b6602e3020ee88fe9523ca80e8630faf6b2fc904fd84560", size = 71500, upload-time = "2026-03-22T15:56:31.876Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e1/a6cca2cc72e13f00030c6a649f57ae703eb2c620806ab70c40db8eab33fa/cbor2-5.9.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0322296b9d52f55880e300ba8ba09ecf644303b99b51138bbb1c0fb644fa7c3e", size = 286953, upload-time = "2026-03-22T15:56:33.292Z" },
+    { url = "https://files.pythonhosted.org/packages/08/3c/24cd5ef488a957d90e016f200a3aad820e4c2f85edd61c9fe4523007a1ee/cbor2-5.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:422817286c1d0ce947fb2f7eca9212b39bddd7231e8b452e2d2cc52f15332dba", size = 285454, upload-time = "2026-03-22T15:56:34.703Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/35/dca96818494c0ba47cdd73e8d809b27fa91f8fa0ce32a068a09237687454/cbor2-5.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9a4907e0c3035bb8836116854ed8e56d8aef23909d601fa59706320897ec2551", size = 279441, upload-time = "2026-03-22T15:56:35.888Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/44/d3362378b16e53cf7e535a3f5aed8476e2109068154e24e31981ef5bde9e/cbor2-5.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fb7afe77f8d269e42d7c4b515c6fd14f1ccc0625379fb6829b269f493d16eddd", size = 279673, upload-time = "2026-03-22T15:56:37.08Z" },
+    { url = "https://files.pythonhosted.org/packages/43/d1/3533a697e5842fff7c2f64912eb251f8dcab3a8b5d88e228d6eebc3b5021/cbor2-5.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:86baf870d4c0bfc6f79de3801f3860a84ab76d9c8b0abb7f081f2c14c38d79d3", size = 71940, upload-time = "2026-03-22T15:56:38.366Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/e2/c6ba75f3fb25dfa15ab6999cc8709c821987e9ed8e375d7f58539261bcb9/cbor2-5.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:7221483fad0c63afa4244624d552abf89d7dfdbc5f5edfc56fc1ff2b4b818975", size = 67639, upload-time = "2026-03-22T15:56:39.39Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ff/b83492b096fbef26e9cb62c1a4bf2d3cef579ea7b33138c6c37c4ae66f67/cbor2-5.9.0-py3-none-any.whl", hash = "sha256:27695cbd70c90b8de5c4a284642c2836449b14e2c2e07e3ffe0744cb7669a01b", size = 24627, upload-time = "2026-03-22T15:56:48.847Z" },
 ]
 
 [[package]]
@@ -2465,6 +2482,8 @@ dependencies = [
     { name = "typer" },
     { name = "tzdata" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "vercel" },
+    { name = "vercel-workers", extra = ["dramatiq"] },
 ]
 
 [package.dev-dependencies]
@@ -2561,6 +2580,8 @@ requires-dist = [
     { name = "typer", specifier = ">=0.26.7" },
     { name = "tzdata", specifier = ">=2026.2" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.49.0" },
+    { name = "vercel", specifier = "==0.5.9" },
+    { name = "vercel-workers", extras = ["dramatiq"], specifier = "==0.0.25" },
 ]
 
 [package.metadata.requires-dev]
@@ -3981,6 +4002,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/07/bcfd5ebd7cb308026ab78a353e091bd699593358be49197d39d004e5ad83/vcrpy-8.1.1.tar.gz", hash = "sha256:58e3053e33b423f3594031cb758c3f4d1df931307f1e67928e30cf352df7709f", size = 85770, upload-time = "2026-01-04T19:22:03.886Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/d7/f79b05a5d728f8786876a7d75dfb0c5cae27e428081b2d60152fb52f155f/vcrpy-8.1.1-py3-none-any.whl", hash = "sha256:2d16f31ad56493efb6165182dd99767207031b0da3f68b18f975545ede8ac4b9", size = 42445, upload-time = "2026-01-04T19:22:02.532Z" },
+]
+
+[[package]]
+name = "vercel"
+version = "0.5.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "cbor2" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "vercel-workers" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/e9/86d6780301e36ecfe45ec401212593f24c555b284b5b080ac9a6253803ec/vercel-0.5.9.tar.gz", hash = "sha256:88d2c27ecf7e02de67b711d4dd9df84e70c6ae1823c09f1fd67146e3d54be462", size = 119164, upload-time = "2026-05-19T19:41:01.261Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/0e/dc0cb599036ff3055428459a427ed895e1a4cd3db387655672c5d2dba04b/vercel-0.5.9-py3-none-any.whl", hash = "sha256:f87a354fc110f04f3d6a2270c800cd8d42a763ea116b2625fc049d54a856a31b", size = 140907, upload-time = "2026-05-19T19:40:59.84Z" },
+]
+
+[[package]]
+name = "vercel-workers"
+version = "0.0.25"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "vercel" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/df/04d37021ad7ca53b7599c313e411d91623c7a005c741f491d1eefb7a9f0c/vercel_workers-0.0.25.tar.gz", hash = "sha256:212ded01400b524be51d251df49f801caf115ad7d48cca7eb168cbeceda3def3", size = 64149, upload-time = "2026-06-20T19:26:27.177Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/5a/2ae6debc94fcfd7ce06b0e4ac5505be29ca04e76d6c99af35d4372dd7eda/vercel_workers-0.0.25-py3-none-any.whl", hash = "sha256:6901228a90e83e292e6a176161e66e6a7c43d9f4fd9e13d6bd87092ad09ffd8b", size = 61680, upload-time = "2026-06-20T19:26:25.971Z" },
+]
+
+[package.optional-dependencies]
+dramatiq = [
+    { name = "dramatiq" },
 ]
 
 [[package]]

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,49 @@
+{
+  "build": {
+    "env": {
+      "VERCEL_PYTHON_ON_HIVE": "1",
+      "VERCEL_PYTHON_COMPILEALL": "1"
+    }
+  },
+  "experimentalServices": {
+    "frontend": {
+      "type": "web",
+      "framework": "nextjs",
+      "root": "clients/apps/web",
+      "mount": "/"
+    },
+    "api": {
+      "type": "web",
+      "framework": "fastapi",
+      "root": "server",
+      "entrypoint": "polar.app:app",
+      "mount": "/api",
+      "buildCommand": "export PATH=/pnpm10/node_modules/.bin:$PATH && uv run task backoffice",
+      "preDeployCommand": "uv run --no-sync task db_migrate"
+    },
+    "worker": {
+      "type": "job",
+      "trigger": "queue",
+      "runtime": "python",
+      "root": "server",
+      "entrypoint": "polar/worker/run.py",
+      "topics": [
+        "high-priority",
+        "medium-priority",
+        "low-priority",
+        "webhooks",
+        "tinybird",
+        "invoices-and-receipts"
+      ],
+      "buildCommand": "export PATH=/pnpm10/node_modules/.bin:$PATH && uv run task emails"
+    },
+    "cron": {
+      "type": "job",
+      "trigger": "schedule",
+      "runtime": "python",
+      "root": "server",
+      "entrypoint": "polar.worker.cron:crontab",
+      "schedule": "<dynamic>"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the ability to run all Polar components on Vercel as development infrastructure.

## What

Most of the changes relate to [Vercel's new Services](https://vercel.com/docs/services) feature and how it works.

## Why

Discussed as an option to test-drive Services and improve the development experience for preview/test environments.

## How

1. Added `vercel.json` file with services specification
2. Modified/gated `server` code so it's aware of the Vercel infrastructure via `settings.is_vercel()` method, so other environments won't be affected
3. Modified client app so it can work with API mounted under the same host

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [X] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [X] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [X] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [X] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

