### PR TITLE
ci: Build docker on a larger machine

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -221,6 +221,8 @@ jobs:
           context: ./server
           target: production
           platforms: linux/amd64
+          cache-from: type=registry,ref=ghcr.io/polarsource/polar:buildcache
+          cache-to: type=registry,ref=ghcr.io/polarsource/polar:buildcache,mode=max
           build-args: |
             RELEASE_VERSION=${{ github.sha }}
           secrets: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -178,7 +178,7 @@ jobs:
     # needs the build.
     if: needs.changes.outputs.backend-sandbox == 'true' || needs.changes.outputs.backend-production == 'true' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 20
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: blacksmith-8vcpu-ubuntu-2404
     permissions:
       contents: read
       packages: write

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -8,7 +8,8 @@ WORKDIR /app
 
 COPY ./emails/pnpm-lock.yaml .
 COPY ./emails/package.json .
-RUN pnpm install --frozen-lockfile
+RUN --mount=type=cache,target=/pnpm/store \
+  pnpm install --frozen-lockfile --store-dir=/pnpm/store
 
 COPY ./emails/src src/
 COPY ./emails/tsconfig.json .
@@ -27,7 +28,8 @@ WORKDIR /app
 COPY ./polar/backoffice/pnpm-lock.yaml .
 COPY ./polar/backoffice/package.json .
 COPY ./polar/backoffice/pnpm-workspace.yaml .
-RUN pnpm install --frozen-lockfile
+RUN --mount=type=cache,target=/pnpm/store \
+  pnpm install --frozen-lockfile --store-dir=/pnpm/store
 
 COPY ./polar/backoffice/ .
 

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -89,7 +89,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.11.24 /uv /uvx /bin/
 
 ENV PYTHONUNBUFFERED=1
 ENV UV_COMPILE_BYTECODE=1
-ENV UV_NO_CACHE=1
+ENV UV_LINK_MODE=copy
 ENV UV_NO_SYNC=1
 ENV PATH="/root/.local/bin:$PATH"
 
@@ -97,12 +97,12 @@ WORKDIR /app/server
 
 RUN --mount=type=bind,source=uv.lock,target=uv.lock \
   --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+  --mount=type=cache,target=/root/.cache/uv \
   apt-get update \
   && apt-get install -y \
   git \
   build-essential \
-  redis \
-  libpq-dev \
+  libpq5 \
   && uv sync --no-group dev --frozen \
   && uv tool install tinybird --python 3.13 \
   && apt-get autoremove -y build-essential

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -132,13 +132,13 @@ COPY --from=ghcr.io/astral-sh/uv:0.11.24 /uv /uvx /bin/
 ENV PYTHONUNBUFFERED=1
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE=copy
-ENV UV_NO_CACHE=1
 ENV UV_NO_SYNC=1
 
 WORKDIR /app/server
 
 RUN --mount=type=bind,source=uv.lock,target=uv.lock \
   --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+  --mount=type=cache,target=/root/.cache/uv \
   dnf install -y gcc gcc-c++ git make \
   && uv sync --no-group dev --frozen \
   && dnf clean all
@@ -162,8 +162,8 @@ ENV RELEASE_VERSION=${RELEASE_VERSION}
 
 COPY --from=lambda-build /app /app
 COPY --from=lambda-build /data /data
-COPY --from=docker.io/tailscale/tailscale:stable /usr/local/bin/tailscaled /var/runtime/tailscaled
-COPY --from=docker.io/tailscale/tailscale:stable /usr/local/bin/tailscale /var/runtime/tailscale
+COPY --from=docker.io/tailscale/tailscale:v1.98.4 /usr/local/bin/tailscaled /var/runtime/tailscaled
+COPY --from=docker.io/tailscale/tailscale:v1.98.4 /usr/local/bin/tailscale /var/runtime/tailscale
 
 ENV LAMBDA_TASK_ROOT=/app/server
 ENV PATH="/app/server/.venv/bin:$PATH"

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -113,7 +113,6 @@ COPY --from=build-emails-bin /app/bin/react-email-pkg /app/server/
 ENV POLAR_EMAIL_RENDERER_BINARY_PATH=/app/server/react-email-pkg
 
 COPY --from=build-backoffice /app/static /app/server/polar/backoffice/static
-RUN ls -la /app/server/polar/backoffice/static
 
 COPY --from=download-ipinfo /data /data
 ENV POLAR_IP_GEOLOCATION_DATABASE_DIRECTORY_PATH=/data

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -83,7 +83,7 @@ FROM --platform=$BUILDPLATFORM python:3.14-slim AS production
 LABEL org.opencontainers.image.source=https://github.com/polarsource/polar
 LABEL org.opencontainers.image.description="Polar"
 LABEL org.opencontainers.image.licenses=Apache-2.0
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.24 /uv /uvx /bin/
 
 ENV PYTHONUNBUFFERED=1
 ENV UV_COMPILE_BYTECODE=1
@@ -126,7 +126,7 @@ CMD ["uv", "run", "uvicorn", "polar.app:app", "--host", "0.0.0.0", "--port", "10
 
 # Stage 6: AWS Lambda image (SQS-driven background tasks, POC)
 FROM public.ecr.aws/lambda/python:3.14 AS lambda-build
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.24 /uv /uvx /bin/
 
 ENV PYTHONUNBUFFERED=1
 ENV UV_COMPILE_BYTECODE=1


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use a larger GitHub Actions runner for Docker builds to speed up deploys and reduce timeouts. Switch the deploy workflow from `blacksmith-4vcpu-ubuntu-2404` to `blacksmith-8vcpu-ubuntu-2404` for backend sandbox and production builds.

<sup>Written for commit cb0e30e9b8f4750f6b19398eb31533124ef9d6dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

