### PR TITLE
feat(oauth2): issue user tokens down-scoped to one org for web grant

### DIFF
--- a/server/polar/oauth2/grants/web.py
+++ b/server/polar/oauth2/grants/web.py
@@ -12,12 +12,11 @@ from authlib.oauth2.rfc6749.grants import BaseGrant, TokenEndpointMixin
 from authlib.oauth2.rfc6749.hooks import hooked
 from sqlalchemy import select
 
-from polar.auth.permission import OrganizationPermission
 from polar.authz.repository import select_user_org_ids
 from polar.config import settings
 from polar.kit.crypto import get_token_hash
 from polar.kit.utils import utc_now
-from polar.models import Organization, User, UserSession
+from polar.models import UserSession
 
 from ..sub_type import SubType, SubTypeValue
 
@@ -91,39 +90,33 @@ class WebGrant(BaseGrant, TokenEndpointMixin):
             raise InvalidGrantError()
 
         user = user_session.user
-        sub_value: User | Organization | None = None
-        if sub_type == SubType.user:
-            sub_value = user
-            # Inherit the session's down-scope so the token can't be broader
-            # than the session it's exchanged from.
-            self.request.organization_ids = [
-                scope.organization_id for scope in user_session.organization_scopes
-            ]
-        elif sub_type == SubType.organization:
+        session_organization_ids = {
+            scope.organization_id for scope in user_session.organization_scopes
+        }
+
+        if sub_type == SubType.organization:
             assert sub is not None
             try:
                 sub_uuid = uuid.UUID(sub)
             except ValueError as e:
                 raise InvalidRequestError("Invalid 'sub' UUID") from e
-            organization = self._get_organization_admin(sub_uuid, user)
-            if organization is None:
+            # The OAuth server only issues user tokens now; sub_type=organization
+            # mints a user token down-scoped to the single requested org. It must
+            # be one the user is a member of, within the session's own down-scope,
+            # so the token can never be broader than its session.
+            member_organization_ids = set(
+                self.server.session.execute(select_user_org_ids(user.id))
+                .scalars()
+                .all()
+            )
+            if session_organization_ids:
+                member_organization_ids &= session_organization_ids
+            if sub_uuid not in member_organization_ids:
                 raise InvalidGrantError()
-            sub_value = organization
+            self.request.organization_ids = [sub_uuid]
+        else:
+            # Inherit the session's down-scope so the token can't be broader
+            # than the session it's exchanged from.
+            self.request.organization_ids = list(session_organization_ids)
 
-        assert sub_value is not None
-        return sub_type, sub_value
-
-    def _get_organization_admin(
-        self, organization_id: uuid.UUID, user: User
-    ) -> Organization | None:
-        statement = select(Organization).where(
-            Organization.id == organization_id,
-            Organization.id.in_(
-                select_user_org_ids(
-                    user.id,
-                    permission=OrganizationPermission.organization_manage,
-                )
-            ),
-        )
-        result = self.server.session.execute(statement)
-        return result.unique().scalar_one_or_none()
+        return SubType.user, user

--- a/server/tests/oauth2/endpoints/test_oauth2.py
+++ b/server/tests/oauth2/endpoints/test_oauth2.py
@@ -1671,10 +1671,23 @@ class TestOAuth2Token:
         json = response.json()
 
         access_token = json["access_token"]
-        assert access_token.startswith("polar_at_o_")
+        assert access_token.startswith("polar_at_u_")
         assert "refresh_token" not in json
 
-    async def test_web_grant_sub_organization_member_without_manage_forbidden(
+        oauth2_token = (
+            sync_session.execute(
+                select(OAuth2Token).where(
+                    OAuth2Token.access_token
+                    == get_token_hash(access_token, secret=settings.SECRET)
+                )
+            )
+            .unique()
+            .scalar_one()
+        )
+        assert oauth2_token.sub_type == SubType.user
+        assert oauth2_token.organization_ids == frozenset({organization.id})
+
+    async def test_web_grant_sub_organization_member_allowed(
         self,
         save_fixture: SaveFixture,
         sync_session: Session,
@@ -1713,7 +1726,21 @@ class TestOAuth2Token:
 
         response = await client.post("/v1/oauth2/token", data=data)
 
-        assert response.status_code == 400
+        assert response.status_code == 200
+        access_token = response.json()["access_token"]
+        assert access_token.startswith("polar_at_u_")
+
+        oauth2_token = (
+            sync_session.execute(
+                select(OAuth2Token).where(
+                    OAuth2Token.access_token
+                    == get_token_hash(access_token, secret=settings.SECRET)
+                )
+            )
+            .unique()
+            .scalar_one()
+        )
+        assert oauth2_token.organization_ids == frozenset({organization.id})
 
     async def test_web_grant_user_inherits_session_down_scope(
         self,
@@ -1850,10 +1877,22 @@ class TestOAuth2Token:
         response = await client.post("/v1/oauth2/token", data=data)
 
         assert response.status_code == 200
-        json = response.json()
-        assert json["access_token"].startswith("polar_at_o_")
+        access_token = response.json()["access_token"]
+        assert access_token.startswith("polar_at_u_")
 
-    async def test_web_grant_sub_organization_manage_in_other_org_forbidden(
+        oauth2_token = (
+            sync_session.execute(
+                select(OAuth2Token).where(
+                    OAuth2Token.access_token
+                    == get_token_hash(access_token, secret=settings.SECRET)
+                )
+            )
+            .unique()
+            .scalar_one()
+        )
+        assert oauth2_token.organization_ids == frozenset({organization.id})
+
+    async def test_web_grant_sub_organization_non_member_forbidden(
         self,
         save_fixture: SaveFixture,
         sync_session: Session,
@@ -1879,6 +1918,104 @@ class TestOAuth2Token:
             user=user,
             scopes=set(Scope),
             expires_at=utc_now() + timedelta(seconds=60),
+        )
+        await save_fixture(user_session)
+
+        data = {
+            "grant_type": "web",
+            "session_token": token,
+            "client_id": web_grant_oauth2_client.client_id,
+            "client_secret": web_grant_oauth2_client.client_secret,
+            "sub_type": "organization",
+            "sub": str(organization.id),
+        }
+
+        response = await client.post("/v1/oauth2/token", data=data)
+
+        assert response.status_code == 400
+
+    async def test_web_grant_sub_organization_within_session_down_scope(
+        self,
+        save_fixture: SaveFixture,
+        sync_session: Session,
+        client: AsyncClient,
+        user: User,
+        organization: Organization,
+        user_organization: UserOrganization,
+        web_grant_oauth2_client: OAuth2Client,
+    ) -> None:
+        token, token_hash = generate_token_hash_pair(
+            secret=settings.SECRET, prefix=USER_SESSION_TOKEN_PREFIX
+        )
+        user_session = UserSession(
+            token=token_hash,
+            user_agent="tests",
+            user=user,
+            scopes=set(Scope),
+            expires_at=utc_now() + timedelta(seconds=60),
+            organization_scopes=[
+                UserSessionOrganization(organization_id=organization.id)
+            ],
+        )
+        await save_fixture(user_session)
+
+        data = {
+            "grant_type": "web",
+            "session_token": token,
+            "client_id": web_grant_oauth2_client.client_id,
+            "client_secret": web_grant_oauth2_client.client_secret,
+            "sub_type": "organization",
+            "sub": str(organization.id),
+        }
+
+        response = await client.post("/v1/oauth2/token", data=data)
+
+        assert response.status_code == 200
+        access_token = response.json()["access_token"]
+        assert access_token.startswith("polar_at_u_")
+
+        oauth2_token = (
+            sync_session.execute(
+                select(OAuth2Token).where(
+                    OAuth2Token.access_token
+                    == get_token_hash(access_token, secret=settings.SECRET)
+                )
+            )
+            .unique()
+            .scalar_one()
+        )
+        assert oauth2_token.organization_ids == frozenset({organization.id})
+
+    async def test_web_grant_sub_organization_outside_session_down_scope_forbidden(
+        self,
+        save_fixture: SaveFixture,
+        sync_session: Session,
+        client: AsyncClient,
+        user: User,
+        organization: Organization,
+        organization_second: Organization,
+        user_organization: UserOrganization,
+        web_grant_oauth2_client: OAuth2Client,
+    ) -> None:
+        await save_fixture(
+            UserOrganization(
+                user=user,
+                organization=organization_second,
+                role=OrganizationRole.owner,
+            )
+        )
+        token, token_hash = generate_token_hash_pair(
+            secret=settings.SECRET, prefix=USER_SESSION_TOKEN_PREFIX
+        )
+        user_session = UserSession(
+            token=token_hash,
+            user_agent="tests",
+            user=user,
+            scopes=set(Scope),
+            expires_at=utc_now() + timedelta(seconds=60),
+            organization_scopes=[
+                UserSessionOrganization(organization_id=organization_second.id)
+            ],
         )
         await save_fixture(user_session)
 


### PR DESCRIPTION
## Summary

Last OAuth path still minting org-subject tokens. Now grant_type=web + sub_type=organization issues a user token down-scoped to the single requested org (sub).

- Org must be a membership (any role) ∩ the session's own down-scope — token can't be broader than its session.
- Single-org down-scoped user token → create endpoints resolve organization_id implicitly (org-token parity), so "Create with AI" / Gram is unchanged.

Verified locally: exchange returns polar_at_u_…; POST /v1/products with no organization_id creates in the scoped org.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

