### PR TITLE
tf: Set up AWS organizations and accounts

### DIFF
--- a/terraform/organization/README.md
+++ b/terraform/organization/README.md
@@ -1,0 +1,33 @@
+# AWS Organizations
+
+This Terraform root manages Polar's AWS Organizations structure.
+
+## Layout
+
+```text
+AWS Organization
+├── Management account: polar
+└── Workloads
+    ├── Production
+    │   └── production
+    ├── Sandbox
+    │   └── sandbox
+    └── Test
+        └── test
+```
+
+The management account owns the AWS Organization control plane. It should stay limited to
+organization administration, billing, account lifecycle, delegated administrator registration,
+and other tasks that must run from the management account.
+
+Application workloads live under the `Workloads` OU:
+
+- `Production` contains the public production environment.
+- `Sandbox` contains the sandbox production-class environment.
+- `Test` contains the staging/test environment.
+
+## Guardrails
+
+- Attach guardrails that apply to every application account to `Workloads`.
+- Attach production-class guardrails to both `Production` and `Sandbox`.
+- Attach test/staging-specific guardrails to `Test`.

--- a/terraform/organization/main.tf
+++ b/terraform/organization/main.tf
@@ -1,0 +1,113 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+data "aws_organizations_organization" "current" {}
+
+locals {
+  management_account = {
+    id = "975049931254"
+  }
+
+  workload_organizational_units = {
+    production = {
+      name = "Production"
+    }
+    sandbox = {
+      name = "Sandbox"
+    }
+    test = {
+      name = "Test"
+    }
+  }
+
+  workload_accounts = {
+    production = {
+      id                  = "538043300756"
+      name                = "production"
+      email               = var.production_account_email
+      organizational_unit = "production"
+    }
+    sandbox = {
+      id                  = "427025827993"
+      name                = "sandbox"
+      email               = var.sandbox_account_email
+      organizational_unit = "sandbox"
+    }
+    test = {
+      id                  = "805865757777"
+      name                = "test"
+      email               = var.test_account_email
+      organizational_unit = "test"
+    }
+  }
+
+  organization_accounts_by_id = {
+    for account in data.aws_organizations_organization.current.accounts :
+    account.id => account
+  }
+
+  root_id = data.aws_organizations_organization.current.roots[0].id
+}
+
+check "management_account" {
+  assert {
+    condition     = data.aws_organizations_organization.current.master_account_id == local.management_account.id
+    error_message = "Terraform must run from the Polar management account (${local.management_account.id})."
+  }
+
+  assert {
+    condition     = data.aws_organizations_organization.current.master_account_email == var.management_account_email
+    error_message = "The Polar management account email must match the configured management_account_email variable."
+  }
+}
+
+check "workload_accounts" {
+  assert {
+    condition = alltrue([
+      for account in local.workload_accounts :
+      contains(keys(local.organization_accounts_by_id), account.id)
+    ])
+    error_message = "Production, sandbox, and test accounts must already be members of the AWS Organization before import."
+  }
+}
+
+resource "aws_organizations_organizational_unit" "workloads" {
+  name      = "Workloads"
+  parent_id = local.root_id
+}
+
+resource "aws_organizations_organizational_unit" "workload" {
+  for_each = local.workload_organizational_units
+
+  name      = each.value.name
+  parent_id = aws_organizations_organizational_unit.workloads.id
+}
+
+resource "aws_organizations_account" "workload" {
+  for_each = local.workload_accounts
+
+  name              = each.value.name
+  email             = each.value.email
+  parent_id         = aws_organizations_organizational_unit.workload[each.value.organizational_unit].id
+  close_on_deletion = false
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+import {
+  to = aws_organizations_account.workload["production"]
+  id = "538043300756"
+}
+
+import {
+  to = aws_organizations_account.workload["sandbox"]
+  id = "427025827993"
+}
+
+import {
+  to = aws_organizations_account.workload["test"]
+  id = "805865757777"
+}

--- a/terraform/organization/main.tf
+++ b/terraform/organization/main.tf
@@ -42,11 +42,6 @@ locals {
     }
   }
 
-  organization_accounts_by_id = {
-    for account in data.aws_organizations_organization.current.accounts :
-    account.id => account
-  }
-
   root_id = data.aws_organizations_organization.current.roots[0].id
 }
 
@@ -54,21 +49,6 @@ check "management_account" {
   assert {
     condition     = data.aws_organizations_organization.current.master_account_id == local.management_account.id
     error_message = "Terraform must run from the Polar management account (${local.management_account.id})."
-  }
-
-  assert {
-    condition     = data.aws_organizations_organization.current.master_account_email == var.management_account_email
-    error_message = "The Polar management account email must match the configured management_account_email variable."
-  }
-}
-
-check "workload_accounts" {
-  assert {
-    condition = alltrue([
-      for account in local.workload_accounts :
-      contains(keys(local.organization_accounts_by_id), account.id)
-    ])
-    error_message = "Production, sandbox, and test accounts must already be members of the AWS Organization before import."
   }
 }
 

--- a/terraform/organization/outputs.tf
+++ b/terraform/organization/outputs.tf
@@ -1,0 +1,33 @@
+output "management_account" {
+  value = {
+    id   = data.aws_organizations_organization.current.master_account_id
+    name = data.aws_organizations_organization.current.master_account_name
+  }
+}
+
+output "organizational_units" {
+  value = {
+    workloads = {
+      id   = aws_organizations_organizational_unit.workloads.id
+      name = aws_organizations_organizational_unit.workloads.name
+    }
+    workload_environments = {
+      for key, organizational_unit in aws_organizations_organizational_unit.workload :
+      key => {
+        id   = organizational_unit.id
+        name = organizational_unit.name
+      }
+    }
+  }
+}
+
+output "workload_accounts" {
+  value = {
+    for key, account in aws_organizations_account.workload :
+    key => {
+      id                  = account.id
+      name                = account.name
+      organizational_unit = local.workload_accounts[key].organizational_unit
+    }
+  }
+}

--- a/terraform/organization/terraform.tf
+++ b/terraform/organization/terraform.tf
@@ -1,0 +1,17 @@
+terraform {
+  cloud {
+    organization = "polar-sh"
+    workspaces {
+      name = "organization"
+    }
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.92"
+    }
+  }
+
+  required_version = ">= 1.5"
+}

--- a/terraform/organization/variables.tf
+++ b/terraform/organization/variables.tf
@@ -1,0 +1,27 @@
+variable "management_account_email" {
+  description = "Email address for the AWS Organizations management account."
+  type        = string
+  sensitive   = true
+  nullable    = false
+}
+
+variable "production_account_email" {
+  description = "Email address for the production AWS account."
+  type        = string
+  sensitive   = true
+  nullable    = false
+}
+
+variable "sandbox_account_email" {
+  description = "Email address for the sandbox AWS account."
+  type        = string
+  sensitive   = true
+  nullable    = false
+}
+
+variable "test_account_email" {
+  description = "Email address for the test AWS account."
+  type        = string
+  sensitive   = true
+  nullable    = false
+}

--- a/terraform/organization/variables.tf
+++ b/terraform/organization/variables.tf
@@ -1,10 +1,3 @@
-variable "management_account_email" {
-  description = "Email address for the AWS Organizations management account."
-  type        = string
-  sensitive   = true
-  nullable    = false
-}
-
 variable "production_account_email" {
   description = "Email address for the production AWS account."
   type        = string


### PR DESCRIPTION
Configures organization units, accounts and sets up an organization folder for the management account


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

