### PR TITLE
feat(member): add copy member login link

### DIFF
--- a/clients/apps/web/src/components/Customer/MembersSection.tsx
+++ b/clients/apps/web/src/components/Customer/MembersSection.tsx
@@ -1,11 +1,9 @@
 'use client'
 
 import { useModal } from '@/components/Modal/useModal'
-import { toast } from '@/components/Toast/use-toast'
-import { useSafeCopy } from '@/hooks/clipboard'
+import { useCopyMemberLoginLink } from '@/hooks/useCopyMemberLoginLink'
 import { useMembers } from '@/hooks/queries/members'
 import { useMultipleCustomerSeats } from '@/hooks/queries/seats'
-import { CONFIG } from '@/utils/config'
 import MoreVertOutlined from '@mui/icons-material/MoreVertOutlined'
 import { schemas } from '@polar-sh/client'
 import {
@@ -59,7 +57,7 @@ export const MembersSection = ({
   orders,
 }: MembersSectionProps) => {
   const { data: membersData, isLoading } = useMembers(customer.id)
-  const safeCopy = useSafeCopy(toast)
+  const copyMemberLoginLink = useCopyMemberLoginLink(organization.slug)
 
   const isEnabled =
     organization?.feature_settings?.member_model_enabled &&
@@ -110,18 +108,6 @@ export const MembersSection = ({
     })
     return map
   }, [seats])
-
-  const handleCopyLoginLink = async (memberEmail: string) => {
-    const link = `${CONFIG.FRONTEND_BASE_URL}/${organization.slug}/portal/request?email=${encodeURIComponent(
-      memberEmail,
-    )}`
-    await safeCopy(link)
-    toast({
-      title: 'Login link copied',
-      description:
-        'Share it with the member so they can sign in to the customer portal with their email.',
-    })
-  }
 
   if (!isEnabled) {
     return null
@@ -216,7 +202,7 @@ export const MembersSection = ({
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
                     <DropdownMenuItem
-                      onClick={() => handleCopyLoginLink(original.email)}
+                      onClick={() => copyMemberLoginLink(original.email)}
                     >
                       Copy login link
                     </DropdownMenuItem>

--- a/clients/apps/web/src/components/Customer/MembersSection.tsx
+++ b/clients/apps/web/src/components/Customer/MembersSection.tsx
@@ -1,11 +1,16 @@
 'use client'
 
 import { useModal } from '@/components/Modal/useModal'
+import { toast } from '@/components/Toast/use-toast'
+import { useSafeCopy } from '@/hooks/clipboard'
 import { useMembers } from '@/hooks/queries/members'
 import { useMultipleCustomerSeats } from '@/hooks/queries/seats'
+import { CONFIG } from '@/utils/config'
+import MoreVertOutlined from '@mui/icons-material/MoreVertOutlined'
 import { schemas } from '@polar-sh/client'
 import {
   Avatar,
+  Button,
   DataTable,
   InlineModal,
   Status,
@@ -14,6 +19,12 @@ import {
 } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@polar-sh/ui/components/ui/dropdown-menu'
 import { useMemo, useState } from 'react'
 import { EditMemberModal } from './EditMemberModal'
 import { seatStatusDisplayConfig } from '../Seats/seatStatus'
@@ -48,6 +59,7 @@ export const MembersSection = ({
   orders,
 }: MembersSectionProps) => {
   const { data: membersData, isLoading } = useMembers(customer.id)
+  const safeCopy = useSafeCopy(toast)
 
   const isEnabled =
     organization?.feature_settings?.member_model_enabled &&
@@ -99,6 +111,18 @@ export const MembersSection = ({
     return map
   }, [seats])
 
+  const handleCopyLoginLink = async (memberEmail: string) => {
+    const link = `${CONFIG.FRONTEND_BASE_URL}/${organization.slug}/portal/request?email=${encodeURIComponent(
+      memberEmail,
+    )}`
+    await safeCopy(link)
+    toast({
+      title: 'Login link copied',
+      description:
+        'Share it with the member so they can sign in to the customer portal with their email.',
+    })
+  }
+
   if (!isEnabled) {
     return null
   }
@@ -114,6 +138,7 @@ export const MembersSection = ({
           {
             header: 'Member',
             accessorKey: 'email',
+            size: 260,
             cell: ({ row: { original } }) => (
               <Box alignItems="center" gap="m">
                 <Avatar
@@ -175,6 +200,29 @@ export const MembersSection = ({
             accessorKey: 'created_at',
             cell: ({ row: { original } }) => (
               <FormattedDateTime datetime={original.created_at} />
+            ),
+          },
+          {
+            id: 'actions',
+            header: () => null,
+            size: 60,
+            cell: ({ row: { original } }) => (
+              <Box justifyContent="end" onClick={(e) => e.stopPropagation()}>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button className="h-8 w-8" variant="ghost" size="icon">
+                      <MoreVertOutlined fontSize="inherit" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem
+                      onClick={() => handleCopyLoginLink(original.email)}
+                    >
+                      Copy login link
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </Box>
             ),
           },
         ]}

--- a/clients/apps/web/src/components/CustomerPortal/CustomerPortalOrder.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerPortalOrder.tsx
@@ -241,6 +241,7 @@ const CustomerPortalOrder = ({
                 ? { subscriptionId: order.subscription_id }
                 : { orderId: order.id }
             }
+            organizationSlug={order.product?.organization.slug ?? ''}
           />
         )}
 

--- a/clients/apps/web/src/components/CustomerPortal/CustomerPortalSettings.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerPortalSettings.tsx
@@ -180,7 +180,10 @@ export const CustomerPortalSettings = ({
             </WellHeader>
             <Separator className="dark:bg-polar-700" />
             <WellContent>
-              <CustomerPortalTeamSection api={api} />
+              <CustomerPortalTeamSection
+                api={api}
+                organizationSlug={organization.slug}
+              />
             </WellContent>
           </Well>
         )}

--- a/clients/apps/web/src/components/CustomerPortal/CustomerPortalSubscription.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerPortalSubscription.tsx
@@ -199,6 +199,7 @@ const CustomerPortalSubscription = ({
         <SeatManagementTable
           api={api}
           identifier={{ subscriptionId: subscription.id }}
+          organizationSlug={subscription.product.organization.slug}
           prorationBehavior={
             subscription.product.organization.proration_behavior
           }

--- a/clients/apps/web/src/components/CustomerPortal/CustomerPortalTeam.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerPortalTeam.tsx
@@ -7,8 +7,7 @@ import {
   useRemoveCustomerPortalMember,
   useUpdateCustomerPortalMember,
 } from '@/hooks/queries/customerPortal'
-import { useSafeCopy } from '@/hooks/clipboard'
-import { CONFIG } from '@/utils/config'
+import { useCopyMemberLoginLink } from '@/hooks/useCopyMemberLoginLink'
 import { validateEmail } from '@/utils/validation'
 import MoreVertOutlined from '@mui/icons-material/MoreVertOutlined'
 import { Client, schemas } from '@polar-sh/client'
@@ -61,7 +60,7 @@ export const CustomerPortalTeamSection = ({
   const updateMember = useUpdateCustomerPortalMember(api)
   const removeMember = useRemoveCustomerPortalMember(api)
   const addMember = useAddCustomerPortalMember(api)
-  const safeCopy = useSafeCopy(toast)
+  const copyMemberLoginLink = useCopyMemberLoginLink(organizationSlug)
 
   const [memberToRemove, setMemberToRemove] = useState<string | null>(null)
   const [loadingMembers, setLoadingMembers] = useState<Set<string>>(new Set())
@@ -140,18 +139,6 @@ export const CustomerPortalTeamSection = ({
         return next
       })
     }
-  }
-
-  const handleCopyLoginLink = async (memberEmail: string) => {
-    const link = `${CONFIG.FRONTEND_BASE_URL}/${organizationSlug}/portal/request?email=${encodeURIComponent(
-      memberEmail,
-    )}`
-    await safeCopy(link)
-    toast({
-      title: 'Login link copied',
-      description:
-        'Share it with the member so they can sign in to the portal with their email.',
-    })
   }
 
   const handleRemoveMember = async (memberId: string) => {
@@ -291,7 +278,7 @@ export const CustomerPortalTeamSection = ({
                           </DropdownMenuTrigger>
                           <DropdownMenuContent align="end">
                             <DropdownMenuItem
-                              onClick={() => handleCopyLoginLink(member.email)}
+                              onClick={() => copyMemberLoginLink(member.email)}
                               disabled={isLoading}
                             >
                               Copy login link

--- a/clients/apps/web/src/components/CustomerPortal/CustomerPortalTeam.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerPortalTeam.tsx
@@ -7,6 +7,8 @@ import {
   useRemoveCustomerPortalMember,
   useUpdateCustomerPortalMember,
 } from '@/hooks/queries/customerPortal'
+import { useSafeCopy } from '@/hooks/clipboard'
+import { CONFIG } from '@/utils/config'
 import { validateEmail } from '@/utils/validation'
 import MoreVertOutlined from '@mui/icons-material/MoreVertOutlined'
 import { Client, schemas } from '@polar-sh/client'
@@ -31,6 +33,7 @@ import { toast } from '../Toast/use-toast'
 
 interface CustomerPortalTeamSectionProps {
   api: Client
+  organizationSlug: string
 }
 
 const roleDisplayNames: Record<string, string> = {
@@ -51,12 +54,14 @@ const roleToDisplayName = (role: string): string => {
 
 export const CustomerPortalTeamSection = ({
   api,
+  organizationSlug,
 }: CustomerPortalTeamSectionProps) => {
   const { data: members } = useCustomerPortalMembers(api)
   const { data: authenticatedUser } = usePortalAuthenticatedUser(api)
   const updateMember = useUpdateCustomerPortalMember(api)
   const removeMember = useRemoveCustomerPortalMember(api)
   const addMember = useAddCustomerPortalMember(api)
+  const safeCopy = useSafeCopy(toast)
 
   const [memberToRemove, setMemberToRemove] = useState<string | null>(null)
   const [loadingMembers, setLoadingMembers] = useState<Set<string>>(new Set())
@@ -135,6 +140,18 @@ export const CustomerPortalTeamSection = ({
         return next
       })
     }
+  }
+
+  const handleCopyLoginLink = async (memberEmail: string) => {
+    const link = `${CONFIG.FRONTEND_BASE_URL}/${organizationSlug}/portal/request?email=${encodeURIComponent(
+      memberEmail,
+    )}`
+    await safeCopy(link)
+    toast({
+      title: 'Login link copied',
+      description:
+        'Share it with the member so they can sign in to the portal with their email.',
+    })
   }
 
   const handleRemoveMember = async (memberId: string) => {
@@ -273,6 +290,12 @@ export const CustomerPortalTeamSection = ({
                             </Button>
                           </DropdownMenuTrigger>
                           <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              onClick={() => handleCopyLoginLink(member.email)}
+                              disabled={isLoading}
+                            >
+                              Copy login link
+                            </DropdownMenuItem>
                             <DropdownMenuItem
                               onClick={() => setMemberToRemove(member.id)}
                               disabled={isLoading}

--- a/clients/apps/web/src/components/CustomerPortal/SeatManagementTable.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/SeatManagementTable.tsx
@@ -7,8 +7,7 @@ import {
   useRevokeSeat,
   useUpdateCustomerPortalMember,
 } from '@/hooks/queries/customerPortal'
-import { useSafeCopy } from '@/hooks/clipboard'
-import { CONFIG } from '@/utils/config'
+import { useCopyMemberLoginLink } from '@/hooks/useCopyMemberLoginLink'
 import { validateEmail } from '@/utils/validation'
 import MoreVertOutlined from '@mui/icons-material/MoreVertOutlined'
 import { Client, schemas } from '@polar-sh/client'
@@ -52,7 +51,7 @@ export const SeatManagementTable = ({
   organizationSlug,
   prorationBehavior,
 }: SeatManagementTableProps) => {
-  const safeCopy = useSafeCopy(toast)
+  const copyMemberLoginLink = useCopyMemberLoginLink(organizationSlug)
 
   const { data: seatsData, isLoading: isLoadingSeats } = useCustomerSeats(
     api,
@@ -158,18 +157,6 @@ export const SeatManagementTable = ({
         return next
       })
     }
-  }
-
-  const handleCopyLoginLink = async (memberEmail: string) => {
-    const link = `${CONFIG.FRONTEND_BASE_URL}/${organizationSlug}/portal/request?email=${encodeURIComponent(
-      memberEmail,
-    )}`
-    await safeCopy(link)
-    toast({
-      title: 'Login link copied',
-      description:
-        'Share it with the member so they can sign in to the portal with their email.',
-    })
   }
 
   const startEditingName = (seat: CustomerSeat) => {
@@ -302,7 +289,7 @@ export const SeatManagementTable = ({
                                   memberEmail !== '—' && (
                                     <DropdownMenuItem
                                       onClick={() =>
-                                        handleCopyLoginLink(memberEmail)
+                                        copyMemberLoginLink(memberEmail)
                                       }
                                       disabled={isSeatLoading}
                                     >

--- a/clients/apps/web/src/components/CustomerPortal/SeatManagementTable.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/SeatManagementTable.tsx
@@ -7,6 +7,8 @@ import {
   useRevokeSeat,
   useUpdateCustomerPortalMember,
 } from '@/hooks/queries/customerPortal'
+import { useSafeCopy } from '@/hooks/clipboard'
+import { CONFIG } from '@/utils/config'
 import { validateEmail } from '@/utils/validation'
 import MoreVertOutlined from '@mui/icons-material/MoreVertOutlined'
 import { Client, schemas } from '@polar-sh/client'
@@ -34,6 +36,7 @@ type SeatBasedOrder = { orderId: string }
 interface SeatManagementTableProps {
   api: Client
   identifier: SeatBasedSubscription | SeatBasedOrder
+  organizationSlug: string
   prorationBehavior?: schemas['CustomerOrganization']['proration_behavior']
 }
 
@@ -46,8 +49,11 @@ function isSeatBasedSubscription(
 export const SeatManagementTable = ({
   api,
   identifier,
+  organizationSlug,
   prorationBehavior,
 }: SeatManagementTableProps) => {
+  const safeCopy = useSafeCopy(toast)
+
   const { data: seatsData, isLoading: isLoadingSeats } = useCustomerSeats(
     api,
     isSeatBasedSubscription(identifier)
@@ -152,6 +158,18 @@ export const SeatManagementTable = ({
         return next
       })
     }
+  }
+
+  const handleCopyLoginLink = async (memberEmail: string) => {
+    const link = `${CONFIG.FRONTEND_BASE_URL}/${organizationSlug}/portal/request?email=${encodeURIComponent(
+      memberEmail,
+    )}`
+    await safeCopy(link)
+    toast({
+      title: 'Login link copied',
+      description:
+        'Share it with the member so they can sign in to the portal with their email.',
+    })
   }
 
   const startEditingName = (seat: CustomerSeat) => {
@@ -280,6 +298,17 @@ export const SeatManagementTable = ({
                                 </Button>
                               </DropdownMenuTrigger>
                               <DropdownMenuContent align="end">
+                                {seat.status === 'claimed' &&
+                                  memberEmail !== '—' && (
+                                    <DropdownMenuItem
+                                      onClick={() =>
+                                        handleCopyLoginLink(memberEmail)
+                                      }
+                                      disabled={isSeatLoading}
+                                    >
+                                      Copy login link
+                                    </DropdownMenuItem>
+                                  )}
                                 {seat.member?.id && (
                                   <DropdownMenuItem
                                     onClick={() => startEditingName(seat)}

--- a/clients/apps/web/src/hooks/useCopyMemberLoginLink.ts
+++ b/clients/apps/web/src/hooks/useCopyMemberLoginLink.ts
@@ -1,0 +1,23 @@
+import { toast } from '@/components/Toast/use-toast'
+import { CONFIG } from '@/utils/config'
+import { useCallback } from 'react'
+import { useSafeCopy } from './clipboard'
+
+export const useCopyMemberLoginLink = (organizationSlug: string) => {
+  const safeCopy = useSafeCopy(toast)
+
+  return useCallback(
+    async (memberEmail: string) => {
+      const link = `${CONFIG.FRONTEND_BASE_URL}/${organizationSlug}/portal/request?email=${encodeURIComponent(
+        memberEmail,
+      )}`
+      await safeCopy(link)
+      toast({
+        title: 'Login link copied',
+        description:
+          'Share it with the member to sign in to the customer portal.',
+      })
+    },
+    [organizationSlug, safeCopy],
+  )
+}


### PR DESCRIPTION
## What

Adds a button to _Copy Member Login Link_ in both dashboard and for owners in customer portal. It does not show for non-member seat invitations. As these aren't necessarily members yet.

## Why

When working on the customer portal, I was super confused on how each member would navigate to the email OTP login flow. They get it by email, but these can be lost.

## How

This does not create a member session token. It only navigates to the portal login page with the email prefilled, they themself will go through login flow with the OTP.

## Checklist

https://github.com/user-attachments/assets/ade306ef-1e3b-4c0e-a1bb-3a752c966e43


<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [X] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [X] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [X] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [X] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

