### PR TITLE
Require authentication on `/feedback`

### DIFF
--- a/clients/apps/web/src/proxy.test.ts
+++ b/clients/apps/web/src/proxy.test.ts
@@ -259,6 +259,25 @@ describe('middleware function', () => {
     )
   })
 
+  it('should strip spoofed user headers from forwarded routes', async () => {
+    const request = new NextRequest('https://example.com/docs/overview', {
+      headers: {
+        'x-polar-user': Buffer.from(
+          JSON.stringify({ id: 'spoofed', email: 'attacker@example.com' }),
+        ).toString('base64'),
+      },
+    })
+
+    const response = await proxy(request)
+
+    expect(response.status).toBe(200)
+    expect(getForwardedRequestHeader(response, 'x-polar-user')).toBeNull()
+    expect(getForwardedRequestHeaderNames(response)).not.toContain(
+      'x-polar-user',
+    )
+    expect(createServerSideAPI).not.toHaveBeenCalled()
+  })
+
   it('should redirect to login with query params preserved', async () => {
     const request = new NextRequest(
       'https://example.com/dashboard?foo=bar&baz=qux',

--- a/clients/apps/web/src/proxy.test.ts
+++ b/clients/apps/web/src/proxy.test.ts
@@ -9,6 +9,14 @@ vi.mock('./utils/client', () => ({
 
 const nextConfig = {}
 
+const getForwardedRequestHeader = (
+  response: Response,
+  header: string,
+): string | null => response.headers.get(`x-middleware-request-${header}`)
+
+const getForwardedRequestHeaderNames = (response: Response): string[] =>
+  response.headers.get('x-middleware-override-headers')?.split(',') ?? []
+
 describe('proxy matcher configuration', () => {
   it('should run for dashboard routes', () => {
     expect(
@@ -214,6 +222,7 @@ describe('middleware function', () => {
 
   it('should allow authenticated users to access protected routes', async () => {
     const mockUser = { id: '123', email: 'test@example.com' }
+    const spoofedUser = { id: 'spoofed', email: 'attacker@example.com' }
     createServerSideAPI.mockResolvedValue({
       GET: vi.fn().mockResolvedValue({
         data: mockUser,
@@ -221,13 +230,19 @@ describe('middleware function', () => {
       }),
     })
 
-    const request = new NextRequest('https://example.com/dashboard')
+    const request = new NextRequest('https://example.com/dashboard', {
+      headers: {
+        'x-polar-user': Buffer.from(JSON.stringify(spoofedUser)).toString(
+          'base64',
+        ),
+      },
+    })
     request.cookies.set('polar_session', 'valid-session-token')
 
     const response = await proxy(request)
 
     expect(response.status).toBe(200)
-    expect(response.headers.get('x-polar-user')).toBe(
+    expect(getForwardedRequestHeader(response, 'x-polar-user')).toBe(
       Buffer.from(JSON.stringify(mockUser)).toString('base64'),
     )
   })
@@ -238,7 +253,10 @@ describe('middleware function', () => {
     const response = await proxy(request)
 
     expect(response.status).toBe(200)
-    expect(response.headers.get('x-polar-user')).toBeNull()
+    expect(getForwardedRequestHeader(response, 'x-polar-user')).toBeNull()
+    expect(getForwardedRequestHeaderNames(response)).not.toContain(
+      'x-polar-user',
+    )
   })
 
   it('should redirect to login with query params preserved', async () => {

--- a/clients/apps/web/src/proxy.ts
+++ b/clients/apps/web/src/proxy.ts
@@ -10,6 +10,8 @@ import { POLAR_ENV_COOKIE } from './utils/cookies'
 
 const POLAR_AUTH_COOKIE_KEY =
   process.env.POLAR_AUTH_COOKIE_KEY || 'polar_session'
+const POLAR_USER_HEADER = 'x-polar-user'
+const POLAR_DISTINCT_ID_HEADER = 'x-polar-distinct-id'
 
 const IS_SANDBOX =
   (process.env.NEXT_PUBLIC_ENVIRONMENT ||
@@ -97,6 +99,9 @@ const getLoginResponse = (request: NextRequest): NextResponse => {
 }
 
 export async function proxy(request: NextRequest) {
+  const requestHeaders = new Headers(request.headers)
+  requestHeaders.delete(POLAR_USER_HEADER)
+
   // Do not run middleware for forwarded routes
   // @pieterbeulque added this because the `config.matcher` behavior below
   // doesn't appear to be working consistently with Vercel rewrites
@@ -267,16 +272,19 @@ export async function proxy(request: NextRequest) {
   const { id: distinctId, isNew: isNewDistinctId } =
     getOrCreateDistinctId(request)
 
-  const headers: Record<string, string> = {
-    'x-polar-distinct-id': distinctId,
-  }
+  requestHeaders.set(POLAR_DISTINCT_ID_HEADER, distinctId)
   if (user) {
-    headers['x-polar-user'] = Buffer.from(JSON.stringify(user)).toString(
-      'base64',
+    requestHeaders.set(
+      POLAR_USER_HEADER,
+      Buffer.from(JSON.stringify(user)).toString('base64'),
     )
   }
 
-  const response = NextResponse.next({ headers })
+  const response = NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  })
 
   if (isNewDistinctId) {
     response.cookies.set(DISTINCT_ID_COOKIE, distinctId, {

--- a/clients/apps/web/src/proxy.ts
+++ b/clients/apps/web/src/proxy.ts
@@ -3,7 +3,11 @@ import { nanoid } from 'nanoid'
 import { RequestCookiesAdapter } from 'next/dist/server/web/spec-extension/adapters/request-cookies'
 import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
-import { COOKIE_MAX_AGE, DISTINCT_ID_COOKIE } from './experiments/constants'
+import {
+  COOKIE_MAX_AGE,
+  DISTINCT_ID_COOKIE,
+  DISTINCT_ID_HEADER,
+} from './experiments/constants'
 import { createServerSideAPI } from './utils/client'
 import { CONFIG } from './utils/config'
 import { POLAR_ENV_COOKIE } from './utils/cookies'
@@ -11,7 +15,6 @@ import { POLAR_ENV_COOKIE } from './utils/cookies'
 const POLAR_AUTH_COOKIE_KEY =
   process.env.POLAR_AUTH_COOKIE_KEY || 'polar_session'
 const POLAR_USER_HEADER = 'x-polar-user'
-const POLAR_DISTINCT_ID_HEADER = 'x-polar-distinct-id'
 
 const IS_SANDBOX =
   (process.env.NEXT_PUBLIC_ENVIRONMENT ||
@@ -277,7 +280,7 @@ export async function proxy(request: NextRequest) {
   const { id: distinctId, isNew: isNewDistinctId } =
     getOrCreateDistinctId(request)
 
-  requestHeaders.set(POLAR_DISTINCT_ID_HEADER, distinctId)
+  requestHeaders.set(DISTINCT_ID_HEADER, distinctId)
   if (user) {
     requestHeaders.set(
       POLAR_USER_HEADER,

--- a/clients/apps/web/src/proxy.ts
+++ b/clients/apps/web/src/proxy.ts
@@ -46,6 +46,7 @@ const AUTHENTICATED_ROUTES = [
   new RegExp('^/finance(/.*)?$'),
   new RegExp('^/settings(/.*)?$'),
   new RegExp('^/oauth2(/.*)?$'),
+  new RegExp('^/feedback(/.*)?$'),
   new RegExp('^/to(/.*)?$'),
 ]
 

--- a/clients/apps/web/src/proxy.ts
+++ b/clients/apps/web/src/proxy.ts
@@ -107,7 +107,11 @@ export async function proxy(request: NextRequest) {
   // @pieterbeulque added this because the `config.matcher` behavior below
   // doesn't appear to be working consistently with Vercel rewrites
   if (isForwardedRoute(request)) {
-    return NextResponse.next()
+    return NextResponse.next({
+      request: {
+        headers: requestHeaders,
+      },
+    })
   }
 
   if (request.nextUrl.pathname.startsWith('/to/')) {


### PR DESCRIPTION
Require authentication for the support form + fix X-Polar-User spoofing by always stripping it from the forwarded headers

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

