### PR TITLE
Allow iOS widget to refresh token

### DIFF
--- a/clients/apps/app/app.config.js
+++ b/clients/apps/app/app.config.js
@@ -64,6 +64,9 @@ module.exports = {
         'com.apple.security.application-groups': [
           'group.com.polarsource.Polar',
         ],
+        'keychain-access-groups': [
+          '$(AppIdentifierPrefix)com.polarsource.Polar',
+        ],
       },
       associatedDomains: ['applinks:polar.godetour.link'],
     },

--- a/clients/apps/app/auth/refresher.test.ts
+++ b/clients/apps/app/auth/refresher.test.ts
@@ -16,6 +16,12 @@ jest.mock('expo-auth-session', () => {
   }
 })
 
+const mockGetStorageItemAsync = jest.fn<Promise<string | null>, [string]>()
+
+jest.mock('@/hooks/storage', () => ({
+  getStorageItemAsync: (key: string) => mockGetStorageItemAsync(key),
+}))
+
 let configureRefresher: (typeof RefresherModule)['configureRefresher']
 let hasRefreshToken: (typeof RefresherModule)['hasRefreshToken']
 let isAccessTokenStale: (typeof RefresherModule)['isAccessTokenStale']
@@ -68,6 +74,8 @@ beforeEach(() => {
     refreshAccessToken,
   } = require('./refresher') as typeof RefresherModule)
   mockRefreshAsync.mockReset()
+  mockGetStorageItemAsync.mockReset()
+  mockGetStorageItemAsync.mockResolvedValue(null)
   jest.useFakeTimers().setSystemTime(NOW)
 })
 
@@ -298,6 +306,46 @@ describe('refreshAccessToken', () => {
     expect(result).toBeNull()
     expect(setSession).not.toHaveBeenCalledWith(null)
     expect(hasRefreshToken()).toBe(true)
+  })
+
+  it('on invalid_grant, adopts a token the widget rotated instead of clearing', async () => {
+    mockGetStorageItemAsync.mockImplementation(async (key) => {
+      if (key === 'session_refresh_token') return 'widget-rotated-rt'
+      if (key === 'session') return 'widget-access-token'
+      if (key === 'session_expires_at') return String(NOW + 120_000)
+      return null
+    })
+    const { setSession } = configure({ refreshToken: 'old-rt' })
+    mockRefreshAsync.mockRejectedValueOnce(
+      new TokenError({ error: 'invalid_grant' }),
+    )
+
+    const result = await refreshAccessToken()
+
+    expect(result).toBe('widget-access-token')
+    expect(setSession).toHaveBeenCalledWith({
+      accessToken: 'widget-access-token',
+      refreshToken: 'widget-rotated-rt',
+      expiresAt: NOW + 120_000,
+    })
+    expect(setSession).not.toHaveBeenCalledWith(null)
+    expect(hasRefreshToken()).toBe(true)
+  })
+
+  it('on invalid_grant, clears the session when storage holds the same refresh token', async () => {
+    mockGetStorageItemAsync.mockImplementation(async (key) =>
+      key === 'session_refresh_token' ? 'old-rt' : null,
+    )
+    const { setSession } = configure({ refreshToken: 'old-rt' })
+    mockRefreshAsync.mockRejectedValueOnce(
+      new TokenError({ error: 'invalid_grant' }),
+    )
+
+    const result = await refreshAccessToken()
+
+    expect(result).toBeNull()
+    expect(setSession).toHaveBeenCalledWith(null)
+    expect(hasRefreshToken()).toBe(false)
   })
 
   describe('concurrency dedup', () => {

--- a/clients/apps/app/auth/refresher.ts
+++ b/clients/apps/app/auth/refresher.ts
@@ -1,5 +1,10 @@
+import { getStorageItemAsync } from '@/hooks/storage'
 import { refreshAsync } from 'expo-auth-session'
 import { CLIENT_ID, discovery } from './oauthConfig'
+
+export const ACCESS_TOKEN_KEY = 'session'
+export const REFRESH_TOKEN_KEY = 'session_refresh_token'
+export const EXPIRES_AT_KEY = 'session_expires_at'
 
 export type SessionData = {
   accessToken: string
@@ -91,6 +96,37 @@ export function isAccessTokenStale(): boolean {
   return state.expiresAt - Date.now() < marginMs
 }
 
+async function adoptRotatedSession(
+  usedRefreshToken: string,
+): Promise<string | null> {
+  const latestRefreshToken = await getStorageItemAsync(REFRESH_TOKEN_KEY)
+  if (!latestRefreshToken || latestRefreshToken === usedRefreshToken) {
+    return null
+  }
+
+  const accessToken = await getStorageItemAsync(ACCESS_TOKEN_KEY)
+  if (!accessToken) {
+    return null
+  }
+
+  const expiresAtRaw = await getStorageItemAsync(EXPIRES_AT_KEY)
+  const parsedExpiresAt = expiresAtRaw
+    ? Number.parseInt(expiresAtRaw, 10)
+    : null
+
+  const next: SessionData = {
+    accessToken,
+    refreshToken: latestRefreshToken,
+    expiresAt: Number.isFinite(parsedExpiresAt) ? parsedExpiresAt : null,
+  }
+
+  state.accessToken = next.accessToken
+  state.refreshToken = next.refreshToken ?? null
+  state.expiresAt = next.expiresAt ?? null
+  state.setSession?.(next)
+  return next.accessToken
+}
+
 export async function refreshAccessToken(): Promise<string | null> {
   if (!state.refreshToken || !state.setSession) {
     return null
@@ -131,6 +167,12 @@ export async function refreshAccessToken(): Promise<string | null> {
       if (!shouldClearSessionAfterTokenRefreshFailure(error)) {
         return null
       }
+
+      const adoptedAccessToken = await adoptRotatedSession(currentRefreshToken)
+      if (adoptedAccessToken) {
+        return adoptedAccessToken
+      }
+
       state.accessToken = null
       state.refreshToken = null
       state.expiresAt = null

--- a/clients/apps/app/hooks/storage.ts
+++ b/clients/apps/app/hooks/storage.ts
@@ -2,6 +2,12 @@ import * as SecureStore from 'expo-secure-store'
 import { useCallback, useEffect, useReducer } from 'react'
 import { Platform } from 'react-native'
 
+// ⚠️ Changing this to a different group would make existing sessions unreadable
+const SECURE_STORE_OPTIONS: SecureStore.SecureStoreOptions = {
+  accessGroup: '55U3YA3QTA.com.polarsource.Polar',
+  keychainAccessible: SecureStore.AFTER_FIRST_UNLOCK,
+}
+
 type UseStateHook<T> = [[boolean, T | null], (value: T | null) => void]
 
 function useAsyncState<T>(
@@ -17,6 +23,10 @@ function useAsyncState<T>(
 }
 
 export async function getStorageItemAsync(key: string): Promise<string | null> {
+  const value = await SecureStore.getItemAsync(key, SECURE_STORE_OPTIONS)
+  if (value !== null) {
+    return value
+  }
   return await SecureStore.getItemAsync(key)
 }
 
@@ -33,9 +43,9 @@ export async function setStorageItemAsync(key: string, value: string | null) {
     }
   } else {
     if (value == null) {
-      await SecureStore.deleteItemAsync(key)
+      await SecureStore.deleteItemAsync(key, SECURE_STORE_OPTIONS)
     } else {
-      await SecureStore.setItemAsync(key, value)
+      await SecureStore.setItemAsync(key, value, SECURE_STORE_OPTIONS)
     }
   }
 }
@@ -55,7 +65,7 @@ export function useStorageState(key: string): UseStateHook<string> {
         console.error('Local storage is unavailable:', e)
       }
     } else {
-      SecureStore.getItemAsync(key).then((value) => {
+      getStorageItemAsync(key).then((value) => {
         setState(value)
       })
     }

--- a/clients/apps/app/providers/SessionProvider.tsx
+++ b/clients/apps/app/providers/SessionProvider.tsx
@@ -1,4 +1,10 @@
-import { configureRefresher, type SessionData } from '@/auth/refresher'
+import {
+  ACCESS_TOKEN_KEY,
+  configureRefresher,
+  EXPIRES_AT_KEY,
+  REFRESH_TOKEN_KEY,
+  type SessionData,
+} from '@/auth/refresher'
 import { useStorageState } from '@/hooks/storage'
 import { ExtensionStorage } from '@bacons/apple-targets'
 import {
@@ -9,10 +15,6 @@ import {
   useMemo,
   type PropsWithChildren,
 } from 'react'
-
-const ACCESS_TOKEN_KEY = 'session'
-const REFRESH_TOKEN_KEY = 'session_refresh_token'
-const EXPIRES_AT_KEY = 'session_expires_at'
 
 const widgetStorage = new ExtensionStorage('group.com.polarsource.Polar')
 

--- a/clients/apps/app/targets/widget/WidgetTokenStore.swift
+++ b/clients/apps/app/targets/widget/WidgetTokenStore.swift
@@ -1,0 +1,191 @@
+import Foundation
+
+enum WidgetTokenStore {
+    private static let accessGroup = "55U3YA3QTA.com.polarsource.Polar"
+    private static let appGroup = "group.com.polarsource.Polar"
+
+    private static let writeService = "app:no-auth"
+    private static let readServices = ["app:no-auth", "app:auth", "app"]
+
+    private static let clientID =
+        "polar_ci_yZLBGwoWZVsOdfN5CODRwVSTlJfwJhXqwg65e2CuNMZ"
+    private static let tokenEndpoint =
+        URL(string: "https://api.polar.sh/v1/oauth2/token")!
+
+    private static let accessTokenKey = "session"
+    private static let refreshTokenKey = "session_refresh_token"
+    private static let expiresAtKey = "session_expires_at"
+    private static let legacyTokenKey = "widget_api_token"
+
+    private static let refreshMarginMs: Double = 60_000
+
+    static func apiToken() async -> String? {
+        if let fresh = freshAccessToken() {
+            return fresh
+        }
+        if let refreshed = await refreshSerialized() {
+            return refreshed
+        }
+        return UserDefaults(suiteName: appGroup)?.string(forKey: legacyTokenKey)
+    }
+
+    static func forceRefresh() async -> String? {
+        return await withRefreshLock {
+            if let fresh = freshAccessToken() {
+                return fresh
+            }
+            return await performRefresh() ?? freshAccessToken()
+        }
+    }
+
+    private static func freshAccessToken() -> String? {
+        guard let token = keychainRead(accessTokenKey) else { return nil }
+        guard let raw = keychainRead(expiresAtKey), let expiresAtMs = Double(raw)
+        else {
+            return nil
+        }
+        let nowMs = Date().timeIntervalSince1970 * 1000
+        return (expiresAtMs - nowMs) > refreshMarginMs ? token : nil
+    }
+
+    private static func refreshSerialized() async -> String? {
+        return await withRefreshLock {
+            if let fresh = freshAccessToken() {
+                return fresh
+            }
+            return await performRefresh() ?? freshAccessToken()
+        }
+    }
+
+    private struct RefreshResponse: Decodable {
+        let accessToken: String
+        let refreshToken: String?
+        let expiresIn: Double?
+
+        enum CodingKeys: String, CodingKey {
+            case accessToken = "access_token"
+            case refreshToken = "refresh_token"
+            case expiresIn = "expires_in"
+        }
+    }
+
+    private static func performRefresh() async -> String? {
+        guard let refreshToken = keychainRead(refreshTokenKey) else { return nil }
+
+        var request = URLRequest(url: tokenEndpoint)
+        request.httpMethod = "POST"
+        request.setValue(
+            "application/x-www-form-urlencoded",
+            forHTTPHeaderField: "Content-Type"
+        )
+
+        var components = URLComponents()
+        components.queryItems = [
+            URLQueryItem(name: "grant_type", value: "refresh_token"),
+            URLQueryItem(name: "client_id", value: clientID),
+            URLQueryItem(name: "refresh_token", value: refreshToken),
+        ]
+        request.httpBody = components.percentEncodedQuery?.data(using: .utf8)
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200
+            else {
+                return nil
+            }
+            let decoded = try JSONDecoder().decode(RefreshResponse.self, from: data)
+
+            keychainWrite(accessTokenKey, decoded.accessToken)
+            if let newRefreshToken = decoded.refreshToken {
+                keychainWrite(refreshTokenKey, newRefreshToken)
+            }
+            if let expiresIn = decoded.expiresIn {
+                let expiresAtMs =
+                    (Date().timeIntervalSince1970 * 1000) + (expiresIn * 1000)
+                keychainWrite(expiresAtKey, String(Int(expiresAtMs)))
+            }
+            UserDefaults(suiteName: appGroup)?
+                .set(decoded.accessToken, forKey: legacyTokenKey)
+            return decoded.accessToken
+        } catch {
+            return nil
+        }
+    }
+
+    private static func withRefreshLock(_ body: () async -> String?) async
+        -> String?
+    {
+        guard
+            let container = FileManager.default.containerURL(
+                forSecurityApplicationGroupIdentifier: appGroup
+            )
+        else {
+            return await body()
+        }
+        let lockURL = container.appendingPathComponent("token-refresh.lock")
+        let fd = open(lockURL.path, O_CREAT | O_RDWR, 0o600)
+        if fd == -1 {
+            return await body()
+        }
+        defer { close(fd) }
+        flock(fd, LOCK_EX)
+        defer { flock(fd, LOCK_UN) }
+        return await body()
+    }
+
+    private static func keychainBaseQuery(_ key: String, service: String)
+        -> [String: Any]
+    {
+        let account = Data(key.utf8)
+        return [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecAttrGeneric as String: account,
+            kSecAttrAccessGroup as String: accessGroup,
+        ]
+    }
+
+    private static func keychainRead(_ key: String) -> String? {
+        for service in readServices {
+            var query = keychainBaseQuery(key, service: service)
+            query[kSecReturnData as String] = true
+            query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+            var result: CFTypeRef?
+            let status = SecItemCopyMatching(query as CFDictionary, &result)
+            if status == errSecSuccess, let data = result as? Data,
+                let value = String(data: data, encoding: .utf8)
+            {
+                return value
+            }
+        }
+        return nil
+    }
+
+    @discardableResult
+    private static func keychainWrite(_ key: String, _ value: String) -> Bool {
+        let base = keychainBaseQuery(key, service: writeService)
+        let valueData = Data(value.utf8)
+
+        let updateStatus = SecItemUpdate(
+            base as CFDictionary,
+            [
+                kSecValueData as String: valueData,
+                kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+            ] as CFDictionary
+        )
+        if updateStatus == errSecSuccess {
+            return true
+        }
+
+        if updateStatus != errSecItemNotFound {
+            SecItemDelete(base as CFDictionary)
+        }
+
+        var addQuery = base
+        addQuery[kSecValueData as String] = valueData
+        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        return SecItemAdd(addQuery as CFDictionary, nil) == errSecSuccess
+    }
+}

--- a/clients/apps/app/targets/widget/expo-target.config.js
+++ b/clients/apps/app/targets/widget/expo-target.config.js
@@ -5,6 +5,7 @@ module.exports = (config) => ({
   entitlements: {
     'com.apple.security.application-groups':
       config.ios.entitlements['com.apple.security.application-groups'],
+    'keychain-access-groups': config.ios.entitlements['keychain-access-groups'],
   },
   colors: {
     accent: '#FF7B54',

--- a/clients/apps/app/targets/widget/generated.entitlements
+++ b/clients/apps/app/targets/widget/generated.entitlements
@@ -6,5 +6,9 @@
     <array>
       <string>group.com.polarsource.Polar</string>
     </array>
+    <key>keychain-access-groups</key>
+    <array>
+      <string>$(AppIdentifierPrefix)com.polarsource.Polar</string>
+    </array>
   </dict>
 </plist>

--- a/clients/apps/app/targets/widget/widgets.swift
+++ b/clients/apps/app/targets/widget/widgets.swift
@@ -26,7 +26,7 @@ struct Provider: AppIntentTimelineProvider {
             return SimpleEntry(date: Date(), configuration: configuration, metricValue: metricValue, metricValueDouble: metricValueDouble, organizationName: orgName, chartData: chartData, lastUpdated: Date(), isError: false, isUnauthorized: false, combinedMetrics: combinedMetrics)
         }
         
-        let apiToken = defaults?.string(forKey: "widget_api_token")
+        let apiToken = await WidgetTokenStore.apiToken()
         let organizationId = defaults?.string(forKey: "widget_organization_id")
         let isUnauthorized = await checkIfUnauthorized(apiToken: apiToken, organizationId: organizationId)
         
@@ -47,7 +47,7 @@ struct Provider: AppIntentTimelineProvider {
         if let (metricValue, metricValueDouble, chartData, _) = result {
             entry = SimpleEntry(date: currentDate, configuration: configuration, metricValue: metricValue, metricValueDouble: metricValueDouble, organizationName: orgName, chartData: chartData, lastUpdated: currentDate, isError: false, isUnauthorized: false, combinedMetrics: combinedMetrics)
         } else {
-            let apiToken = defaults?.string(forKey: "widget_api_token")
+            let apiToken = await WidgetTokenStore.apiToken()
             let organizationId = defaults?.string(forKey: "widget_organization_id")
             let isUnauthorized = await checkIfUnauthorized(apiToken: apiToken, organizationId: organizationId)
             
@@ -76,9 +76,11 @@ struct Provider: AppIntentTimelineProvider {
     }
     
     private func checkIfUnauthorized(apiToken: String?, organizationId: String?) async -> Bool {
-        guard let apiToken = apiToken,
-              let organizationId = organizationId else {
+        guard let organizationId = organizationId else {
             return false
+        }
+        guard let apiToken = apiToken else {
+            return true
         }
         
         let endDate = Date()
@@ -121,10 +123,37 @@ struct Provider: AppIntentTimelineProvider {
         }
     }
     
+    private func authorizedMetricsData(url: URL) async -> Data? {
+        guard var token = await WidgetTokenStore.apiToken() else {
+            return nil
+        }
+
+        for attempt in 0..<2 {
+            var request = URLRequest(url: url)
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+
+            do {
+                let (data, response) = try await URLSession.shared.data(for: request)
+                if let httpResponse = response as? HTTPURLResponse,
+                   httpResponse.statusCode == 401 {
+                    if attempt == 0, let refreshed = await WidgetTokenStore.forceRefresh() {
+                        token = refreshed
+                        continue
+                    }
+                    return nil
+                }
+                return data
+            } catch {
+                return nil
+            }
+        }
+
+        return nil
+    }
+
     private func fetchMetrics(days: Int, metricType: MetricType) async -> (Int, Double?, [RevenueData], Int?)? {
         let defaults = UserDefaults(suiteName: "group.com.polarsource.Polar")
-        guard let apiToken = defaults?.string(forKey: "widget_api_token"),
-              let organizationId = defaults?.string(forKey: "widget_organization_id") else {
+        guard let organizationId = defaults?.string(forKey: "widget_organization_id") else {
             return nil
         }
         
@@ -152,21 +181,11 @@ struct Provider: AppIntentTimelineProvider {
             return nil
         }
         
-        var request = URLRequest(url: url)
-        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
-        
+        guard let data = await authorizedMetricsData(url: url) else {
+            return nil
+        }
+
         do {
-            let (data, response) = try await URLSession.shared.data(for: request)
-            
-            var statusCode: Int?
-            if let httpResponse = response as? HTTPURLResponse {
-                statusCode = httpResponse.statusCode
-                
-                if httpResponse.statusCode == 401 {
-                    return nil
-                }
-            }
-            
             let decodedResponse = try JSONDecoder().decode(MetricsResponse.self, from: data)
             
             let metricValue: Int
@@ -206,7 +225,7 @@ struct Provider: AppIntentTimelineProvider {
                 return RevenueData(day: index + 1, amount: cumulativeValue)
             }
             
-            return (metricValue, metricValueDouble, chartData, statusCode)
+            return (metricValue, metricValueDouble, chartData, 200)
             
         } catch {
             return nil
@@ -215,8 +234,7 @@ struct Provider: AppIntentTimelineProvider {
     
     private func fetchAllMetrics(days: Int) async -> CombinedMetrics? {
         let defaults = UserDefaults(suiteName: "group.com.polarsource.Polar")
-        guard let apiToken = defaults?.string(forKey: "widget_api_token"),
-              let organizationId = defaults?.string(forKey: "widget_organization_id") else {
+        guard let organizationId = defaults?.string(forKey: "widget_organization_id") else {
             return nil
         }
         
@@ -244,12 +262,11 @@ struct Provider: AppIntentTimelineProvider {
             return nil
         }
         
-        var request = URLRequest(url: url)
-        request.setValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
-        
+        guard let data = await authorizedMetricsData(url: url) else {
+            return nil
+        }
+
         do {
-            let (data, _) = try await URLSession.shared.data(for: request)
-            
             let decodedResponse = try JSONDecoder().decode(MetricsResponse.self, from: data)
             
             let revenueValue = Int(Double(decodedResponse.totals.revenue ?? 0) / 100.0)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enables the iOS widget to share and refresh OAuth tokens with the app via a shared Keychain, keeping widget metrics current and preventing 401s. The app can adopt a rotated session so users stay signed in when the widget refreshes tokens.

- New Features
  - Added WidgetTokenStore.swift to read/write tokens in the shared Keychain and refresh via the OAuth token endpoint; uses a file lock to serialize refreshes.
  - Enabled shared Keychain entitlements for both app and widget; configured `expo-secure-store` with the shared access group and AfterFirstUnlock, with group-first reads and fallback; exported unified session keys for reuse.
  - Widget fetches with WidgetTokenStore.apiToken() and retries once with forceRefresh() on 401; treats missing token as unauthorized and keeps legacy `widget_api_token` as fallback.
  - Auth refresher adopts a session rotated by the widget on invalid_grant (from shared storage) instead of clearing; otherwise clears when tokens match.

- Migration
  - Add Keychain Access Group `$(AppIdentifierPrefix)com.polarsource.Polar` to both app and widget in the Apple Developer portal and update provisioning profiles.
  - Ensure the team prefix matches `55U3YA3QTA`; if not, update the `accessGroup` in Swift and SecureStore options.

<sup>Written for commit 6dffe15725a925e740ad996d1e769751b726fdea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

