### PR TITLE
Make social links optional in account review

### DIFF
--- a/clients/apps/web/src/components/Finance/Account/sections/SocialLinksSection.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/SocialLinksSection.tsx
@@ -83,7 +83,7 @@ export const SocialLinksSection = ({ organization: initialOrg }: Props) => {
             </Button>
           }
         >
-          <SocialLinksField required />
+          <SocialLinksField />
         </SectionLayout>
       </form>
     </Form>

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -585,7 +585,7 @@ class OrganizationReviewSubmission(Schema):
     name: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
     website: Annotated[str, StringConstraints(min_length=1)]
     email: EmailStrDNS
-    socials: list[OrganizationSocialLink] = Field(min_length=1)
+    socials: list[OrganizationSocialLink] = Field(default_factory=list)
     details: Annotated[
         OrganizationReviewSubmissionDetails,
         BeforeValidator(_empty_review_submission_details_to_dict),

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1594,6 +1594,7 @@ class OrganizationService:
         ]
 
         submitted_at = organization.details_submitted_at
+        optional_keys = {OrganizationReviewCheckKey.IDENTITY_SOCIAL_LINKS}
         is_blocked = any(
             step.status
             in (
@@ -1601,6 +1602,7 @@ class OrganizationService:
                 OrganizationReviewCheckStatus.PENDING,
             )
             for step in preliminary_steps
+            if step.key not in optional_keys
         )
         can_submit = submitted_at is None and not is_blocked
 

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -523,7 +523,7 @@ class TestUpdateOrganization:
         error_locations = {tuple(error["loc"]) for error in response.json()["detail"]}
         assert ("body", "website") in error_locations
         assert ("body", "email") in error_locations
-        assert ("body", "socials") in error_locations
+        assert ("body", "socials") not in error_locations
         assert ("body", "details", "product_description") in error_locations
 
     @pytest.mark.auth

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -402,7 +402,7 @@ class TestUpdateReviewSubmission:
         error_locations = {tuple(error["loc"]) for error in exc_info.value.errors()}
         assert ("body", "website") in error_locations
         assert ("body", "email") in error_locations
-        assert ("body", "socials") in error_locations
+        assert ("body", "socials") not in error_locations
         assert ("body", "details", "product_description") in error_locations
 
     @pytest.mark.auth
@@ -2339,6 +2339,23 @@ class TestGetReviewState:
             step.status == OrganizationReviewCheckStatus.PASSED
             for step in state.preliminary_steps
         )
+
+    async def test_missing_socials_does_not_block_submission(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        await _setup_passing_org(save_fixture, organization, user)
+        organization.socials = []
+        await save_fixture(organization)
+
+        state = await organization_service.get_review_state(session, organization)
+
+        socials_step = _step(state, OrganizationReviewCheckKey.IDENTITY_SOCIAL_LINKS)
+        assert socials_step.status == OrganizationReviewCheckStatus.PENDING
+        assert state.can_submit is True
 
     async def test_submitted_blocks_resubmission(
         self,


### PR DESCRIPTION
☝️ 

| Before | After  |
|--------|--------|
| <img width="1840" height="1133" alt="Screenshot 2026-06-24 at 13 35 25" src="https://github.com/user-attachments/assets/c343c27d-0d77-4e31-804b-b4313ede582e" /> | <img width="1840" height="1133" alt="Screenshot 2026-06-24 at 13 45 39" src="https://github.com/user-attachments/assets/9291032c-e049-41a3-8867-e3dcbc465679" /> |





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make social links optional in the account review so users can submit without adding socials. The socials check stays as pending but no longer blocks submission.

- **New Features**
  - UI: `SocialLinksField` is not required.
  - API: `OrganizationReviewSubmission.socials` now optional (defaults to []).
  - Review state: `IDENTITY_SOCIAL_LINKS` is optional; submission allowed even if pending. Tests updated.

<sup>Written for commit 4ad12de4f034dd27d63a59ff30908bbe72a33a9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

