### PR TITLE
Allow email domain subdomains to match website domains

### DIFF
--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -150,6 +150,20 @@ def _is_hosted_website_domain(website_domain: str) -> bool:
     )
 
 
+def _email_domain_matches_website(email_domain: str, website_domain: str) -> bool:
+    """Whether the support email domain belongs to the website's domain.
+
+    A subdomain relationship in either direction counts as a match, so a
+    `support@example.com` email is accepted for a website hosted on a subdomain
+    like `app.example.com`, and vice versa.
+    """
+    if email_domain == website_domain:
+        return True
+    return website_domain.endswith(f".{email_domain}") or email_domain.endswith(
+        f".{website_domain}"
+    )
+
+
 def _append_internal_note(
     organization: Organization, message: str, *, reason: str | None = None
 ) -> None:
@@ -1662,7 +1676,7 @@ class OrganizationService:
 
         if (
             website_domain
-            and email_domain != website_domain
+            and not _email_domain_matches_website(email_domain, website_domain)
             and not _is_hosted_website_domain(website_domain)
         ):
             reasons.append(OrganizationReviewCheckReason.IDENTITY_DOMAIN_MISMATCH)

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1798,6 +1798,54 @@ class TestGetReviewState:
     @pytest.mark.parametrize(
         "website",
         [
+            "https://bolt.example.com",
+            "https://www.bolt.example.com",
+        ],
+    )
+    async def test_email_matching_website_subdomain_passes(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        website: str,
+    ) -> None:
+        # The merchant's support email lives on the apex domain while the
+        # product is hosted on a subdomain — they still belong to the same
+        # organization, so this must not be flagged as a mismatch.
+        organization.email = "support@example.com"
+        organization.website = website
+        await save_fixture(organization)
+
+        state = await organization_service.get_review_state(session, organization)
+        step = _step(state, OrganizationReviewCheckKey.IDENTITY_EMAIL)
+
+        assert step.status == OrganizationReviewCheckStatus.PASSED
+        assert (
+            OrganizationReviewCheckReason.IDENTITY_DOMAIN_MISMATCH not in step.reasons
+        )
+
+    async def test_email_subdomain_matching_website_apex_passes(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        # Reverse relationship: support email on a subdomain, website on the apex.
+        organization.email = "support@mail.example.com"
+        organization.website = "https://example.com"
+        await save_fixture(organization)
+
+        state = await organization_service.get_review_state(session, organization)
+        step = _step(state, OrganizationReviewCheckKey.IDENTITY_EMAIL)
+
+        assert step.status == OrganizationReviewCheckStatus.PASSED
+        assert (
+            OrganizationReviewCheckReason.IDENTITY_DOMAIN_MISMATCH not in step.reasons
+        )
+
+    @pytest.mark.parametrize(
+        "website",
+        [
             "https://framer.com/acme",
             "https://acme.framer.com",
         ],


### PR DESCRIPTION
## Summary

Allow organization email domains and website domains to match when one is a subdomain of the other, rather than requiring exact domain matches.

## What

Modified the email domain validation logic in the organization review check to accept subdomain relationships in either direction:
- A support email on the apex domain (e.g., `support@example.com`) is now accepted for websites hosted on subdomains (e.g., `https://app.example.com`)
- A support email on a subdomain (e.g., `support@mail.example.com`) is now accepted for websites on the apex domain (e.g., `https://example.com`)

Added a new helper function `_email_domain_matches_website()` that checks for both exact matches and subdomain relationships.

## Why

Organizations commonly host their product on a subdomain while maintaining support infrastructure on the apex domain (or vice versa). These should be recognized as belonging to the same organization rather than flagged as a domain mismatch during the review process.

## How

1. Created `_email_domain_matches_website()` function that returns `True` if:
   - The domains are exactly equal, OR
   - One domain ends with `.{other_domain}` (subdomain relationship in either direction)

2. Updated the email check logic to use this new function instead of a simple equality check

3. Added comprehensive test coverage:
   - `test_email_matching_website_subdomain_passes`: Tests apex domain email with subdomain website (parameterized for both `bolt.example.com` and `www.bolt.example.com`)
   - `test_email_subdomain_matching_website_apex_passes`: Tests subdomain email with apex domain website

## Checklist

- [x] This PR addresses a single concern (subdomain matching for organization domains)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests (2 new test cases added)
- [x] No unrelated changes included

https://claude.ai/code/session_01RR5xFjY7bQ9dnRmWP8HVyH

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

