### PR TITLE
move edit member action to button

### DIFF
--- a/clients/apps/web/src/components/Customer/MembersSection.tsx
+++ b/clients/apps/web/src/components/Customer/MembersSection.tsx
@@ -201,6 +201,16 @@ export const MembersSection = ({
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
+                    {customer.type === 'team' && (
+                      <DropdownMenuItem
+                        onClick={() => {
+                          setSelectedMember(original)
+                          showEditMemberModal()
+                        }}
+                      >
+                        Edit member
+                      </DropdownMenuItem>
+                    )}
                     <DropdownMenuItem
                       onClick={() => copyMemberLoginLink(original.email)}
                     >
@@ -214,13 +224,6 @@ export const MembersSection = ({
         ]}
         isLoading={isLoading}
         className="text-sm"
-        onRowClick={({ original }) => {
-          if (customer.type !== 'team') {
-            return
-          }
-          setSelectedMember(original)
-          showEditMemberModal()
-        }}
       />
       <InlineModal
         isShown={isEditMemberModalShown}

--- a/clients/apps/web/src/components/Customer/MembersSection.tsx
+++ b/clients/apps/web/src/components/Customer/MembersSection.tsx
@@ -201,16 +201,14 @@ export const MembersSection = ({
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
-                    {customer.type === 'team' && (
-                      <DropdownMenuItem
-                        onClick={() => {
-                          setSelectedMember(original)
-                          showEditMemberModal()
-                        }}
-                      >
-                        Edit member
-                      </DropdownMenuItem>
-                    )}
+                    <DropdownMenuItem
+                      onClick={() => {
+                        setSelectedMember(original)
+                        showEditMemberModal()
+                      }}
+                    >
+                      Edit member
+                    </DropdownMenuItem>
                     <DropdownMenuItem
                       onClick={() => copyMemberLoginLink(original.email)}
                     >


### PR DESCRIPTION
The edit member button makes more sense being positioned on the context menu button rather when clicking the row.
| Example |
|---|
| <img width="778" height="295" alt="Screenshot 2026-06-25 at 09 44 18" src="https://github.com/user-attachments/assets/68d6cdb9-1052-4302-b9f5-56e4b1299fcb" /> |

- [X] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [X] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [X] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [X] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

