### PR TITLE
slack benefit: polish form

### DIFF
--- a/clients/apps/web/src/components/Benefit/SlackIntegrationSetupPanel.tsx
+++ b/clients/apps/web/src/components/Benefit/SlackIntegrationSetupPanel.tsx
@@ -90,12 +90,12 @@ export const SlackIntegrationSetupPanel = ({
   }
 
   return (
-    <Box display="flex" flexDirection="column" rowGap="l">
+    <Box display="flex" flexDirection="column" rowGap="xl">
       <SetupSection
         title="1. Create your Slack app"
         description="Create a Slack app from this manifest, then paste the credentials below."
       >
-        <Box display="flex" flexDirection="column" rowGap="m">
+        <Box display="flex" flexDirection="column" rowGap="l">
           <Box display="flex" flexDirection="column" rowGap="s">
             <Label htmlFor="slack-display-name">Display name</Label>
             <Input
@@ -108,27 +108,22 @@ export const SlackIntegrationSetupPanel = ({
               Shown on the bot user inside your Slack workspace.
             </Text>
           </Box>
-          <ManifestBlock manifest={displayedManifest} />
-          <Box display="flex" flexDirection="column" rowGap="s">
-            <Button
-              asChild
-              variant="secondary"
-              size="sm"
-              wrapperClassNames="self-start"
+          <Button asChild>
+            <a
+              href="https://api.slack.com/apps?new_app=1"
+              target="_blank"
+              rel="noopener noreferrer"
             >
-              <a
-                href="https://api.slack.com/apps?new_app=1"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Create app on api.slack.com
-              </a>
-            </Button>
-            <Text color="muted" variant="caption">
+              Create app on api.slack.com
+            </a>
+          </Button>
+          <Box display="flex" flexDirection="column" rowGap="s">
+            <Text color="muted">
               Choose &ldquo;From an app manifest&rdquo;, pick your workspace,
               and paste the manifest above.
             </Text>
           </Box>
+          <ManifestBlock manifest={displayedManifest} />
         </Box>
       </SetupSection>
 
@@ -238,7 +233,7 @@ const ManifestBlock = ({ manifest }: { manifest: string }) => {
           Copy manifest
         </Button>
       </Box>
-      <Well className="overflow-x-auto p-3 text-xs">
+      <Well className="dark:text-polar-500 overflow-x-auto rounded-md p-4 text-xs text-gray-500">
         {manifest ? (
           <SyntaxHighlighterClient lang="bash" code={manifest} />
         ) : (

--- a/clients/apps/web/src/components/Benefit/SlackSharedChannelBenefitForm.test.tsx
+++ b/clients/apps/web/src/components/Benefit/SlackSharedChannelBenefitForm.test.tsx
@@ -40,6 +40,12 @@ vi.mock('@polar-sh/orbit/Box', () => ({
 }))
 
 vi.mock('@polar-sh/orbit', () => ({
+  Alert: ({ title, description }: { title: string; description?: string }) => (
+    <div>
+      <p>{title}</p>
+      <p>{description}</p>
+    </div>
+  ),
   Button: ({ children, ...props }: { children: ReactNode }) => (
     <button {...props}>{children}</button>
   ),

--- a/clients/apps/web/src/components/Benefit/SlackSharedChannelBenefitForm.tsx
+++ b/clients/apps/web/src/components/Benefit/SlackSharedChannelBenefitForm.tsx
@@ -6,7 +6,6 @@ import {
 import { schemas } from '@polar-sh/client'
 import {
   Alert,
-  Button,
   Checkbox,
   Input,
   Select,

--- a/clients/apps/web/src/components/Benefit/SlackSharedChannelBenefitForm.tsx
+++ b/clients/apps/web/src/components/Benefit/SlackSharedChannelBenefitForm.tsx
@@ -5,6 +5,7 @@ import {
 } from '@/hooks/queries'
 import { schemas } from '@polar-sh/client'
 import {
+  Alert,
   Button,
   Checkbox,
   Input,
@@ -145,7 +146,7 @@ export const SlackSharedChannelBenefitForm = ({
       <FormField
         control={control}
         name="properties.slack_integration_id"
-        rules={{ required: 'Connect Slack before creating this benefit.' }}
+        rules={{ required: true }}
         render={({ field }) => (
           <FormItem>
             <FormControl>
@@ -383,22 +384,12 @@ const SlackConnectedBanner = ({
 
   return (
     <>
-      <Box
-        display="flex"
-        alignItems="center"
-        justifyContent="between"
-        padding="m"
-        borderRadius="m"
-        backgroundColor="background-success"
-        columnGap="m"
-      >
-        <Text variant="caption">
-          Connected to {integration.team_name ?? integration.team_id}
-        </Text>
-        <Button variant="ghost" size="sm" onClick={() => setShowConfirm(true)}>
-          Disconnect
-        </Button>
-      </Box>
+      <Alert
+        title={`Connected to ${integration.team_name ?? integration.team_id}`}
+        description="You've successfully connected the Slack integration"
+        actions={[{ text: 'Disconnect', onClick: () => setShowConfirm(true) }]}
+      />
+
       <ConfirmModal
         isShown={showConfirm}
         hide={() => setShowConfirm(false)}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Polished the Slack integration setup and shared channel benefit form for a clearer setup flow, a more consistent UI, and stable tests.

- **Refactors**
  - Setup panel: moved “Create app” before the manifest, tweaked copy, and increased spacing.
  - Manifest: restyled `Well` for readability and dark mode.
  - Benefit form: replaced the banner with an `Alert` (with Disconnect), simplified Slack integration ID validation, and removed an unused import.

- **Bug Fixes**
  - Tests: mocked `Alert` in `SlackSharedChannelBenefitForm` tests to fix failures.

<sup>Written for commit 80d1332f368dbb2ab4f6355d616b575a72592e5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

