### PR TITLE
Return 410 on expired checkouts even post deletion

### DIFF
--- a/clients/apps/web/src/app/(checkout)/checkout/[clientSecret]/page.tsx
+++ b/clients/apps/web/src/app/(checkout)/checkout/[clientSecret]/page.tsx
@@ -67,7 +67,7 @@ export default async function Page(props: {
       notFound()
     } else if (
       error instanceof ClientResponseError &&
-      error.response.status === 410
+      (error.response.status === 403 || error.response.status === 410)
     ) {
       notFound() // TODO: show expired checkout page
     } else {

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -1475,11 +1475,11 @@ class CheckoutService:
         if checkout is None:
             raise ResourceNotFound()
 
-        if not checkout.organization.can_authenticate:
-            raise NotPermitted()
-
         if checkout.is_expired:
             raise ExpiredCheckoutError()
+
+        if not checkout.organization.can_authenticate:
+            raise NotPermitted()
         return checkout
 
     async def mark_opened(

--- a/server/tests/checkout/test_endpoints.py
+++ b/server/tests/checkout/test_endpoints.py
@@ -749,6 +749,26 @@ class TestClientGet:
 
         assert response.status_code == 410
 
+    async def test_expired_blocked_organization(
+        self,
+        api_prefix: str,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        product: Product,
+    ) -> None:
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product],
+            status=CheckoutStatus.expired,
+            expires_at=utc_now() - timedelta(days=1),
+        )
+        checkout.organization.set_status(OrganizationStatus.BLOCKED)
+        await save_fixture(checkout.organization)
+
+        response = await client.get(f"{api_prefix}/client/{checkout.client_secret}")
+
+        assert response.status_code == 410
+
     async def test_valid(
         self, api_prefix: str, client: AsyncClient, checkout_open: Checkout
     ) -> None:

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -27,6 +27,7 @@ from polar.checkout.service import (
     AlreadyActiveSubscriptionError,
     CheckoutCustomerDeleted,
     CheckoutCustomerExternalIdMismatch,
+    ExpiredCheckoutError,
     NotConfirmedCheckout,
     NotOpenCheckout,
     TrialAlreadyRedeemed,
@@ -2893,6 +2894,22 @@ class TestGetByClientSecret:
         await save_fixture(checkout_one_time_fixed.organization)
 
         with pytest.raises(NotPermitted):
+            await checkout_service.get_by_client_secret(
+                session, checkout_one_time_fixed.client_secret
+            )
+
+    async def test_raises_expired_before_not_permitted_for_blocked_organization(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        checkout_one_time_fixed: Checkout,
+    ) -> None:
+        checkout_one_time_fixed.expires_at = utc_now() - timedelta(days=1)
+        checkout_one_time_fixed.organization.set_status(OrganizationStatus.BLOCKED)
+        await save_fixture(checkout_one_time_fixed)
+        await save_fixture(checkout_one_time_fixed.organization)
+
+        with pytest.raises(ExpiredCheckoutError):
             await checkout_service.get_by_client_secret(
                 session, checkout_one_time_fixed.client_secret
             )


### PR DESCRIPTION
We throw a server error instead of a not found error if a checkout page throws a 403, cluttering our Vercel SSR logs with errors. By checking the checkout expiration first, we can work around that.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

