### PR TITLE
Make auto reply messages ignore unread in backoffice

### DIFF
--- a/server/polar/organization_review/tasks.py
+++ b/server/polar/organization_review/tasks.py
@@ -395,14 +395,20 @@ async def post_appeal_greeting(case_id: uuid.UUID) -> None:
         existing = await message_repository.list_by_case(case_id, visible_to=None)
         if any(
             message.author_kind == SupportCaseMessageAuthorKind.platform
+            or (
+                message.author_kind == SupportCaseMessageAuthorKind.system
+                and message.audience
+            )
             for message in existing
         ):
             return
 
+        # Posted as `system`: an automated greeting isn't a human reply, so it
+        # must not clear the "awaiting platform reply" signal in the backoffice.
         await support_case_service.post_message(
             session,
             case,
-            author_kind=SupportCaseMessageAuthorKind.platform,
+            author_kind=SupportCaseMessageAuthorKind.system,
             body=HUMAN_REVIEW_GREETING,
             audience=[SupportCaseAudience.merchant],
         )

--- a/server/polar/support_case/repository.py
+++ b/server/polar/support_case/repository.py
@@ -108,12 +108,15 @@ class SupportCaseMessageRepository(
         Defined by exclusion (not ``platform``/``system``) so it stays correct
         for any participant kind. Internal notes and lifecycle events (empty
         audience) are ignored, so they don't clear it.
+
+        ``system`` messages are excluded entirely since they're automated.
         """
         latest_author = (
             select(SupportCaseMessage.author_kind)
             .where(
                 SupportCaseMessage.case_id == SupportCase.id,
                 func.cardinality(SupportCaseMessage.audience) > 0,
+                SupportCaseMessage.author_kind != SupportCaseMessageAuthorKind.system,
             )
             .order_by(SupportCaseMessage.created_at.desc())
             .limit(1)

--- a/server/tests/backoffice/support_cases/test_queries.py
+++ b/server/tests/backoffice/support_cases/test_queries.py
@@ -1,6 +1,8 @@
 """Tests for the shared backoffice support-case list query — the polymorphic
 join that resolves an organization for both appeal and dispute cases."""
 
+from datetime import UTC, datetime
+
 import pytest
 
 from polar.backoffice.support_cases.queries import (
@@ -202,3 +204,57 @@ class TestOpenCaseOrganizationIds:
             )
         )
         assert organization.id in set(result.scalars().all())
+
+    async def test_system_message_does_not_clear_awaiting(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        case = await _dispute_case(save_fixture, organization, customer, product)
+
+        await save_fixture(
+            SupportCaseMessage(
+                case=case,
+                type=SupportCaseMessageType.chat,
+                author_kind=SupportCaseMessageAuthorKind.merchant,
+                body="Here is my evidence.",
+                audience=[SupportCaseAudience.merchant],
+                created_at=datetime(2026, 6, 23, 12, 0, tzinfo=UTC),
+            )
+        )
+        await save_fixture(
+            SupportCaseMessage(
+                case=case,
+                type=SupportCaseMessageType.chat,
+                author_kind=SupportCaseMessageAuthorKind.system,
+                body="Thanks for reaching out!",
+                audience=[SupportCaseAudience.merchant],
+                created_at=datetime(2026, 6, 23, 12, 1, tzinfo=UTC),
+            )
+        )
+        result = await session.execute(
+            open_case_organization_ids(
+                organization_ids=[organization.id], awaiting_reply=True
+            )
+        )
+        assert organization.id in set(result.scalars().all())
+
+        await save_fixture(
+            SupportCaseMessage(
+                case=case,
+                type=SupportCaseMessageType.chat,
+                author_kind=SupportCaseMessageAuthorKind.platform,
+                body="We've responded.",
+                audience=[SupportCaseAudience.merchant],
+                created_at=datetime(2026, 6, 23, 12, 2, tzinfo=UTC),
+            )
+        )
+        result = await session.execute(
+            open_case_organization_ids(
+                organization_ids=[organization.id], awaiting_reply=True
+            )
+        )
+        assert organization.id not in set(result.scalars().all())

--- a/server/tests/organization_review/test_appeal_case.py
+++ b/server/tests/organization_review/test_appeal_case.py
@@ -353,14 +353,14 @@ class TestPostAppealGreeting:
 
         message_repository = SupportCaseMessageRepository.from_session(session)
         messages = await message_repository.list_by_case(case.id)
-        platform = [
+        greeting = [
             message
             for message in messages
-            if message.author_kind == SupportCaseMessageAuthorKind.platform
+            if message.author_kind == SupportCaseMessageAuthorKind.system
             and message.type == SupportCaseMessageType.chat
         ]
-        assert len(platform) == 1
-        assert platform[0].body == HUMAN_REVIEW_GREETING
+        assert len(greeting) == 1
+        assert greeting[0].body == HUMAN_REVIEW_GREETING
         publish_mock.assert_called_once_with(case.organization_id)
 
     async def test_idempotent(
@@ -390,9 +390,10 @@ class TestPostAppealGreeting:
 
         message_repository = SupportCaseMessageRepository.from_session(session)
         messages = await message_repository.list_by_case(case.id)
-        platform = [
+        greeting = [
             message
             for message in messages
-            if message.author_kind == SupportCaseMessageAuthorKind.platform
+            if message.author_kind == SupportCaseMessageAuthorKind.system
+            and message.type == SupportCaseMessageType.chat
         ]
-        assert len(platform) == 1
+        assert len(greeting) == 1


### PR DESCRIPTION
## Summary

We've added an auto reply to the first appeal message, telling the user we will respond in 1-2 business days. However this meant that we no longer have an `Awaiting reply` state in Backoffice, since we've technically have replied (but automatically). This makes it hard for support to know which tickets they are needed in.

## Screenshot

<img width="1725" height="997" alt="Monosnap Cases · Polar Backoffice 2026-06-23 13-39-53" src="https://github.com/user-attachments/assets/7c8a2c61-6769-47b7-8767-974b9c7c9397" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

