### PR TITLE
chore(infra): Stop explicitly setting the username for the db in sandbox/prod

### DIFF
--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -65,7 +65,6 @@ resource "render_postgres" "db" {
   environment_id = render_project.polar.environments["Production"].id
   name           = "db"
   database_name  = "polar_cpit"
-  database_user  = "polar_cpit_user"
   plan           = "pro_64gb"
   region         = "ohio"
   version        = "15"
@@ -83,7 +82,6 @@ resource "render_postgres" "db" {
     ignore_changes = [
       ip_allow_list,
       disk_size_gb,
-      database_user,
       database_name,
     ]
   }

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -37,6 +37,7 @@ resource "render_postgres" "db" {
   environment_id = local.environment_id
   name           = "db-test"
   database_name  = "polar_cpit"
+  database_user  = "polar_cpit_user"
   plan           = "pro_4gb"
   region         = "ohio"
   version        = "15"
@@ -52,6 +53,7 @@ resource "render_postgres" "db" {
     prevent_destroy = true
     ignore_changes = [
       ip_allow_list,
+      database_user,
       database_name,
     ]
   }

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -37,7 +37,6 @@ resource "render_postgres" "db" {
   environment_id = local.environment_id
   name           = "db-test"
   database_name  = "polar_cpit"
-  database_user  = "polar_cpit_user"
   plan           = "pro_4gb"
   region         = "ohio"
   version        = "15"
@@ -53,7 +52,6 @@ resource "render_postgres" "db" {
     prevent_destroy = true
     ignore_changes = [
       ip_allow_list,
-      database_user,
       database_name,
     ]
   }


### PR DESCRIPTION
# Why

- Stop having and ignoring drift for the db
- Make it easier to do db credentials rotation (creating new default credentials in render)

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop explicitly setting the Postgres username in the production Terraform config so Render manages it by default. This avoids Terraform drift and aligns with provider defaults.

- **Refactors**
  - Removed `database_user` from `render_postgres.db` and from `lifecycle.ignore_changes` in `terraform/production/render.tf`.

<sup>Written for commit 22c2de8968781cd57390ecb3a09031839bd13ec9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

