### PR TITLE
 tf/aws: Set values forrectly for SAR CF 

### DIFF
--- a/terraform/identity/ssosync.tf
+++ b/terraform/identity/ssosync.tf
@@ -27,6 +27,33 @@ resource "aws_secretsmanager_secret_version" "scim_access_token" {
   secret_string = var.ssosync_scim_access_token
 }
 
+resource "aws_secretsmanager_secret" "google_admin_email" {
+  name = "SSOSyncGoogleAdminEmail"
+}
+
+resource "aws_secretsmanager_secret_version" "google_admin_email" {
+  secret_id     = aws_secretsmanager_secret.google_admin_email.id
+  secret_string = var.ssosync_google_admin_email
+}
+
+resource "aws_secretsmanager_secret" "scim_endpoint" {
+  name = "SSOSyncSCIMEndpointUrl"
+}
+
+resource "aws_secretsmanager_secret_version" "scim_endpoint" {
+  secret_id     = aws_secretsmanager_secret.scim_endpoint.id
+  secret_string = var.ssosync_scim_endpoint
+}
+
+resource "aws_secretsmanager_secret" "google_customer_id" {
+  name = "SSOSyncGoogleCustomerId"
+}
+
+resource "aws_secretsmanager_secret_version" "google_customer_id" {
+  secret_id     = aws_secretsmanager_secret.google_customer_id.id
+  secret_string = "my_customer"
+}
+
 resource "aws_serverlessapplicationrepository_cloudformation_stack" "ssosync" {
   name             = "ssosync"
   application_id   = local.ssosync_application_id
@@ -42,8 +69,9 @@ resource "aws_serverlessapplicationrepository_cloudformation_stack" "ssosync" {
   parameters = {
     DeployPattern           = "App only"
     GoogleCredentials       = aws_secretsmanager_secret.google_credentials.arn
-    GoogleAdminEmail        = var.ssosync_google_admin_email
-    SCIMEndpointUrl         = var.ssosync_scim_endpoint
+    GoogleAdminEmail        = aws_secretsmanager_secret.google_admin_email.arn
+    GoogleCustomerId        = aws_secretsmanager_secret.google_customer_id.arn
+    SCIMEndpointUrl         = aws_secretsmanager_secret.scim_endpoint.arn
     SCIMEndpointAccessToken = aws_secretsmanager_secret.scim_access_token.arn
     SyncMethod              = "groups"
     IncludeGroups           = join(",", local.staff_group_emails)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Move SSOSync config into AWS Secrets Manager and pass secret ARNs to the SAR CloudFormation stack to secure values and fix parameter handling. Enable trusted access for AWS Account Management so the org can configure member accounts.

- **New Features**
  - SSOSync: added secrets for Google admin email, SCIM endpoint URL, and Google customer ID; wired their ARNs into `GoogleAdminEmail`, `GoogleCustomerId`, and `SCIMEndpointUrl`.
  - Organizations: added `account.amazonaws.com` to `aws_service_access_principals` (alongside `sso.amazonaws.com`).

<sup>Written for commit b4de4d99cdadbd87b2d50a4e72e53490c8f4eaa3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

