### PR TITLE
Catch undefined `prorations`

### DIFF
--- a/clients/apps/web/src/components/CustomerPortal/CurrentPeriodOverview.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CurrentPeriodOverview.tsx
@@ -52,8 +52,8 @@ export const CurrentPeriodOverview = ({
   }
 
   const hasMeters = subscription.meters.length > 0
-  const hasProrations =
-    subscriptionPreview && subscriptionPreview.prorations.length > 0
+  const prorations = subscriptionPreview?.prorations ?? []
+  const hasProrations = prorations.length > 0
   const hasTaxes = subscriptionPreview && subscriptionPreview.tax_amount > 0
   const hasDiscount =
     subscriptionPreview && subscriptionPreview.discount_amount > 0
@@ -129,7 +129,7 @@ export const CurrentPeriodOverview = ({
         <>
           <span className="font-medium">Prorations</span>
 
-          {subscriptionPreview.prorations.map((proration, index) => (
+          {prorations.map((proration, index) => (
             <div key={index} className="flex items-center justify-between">
               <span className="dark:text-polar-400 text-gray-600">
                 {proration.label}

--- a/clients/apps/web/src/components/Subscriptions/UpcomingChargeCard.tsx
+++ b/clients/apps/web/src/components/Subscriptions/UpcomingChargeCard.tsx
@@ -50,7 +50,8 @@ const UpcomingChargeCard = ({
   const isFreeProduct = subscription.prices.some(isFreePrice)
 
   const hasMeters = subscription.meters.length > 0
-  const hasProrations = chargePreview && chargePreview.prorations.length > 0
+  const prorations = chargePreview?.prorations ?? []
+  const hasProrations = prorations.length > 0
   const hasTaxes = chargePreview && chargePreview.tax_amount > 0
   const hasDiscount = chargePreview && chargePreview.discount_amount > 0
 
@@ -123,7 +124,7 @@ const UpcomingChargeCard = ({
                 <span className="font-medium">Prorations</span>
               </div>
 
-              {chargePreview.prorations.map((proration, index) => (
+              {prorations.map((proration, index) => (
                 <DetailRow
                   key={index}
                   label={proration.label}


### PR DESCRIPTION
Fix for a customer reported error, but it shouldn't happen because `prorations` is always an array. 🤷 

(Sentry DASHBOARD-78H)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

