### PR TITLE
fix(dashboard): Sync subscription status colors across the dashboard

### DIFF
--- a/clients/apps/web/src/components/Customer/CustomerContextView.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerContextView.tsx
@@ -14,6 +14,7 @@ import Link from 'next/link'
 import { DetailRow } from '../Shared/DetailRow'
 import { useSubscriptions } from '@/hooks/queries'
 import { PropsWithChildren } from 'react'
+import { getSubscriptionStatusBorderColor } from '../Subscriptions/utils'
 
 interface CustomerContextViewProps {
   organization: schemas['Organization']
@@ -181,16 +182,6 @@ const STATUS_ORDER: Record<schemas['SubscriptionStatus'], number> = {
   incomplete_expired: 6,
 }
 
-const STATUS_COLORS: Record<schemas['SubscriptionStatus'], string> = {
-  active: 'border-green-500',
-  trialing: 'border-blue-500',
-  past_due: 'border-yellow-500',
-  unpaid: 'border-orange-500',
-  canceled: 'border-red-500',
-  incomplete: 'dark:border-polar-500 border-gray-500',
-  incomplete_expired: 'dark:border-polar-500 border-gray-500',
-}
-
 const INTERVAL_LABELS: Record<
   schemas['SubscriptionRecurringInterval'],
   string
@@ -218,10 +209,10 @@ const SubscriptionRow = ({
   subscription,
   organization,
 }: SubscriptionRowProps) => {
-  const statusColor =
-    subscription.cancel_at_period_end && subscription.status === 'active'
-      ? 'border-yellow-500'
-      : STATUS_COLORS[subscription.status]
+  const statusColor = getSubscriptionStatusBorderColor(
+    subscription.status,
+    subscription.cancel_at_period_end,
+  )
 
   const formattedPrice =
     subscription.amount === 0

--- a/clients/apps/web/src/components/Settings/Billing/BillingSubscriptionCard.tsx
+++ b/clients/apps/web/src/components/Settings/Billing/BillingSubscriptionCard.tsx
@@ -7,6 +7,7 @@ import { Box } from '@polar-sh/orbit/Box'
 import { Button } from '@polar-sh/orbit'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import { Pill } from '@polar-sh/orbit'
+import { getSubscriptionStatusColor } from '@/components/Subscriptions/utils'
 
 const formatPrice = formatCurrency('standard', 'en-US')
 
@@ -18,16 +19,6 @@ const STATUS_LABEL: Record<string, string> = {
   unpaid: 'Unpaid',
   incomplete: 'Incomplete',
   incomplete_expired: 'Expired',
-}
-
-const STATUS_COLOR: Record<string, 'green' | 'yellow' | 'red' | 'blue'> = {
-  active: 'green',
-  past_due: 'yellow',
-  canceled: 'red',
-  trialing: 'blue',
-  unpaid: 'red',
-  incomplete: 'yellow',
-  incomplete_expired: 'red',
 }
 
 const Detail = ({
@@ -93,7 +84,7 @@ export const BillingSubscriptionCard = ({
     : null
 
   const intervalLabel = subscription.recurring_interval ?? 'period'
-  const status = subscription.status
+  const status = subscription.status as schemas['SubscriptionStatus']
 
   return (
     <Box
@@ -116,7 +107,7 @@ export const BillingSubscriptionCard = ({
             <Text variant="heading-xxs" as="h3">
               {plan.name}
             </Text>
-            <Pill color={STATUS_COLOR[status] ?? 'blue'}>
+            <Pill color={getSubscriptionStatusColor(status)}>
               {STATUS_LABEL[status] ?? status}
             </Pill>
             {scheduledPlan && (

--- a/clients/apps/web/src/components/Subscriptions/SubscriptionStatus.tsx
+++ b/clients/apps/web/src/components/Subscriptions/SubscriptionStatus.tsx
@@ -3,7 +3,10 @@ import { Pill } from '@polar-sh/orbit'
 import { CircleX, Clock } from 'lucide-react'
 import { useMemo } from 'react'
 import { twMerge } from 'tailwind-merge'
-import { subscriptionStatusDisplayNames } from './utils'
+import {
+  getSubscriptionStatusBorderColor,
+  subscriptionStatusDisplayNames,
+} from './utils'
 
 const StatusLabel = ({
   color,
@@ -56,15 +59,10 @@ export const SubscriptionStatus = ({
   const { status, ends_at } = subscription
   const isEnding = useMemo(() => ends_at !== null, [ends_at])
 
-  const color = useMemo(() => {
-    if (status === 'active') {
-      return isEnding ? 'border-yellow-500' : 'border-emerald-500'
-    }
-    if (status === 'trialing') {
-      return 'border-cyan-500'
-    }
-    return 'border-red-500'
-  }, [status, isEnding])
+  const color = useMemo(
+    () => getSubscriptionStatusBorderColor(status, isEnding),
+    [status, isEnding],
+  )
 
   const icon = useMemo(() => {
     if (!isEnding) {

--- a/clients/apps/web/src/components/Subscriptions/utils.tsx
+++ b/clients/apps/web/src/components/Subscriptions/utils.tsx
@@ -1,4 +1,5 @@
 import { schemas } from '@polar-sh/client'
+import type { PillColor } from '@polar-sh/orbit'
 import { useMemo } from 'react'
 import { twMerge } from 'tailwind-merge'
 
@@ -13,6 +14,39 @@ export const subscriptionStatusDisplayNames: {
   canceled: 'Canceled',
   unpaid: 'Unpaid',
 }
+
+export const getSubscriptionStatusColor = (
+  status: schemas['SubscriptionStatus'],
+  isEnding = false,
+): PillColor => {
+  switch (status) {
+    case 'active':
+      return isEnding ? 'yellow' : 'green'
+    case 'trialing':
+      return 'blue'
+    case 'past_due':
+      return 'yellow'
+    case 'unpaid':
+    case 'canceled':
+      return 'red'
+    default:
+      return 'gray'
+  }
+}
+
+const STATUS_BORDER_COLOR: Record<PillColor, string> = {
+  green: 'border-emerald-500',
+  yellow: 'border-yellow-500',
+  red: 'border-red-500',
+  blue: 'border-blue-500',
+  gray: 'dark:border-polar-500 border-gray-500',
+  purple: 'border-purple-500',
+}
+
+export const getSubscriptionStatusBorderColor = (
+  status: schemas['SubscriptionStatus'],
+  isEnding = false,
+): string => STATUS_BORDER_COLOR[getSubscriptionStatusColor(status, isEnding)]
 
 export const SubscriptionStatusLabel = ({
   className,
@@ -30,18 +64,14 @@ export const SubscriptionStatusLabel = ({
     }
   }, [subscription])
 
-  const statusColor = useMemo(() => {
-    switch (subscription.status) {
-      case 'active':
-        return subscription.cancel_at_period_end
-          ? 'border-yellow-500'
-          : 'border-emerald-500'
-      case 'trialing':
-        return 'border-cyan-500'
-      default:
-        return 'border-red-500'
-    }
-  }, [subscription])
+  const statusColor = useMemo(
+    () =>
+      getSubscriptionStatusBorderColor(
+        subscription.status,
+        subscription.cancel_at_period_end,
+      ),
+    [subscription.status, subscription.cancel_at_period_end],
+  )
 
   return (
     <div className={twMerge('flex flex-row items-center gap-x-2', className)}>


### PR DESCRIPTION
## Summary

Subscription status indicators used four independently hardcoded
status→color maps, so the same status rendered different colors in
different places. For example `past_due` showing yellow in the customer
sidebar but red in the subscriptions table. This centralizes the mapping
into a single helper and aligns every call site.

| Past Due color example |
|---|
| <img width="957" height="398" alt="Screenshot 2026-06-23 at 16 13 45" src="https://github.com/user-attachments/assets/fffbaa5f-a17d-49d3-9c9b-1d9641658b23" /> |


## Color mapping

| Status               | SubscriptionStatus<br>(table) | SubscriptionStatusLabel | CustomerContextView<br>(sidebar) | BillingSubscriptionCard<br>(pill) | After<br>(all) |
| -------------------- | ----------------------------- | ----------------------- | --------------------------------- | --------------------------------- | -------------- |
| `active`             | emerald                       | emerald                | green                             | green                             | green          |
| `active + ending`    | yellow                        | yellow                 | yellow                            | green¹                            | yellow¹        |
| `trialing`           | cyan                          | cyan                   | blue                              | blue                              | blue           |
| `past_due`           | red                           | red                    | yellow                            | yellow                            | yellow         |
| `unpaid`             | red                           | red                    | orange                            | red                               | red            |
| `canceled`           | red                           | red                    | red                               | red                               | red            |
| `incomplete`         | red                           | red                    | gray                              | yellow                            | gray           |
| `incomplete_expired` | red                           | red                    | gray                              | red                               | gray           |

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

