### PR TITLE
tf/aws: Allow the organization to configure accounts

### DIFF
--- a/terraform/organization/main.tf
+++ b/terraform/organization/main.tf
@@ -9,7 +9,7 @@ provider "aws" {
 
 resource "aws_organizations_organization" "current" {
   feature_set                   = "ALL"
-  aws_service_access_principals = ["sso.amazonaws.com"]
+  aws_service_access_principals = ["account.amazonaws.com", "sso.amazonaws.com"]
   enabled_policy_types          = ["SERVICE_CONTROL_POLICY"]
 
   lifecycle {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable trusted access for AWS Account Management by adding `account.amazonaws.com` to `aws_service_access_principals` in the Organizations Terraform. This lets the org configure member accounts alongside `sso.amazonaws.com`.

<sup>Written for commit 0fd3dfe9d2e1106544f4b4c98631a48da7328931. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

