### PR TITLE
tf/aws: Break circular dependency between lambda and policy

### DIFF
--- a/terraform/modules/aws_task_worker/outputs.tf
+++ b/terraform/modules/aws_task_worker/outputs.tf
@@ -15,7 +15,7 @@ output "dlq_arn" {
 
 output "function_name" {
   description = "Lambda function name (used by CI to update-function-code)."
-  value       = aws_lambda_function.task.function_name
+  value       = local.function_name
 }
 
 output "function_arn" {

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -97,6 +97,8 @@ resource "aws_iam_user_policy" "tasks_producer" {
 # GitHub Actions OIDC role (builds the task-worker image and deploys it)
 # =============================================================================
 
+data "aws_caller_identity" "current" {}
+
 data "aws_iam_policy_document" "lambda_worker_deploy" {
   statement {
     sid       = "EcrAuthorization"
@@ -121,7 +123,7 @@ data "aws_iam_policy_document" "lambda_worker_deploy" {
   statement {
     sid       = "UpdateFunctionCode"
     actions   = ["lambda:UpdateFunctionCode"]
-    resources = [module.dummy_lambda_worker.function_arn]
+    resources = ["arn:aws:lambda:us-east-2:${data.aws_caller_identity.current.account_id}:function:${module.dummy_lambda_worker.function_name}"]
   }
 }
 


### PR DESCRIPTION
Otherwise it's not possible to apply the sandbox state