### PR TITLE
Tweak AUP validation system prompt

### DIFF
--- a/clients/apps/web/src/app/(main)/onboarding/validate-description/route.ts
+++ b/clients/apps/web/src/app/(main)/onboarding/validate-description/route.ts
@@ -143,10 +143,14 @@ Ask a clarifying question when the description is ambiguous on one of these poin
 
 - **"for kids" / child-directed** → is it sold to parents, teachers, or institutions — or marketed directly to children?
 - **Financial tools** → does it execute or facilitate actual trades/investments, or only display information and analytics?
+  Regular budgetting applications or spreadsheet templates are fine. Investment advice is where we draw the line.
 - **Security / pentesting tools** → does it include controls restricting usage to systems the user owns or has explicit permission to test?
 - **Crypto platform** → does it execute or broker token transactions, or only track and display portfolio data?
 - **Medical or legal content** → only flag if the product explicitly offers diagnosis,  treatment plans, legal strategy, or actionable legal guidance. General
   reference, how-to guides, and domain-specific advice (farming, cooking, fitness, etc.) are fine, even if presented in personalized manner.
+- **Medical software or data handling** → only flag if the product explicitly offers diagnosis, treatment plans. Processing medical data by itself is not a risk,
+  the risk factor is with medical advice. Health API's, glucose readers, biomarkers are fine. The risk starts when there are actionable recommendations or advice generated
+  by the application.
 - **Lead generation / outreach tools** → does it include rate limiting, consent verification, or other controls preventing automated bulk outreach?
 - **AI content generation** → does it include quality controls or human review, or does it publish content fully autonomously at scale? NSFW content guards should be asked about and clarified.
 - **VPN or proxy service** → does it include controls preventing use to access geo-restricted or illegal content?


### PR DESCRIPTION
Resolves two cases reported in Plain, but without an eval set, this is a bit silly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the AUP validation system prompt to reduce false positives in the onboarding description validator.

- **Bug Fixes**
  - Financial tools: Allow budgeting apps and templates; flag only when giving investment advice.
  - Medical: Do not flag apps that only handle health data (APIs, sensors); flag when offering diagnosis, treatment plans, or actionable medical advice.

<sup>Written for commit c275aa20f7d26a507ecba5b904682c8f12f97ca2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

