### PR TITLE
lambda: Move configuration of which tasks goes into sqs to variables

### DIFF
--- a/terraform/global/production.tf
+++ b/terraform/global/production.tf
@@ -571,3 +571,16 @@ resource "tfe_variable" "vercel_next_public_stripe_payment_method_configuration_
   sensitive       = true
   variable_set_id = tfe_variable_set.production.id
 }
+
+resource "tfe_variable" "worker_sqs_actors_production" {
+  key             = "worker_sqs_actors"
+  category        = "terraform"
+  description     = "JSON array of Dramatiq actor names routed to the SQS execution engine for production"
+  sensitive       = false
+  value           = "[\"dummy\"]"
+  variable_set_id = tfe_variable_set.production.id
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}

--- a/terraform/global/sandbox.tf
+++ b/terraform/global/sandbox.tf
@@ -489,3 +489,16 @@ resource "tfe_variable" "vercel_next_public_stripe_payment_method_configuration_
   sensitive       = true
   variable_set_id = tfe_variable_set.sandbox.id
 }
+
+resource "tfe_variable" "worker_sqs_actors_sandbox" {
+  key             = "worker_sqs_actors"
+  category        = "terraform"
+  description     = "JSON array of Dramatiq actor names routed to the SQS execution engine for sandbox"
+  sensitive       = false
+  value           = "[\"dummy\"]"
+  variable_set_id = tfe_variable_set.sandbox.id
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}

--- a/terraform/global/test.tf
+++ b/terraform/global/test.tf
@@ -475,3 +475,16 @@ resource "tfe_variable" "vercel_next_public_stripe_payment_method_configuration_
   sensitive       = true
   variable_set_id = tfe_variable_set.test.id
 }
+
+resource "tfe_variable" "worker_sqs_actors_test" {
+  key             = "worker_sqs_actors"
+  category        = "terraform"
+  description     = "JSON array of Dramatiq actor names routed to the SQS execution engine for test"
+  sensitive       = false
+  value           = "[\"dummy\"]"
+  variable_set_id = tfe_variable_set.test.id
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -236,7 +236,7 @@ module "sandbox" {
 
   worker_sqs_config = {
     enabled               = "true"
-    actors                = jsonencode(["dummy"])
+    actors                = var.worker_sqs_actors
     queue_prefix          = "polar-sandbox-tasks"
     aws_access_key_id     = aws_iam_access_key.tasks_producer.id
     aws_secret_access_key = aws_iam_access_key.tasks_producer.secret

--- a/terraform/sandbox/variables.tf
+++ b/terraform/sandbox/variables.tf
@@ -419,3 +419,9 @@ variable "next_public_stripe_payment_method_configuration" {
   type        = string
   sensitive   = true
 }
+
+variable "worker_sqs_actors" {
+  description = "JSON array of Dramatiq actor names routed to the SQS execution engine"
+  type        = string
+  default     = "[\"dummy\"]"
+}


### PR DESCRIPTION
This will make it easier to test and configure which tasks goes onto SQS and Lambda as opposed to to Dramatiq


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make SQS task routing configurable per environment by moving the list of Dramatiq actors into variables. This simplifies testing and lets us change routing without code changes.

- **New Features**
  - Added `tfe_variable "worker_sqs_actors"` for production, sandbox, and test (JSON array of actor names routed to SQS; `ignore_changes` so values are managed in Terraform Cloud).
  - Introduced `variable "worker_sqs_actors"` in sandbox and updated `render.tf` to use it instead of hardcoded `jsonencode(["dummy"])`.

- **Migration**
  - In Terraform Cloud, set `worker_sqs_actors` for each environment to a JSON array of actor names to route via SQS (e.g., ["actor1","actor2"]).

<sup>Written for commit 84c57522a30ebdd401d7e3db2f3ca928c9289258. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

