### PR TITLE
Display disputes in the dashboard

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/disputes/DisputesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/disputes/DisputesPage.tsx
@@ -1,0 +1,202 @@
+'use client'
+
+import { DisputeStatusSelect } from '@/components/Disputes/DisputeStatusSelect'
+import { DashboardBody } from '@/components/Layout/DashboardLayout'
+import { useDisputes } from '@/hooks/queries/disputes'
+import {
+  DataTablePaginationState,
+  DataTableSortingState,
+  getAPIParams,
+  serializeSearchParams,
+} from '@/utils/datatable'
+import {
+  DisputeStatusDisplayColor,
+  DisputeStatusDisplayTitle,
+  type DisputeStatusFilter,
+  getDisputeReasonDisplay,
+} from '@/utils/dispute'
+import { schemas } from '@polar-sh/client'
+import { formatCurrency } from '@polar-sh/currency'
+import { Status, Text, Truncated } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import {
+  DataTable,
+  DataTableColumnDef,
+  DataTableColumnHeader,
+} from '@polar-sh/orbit'
+import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
+import { useRouter } from 'next/navigation'
+import React from 'react'
+
+interface Props {
+  organization: schemas['Organization']
+  pagination: DataTablePaginationState
+  sorting: DataTableSortingState
+  status?: DisputeStatusFilter
+}
+
+const DisputesPage = ({
+  organization,
+  pagination,
+  sorting,
+  status = 'any',
+}: Props) => {
+  const router = useRouter()
+
+  const buildUrl = (
+    nextPagination: DataTablePaginationState,
+    nextSorting: DataTableSortingState,
+    nextStatus: DisputeStatusFilter,
+  ) => {
+    const params = serializeSearchParams(nextPagination, nextSorting)
+    if (nextStatus !== 'any') {
+      params.append('status', nextStatus)
+    }
+    return `/dashboard/${organization.slug}/sales/disputes?${params}`
+  }
+
+  const setPagination = (
+    updaterOrValue:
+      | DataTablePaginationState
+      | ((old: DataTablePaginationState) => DataTablePaginationState),
+  ) => {
+    const updated =
+      typeof updaterOrValue === 'function'
+        ? updaterOrValue(pagination)
+        : updaterOrValue
+    router.push(buildUrl(updated, sorting, status))
+  }
+
+  const setSorting = (
+    updaterOrValue:
+      | DataTableSortingState
+      | ((old: DataTableSortingState) => DataTableSortingState),
+  ) => {
+    const updated =
+      typeof updaterOrValue === 'function'
+        ? updaterOrValue(sorting)
+        : updaterOrValue
+    router.push(buildUrl(pagination, updated, status))
+  }
+
+  const setStatus = (value: DisputeStatusFilter) => {
+    router.push(buildUrl(pagination, sorting, value))
+  }
+
+  const disputesHook = useDisputes(organization.id, {
+    ...getAPIParams(pagination, sorting),
+    status: status === 'any' ? undefined : [status],
+  })
+
+  const disputes = disputesHook.data?.items || []
+  const rowCount = disputesHook.data?.pagination.total_count ?? 0
+  const pageCount = disputesHook.data?.pagination.max_page ?? 1
+
+  const columns: DataTableColumnDef<schemas['Dispute']>[] = [
+    {
+      accessorKey: 'customer',
+      enableSorting: false,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Customer" />
+      ),
+      cell: ({ row: { original: dispute } }) => (
+        <Truncated>
+          <Text>{dispute.customer.name || dispute.customer.email}</Text>
+        </Truncated>
+      ),
+    },
+    {
+      accessorKey: 'status',
+      enableSorting: false,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Status" />
+      ),
+      cell: ({ row: { original: dispute } }) => (
+        <Status
+          status={DisputeStatusDisplayTitle[dispute.status]}
+          color={DisputeStatusDisplayColor[dispute.status]}
+          size="small"
+        />
+      ),
+    },
+    {
+      accessorKey: 'reason',
+      enableSorting: false,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Reason" />
+      ),
+      cell: ({ row: { original: dispute } }) => (
+        <Text color="muted">{getDisputeReasonDisplay(dispute.reason)}</Text>
+      ),
+    },
+    {
+      accessorKey: 'amount',
+      enableSorting: true,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Amount" />
+      ),
+      cell: ({ row: { original: dispute } }) => (
+        <Text>
+          {formatCurrency('standard')(dispute.amount, dispute.currency)}
+        </Text>
+      ),
+    },
+    {
+      accessorKey: 'evidence_due_by',
+      enableSorting: false,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Respond by" />
+      ),
+      cell: ({ row: { original: dispute } }) => {
+        if (!dispute.evidence_due_by) {
+          return <Text color="muted">—</Text>
+        }
+        if (dispute.past_due) {
+          return <Text color="danger">Overdue</Text>
+        }
+        return <FormattedDateTime datetime={dispute.evidence_due_by} />
+      },
+    },
+    {
+      accessorKey: 'created_at',
+      enableSorting: true,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Opened" />
+      ),
+      cell: ({ row: { original: dispute } }) => (
+        <FormattedDateTime datetime={dispute.created_at} />
+      ),
+    },
+  ]
+
+  return (
+    <DashboardBody wide title="Disputes">
+      <Box flexDirection="column" rowGap="l">
+        <Box alignItems="center" columnGap="m">
+          <Box width={220}>
+            <DisputeStatusSelect value={status} onChange={setStatus} />
+          </Box>
+        </Box>
+        <DataTable
+          columns={columns}
+          data={disputes}
+          rowCount={rowCount}
+          pageCount={pageCount}
+          pagination={pagination}
+          onPaginationChange={setPagination}
+          sorting={sorting}
+          onSortingChange={setSorting}
+          isLoading={disputesHook.isLoading}
+          getRowId={(row) => row.id}
+          onRowClick={(row) =>
+            router.push(
+              `/dashboard/${organization.slug}/sales/disputes/${row.original.id}`,
+            )
+          }
+        />
+      </Box>
+    </DashboardBody>
+  )
+}
+
+export default DisputesPage

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/disputes/[id]/DisputeDetailPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/disputes/[id]/DisputeDetailPage.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { DashboardBody } from '@/components/Layout/DashboardLayout'
+import { useDispute } from '@/hooks/queries/disputes'
+import { schemas } from '@polar-sh/client'
+import { Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { Loader2 } from 'lucide-react'
+import React from 'react'
+import { DisputeDetailView } from './DisputeDetailView'
+
+interface Props {
+  organization: schemas['Organization']
+  disputeId: string
+}
+
+const DisputeDetailPage = ({ organization, disputeId }: Props) => {
+  const { data: dispute, isLoading } = useDispute(disputeId)
+
+  if (isLoading) {
+    return (
+      <DashboardBody>
+        <Box alignItems="center" justifyContent="center" paddingVertical="3xl">
+          <Loader2 className="dark:text-polar-400 h-5 w-5 animate-spin text-gray-500" />
+        </Box>
+      </DashboardBody>
+    )
+  }
+
+  if (!dispute) {
+    return (
+      <DashboardBody>
+        <Box
+          flexDirection="column"
+          alignItems="center"
+          justifyContent="center"
+          paddingVertical="3xl"
+          rowGap="s"
+          textAlign="center"
+        >
+          <Text variant="label">Dispute not found</Text>
+          <Text color="muted">
+            This dispute does not exist or you do not have access to it.
+          </Text>
+        </Box>
+      </DashboardBody>
+    )
+  }
+
+  return <DisputeDetailView organization={organization} dispute={dispute} />
+}
+
+export default DisputeDetailPage

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/disputes/[id]/DisputeDetailView.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/disputes/[id]/DisputeDetailView.tsx
@@ -1,0 +1,132 @@
+'use client'
+
+import { CustomerContextView } from '@/components/Customer/CustomerContextView'
+import { DisputeBanner } from '@/components/Disputes/DisputeBanner'
+import { DisputeCountdownBadge } from '@/components/Disputes/DisputeCountdownBadge'
+import { DashboardBody } from '@/components/Layout/DashboardLayout'
+import { OrderStatus } from '@/components/Orders/OrderStatus'
+import { DetailRow } from '@/components/Shared/DetailRow'
+import { useOrder } from '@/hooks/queries/orders'
+import { buildCustomerDashboardPath } from '@/utils/customer'
+import { schemas } from '@polar-sh/client'
+import { formatCurrency } from '@polar-sh/currency'
+import { Button, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
+import ShadowBox from '@polar-sh/ui/components/atoms/ShadowBox'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import React from 'react'
+
+const format = formatCurrency('accounting')
+
+interface Props {
+  organization: schemas['Organization']
+  dispute: schemas['Dispute']
+}
+
+export const DisputeDetailView = ({ organization, dispute }: Props) => {
+  const { data: order } = useOrder(dispute.order_id)
+
+  if (order && order.customer.organization_id !== organization.id) {
+    notFound()
+  }
+
+  return (
+    <DashboardBody
+      title={
+        <Box
+          alignItems="center"
+          justifyContent="between"
+          columnGap="m"
+          flexGrow={1}
+        >
+          <Box flexDirection="column" rowGap="xs">
+            <Box alignItems="center" columnGap="s">
+              <Text variant="heading-xs" as="h2">
+                {formatCurrency('standard')(dispute.amount, dispute.currency)}{' '}
+                {dispute.currency.toUpperCase()}
+              </Text>
+              <DisputeCountdownBadge dispute={dispute} />
+            </Box>
+            {order && (
+              <Text color="muted">
+                Charged to{' '}
+                <Link
+                  href={buildCustomerDashboardPath(
+                    organization.slug,
+                    order.customer,
+                  )}
+                  className="underline"
+                >
+                  {order.customer.name || order.customer.email}
+                </Link>
+              </Text>
+            )}
+          </Box>
+          {order && (
+            <Link href={`/dashboard/${organization.slug}/sales/${order.id}`}>
+              <Button variant="secondary">View order</Button>
+            </Link>
+          )}
+        </Box>
+      }
+      contextViewTitle="Details"
+      contextViewClassName="bg-transparent dark:bg-transparent border-none rounded-none md:shadow-none"
+      contextView={
+        order ? (
+          <CustomerContextView
+            organization={organization}
+            customer={order.customer}
+          />
+        ) : undefined
+      }
+    >
+      <Box flexDirection="column" rowGap="xl">
+        <DisputeBanner dispute={dispute} />
+
+        {order && (
+          <ShadowBox className="flex flex-col gap-4">
+            <h2 className="text-lg">Order</h2>
+            <div className="flex flex-col">
+              <DetailRow label="Product" value={order.product?.name ?? '—'} />
+              <DetailRow
+                label="Status"
+                value={<OrderStatus status={order.status} />}
+              />
+              <DetailRow
+                label="Subtotal"
+                value={format(order.subtotal_amount, order.currency)}
+              />
+              <DetailRow
+                label="Discount"
+                value={
+                  order.discount_amount
+                    ? format(-order.discount_amount, order.currency)
+                    : '—'
+                }
+              />
+              <DetailRow
+                label="Net amount"
+                value={format(order.net_amount, order.currency)}
+              />
+              <DetailRow
+                label="Tax"
+                value={format(order.tax_amount, order.currency)}
+              />
+              <DetailRow
+                label="Total"
+                value={format(order.total_amount, order.currency)}
+              />
+              <DetailRow
+                label="Date"
+                value={<FormattedDateTime datetime={order.created_at} />}
+              />
+              <DetailRow label="Invoice" value={order.invoice_number ?? '—'} />
+            </div>
+          </ShadowBox>
+        )}
+      </Box>
+    </DashboardBody>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/disputes/[id]/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/disputes/[id]/page.tsx
@@ -1,0 +1,28 @@
+import { getServerSideAPI } from '@/utils/client/serverside'
+import { getOrganizationBySlugOrNotFound } from '@/utils/organization'
+import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import DisputeDetailPage from './DisputeDetailPage'
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Dispute',
+  }
+}
+
+export default async function Page(props: {
+  params: Promise<{ organization: string; id: string }>
+}) {
+  const params = await props.params
+  const api = await getServerSideAPI()
+  const organization = await getOrganizationBySlugOrNotFound(
+    api,
+    params.organization,
+  )
+
+  if (!organization.feature_settings?.disputes_enabled) {
+    notFound()
+  }
+
+  return <DisputeDetailPage organization={organization} disputeId={params.id} />
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/disputes/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/disputes/page.tsx
@@ -1,0 +1,50 @@
+import { getServerSideAPI } from '@/utils/client/serverside'
+import { DataTableSearchParams, parseSearchParams } from '@/utils/datatable'
+import { isDisputeStatus } from '@/utils/dispute'
+import { getOrganizationBySlugOrNotFound } from '@/utils/organization'
+import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import DisputesPage from './DisputesPage'
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Disputes',
+  }
+}
+
+export default async function Page(props: {
+  params: Promise<{ organization: string }>
+  searchParams: Promise<DataTableSearchParams & { status?: string | string[] }>
+}) {
+  const searchParams = await props.searchParams
+  const params = await props.params
+  const api = await getServerSideAPI()
+  const organization = await getOrganizationBySlugOrNotFound(
+    api,
+    params.organization,
+  )
+
+  if (!organization.feature_settings?.disputes_enabled) {
+    notFound()
+  }
+
+  const { pagination, sorting } = parseSearchParams(
+    searchParams,
+    [{ id: 'created_at', desc: true }],
+    50,
+  )
+
+  const rawStatus = Array.isArray(searchParams.status)
+    ? searchParams.status[0]
+    : searchParams.status
+  const status = rawStatus && isDisputeStatus(rawStatus) ? rawStatus : 'any'
+
+  return (
+    <DisputesPage
+      organization={organization}
+      pagination={pagination}
+      sorting={sorting}
+      status={status}
+    />
+  )
+}

--- a/clients/apps/web/src/components/Dashboard/navigation.tsx
+++ b/clients/apps/web/src/components/Dashboard/navigation.tsx
@@ -7,6 +7,7 @@ import CodeOutlined from '@mui/icons-material/CodeOutlined'
 import DiamondOutlined from '@mui/icons-material/DiamondOutlined'
 import DiscountOutlined from '@mui/icons-material/DiscountOutlined'
 import DonutLargeOutlined from '@mui/icons-material/DonutLargeOutlined'
+import GavelOutlined from '@mui/icons-material/GavelOutlined'
 import HiveOutlined from '@mui/icons-material/HiveOutlined'
 import LinkOutlined from '@mui/icons-material/LinkOutlined'
 import PeopleAltOutlined from '@mui/icons-material/PeopleAltOutlined'
@@ -280,6 +281,12 @@ const generalRoutesList = (org?: schemas['Organization']): Route[] => [
         title: 'Checkouts',
         link: `/dashboard/${org?.slug}/sales/checkouts`,
         icon: <ShoppingCart />,
+      },
+      {
+        title: 'Disputes',
+        link: `/dashboard/${org?.slug}/sales/disputes`,
+        icon: <GavelOutlined fontSize="inherit" />,
+        if: !!org?.feature_settings?.disputes_enabled,
       },
     ],
   },

--- a/clients/apps/web/src/components/Disputes/DisputeBanner.tsx
+++ b/clients/apps/web/src/components/Disputes/DisputeBanner.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { toast } from '@/components/Toast/use-toast'
+import { getDisputeReasonExplanation } from '@/utils/dispute'
+import { schemas } from '@polar-sh/client'
+import { Button, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+
+const DISPUTE_DOCS_URL =
+  'https://polar.sh/docs/merchant-of-record/fees#dispute/chargeback-fees'
+
+export const DisputeBanner = ({ dispute }: { dispute: schemas['Dispute'] }) => {
+  const needsResponse = dispute.status === 'needs_response'
+
+  return (
+    <Box
+      flexDirection="column"
+      borderRadius="l"
+      borderWidth={1}
+      borderStyle="solid"
+      borderColor="border-primary"
+      backgroundColor="background-primary"
+      overflow="hidden"
+    >
+      <Box flexDirection="column" rowGap="m" padding="xl">
+        <Text variant="heading-xxs" as="h3">
+          The customer disputed this payment
+        </Text>
+        <Text color="muted">{getDisputeReasonExplanation(dispute.reason)}</Text>
+        {needsResponse && (
+          <Text color="muted">
+            You may either provide evidence that clarifies the transaction to
+            help your customer recognize it, or accept this dispute immediately
+            to refund the customer and close the dispute.
+          </Text>
+        )}
+      </Box>
+
+      {needsResponse && (
+        <Box
+          alignItems="center"
+          justifyContent="between"
+          columnGap="m"
+          padding="l"
+          borderTopWidth={1}
+          borderStyle="solid"
+          borderColor="border-primary"
+        >
+          <a
+            href={DISPUTE_DOCS_URL}
+            target="_blank"
+            rel="noreferrer"
+            className="text-sm underline"
+          >
+            Learn more about dispute fees
+          </a>
+          <Box alignItems="center" columnGap="s">
+            <Button
+              variant="secondary"
+              onClick={() =>
+                toast({
+                  title: 'Coming soon',
+                  description: 'Accepting disputes isn’t available yet.',
+                })
+              }
+            >
+              Accept dispute
+            </Button>
+            <Button
+              onClick={() =>
+                toast({
+                  title: 'Coming soon',
+                  description: 'Countering disputes isn’t available yet.',
+                })
+              }
+            >
+              Counter dispute
+            </Button>
+          </Box>
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/clients/apps/web/src/components/Disputes/DisputeCountdownBadge.tsx
+++ b/clients/apps/web/src/components/Disputes/DisputeCountdownBadge.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import {
+  DisputeStatusDisplayColor,
+  DisputeStatusDisplayTitle,
+} from '@/utils/dispute'
+import { schemas } from '@polar-sh/client'
+import { Status } from '@polar-sh/orbit'
+import { differenceInCalendarDays } from 'date-fns'
+import { useState } from 'react'
+
+export const DisputeCountdownBadge = ({
+  dispute,
+}: {
+  dispute: schemas['Dispute']
+}) => {
+  const [now] = useState(() => new Date())
+
+  if (dispute.evidence_due_by) {
+    if (dispute.past_due) {
+      return <Status status="Overdue" color="red" size="small" />
+    }
+    const days = differenceInCalendarDays(
+      new Date(dispute.evidence_due_by),
+      now,
+    )
+    const label =
+      days <= 0
+        ? 'Due today'
+        : days === 1
+          ? '1 day to respond'
+          : `${days} days to respond`
+    return <Status status={label} color="yellow" size="small" />
+  }
+
+  return (
+    <Status
+      status={DisputeStatusDisplayTitle[dispute.status]}
+      color={DisputeStatusDisplayColor[dispute.status]}
+      size="small"
+    />
+  )
+}

--- a/clients/apps/web/src/components/Disputes/DisputeStatusSelect.tsx
+++ b/clients/apps/web/src/components/Disputes/DisputeStatusSelect.tsx
@@ -1,0 +1,50 @@
+import {
+  DisputeStatusDisplayTitle,
+  type DisputeStatusFilter,
+} from '@/utils/dispute'
+import { schemas } from '@polar-sh/client'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from '@polar-sh/orbit'
+import React from 'react'
+
+const STATUSES: schemas['DisputeStatus'][] = [
+  'needs_response',
+  'under_review',
+  'won',
+  'lost',
+  'prevented',
+  'early_warning',
+]
+
+interface Props {
+  value: DisputeStatusFilter
+  onChange: (value: DisputeStatusFilter) => void
+}
+
+export const DisputeStatusSelect: React.FC<Props> = ({ value, onChange }) => (
+  <Select
+    value={value}
+    onValueChange={(value) => onChange(value as DisputeStatusFilter)}
+  >
+    <SelectTrigger>
+      <SelectValue placeholder="Select a status" />
+    </SelectTrigger>
+    <SelectContent>
+      <SelectItem value="any">
+        <span className="whitespace-nowrap">Any status</span>
+      </SelectItem>
+      <SelectSeparator />
+      {STATUSES.map((status) => (
+        <SelectItem key={status} value={status}>
+          {DisputeStatusDisplayTitle[status]}
+        </SelectItem>
+      ))}
+    </SelectContent>
+  </Select>
+)

--- a/clients/apps/web/src/hooks/queries/disputes.ts
+++ b/clients/apps/web/src/hooks/queries/disputes.ts
@@ -3,6 +3,15 @@ import { operations, unwrap } from '@polar-sh/client'
 import { useQuery } from '@tanstack/react-query'
 import { defaultRetry } from './retry'
 
+export const useDispute = (id: string) =>
+  useQuery({
+    queryKey: ['disputes', { id }],
+    queryFn: () =>
+      unwrap(api.GET('/v1/disputes/{id}', { params: { path: { id } } })),
+    retry: defaultRetry,
+    enabled: !!id,
+  })
+
 export const useDisputes = (
   organizationId: string,
   parameters?: Omit<
@@ -11,7 +20,7 @@ export const useDisputes = (
   >,
 ) =>
   useQuery({
-    queryKey: ['wallets', { organizationId, parameters }],
+    queryKey: ['disputes', { organizationId, parameters }],
     queryFn: () =>
       unwrap(
         api.GET('/v1/disputes/', {

--- a/clients/apps/web/src/utils/dispute.ts
+++ b/clients/apps/web/src/utils/dispute.ts
@@ -24,3 +24,50 @@ export const DisputeStatusDisplayColor: Record<
   won: 'green',
   lost: 'red',
 }
+
+export type DisputeStatusFilter = schemas['DisputeStatus'] | 'any'
+
+export const isDisputeStatus = (
+  value: string,
+): value is schemas['DisputeStatus'] => value in DisputeStatusDisplayTitle
+
+export const DisputeReasonDisplay: Record<string, string> = {
+  bank_cannot_process: 'Bank cannot process',
+  check_returned: 'Check returned',
+  credit_not_processed: 'Credit not processed',
+  customer_initiated: 'Customer initiated',
+  debit_not_authorized: 'Debit not authorized',
+  duplicate: 'Duplicate',
+  fraudulent: 'Fraudulent',
+  general: 'General',
+  incorrect_account_details: 'Incorrect account details',
+  insufficient_funds: 'Insufficient funds',
+  product_not_received: 'Product not received',
+  product_unacceptable: 'Product unacceptable',
+  subscription_canceled: 'Subscription canceled',
+  unrecognized: 'Unrecognized',
+}
+
+export const getDisputeReasonDisplay = (reason: string | null): string =>
+  reason ? (DisputeReasonDisplay[reason] ?? reason.replace(/_/g, ' ')) : '—'
+
+export const DisputeReasonExplanation: Record<string, string> = {
+  fraudulent:
+    "The cardholder told their bank they didn't authorize this payment.",
+  unrecognized:
+    "The account owner doesn't recognize the payment appearing on their account statement.",
+  duplicate:
+    'The customer says they were charged more than once for the same purchase.',
+  product_not_received:
+    'The customer says they never received the product or service.',
+  product_unacceptable:
+    "The customer says the product or service wasn't as described or was defective.",
+  subscription_canceled:
+    'The customer says they were charged after canceling their subscription.',
+  credit_not_processed:
+    'The customer says a refund they were owed was never processed.',
+}
+
+export const getDisputeReasonExplanation = (reason: string | null): string =>
+  (reason ? DisputeReasonExplanation[reason] : undefined) ??
+  'The customer disputed this payment with their bank.'

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -19447,13 +19447,13 @@ export interface components {
       currency: string
       /**
        * Reason
-       * @description The reason for the dispute as reported by the card network (e.g. `fraudulent`, `product_not_received`). `null` until the processor reports it.
+       * @description The reason for the dispute as reported by the card network (e.g. `fraudulent`, `product_not_received`). `None` until the processor reports it.
        * @example fraudulent
        */
       reason: string | null
       /**
        * Evidence Due By
-       * @description Deadline to submit evidence in response to the dispute. `null` when no response is required.
+       * @description Deadline to submit evidence in response to the dispute. `None` when no response is required.
        */
       evidence_due_by: string | null
       /**
@@ -19489,18 +19489,84 @@ export interface components {
       /**
        * Id
        * Format: uuid4
+       * @description The ID of the customer.
+       * @example 992fae2a-2a17-4b7a-8d9e-e287cf90131b
        */
       id: string
       /**
-       * Email
-       * @description The email of the disputed payment's customer.
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
        */
-      email: string
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      metadata: components['schemas']['MetadataOutputType']
+      /**
+       * External Id
+       * @description The ID of the customer in your system. This must be unique within the organization. Once set, it can't be updated.
+       * @example usr_1337
+       */
+      external_id?: string | null
+      /**
+       * Email
+       * @description The email address of the customer. This must be unique within the organization.
+       * @example customer@example.com
+       */
+      email?: string | null
+      /**
+       * Email Verified
+       * @description Whether the customer email address is verified. The address is automatically verified when the customer accesses the customer portal using their email address.
+       * @example true
+       */
+      email_verified: boolean
+      /**
+       * @description The type of customer: 'individual' for single users, 'team' for customers with multiple members.
+       * @example individual
+       */
+      type: components['schemas']['CustomerType']
       /**
        * Name
-       * @description The name of the disputed payment's customer.
+       * @description The name of the customer.
+       * @example John Doe
        */
       name: string | null
+      /**
+       * Billing Name
+       * @description The name that should appear on the customer's invoices. Falls back to the customer name when not explicitly set.
+       * @example John Doe
+       */
+      billing_name: string | null
+      billing_address: components['schemas']['Address'] | null
+      /** Tax Id */
+      tax_id: [string, components['schemas']['TaxIDFormat']] | null
+      /** Locale */
+      locale?: string | null
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description The ID of the organization owning the customer.
+       * @example 1dbfc517-0bbf-4301-9ba8-555ca42b9737
+       */
+      organization_id: string
+      /**
+       * Default Payment Method Id
+       * @description The ID of the customer's default payment method, if any. Use the payment methods endpoint to retrieve its details.
+       */
+      default_payment_method_id?: string | null
+      /**
+       * Deleted At
+       * @description Timestamp for when the customer was soft deleted.
+       */
+      deleted_at: string | null
+      /**
+       * Avatar Url
+       * @example https://www.gravatar.com/avatar/xxx?d=404
+       */
+      avatar_url: string | null
     }
     /**
      * DisputeSortProperty
@@ -28873,13 +28939,13 @@ export interface components {
       currency: string
       /**
        * Reason
-       * @description The reason for the dispute as reported by the card network (e.g. `fraudulent`, `product_not_received`). `null` until the processor reports it.
+       * @description The reason for the dispute as reported by the card network (e.g. `fraudulent`, `product_not_received`). `None` until the processor reports it.
        * @example fraudulent
        */
       reason: string | null
       /**
        * Evidence Due By
-       * @description Deadline to submit evidence in response to the dispute. `null` when no response is required.
+       * @description Deadline to submit evidence in response to the dispute. `None` when no response is required.
        */
       evidence_due_by: string | null
       /**

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -19446,6 +19446,23 @@ export interface components {
        */
       currency: string
       /**
+       * Reason
+       * @description The reason for the dispute as reported by the card network (e.g. `fraudulent`, `product_not_received`). `null` until the processor reports it.
+       * @example fraudulent
+       */
+      reason: string | null
+      /**
+       * Evidence Due By
+       * @description Deadline to submit evidence in response to the dispute. `null` when no response is required.
+       */
+      evidence_due_by: string | null
+      /**
+       * Past Due
+       * @description Whether the evidence submission deadline has passed.
+       * @example false
+       */
+      past_due: boolean
+      /**
        * Order Id
        * Format: uuid4
        * @description The ID of the order associated with the dispute.
@@ -19459,11 +19476,31 @@ export interface components {
        * @example 42b94870-36b9-4573-96b6-b90b1c99a353
        */
       payment_id: string
+      /** @description The customer who was charged for the disputed payment. */
+      customer: components['schemas']['DisputeCustomer']
       /**
        * Case Id
        * @description The ID of the support case for this dispute, if one was opened.
        */
       case_id: string | null
+    }
+    /** DisputeCustomer */
+    DisputeCustomer: {
+      /**
+       * Id
+       * Format: uuid4
+       */
+      id: string
+      /**
+       * Email
+       * @description The email of the disputed payment's customer.
+       */
+      email: string
+      /**
+       * Name
+       * @description The name of the disputed payment's customer.
+       */
+      name: string | null
     }
     /**
      * DisputeSortProperty
@@ -24960,6 +24997,12 @@ export interface components {
        * @default false
        */
       preview_access_enabled: boolean
+      /**
+       * Disputes Enabled
+       * @description If this organization has the disputes dashboard enabled
+       * @default false
+       */
+      disputes_enabled: boolean
     }
     /**
      * OrganizationFeatureSettingsUpdate
@@ -28828,6 +28871,23 @@ export interface components {
        * @example usd
        */
       currency: string
+      /**
+       * Reason
+       * @description The reason for the dispute as reported by the card network (e.g. `fraudulent`, `product_not_received`). `null` until the processor reports it.
+       * @example fraudulent
+       */
+      reason: string | null
+      /**
+       * Evidence Due By
+       * @description Deadline to submit evidence in response to the dispute. `null` when no response is required.
+       */
+      evidence_due_by: string | null
+      /**
+       * Past Due
+       * @description Whether the evidence submission deadline has passed.
+       * @example false
+       */
+      past_due: boolean
       /**
        * Order Id
        * Format: uuid4

--- a/server/polar/dispute/repository.py
+++ b/server/polar/dispute/repository.py
@@ -13,7 +13,7 @@ from polar.kit.repository import (
     RepositorySortingMixin,
     SortingClause,
 )
-from polar.models import Dispute, Payment
+from polar.models import Dispute, Order, Payment
 from polar.models.dispute import DisputeAlertProcessor
 
 from .sorting import DisputeSortProperty
@@ -87,7 +87,10 @@ class DisputeRepository(
         statement = (
             self.get_base_statement()
             .join(Dispute.payment)
-            .options(contains_eager(Dispute.payment))
+            .options(
+                contains_eager(Dispute.payment),
+                joinedload(Dispute.order).joinedload(Order.customer),
+            )
         )
         statement = statement.where(Payment.organization_id.in_(org_ids))
         return statement

--- a/server/polar/dispute/repository.py
+++ b/server/polar/dispute/repository.py
@@ -1,7 +1,7 @@
 from uuid import UUID
 
 from sqlalchemy import Select
-from sqlalchemy.orm import contains_eager, joinedload
+from sqlalchemy.orm import joinedload
 
 from polar.authz.types import AccessibleOrganizationID
 from polar.enums import PaymentProcessor
@@ -84,21 +84,16 @@ class DisputeRepository(
     def get_statement_by_org_ids(
         self, org_ids: set[AccessibleOrganizationID]
     ) -> Select[tuple[Dispute]]:
-        statement = (
+        return (
             self.get_base_statement()
             .join(Dispute.payment)
-            .options(
-                contains_eager(Dispute.payment),
-                joinedload(Dispute.order).joinedload(Order.customer),
-            )
+            .where(Payment.organization_id.in_(org_ids))
         )
-        statement = statement.where(Payment.organization_id.in_(org_ids))
-        return statement
 
     def get_eager_options(self) -> Options:
         return (
             joinedload(Dispute.payment).joinedload(Payment.organization),
-            joinedload(Dispute.order),
+            joinedload(Dispute.order).joinedload(Order.customer),
         )
 
     def get_sorting_clause(self, property: DisputeSortProperty) -> SortingClause:

--- a/server/polar/dispute/schemas.py
+++ b/server/polar/dispute/schemas.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Annotated
 
 from fastapi import Path
@@ -8,11 +9,23 @@ from polar.kit.schemas import (
     ORDER_ID_EXAMPLE,
     PAYMENT_ID_EXAMPLE,
     IDSchema,
+    Schema,
     TimestampedSchema,
 )
 from polar.models.dispute import DisputeStatus
 
 DisputeID = Annotated[UUID4, Path(description="The dispute ID.")]
+
+
+class DisputeCustomer(Schema):
+    id: UUID4
+    email: Annotated[
+        str, Field(description="The email of the disputed payment's customer.")
+    ]
+    name: Annotated[
+        str | None, Field(description="The name of the disputed payment's customer.")
+    ]
+
 
 DisputeNotFound = {
     "description": "Dispute not found.",
@@ -55,6 +68,33 @@ class DisputeBase(IDSchema, TimestampedSchema):
     currency: Annotated[
         str, Field(description="Currency code of the dispute.", examples=["usd"])
     ]
+    reason: Annotated[
+        str | None,
+        Field(
+            description=(
+                "The reason for the dispute as reported by the card network "
+                "(e.g. `fraudulent`, `product_not_received`). "
+                "`null` until the processor reports it."
+            ),
+            examples=["fraudulent"],
+        ),
+    ]
+    evidence_due_by: Annotated[
+        datetime | None,
+        Field(
+            description=(
+                "Deadline to submit evidence in response to the dispute. "
+                "`null` when no response is required."
+            ),
+        ),
+    ]
+    past_due: Annotated[
+        bool,
+        Field(
+            description="Whether the evidence submission deadline has passed.",
+            examples=[False],
+        ),
+    ]
     order_id: Annotated[
         UUID4,
         Field(
@@ -78,6 +118,10 @@ class Dispute(DisputeBase):
     A dispute is a challenge raised by a customer or their bank regarding a payment.
     """
 
+    customer: Annotated[
+        DisputeCustomer,
+        Field(description="The customer who was charged for the disputed payment."),
+    ]
     case_id: Annotated[
         UUID4 | None,
         Field(

--- a/server/polar/dispute/schemas.py
+++ b/server/polar/dispute/schemas.py
@@ -4,12 +4,12 @@ from typing import Annotated
 from fastapi import Path
 from pydantic import UUID4, Field
 
+from polar.customer.schemas.customer import CustomerBase
 from polar.exceptions import ResourceNotFound
 from polar.kit.schemas import (
     ORDER_ID_EXAMPLE,
     PAYMENT_ID_EXAMPLE,
     IDSchema,
-    Schema,
     TimestampedSchema,
 )
 from polar.models.dispute import DisputeStatus
@@ -17,14 +17,7 @@ from polar.models.dispute import DisputeStatus
 DisputeID = Annotated[UUID4, Path(description="The dispute ID.")]
 
 
-class DisputeCustomer(Schema):
-    id: UUID4
-    email: Annotated[
-        str, Field(description="The email of the disputed payment's customer.")
-    ]
-    name: Annotated[
-        str | None, Field(description="The name of the disputed payment's customer.")
-    ]
+class DisputeCustomer(CustomerBase): ...
 
 
 DisputeNotFound = {
@@ -74,7 +67,7 @@ class DisputeBase(IDSchema, TimestampedSchema):
             description=(
                 "The reason for the dispute as reported by the card network "
                 "(e.g. `fraudulent`, `product_not_received`). "
-                "`null` until the processor reports it."
+                "`None` until the processor reports it."
             ),
             examples=["fraudulent"],
         ),
@@ -84,7 +77,7 @@ class DisputeBase(IDSchema, TimestampedSchema):
         Field(
             description=(
                 "Deadline to submit evidence in response to the dispute. "
-                "`null` when no response is required."
+                "`None` when no response is required."
             ),
         ),
     ]

--- a/server/polar/dispute/service.py
+++ b/server/polar/dispute/service.py
@@ -70,7 +70,9 @@ class DisputeService:
         org_ids = await get_accessible_org_ids(
             session, auth_subject, permission=OrganizationPermission.sales_read
         )
-        statement = repository.get_statement_by_org_ids(org_ids)
+        statement = repository.get_statement_by_org_ids(org_ids).options(
+            *repository.get_eager_options()
+        )
 
         if organization_id is not None:
             statement = statement.where(Payment.organization_id.in_(organization_id))
@@ -97,7 +99,11 @@ class DisputeService:
         org_ids = await get_accessible_org_ids(
             session, auth_subject, permission=OrganizationPermission.sales_read
         )
-        statement = repository.get_statement_by_org_ids(org_ids).where(Dispute.id == id)
+        statement = (
+            repository.get_statement_by_org_ids(org_ids)
+            .options(*repository.get_eager_options())
+            .where(Dispute.id == id)
+        )
         return await repository.get_one_or_none(statement)
 
     async def upsert_from_stripe(

--- a/server/polar/models/dispute.py
+++ b/server/polar/models/dispute.py
@@ -29,7 +29,7 @@ from polar.kit.db.models import RecordModel
 from polar.kit.extensions.sqlalchemy.types import StringEnum
 
 if TYPE_CHECKING:
-    from polar.models import Order, Payment
+    from polar.models import Customer, Order, Payment
 
 
 class DisputeStatus(StrEnum):
@@ -147,6 +147,10 @@ class Dispute(RecordModel):
             .correlate_except(DisputeSupportCase)
             .scalar_subquery()
         )
+
+    @property
+    def customer(self) -> "Customer":
+        return self.order.customer
 
     @hybrid_property
     def resolved(self) -> bool:

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -174,6 +174,10 @@ class OrganizationFeatureSettings(Schema):
         False,
         description="If this organization has preview access to new features enabled",
     )
+    disputes_enabled: bool = Field(
+        False,
+        description="If this organization has the disputes dashboard enabled",
+    )
 
 
 class OrganizationFeatureSettingsUpdate(Schema):

--- a/server/tests/dispute/test_endpoints.py
+++ b/server/tests/dispute/test_endpoints.py
@@ -33,6 +33,17 @@ async def dispute_organization_second(
     return await create_dispute(save_fixture, order, payment)
 
 
+@pytest_asyncio.fixture
+async def dispute(
+    save_fixture: SaveFixture,
+    product: Product,
+    customer: Customer,
+) -> Dispute:
+    order = await create_order(save_fixture, product=product, customer=customer)
+    payment = await create_payment(save_fixture, customer.organization, order=order)
+    return await create_dispute(save_fixture, order, payment)
+
+
 @pytest.mark.asyncio
 class TestListDisputes:
     async def test_anonymous(self, client: AsyncClient) -> None:
@@ -52,6 +63,24 @@ class TestListDisputes:
         assert response.status_code == 200
         json = response.json()
         assert json["pagination"]["total_count"] == 0
+
+    @pytest.mark.auth
+    async def test_user_sees_own_dispute_with_customer(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        dispute: Dispute,
+        customer: Customer,
+    ) -> None:
+        response = await client.get("/v1/disputes/")
+
+        assert response.status_code == 200
+        json = response.json()
+        assert json["pagination"]["total_count"] == 1
+        item = json["items"][0]
+        assert item["id"] == str(dispute.id)
+        assert item["customer"]["id"] == str(customer.id)
+        assert item["customer"]["email"] == customer.email
 
 
 @pytest.mark.asyncio
@@ -107,3 +136,19 @@ class TestGetDispute:
 
         assert response.status_code == 200
         assert response.json()["case_id"] is None
+
+    @pytest.mark.auth
+    async def test_user_gets_own_dispute_with_customer(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        dispute: Dispute,
+        customer: Customer,
+    ) -> None:
+        response = await client.get(f"/v1/disputes/{dispute.id}")
+
+        assert response.status_code == 200
+        json = response.json()
+        assert json["id"] == str(dispute.id)
+        assert json["customer"]["id"] == str(customer.id)
+        assert json["customer"]["email"] == customer.email


### PR DESCRIPTION
## Summary

This PR will add a new dashboard page where the merchant can see all their disputes, and also detail about the dispute. There's no current functionality to actually accept/counter a dispute, that will be added in follow up PR's.

**The functionality is not yet done**, so to keep the PR size down I've hidden it behind the `disputes_enabled` flag

## Screenshots

| List view | Details view  |
|--------|--------|
| <img width="1840" height="1133" alt="Screenshot 2026-06-26 at 12 50 05" src="https://github.com/user-attachments/assets/f1473fc1-14af-406f-80cb-db90f03a8c63" /> | <img width="1840" height="1133" alt="Screenshot 2026-06-26 at 12 50 07" src="https://github.com/user-attachments/assets/0b4fe0c8-c75f-4267-ba02-ec81e372f4d2" /> |






<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

