### PR TITLE
Fix identity verification state for none owner users

### DIFF
--- a/clients/apps/web/src/components/Finance/Account/sections/IdentityVerificationSection.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/IdentityVerificationSection.tsx
@@ -32,8 +32,14 @@ export const IdentityVerificationSection = ({
     })
   }, [identityVerificationStatus, organization.id])
 
+  const notAuthorized = (step.reasons ?? []).includes('not_authorized')
+  const status =
+    step.status === 'passed' ? 'verified' : identityVerificationStatus
+
   const tone = step.status === 'failed' ? 'danger' : 'warning'
   const showBanners =
+    !notAuthorized &&
+    step.status !== 'passed' &&
     reasonItems.length > 0 &&
     (identityVerificationStatus === 'failed' ||
       identityVerificationStatus === 'unverified' ||
@@ -42,8 +48,9 @@ export const IdentityVerificationSection = ({
   return (
     <>
       <IdentityVerificationStatusContent
-        status={identityVerificationStatus}
+        status={status}
         onStart={start}
+        notAuthorized={notAuthorized}
       />
       {showBanners && (
         <Box flexDirection="column" rowGap="m">

--- a/clients/apps/web/src/components/Identity/IdentityVerificationStatusContent.tsx
+++ b/clients/apps/web/src/components/Identity/IdentityVerificationStatusContent.tsx
@@ -14,6 +14,7 @@ import {
 interface Props {
   status: schemas['IdentityVerificationStatus'] | undefined
   onStart: () => void
+  notAuthorized?: boolean
   unverifiedDescription?: string
 }
 
@@ -23,8 +24,20 @@ const DEFAULT_UNVERIFIED_DESCRIPTION =
 export const IdentityVerificationStatusContent = ({
   status,
   onStart,
+  notAuthorized = false,
   unverifiedDescription = DEFAULT_UNVERIFIED_DESCRIPTION,
 }: Props) => {
+  if (notAuthorized) {
+    return (
+      <StatusBlock
+        tone="pending"
+        icon={ClockIcon}
+        title="Waiting for owner"
+        description="Waiting for this organization's owner to finish identity verification."
+      />
+    )
+  }
+
   if (status === 'verified') {
     return (
       <StatusBlock

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -25669,6 +25669,7 @@ export interface components {
      */
     OrganizationReviewCheckReason:
       | 'not_started'
+      | 'not_authorized'
       | 'in_progress'
       | 'external_pending'
       | 'identity.rejected'
@@ -58948,6 +58949,7 @@ export const organizationReviewCheckReasonValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['OrganizationReviewCheckReason']
 > = [
   'not_started',
+  'not_authorized',
   'in_progress',
   'external_pending',
   'identity.rejected',

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -972,7 +972,9 @@ async def get_review(
     Powers the account review UI: pre-submission gating checks plus,
     after submission, the AI verdict and appeal state.
     """
-    return await organization_service.get_review_state(session, authz.organization)
+    return await organization_service.get_review_state(
+        session, authz.organization, authz.auth_subject
+    )
 
 
 @router.post(

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -682,6 +682,7 @@ class OrganizationReviewCheckReason(StrEnum):
 
     # Universal
     NOT_STARTED = "not_started"
+    NOT_AUTHORIZED = "not_authorized"
     IN_PROGRESS = "in_progress"
     EXTERNAL_PENDING = "external_pending"
 

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -13,7 +13,7 @@ from pydantic import ValidationError as PydanticValidationError
 from sqlalchemy.exc import IntegrityError
 
 from polar.account.service import account as account_service
-from polar.auth.models import AuthSubject
+from polar.auth.models import AuthSubject, is_user
 from polar.authz.service import get_accessible_org_ids
 from polar.checkout_link.repository import CheckoutLinkRepository
 from polar.config import settings
@@ -1556,6 +1556,7 @@ class OrganizationService:
         self,
         session: AsyncReadSession,
         organization: Organization,
+        auth_subject: AuthSubject[User | Organization] | None = None,
     ) -> OrganizationReviewState:
         """Build the merchant self-review checklist state.
 
@@ -1572,6 +1573,17 @@ class OrganizationService:
 
         organization_repository = OrganizationRepository.from_session(session)
         owner_user = await organization_repository.get_owner_user(organization)
+
+        # Identity verification is the owner's to complete. When a non-owner
+        # member is viewing, surface that they can't action it
+        current_user = (
+            auth_subject.subject
+            if auth_subject is not None and is_user(auth_subject)
+            else None
+        )
+        identity_restricted = current_user is not None and not (
+            owner_user is not None and current_user.id == owner_user.id
+        )
 
         review_repository = OrganizationReviewRepository.from_session(session)
         review = await review_repository.get_by_organization(organization.id)
@@ -1592,7 +1604,9 @@ class OrganizationService:
             self._build_product_description_check(organization),
             product_configuration_check,
             setup_readiness_check,
-            self._build_identity_verification_check(owner_user),
+            self._build_identity_verification_check(
+                owner_user, restricted=identity_restricted
+            ),
             self._build_payout_account_check(payout_account),
             self._build_socials_check(organization),
             await product_url_task,
@@ -1714,9 +1728,21 @@ class OrganizationService:
         return self._passed_check(key)
 
     def _build_identity_verification_check(
-        self, owner_user: User | None
+        self, owner_user: User | None, *, restricted: bool = False
     ) -> OrganizationReviewCheck:
         key = OrganizationReviewCheckKey.IDENTITY_STRIPE_VERIFICATION
+        check = self._owner_identity_check(owner_user, key)
+        if restricted and check.status != OrganizationReviewCheckStatus.PASSED:
+            return OrganizationReviewCheck(
+                key=key,
+                status=check.status,
+                reasons=[OrganizationReviewCheckReason.NOT_AUTHORIZED],
+            )
+        return check
+
+    def _owner_identity_check(
+        self, owner_user: User | None, key: OrganizationReviewCheckKey
+    ) -> OrganizationReviewCheck:
         if owner_user is None:
             return self._not_started_check(key)
 

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -63,6 +63,7 @@ from polar.support_case.repository import SupportCaseMessageRepository
 from polar.user_organization.service import (
     user_organization as user_organization_service,
 )
+from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_benefit,
@@ -1716,6 +1717,36 @@ class TestGetReviewState:
                 OrganizationReviewCheckReason.NOT_STARTED in reasons
                 for reasons in reason_lists
             )
+
+    @pytest.mark.auth
+    async def test_identity_owner_viewer_sees_not_started(
+        self,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        state = await organization_service.get_review_state(
+            session, organization, auth_subject
+        )
+        step = _step(state, OrganizationReviewCheckKey.IDENTITY_STRIPE_VERIFICATION)
+        assert step.status == OrganizationReviewCheckStatus.PENDING
+        assert OrganizationReviewCheckReason.NOT_STARTED in step.reasons
+
+    @pytest.mark.auth(AuthSubjectFixture(subject="user_second"))
+    async def test_identity_non_owner_viewer_sees_not_authorized(
+        self,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        state = await organization_service.get_review_state(
+            session, organization, auth_subject
+        )
+        step = _step(state, OrganizationReviewCheckKey.IDENTITY_STRIPE_VERIFICATION)
+        assert step.status == OrganizationReviewCheckStatus.PENDING
+        assert step.reasons == [OrganizationReviewCheckReason.NOT_AUTHORIZED]
 
     async def test_email_set_passes(
         self,


### PR DESCRIPTION
## Summary

Non owners of an organization will see this during onboarding which is confusing:

<img width="814" height="306" alt="Screenshot 2026-06-24 at 17 33 46" src="https://github.com/user-attachments/assets/f8b8e16c-111e-498f-af44-fdc30f2549c7" />

Becase it's the _admin_ who has to verify their identification. This PR fixes that.

### Screenshots


<img width="1840" height="1134" alt="Screenshot 2026-06-24 at 17 36 59" src="https://github.com/user-attachments/assets/67aed0e2-4e66-48bb-9646-761762730ab5" />



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

