### PR TITLE
server: pin FastAPI to 0.136.3

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 readme = "README.md"
 requires-python = ">=3.14.0"
 dependencies = [
-  "fastapi>=0.136.3",
+  "fastapi==0.136.3", # Don't unpin this until https://github.com/open-telemetry/opentelemetry-python-contrib/issues/4699 is resolved
   "uvicorn[standard]>=0.49.0",
   "asyncpg>=0.29.0",
   "alembic>=1.9.2",

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-06-15T15:30:35.004792Z"
+exclude-newer = "2026-06-17T07:51:38.371259Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -2494,7 +2494,7 @@ requires-dist = [
     { name = "dramatiq", extras = ["redis", "watch"], git = "https://github.com/frankie567/dramatiq?rev=memory-leak-asyncio-ter" },
     { name = "email-validator", specifier = ">=2.1.0.post1" },
     { name = "exponent-server-sdk", specifier = ">=2.1.0" },
-    { name = "fastapi", specifier = ">=0.136.3" },
+    { name = "fastapi", specifier = "==0.136.3" },
     { name = "firecrawl-py", specifier = ">=4.28.2" },
     { name = "fpdf2", specifier = ">=2.8.3" },
     { name = "genai-prices", specifier = ">=0.0.66" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hard-pin `fastapi` to 0.136.3 to prevent regressions from newer releases and keep the server stable. This is temporary until https://github.com/open-telemetry/opentelemetry-python-contrib/issues/4699 is resolved.

<sup>Written for commit 3d5a5094d3c2053d593abf96ce626d995add6d17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

