### PR TITLE
lambda: Configure logfire correctly

### DIFF
--- a/server/polar/worker/_runner.py
+++ b/server/polar/worker/_runner.py
@@ -1,9 +1,11 @@
+import contextlib
 import functools
 import inspect
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from typing import Any
 
 import dramatiq
+import logfire
 import structlog
 from dramatiq.middleware.current_message import CurrentMessage
 
@@ -79,6 +81,27 @@ def validate_allowlist() -> None:
             )
 
 
+@contextlib.contextmanager
+def _task_span(
+    actor_name: str,
+    message: dramatiq.Message[Any],
+    correlation_id: str,
+    source_correlation_id: str | None,
+) -> Iterator[None]:
+    if actor_name in settings.LOGFIRE_IGNORED_ACTORS:
+        with logfire.suppress_instrumentation():
+            yield
+    else:
+        with logfire.span(
+            "TASK {actor}",
+            actor=actor_name,
+            message=message.asdict(),
+            correlation_id=correlation_id,
+            source_correlation_id=source_correlation_id,
+        ):
+            yield
+
+
 async def run_task(
     actor_name: str,
     args: Sequence[Any] = (),
@@ -115,7 +138,8 @@ async def run_task(
     )
     token = CurrentMessage._MESSAGE.set(message)
     try:
-        await fn(*args, **kwargs)
+        with _task_span(actor_name, message, correlation_id, source_correlation_id):
+            await fn(*args, **kwargs)
     finally:
         CurrentMessage._MESSAGE.reset(token)
         structlog.contextvars.unbind_contextvars(

--- a/server/polar/worker/aws_lambda.py
+++ b/server/polar/worker/aws_lambda.py
@@ -1,6 +1,7 @@
 import asyncio
 from typing import Any
 
+import logfire
 import structlog
 
 from polar.logfire import configure_logfire
@@ -27,25 +28,30 @@ bootstrap()
 
 def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
     batch_item_failures: list[dict[str, str]] = []
-    for record in event.get("Records", []):
-        message_id = record["messageId"]
-        try:
-            actor, args, kwargs, correlation_id = parse_envelope(record["body"])
-            receive_count = int(
-                record.get("attributes", {}).get("ApproximateReceiveCount", "1")
-            )
-            _loop.run_until_complete(
-                run_task(
-                    actor,
-                    args,
-                    kwargs,
-                    receive_count=receive_count,
-                    source_correlation_id=correlation_id,
+    try:
+        for record in event.get("Records", []):
+            message_id = record["messageId"]
+            try:
+                actor, args, kwargs, correlation_id = parse_envelope(record["body"])
+                receive_count = int(
+                    record.get("attributes", {}).get("ApproximateReceiveCount", "1")
                 )
-            )
-        except Exception:
-            log.error(
-                "polar.worker.sqs_task_failed", message_id=message_id, exc_info=True
-            )
-            batch_item_failures.append({"itemIdentifier": message_id})
+                _loop.run_until_complete(
+                    run_task(
+                        actor,
+                        args,
+                        kwargs,
+                        receive_count=receive_count,
+                        source_correlation_id=correlation_id,
+                    )
+                )
+            except Exception:
+                log.error(
+                    "polar.worker.sqs_task_failed",
+                    message_id=message_id,
+                    exc_info=True,
+                )
+                batch_item_failures.append({"itemIdentifier": message_id})
+    finally:
+        logfire.force_flush()
     return {"batchItemFailures": batch_item_failures}

--- a/terraform/modules/aws_task_worker/main.tf
+++ b/terraform/modules/aws_task_worker/main.tf
@@ -103,6 +103,7 @@ resource "aws_lambda_function" "task" {
 
   environment {
     variables = merge(
+      { SERVICE_NAME = local.function_name },
       var.environment_variables,
       var.secret_environment_variables,
       { POLAR_DATABASE_POOL_SIZE = "1" },

--- a/terraform/modules/aws_task_worker/main.tf
+++ b/terraform/modules/aws_task_worker/main.tf
@@ -103,10 +103,10 @@ resource "aws_lambda_function" "task" {
 
   environment {
     variables = merge(
-      { SERVICE_NAME = local.function_name },
       var.environment_variables,
       var.secret_environment_variables,
       { POLAR_DATABASE_POOL_SIZE = "1" },
+      { SERVICE_NAME = local.function_name },
     )
   }
 


### PR DESCRIPTION
For logfire logs from lambda we need to set the service name and flush it before the lambda execution finishes

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

