### PR TITLE
Mark disputes/appeals as read in Backoffice

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
@@ -415,7 +415,7 @@ class SupportCaseSection:
             ):
                 pass
             with tag.div(
-                classes="grid grid-cols-[minmax(0,15rem)_minmax(0,1fr)] gap-x-6 gap-y-5"
+                classes="grid grid-cols-[minmax(0,15rem)_minmax(0,1fr)] gap-x-6 gap-y-10"
             ):
                 for message in messages:
                     self._render_entry(request, message)
@@ -503,7 +503,7 @@ class SupportCaseSection:
             if message.body:
                 with tag.div(classes=f"flex {justify}"):
                     with tag.div(
-                        classes=f"max-w-md text-sm whitespace-pre-wrap {self._bubble(message, internal)}"
+                        classes=f"max-w-md text-sm leading-relaxed whitespace-pre-wrap p-3 rounded-s {self._bubble(message, internal)}"
                     ):
                         text(message.body)
             for attachment in attachments:
@@ -545,16 +545,16 @@ class SupportCaseSection:
     def _bubble(self, message: SupportCaseMessage, internal: bool) -> str:
         if internal:
             return (
-                "bg-warning/10 border-l-2 border-warning rounded-lg px-3 py-2 "
+                "bg-warning/10 border-l-2 border-warning rounded-2xl px-5 py-3.5 "
                 "text-base-content/80"
             )
         if message.type == SupportCaseMessageType.appeal_approved:
-            return "bg-success/10 rounded-xl px-4 py-2.5"
+            return "bg-success/10 rounded-2xl px-5 py-3.5"
         if message.type == SupportCaseMessageType.appeal_denied:
-            return "bg-error/10 rounded-xl px-4 py-2.5"
+            return "bg-error/10 rounded-2xl px-5 py-3.5"
         if message.author_kind == SupportCaseMessageAuthorKind.merchant:
-            return "bg-info/10 rounded-2xl rounded-tr-md px-4 py-2.5"
-        return "bg-base-200 rounded-2xl rounded-tl-md px-4 py-2.5"
+            return "bg-info/10 rounded-2xl px-5 py-3.5"
+        return "bg-base-200 rounded-2xl px-5 py-3.5"
 
     # -- Composer -----------------------------------------------------------
 

--- a/server/polar/backoffice/organizations_v2/views/sections/support_cases_list_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/support_cases_list_section.py
@@ -55,6 +55,7 @@ class SupportCasesListSection:
                         is_open,
                         assignee_email,
                         awaiting_platform,
+                        _unread,
                     ) in self.rows:
                         case_url = case_detail_url(
                             request, case.id, return_to=return_to

--- a/server/polar/backoffice/support_cases/endpoints.py
+++ b/server/polar/backoffice/support_cases/endpoints.py
@@ -155,7 +155,8 @@ def _render_table(request: Request, rows: Sequence[Row], sort: str) -> None:
                     organization,
                     is_open,
                     assignee_email,
-                    awaiting_platform,
+                    _awaiting_platform,
+                    unread,
                 ) in rows:
                     case_url = str(
                         request.url_for("support_cases:detail", case_id=case.id)
@@ -165,7 +166,10 @@ def _render_table(request: Request, rows: Sequence[Row], sort: str) -> None:
                         _=f"on click set window.location to '{case_url}'",
                     ):
                         with tag.td():
-                            with tag.a(href=case_url, classes="link"):
+                            link_classes = "no-underline"
+                            if unread:
+                                link_classes += " font-semibold"
+                            with tag.a(href=case_url, classes=link_classes):
                                 text(organization.name)
                         with tag.td():
                             support_tier_badge(organization.support_tier)
@@ -174,10 +178,10 @@ def _render_table(request: Request, rows: Sequence[Row], sort: str) -> None:
                         with tag.td():
                             with tag.div(classes="flex items-center gap-2"):
                                 _status_badge(is_open)
-                                if awaiting_platform:
+                                if unread:
                                     with tag.span(
                                         classes="tooltip text-warning",
-                                        data_tip="Awaiting reply",
+                                        data_tip="Unread",
                                     ):
                                         text("●")
                         with tag.td():
@@ -326,10 +330,12 @@ async def case_detail(
     request: Request,
     case_id: UUID4,
     return_to: Annotated[str | None, Query()] = None,
-    session: AsyncSession = Depends(get_db_read_session),
+    session: AsyncSession = Depends(get_db_session),
     user_session: UserSession = Depends(get_admin),
 ) -> None:
     case, organization = await _load_case_and_organization(session, case_id)
+
+    await support_case_service.mark_read(session, case, user=user_session.user)
 
     message_repository = SupportCaseMessageRepository.from_session(session)
     is_open = await message_repository.is_open(case.id)
@@ -411,6 +417,7 @@ async def list_cases(
         status=status,
         assigned=assigned,
         assigned_user_id=user_session.user_id,
+        viewer_user_id=user_session.user_id,
         case_type=type,
         sort=sort,
     )

--- a/server/polar/backoffice/support_cases/queries.py
+++ b/server/polar/backoffice/support_cases/queries.py
@@ -9,7 +9,7 @@ from collections.abc import Sequence
 from typing import Any, cast
 from uuid import UUID
 
-from sqlalchemy import Select, func, select
+from sqlalchemy import Select, and_, func, or_, select
 
 from polar.models import Dispute, Order, Organization, User
 from polar.models.organization_review import OrganizationReview
@@ -17,12 +17,16 @@ from polar.models.support_case import (
     DisputeSupportCase,
     ReviewAppealSupportCase,
     SupportCase,
+    SupportCaseMessage,
+    SupportCaseMessageType,
+    SupportCaseParticipant,
+    SupportCaseParticipantKind,
     SupportCaseType,
 )
 from polar.support_case.repository import SupportCaseMessageRepository
 
-# (case, organization, is_open, assignee_email, awaiting_platform)
-Row = tuple[SupportCase, Organization, bool, str | None, bool]
+# (case, organization, is_open, assignee_email, awaiting_platform, unread)
+Row = tuple[SupportCase, Organization, bool, str | None, bool, bool]
 
 # Human-readable label per case type, shared by every case list.
 TYPE_LABELS: dict[SupportCaseType, str] = {
@@ -39,6 +43,7 @@ def cases_statement(
     status: str = "all",
     assigned: str = "all",
     assigned_user_id: UUID | None = None,
+    viewer_user_id: UUID | None = None,
     case_type: str = "all",
     sort: str = "recency",
 ) -> Select[Row]:
@@ -50,6 +55,35 @@ def cases_statement(
     """
     is_open = SupportCaseMessageRepository.is_open_expression()
     awaiting_platform = SupportCaseMessageRepository.awaiting_platform_expression()
+
+    latest_activity = (
+        select(func.max(SupportCaseMessage.created_at))
+        .where(
+            SupportCaseMessage.case_id == SupportCase.id,
+            SupportCaseMessage.type.notin_(
+                [
+                    SupportCaseMessageType.assigned,
+                    SupportCaseMessageType.released,
+                ]
+            ),
+        )
+        .scalar_subquery()
+    )
+    viewer_read_at = (
+        select(SupportCaseParticipant.last_read_at)
+        .where(
+            SupportCaseParticipant.case_id == SupportCase.id,
+            SupportCaseParticipant.kind == SupportCaseParticipantKind.platform,
+            SupportCaseParticipant.platform_user_id == viewer_user_id,
+            SupportCaseParticipant.deleted_at.is_(None),
+        )
+        .scalar_subquery()
+    )
+    unread = and_(
+        latest_activity.isnot(None),
+        or_(viewer_read_at.is_(None), viewer_read_at < latest_activity),
+    )
+
     statement = (
         select(
             SupportCase,
@@ -57,6 +91,7 @@ def cases_statement(
             is_open.label("is_open"),
             User.email.label("assignee_email"),
             awaiting_platform.label("awaiting_platform"),
+            unread.label("unread"),
         )
         .outerjoin(
             OrganizationReview,

--- a/server/polar/models/support_case.py
+++ b/server/polar/models/support_case.py
@@ -280,9 +280,6 @@ class SupportCaseParticipant(RecordModel):
         nullable=True,
         default=None,
     )
-    # UNUSED: never written or read yet. Reserved for per-participant unread
-    # state; the backoffice "awaiting reply" dot is derived from message order
-    # instead. Drop this column if no upcoming case feature claims it.
     last_read_at: Mapped[datetime | None] = mapped_column(
         TIMESTAMP(timezone=True), nullable=True, default=None
     )

--- a/server/polar/support_case/repository.py
+++ b/server/polar/support_case/repository.py
@@ -1,7 +1,9 @@
 from collections.abc import Sequence
+from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import ColumnElement, func, select
+from sqlalchemy import ColumnElement, func, select, text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import joinedload
 
 from polar.kit.repository.base import (
@@ -19,6 +21,7 @@ from polar.models.support_case import (
     SupportCaseMessageAuthorKind,
     SupportCaseMessageType,
     SupportCaseParticipant,
+    SupportCaseParticipantKind,
 )
 
 # Message types whose latest occurrence determines the open/closed state.
@@ -133,6 +136,35 @@ class SupportCaseParticipantRepository(
     RepositoryBase[SupportCaseParticipant],
 ):
     model = SupportCaseParticipant
+
+    async def upsert_platform_read(
+        self, case_id: UUID, user_id: UUID, *, read_at: datetime
+    ) -> SupportCaseParticipant:
+        """Atomically stamp a staff member's read state for a case.
+
+        Inserts the platform participant or, if one already exists, bumps its
+        ``last_read_at``. A single ``INSERT ... ON CONFLICT DO UPDATE`` so that
+        concurrent first reads (two tabs, a double-click) can't race the partial
+        unique ``(case_id, platform_user_id)`` index into an error.
+        """
+        statement = (
+            pg_insert(SupportCaseParticipant)
+            .values(
+                case_id=case_id,
+                kind=SupportCaseParticipantKind.platform,
+                platform_user_id=user_id,
+                last_read_at=read_at,
+            )
+            .on_conflict_do_update(
+                index_elements=["case_id", "platform_user_id"],
+                index_where=text("platform_user_id IS NOT NULL AND deleted_at IS NULL"),
+                set_={"last_read_at": read_at},
+            )
+            .returning(SupportCaseParticipant)
+            .execution_options(populate_existing=True)
+        )
+        result = await self.session.execute(statement)
+        return result.scalars().one()
 
 
 class SupportCaseAttachmentRepository(

--- a/server/polar/support_case/service.py
+++ b/server/polar/support_case/service.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from datetime import UTC, datetime
 
 from polar.models import Customer, File, Organization, User
 from polar.models.support_case import (
@@ -43,6 +44,20 @@ class SupportCaseService:
             audience=audience,
         )
         return case
+
+    async def mark_read(
+        self, session: AsyncSession, case: SupportCase, *, user: User
+    ) -> SupportCaseParticipant:
+        """Record that a staff member has read the case up to now.
+
+        Upserts the staff member's ``platform`` participant and stamps
+        ``last_read_at``. Per-staff: each viewer tracks their own read state,
+        and the latest reader across staff is shown in the list.
+        """
+        repository = SupportCaseParticipantRepository.from_session(session)
+        return await repository.upsert_platform_read(
+            case.id, user.id, read_at=datetime.now(UTC)
+        )
 
     async def add_participant(
         self,

--- a/server/tests/backoffice/support_cases/test_queries.py
+++ b/server/tests/backoffice/support_cases/test_queries.py
@@ -1,6 +1,9 @@
 """Tests for the shared backoffice support-case list query — the polymorphic
 join that resolves an organization for both appeal and dispute cases."""
 
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
 import pytest
 
 from polar.backoffice.support_cases.queries import (
@@ -8,7 +11,7 @@ from polar.backoffice.support_cases.queries import (
     cases_statement,
     open_case_organization_ids,
 )
-from polar.models import Customer, Organization, OrganizationReview, Product
+from polar.models import Customer, Organization, OrganizationReview, Product, User
 from polar.models.support_case import (
     DisputeSupportCase,
     ReviewAppealSupportCase,
@@ -17,6 +20,8 @@ from polar.models.support_case import (
     SupportCaseMessage,
     SupportCaseMessageAuthorKind,
     SupportCaseMessageType,
+    SupportCaseParticipant,
+    SupportCaseParticipantKind,
     SupportCaseType,
 )
 from polar.postgres import AsyncSession
@@ -98,7 +103,7 @@ class TestCasesStatement:
         assert appeal.id in by_id
         assert dispute.id in by_id
         # Each row resolves to the owning organization, regardless of type.
-        for case, org, is_open, _assignee, _awaiting in rows:
+        for case, org, is_open, *_rest in rows:
             assert org.id == organization.id
             assert is_open is True
         assert by_id[appeal.id][0].type == SupportCaseType.review_appeal
@@ -148,6 +153,70 @@ class TestCasesStatement:
 
         assert dispute.id not in [row[0].id for row in open_rows]
         assert dispute.id in [row[0].id for row in closed_rows]
+
+    async def test_unread_per_viewer(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+        user: User,
+    ) -> None:
+        case = await _dispute_case(save_fixture, organization, customer, product)
+        base = datetime.now(UTC)
+        await save_fixture(
+            SupportCaseMessage(
+                case=case,
+                type=SupportCaseMessageType.chat,
+                author_kind=SupportCaseMessageAuthorKind.merchant,
+                body="Here is my evidence.",
+                audience=[SupportCaseAudience.merchant],
+                created_at=base + timedelta(minutes=1),
+            )
+        )
+
+        rows = await _rows(
+            session, organization_id=organization.id, viewer_user_id=user.id
+        )
+        *_, unread = rows[0]
+        assert unread is True
+
+        await save_fixture(
+            SupportCaseParticipant(
+                case=case,
+                kind=SupportCaseParticipantKind.platform,
+                platform_user=user,
+                last_read_at=base + timedelta(minutes=2),
+            )
+        )
+        rows = await _rows(
+            session, organization_id=organization.id, viewer_user_id=user.id
+        )
+        *_, unread = rows[0]
+        assert unread is False
+
+        rows = await _rows(
+            session, organization_id=organization.id, viewer_user_id=uuid4()
+        )
+        *_, unread = rows[0]
+        assert unread is True
+
+        await save_fixture(
+            SupportCaseMessage(
+                case=case,
+                type=SupportCaseMessageType.chat,
+                author_kind=SupportCaseMessageAuthorKind.merchant,
+                body="Any update?",
+                audience=[SupportCaseAudience.merchant],
+                created_at=base + timedelta(minutes=3),
+            )
+        )
+        rows = await _rows(
+            session, organization_id=organization.id, viewer_user_id=user.id
+        )
+        *_, unread = rows[0]
+        assert unread is True
 
 
 @pytest.mark.asyncio

--- a/server/tests/support_case/test_service.py
+++ b/server/tests/support_case/test_service.py
@@ -1,8 +1,14 @@
 import pytest
 
 from polar.models import Organization, OrganizationReview, User
-from polar.models.support_case import ReviewAppealSupportCase, SupportCaseMessageType
+from polar.models.support_case import (
+    ReviewAppealSupportCase,
+    SupportCaseMessageType,
+    SupportCaseParticipant,
+    SupportCaseParticipantKind,
+)
 from polar.postgres import AsyncSession
+from polar.support_case.repository import SupportCaseParticipantRepository
 from polar.support_case.service import support_case as support_case_service
 from tests.fixtures.database import SaveFixture
 
@@ -48,3 +54,32 @@ class TestAssignment:
         assert case.assigned_user_id is None
         assert released.type == SupportCaseMessageType.released
         assert released.audience == []
+
+
+@pytest.mark.asyncio
+class TestMarkRead:
+    async def test_creates_then_updates_participant(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        case = await _case(save_fixture, organization)
+
+        first = await support_case_service.mark_read(session, case, user=user)
+        assert first.kind == SupportCaseParticipantKind.platform
+        assert first.platform_user_id == user.id
+        assert first.last_read_at is not None
+
+        second = await support_case_service.mark_read(session, case, user=user)
+        assert second.id == first.id
+        assert second.last_read_at is not None
+        assert second.last_read_at >= first.last_read_at
+
+        repository = SupportCaseParticipantRepository.from_session(session)
+        statement = repository.get_base_statement().where(
+            SupportCaseParticipant.case_id == case.id,
+            SupportCaseParticipant.kind == SupportCaseParticipantKind.platform,
+        )
+        assert len(await repository.get_all(statement)) == 1


### PR DESCRIPTION
## Summary

We've added an auto reply to the first appeal message, telling the user we will respond in 1-2 business days. However this meant that we no longer have an `Awaiting reply` state in Backoffice, since we've technically have replied (but automatically). This makes it hard for support to know which tickets they are needed in.

This PR fixes that by leveraging the `last_read_at` column and the new `mark_read` method

## Screenshot

<img width="1725" height="997" alt="Monosnap Cases · Polar Backoffice 2026-06-23 13-39-53" src="https://github.com/user-attachments/assets/7c8a2c61-6769-47b7-8767-974b9c7c9397" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

