### PR TITLE
tf: fix sandbox drain worker command

### DIFF
--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -154,7 +154,7 @@ module "sandbox" {
     # Temporary drain worker - listens to ALL queues on production Redis
     # This allows draining in-flight tasks from the current shared Redis
     worker-sandbox-drain = {
-      start_command      = "uv run dramatiq polar.worker.run -p 2 -t 4 --queues high_priority,medium_priority,low_priority,webhooks,tinybird,invoices_and_receipts"
+      start_command      = "uv run dramatiq polar.worker.run -p 2 -t 4 --queues high_priority medium_priority low_priority webhooks tinybird invoices_and_receipts"
       dramatiq_prom_port = "10004"
       plan               = "standard"
       redis_host         = local.production_redis_host


### PR DESCRIPTION

It would have been too good to get it right on first attempt (applied the change manually on Render already, confirmed it works)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the sandbox drain worker start command to pass queues as space-separated args to `dramatiq` via `uv`, so it drains in-flight tasks from production Redis as intended. Changed `--queues` from comma-separated to space-separated to match `dramatiq` CLI expectations.

<sup>Written for commit 5e14bd2b38854a2930e93e3fa616d41b3ae93f7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

