### PR TITLE
aws: Set up roles and permission boundaries

### DIFF
--- a/terraform/modules/aws_task_worker/main.tf
+++ b/terraform/modules/aws_task_worker/main.tf
@@ -35,9 +35,10 @@ data "aws_iam_policy_document" "lambda_assume" {
 }
 
 resource "aws_iam_role" "lambda" {
-  name               = local.function_name
-  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
-  tags               = var.tags
+  name                 = local.function_name
+  assume_role_policy   = data.aws_iam_policy_document.lambda_assume.json
+  permissions_boundary = var.permissions_boundary_arn
+  tags                 = var.tags
 }
 
 data "aws_iam_policy_document" "lambda" {

--- a/terraform/modules/aws_task_worker/variables.tf
+++ b/terraform/modules/aws_task_worker/variables.tf
@@ -105,3 +105,9 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "permissions_boundary_arn" {
+  description = "Optional permissions boundary ARN to attach to the Lambda IAM role."
+  type        = string
+  default     = null
+}

--- a/terraform/modules/github_oidc/main.tf
+++ b/terraform/modules/github_oidc/main.tf
@@ -36,6 +36,12 @@ variable "policy_arns" {
   default     = {}
 }
 
+variable "permissions_boundary_arn" {
+  description = "Optional permissions boundary ARN to attach to the role."
+  type        = string
+  default     = null
+}
+
 resource "aws_iam_openid_connect_provider" "github" {
   url             = "https://token.actions.githubusercontent.com"
   client_id_list  = ["sts.amazonaws.com"]
@@ -43,7 +49,8 @@ resource "aws_iam_openid_connect_provider" "github" {
 }
 
 resource "aws_iam_role" "github_actions" {
-  name = var.role_name
+  name                 = var.role_name
+  permissions_boundary = var.permissions_boundary_arn
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/terraform/modules/lambda_edge_resizer/main.tf
+++ b/terraform/modules/lambda_edge_resizer/main.tf
@@ -20,8 +20,9 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role" "this" {
-  name               = var.function_name
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  name                 = var.function_name
+  assume_role_policy   = data.aws_iam_policy_document.assume_role.json
+  permissions_boundary = var.permissions_boundary_arn
 }
 
 data "aws_iam_policy_document" "this" {

--- a/terraform/modules/lambda_edge_resizer/variables.tf
+++ b/terraform/modules/lambda_edge_resizer/variables.tf
@@ -34,3 +34,9 @@ variable "timeout" {
   type        = number
   default     = 30
 }
+
+variable "permissions_boundary_arn" {
+  description = "Optional permissions boundary ARN to attach to the Lambda IAM role."
+  type        = string
+  default     = null
+}

--- a/terraform/modules/permission_boundary/main.tf
+++ b/terraform/modules/permission_boundary/main.tf
@@ -1,0 +1,135 @@
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+variable "policy_name" {
+  description = "Name of the permission boundary managed policy."
+  type        = string
+  default     = "PolarPermissionBoundary"
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+locals {
+  boundary_arn = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:policy/${var.policy_name}"
+}
+
+data "aws_iam_policy_document" "boundary" {
+  statement {
+    sid       = "AllowAllByDefault"
+    effect    = "Allow"
+    actions   = ["*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "DenyCreatingPrincipalsWithoutBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:CreateRole",
+      "iam:CreateUser",
+      "iam:PutRolePermissionsBoundary",
+      "iam:PutUserPermissionsBoundary",
+    ]
+    resources = ["*"]
+
+    condition {
+      test     = "ArnNotEquals"
+      variable = "iam:PermissionsBoundary"
+      values   = [local.boundary_arn]
+    }
+  }
+
+  statement {
+    sid    = "DenyManagingRolesWithoutBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:AttachRolePolicy",
+      "iam:DeleteRolePolicy",
+      "iam:DetachRolePolicy",
+      "iam:PassRole",
+      "iam:PutRolePolicy",
+      "iam:UpdateAssumeRolePolicy",
+    ]
+    resources = ["arn:${data.aws_partition.current.partition}:iam::*:role/*"]
+
+    condition {
+      test     = "ArnNotEquals"
+      variable = "iam:PermissionsBoundary"
+      values   = [local.boundary_arn]
+    }
+  }
+
+  statement {
+    sid           = "DenyAssumingNonPolarRoles"
+    effect        = "Deny"
+    actions       = ["sts:AssumeRole"]
+    not_resources = ["arn:${data.aws_partition.current.partition}:iam::*:role/polar-*"]
+  }
+
+  statement {
+    sid    = "DenyRemovingPermissionBoundary"
+    effect = "Deny"
+    actions = [
+      "iam:DeleteRolePermissionsBoundary",
+      "iam:DeleteUserPermissionsBoundary",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "DenyBoundaryPolicyMutation"
+    effect = "Deny"
+    actions = [
+      "iam:CreatePolicyVersion",
+      "iam:DeletePolicy",
+      "iam:DeletePolicyVersion",
+      "iam:SetDefaultPolicyVersion",
+    ]
+    resources = [local.boundary_arn]
+  }
+
+  statement {
+    sid       = "DenyOrganizationTampering"
+    effect    = "Deny"
+    actions   = ["organizations:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "DenyDisablingSecurityServices"
+    effect = "Deny"
+    actions = [
+      "cloudtrail:DeleteTrail",
+      "cloudtrail:StopLogging",
+      "cloudtrail:UpdateTrail",
+      "config:DeleteConfigurationRecorder",
+      "config:DeleteDeliveryChannel",
+      "config:StopConfigurationRecorder",
+      "guardduty:DeleteDetector",
+      "guardduty:DisassociateFromAdministratorAccount",
+      "guardduty:DisassociateFromMasterAccount",
+      "guardduty:StopMonitoringMembers",
+      "securityhub:DeleteInvitations",
+      "securityhub:DisableImportFindingsForProduct",
+      "securityhub:DisableOrganizationAdminAccount",
+      "securityhub:DisableSecurityHub",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "boundary" {
+  name        = var.policy_name
+  description = "Permission boundary for internal roles and users. Caps effective privileges and blocks privilege escalation via role creation."
+  policy      = data.aws_iam_policy_document.boundary.json
+}

--- a/terraform/modules/permission_boundary/main.tf
+++ b/terraform/modules/permission_boundary/main.tf
@@ -56,7 +56,6 @@ data "aws_iam_policy_document" "boundary" {
       "iam:AttachRolePolicy",
       "iam:DeleteRolePolicy",
       "iam:DetachRolePolicy",
-      "iam:PassRole",
       "iam:PutRolePolicy",
       "iam:UpdateAssumeRolePolicy",
     ]
@@ -70,9 +69,12 @@ data "aws_iam_policy_document" "boundary" {
   }
 
   statement {
-    sid           = "DenyAssumingNonPolarRoles"
-    effect        = "Deny"
-    actions       = ["sts:AssumeRole"]
+    sid    = "DenyAssumingOrPassingNonPolarRoles"
+    effect = "Deny"
+    actions = [
+      "sts:AssumeRole",
+      "iam:PassRole",
+    ]
     not_resources = ["arn:${data.aws_partition.current.partition}:iam::*:role/polar-*"]
   }
 

--- a/terraform/modules/permission_boundary/outputs.tf
+++ b/terraform/modules/permission_boundary/outputs.tf
@@ -1,0 +1,7 @@
+output "policy_arn" {
+  value = aws_iam_policy.boundary.arn
+}
+
+output "policy_name" {
+  value = aws_iam_policy.boundary.name
+}

--- a/terraform/modules/terraform_cloud_run_role/main.tf
+++ b/terraform/modules/terraform_cloud_run_role/main.tf
@@ -47,6 +47,12 @@ variable "policy_arns" {
   type        = map(string)
 }
 
+variable "permissions_boundary_arn" {
+  description = "Optional permissions boundary ARN to attach to the role."
+  type        = string
+  default     = null
+}
+
 resource "aws_iam_openid_connect_provider" "terraform_cloud" {
   url            = "https://${var.terraform_cloud_hostname}"
   client_id_list = [var.audience]
@@ -80,8 +86,9 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role" "terraform_cloud" {
-  name               = var.role_name
-  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+  name                 = var.role_name
+  assume_role_policy   = data.aws_iam_policy_document.assume_role.json
+  permissions_boundary = var.permissions_boundary_arn
 }
 
 resource "aws_iam_role_policy_attachment" "policies" {

--- a/terraform/organization/README.md
+++ b/terraform/organization/README.md
@@ -52,3 +52,32 @@ test account       -> test workspace
 
 The HCP Terraform workspace variables that point each workspace at its AWS role are managed from
 `terraform/global`.
+
+## Staff access (IAM Identity Center)
+
+`identity_center.tf` defines three access tiers, each with a per-account permission set named
+`Polar<Tier><Account>` (e.g. `PolarReadOnlySandbox`). Sets are assigned to Google Workspace groups
+across all accounts:
+
+| Group                                            | Permission set              | Access                                              |
+| ------------------------------------------------ | --------------------------- | --------------------------------------------------- |
+| `awsadmins@polar.sh`                             | `PolarAdmin<Account>`       | Unrestricted administrator                          |
+| `awsengineers@polar.sh`, `engineering@polar.sh`  | `PolarEngineering<Account>` | Administrator, bounded by `PolarPermissionBoundary` |
+| `awsaccess@polar.sh`                             | `PolarReadOnly<Account>`    | Read-only                                           |
+
+Group membership is not managed here; manage it in the Identity Center console or via SCIM from
+Google Workspace.
+
+## Permission boundary
+
+`PolarPermissionBoundary` (the `permission_boundary` module) is deployed to every account and caps
+the privileges of internal roles and users. It is enforced in three ways:
+
+- The `PolarEngineering*` permission sets attach it to engineer sessions.
+- Role-creating modules take a `permissions_boundary_arn` so application and CI roles carry it; the
+  `terraform-cloud` automation roles are exempt.
+- The `RequirePermissionsBoundary` SCP on the `Workloads` OU requires the boundary on new
+  roles/users and protects it from removal.
+
+The `organization` workspace creates the boundary in every account, so it must apply before the
+`sandbox`/`test` workspaces that reference it.

--- a/terraform/organization/README.md
+++ b/terraform/organization/README.md
@@ -62,7 +62,7 @@ across all accounts:
 | Group                                            | Permission set              | Access                                              |
 | ------------------------------------------------ | --------------------------- | --------------------------------------------------- |
 | `awsadmins@polar.sh`                             | `PolarAdmin<Account>`       | Unrestricted administrator                          |
-| `awsengineers@polar.sh`, `engineering@polar.sh`  | `PolarEngineering<Account>` | Administrator, bounded by `PolarPermissionBoundary` |
+| `awsengineers@polar.sh`, `engineering@polar.sh`  | `PolarEngineering<Account>` | Power-user (no IAM/Organizations), bounded by `PolarPermissionBoundary` |
 | `awsaccess@polar.sh`                             | `PolarReadOnly<Account>`    | Read-only                                           |
 
 Group membership is not managed here; manage it in the Identity Center console or via SCIM from

--- a/terraform/organization/identity_center.tf
+++ b/terraform/organization/identity_center.tf
@@ -26,8 +26,8 @@ locals {
     }
     engineering = {
       base_name          = "PolarEngineering"
-      description        = "Administrator access confined by the Polar permission boundary."
-      managed_policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+      description        = "Power-user access (no IAM/Organizations management) confined by the Polar permission boundary."
+      managed_policy_arn = "arn:aws:iam::aws:policy/PowerUserAccess"
       boundary           = true
       groups             = ["awsengineers", "engineering"]
     }

--- a/terraform/organization/identity_center.tf
+++ b/terraform/organization/identity_center.tf
@@ -1,0 +1,137 @@
+locals {
+  sso_instance_arn      = local.production_legacy_sso_instance_arn
+  sso_identity_store_id = local.production_legacy_sso_identity_store_id
+
+  staff_target_accounts = {
+    management = local.management_account.id
+    production = local.workload_accounts.production.id
+    sandbox    = local.workload_accounts.sandbox.id
+    test       = local.workload_accounts.test.id
+  }
+
+  identity_center_groups = {
+    awsadmins    = { display_name = "awsadmins@polar.sh" }
+    awsengineers = { display_name = "awsengineers@polar.sh" }
+    engineering  = { display_name = "engineering@polar.sh" }
+    awsaccess    = { display_name = "awsaccess@polar.sh" }
+  }
+
+  access_tiers = {
+    admin = {
+      base_name          = "PolarAdmin"
+      description        = "Unrestricted administrator access."
+      managed_policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+      boundary           = false
+      groups             = ["awsadmins"]
+    }
+    engineering = {
+      base_name          = "PolarEngineering"
+      description        = "Administrator access confined by the Polar permission boundary."
+      managed_policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+      boundary           = true
+      groups             = ["awsengineers", "engineering"]
+    }
+    read_only = {
+      base_name          = "PolarReadOnly"
+      description        = "Read-only access across the account."
+      managed_policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+      boundary           = false
+      groups             = ["awsaccess"]
+    }
+  }
+
+  account_permission_sets = merge([
+    for tier_key, tier in local.access_tiers : {
+      for account_key, account_id in local.staff_target_accounts :
+      "${tier_key}-${account_key}" => {
+        name               = "${tier.base_name}${title(account_key)}"
+        description        = tier.description
+        managed_policy_arn = tier.managed_policy_arn
+        boundary           = tier.boundary
+        groups             = tier.groups
+        account_id         = account_id
+      }
+    }
+  ]...)
+
+  boundary_permission_sets = {
+    for key, permission_set in local.account_permission_sets :
+    key => permission_set if permission_set.boundary
+  }
+
+  account_permission_set_assignments = merge([
+    for key, permission_set in local.account_permission_sets : {
+      for group in permission_set.groups :
+      "${key}-${group}" => {
+        permission_set = key
+        account_id     = permission_set.account_id
+        group          = group
+      }
+    }
+  ]...)
+}
+
+resource "aws_identitystore_group" "staff" {
+  for_each = local.identity_center_groups
+
+  identity_store_id = local.sso_identity_store_id
+  display_name      = each.value.display_name
+}
+
+resource "aws_ssoadmin_permission_set" "account" {
+  for_each = local.account_permission_sets
+
+  name             = each.value.name
+  description      = each.value.description
+  instance_arn     = local.sso_instance_arn
+  session_duration = "PT8H"
+}
+
+resource "aws_ssoadmin_managed_policy_attachment" "account" {
+  for_each = local.account_permission_sets
+
+  instance_arn       = local.sso_instance_arn
+  managed_policy_arn = each.value.managed_policy_arn
+  permission_set_arn = aws_ssoadmin_permission_set.account[each.key].arn
+}
+
+resource "aws_ssoadmin_permissions_boundary_attachment" "account" {
+  for_each = local.boundary_permission_sets
+
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.account[each.key].arn
+
+  permissions_boundary {
+    customer_managed_policy_reference {
+      name = module.permission_boundary_management.policy_name
+      path = "/"
+    }
+  }
+
+  depends_on = [
+    module.permission_boundary_management,
+    module.permission_boundary_production,
+    module.permission_boundary_sandbox,
+    module.permission_boundary_test,
+  ]
+}
+
+resource "aws_ssoadmin_account_assignment" "account" {
+  for_each = local.account_permission_set_assignments
+
+  instance_arn       = local.sso_instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.account[each.value.permission_set].arn
+  principal_id       = aws_identitystore_group.staff[each.value.group].group_id
+  principal_type     = "GROUP"
+  target_id          = each.value.account_id
+  target_type        = "AWS_ACCOUNT"
+
+  depends_on = [
+    aws_ssoadmin_managed_policy_attachment.account,
+    aws_ssoadmin_permissions_boundary_attachment.account,
+    module.permission_boundary_management,
+    module.permission_boundary_production,
+    module.permission_boundary_sandbox,
+    module.permission_boundary_test,
+  ]
+}

--- a/terraform/organization/permission_boundary.tf
+++ b/terraform/organization/permission_boundary.tf
@@ -1,0 +1,27 @@
+module "permission_boundary_management" {
+  source = "../modules/permission_boundary"
+  providers = {
+    aws = aws
+  }
+}
+
+module "permission_boundary_production" {
+  source = "../modules/permission_boundary"
+  providers = {
+    aws = aws.production
+  }
+}
+
+module "permission_boundary_sandbox" {
+  source = "../modules/permission_boundary"
+  providers = {
+    aws = aws.sandbox
+  }
+}
+
+module "permission_boundary_test" {
+  source = "../modules/permission_boundary"
+  providers = {
+    aws = aws.test
+  }
+}

--- a/terraform/organization/production.tf
+++ b/terraform/organization/production.tf
@@ -196,11 +196,12 @@ module "production_image_resizer" {
     aws = aws
   }
 
-  function_name     = "polar-image-resizer"
-  s3_bucket         = aws_s3_bucket.production_lambda_artifacts.id
-  s3_key            = data.aws_s3_object.production_image_resizer_package.key
-  s3_object_version = data.aws_s3_object.production_image_resizer_package.version_id
-  source_bucket_arn = module.production_s3_buckets.public_files_bucket_arn
+  function_name            = "polar-image-resizer"
+  s3_bucket                = aws_s3_bucket.production_lambda_artifacts.id
+  s3_key                   = data.aws_s3_object.production_image_resizer_package.key
+  s3_object_version        = data.aws_s3_object.production_image_resizer_package.version_id
+  source_bucket_arn        = module.production_s3_buckets.public_files_bucket_arn
+  permissions_boundary_arn = module.permission_boundary_management.policy_arn
 }
 
 module "production_cloudfront_public_assets" {
@@ -328,6 +329,7 @@ module "production_github_oidc_backup" {
     lambda_artifacts = aws_iam_policy.production_lambda_artifacts_upload.arn
     e2e_reports      = aws_iam_policy.production_e2e_reports_upload.arn
   }
+  permissions_boundary_arn = module.permission_boundary_management.policy_arn
 }
 
 module "production_application_access" {

--- a/terraform/organization/sandbox.tf
+++ b/terraform/organization/sandbox.tf
@@ -37,11 +37,12 @@ module "sandbox_image_resizer" {
     aws = aws
   }
 
-  function_name     = "polar-sandbox-image-resizer"
-  s3_bucket         = aws_s3_bucket.production_lambda_artifacts.id
-  s3_key            = data.aws_s3_object.sandbox_image_resizer_package.key
-  s3_object_version = data.aws_s3_object.sandbox_image_resizer_package.version_id
-  source_bucket_arn = module.sandbox_s3_buckets.public_files_bucket_arn
+  function_name            = "polar-sandbox-image-resizer"
+  s3_bucket                = aws_s3_bucket.production_lambda_artifacts.id
+  s3_key                   = data.aws_s3_object.sandbox_image_resizer_package.key
+  s3_object_version        = data.aws_s3_object.sandbox_image_resizer_package.version_id
+  source_bucket_arn        = module.sandbox_s3_buckets.public_files_bucket_arn
+  permissions_boundary_arn = module.permission_boundary_management.policy_arn
 }
 
 module "sandbox_cloudfront_assets" {

--- a/terraform/organization/service_control_policies.tf
+++ b/terraform/organization/service_control_policies.tf
@@ -1,4 +1,12 @@
 locals {
+  permission_boundary_policy_name = "PolarPermissionBoundary"
+
+  permission_boundary_exempt_principals = [
+    "arn:aws:iam::*:role/${var.member_account_bootstrap_role_name}",
+    "arn:aws:iam::*:role/${local.terraform_cloud.role_name}",
+    "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*AWSReservedSSO_PolarAdmin*",
+  ]
+
   service_control_policies = {
     workloads_baseline = {
       name        = "WorkloadsBaseline"
@@ -109,6 +117,71 @@ locals {
               "savingsplans:CreateSavingsPlan",
             ]
             Resource = "*"
+          },
+        ]
+      }
+    }
+
+    require_permissions_boundary = {
+      name        = "RequirePermissionsBoundary"
+      description = "Require the Polar permission boundary on IAM roles and users created in workload accounts, and protect it from removal."
+      target_ids  = [aws_organizations_organizational_unit.workloads.id]
+      content = {
+        Version = "2012-10-17"
+        Statement = [
+          {
+            Sid         = "RequireBoundaryOnRoleCreation"
+            Effect      = "Deny"
+            Action      = "iam:CreateRole"
+            NotResource = ["arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*"]
+            Condition = {
+              ArnNotLike = {
+                "iam:PermissionsBoundary" = "arn:aws:iam::*:policy/${local.permission_boundary_policy_name}"
+                "aws:PrincipalArn"        = local.permission_boundary_exempt_principals
+              }
+            }
+          },
+          {
+            Sid      = "RequireBoundaryOnUserCreation"
+            Effect   = "Deny"
+            Action   = "iam:CreateUser"
+            Resource = "*"
+            Condition = {
+              ArnNotLike = {
+                "iam:PermissionsBoundary" = "arn:aws:iam::*:policy/${local.permission_boundary_policy_name}"
+                "aws:PrincipalArn"        = local.permission_boundary_exempt_principals
+              }
+            }
+          },
+          {
+            Sid    = "DenyRemovingPermissionBoundary"
+            Effect = "Deny"
+            Action = [
+              "iam:DeleteRolePermissionsBoundary",
+              "iam:DeleteUserPermissionsBoundary",
+            ]
+            Resource = "*"
+            Condition = {
+              ArnNotLike = {
+                "aws:PrincipalArn" = local.permission_boundary_exempt_principals
+              }
+            }
+          },
+          {
+            Sid    = "ProtectBoundaryPolicy"
+            Effect = "Deny"
+            Action = [
+              "iam:CreatePolicyVersion",
+              "iam:DeletePolicy",
+              "iam:DeletePolicyVersion",
+              "iam:SetDefaultPolicyVersion",
+            ]
+            Resource = "arn:aws:iam::*:policy/${local.permission_boundary_policy_name}"
+            Condition = {
+              ArnNotLike = {
+                "aws:PrincipalArn" = local.permission_boundary_exempt_principals
+              }
+            }
           },
         ]
       }

--- a/terraform/organization/service_control_policies.tf
+++ b/terraform/organization/service_control_policies.tf
@@ -5,6 +5,7 @@ locals {
     "arn:aws:iam::*:role/${var.member_account_bootstrap_role_name}",
     "arn:aws:iam::*:role/${local.terraform_cloud.role_name}",
     "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*AWSReservedSSO_PolarAdmin*",
+    "arn:aws:iam::*:role/aws-service-role/sso.amazonaws.com/AWSServiceRoleForSSO",
   ]
 
   service_control_policies = {
@@ -130,10 +131,10 @@ locals {
         Version = "2012-10-17"
         Statement = [
           {
-            Sid         = "RequireBoundaryOnRoleCreation"
-            Effect      = "Deny"
-            Action      = "iam:CreateRole"
-            NotResource = ["arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*"]
+            Sid      = "RequireBoundaryOnRoleCreation"
+            Effect   = "Deny"
+            Action   = "iam:CreateRole"
+            Resource = "*"
             Condition = {
               ArnNotLike = {
                 "iam:PermissionsBoundary" = "arn:aws:iam::*:policy/${local.permission_boundary_policy_name}"

--- a/terraform/organization/service_control_policies.tf
+++ b/terraform/organization/service_control_policies.tf
@@ -5,8 +5,12 @@ locals {
     "arn:aws:iam::*:role/${var.member_account_bootstrap_role_name}",
     "arn:aws:iam::*:role/${local.terraform_cloud.role_name}",
     "arn:aws:iam::*:role/aws-reserved/sso.amazonaws.com/*AWSReservedSSO_PolarAdmin*",
-    "arn:aws:iam::*:role/aws-service-role/sso.amazonaws.com/AWSServiceRoleForSSO",
   ]
+
+  permission_boundary_role_creation_exempt_principals = concat(
+    local.permission_boundary_exempt_principals,
+    ["arn:aws:iam::*:role/aws-service-role/sso.amazonaws.com/AWSServiceRoleForSSO"],
+  )
 
   service_control_policies = {
     workloads_baseline = {
@@ -138,7 +142,7 @@ locals {
             Condition = {
               ArnNotLike = {
                 "iam:PermissionsBoundary" = "arn:aws:iam::*:policy/${local.permission_boundary_policy_name}"
-                "aws:PrincipalArn"        = local.permission_boundary_exempt_principals
+                "aws:PrincipalArn"        = local.permission_boundary_role_creation_exempt_principals
               }
             }
           },

--- a/terraform/organization/service_control_policies.tf
+++ b/terraform/organization/service_control_policies.tf
@@ -157,7 +157,9 @@ locals {
             Sid    = "DenyRemovingPermissionBoundary"
             Effect = "Deny"
             Action = [
+              "iam:PutRolePermissionsBoundary",
               "iam:DeleteRolePermissionsBoundary",
+              "iam:PutUserPermissionsBoundary",
               "iam:DeleteUserPermissionsBoundary",
             ]
             Resource = "*"

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -1,3 +1,7 @@
+data "aws_iam_policy" "permission_boundary" {
+  name = "PolarPermissionBoundary"
+}
+
 module "lambda_worker_ecr" {
   source = "../modules/ecr_repository"
 
@@ -23,14 +27,15 @@ resource "aws_vpc_security_group_ingress_rule" "redis_lambda" {
 module "dummy_lambda_worker" {
   source = "../modules/aws_task_worker"
 
-  environment          = "sandbox"
-  name                 = "dummy"
-  queue_name           = "polar-sandbox-tasks-dummy"
-  image_uri            = "${module.lambda_worker_ecr.repository_url}:latest"
-  enabled              = true
-  reserved_concurrency = null
-  subnet_ids           = local.lambda_subnet_ids
-  security_group_ids   = local.lambda_security_group_ids
+  environment              = "sandbox"
+  name                     = "dummy"
+  queue_name               = "polar-sandbox-tasks-dummy"
+  image_uri                = "${module.lambda_worker_ecr.repository_url}:latest"
+  enabled                  = true
+  reserved_concurrency     = null
+  subnet_ids               = local.lambda_subnet_ids
+  security_group_ids       = local.lambda_security_group_ids
+  permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
 
   environment_variables = {
     POLAR_ENV                     = "sandbox"
@@ -142,4 +147,5 @@ module "github_oidc_lambda_worker" {
   policy_arns = {
     deploy = aws_iam_policy.lambda_worker_deploy.arn
   }
+  permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
 }


### PR DESCRIPTION
This maps groups to roles to permissions, and sets up a structure of access for: 

- Admin
- Engineering
- Read only

We also introduce a permission boundary to prevent privilege escalation via role creation


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

