### PR TITLE
Remove payment requirement for invoice generation

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -22476,17 +22476,6 @@ export interface components {
       /** Detail */
       detail: string
     }
-    /** NotPaidOrder */
-    NotPaidOrder: {
-      /**
-       * Error
-       * @example NotPaidOrder
-       * @constant
-       */
-      error: 'NotPaidOrder'
-      /** Detail */
-      detail: string
-    }
     /** NotPermitted */
     NotPermitted: {
       /**
@@ -39275,15 +39264,13 @@ export interface operations {
           'application/json': unknown
         }
       }
-      /** @description Order is not paid or is missing billing name or address. */
+      /** @description Order is missing billing name or address. */
       422: {
         headers: {
           [name: string]: unknown
         }
         content: {
-          'application/json':
-            | components['schemas']['MissingInvoiceBillingDetails']
-            | components['schemas']['NotPaidOrder']
+          'application/json': components['schemas']['MissingInvoiceBillingDetails']
         }
       }
     }
@@ -45239,15 +45226,13 @@ export interface operations {
           'application/json': unknown
         }
       }
-      /** @description Order is not paid or is missing billing name or address. */
+      /** @description Order is missing billing name or address. */
       422: {
         headers: {
           [name: string]: unknown
         }
         content: {
-          'application/json':
-            | components['schemas']['MissingInvoiceBillingDetails']
-            | components['schemas']['NotPaidOrder']
+          'application/json': components['schemas']['MissingInvoiceBillingDetails']
         }
       }
     }

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -39264,6 +39264,15 @@ export interface operations {
           'application/json': unknown
         }
       }
+      /** @description Order not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
       /** @description Order is missing billing name or address. */
       422: {
         headers: {
@@ -45224,6 +45233,15 @@ export interface operations {
         }
         content: {
           'application/json': unknown
+        }
+      }
+      /** @description Order not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
         }
       }
       /** @description Order is missing billing name or address. */

--- a/server/polar/customer_portal/endpoints/order.py
+++ b/server/polar/customer_portal/endpoints/order.py
@@ -139,6 +139,7 @@ async def update(
     status_code=202,
     summary="Generate Order Invoice",
     responses={
+        404: OrderNotFound,
         422: {
             "description": "Order is missing billing name or address.",
             "model": MissingInvoiceBillingDetails.schema(),

--- a/server/polar/customer_portal/endpoints/order.py
+++ b/server/polar/customer_portal/endpoints/order.py
@@ -13,7 +13,6 @@ from polar.openapi import APITag
 from polar.order.schemas import OrderID
 from polar.order.service import (
     MissingInvoiceBillingDetails,
-    NotPaidOrder,
     PaymentAlreadyInProgress,
 )
 from polar.payment.repository import PaymentRepository
@@ -141,8 +140,8 @@ async def update(
     summary="Generate Order Invoice",
     responses={
         422: {
-            "description": "Order is not paid or is missing billing name or address.",
-            "model": MissingInvoiceBillingDetails.schema() | NotPaidOrder.schema(),
+            "description": "Order is missing billing name or address.",
+            "model": MissingInvoiceBillingDetails.schema(),
         },
     },
 )

--- a/server/polar/order/endpoints.py
+++ b/server/polar/order/endpoints.py
@@ -43,7 +43,6 @@ from .schemas import (
 )
 from .service import (
     MissingInvoiceBillingDetails,
-    NotPaidOrder,
     OffSessionChargesNotEnabled,
     OrderNotDraft,
     OrganizationNotReadyForPayments,
@@ -306,8 +305,8 @@ async def finalize(
     summary="Generate Order Invoice",
     responses={
         422: {
-            "description": "Order is not paid or is missing billing name or address.",
-            "model": MissingInvoiceBillingDetails.schema() | NotPaidOrder.schema(),
+            "description": "Order is missing billing name or address.",
+            "model": MissingInvoiceBillingDetails.schema(),
         },
     },
 )

--- a/server/polar/order/endpoints.py
+++ b/server/polar/order/endpoints.py
@@ -304,6 +304,7 @@ async def finalize(
     status_code=202,
     summary="Generate Order Invoice",
     responses={
+        404: OrderNotFound,
         422: {
             "description": "Order is missing billing name or address.",
             "model": MissingInvoiceBillingDetails.schema(),

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -180,13 +180,6 @@ class AlreadyBalancedOrder(OrderError):
         super().__init__(message)
 
 
-class NotPaidOrder(OrderError):
-    def __init__(self, order: Order) -> None:
-        self.order = order
-        message = f"Order {order.id} is not paid, so an invoice cannot be generated."
-        super().__init__(message, 422)
-
-
 class MissingInvoiceBillingDetails(OrderError):
     def __init__(self, order: Order) -> None:
         self.order = order
@@ -528,9 +521,6 @@ class OrderService:
     async def trigger_invoice_generation(
         self, session: AsyncSession, order: Order
     ) -> None:
-        if not order.paid:
-            raise NotPaidOrder(order)
-
         if order.billing_name is None or order.billing_address is None:
             raise MissingInvoiceBillingDetails(order)
 

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -75,7 +75,6 @@ from polar.order.service import (
     MissingCheckoutCustomer,
     MissingInvoiceBillingDetails,
     NoPendingBillingEntries,
-    NotPaidOrder,
     NotRecurringProduct,
     OffSessionChargesNotEnabled,
     OrderNotDraft,
@@ -2580,7 +2579,7 @@ class TestSendConfirmationEmail:
 
 @pytest.mark.asyncio
 class TestTriggerInvoiceGeneration:
-    async def test_not_paid(
+    async def test_not_paid_triggers_generation(
         self,
         enqueue_job_mock: MagicMock,
         save_fixture: SaveFixture,
@@ -2597,10 +2596,9 @@ class TestTriggerInvoiceGeneration:
             billing_address=Address(country=CountryAlpha2("US")),
         )
 
-        with pytest.raises(NotPaidOrder):
-            await order_service.trigger_invoice_generation(session, order)
+        await order_service.trigger_invoice_generation(session, order)
 
-        enqueue_job_mock.assert_not_called()
+        enqueue_job_mock.assert_called_once_with("order.invoice", order_id=order.id)
 
     async def test_missing_billing(
         self,


### PR DESCRIPTION
## Summary

Remove the requirement that orders must be paid before invoice generation can be triggered. This allows invoices to be generated for unpaid orders as long as billing details are present.

## What

- Removed `NotPaidOrder` error class from order service
- Removed the payment status check from `trigger_invoice_generation()` method
- Updated API schemas and endpoint documentation to remove `NotPaidOrder` from 422 response
- Updated tests to reflect that unpaid orders can now trigger invoice generation

## Why

The payment status check was overly restrictive. Invoices should be generatable for any order with complete billing information, regardless of payment status. This allows for more flexible invoice management workflows.

## How

1. Deleted the `NotPaidOrder` exception class and its usage in `order/service.py`
2. Removed the `if not order.paid` check from `trigger_invoice_generation()`
3. Updated OpenAPI schema in `v1.ts` to remove `NotPaidOrder` from response types
4. Updated endpoint documentation in both `customer_portal/endpoints/order.py` and `order/endpoints.py`
5. Updated test `test_not_paid` to `test_not_paid_triggers_generation` to verify unpaid orders can generate invoices

## Checklist

- [x] This PR addresses a single concern (removing payment requirement for invoice generation)
- [x] The diff is reasonably sized and easy to review
- [x] Tests updated to reflect new behavior
- [x] API documentation updated to match implementation

https://claude.ai/code/session_017TLSwBWc4J9ZcZdunNa4NW

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

