### PR TITLE
Add dev analytics

### DIFF
--- a/dev/cli/_analytics_send.py
+++ b/dev/cli/_analytics_send.py
@@ -1,0 +1,44 @@
+import json
+import sys
+import urllib.request
+import uuid
+from pathlib import Path
+
+_ID_FILE = Path.home() / ".config" / "polar" / "dev_cli_id"
+
+
+def _distinct_id() -> str:
+    try:
+        existing = _ID_FILE.read_text().strip() if _ID_FILE.exists() else ""
+        if existing:
+            return existing
+        _ID_FILE.parent.mkdir(parents=True, exist_ok=True)
+        new_id = uuid.uuid4().hex
+        _ID_FILE.write_text(new_id + "\n")
+        return new_id
+    except Exception:
+        return uuid.uuid4().hex
+
+
+def main() -> None:
+    data = json.loads(sys.stdin.read())
+    body = json.dumps(
+        {
+            "event": data["event"],
+            "distinct_id": data.get("distinct_id") or _distinct_id(),
+            "properties": data["properties"],
+        }
+    ).encode()
+    request = urllib.request.Request(
+        data["url"],
+        data=body,
+        headers={"Content-Type": "application/json"},
+    )
+    urllib.request.urlopen(request, timeout=5).read()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception:
+        pass

--- a/dev/cli/analytics.py
+++ b/dev/cli/analytics.py
@@ -1,0 +1,122 @@
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ANALYTICS_URL = "https://polar-dev-analytics.vercel.app/api/track"
+EVENT = "dev_cli_command"
+_GROUP_COMMANDS = {"db", "docker"}
+_FLAG_NAME = re.compile(r"^--?[A-Za-z][A-Za-z0-9-]{0,39}$")
+_REDACTED = "<redacted>"
+_TOKENISH = re.compile(r"^[A-Za-z0-9_.\-]+$")
+_SECRET_PREFIX = re.compile(
+    r"^(polar_|sk_|pk_|rk_|whsec_|ghp_|gho_|ghu_|ghs_|ghr_|github_pat_|glpat-|"
+    r"xox[baprs]-|AKIA|ASIA|AIza|ya29\.|eyJ[A-Za-z0-9_-]+\.)"
+)
+
+
+def _looks_like_secret(token: str) -> bool:
+    if _SECRET_PREFIX.match(token):
+        return True
+    if len(token) < 20 or not _TOKENISH.match(token):
+        return False
+    has_digit = any(character.isdigit() for character in token)
+    has_upper = any(character.isupper() for character in token)
+    has_lower = any(character.islower() for character in token)
+    return has_digit or (has_upper and has_lower)
+
+
+def _redact(token: str) -> str:
+    return _REDACTED if _looks_like_secret(token) else token
+
+
+def _disabled() -> bool:
+    return bool(
+        os.environ.get("DEV_CLI_NO_ANALYTICS") or os.environ.get("DO_NOT_TRACK")
+    )
+
+
+def _endpoint() -> str:
+    return (os.environ.get("DEV_CLI_ANALYTICS_URL") or ANALYTICS_URL).strip()
+
+
+def parse_invocation(argv: list[str]) -> tuple[str, list[str], str]:
+    args = argv[1:]
+
+    leading: list[str] = []
+    for arg in args:
+        if arg.startswith("-"):
+            break
+        leading.append(arg)
+        if len(leading) >= 2:
+            break
+
+    if not leading:
+        command = "<no command>"
+    elif len(leading) >= 2 and leading[0] in _GROUP_COMMANDS:
+        command = f"{leading[0]} {_redact(leading[1])}"
+    else:
+        command = _redact(leading[0])
+
+    flag_names = (
+        arg.split("=", 1)[0] for arg in args if arg.startswith("-")
+    )
+    flags = sorted(
+        {_redact(name) for name in flag_names if _FLAG_NAME.match(name)}
+    )
+    invocation = " ".join([command, *flags])
+    return command, flags, invocation
+
+
+def _git_identity() -> tuple[str, str]:
+    def _config(key: str) -> str:
+        try:
+            result = subprocess.run(
+                ["git", "config", "--get", key],
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+            return result.stdout.strip() if result.returncode == 0 else ""
+        except Exception:
+            return ""
+
+    return _config("user.name"), _config("user.email")
+
+
+def track(argv: list[str]) -> None:
+    endpoint = _endpoint()
+    if _disabled() or not endpoint:
+        return
+    command, flags, invocation = parse_invocation(argv)
+    git_name, git_email = _git_identity()
+    payload = json.dumps(
+        {
+            "url": endpoint,
+            "event": EVENT,
+            "distinct_id": git_email or None,
+            "properties": {
+                "command": command,
+                "invocation": invocation,
+                "flags": flags,
+                "os": sys.platform,
+                "git_name": git_name,
+                "git_email": git_email,
+            },
+        }
+    )
+    try:
+        sender = Path(__file__).with_name("_analytics_send.py")
+        proc = subprocess.Popen(
+            [sys.executable, str(sender)],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        proc.stdin.write(payload.encode())
+        proc.stdin.close()
+    except Exception:
+        pass

--- a/dev/cli/cli.py
+++ b/dev/cli/cli.py
@@ -365,4 +365,11 @@ register_commands()
 
 
 if __name__ == "__main__":
+    try:
+        import analytics
+
+        analytics.track(sys.argv)
+    except Exception:
+        pass
+
     app()


### PR DESCRIPTION
## Summary

Add super basic analytics to our `dev` commands, reported to PostHog, so that we can **deprecate unused ones** and **make popular one's better**.

Some features:

* Posts the command to a proxy at https://polar-dev-analytics.vercel.app/api/track to make sure we're not leaking env vars needed for the tracking
* Passes the command to PostHog, e.g `dev up` and any arguments, e.g `dev stripe --listen`
* Attaches the `git` user, so we can make sure the feature is not abused
* If we detect something that resembles a token, e.g `dev polar_pat_` or `dev sk_`, we redact that value

## Screenshot

<img width="1494" height="736" alt="Screenshot 2026-06-25 at 16 07 52" src="https://github.com/user-attachments/assets/c97a6576-55e8-472e-a784-4e3180019878" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

