### PR TITLE
Allow skipping AUP validation post-deny

### DIFF
--- a/clients/apps/web/src/components/Finance/Account/sections/ProductDescriptionSection.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/ProductDescriptionSection.tsx
@@ -165,9 +165,9 @@ export const ProductDescriptionSection = ({ organization }: Props) => {
   const counterColor = getCounterColor()
 
   const showContinueAnyway =
-    aup.verdict === 'CLARIFY' &&
-    aup.history.length >= 3 &&
-    productDescription.trim().length > 30 &&
+    aup.verdict &&
+    aup.history.length >= 2 &&
+    productDescription.trim().length >= MIN_LENGTH &&
     !aup.isValidating
 
   const submitDisabled =
@@ -191,7 +191,7 @@ export const ProductDescriptionSection = ({ organization }: Props) => {
                   loading={submitting === 'submitting-anyway'}
                   disabled={submitting === 'submitting'}
                 >
-                  Continue without review
+                  Continue anyway. This may trigger a manual review.
                 </Button>
               )}
               <Button

--- a/clients/apps/web/src/components/Onboarding/OnboardingShell.tsx
+++ b/clients/apps/web/src/components/Onboarding/OnboardingShell.tsx
@@ -53,12 +53,22 @@ export function OnboardingShell({
         gap="l"
         color="text-tertiary"
       >
+        {hadOrgs && (
+          <Link
+            href="/dashboard"
+            className="dark:hover:text-polar-200 text-sm hover:text-gray-900"
+          >
+            Back to dashboard
+          </Link>
+        )}
+
         <Link
           href="/dashboard/account/preferences"
           className="dark:hover:text-polar-200 text-sm hover:text-gray-900"
         >
           User settings
         </Link>
+
         <a
           href={`${CONFIG.BASE_URL}/v1/auth/logout`}
           className="dark:hover:text-polar-200 text-sm hover:text-gray-900"
@@ -130,14 +140,6 @@ export function OnboardingShell({
                 )}
               </Box>
               {children}
-              {hadOrgs && (
-                <Link
-                  href="/dashboard"
-                  className="dark:text-polar-400 dark:hover:text-polar-200 text-center text-sm text-gray-500 hover:text-gray-900"
-                >
-                  Back to dashboard
-                </Link>
-              )}
             </Box>
           </motion.div>
         </Box>

--- a/clients/apps/web/src/components/Onboarding/ProductDetailsStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/ProductDetailsStep.tsx
@@ -2,10 +2,10 @@
 
 import { useAuth } from '@/hooks'
 import { useCreateOrganization } from '@/hooks/queries'
-import { useAupValidation } from '@/hooks/useAupValidation'
+import { AupVerdict, useAupValidation } from '@/hooks/useAupValidation'
 import { schemas } from '@polar-sh/client'
 import { Box } from '@polar-sh/orbit/Box'
-import { Button } from '@polar-sh/orbit'
+import { Button, Text } from '@polar-sh/orbit'
 import { Input } from '@polar-sh/orbit'
 import { TextArea } from '@polar-sh/orbit'
 import {
@@ -107,7 +107,10 @@ export function ProductDetailsStep() {
     [sellingCategories],
   )
 
-  const submitOrg = async (formData: FormSchema) => {
+  const submitOrg = async (
+    formData: FormSchema,
+    verdict: AupVerdict | null,
+  ) => {
     setApiLoading(true)
 
     if (!data.orgName || !data.orgSlug) {
@@ -186,7 +189,10 @@ export function ProductDetailsStep() {
       orgSlug: organization.slug,
     })
 
-    trackStepCompleted('product', { organization_id: organization.id })
+    trackStepCompleted('product', {
+      organization_id: organization.id,
+      ...(verdict && { aup_verdict: verdict }),
+    })
     await showApiResponse(201, 'Created')
     router.push('/onboarding/complete')
     return true
@@ -209,7 +215,7 @@ export function ProductDetailsStep() {
     if (result.verdict === 'DENY' || result.verdict === 'CLARIFY') return
 
     setLoading('submitting')
-    const success = await submitOrg(formData)
+    const success = await submitOrg(formData, result.verdict)
     if (!success) {
       setLoading(null)
     }
@@ -218,7 +224,7 @@ export function ProductDetailsStep() {
   const onContinueAnyway = async () => {
     setLoading('submitting-anyway')
     const formData = form.getValues()
-    const success = await submitOrg(formData)
+    const success = await submitOrg(formData, aup.verdict)
     if (!success) {
       setLoading(null)
     }
@@ -381,27 +387,33 @@ export function ProductDetailsStep() {
                 blockedSelected.length > 0 ||
                 sellingCategories.length === 0 ||
                 pricingModel.length === 0 ||
-                productDescription.trim().length === 0
+                productDescription.trim().length < 30
               }
               fullWidth
             >
               {aup.verdict ? 'Review again' : 'Launch Dashboard'}
             </Button>
 
-            {aup.verdict === 'CLARIFY' &&
-              aup.history.length >= 3 &&
+            {aup.verdict &&
+              aup.history.length >= 2 &&
               productDescription.trim().length > 30 &&
               !aup.isValidating && (
-                <Button
-                  variant="ghost"
-                  type="button"
-                  fullWidth
-                  onClick={onContinueAnyway}
-                  disabled={loading === 'submitting'}
-                  loading={loading === 'submitting-anyway'}
-                >
-                  Continue without review
-                </Button>
+                <>
+                  <Button
+                    variant="ghost"
+                    type="button"
+                    fullWidth
+                    onClick={onContinueAnyway}
+                    disabled={loading === 'submitting'}
+                    loading={loading === 'submitting-anyway'}
+                  >
+                    Continue anyway
+                  </Button>
+                  <Text variant="caption" color="muted" align="center">
+                    You can continue setting up your account, but it will
+                    require manual review before you can accept payments.
+                  </Text>
+                </>
               )}
             {form.formState.errors.root && (
               <p className="text-sm text-red-500 dark:text-red-500">

--- a/clients/apps/web/src/components/Onboarding/ProductDetailsStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/ProductDetailsStep.tsx
@@ -46,6 +46,9 @@ interface FormSchema {
   currentlySellingOn: string[]
 }
 
+const MIN_LENGTH = 30
+const MAX_LENGTH = 3000
+
 export function ProductDetailsStep() {
   const router = useRouter()
   const { setUserOrganizations } = useAuth()
@@ -230,6 +233,14 @@ export function ProductDetailsStep() {
     }
   }
 
+  const charCount = productDescription?.length ?? 0
+
+  const counterColor = useMemo(() => {
+    if (charCount > MAX_LENGTH) return 'danger'
+    if (charCount > 0 && charCount < MIN_LENGTH) return 'warning'
+    return 'muted'
+  }, [charCount])
+
   return (
     <OnboardingShell
       title="Product Details"
@@ -272,7 +283,12 @@ export function ProductDetailsStep() {
                     style={{ fieldSizing: 'content' } as React.CSSProperties}
                   />
                 </FormControl>
-                <FormMessage />
+                <Box alignItems="center" justifyContent="between" columnGap="s">
+                  <FormMessage />
+                  <Text variant="caption" color={counterColor}>
+                    {charCount}/{MAX_LENGTH} (min {MIN_LENGTH})
+                  </Text>
+                </Box>
               </FormItem>
             )}
           />
@@ -387,7 +403,7 @@ export function ProductDetailsStep() {
                 blockedSelected.length > 0 ||
                 sellingCategories.length === 0 ||
                 pricingModel.length === 0 ||
-                productDescription.trim().length < 30
+                productDescription.trim().length < MIN_LENGTH
               }
               fullWidth
             >
@@ -396,7 +412,7 @@ export function ProductDetailsStep() {
 
             {aup.verdict &&
               aup.history.length >= 2 &&
-              productDescription.trim().length > 30 &&
+              productDescription.trim().length >= MIN_LENGTH &&
               !aup.isValidating && (
                 <>
                   <Button

--- a/clients/apps/web/src/components/Onboarding/ProductDetailsStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/ProductDetailsStep.tsx
@@ -410,8 +410,8 @@ export function ProductDetailsStep() {
                     Continue anyway
                   </Button>
                   <Text variant="caption" color="muted" align="center">
-                    You can continue setting up your account, but it will
-                    require manual review before you can accept payments.
+                    You can continue setting up your account, but it may require
+                    manual review before you can accept payments.
                   </Text>
                 </>
               )}


### PR DESCRIPTION
Updated this in both the onboarding flow & the self-review checklist, both acknowledging that this may trigger a manual review process.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

