### PR TITLE
fix(web): use the grouped scope selector for OAuth app scopes

### DIFF
--- a/clients/apps/web/src/components/Settings/OAuth/OAuthForm.tsx
+++ b/clients/apps/web/src/components/Settings/OAuth/OAuthForm.tsx
@@ -15,16 +15,14 @@ import {
   FormLabel,
   FormMessage,
 } from '@polar-sh/ui/components/ui/form'
-import { type MouseEvent } from 'react'
 
 import ImageUpload from '@/components/Form/ImageUpload'
 import AddOutlined from '@mui/icons-material/AddOutlined'
 import ClearOutlined from '@mui/icons-material/ClearOutlined'
 import { enums } from '@polar-sh/client'
-import { Checkbox } from '@polar-sh/orbit'
 import Link from 'next/link'
-import { useCallback, useMemo } from 'react'
 import { useFieldArray, useFormContext } from 'react-hook-form'
+import { TreeMultiSelect } from '../TreeMultiSelect'
 import { EnhancedOAuth2ClientConfiguration } from './NewOAuthClientModal'
 
 export const FieldName = () => {
@@ -255,81 +253,26 @@ export const FieldRedirectURIs = () => {
 }
 
 export const FieldScopes = () => {
-  const { control, watch, setValue } =
-    useFormContext<EnhancedOAuth2ClientConfiguration>()
-  const sortedAvailableScopes = Array.from(enums.availableScopeValues).sort(
-    (a, b) => a.localeCompare(b),
-  )
-
-  const currentScopes = watch('scope')
-
-  const allSelected = useMemo(
-    () => sortedAvailableScopes.every((scope) => currentScopes.includes(scope)),
-    [currentScopes, sortedAvailableScopes],
-  )
-
-  const onToggleAll = useCallback(
-    (e: MouseEvent<HTMLButtonElement>) => {
-      e.preventDefault()
-
-      let values: typeof currentScopes = []
-      if (!allSelected) {
-        values = sortedAvailableScopes
-      }
-
-      setValue('scope', values)
-    },
-    [setValue, allSelected, sortedAvailableScopes],
-  )
+  const { control } = useFormContext<EnhancedOAuth2ClientConfiguration>()
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex flex-row items-center">
-        <h2 className="text-sm leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-          Scopes
-        </h2>
-
-        <div className="flex-auto text-right">
-          <Button onClick={onToggleAll} variant="secondary" size="sm">
-            {!allSelected ? 'Select All' : 'Unselect All'}
-          </Button>
-        </div>
-      </div>
-
-      <div className="flex flex-col gap-2">
-        {sortedAvailableScopes.map((scope) => (
-          <FormField
-            key={scope}
-            control={control}
-            name="scope"
-            render={({ field }) => {
-              return (
-                <FormItem className="flex flex-row items-center space-y-0 space-x-3">
-                  <FormControl>
-                    <Checkbox
-                      checked={field.value?.includes(scope)}
-                      onCheckedChange={(checked) => {
-                        if (checked) {
-                          field.onChange([...(field.value || []), scope])
-                        } else {
-                          field.onChange(
-                            (field.value || []).filter((v) => v !== scope),
-                          )
-                        }
-                      }}
-                    />
-                  </FormControl>
-                  <FormLabel className="text-sm leading-none">
-                    {scope}
-                  </FormLabel>
-                  <FormMessage />
-                </FormItem>
-              )
-            }}
-          />
-        ))}
-      </div>
-    </div>
+    <FormField
+      control={control}
+      name="scope"
+      render={({ field }) => (
+        <FormItem>
+          <FormControl>
+            <TreeMultiSelect
+              title="Scopes"
+              options={enums.availableScopeValues}
+              value={field.value ?? []}
+              onChange={field.onChange}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
   )
 }
 


### PR DESCRIPTION
## Summary

The OAuth Application form (`/dashboard/account/developer` → New/Edit OAuth App) rendered scopes as a long **flat checkbox list** of raw scope strings. This swaps it to the shared `TreeMultiSelect` — the same component the **Organization Access Tokens** and **Webhooks** forms already use — so scopes are grouped by resource, indented, with an indeterminate "dash" when a group is partially selected (e.g. `read` but not `write`), plus a per-group / select-all toggle.

## Why
Consistency with the rest of settings, and a far more readable scope picker. Net ~-70 lines: the bespoke flat list (manual select-all, per-scope `FormField`) is replaced by the existing reusable component.



### Before / After

| Before | After |
|---|---|
| <img width="1152" alt="Before — flat scope list" src="https://github.com/user-attachments/assets/194f1a63-a5f6-481c-89e0-ceeb9ce4aa28" /> | <img width="1337" alt="After — grouped scope selector" src="https://github.com/user-attachments/assets/97c4cf13-85b3-41f6-a3cc-79fb9ce99ba0" /> |

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

