### PR TITLE
tf/aws: Enable SERVICE_CONTROL_POLICY on the AWS org

### DIFF
--- a/terraform/organization/main.tf
+++ b/terraform/organization/main.tf
@@ -2,7 +2,15 @@ provider "aws" {
   region = "us-east-1"
 }
 
-data "aws_organizations_organization" "current" {}
+resource "aws_organizations_organization" "current" {
+  feature_set                   = "ALL"
+  aws_service_access_principals = ["sso.amazonaws.com"]
+  enabled_policy_types          = ["SERVICE_CONTROL_POLICY"]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
 
 locals {
   management_account = {
@@ -42,12 +50,12 @@ locals {
     }
   }
 
-  root_id = data.aws_organizations_organization.current.roots[0].id
+  root_id = aws_organizations_organization.current.roots[0].id
 }
 
 check "management_account" {
   assert {
-    condition     = data.aws_organizations_organization.current.master_account_id == local.management_account.id
+    condition     = aws_organizations_organization.current.master_account_id == local.management_account.id
     error_message = "Terraform must run from the Polar management account (${local.management_account.id})."
   }
 }
@@ -79,6 +87,11 @@ resource "aws_organizations_account" "workload" {
   lifecycle {
     prevent_destroy = true
   }
+}
+
+import {
+  to = aws_organizations_organization.current
+  id = "o-hrbfnn1uf5"
 }
 
 import {

--- a/terraform/organization/outputs.tf
+++ b/terraform/organization/outputs.tf
@@ -1,7 +1,7 @@
 output "management_account" {
   value = {
-    id   = data.aws_organizations_organization.current.master_account_id
-    name = data.aws_organizations_organization.current.master_account_name
+    id   = aws_organizations_organization.current.master_account_id
+    name = aws_organizations_organization.current.master_account_name
   }
 }
 

--- a/terraform/organization/service_control_policies.tf
+++ b/terraform/organization/service_control_policies.tf
@@ -140,4 +140,6 @@ resource "aws_organizations_policy_attachment" "service_control" {
 
   policy_id = aws_organizations_policy.service_control[each.value.policy_key].id
   target_id = each.value.target_id
+
+  depends_on = [aws_organizations_organization.current]
 }


### PR DESCRIPTION
This creates the AWS org as a resource (and imports the existing one) instead, allowing us to modify it. 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable Service Control Policies on the AWS Organization and bring the org under Terraform management. This makes SCP attachments work and prevents accidental org deletion.

- **New Features**
  - Manage `aws_organizations_organization` with `feature_set = "ALL"`, `enabled_policy_types = ["SERVICE_CONTROL_POLICY"]`, and service access for `sso.amazonaws.com`.
  - Add `lifecycle { prevent_destroy = true }` to protect the org.

- **Refactors**
  - Replace the data source with the resource; update `root_id` and outputs to reference it.
  - Add an import block for the existing org (`o-hrbfnn1uf5`) to sync state.
  - Add `depends_on` to `aws_organizations_policy_attachment` to ensure correct apply order.

<sup>Written for commit 4de7239d66909236e100b6ae427dd7bec2da96fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

