### PR TITLE
fix(organization): close appeal case on backoffice deletion

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -3875,7 +3875,7 @@ async def delete_dialog(
         raise HTTPException(status_code=404, detail="Organization not found")
 
     if request.method == "POST":
-        await organization_service.delete(session, organization)
+        await organization_service.soft_delete_organization(session, organization)
 
         return HXRedirectResponse(
             request,

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -557,56 +557,6 @@ class OrganizationService:
         await self._after_update(session, organization)
         return organization
 
-    async def delete(
-        self,
-        session: AsyncSession,
-        organization: Organization,
-    ) -> Organization:
-        """Anonymizes fields on the Organization that can contain PII and then
-        soft-deletes the Organization.
-
-        DOES NOT:
-        - Delete or anonymize Users related Organization
-        - Delete or anonymize Account of the Organization
-        - Delete or anonymize Customers, Products, Discounts, Benefits, Checkouts of the Organization
-        - Revoke Benefits granted
-        - Remove API tokens (organization or personal)
-        """
-        repository = OrganizationRepository.from_session(session)
-
-        update_dict: dict[str, Any] = {}
-
-        pii_fields = ["name", "slug", "website", "customer_invoice_prefix"]
-        github_fields = ["bio", "company", "blog", "location", "twitter_username"]
-        for pii_field in pii_fields + github_fields:
-            value = getattr(organization, pii_field)
-            if value:
-                update_dict[pii_field] = anonymize_for_deletion(
-                    value, organization.created_at
-                )
-
-        if organization.email:
-            update_dict["email"] = anonymize_email_for_deletion(
-                organization.email, organization.created_at
-            )
-
-        if organization._avatar_url:
-            # Anonymize by setting to Polar logo
-            update_dict["avatar_url"] = (
-                "https://avatars.githubusercontent.com/u/105373340?s=48&v=4"
-            )
-        if organization.details:
-            update_dict["details"] = {}
-
-        if organization.socials:
-            update_dict["socials"] = []
-
-        organization = await repository.update(organization, update_dict=update_dict)
-        await repository.soft_delete(organization)
-        polar_self_service.enqueue_delete_customer(organization_id=organization.id)
-
-        return organization
-
     async def check_can_delete(
         self,
         session: AsyncReadSession,
@@ -700,8 +650,8 @@ class OrganizationService:
             )
             return check_result
 
-        # Soft delete the organization
-        await self.soft_delete_organization(session, organization)
+        # Soft delete the organization, releasing its slug for reuse
+        await self.soft_delete_organization(session, organization, release_slug=True)
 
         return OrganizationDeletionCheckResult(
             can_delete_immediately=True,
@@ -712,25 +662,31 @@ class OrganizationService:
         self,
         session: AsyncSession,
         organization: Organization,
+        *,
+        release_slug: bool = False,
     ) -> Organization:
-        """Soft-delete an organization, releasing its slug for reuse.
+        """Soft-delete an organization, anonymizing its PII.
 
-        Anonymizes PII fields, archives the previous slug to ``slug_history``,
-        and rewrites the live slug to a tombstone so a new organization can
-        claim the original.
+        When ``release_slug`` is set, the previous slug is archived to
+        ``slug_history`` and the live slug is rewritten to a tombstone so a new
+        organization can claim the original. Otherwise the slug is scrubbed like
+        any other PII field, leaving no recoverable trace.
         """
         repository = OrganizationRepository.from_session(session)
 
-        now = datetime.now(UTC)
-        update_dict: dict[str, Any] = {
-            "slug_history": [
+        update_dict: dict[str, Any] = {}
+        pii_fields = ["name", "website", "customer_invoice_prefix"]
+
+        if release_slug:
+            now = datetime.now(UTC)
+            update_dict["slug_history"] = [
                 *organization.slug_history,
                 {"slug": organization.slug, "deleted_at": now.isoformat()},
-            ],
-            "slug": f"__deleted__-{organization.slug}-{organization.id}",
-        }
+            ]
+            update_dict["slug"] = f"__deleted__-{organization.slug}-{organization.id}"
+        else:
+            pii_fields = ["name", "slug", "website", "customer_invoice_prefix"]
 
-        pii_fields = ["name", "website", "customer_invoice_prefix"]
         github_fields = ["bio", "company", "blog", "location", "twitter_username"]
         for pii_field in pii_fields + github_fields:
             value = getattr(organization, pii_field)

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -3263,7 +3263,7 @@ class TestSoftDeleteOrganization:
         await save_fixture(organization)
 
         result = await organization_service.soft_delete_organization(
-            session, organization
+            session, organization, release_slug=True
         )
 
         # The live slug should no longer be the original, freeing it for reuse.
@@ -3295,7 +3295,9 @@ class TestSoftDeleteOrganization:
         organization: Organization,
     ) -> None:
         original_slug = organization.slug
-        await organization_service.soft_delete_organization(session, organization)
+        await organization_service.soft_delete_organization(
+            session, organization, release_slug=True
+        )
         await session.flush()
 
         repository = OrganizationRepository.from_session(session)
@@ -3317,7 +3319,7 @@ class TestSoftDeleteOrganization:
         await save_fixture(organization)
 
         result = await organization_service.soft_delete_organization(
-            session, organization
+            session, organization, release_slug=True
         )
 
         assert len(result.slug_history) == 2
@@ -3344,24 +3346,24 @@ class TestSoftDeleteOrganization:
         assert result.details == {}
         assert result.socials == []
 
-
-@pytest.mark.asyncio
-class TestDelete:
-    async def test_enqueues_polar_self_customer_deletion(
+    async def test_scrubs_slug_without_releasing(
         self,
         mocker: MockerFixture,
         session: AsyncSession,
         organization: Organization,
     ) -> None:
-        enqueue_delete_customer_mock = mocker.patch(
-            "polar.organization.service.polar_self_service.enqueue_delete_customer"
+        # Backoffice/erasure deletions scrub the slug as PII rather than
+        # archiving it for reuse, leaving no recoverable trace of the original.
+        mocker.patch("polar.organization.service.polar_self_service")
+        original_slug = organization.slug
+
+        result = await organization_service.soft_delete_organization(
+            session, organization
         )
 
-        await organization_service.delete(session, organization)
-
-        enqueue_delete_customer_mock.assert_called_once_with(
-            organization_id=organization.id
-        )
+        assert result.slug != original_slug
+        assert original_slug not in result.slug
+        assert result.slug_history == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Backoffice org deletion never closed the org's open appeal support case, leaving it sitting open in the support queue indefinitely ([feedback#189](https://github.com/polarsource/feedback/issues/189)). The self-service deletion path already closed it.

Collapses the two soft-delete paths into a single `soft_delete_organization`, gated by a `release_slug` flag that preserves the one intentional difference:
- **self-service** → releases the slug for reuse (archive + tombstone)
- **backoffice** → scrubs the slug as PII (no recoverable trace, erasure-friendly)

Everything else — PII anonymization, appeal-case close, customer-deletion enqueue, log — is now shared, so the paths can't drift again

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

