### PR TITLE
Temporarily disable E2E runs

### DIFF
--- a/.github/workflows/e2e_flakiness_analysis.yaml
+++ b/.github/workflows/e2e_flakiness_analysis.yaml
@@ -1,9 +1,6 @@
 name: "E2E Flakiness Analysis"
 
 on:
-  workflow_run:
-    workflows: ["E2E Tests", "Preview Environments"]
-    types: [completed]
   workflow_dispatch:
     inputs:
       run_id:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -259,19 +259,6 @@ jobs:
             --sha "$SHA" \
             --github-output "$GITHUB_OUTPUT"
 
-  # --- E2E Tests ---
-  e2e:
-    name: "Preview: E2E"
-    needs: preview
-    if: |
-      github.event_name == 'pull_request' &&
-      needs.preview.result == 'success' &&
-      needs.preview.outputs.preview_url != ''
-    uses: ./.github/workflows/test_e2e.yaml
-    with:
-      preview_url: ${{ needs.preview.outputs.preview_url }}
-    secrets: inherit
-
   # --- PR Comment ---
   preview_comment:
     name: "Preview: Comment"

--- a/.github/workflows/test_e2e.yaml
+++ b/.github/workflows/test_e2e.yaml
@@ -5,8 +5,6 @@ on:
     inputs:
       preview_url:
         type: string
-  schedule:
-    - cron: "*/30 * * * *"
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Temporarily disable automatic E2E runs in GitHub Actions to reduce flakiness and noise. E2E and flakiness analysis now run only when triggered manually.

- **Refactors**
  - Removed the E2E job from `preview.yml`.
  - Stopped `e2e_flakiness_analysis.yaml` from auto-running on `workflow_run`.
  - Removed the cron schedule from `test_e2e.yaml`; keep `workflow_call` and `workflow_dispatch` only.

<sup>Written for commit 508138f6f396dfa1f379a8db74d2e53ae4ecf1e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

