### PR TITLE
docs: drop seat-based pricing beta notice, add members intro

### DIFF
--- a/docs/features/seat-based-pricing.mdx
+++ b/docs/features/seat-based-pricing.mdx
@@ -14,11 +14,15 @@ Seat-based pricing allows you to sell products where a billing manager purchases
 - Products with flat, graduated, or volume-discounted seat pricing
 </Info>
 
-## Feature Flag
+## Customers and members
 
-<Warning>
-  Seat-based pricing is currently in beta. Enable it under Settings → General → Features.
-</Warning>
+Seat-based products separate who pays from who uses, modeled through three entities:
+
+- A **Customer** is the billing entity — who pays. They own subscriptions, orders, and payment methods. On their first seat-based purchase, the customer is permanently upgraded to `type: "team"`, which enables members and team management.
+- A **Member** is a person under a customer — who uses. Each member has their own email, role (`owner`, `billing_manager`, or `member`), and receives benefit grants independently. The purchaser becomes an `owner` member. Both `owner` and `billing_manager` roles can manage seats and the subscription.
+- A **CustomerSeat** is the link between a product and a member. It tracks assignment status (`pending`, `claimed`, `revoked`) and holds the invitation token.
+
+Because benefits are granted to members, not to the billing customer, always identify the end user by their member — not the customer who paid.
 
 ## How it works
 

--- a/docs/guides/seat-based-pricing.mdx
+++ b/docs/guides/seat-based-pricing.mdx
@@ -6,10 +6,6 @@ description: "Complete guide to implementing team products with seat-based prici
 
 Seat-based pricing lets you sell products where one person buys seats and assigns them to their team. Each seat holder gets their own benefits — license keys, Discord roles, file downloads, or anything else you offer.
 
-<Warning>
-  Seat-based pricing is currently in beta. Enable it under Settings → General → Features.
-</Warning>
-
 ## Understanding the model
 
 Before writing any code, there are three entities you need to understand. They change how you think about every API call, webhook, and portal flow.


### PR DESCRIPTION
## Summary

Seat-based pricing is no longer in beta, so the docs should stop calling it one. Also surfaces the Customer/Member model on the feature page, where it was previously only in the guide.

## What

- Remove the "currently in beta" warning from the seat-based pricing feature page and from the implementation guide.
- Add a concise "Customers and members" section to the feature page covering the three entities (Customer, Member, CustomerSeat) and the rule that benefits track to members.

## Why

The feature is GA, and the high-level feature page lacked the conceptual model a reader needs before diving into the guide.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

