### PR TITLE
tf/aws: Set up roles per account

### DIFF
--- a/terraform/global/aws.tf
+++ b/terraform/global/aws.tf
@@ -1,0 +1,54 @@
+locals {
+  terraform_cloud_aws_run_role_name = "terraform-cloud"
+
+  terraform_cloud_aws_workspaces = {
+    organization = {
+      account_id = "975049931254"
+      workspace  = "organization"
+    }
+    production = {
+      account_id = "538043300756"
+      workspace  = "polar"
+    }
+    sandbox = {
+      account_id = "427025827993"
+      workspace  = "sandbox"
+    }
+    test = {
+      account_id = "805865757777"
+      workspace  = "test"
+    }
+  }
+}
+
+data "tfe_workspace_ids" "aws" {
+  organization = "polar-sh"
+  names = [
+    for workspace in local.terraform_cloud_aws_workspaces :
+    workspace.workspace
+  ]
+}
+
+resource "tfe_variable" "tfc_aws_provider_auth" {
+  for_each = local.terraform_cloud_aws_workspaces
+
+  key         = "TFC_AWS_PROVIDER_AUTH"
+  value       = "true"
+  category    = "env"
+  description = "Enable AWS provider authentication via OIDC."
+  workspace_id = data.tfe_workspace_ids.aws.ids[
+    each.value.workspace
+  ]
+}
+
+resource "tfe_variable" "tfc_aws_run_role_arn" {
+  for_each = local.terraform_cloud_aws_workspaces
+
+  key         = "TFC_AWS_RUN_ROLE_ARN"
+  value       = "arn:aws:iam::${each.value.account_id}:role/${local.terraform_cloud_aws_run_role_name}"
+  category    = "env"
+  description = "AWS IAM role ARN for HCP Terraform runs."
+  workspace_id = data.tfe_workspace_ids.aws.ids[
+    each.value.workspace
+  ]
+}

--- a/terraform/global/main.tf
+++ b/terraform/global/main.tf
@@ -114,22 +114,6 @@ resource "tfe_variable" "render_owner_id" {
   variable_set_id = tfe_variable_set.global.id
 }
 
-resource "tfe_variable" "tfc_aws_provider_auth" {
-  key             = "TFC_AWS_PROVIDER_AUTH"
-  value           = "true"
-  category        = "env"
-  description     = "Enable AWS provider authentication via OIDC"
-  variable_set_id = tfe_variable_set.global.id
-}
-
-resource "tfe_variable" "tfc_aws_run_role_arn" {
-  key             = "TFC_AWS_RUN_ROLE_ARN"
-  value           = "arn:aws:iam::975049931254:role/terraform-cloud"
-  category        = "env"
-  description     = "AWS IAM Role ARN for Terraform Cloud runs"
-  variable_set_id = tfe_variable_set.global.id
-}
-
 resource "tfe_variable" "grafana_cloud_prometheus_url" {
   key             = "grafana_cloud_prometheus_url"
   category        = "terraform"

--- a/terraform/modules/terraform_cloud_run_role/main.tf
+++ b/terraform/modules/terraform_cloud_run_role/main.tf
@@ -1,0 +1,92 @@
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+variable "role_name" {
+  description = "Name of the IAM role for HCP Terraform runs."
+  type        = string
+  default     = "terraform-cloud"
+}
+
+variable "terraform_cloud_organization" {
+  description = "HCP Terraform organization name."
+  type        = string
+}
+
+variable "terraform_cloud_project" {
+  description = "HCP Terraform project name."
+  type        = string
+}
+
+variable "terraform_cloud_workspace" {
+  description = "HCP Terraform workspace name."
+  type        = string
+}
+
+variable "terraform_cloud_hostname" {
+  description = "HCP Terraform hostname without scheme."
+  type        = string
+  default     = "app.terraform.io"
+}
+
+variable "audience" {
+  description = "OIDC audience used by HCP Terraform dynamic AWS credentials."
+  type        = string
+  default     = "aws.workload.identity"
+}
+
+variable "policy_arns" {
+  description = "Map of key => IAM policy ARN to attach to the role."
+  type        = map(string)
+}
+
+resource "aws_iam_openid_connect_provider" "terraform_cloud" {
+  url            = "https://${var.terraform_cloud_hostname}"
+  client_id_list = [var.audience]
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.terraform_cloud.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${var.terraform_cloud_hostname}:aud"
+      values   = [var.audience]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "${var.terraform_cloud_hostname}:sub"
+      values = [
+        "organization:${var.terraform_cloud_organization}:project:${var.terraform_cloud_project}:workspace:${var.terraform_cloud_workspace}:run_phase:*",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "terraform_cloud" {
+  name               = var.role_name
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "policies" {
+  for_each = var.policy_arns
+
+  role       = aws_iam_role.terraform_cloud.name
+  policy_arn = each.value
+}

--- a/terraform/modules/terraform_cloud_run_role/outputs.tf
+++ b/terraform/modules/terraform_cloud_run_role/outputs.tf
@@ -1,0 +1,7 @@
+output "role_arn" {
+  value = aws_iam_role.terraform_cloud.arn
+}
+
+output "oidc_provider_arn" {
+  value = aws_iam_openid_connect_provider.terraform_cloud.arn
+}

--- a/terraform/organization/README.md
+++ b/terraform/organization/README.md
@@ -31,3 +31,24 @@ Application workloads live under the `Workloads` OU:
 - Attach guardrails that apply to every application account to `Workloads`.
 - Attach production-class guardrails to both `Production` and `Sandbox`.
 - Attach test/staging-specific guardrails to `Test`.
+
+## Terraform Ownership
+
+Terraform manages the workload OUs and member account placement.
+
+The management account is verified through the Organizations data source but is not managed as an
+`aws_organizations_account` resource because that resource manages member accounts, not the
+management account itself.
+
+Terraform also creates an HCP Terraform run role named `terraform-cloud` in each workload account.
+Those roles trust HCP Terraform's AWS dynamic credentials issuer and are scoped to the matching
+workspace:
+
+```text
+production account -> polar workspace
+sandbox account    -> sandbox workspace
+test account       -> test workspace
+```
+
+The HCP Terraform workspace variables that point each workspace at its AWS role are managed from
+`terraform/global`.

--- a/terraform/organization/main.tf
+++ b/terraform/organization/main.tf
@@ -72,6 +72,10 @@ resource "aws_organizations_account" "workload" {
   parent_id         = aws_organizations_organizational_unit.workload[each.value.organizational_unit].id
   close_on_deletion = false
 
+  tags = {
+    environment = each.key
+  }
+
   lifecycle {
     prevent_destroy = true
   }

--- a/terraform/organization/outputs.tf
+++ b/terraform/organization/outputs.tf
@@ -31,3 +31,11 @@ output "workload_accounts" {
     }
   }
 }
+
+output "terraform_cloud_run_roles" {
+  value = {
+    production = module.terraform_cloud_run_role_production.role_arn
+    sandbox    = module.terraform_cloud_run_role_sandbox.role_arn
+    test       = module.terraform_cloud_run_role_test.role_arn
+  }
+}

--- a/terraform/organization/terraform_cloud.tf
+++ b/terraform/organization/terraform_cloud.tf
@@ -1,0 +1,91 @@
+locals {
+  terraform_cloud = {
+    organization = "polar-sh"
+    role_name    = "terraform-cloud"
+
+    workspaces = {
+      production = {
+        project   = "Production"
+        workspace = "polar"
+      }
+      sandbox = {
+        project   = "sandbox"
+        workspace = "sandbox"
+      }
+      test = {
+        project   = "test"
+        workspace = "test"
+      }
+    }
+
+    run_role_policy_arns = {
+      administrator_access = "arn:aws:iam::aws:policy/AdministratorAccess"
+    }
+  }
+}
+
+provider "aws" {
+  alias  = "production"
+  region = "us-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.workload_accounts.production.id}:role/${var.member_account_bootstrap_role_name}"
+  }
+}
+
+provider "aws" {
+  alias  = "sandbox"
+  region = "us-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.workload_accounts.sandbox.id}:role/${var.member_account_bootstrap_role_name}"
+  }
+}
+
+provider "aws" {
+  alias  = "test"
+  region = "us-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.workload_accounts.test.id}:role/${var.member_account_bootstrap_role_name}"
+  }
+}
+
+module "terraform_cloud_run_role_production" {
+  source = "../modules/terraform_cloud_run_role"
+  providers = {
+    aws = aws.production
+  }
+
+  role_name                    = local.terraform_cloud.role_name
+  terraform_cloud_organization = local.terraform_cloud.organization
+  terraform_cloud_project      = local.terraform_cloud.workspaces.production.project
+  terraform_cloud_workspace    = local.terraform_cloud.workspaces.production.workspace
+  policy_arns                  = local.terraform_cloud.run_role_policy_arns
+}
+
+module "terraform_cloud_run_role_sandbox" {
+  source = "../modules/terraform_cloud_run_role"
+  providers = {
+    aws = aws.sandbox
+  }
+
+  role_name                    = local.terraform_cloud.role_name
+  terraform_cloud_organization = local.terraform_cloud.organization
+  terraform_cloud_project      = local.terraform_cloud.workspaces.sandbox.project
+  terraform_cloud_workspace    = local.terraform_cloud.workspaces.sandbox.workspace
+  policy_arns                  = local.terraform_cloud.run_role_policy_arns
+}
+
+module "terraform_cloud_run_role_test" {
+  source = "../modules/terraform_cloud_run_role"
+  providers = {
+    aws = aws.test
+  }
+
+  role_name                    = local.terraform_cloud.role_name
+  terraform_cloud_organization = local.terraform_cloud.organization
+  terraform_cloud_project      = local.terraform_cloud.workspaces.test.project
+  terraform_cloud_workspace    = local.terraform_cloud.workspaces.test.workspace
+  policy_arns                  = local.terraform_cloud.run_role_policy_arns
+}

--- a/terraform/organization/variables.tf
+++ b/terraform/organization/variables.tf
@@ -18,3 +18,9 @@ variable "test_account_email" {
   sensitive   = true
   nullable    = false
 }
+
+variable "member_account_bootstrap_role_name" {
+  description = "IAM role name Terraform uses from the management account to bootstrap IAM resources in member accounts."
+  type        = string
+  default     = "OrganizationAccountAccessRole"
+}


### PR DESCRIPTION
Have a role per account that terraform cloud can use instead of a single hard coded one

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

