### PR TITLE
tf/aws: Set up new account to handle identity group syncing

### DIFF
--- a/terraform/global/aws.tf
+++ b/terraform/global/aws.tf
@@ -18,6 +18,10 @@ locals {
       account_id = "805865757777"
       workspace  = "test"
     }
+    identity = {
+      account_id = "986542260309"
+      workspace  = "identity"
+    }
   }
 }
 

--- a/terraform/identity/main.tf
+++ b/terraform/identity/main.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "us-east-1"
+}

--- a/terraform/identity/ssosync.tf
+++ b/terraform/identity/ssosync.tf
@@ -1,0 +1,53 @@
+locals {
+  ssosync_application_id = "arn:aws:serverlessrepo:us-east-2:004480582608:applications/SSOSync"
+
+  staff_group_emails = [
+    "awsadmins@polar.sh",
+    "awsengineers@polar.sh",
+    "engineering@polar.sh",
+    "awsaccess@polar.sh",
+  ]
+}
+
+resource "aws_secretsmanager_secret" "google_credentials" {
+  name = "SSOSyncGoogleCredentials"
+}
+
+resource "aws_secretsmanager_secret_version" "google_credentials" {
+  secret_id     = aws_secretsmanager_secret.google_credentials.id
+  secret_string = var.ssosync_google_credentials
+}
+
+resource "aws_secretsmanager_secret" "scim_access_token" {
+  name = "SSOSyncSCIMAccessToken"
+}
+
+resource "aws_secretsmanager_secret_version" "scim_access_token" {
+  secret_id     = aws_secretsmanager_secret.scim_access_token.id
+  secret_string = var.ssosync_scim_access_token
+}
+
+resource "aws_serverlessapplicationrepository_cloudformation_stack" "ssosync" {
+  name             = "ssosync"
+  application_id   = local.ssosync_application_id
+  semantic_version = var.ssosync_version
+
+  capabilities = [
+    "CAPABILITY_IAM",
+    "CAPABILITY_NAMED_IAM",
+    "CAPABILITY_AUTO_EXPAND",
+  ]
+
+  parameters = {
+    DeployPattern           = "App only"
+    GoogleCredentials       = aws_secretsmanager_secret.google_credentials.arn
+    GoogleAdminEmail        = var.ssosync_google_admin_email
+    SCIMEndpointUrl         = var.ssosync_scim_endpoint
+    SCIMEndpointAccessToken = aws_secretsmanager_secret.scim_access_token.arn
+    SyncMethod              = "groups"
+    IncludeGroups           = join(",", local.staff_group_emails)
+    LogLevel                = "info"
+    LogFormat               = "json"
+    ScheduleExpression      = var.ssosync_schedule_expression
+  }
+}

--- a/terraform/identity/terraform.tf
+++ b/terraform/identity/terraform.tf
@@ -1,0 +1,17 @@
+terraform {
+  cloud {
+    organization = "polar-sh"
+    workspaces {
+      name = "identity"
+    }
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.92"
+    }
+  }
+
+  required_version = ">= 1.2"
+}

--- a/terraform/identity/variables.tf
+++ b/terraform/identity/variables.tf
@@ -1,0 +1,37 @@
+variable "ssosync_google_admin_email" {
+  description = "Google Workspace admin email to impersonate."
+  type        = string
+  nullable    = false
+}
+
+variable "ssosync_google_credentials" {
+  description = "Google service account credentials JSON."
+  type        = string
+  sensitive   = true
+  nullable    = false
+}
+
+variable "ssosync_scim_endpoint" {
+  description = "Identity Center SCIM endpoint URL."
+  type        = string
+  nullable    = false
+}
+
+variable "ssosync_scim_access_token" {
+  description = "Identity Center SCIM access token."
+  type        = string
+  sensitive   = true
+  nullable    = false
+}
+
+variable "ssosync_schedule_expression" {
+  description = "ssosync EventBridge schedule; empty disables it."
+  type        = string
+  default     = ""
+}
+
+variable "ssosync_version" {
+  description = "Pinned ssosync SAR version; null uses the latest."
+  type        = string
+  default     = null
+}

--- a/terraform/organization/README.md
+++ b/terraform/organization/README.md
@@ -7,13 +7,15 @@ This Terraform root manages Polar's AWS Organizations structure.
 ```text
 AWS Organization
 ├── Management account: polar
-└── Workloads
-    ├── Production
-    │   └── production
-    ├── Sandbox
-    │   └── sandbox
-    └── Test
-        └── test
+├── Workloads
+│   ├── Production
+│   │   └── production
+│   ├── Sandbox
+│   │   └── sandbox
+│   └── Test
+│       └── test
+└── Security
+    └── identity
 ```
 
 The management account owns the AWS Organization control plane. It should stay limited to
@@ -65,8 +67,7 @@ across all accounts:
 | `awsengineers@polar.sh`, `engineering@polar.sh`  | `PolarEngineering<Account>` | Power-user (no IAM/Organizations), bounded by `PolarPermissionBoundary` |
 | `awsaccess@polar.sh`                             | `PolarReadOnly<Account>`    | Read-only                                           |
 
-Group membership is not managed here; manage it in the Identity Center console or via SCIM from
-Google Workspace.
+Group membership comes from Google Workspace via ssosync (`terraform/identity`), not from here.
 
 ## Permission boundary
 

--- a/terraform/organization/identity_account.tf
+++ b/terraform/organization/identity_account.tf
@@ -1,0 +1,36 @@
+locals {
+  identity_account = {
+    name = "identity"
+    id   = "986542260309"
+  }
+}
+
+resource "aws_organizations_organizational_unit" "security" {
+  name      = "Security"
+  parent_id = local.root_id
+}
+
+resource "aws_organizations_account" "identity" {
+  name              = local.identity_account.name
+  email             = var.identity_account_email
+  parent_id         = aws_organizations_organizational_unit.security.id
+  close_on_deletion = false
+
+  tags = {
+    purpose = "identity"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_organizations_delegated_administrator" "identity_center" {
+  account_id        = aws_organizations_account.identity.id
+  service_principal = "sso.amazonaws.com"
+}
+
+import {
+  to = aws_organizations_account.identity
+  id = "986542260309"
+}

--- a/terraform/organization/outputs.tf
+++ b/terraform/organization/outputs.tf
@@ -32,11 +32,19 @@ output "workload_accounts" {
   }
 }
 
+output "identity_account" {
+  value = {
+    id   = aws_organizations_account.identity.id
+    name = aws_organizations_account.identity.name
+  }
+}
+
 output "terraform_cloud_run_roles" {
   value = {
     production = module.terraform_cloud_run_role_production.role_arn
     sandbox    = module.terraform_cloud_run_role_sandbox.role_arn
     test       = module.terraform_cloud_run_role_test.role_arn
+    identity   = module.terraform_cloud_run_role_identity.role_arn
   }
 }
 

--- a/terraform/organization/terraform_cloud.tf
+++ b/terraform/organization/terraform_cloud.tf
@@ -16,6 +16,10 @@ locals {
         project   = "test"
         workspace = "test"
       }
+      identity = {
+        project   = "Polar"
+        workspace = "identity"
+      }
     }
 
     run_role_policy_arns = {
@@ -48,6 +52,15 @@ provider "aws" {
 
   assume_role {
     role_arn = "arn:aws:iam::${local.workload_accounts.test.id}:role/${var.member_account_bootstrap_role_name}"
+  }
+}
+
+provider "aws" {
+  alias  = "identity"
+  region = "us-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.identity_account.id}:role/${var.member_account_bootstrap_role_name}"
   }
 }
 
@@ -87,5 +100,18 @@ module "terraform_cloud_run_role_test" {
   terraform_cloud_organization = local.terraform_cloud.organization
   terraform_cloud_project      = local.terraform_cloud.workspaces.test.project
   terraform_cloud_workspace    = local.terraform_cloud.workspaces.test.workspace
+  policy_arns                  = local.terraform_cloud.run_role_policy_arns
+}
+
+module "terraform_cloud_run_role_identity" {
+  source = "../modules/terraform_cloud_run_role"
+  providers = {
+    aws = aws.identity
+  }
+
+  role_name                    = local.terraform_cloud.role_name
+  terraform_cloud_organization = local.terraform_cloud.organization
+  terraform_cloud_project      = local.terraform_cloud.workspaces.identity.project
+  terraform_cloud_workspace    = local.terraform_cloud.workspaces.identity.workspace
   policy_arns                  = local.terraform_cloud.run_role_policy_arns
 }

--- a/terraform/organization/variables.tf
+++ b/terraform/organization/variables.tf
@@ -24,3 +24,10 @@ variable "member_account_bootstrap_role_name" {
   type        = string
   default     = "OrganizationAccountAccessRole"
 }
+
+variable "identity_account_email" {
+  description = "Email address for the identity AWS account."
+  type        = string
+  sensitive   = true
+  nullable    = false
+}


### PR DESCRIPTION
Since Google Workspace SAML does not sync groups, we need to handle that specifically. This sets up aws-sso via the official SAM CF stack.

This replaces the existing sync from Google

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

