### PR TITLE
tf/aws: Give SSOSync capabilities needed

### DIFF
--- a/terraform/identity/ssosync.tf
+++ b/terraform/identity/ssosync.tf
@@ -36,6 +36,7 @@ resource "aws_serverlessapplicationrepository_cloudformation_stack" "ssosync" {
     "CAPABILITY_IAM",
     "CAPABILITY_NAMED_IAM",
     "CAPABILITY_AUTO_EXPAND",
+    "CAPABILITY_RESOURCE_POLICY",
   ]
 
   parameters = {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add CloudFormation CAPABILITY_RESOURCE_POLICY to the SSOSync `aws_serverlessapplicationrepository_cloudformation_stack` so it can create/update resource policies and deploy successfully. This prevents deployment failures when the app needs to set a resource policy.

<sup>Written for commit 7aeaacfae064ccc72c0e64de3f33fd61f662baa0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

