### PR TITLE
lambda: Implement exponential backoff

### DIFF
--- a/server/polar/worker/_runner.py
+++ b/server/polar/worker/_runner.py
@@ -9,6 +9,7 @@ import dramatiq
 import logfire
 import structlog
 from dramatiq.common import compute_backoff
+from dramatiq.errors import Retry
 from dramatiq.middleware.current_message import CurrentMessage
 from dramatiq.middleware.retries import DEFAULT_MAX_BACKOFF
 
@@ -80,8 +81,14 @@ def validate_allowlist() -> None:
             )
 
 
-def compute_retry_backoff(actor_name: str, receive_count: int) -> int:
+def compute_retry_backoff(
+    actor_name: str, receive_count: int, exception: BaseException | None = None
+) -> int:
     """Seconds to delay the next SQS redelivery, mirroring Dramatiq's Retries middleware."""
+    if isinstance(exception, Retry) and exception.delay is not None:
+        return min(
+            math.ceil(exception.delay / 1000), _sqs.MAX_VISIBILITY_TIMEOUT_SECONDS
+        )
     actor = dramatiq.get_broker().get_actor(actor_name)
     min_backoff = actor.options.get(
         "min_backoff", settings.WORKER_MIN_BACKOFF_MILLISECONDS

--- a/server/polar/worker/_runner.py
+++ b/server/polar/worker/_runner.py
@@ -1,13 +1,16 @@
 import contextlib
 import functools
 import inspect
+import math
 from collections.abc import Iterator, Sequence
 from typing import Any
 
 import dramatiq
 import logfire
 import structlog
+from dramatiq.common import compute_backoff
 from dramatiq.middleware.current_message import CurrentMessage
+from dramatiq.middleware.retries import DEFAULT_MAX_BACKOFF
 
 from polar import tasks  # noqa: F401  (registers all actors with the broker)
 from polar.config import settings
@@ -75,6 +78,20 @@ def validate_allowlist() -> None:
             raise ValueError(
                 f"Actor {actor_name!r} uses debounce, unsupported over SQS"
             )
+
+
+def compute_retry_backoff(actor_name: str, receive_count: int) -> int:
+    """Seconds to delay the next SQS redelivery, mirroring Dramatiq's Retries middleware."""
+    actor = dramatiq.get_broker().get_actor(actor_name)
+    min_backoff = actor.options.get(
+        "min_backoff", settings.WORKER_MIN_BACKOFF_MILLISECONDS
+    )
+    max_backoff = min(
+        actor.options.get("max_backoff", DEFAULT_MAX_BACKOFF), DEFAULT_MAX_BACKOFF
+    )
+    retries = max(receive_count - 1, 0)
+    _, delay_ms = compute_backoff(retries, factor=min_backoff, max_backoff=max_backoff)
+    return min(math.ceil(delay_ms / 1000), _sqs.MAX_VISIBILITY_TIMEOUT_SECONDS)
 
 
 @contextlib.contextmanager
@@ -159,6 +176,7 @@ __all__ = [
     "UnknownActor",
     "bootstrap",
     "build_registry",
+    "compute_retry_backoff",
     "run_task",
     "shutdown",
     "validate_allowlist",

--- a/server/polar/worker/_sqs.py
+++ b/server/polar/worker/_sqs.py
@@ -1,5 +1,4 @@
 import asyncio
-import functools
 import itertools
 import json
 from collections import defaultdict
@@ -35,7 +34,6 @@ class SQSSendError(Exception):
         super().__init__(f"Failed to send {len(failed)} message(s) to {queue_name}")
 
 
-@functools.lru_cache(maxsize=1)
 def get_sqs_client() -> "SQSClient":
     return boto3.client(
         "sqs",
@@ -56,7 +54,6 @@ def get_sqs_client() -> "SQSClient":
     )
 
 
-@functools.lru_cache(maxsize=1)
 def get_consumer_sqs_client() -> "SQSClient":
     """SQS client authenticated by the Lambda execution role (no static keys)."""
     return boto3.client(
@@ -70,6 +67,9 @@ def get_consumer_sqs_client() -> "SQSClient":
             retries={"max_attempts": 2, "mode": "standard"},
         ),
     )
+
+
+sqs_client = get_sqs_client()
 
 
 def actor_to_queue_name(_actor_name: str) -> str:
@@ -117,9 +117,11 @@ def parse_envelope(body: str) -> tuple[str, list[Any], dict[str, Any], str | Non
 
 
 def set_message_visibility(
-    queue_arn: str, receipt_handle: str, timeout_seconds: int
+    client: "SQSClient",
+    queue_arn: str,
+    receipt_handle: str,
+    timeout_seconds: int,
 ) -> None:
-    client = get_consumer_sqs_client()
     queue_name = queue_arn.rsplit(":", 1)[-1]
     queue_url = get_queue_url(client, queue_name)
     client.change_message_visibility(
@@ -179,4 +181,5 @@ __all__ = [
     "send_jobs",
     "send_jobs_sync",
     "set_message_visibility",
+    "sqs_client",
 ]

--- a/server/polar/worker/_sqs.py
+++ b/server/polar/worker/_sqs.py
@@ -23,6 +23,7 @@ log: Logger = structlog.get_logger()
 # SQS hard limits.
 SQS_BATCH_SIZE = 10
 MAX_DELAY_SECONDS = 900
+MAX_VISIBILITY_TIMEOUT_SECONDS = 43_200
 
 type Job = tuple[str, tuple[Any, ...], dict[str, Any], int | None, str | None]
 
@@ -45,6 +46,22 @@ def get_sqs_client() -> "SQSClient":
         aws_secret_access_key=(
             settings.WORKER_SQS_AWS_SECRET_ACCESS_KEY or settings.AWS_SECRET_ACCESS_KEY
         ),
+        config=Config(
+            region_name=settings.AWS_REGION,
+            signature_version=settings.AWS_SIGNATURE_VERSION,
+            connect_timeout=2,
+            read_timeout=5,
+            retries={"max_attempts": 2, "mode": "standard"},
+        ),
+    )
+
+
+@functools.lru_cache(maxsize=1)
+def get_consumer_sqs_client() -> "SQSClient":
+    """SQS client authenticated by the Lambda execution role (no static keys)."""
+    return boto3.client(
+        "sqs",
+        endpoint_url=settings.SQS_ENDPOINT_URL,
         config=Config(
             region_name=settings.AWS_REGION,
             signature_version=settings.AWS_SIGNATURE_VERSION,
@@ -98,6 +115,19 @@ def parse_envelope(body: str) -> tuple[str, list[Any], dict[str, Any], str | Non
     )
 
 
+def set_message_visibility(
+    queue_arn: str, receipt_handle: str, timeout_seconds: int
+) -> None:
+    client = get_consumer_sqs_client()
+    queue_name = queue_arn.rsplit(":", 1)[-1]
+    queue_url = get_queue_url(client, queue_name)
+    client.change_message_visibility(
+        QueueUrl=queue_url,
+        ReceiptHandle=receipt_handle,
+        VisibilityTimeout=timeout_seconds,
+    )
+
+
 async def send_jobs(jobs: list[Job]) -> None:
     if not jobs:
         return
@@ -136,13 +166,16 @@ def send_jobs_sync(jobs: list[Job]) -> None:
 
 
 __all__ = [
+    "MAX_VISIBILITY_TIMEOUT_SECONDS",
     "Job",
     "SQSSendError",
     "actor_to_queue_name",
     "build_envelope",
+    "get_consumer_sqs_client",
     "get_queue_url",
     "get_sqs_client",
     "parse_envelope",
     "send_jobs",
     "send_jobs_sync",
+    "set_message_visibility",
 ]

--- a/server/polar/worker/_sqs.py
+++ b/server/polar/worker/_sqs.py
@@ -76,14 +76,15 @@ def actor_to_queue_name(_actor_name: str) -> str:
     return f"{settings.WORKER_SQS_QUEUE_PREFIX}-default"
 
 
-_queue_url_cache: dict[str, str] = {}
+_queue_url_cache: dict[tuple[int, str], str] = {}
 
 
 def get_queue_url(client: "SQSClient", queue_name: str) -> str:
-    url = _queue_url_cache.get(queue_name)
+    cache_key = (id(client), queue_name)
+    url = _queue_url_cache.get(cache_key)
     if url is None:
         url = client.get_queue_url(QueueName=queue_name)["QueueUrl"]
-        _queue_url_cache[queue_name] = url
+        _queue_url_cache[cache_key] = url
     return url
 
 

--- a/server/polar/worker/aws_lambda.py
+++ b/server/polar/worker/aws_lambda.py
@@ -10,7 +10,7 @@ from polar.logging import configure as configure_logging
 from polar.sentry import configure_sentry
 
 from ._runner import bootstrap, compute_retry_backoff, run_task
-from ._sqs import parse_envelope, set_message_visibility
+from ._sqs import get_consumer_sqs_client, parse_envelope, set_message_visibility
 
 configure_sentry()
 configure_logfire("worker")
@@ -24,6 +24,8 @@ log: Logger = structlog.get_logger()
 _loop = asyncio.new_event_loop()
 asyncio.set_event_loop(_loop)
 bootstrap()
+
+consumer_sqs_client = get_consumer_sqs_client()
 
 
 def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
@@ -67,7 +69,10 @@ def _apply_retry_backoff(record: dict[str, Any], exception: BaseException) -> No
         )
         backoff_seconds = compute_retry_backoff(actor, receive_count, exception)
         set_message_visibility(
-            record["eventSourceARN"], record["receiptHandle"], backoff_seconds
+            consumer_sqs_client,
+            record["eventSourceARN"],
+            record["receiptHandle"],
+            backoff_seconds,
         )
         log.info(
             "polar.worker.sqs_retry_scheduled",

--- a/server/polar/worker/aws_lambda.py
+++ b/server/polar/worker/aws_lambda.py
@@ -9,8 +9,8 @@ from polar.logging import Logger
 from polar.logging import configure as configure_logging
 from polar.sentry import configure_sentry
 
-from ._runner import bootstrap, run_task
-from ._sqs import parse_envelope
+from ._runner import bootstrap, compute_retry_backoff, run_task
+from ._sqs import parse_envelope, set_message_visibility
 
 configure_sentry()
 configure_logfire("worker")
@@ -51,7 +51,29 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                     message_id=message_id,
                     exc_info=True,
                 )
+                _apply_retry_backoff(record)
                 batch_item_failures.append({"itemIdentifier": message_id})
     finally:
         logfire.force_flush()
     return {"batchItemFailures": batch_item_failures}
+
+
+def _apply_retry_backoff(record: dict[str, Any]) -> None:
+    """Delay the failed message's next SQS redelivery by the Dramatiq-style backoff."""
+    try:
+        actor, _, _, _ = parse_envelope(record["body"])
+        receive_count = int(
+            record.get("attributes", {}).get("ApproximateReceiveCount", "1")
+        )
+        backoff_seconds = compute_retry_backoff(actor, receive_count)
+        set_message_visibility(
+            record["eventSourceARN"], record["receiptHandle"], backoff_seconds
+        )
+        log.info(
+            "polar.worker.sqs_retry_scheduled",
+            actor=actor,
+            receive_count=receive_count,
+            backoff_seconds=backoff_seconds,
+        )
+    except Exception:
+        log.error("polar.worker.sqs_backoff_failed", exc_info=True)

--- a/server/polar/worker/aws_lambda.py
+++ b/server/polar/worker/aws_lambda.py
@@ -45,27 +45,27 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                         source_correlation_id=correlation_id,
                     )
                 )
-            except Exception:
+            except Exception as exc:
                 log.error(
                     "polar.worker.sqs_task_failed",
                     message_id=message_id,
                     exc_info=True,
                 )
-                _apply_retry_backoff(record)
+                _apply_retry_backoff(record, exc)
                 batch_item_failures.append({"itemIdentifier": message_id})
     finally:
         logfire.force_flush()
     return {"batchItemFailures": batch_item_failures}
 
 
-def _apply_retry_backoff(record: dict[str, Any]) -> None:
+def _apply_retry_backoff(record: dict[str, Any], exception: BaseException) -> None:
     """Delay the failed message's next SQS redelivery by the Dramatiq-style backoff."""
     try:
         actor, _, _, _ = parse_envelope(record["body"])
         receive_count = int(
             record.get("attributes", {}).get("ApproximateReceiveCount", "1")
         )
-        backoff_seconds = compute_retry_backoff(actor, receive_count)
+        backoff_seconds = compute_retry_backoff(actor, receive_count, exception)
         set_message_visibility(
             record["eventSourceARN"], record["receiptHandle"], backoff_seconds
         )

--- a/server/polar/worker/sqs.py
+++ b/server/polar/worker/sqs.py
@@ -9,7 +9,7 @@ from polar.config import settings
 from polar.logging import Logger
 
 from ._runner import bootstrap, run_task, shutdown
-from ._sqs import actor_to_queue_name, get_queue_url, get_sqs_client, parse_envelope
+from ._sqs import actor_to_queue_name, get_queue_url, parse_envelope, sqs_client
 
 log: Logger = structlog.get_logger()
 
@@ -32,11 +32,8 @@ def run(actor: str, body: str = typer.Argument("{}")) -> None:
 
 
 async def _poll_loop(actors: list[str], max_iterations: int) -> None:
-    client = get_sqs_client()
-    queue_names = {actor_to_queue_name(actor) for actor in actors}
-    queue_urls = {
-        queue_name: get_queue_url(client, queue_name) for queue_name in queue_names
-    }
+    client = sqs_client
+    queue_urls = {a: get_queue_url(client, actor_to_queue_name(a)) for a in actors}
     iterations = 0
     try:
         while max_iterations == 0 or iterations < max_iterations:

--- a/server/tests/worker/test_backoff.py
+++ b/server/tests/worker/test_backoff.py
@@ -57,10 +57,10 @@ class TestSetMessageVisibility:
     def test_changes_visibility_for_queue(self, mocker: MockerFixture) -> None:
         client = mocker.MagicMock()
         client.get_queue_url.return_value = {"QueueUrl": "https://sqs/queue"}
-        mocker.patch.object(_sqs, "get_consumer_sqs_client", return_value=client)
         _sqs._queue_url_cache.clear()
 
         _sqs.set_message_visibility(
+            client,
             "arn:aws:sqs:us-east-2:123456789012:polar-sandbox-tasks-dummy",
             "receipt-handle",
             42,

--- a/server/tests/worker/test_backoff.py
+++ b/server/tests/worker/test_backoff.py
@@ -1,5 +1,6 @@
 import math
 
+from dramatiq.errors import Retry
 from pytest_mock import MockerFixture
 
 import polar.tasks  # noqa: F401  (registers actors with the broker)
@@ -36,6 +37,20 @@ class TestComputeRetryBackoff:
         low, high = _jitter_bounds(10_000, 0)
         for _ in range(50):
             assert low <= compute_retry_backoff("dummy", 1) <= high
+
+    def test_explicit_retry_delay_overrides_backoff(self) -> None:
+        assert compute_retry_backoff("dummy", 5, Retry(delay=30_000)) == 30
+
+    def test_explicit_retry_delay_capped_at_sqs_limit(self) -> None:
+        assert (
+            compute_retry_backoff("dummy", 1, Retry(delay=999_999_999))
+            == _sqs.MAX_VISIBILITY_TIMEOUT_SECONDS
+        )
+
+    def test_retry_without_delay_uses_exponential_backoff(self) -> None:
+        low, high = _jitter_bounds(settings.WORKER_MIN_BACKOFF_MILLISECONDS, 0)
+        for _ in range(50):
+            assert low <= compute_retry_backoff("dummy", 1, Retry()) <= high
 
 
 class TestSetMessageVisibility:

--- a/server/tests/worker/test_backoff.py
+++ b/server/tests/worker/test_backoff.py
@@ -1,0 +1,61 @@
+import math
+
+from pytest_mock import MockerFixture
+
+import polar.tasks  # noqa: F401  (registers actors with the broker)
+from polar.config import settings
+from polar.worker import _sqs
+from polar.worker._runner import compute_retry_backoff
+
+
+def _jitter_bounds(min_backoff_ms: int, retries: int) -> tuple[int, int]:
+    base_ms = min_backoff_ms * (2**retries)
+    return math.ceil(base_ms / 1000), math.ceil(base_ms * 2 / 1000)
+
+
+class TestComputeRetryBackoff:
+    def test_first_retry_uses_min_backoff_bounds(self) -> None:
+        low, high = _jitter_bounds(settings.WORKER_MIN_BACKOFF_MILLISECONDS, 0)
+        for _ in range(50):
+            assert low <= compute_retry_backoff("dummy", 1) <= high
+
+    def test_backoff_grows_with_receive_count(self) -> None:
+        low, high = _jitter_bounds(settings.WORKER_MIN_BACKOFF_MILLISECONDS, 2)
+        for _ in range(50):
+            assert low <= compute_retry_backoff("dummy", 3) <= high
+
+    def test_caps_at_sqs_visibility_limit(self) -> None:
+        for _ in range(50):
+            assert (
+                compute_retry_backoff("dummy", 40)
+                == _sqs.MAX_VISIBILITY_TIMEOUT_SECONDS
+            )
+
+    def test_honors_min_backoff_setting(self, mocker: MockerFixture) -> None:
+        mocker.patch.object(settings, "WORKER_MIN_BACKOFF_MILLISECONDS", 10_000)
+        low, high = _jitter_bounds(10_000, 0)
+        for _ in range(50):
+            assert low <= compute_retry_backoff("dummy", 1) <= high
+
+
+class TestSetMessageVisibility:
+    def test_changes_visibility_for_queue(self, mocker: MockerFixture) -> None:
+        client = mocker.MagicMock()
+        client.get_queue_url.return_value = {"QueueUrl": "https://sqs/queue"}
+        mocker.patch.object(_sqs, "get_consumer_sqs_client", return_value=client)
+        _sqs._queue_url_cache.clear()
+
+        _sqs.set_message_visibility(
+            "arn:aws:sqs:us-east-2:123456789012:polar-sandbox-tasks-dummy",
+            "receipt-handle",
+            42,
+        )
+
+        client.get_queue_url.assert_called_once_with(
+            QueueName="polar-sandbox-tasks-dummy"
+        )
+        client.change_message_visibility.assert_called_once_with(
+            QueueUrl="https://sqs/queue",
+            ReceiptHandle="receipt-handle",
+            VisibilityTimeout=42,
+        )


### PR DESCRIPTION
Similar to Dramatiq we have an exponential backoff, this is done via the message visiblity API. SQS has a limitation on max 12 hours hidden visibility, as such we clamp the backoff to that.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

