### PR TITLE
Fix benefit type detection for review checklist

### DIFF
--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -113,14 +113,20 @@ _MIN_REVIEW_THRESHOLD = 10_000
 SNOOZE_MIN_DAYS = 1
 SNOOZE_MAX_DAYS = 7
 
-# Benefit types Polar fulfills without merchant API integration.
-_CHECKOUT_FULFILLABLE_BENEFITS: frozenset[BenefitType] = frozenset(
-    {
-        BenefitType.downloadables,
-        BenefitType.license_keys,
-        BenefitType.github_repository,
-        BenefitType.discord,
-    }
+# Benefit types that deliver nothing to the customer without a merchant API
+# integration: `feature_flag` (the merchant's app has to read the flag via the
+# API) and `meter_credit` (the credit is only meaningful once the merchant
+# ingests usage events via the API).
+_CHECKOUT_API_ONLY_BENEFITS: frozenset[BenefitType] = frozenset(
+    {BenefitType.feature_flag, BenefitType.meter_credit}
+)
+
+# Every other benefit delivers something on
+# its own — Polar grants it automatically (downloadables, license_keys,
+# github_repository, discord, slack_shared_channel) or the customer sees it in
+# their portal (custom note).
+_CHECKOUT_FULFILLABLE_BENEFITS: frozenset[BenefitType] = (
+    frozenset(BenefitType) - _CHECKOUT_API_ONLY_BENEFITS
 )
 
 # Hosting domains where it's unreasonable to expect the organization's support email to

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -2115,11 +2115,25 @@ class TestGetReviewState:
             assert sub.status == OrganizationReviewCheckStatus.PENDING
             assert OrganizationReviewCheckReason.NOT_STARTED in sub.reasons
 
+    @pytest.mark.parametrize(
+        "benefit_type",
+        [
+            BenefitType.downloadables,
+            BenefitType.license_keys,
+            BenefitType.github_repository,
+            BenefitType.discord,
+            BenefitType.slack_shared_channel,
+            # `custom` is a free-form note, but the customer still sees it in
+            # their portal post-purchase — no API integration required.
+            BenefitType.custom,
+        ],
+    )
     async def test_setup_readiness_checkout_link_with_eligible_benefit_passes(
         self,
         save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
+        benefit_type: BenefitType,
     ) -> None:
         product = await create_product(
             save_fixture, organization=organization, recurring_interval=None
@@ -2127,7 +2141,7 @@ class TestGetReviewState:
         benefit = await create_benefit(
             save_fixture,
             organization=organization,
-            type=BenefitType.license_keys,
+            type=benefit_type,
         )
         await set_product_benefits(save_fixture, product=product, benefits=[benefit])
         await create_checkout_link(save_fixture, products=[product])
@@ -2152,10 +2166,12 @@ class TestGetReviewState:
     @pytest.mark.parametrize(
         "benefit_type",
         [
+            # Benefits a checkout link can't fulfill on its own — they only mean
+            # something once the merchant integrates the API. `feature_flag`:
+            # the merchant's app reads the flag. `meter_credit`: the credit is
+            # consumed via usage events the merchant ingests.
             BenefitType.feature_flag,
             BenefitType.meter_credit,
-            # `custom` is a free-form note with no automated fulfillment.
-            BenefitType.custom,
         ],
     )
     async def test_setup_readiness_ineligible_benefit_does_not_count(


### PR DESCRIPTION
Some people relying on providing links (e.g. Framer remix templates) in a custom note got stuck, while this is a recommended use case.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes benefit type detection in the review checklist so checkout links count when benefits are auto-fulfilled or visible in the customer portal. This unblocks products using `custom` notes (e.g., link drops) and other non-API benefits.

- **Bug Fixes**
  - Added `_CHECKOUT_API_ONLY_BENEFITS` (`feature_flag`, `meter_credit`) and treat all other types as fulfillable for the checkout link check.
  - Marked `slack_shared_channel` and `custom` as eligible; kept downloadables, license keys, GitHub repo, and Discord eligible.
  - Updated tests to parametrize eligible vs. ineligible benefit types.

<sup>Written for commit b331509614c7b8d1d2506db84ed5d9f83f1f3c9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

