### PR TITLE
feat(backoffice): internal notes on closed cases + required internal note on appeal approval

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -61,6 +61,7 @@ from polar.models.organization_agent_review import OrganizationAgentReview
 from polar.models.organization_review import OrganizationReview
 from polar.models.support_case import (
     ReviewAppealSupportCase,
+    SupportCaseMessageAuthorKind,
 )
 from polar.models.transaction import TransactionType
 from polar.models.user import IdentityVerificationStatus
@@ -1664,10 +1665,17 @@ async def appeal_case_approve_dialog(
 
     if request.method == "POST":
         form_data = await request.form()
-        reason = str(form_data.get("reason", "")).strip() or None
+        # Approving overrides the AI's denial: the internal note is mandatory and
+        # staff-only, so a later re-flag shows who overrode and why. The merchant
+        # message is optional and the only part the merchant sees.
+        internal_note = str(form_data.get("internal_note", "")).strip() or None
+        merchant_message = str(form_data.get("merchant_message", "")).strip() or None
         message_repository = SupportCaseMessageRepository.from_session(session)
-        if not reason:
-            error_message = "A reason is required to approve the appeal."
+        if not internal_note:
+            error_message = (
+                "An internal note is required to approve — it overrides the AI's "
+                "denial."
+            )
         elif not await message_repository.is_open(case.id):
             error_message = "This appeal case is already closed."
         else:
@@ -1678,12 +1686,20 @@ async def appeal_case_approve_dialog(
                     reviewer_id=user_session.user.id,
                     decision=DecisionType.APPROVE,
                     review_context=ReviewContext.APPEAL,
-                    reason=reason,
+                    reason=internal_note,
+                )
+                await appeal_case_service.add_reply(
+                    session,
+                    case,
+                    author_kind=SupportCaseMessageAuthorKind.platform,
+                    author_user=user_session.user,
+                    body=internal_note,
+                    internal=True,
                 )
                 await organization_service.backoffice_approve(
                     session,
                     organization,
-                    reason=reason,
+                    reason=merchant_message,
                     internal_note="Appeal approved — see support case.",
                     staff_user=user_session.user,
                 )
@@ -1714,19 +1730,32 @@ async def appeal_case_approve_dialog(
                     text(error_message)
             with tag.p():
                 text(
-                    "Approving reactivates the organization and closes the "
-                    "support case. The merchant is notified of the decision."
+                    "Approving overrides the AI's denial, reactivates the "
+                    "organization and closes the support case. The merchant is "
+                    "notified of the decision."
                 )
             with tag.div(classes="form-control"):
                 with tag.label(classes="label"):
                     with tag.span(classes="label-text"):
-                        text("Reason (required, shared with the merchant)")
+                        text("Internal note (required, not shared with the merchant)")
                 with tag.textarea(
-                    name="reason",
+                    name="internal_note",
                     classes="textarea textarea-bordered w-full",
-                    placeholder="Why are you approving this appeal?",
+                    placeholder="Why are you overriding the AI's denial? "
+                    "Staff-only — recorded for future reviews.",
                     rows="3",
                     required=True,
+                ):
+                    pass
+            with tag.div(classes="form-control"):
+                with tag.label(classes="label"):
+                    with tag.span(classes="label-text"):
+                        text("Message to the merchant (optional, shared with them)")
+                with tag.textarea(
+                    name="merchant_message",
+                    classes="textarea textarea-bordered w-full",
+                    placeholder="Optional note included with the approval.",
+                    rows="3",
                 ):
                     pass
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):

--- a/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
@@ -172,8 +172,7 @@ class SupportCaseSection:
                 if self.dispute is not None:
                     self._render_dispute_details(request, self.dispute)
                 self._render_timeline(request, messages)
-                if is_open:
-                    self._render_composer(request, case)
+                self._render_composer(request, case, is_open)
             yield
 
     # -- Header -------------------------------------------------------------
@@ -559,14 +558,24 @@ class SupportCaseSection:
 
     # -- Composer -----------------------------------------------------------
 
-    def _render_composer(self, request: Request, case: SupportCase) -> None:
+    def _render_composer(
+        self, request: Request, case: SupportCase, is_open: bool
+    ) -> None:
         reply_url = self._with_return_to(
             str(request.url_for("support_cases:reply", case_id=case.id))
         )
-        # Disputes don't have a staff ↔ merchant reply channel yet, so the
-        # composer is internal-notes-only (the endpoint enforces this too).
-        internal_only = self._case_type == SupportCaseType.dispute
+        # The composer is internal-notes-only when there's no live merchant
+        # channel (the endpoint enforces this too): disputes have none yet, and a
+        # closed case only takes internal follow-ups after the decision.
+        internal_only = self._case_type == SupportCaseType.dispute or not is_open
         with tag.div(classes="mt-8 pt-6 border-t border-base-200"):
+            if not is_open:
+                with tag.div(
+                    classes="flex items-center gap-2 mb-3 text-sm text-base-content/60"
+                ):
+                    with tag.span(classes="icon-square"):
+                        pass
+                    text("This case is closed — only internal notes can be added.")
             with tag.form(hx_post=reply_url, classes="flex flex-col gap-3"):
                 with tag.textarea(
                     name="body",

--- a/server/polar/backoffice/support_cases/endpoints.py
+++ b/server/polar/backoffice/support_cases/endpoints.py
@@ -37,7 +37,6 @@ from ..dependencies import get_admin
 from ..layout import layout
 from ..organizations_v2.views.sections.support_case_section import SupportCaseSection
 from ..responses import HXRedirectResponse
-from ..toast import add_toast
 from .queries import TYPE_LABELS, Row, cases_statement
 from .urls import case_detail_url, is_safe_return_to
 
@@ -261,21 +260,26 @@ async def reply_case(
     user_session: UserSession = Depends(get_admin),
 ) -> HXRedirectResponse:
     """Post a staff reply (or internal note) to any case, then notify the
-    organization if it's merchant-visible."""
+    organization if it's merchant-visible. Internal notes are allowed on closed
+    cases too, so staff can keep following up after a decision."""
     case = await SupportCaseRepository.from_session(session).get_by_id(case_id)
     if case is None:
         raise HTTPException(status_code=404, detail="Support case not found")
 
     message_repository = SupportCaseMessageRepository.from_session(session)
-    if not await message_repository.is_open(case.id):
-        await add_toast(request, "This case is closed.", variant="error")
-        return _detail_redirect(request, case_id, return_to)
+    is_open = await message_repository.is_open(case.id)
 
     form_data = await request.form()
     body = str(form_data.get("body", "")).strip()
-    # Disputes have no staff ↔ merchant reply channel yet: staff messages are
-    # always internal notes, regardless of the (absent) composer toggle.
-    internal = bool(form_data.get("internal")) or case.type == SupportCaseType.dispute
+    # Force the message to be internal when there's no live merchant channel:
+    # disputes have no staff ↔ merchant reply channel yet, and a closed case is
+    # internal-notes-only (a merchant-facing message would email the merchant
+    # with no accessible thread to follow up in).
+    internal = (
+        bool(form_data.get("internal"))
+        or case.type == SupportCaseType.dispute
+        or not is_open
+    )
 
     if body:
         audience = [] if internal else [SupportCaseAudience.merchant]

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1223,7 +1223,7 @@ class OrganizationService:
         organization: Organization,
         next_review_threshold: int | None = None,
         *,
-        reason: str,
+        reason: str | None = None,
         internal_note: str | None = None,
         staff_user: User,
     ) -> Organization:
@@ -1241,6 +1241,11 @@ class OrganizationService:
         ``internal_note`` overrides the default reactivation note (and omits the
         reason line) so callers can record a context-specific note instead — the
         appeal flow points to the support case rather than repeating its reason.
+
+        ``reason`` is optional and, when set, becomes the merchant-facing body of
+        the appeal decision message on the support case. The appeal flow keeps it
+        optional (the staff-facing override reason is recorded separately); the
+        org-level reactivation passes its required override reason through here.
         """
         notes = {
             OrganizationStatus.DENIED: "Organization reactivated from denied.",


### PR DESCRIPTION
## Summary

UX improvements asked by the team

https://github.com/user-attachments/assets/0b387f60-77f7-4111-8cab-4220b6b4bd63


## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds internal notes on closed support cases and requires an internal note to approve an appeal, creating a clearer audit trail and avoiding merchant pings on closed threads.

- **New Features**
  - Appeal approval: internal note is required (staff-only); optional merchant message; internal note is recorded on the case; service allows optional `reason`; modal copy updated to reflect overriding the AI.
  - Closed cases: staff can post internal notes; composer forces internal-only for disputes and closed cases and shows a “case is closed” hint; endpoint enforces internal messages in these states.

<sup>Written for commit 3dccff9f6c21b8c034995027284b42970d8f2318. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

