### PR TITLE
tf: wire sandbox workers to their dedicated Redis instance

### DIFF
--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -378,11 +378,18 @@ resource "render_web_service" "worker" {
 
   custom_domains = length(each.value.custom_domains) > 0 ? each.value.custom_domains : null
 
-  env_vars = {
-    SERVICE_NAME             = { value = each.key }
-    dramatiq_prom_port       = { value = each.value.dramatiq_prom_port }
-    POLAR_DATABASE_POOL_SIZE = { value = each.value.database_pool_size }
-  }
+  env_vars = merge(
+    {
+      SERVICE_NAME             = { value = each.key }
+      dramatiq_prom_port       = { value = each.value.dramatiq_prom_port }
+      POLAR_DATABASE_POOL_SIZE = { value = each.value.database_pool_size }
+    },
+    (each.value.redis_host != null && each.value.redis_port != null && each.value.redis_db) ? {
+      POLAR_REDIS_HOST = { value = each.value.redis_host }
+      POLAR_REDIS_PORT = { value = each.value.redis_port }
+      POLAR_REDIS_DB   = { value = each.value.redis_db }
+    } : {}
+  )
 }
 
 resource "render_cron_job" "cron" {

--- a/terraform/modules/render_service/variables.tf
+++ b/terraform/modules/render_service/variables.tf
@@ -49,6 +49,9 @@ variable "workers" {
     plan               = optional(string, "pro")
     num_instances      = optional(number, 1)
     database_pool_size = optional(string, "5")
+    redis_host         = optional(string)
+    redis_port         = optional(string)
+    redis_db           = optional(string)
   }))
 }
 

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -62,8 +62,12 @@ locals {
   read_replica = [for r in data.render_postgres.db.read_replicas : r if r.name == "polar-read"][0]
 
   # Redis connection info
-  redis_host = data.render_redis.redis.id
+  redis_host = render_redis.redis_sandbox.id
   redis_port = "6379"
+
+  # Production Redis connection info - for the drain worker
+  production_redis_host = data.render_redis.redis.id
+  production_redis_port = "6379"
 }
 
 # =============================================================================
@@ -153,6 +157,9 @@ module "sandbox" {
       start_command      = "uv run dramatiq polar.worker.run -p 2 -t 4 --queues high_priority,medium_priority,low_priority,webhooks,tinybird,invoices_and_receipts"
       dramatiq_prom_port = "10004"
       plan               = "standard"
+      redis_host         = local.production_redis_host
+      redis_port         = local.production_redis_port
+      redis_db           = "1"
     }
   }
 
@@ -291,7 +298,7 @@ module "sandbox" {
     workspace           = var.tinybird_workspace
   }
 
-  depends_on = [render_registry_credential.ghcr, data.render_postgres.db, data.render_redis.redis]
+  depends_on = [render_registry_credential.ghcr, data.render_postgres.db, data.render_redis.redis, render_redis.redis_sandbox]
 }
 
 # =============================================================================


### PR DESCRIPTION

That's the touchy one :D Services will now be wired to the sandbox Redis instance. The drain worker has an overload config so it's able to drain in-flight tasks from the production Redis instance.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

