### PR TITLE
Increase downloadables query limit to 100

### DIFF
--- a/clients/apps/web/src/components/Benefit/Downloadables/DownloadablesBenefitGrant.tsx
+++ b/clients/apps/web/src/components/Benefit/Downloadables/DownloadablesBenefitGrant.tsx
@@ -110,6 +110,7 @@ const DownloadablesBenefitGrant = ({
   } = benefitGrant
   const { data: downloadables, isLoading } = useCustomerDownloadables(api, {
     benefit_id: benefitGrant.benefit.id,
+    limit: 100,
   })
 
   const sortedDownloadables = useMemo(() => {


### PR DESCRIPTION
## Summary

**Related Issue**: [Backoffice](https://backoffice.polar.sh/feedbacks/c20cd330-5e2c-4012-9f19-b1396b426346)

I know it's the lazy fix, but hey! 🤷 

Increase the pagination limit for the downloadables query to 100 to ensure all downloadables are fetched for benefit grants.

## What

Added `limit: 100` parameter to the `useCustomerDownloadables` hook call in `DownloadablesBenefitGrant.tsx`.

## Why

The previous query was using the default limit, which may have been insufficient to fetch all available downloadables for a benefit grant. Setting an explicit limit of 100 ensures that more downloadables are retrieved in a single query, reducing the risk of incomplete data being displayed to users.

## How

Added the `limit: 100` configuration option to the `useCustomerDownloadables` API call parameters.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] No unrelated changes or drive-by fixes are included

https://claude.ai/code/session_01MzNWHnSCjer3os5okzSM9U

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

