### PR TITLE
tf/aws: Fix Redis security group catch22

### DIFF
--- a/terraform/modules/aws_redis/main.tf
+++ b/terraform/modules/aws_redis/main.tf
@@ -6,18 +6,9 @@ resource "aws_elasticache_subnet_group" "this" {
 
 resource "aws_security_group" "this" {
   name        = "${var.name}-cache"
-  description = "Ingress to ${var.name} Redis from allowed security groups."
+  description = "Security group for ${var.name} Redis."
   vpc_id      = var.vpc_id
   tags        = var.tags
-}
-
-resource "aws_vpc_security_group_ingress_rule" "redis" {
-  for_each                     = toset(var.ingress_security_group_ids)
-  security_group_id            = aws_security_group.this.id
-  referenced_security_group_id = each.value
-  from_port                    = var.port
-  to_port                      = var.port
-  ip_protocol                  = "tcp"
 }
 
 resource "aws_elasticache_cluster" "this" {

--- a/terraform/modules/aws_redis/variables.tf
+++ b/terraform/modules/aws_redis/variables.tf
@@ -13,11 +13,6 @@ variable "subnet_ids" {
   type        = list(string)
 }
 
-variable "ingress_security_group_ids" {
-  description = "Security groups allowed to reach Redis on the cache port."
-  type        = list(string)
-}
-
 variable "node_type" {
   description = "ElastiCache node type."
   type        = string

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -15,8 +15,8 @@ module "redis" {
 resource "aws_vpc_security_group_ingress_rule" "redis_lambda" {
   security_group_id            = module.redis.security_group_id
   referenced_security_group_id = aws_security_group.lambda.id
-  from_port                    = 6379
-  to_port                      = 6379
+  from_port                    = module.redis.port
+  to_port                      = module.redis.port
   ip_protocol                  = "tcp"
 }
 

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -7,10 +7,17 @@ module "lambda_worker_ecr" {
 module "redis" {
   source = "../modules/aws_redis"
 
-  name                       = "polar-sandbox-worker"
-  vpc_id                     = module.vpc.vpc_id
-  subnet_ids                 = module.vpc.private_subnet_ids
-  ingress_security_group_ids = [aws_security_group.lambda.id]
+  name       = "polar-sandbox-worker"
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnet_ids
+}
+
+resource "aws_vpc_security_group_ingress_rule" "redis_lambda" {
+  security_group_id            = module.redis.security_group_id
+  referenced_security_group_id = aws_security_group.lambda.id
+  from_port                    = 6379
+  to_port                      = 6379
+  ip_protocol                  = "tcp"
 }
 
 module "dummy_lambda_worker" {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a Redis security group dependency loop by removing ingress rules from `aws_redis` and defining them in callers. The module now only creates the SG; `sandbox` adds a Lambda→Redis ingress rule using `module.redis.port`.

- **Bug Fixes**
  - Removed internal ingress rule and `ingress_security_group_ids` from `aws_redis`.
  - Added `aws_vpc_security_group_ingress_rule` in `sandbox` from `aws_security_group.lambda` to `module.redis.security_group_id` using `module.redis.port`.

- **Migration**
  - Stop passing `ingress_security_group_ids` to `aws_redis`.
  - Define ingress rules in callers to `module.redis.security_group_id`, using the module’s `port`.

<sup>Written for commit 69c867d5fe184d908dd837355e077b3a769e1976. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

