### PR TITLE
fix(organization): live review are not shadowed by soft deleted

### DIFF
--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -824,12 +824,20 @@ class Organization(RateLimitGroupMixin, RecordModel):
 
     @declared_attr
     def review(cls) -> Mapped["OrganizationReview | None"]:
+        # The single live review. A partial unique index guarantees at most one
+        # row per organization with deleted_at IS NULL, so a soft-deleted prior
+        # review (e.g. a reset grandfathered one) never shadows the live one.
         return relationship(
             "OrganizationReview",
             lazy="raise",
-            back_populates="organization",
-            cascade="delete, delete-orphan",
-            uselist=False,  # This makes it a one-to-one relationship
+            uselist=False,
+            viewonly=True,
+            primaryjoin=(
+                "and_("
+                "OrganizationReview.organization_id == Organization.id, "
+                "OrganizationReview.deleted_at.is_(None)"
+                ")"
+            ),
         )
 
     @declared_attr

--- a/server/polar/models/organization_review.py
+++ b/server/polar/models/organization_review.py
@@ -76,7 +76,7 @@ class OrganizationReview(RecordModel):
 
     @declared_attr
     def organization(cls) -> Mapped["Organization"]:
-        return relationship("Organization", lazy="raise", back_populates="review")
+        return relationship("Organization", lazy="raise")
 
     def clear_appeal_state(self) -> None:
         self.appeal_submitted_at = None

--- a/server/tests/models/test_organization.py
+++ b/server/tests/models/test_organization.py
@@ -1,0 +1,50 @@
+import pytest
+from sqlalchemy.orm import joinedload
+
+from polar.kit.utils import utc_now
+from polar.models import Organization, OrganizationReview
+from polar.organization.repository import OrganizationRepository
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+
+
+@pytest.mark.asyncio
+class TestReviewRelationship:
+    async def test_resolves_to_live_review_when_soft_deleted_exists(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        """A soft-deleted prior review (e.g. a reset grandfathered one) must not
+        shadow the live one — `organization.review` is the live row only."""
+        await save_fixture(
+            OrganizationReview(
+                organization_id=organization.id,
+                verdict=OrganizationReview.Verdict.FAIL,
+                risk_score=90.0,
+                violated_sections=[],
+                reason="superseded",
+                model_used="test",
+                deleted_at=utc_now(),
+            )
+        )
+        live = OrganizationReview(
+            organization_id=organization.id,
+            verdict=OrganizationReview.Verdict.FAIL,
+            risk_score=90.0,
+            violated_sections=[],
+            reason="live",
+            model_used="test",
+        )
+        await save_fixture(live)
+
+        session.expunge_all()
+        repository = OrganizationRepository.from_session(session)
+        loaded = await repository.get_by_id(
+            organization.id, options=(joinedload(Organization.review),)
+        )
+
+        assert loaded is not None
+        assert loaded.review is not None
+        assert loaded.review.id == live.id


### PR DESCRIPTION
## Summary

The `reset_unconfigured_grandfathered_orgs.py` script (introduced in PR #11584, merged May 13), which was run on 2026-05-18 at ~09:​26 UTC.

It runs this SQL per batch:
```
UPDATE organization_reviews
SET deleted_at = now()
WHERE organization_id = ANY(:ids)
  AND model_used = 'grandfathered'
  AND reason = 'Grandfathered organization'
  AND deleted_at IS NULL
``` 

After soft-deleting the grandfathered reviews, when merchants re-submitted, the SUBMISSION task tried to INSERT a new OrganizationReview — but the unique index on organization_id wasn't partial at the time, so the soft-deleted row still occupied the slot → UniqueViolationError → silent failure + "press deny, nothing happens → press again, org already denied" behavior.

Two follow-up PRs fixed this:
PR #11807 (May 21): SUBMISSION task now updates in-place instead of delete+insert
PR #11944 (May 27): Unique index made partial (WHERE deleted_at IS NULL)

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

