### PR TITLE
Show decline reason in order payment attempts table

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/[id]/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/[id]/SalesPage.tsx
@@ -33,7 +33,8 @@ import { ArrowUpRightIcon } from 'lucide-react'
 import { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
 import { Button } from '@polar-sh/orbit'
-import { DataTable } from '@polar-sh/orbit'
+import { DataTable, type DataTableColumnDef } from '@polar-sh/orbit'
+import type { Row } from '@tanstack/react-table'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import ShadowBox from '@polar-sh/ui/components/atoms/ShadowBox'
 import { Status } from '@polar-sh/orbit'
@@ -57,6 +58,9 @@ const ClientPage: React.FC<ClientPageProps> = ({
   const { data: payments, isLoading: paymentsLoading } = usePayments(
     organization.id,
     { order_id: _order.id },
+  )
+  const hasDeclinedPayment = (payments?.items ?? []).some(
+    (payment) => payment.decline_reason || payment.decline_message,
   )
   const { data: refunds, isLoading: refundsLoading } = useRefunds(_order.id)
   const { data: disputes, isLoading: disputesLoading } = useDisputes(
@@ -414,7 +418,36 @@ const ClientPage: React.FC<ClientPageProps> = ({
                 <PaymentStatus payment={original} />
               ),
             },
-          ]}
+            ...(hasDeclinedPayment
+              ? [
+                  {
+                    accessorKey: 'decline_reason',
+                    header: 'Decline Reason',
+                    cell: ({
+                      row: {
+                        original: { decline_message, decline_reason },
+                      },
+                    }: {
+                      row: Row<schemas['Payment']>
+                    }) => {
+                      const reason = decline_message || decline_reason
+                      return reason ? (
+                        <span
+                          className="block max-w-xs truncate text-sm"
+                          title={reason}
+                        >
+                          {reason}
+                        </span>
+                      ) : (
+                        <span className="text-gray-400 dark:text-polar-500">
+                          —
+                        </span>
+                      )
+                    },
+                  },
+                ]
+              : []),
+          ] satisfies DataTableColumnDef<schemas['Payment']>[]}
           data={payments?.items ?? []}
         />
       </div>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/[id]/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/[id]/SalesPage.tsx
@@ -77,7 +77,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
   const hasSeatBasedOrder = !!order?.seats && order.seats > 0
 
   const hasDeclinedPayment = (payments?.items ?? []).some(
-    (payment) => payment.decline_reason || payment.decline_message,
+    (payment) => payment.status === 'failed',
   )
 
   const { data: seatsData, isLoading: isLoadingSeats } = useOrganizationSeats(

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/[id]/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/[id]/SalesPage.tsx
@@ -33,8 +33,7 @@ import { ArrowUpRightIcon } from 'lucide-react'
 import { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
 import { Button } from '@polar-sh/orbit'
-import { DataTable, type DataTableColumnDef } from '@polar-sh/orbit'
-import type { Row } from '@tanstack/react-table'
+import { DataTable, Truncated, type DataTableColumnDef } from '@polar-sh/orbit'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import ShadowBox from '@polar-sh/ui/components/atoms/ShadowBox'
 import { Status } from '@polar-sh/orbit'
@@ -59,9 +58,6 @@ const ClientPage: React.FC<ClientPageProps> = ({
     organization.id,
     { order_id: _order.id },
   )
-  const hasDeclinedPayment = (payments?.items ?? []).some(
-    (payment) => payment.decline_reason || payment.decline_message,
-  )
   const { data: refunds, isLoading: refundsLoading } = useRefunds(_order.id)
   const { data: disputes, isLoading: disputesLoading } = useDisputes(
     organization.id,
@@ -79,6 +75,10 @@ const ClientPage: React.FC<ClientPageProps> = ({
 
   // Seat management for seat-based orders (view-only)
   const hasSeatBasedOrder = !!order?.seats && order.seats > 0
+
+  const hasDeclinedPayment = (payments?.items ?? []).some(
+    (payment) => payment.decline_reason || payment.decline_message,
+  )
 
   const { data: seatsData, isLoading: isLoadingSeats } = useOrganizationSeats(
     hasSeatBasedOrder ? { orderId: order?.id } : undefined,
@@ -419,35 +419,25 @@ const ClientPage: React.FC<ClientPageProps> = ({
               ),
             },
             ...(hasDeclinedPayment
-              ? [
+              ? ([
                   {
                     accessorKey: 'decline_reason',
-                    header: 'Decline Reason',
-                    cell: ({
-                      row: {
-                        original: { decline_message, decline_reason },
-                      },
-                    }: {
-                      row: Row<schemas['Payment']>
-                    }) => {
-                      const reason = decline_message || decline_reason
+                    header: 'Bank Decline Reason',
+                    cell: ({ row: { original } }) => {
+                      const reason =
+                        original.decline_message || original.decline_reason
                       return reason ? (
-                        <span
-                          className="block max-w-xs truncate text-sm"
-                          title={reason}
-                        >
-                          {reason}
-                        </span>
+                        <Truncated>
+                          <span className="text-sm">{reason}</span>
+                        </Truncated>
                       ) : (
-                        <span className="text-gray-400 dark:text-polar-500">
-                          —
-                        </span>
+                        '—'
                       )
                     },
                   },
-                ]
+                ] satisfies DataTableColumnDef<schemas['Payment']>[])
               : []),
-          ] satisfies DataTableColumnDef<schemas['Payment']>[]}
+          ]}
           data={payments?.items ?? []}
         />
       </div>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/[id]/CheckoutsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/[id]/CheckoutsPage.tsx
@@ -8,7 +8,7 @@ import { ProductListItem } from '@/components/Products/ProductListItem'
 import { useCustomer } from '@/hooks/queries/customers'
 import { usePayments } from '@/hooks/queries/payments'
 import { schemas } from '@polar-sh/client'
-import { DataTable } from '@polar-sh/orbit'
+import { DataTable, Truncated, type DataTableColumnDef } from '@polar-sh/orbit'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import { List } from '@polar-sh/orbit'
 import React from 'react'
@@ -24,6 +24,10 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization, checkout }) => {
   const { data: payments, isLoading: paymentsLoading } = usePayments(
     organization.id,
     { checkout_id: checkout.id },
+  )
+
+  const hasDeclinedPayment = (payments?.items ?? []).some(
+    (payment) => payment.decline_reason || payment.decline_message,
   )
 
   return (
@@ -100,6 +104,25 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization, checkout }) => {
                 <PaymentStatus payment={original} />
               ),
             },
+            ...(hasDeclinedPayment
+              ? ([
+                  {
+                    accessorKey: 'decline_reason',
+                    header: 'Bank Decline Reason',
+                    cell: ({ row: { original } }) => {
+                      const reason =
+                        original.decline_message || original.decline_reason
+                      return reason ? (
+                        <Truncated>
+                          <span className="text-sm">{reason}</span>
+                        </Truncated>
+                      ) : (
+                        '—'
+                      )
+                    },
+                  },
+                ] satisfies DataTableColumnDef<schemas['Payment']>[])
+              : []),
           ]}
           data={payments?.items ?? []}
         />

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/[id]/CheckoutsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/[id]/CheckoutsPage.tsx
@@ -27,7 +27,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization, checkout }) => {
   )
 
   const hasDeclinedPayment = (payments?.items ?? []).some(
-    (payment) => payment.decline_reason || payment.decline_message,
+    (payment) => payment.status === 'failed',
   )
 
   return (

--- a/clients/apps/web/src/components/PaymentStatus/PaymentStatus.tsx
+++ b/clients/apps/web/src/components/PaymentStatus/PaymentStatus.tsx
@@ -4,28 +4,12 @@ import {
 } from '@/utils/payment'
 import { schemas } from '@polar-sh/client'
 import { Status } from '@polar-sh/orbit'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@polar-sh/orbit'
 
 const PaymentStatus = ({
-  payment: { status, decline_message },
+  payment: { status },
 }: {
   payment: schemas['Payment']
 }) => {
-  if (status === 'failed') {
-    return (
-      <Tooltip>
-        <TooltipTrigger className="cursor-help">
-          <Status
-            color={PaymentStatusDisplayColor[status]}
-            status={PaymentStatusDisplayTitle[status]}
-          />
-        </TooltipTrigger>
-        <TooltipContent side="right" className="max-w-64">
-          <p className="text-justify text-sm">{decline_message}</p>
-        </TooltipContent>
-      </Tooltip>
-    )
-  }
   return (
     <Status
       color={PaymentStatusDisplayColor[status]}


### PR DESCRIPTION
**Related Issue**: https://github.com/polarsource/feedback/issues/139

<!-- Brief description of what this PR does -->

Users found it hard to find the actual decline reason given from the bank. It was hidden in a tooltip on the status column of the failed attempt.

This fix shows bank decline reasons in a dedicated column on the order detail payment attempts table (only when a payment has been declined), instead of hiding them behind a tooltip on the status badge. If long Bank decline reason, the decline cell hover will show the rest of the reason.

| Before | After |
|---|---|
| <img width="1400" height="371" alt="Screenshot 2026-06-25 at 08 58 02" src="https://github.com/user-attachments/assets/5628d617-3550-4e21-ac3c-c2a70db861d0" /> | <img width="1432" height="538" alt="Screenshot 2026-06-25 at 08 57 16" src="https://github.com/user-attachments/assets/da3361ba-c5f3-43ce-952c-0a5bc3aa6173" /> |

<!-- Describe the approach you took -->

## Checklist

- [X] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [X] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [X] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [X] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

