### PR TITLE
tf: add drain worker in sandbox

### DIFF
--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -146,6 +146,14 @@ module "sandbox" {
       plan               = "standard"
       dramatiq_prom_port = "10003"
     }
+
+    # Temporary drain worker - listens to ALL queues on production Redis
+    # This allows draining in-flight tasks from the current shared Redis
+    worker-sandbox-drain = {
+      start_command      = "uv run dramatiq polar.worker.run -p 2 -t 4 --queues high_priority,medium_priority,low_priority,webhooks,tinybird,invoices_and_receipts"
+      dramatiq_prom_port = "10004"
+      plan               = "standard"
+    }
   }
 
   google_secrets = {


### PR DESCRIPTION

Listen to all queues. **No change** on the existing workers, they'll all start to work together on executing tasks.

In the next PR, we'll switch API/workers to the new Redis while maintaining the drain worker on the production Redis.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

