### PR TITLE
tf: create a dedicated Redis for sandbox

### DIFF
--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -378,11 +378,22 @@ resource "render_web_service" "worker" {
 
   custom_domains = length(each.value.custom_domains) > 0 ? each.value.custom_domains : null
 
-  env_vars = {
-    SERVICE_NAME             = { value = each.key }
-    dramatiq_prom_port       = { value = each.value.dramatiq_prom_port }
-    POLAR_DATABASE_POOL_SIZE = { value = each.value.database_pool_size }
-  }
+  env_vars = merge(
+    {
+      SERVICE_NAME             = { value = each.key }
+      dramatiq_prom_port       = { value = each.value.dramatiq_prom_port }
+      POLAR_DATABASE_POOL_SIZE = { value = each.value.database_pool_size }
+    },
+    each.value.redis_host != null ? {
+      POLAR_REDIS_HOST = { value = each.value.redis_host }
+    } : {},
+    each.value.redis_port != null ? {
+      POLAR_REDIS_PORT = { value = each.value.redis_port }
+    } : {},
+    each.value.redis_db != null ? {
+      POLAR_REDIS_DB = { value = each.value.redis_db }
+    } : {}
+  )
 }
 
 resource "render_cron_job" "cron" {

--- a/terraform/modules/render_service/variables.tf
+++ b/terraform/modules/render_service/variables.tf
@@ -49,6 +49,9 @@ variable "workers" {
     plan               = optional(string, "pro")
     num_instances      = optional(number, 1)
     database_pool_size = optional(string, "5")
+    redis_host         = optional(string)
+    redis_port         = optional(string)
+    redis_db           = optional(string)
   }))
 }
 

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -63,7 +63,7 @@ module "dummy_lambda_worker" {
     POLAR_POSTGRES_SSL            = "true"
     POLAR_REDIS_HOST              = module.redis.host
     POLAR_REDIS_PORT              = tostring(module.redis.port)
-    POLAR_REDIS_DB                = "1"
+    POLAR_REDIS_DB                = "0"
     POLAR_AWS_REGION              = "us-east-2"
     POLAR_WORKER_SQS_ENABLED      = "true"
     POLAR_WORKER_SQS_QUEUE_PREFIX = "polar-sandbox-tasks"

--- a/terraform/sandbox/outputs.tf
+++ b/terraform/sandbox/outputs.tf
@@ -17,3 +17,8 @@ output "egress_ip" {
   description = "Static NAT egress IP for the sandbox VPC. Add this (as a /32) to the database IP allow list."
   value       = module.egress_ip.public_ip
 }
+
+output "redis_sandbox_id" {
+  description = "The sandbox Redis ID. Used for the render_redis data source."
+  value       = render_redis.redis_sandbox.id
+}

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -28,6 +28,23 @@ data "render_redis" "redis" {
 }
 
 # =============================================================================
+# Sandbox Redis Instance
+# =============================================================================
+
+resource "render_redis" "redis_sandbox" {
+  environment_id    = data.tfe_outputs.production.values.sandbox_environment_id
+  name              = "redis-sandbox"
+  plan              = "standard"
+  region            = "ohio"
+  max_memory_policy = "noeviction"
+
+  # Empty IP allow list means only private network connections
+  ip_allow_list = []
+
+  depends_on = [render_registry_credential.ghcr]
+}
+
+# =============================================================================
 # Locals
 # =============================================================================
 
@@ -45,8 +62,12 @@ locals {
   read_replica = [for r in data.render_postgres.db.read_replicas : r if r.name == "polar-read"][0]
 
   # Redis connection info
-  redis_host = data.render_redis.redis.id
+  redis_host = render_redis.redis_sandbox.id
   redis_port = "6379"
+
+  # Production Redis connection info - for the drain worker
+  production_redis_host = data.render_redis.redis.id
+  production_redis_port = "6379"
 }
 
 # =============================================================================
@@ -106,7 +127,7 @@ module "sandbox" {
     database_pool_size     = "10"
     postgres_database      = "polar_sandbox"
     postgres_read_database = "polar_sandbox"
-    redis_db               = "1"
+    redis_db               = "0"
     plan                   = "pro"
   }
 
@@ -128,6 +149,17 @@ module "sandbox" {
       start_command      = "uv run dramatiq polar.worker.run -p 1 -t 3 --queues invoices_and_receipts"
       plan               = "standard"
       dramatiq_prom_port = "10003"
+    }
+
+    # Temporary drain worker - listens to ALL queues on production Redis
+    # This allows draining in-flight tasks from the current shared Redis
+    worker-sandbox-drain = {
+      start_command      = "uv run dramatiq polar.worker.run -p 2 -t 4 --queues high_priority,medium_priority,low_priority,webhooks,tinybird,invoices_and_receipts"
+      dramatiq_prom_port = "10004"
+      plan               = "standard"
+      redis_host         = local.production_redis_host
+      redis_port         = local.production_redis_port
+      redis_db           = "1"
     }
   }
 
@@ -266,7 +298,7 @@ module "sandbox" {
     workspace           = var.tinybird_workspace
   }
 
-  depends_on = [render_registry_credential.ghcr, data.render_postgres.db, data.render_redis.redis]
+  depends_on = [render_registry_credential.ghcr, data.render_postgres.db, data.render_redis.redis, render_redis.redis_sandbox]
 }
 
 # =============================================================================


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Provision a dedicated Redis for the sandbox on Render and point sandbox workers to it, isolating sandbox queues from production. Adds a temporary drain worker to read from the old shared Redis for a clean cutover.

- **New Features**
  - Create `render_redis.redis_sandbox` (`redis-sandbox`, standard, Ohio) with private networking only.
  - Wire sandbox services to the new Redis via `POLAR_REDIS_HOST`, `POLAR_REDIS_PORT`, `POLAR_REDIS_DB` (DB set to `0`), and expose `redis_sandbox_id`.
  - `render_service` module now supports per-worker `redis_host`, `redis_port`, and `redis_db` env vars.

- **Migration**
  - Add `worker-sandbox-drain` to consume from production Redis (`DB 1`) and drain in-flight tasks; remove once queues are empty.

<sup>Written for commit c7b3772356210d777a2ffb8fbbe4e82fa38877f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

