### PR TITLE
test(deps): Guard against FastAPI <-> OpenTelemetry instrumentation skew

### DIFF
--- a/server/tests/observability/test_instrumentation_smoke.py
+++ b/server/tests/observability/test_instrumentation_smoke.py
@@ -7,20 +7,9 @@ from polar.logfire import instrument_fastapi
 
 
 @pytest.mark.asyncio
-async def test_instrument_fastapi_resolves_nested_routes(
+async def test_instrument_fastapi(
     capfire: CaptureLogfire,
 ) -> None:
-    """Guard against FastAPI <-> OpenTelemetry instrumentation skew.
-
-    OTel names each server span by walking ``app.routes`` at *request* time
-    (``_get_route_details``). A breaking change in how FastAPI stores routes
-    (e.g. 0.137's tree with ``_IncludedRouter`` nodes) makes that walk raise
-    mid-request instead of failing at import — so it only shows up once a real
-    request flows through the *instrumented*, nested router tree.
-
-    ``capfire`` forces ``send_to_logfire=False`` and captures spans in memory,
-    so nothing is exported to Logfire or S3 regardless of ambient env.
-    """
     leaf = APIRouter()
 
     @leaf.get("/ping")
@@ -37,6 +26,8 @@ async def test_instrument_fastapi_resolves_nested_routes(
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
         full_match = await client.get("/v1/leaf/ping")
+        """The wrong-method request exercises partial route matching,
+        the only path that catches instrumentation breaking against FastAPI internals."""
         partial_match = await client.post("/v1/leaf/ping")
 
     assert full_match.status_code == 200

--- a/server/tests/observability/test_instrumentation_smoke.py
+++ b/server/tests/observability/test_instrumentation_smoke.py
@@ -1,0 +1,38 @@
+import httpx
+import pytest
+from fastapi import APIRouter, FastAPI
+
+from polar.logfire import instrument_fastapi
+
+
+@pytest.mark.asyncio
+async def test_instrument_fastapi_resolves_nested_routes() -> None:
+    """Guard against FastAPI <-> OpenTelemetry instrumentation skew.
+
+    OTel names each server span by walking ``app.routes`` at *request* time
+    (``_get_route_details``). A breaking change in how FastAPI stores routes
+    (e.g. 0.137's tree with ``_IncludedRouter`` nodes) makes that walk raise
+    mid-request instead of failing at import — so it only shows up once a real
+    request flows through the *instrumented*, nested router tree.
+    """
+    leaf = APIRouter()
+
+    @leaf.get("/ping")
+    async def ping() -> dict[str, bool]:
+        return {"ok": True}
+
+    mid = APIRouter()
+    mid.include_router(leaf, prefix="/leaf")
+    app = FastAPI()
+    app.include_router(mid, prefix="/v1")
+
+    instrument_fastapi(app)  # same call as polar/app.py:264
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport, base_url="http://test"
+    ) as client:
+        response = await client.get("/v1/leaf/ping")
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}

--- a/server/tests/observability/test_instrumentation_smoke.py
+++ b/server/tests/observability/test_instrumentation_smoke.py
@@ -1,12 +1,15 @@
 import httpx
 import pytest
 from fastapi import APIRouter, FastAPI
+from logfire.testing import CaptureLogfire
 
 from polar.logfire import instrument_fastapi
 
 
 @pytest.mark.asyncio
-async def test_instrument_fastapi_resolves_nested_routes() -> None:
+async def test_instrument_fastapi_resolves_nested_routes(
+    capfire: CaptureLogfire,
+) -> None:
     """Guard against FastAPI <-> OpenTelemetry instrumentation skew.
 
     OTel names each server span by walking ``app.routes`` at *request* time
@@ -14,6 +17,9 @@ async def test_instrument_fastapi_resolves_nested_routes() -> None:
     (e.g. 0.137's tree with ``_IncludedRouter`` nodes) makes that walk raise
     mid-request instead of failing at import — so it only shows up once a real
     request flows through the *instrumented*, nested router tree.
+
+    ``capfire`` forces ``send_to_logfire=False`` and captures spans in memory,
+    so nothing is exported to Logfire or S3 regardless of ambient env.
     """
     leaf = APIRouter()
 
@@ -36,3 +42,10 @@ async def test_instrument_fastapi_resolves_nested_routes() -> None:
 
     assert response.status_code == 200
     assert response.json() == {"ok": True}
+
+    routes = {
+        span.attributes.get("http.route")
+        for span in capfire.exporter.exported_spans
+        if span.attributes is not None
+    }
+    assert "/v1/leaf/ping" in routes

--- a/server/tests/observability/test_instrumentation_smoke.py
+++ b/server/tests/observability/test_instrumentation_smoke.py
@@ -35,13 +35,12 @@ async def test_instrument_fastapi_resolves_nested_routes(
     instrument_fastapi(app)  # same call as polar/app.py:264
 
     transport = httpx.ASGITransport(app=app)
-    async with httpx.AsyncClient(
-        transport=transport, base_url="http://test"
-    ) as client:
-        response = await client.get("/v1/leaf/ping")
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        full_match = await client.get("/v1/leaf/ping")
+        partial_match = await client.post("/v1/leaf/ping")
 
-    assert response.status_code == 200
-    assert response.json() == {"ok": True}
+    assert full_match.status_code == 200
+    assert partial_match.status_code == 405
 
     routes = {
         span.attributes.get("http.route")


### PR DESCRIPTION
## Summary


## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a smoke test that runs `instrument_fastapi` on a nested-router `FastAPI` app (same call as production) to guard against `FastAPI` <-> `OpenTelemetry` skew at runtime. It sends GET and POST to `/v1/leaf/ping` to hit full- and partial-match paths (200/405), asserts spans include route `/v1/leaf/ping`, and uses `CaptureLogfire` so no traces are exported even if a Logfire token is set.

<sup>Written for commit 2893773da471d6adf2b9781b1772250cf2b7186e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

