### PR TITLE
ci: Deploy sandbox lambda to new account

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -249,7 +249,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6.2.0
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.SANDBOX_AWS_ROLE_ARN }}
           aws-region: us-east-2
 
       - name: Log in to Amazon ECR
@@ -287,7 +287,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6.2.0
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.SANDBOX_AWS_ROLE_ARN }}
           aws-region: us-east-2
       - name: Log in to Amazon ECR
         id: login-ecr

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -92,3 +92,52 @@ resource "aws_iam_user_policy" "tasks_producer" {
   user   = aws_iam_user.tasks_producer.name
   policy = data.aws_iam_policy_document.tasks_producer.json
 }
+
+# =============================================================================
+# GitHub Actions OIDC role (builds the task-worker image and deploys it)
+# =============================================================================
+
+data "aws_iam_policy_document" "lambda_worker_deploy" {
+  statement {
+    sid       = "EcrAuthorization"
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "EcrPush"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:CompleteLayerUpload",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:InitiateLayerUpload",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart",
+    ]
+    resources = [module.lambda_worker_ecr.repository_arn]
+  }
+
+  statement {
+    sid       = "UpdateFunctionCode"
+    actions   = ["lambda:UpdateFunctionCode"]
+    resources = [module.dummy_lambda_worker.function_arn]
+  }
+}
+
+resource "aws_iam_policy" "lambda_worker_deploy" {
+  name   = "github-actions-lambda-worker-deploy"
+  policy = data.aws_iam_policy_document.lambda_worker_deploy.json
+}
+
+module "github_oidc_lambda_worker" {
+  source = "../modules/github_oidc"
+
+  role_name       = "github-actions-lambda-worker"
+  github_org      = "polarsource"
+  github_repo     = "polar"
+  github_subjects = ["ref:refs/heads/main"]
+  policy_arns = {
+    deploy = aws_iam_policy.lambda_worker_deploy.arn
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Deploys the sandbox Lambda to the new AWS account. CI now assumes `SANDBOX_AWS_ROLE_ARN` to build/push the worker image and update the sandbox function.

- **New Features**
  - Sandbox GitHub OIDC role `github-actions-lambda-worker` with ECR push and `lambda:UpdateFunctionCode` permissions, scoped to `polarsource/polar` on `main`.
  - CI workflow updated to use `secrets.SANDBOX_AWS_ROLE_ARN` for both build and deploy steps.

- **Migration**
  - Set repository secret `SANDBOX_AWS_ROLE_ARN` to the new role ARN.

<sup>Written for commit c9c270bb5881e351e354520914f0b016f191535a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

