### PR TITLE
feat(docs): Add database credentials rotation procedure

### DIFF
--- a/handbook/engineering/oncall/rotate-db-credentials.mdx
+++ b/handbook/engineering/oncall/rotate-db-credentials.mdx
@@ -30,7 +30,7 @@ description: "Rotate the Postgres default user/password using Render's built-in 
 3. The new user becomes the **default user** immediately.
 
 <Note>
-  The original/previous user is **not** deleted yet — it keeps working until explicitly deleted in step 5.
+  The original/previous user is **not** deleted yet — it keeps working until explicitly deleted in step 6.
   This is what makes running services (with env vars holding the old credentials) not break and allows the rotation to be done with zero downtime.
 </Note>
 
@@ -59,7 +59,13 @@ Inspect the plan output in [Terraform Cloud](https://app.terraform.io/app/polar-
 - Verify the API + workers come back up on the new credentials.
 - TODO: links / checks — Render service health, sentry, logfire etc.
 
-### 4. Monitor for use of the old credential
+### 4. Update Metabase credentials
+
+Metabase connects to the database with its own copy of the credentials and is **not** managed by Terraform, so update it manually:
+
+- Metabase → **Admin → Databases → `polar_cpit_p9lf` → Edit connection details**, and set the new username and password.
+
+### 5. Monitor for use of the old credential
 
 Confirm nothing is still connecting as the **old** user before deleting it.
 
@@ -74,7 +80,7 @@ ORDER BY usename;
 - TODO: typical settling time; what to do if a stubborn connection lingers (which service, how to
   force a redeploy/restart).
 
-### 5. Delete the old user on Render
+### 6. Delete the old user on Render
 
 1. Render Dashboard → `db` → **Credentials** → trashcan icon next to the **old** user, then confirm.
 2. The user and its credentials are removed immediately.
@@ -94,7 +100,7 @@ ORDER BY usename;
 
 ## Rollback / troubleshooting
 
-**There is no rollback, only roll-forward.** Render can't promote existing credentials back to default — the only way to change the default is to create new credentials (see the Background). So the recovery path for a bad rotation is another rotation (create fresh credentials and re-apply), not reverting to the old user. Until you delete the old user in step 5 its credentials still work, so an in-progress rotation can be safely abandoned before that point.
+**There is no rollback, only roll-forward.** Render can't promote existing credentials back to default — the only way to change the default is to create new credentials (see the Background). So the recovery path for a bad rotation is another rotation (create fresh credentials and re-apply), not reverting to the old user. Until you delete the old user in step 6 its credentials still work, so an in-progress rotation can be safely abandoned before that point.
 
 - TODO: what to do if services fail to connect after apply (re-check plan applied cleanly; the
   default user is whatever Render last promoted).

--- a/handbook/engineering/oncall/rotate-db-credentials.mdx
+++ b/handbook/engineering/oncall/rotate-db-credentials.mdx
@@ -19,7 +19,7 @@ description: "Rotate the Postgres default user/password using Render's built-in 
 - Access to the [Render Dashboard](https://dashboard.render.com/) for the target `db` instance
 - Access to the HCP Terraform Cloud workspace (`production` / `sandbox` / `test`)
 - A way to query the DB to watch active connections — see [Connecting to the prod DB](/engineering/oncall/connecting-to-prod-db)
-- TODO: confirm who needs to approve / be notified
+- Approval / notification: loop in the on-call engineer and the platform lead
 
 ## Procedure
 
@@ -53,9 +53,10 @@ Inspect the plan output in [Terraform Cloud](https://app.terraform.io/app/polar-
   It must **not** show `render_postgres.db` being **replaced/destroyed** (`prevent_destroy = true` should block that, but stop and investigate if you see it).
 </Warning>
 
-### 3. Confirm services redeployed and are healthy
+### 3. Redeploy services and confirm they're healthy
 
-- Verify the API + workers redeployed with the new env vars.
+- The DB credentials live in a shared env group, so services may **not** redeploy automatically when Terraform updates it. For each affected service (API + workers), trigger **Manual Deploy → Deploy latest reference** in the Render Dashboard.
+- Verify the API + workers come back up on the new credentials.
 - TODO: links / checks — Render service health, sentry, logfire etc.
 
 ### 4. Monitor for use of the old credential
@@ -76,7 +77,7 @@ ORDER BY usename;
 ### 5. Delete the old user on Render
 
 1. Render Dashboard → `db` → **Credentials** → trashcan icon next to the **old** user, then confirm.
-2. The user and its credentials are removed immediately. — **except** the database's *original* user. Render never fully deletes the original user; it deactivates it by revoking login privileges, as a safeguard to preserve database objects it owns.
+2. The user and its credentials are removed immediately.
 
 <Note>
   If the user to delete is the _original_ user then technically Render doesn't delete the user but rather revokes its login privileges.
@@ -93,11 +94,12 @@ ORDER BY usename;
 
 ## Rollback / troubleshooting
 
+**There is no rollback, only roll-forward.** Render can't promote existing credentials back to default — the only way to change the default is to create new credentials (see the Background). So the recovery path for a bad rotation is another rotation (create fresh credentials and re-apply), not reverting to the old user. Until you delete the old user in step 5 its credentials still work, so an in-progress rotation can be safely abandoned before that point.
+
 - TODO: what to do if services fail to connect after apply (re-check plan applied cleanly; the
   default user is whatever Render last promoted).
 - TODO: behavior if a new default credential was generated but Terraform was **not** applied
   (env vars stale → services on old user until apply).
-- TODO: how to abort mid-rotation before deleting the old user.
 
 ## Background: how rotation works here
 
@@ -110,7 +112,7 @@ Default credentials are available in terraform and our terraform config populate
 - `POLAR_POSTGRES_PWD` & `POLAR_POSTGRES_READ_PWD` are populated from `render_postgres.db.connection_info.password` which gives the default credentials' password
 
 Both attributes always reflect the **current default credentials**, so they stay in sync (no risk of new-user + old-password).
-This means a single `terraform apply` re-renders these env vars and redeploys the API + workers — replacing Render's manual "update config + redeploy" steps.
+This means a single `terraform apply` re-renders these env vars, replacing Render's manual "update config" step. Because the variables live in a shared env group, services don't always pick up the change automatically — you may need to redeploy each one manually (see step 3).
 
 <Note>
   Read replicas reuse `local.db_user` / `local.db_password` (the primary's default credentials),

--- a/handbook/engineering/oncall/rotate-db-credentials.mdx
+++ b/handbook/engineering/oncall/rotate-db-credentials.mdx
@@ -1,0 +1,124 @@
+---
+title: "Rotate Database Credentials"
+description: "Rotate the Postgres default user/password using Render's built-in credential rotation with zero downtime."
+---
+
+<Warning>
+  Production database operation. Coordinate with the team and announce in advance.
+  Although this is designed to be zero-downtime, missteps can cut every service off from the database.
+</Warning>
+
+## When to use this
+
+- Suspected or confirmed credential leak
+- Routine, scheduled rotation
+- Offboarding / revoking access tied to the current default user
+
+## Prerequisites
+
+- Access to the [Render Dashboard](https://dashboard.render.com/) for the target `db` instance
+- Access to the HCP Terraform Cloud workspace (`production` / `sandbox` / `test`)
+- A way to query the DB to watch active connections — see [Connecting to the prod DB](/engineering/oncall/connecting-to-prod-db)
+- TODO: confirm who needs to approve / be notified
+
+## Procedure
+
+### 1. Generate a new default credential on Render
+
+1. Render Dashboard → the `db` instance → **Info** page → **Credentials** section.
+2. Click **+ New default credential**. Leave the username blank so Render generates one, then click **Create Credential**.
+3. The new user becomes the **default user** immediately.
+
+<Note>
+  The original/previous user is **not** deleted yet — it keeps working until explicitly deleted in step 5.
+  This is what makes running services (with env vars holding the old credentials) not break and allows the rotation to be done with zero downtime.
+</Note>
+
+<Note>
+  See [Render's documentation](https://render.com/docs/postgresql-credentials#adding-a-user) for more details.
+</Note>
+
+### 2. Apply Terraform to pick up the new credentials
+
+Terraform reads the new default `database_user` and `connection_info.password` from Render and
+propagates them to every service.
+
+Inspect the plan output in [Terraform Cloud](https://app.terraform.io/app/polar-sh/workspaces) and apply if everything looks good.
+
+- TODO: confirm the exact set of resources expected to change (env group / service env vars)
+  and add a sample plan snippet.
+
+<Warning>
+  Sanity-check the plan: it must show env-var updates only.
+  It must **not** show `render_postgres.db` being **replaced/destroyed** (`prevent_destroy = true` should block that, but stop and investigate if you see it).
+</Warning>
+
+### 3. Confirm services redeployed and are healthy
+
+- Verify the API + workers redeployed with the new env vars.
+- TODO: links / checks — Render service health, sentry, logfire etc.
+
+### 4. Monitor for use of the old credential
+
+Confirm nothing is still connecting as the **old** user before deleting it.
+
+```sql
+SELECT usename, count(*)
+FROM pg_stat_activity
+GROUP BY usename
+ORDER BY usename;
+```
+
+- Wait until the old username shows zero connections.
+- TODO: typical settling time; what to do if a stubborn connection lingers (which service, how to
+  force a redeploy/restart).
+
+### 5. Delete the old user on Render
+
+1. Render Dashboard → `db` → **Credentials** → trashcan icon next to the **old** user, then confirm.
+2. The user and its credentials are removed immediately. — **except** the database's *original* user. Render never fully deletes the original user; it deactivates it by revoking login privileges, as a safeguard to preserve database objects it owns.
+
+<Note>
+  If the user to delete is the _original_ user then technically Render doesn't delete the user but rather revokes its login privileges.
+  See [Render's documentation](https://render.com/docs/postgresql-credentials#deleting-a-user) for more details.
+</Note>
+
+## Verification
+
+- [ ] `terraform plan` is clean (no pending drift on `render_postgres.db`)
+- [ ] API + workers healthy on the new credential
+- [ ] Old user shows zero active connections
+- [ ] Old user removed
+- [ ] Operation recorded in the on-call log (see Safety Guidelines)
+
+## Rollback / troubleshooting
+
+- TODO: what to do if services fail to connect after apply (re-check plan applied cleanly; the
+  default user is whatever Render last promoted).
+- TODO: behavior if a new default credential was generated but Terraform was **not** applied
+  (env vars stale → services on old user until apply).
+- TODO: how to abort mid-rotation before deleting the old user.
+
+## Background: how rotation works here
+
+We use Render's [built-in credential rotation](https://render.com/docs/postgresql-credentials#rotating-credentials):
+Render designates one role as the instance's **default user** and exposes its credentials in the
+dashboard and connection strings. Creating a new default credential generates a fresh username & password pair and promotes it to the new default.
+
+Default credentials are available in terraform and our terraform config populates env vars based on values read from Render:
+- `POLAR_POSTGRES_USER` & `POLAR_POSTGRES_READ_USER` are populated from `render_postgres.db.database_user` which gives the default credentials' username
+- `POLAR_POSTGRES_PWD` & `POLAR_POSTGRES_READ_PWD` are populated from `render_postgres.db.connection_info.password` which gives the default credentials' password
+
+Both attributes always reflect the **current default credentials**, so they stay in sync (no risk of new-user + old-password).
+This means a single `terraform apply` re-renders these env vars and redeploys the API + workers — replacing Render's manual "update config + redeploy" steps.
+
+<Note>
+  Read replicas reuse `local.db_user` / `local.db_password` (the primary's default credentials),
+  so they rotate together automatically.
+</Note>
+
+## See also
+
+- Render docs: [Rotating credentials](https://render.com/docs/postgresql-credentials#rotating-credentials)
+- [Connecting to the prod DB](/engineering/oncall/connecting-to-prod-db)
+- [Deploy Infra Changes](/engineering/oncall/deploy-infra)

--- a/handbook/engineering/oncall/rotate-db-credentials.mdx
+++ b/handbook/engineering/oncall/rotate-db-credentials.mdx
@@ -96,7 +96,7 @@ ORDER BY usename;
 - [ ] API + workers healthy on the new credential
 - [ ] Old user shows zero active connections
 - [ ] Old user removed
-- [ ] Operation recorded in the on-call log (see Safety Guidelines)
+- [ ] Operation recorded in the on-call log (see [Safety Guidelines](/engineering/oncall/introduction#safety-guidelines))
 
 ## Rollback / troubleshooting
 

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -37,7 +37,6 @@ resource "render_postgres" "db" {
   environment_id = local.environment_id
   name           = "db-test"
   database_name  = "polar_cpit"
-  database_user  = "polar_cpit_user"
   plan           = "pro_4gb"
   region         = "ohio"
   version        = "15"
@@ -53,7 +52,6 @@ resource "render_postgres" "db" {
     prevent_destroy = true
     ignore_changes = [
       ip_allow_list,
-      database_user,
       database_name,
     ]
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an on-call runbook to rotate Render Postgres default credentials with zero downtime using Terraform, and updates test Terraform to read the default user from Render instead of pinning it.

- New Features
  - New page: handbook/engineering/oncall/rotate-db-credentials.mdx.
  - Procedure: create new default credential → apply in Terraform → manually redeploy API/workers if needed → update Metabase → monitor old user → delete old user.
  - Includes prerequisites, safety warnings, SQL to watch connections, verification checklist (links Safety Guidelines), and rollback/troubleshooting notes.
  - Background: how Terraform reads `render_postgres.db.database_user` and `connection_info.password` to set `POLAR_POSTGRES_*` env vars; read replicas rotate automatically; plan sanity-check notes (`prevent_destroy`).

- Refactors
  - Test Terraform: remove pinned `database_user` and its `ignore_changes` so it’s read from Render, aligning test config with the rotation flow.

<sup>Written for commit 35b1a375fe7930fe7706aafd82ea7bd052ed08f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

