### PR TITLE
Stop duplicate /emergency deploys from racing

### DIFF
--- a/.github/workflows/emergency_merge.yml
+++ b/.github/workflows/emergency_merge.yml
@@ -10,6 +10,9 @@ jobs:
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/emergency')
     runs-on: ubuntu-latest
+    concurrency:
+      group: emergency-merge-${{ github.event.issue.number }}
+      cancel-in-progress: false
     permissions:
       pull-requests: write
       contents: write
@@ -51,6 +54,7 @@ jobs:
           private-key: ${{ secrets.EMERGENCY_MERGE_APP_PRIVATE_KEY }}
 
       - name: Merge PR
+        id: merge
         uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
@@ -64,7 +68,12 @@ jobs:
             });
 
             if (pr.state !== 'open') {
-              core.setFailed('PR is not open');
+              if (pr.merged) {
+                core.info(`PR #${prNumber} is already merged — nothing to do`);
+                core.setOutput('outcome', 'already_merged');
+                return;
+              }
+              core.setFailed('PR is closed but not merged');
               return;
             }
 
@@ -101,6 +110,7 @@ jobs:
             try {
               await mergeDirectly();
               core.info(`PR #${prNumber} merged via ${method}`);
+              core.setOutput('outcome', 'merged');
             } catch (error) {
               if (!isInMergeQueue(error)) {
                 core.setFailed(`Failed to merge: ${error.message}`);
@@ -120,6 +130,7 @@ jobs:
               try {
                 await mergeAfterDequeue();
                 core.info(`PR #${prNumber} dequeued and merged via ${method}`);
+                core.setOutput('outcome', 'merged');
               } catch (retryError) {
                 core.setFailed(`Failed to merge: ${retryError.message}`);
               }
@@ -127,7 +138,7 @@ jobs:
 
       - name: Eject other PRs from the merge queue
         id: eject
-        if: success()
+        if: steps.merge.outputs.outcome == 'merged'
         uses: actions/github-script@v9
         with:
           github-token: ${{ steps.app-token.outputs.token }}
@@ -198,6 +209,11 @@ jobs:
         with:
           script: |
             const prNumber = context.payload.issue.number;
+            const outcome = '${{ steps.merge.outputs.outcome }}';
+            if (outcome === 'already_merged') {
+              core.info('PR was already merged by another run — skipping comment');
+              return;
+            }
             const success = '${{ job.status }}' === 'success';
             const body = success
               ? '🚀 Shipped! PR merged successfully.'
@@ -210,7 +226,7 @@ jobs:
             });
 
       - name: Notify Slack
-        if: success()
+        if: steps.merge.outputs.outcome == 'merged'
         uses: actions/github-script@v9
         env:
           SLACK_BOT_TOKEN: ${{ secrets.E2E_SLACK_BOT_TOKEN }}


### PR DESCRIPTION
To avoid situations like https://github.com/polarsource/polar/pull/12633

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops duplicate `/emergency` deploys from racing by serializing runs per PR and making post-steps conditional. Reduces noisy Slack/comments and avoids unintended queue ejects.

- **Bug Fixes**
  - Added workflow concurrency: `emergency-merge-${{ github.event.issue.number }}` with `cancel-in-progress: false` to queue runs instead of racing.
  - Set merge step outputs (`merged`, `already_merged`) and handle closed-but-unmerged PRs with a clear failure.
  - Ran queue ejection and Slack only when `outcome == 'merged'`; skipped comment when `already_merged`.
  - Minor logging improvements in `actions/github-script@v9` steps.

<sup>Written for commit 23abe81405acda2f401508d9c32e848d6a447574. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

