### PR TITLE
tf: add a sandbox Redis

### DIFF
--- a/terraform/sandbox/outputs.tf
+++ b/terraform/sandbox/outputs.tf
@@ -17,3 +17,8 @@ output "egress_ip" {
   description = "Static NAT egress IP for the sandbox VPC. Add this (as a /32) to the database IP allow list."
   value       = module.egress_ip.public_ip
 }
+
+output "redis_sandbox_id" {
+  description = "The sandbox Redis ID. Used for the render_redis data source."
+  value       = render_redis.redis_sandbox.id
+}

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -28,6 +28,23 @@ data "render_redis" "redis" {
 }
 
 # =============================================================================
+# Sandbox Redis Instance
+# =============================================================================
+
+resource "render_redis" "redis_sandbox" {
+  environment_id    = data.tfe_outputs.production.values.sandbox_environment_id
+  name              = "redis-sandbox"
+  plan              = "standard"
+  region            = "ohio"
+  max_memory_policy = "noeviction"
+
+  # Empty IP allow list means only private network connections
+  ip_allow_list = []
+
+  depends_on = [render_registry_credential.ghcr]
+}
+
+# =============================================================================
 # Locals
 # =============================================================================
 


### PR DESCRIPTION
- tf: add a sandbox Redis

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Provisioned a dedicated Redis instance for the sandbox environment and exposed its ID as a Terraform output. This gives sandbox services a private, isolated cache.

- **New Features**
  - Added `render_redis.redis_sandbox` (plan `standard`, region `ohio`, `max_memory_policy` `noeviction`).
  - Limited access to private network only (`ip_allow_list = []`).
  - Exported `redis_sandbox_id` for use with the `render_redis` data source.

<sup>Written for commit 945989de2a51b06b793a8a65088098879bb9e17f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

