### PR TITLE
Void pending orders when canceling past_due subscriptions

### DIFF
--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -92,6 +92,20 @@ class SubscriptionRepository(
         )
         return await self.get_all(statement)
 
+    async def list_billable_by_customer(
+        self, customer_id: UUID, *, options: Options = ()
+    ) -> Sequence[Subscription]:
+        statement = (
+            self.get_base_statement()
+            .where(
+                Subscription.customer_id == customer_id,
+                Subscription.status.in_(SubscriptionStatus.billable_statuses()),
+                Subscription.ended_at.is_(None),
+            )
+            .options(*options)
+        )
+        return await self.get_all(statement)
+
     async def get_all_by_customer(
         self, customer_id: UUID, *, options: Options = ()
     ) -> Sequence[Subscription]:

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1795,8 +1795,14 @@ class SubscriptionService:
     async def cancel_customer(
         self, session: AsyncSession, customer_id: uuid.UUID
     ) -> None:
+        """Immediately cancel all billable subscriptions of a customer.
+
+        Used when a customer is deleted. This includes ``past_due`` subscriptions,
+        whose pending orders would otherwise keep being retried by dunning. Revoking
+        them voids any pending order through ``_on_subscription_revoked``.
+        """
         subscription_repository = SubscriptionRepository.from_session(session)
-        subscriptions = await subscription_repository.list_active_by_customer(
+        subscriptions = await subscription_repository.list_billable_by_customer(
             customer_id, options=subscription_repository.get_eager_options()
         )
         for subscription in subscriptions:

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -57,7 +57,7 @@ from polar.models.checkout import CheckoutStatus
 from polar.models.customer import CustomerType
 from polar.models.customer_seat import SeatStatus
 from polar.models.discount import DiscountDuration, DiscountType
-from polar.models.order import OrderBillingReasonInternal
+from polar.models.order import OrderBillingReasonInternal, OrderStatus
 from polar.models.product_price import ProductPriceAmountType, ProductPriceSeatUnit
 from polar.models.subscription import SubscriptionStatus
 from polar.models.webhook_endpoint import WebhookEventType
@@ -107,6 +107,7 @@ from tests.fixtures.random_objects import (
     create_event,
     create_legacy_recurring_product_price,
     create_meter,
+    create_order,
     create_payment_method,
     create_product,
     create_product_fixed_and_seat,
@@ -6848,6 +6849,51 @@ class TestCancelCustomer:
         assert len(benefit_grant_calls) == 0, (
             "Expected no calls to 'benefit.enqueue_benefits_grants', "
             f"but found {len(benefit_grant_calls)} call(s)"
+        )
+
+    async def test_past_due_subscription_is_canceled_and_voids_pending_orders(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        enqueue_job_mock: MagicMock,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        """A past_due subscription is canceled on customer deletion, and its
+        pending orders are voided instead of being retried by dunning."""
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.past_due,
+            started_at=utc_now(),
+            past_due_at=utc_now(),
+        )
+        await create_order(
+            save_fixture,
+            customer=customer,
+            product=product,
+            subscription=subscription,
+            status=OrderStatus.pending,
+            next_payment_attempt_at=utc_now(),
+        )
+
+        await subscription_service.cancel_customer(session, customer.id)
+
+        await session.refresh(subscription)
+        assert subscription.status == SubscriptionStatus.canceled
+        assert subscription.canceled_at is not None
+        assert subscription.ended_at is not None
+
+        void_calls = [
+            call_args
+            for call_args in enqueue_job_mock.call_args_list
+            if call_args[0][0] == "order.void_pending_orders_for_subscription"
+            and call_args[0][1] == subscription.id
+        ]
+        assert len(void_calls) == 1, (
+            "Expected the past_due subscription's pending orders to be voided, "
+            f"but found {len(void_calls)} void call(s)"
         )
 
 


### PR DESCRIPTION
## Summary

**Related Issue**: [Backoffice](https://backoffice.polar.sh/feedbacks/67833f81-728f-4317-ae97-4cf558cf4688)

When a customer is deleted, their subscriptions are canceled. However, past_due subscriptions with pending orders were only being canceled without voiding those orders, allowing dunning to continue retrying them. This change ensures pending orders are properly voided when past_due subscriptions are revoked.

## What

- Added `list_billable_by_customer()` method to `SubscriptionRepository` to retrieve all billable subscriptions (including `past_due` status) for a customer
- Updated `cancel_customer()` in `SubscriptionService` to use `list_billable_by_customer()` instead of `list_active_by_customer()`, ensuring `past_due` subscriptions are included
- Added comprehensive docstring explaining the behavior and rationale
- Added test case `test_past_due_subscription_is_canceled_and_voids_pending_orders()` to verify pending orders are voided when past_due subscriptions are canceled

## Why

Past_due subscriptions represent failed payment attempts that are being retried by the dunning process. When a customer is deleted, these subscriptions should be canceled and their pending orders voided to prevent further dunning attempts. Previously, only "active" subscriptions were being canceled, leaving past_due subscriptions and their pending orders in limbo.

## How

1. Created a new repository method that queries for subscriptions with billable statuses (which includes `past_due`) that haven't ended
2. Updated the customer cancellation flow to use this new method
3. The existing `_on_subscription_revoked()` handler already voids pending orders when subscriptions are revoked, so no additional service logic was needed
4. Added a test to verify the behavior works correctly

## Checklist

- [x] This PR addresses a single concern (ensuring pending orders are voided for past_due subscriptions on customer deletion)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests (added `test_past_due_subscription_is_canceled_and_voids_pending_orders`)
- [x] Linting and type checking pass
- [x] No unrelated changes included

https://claude.ai/code/session_01B9GfVZj5xtXE3CyUGGhx9g

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

