### PR TITLE
lambda: Add ability to add more lambdas to TF and CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -294,10 +294,12 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
       - name: Update sandbox Lambda function code
         run: |
-          aws lambda update-function-code \
-            --function-name polar-sandbox-worker-dummy \
-            --image-uri "${{ steps.login-ecr.outputs.registry }}/polar-sandbox-lambda-worker:sha-${{ github.sha }}" \
-            --publish
+          for function in polar-sandbox-worker-dummy polar-sandbox-worker-email-send; do
+            aws lambda update-function-code \
+              --function-name "$function" \
+              --image-uri "${{ steps.login-ecr.outputs.registry }}/polar-sandbox-lambda-worker:sha-${{ github.sha }}" \
+              --publish
+          done
 
   # deploy-lambda-production:
   #   name: "Deploy Lambda Worker to Production 🚀"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -294,7 +294,14 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
       - name: Update sandbox Lambda function code
         run: |
-          for function in polar-sandbox-worker-dummy polar-sandbox-worker-email-send; do
+          for function in \
+            polar-sandbox-worker-high-priority \
+            polar-sandbox-worker-medium-priority \
+            polar-sandbox-worker-low-priority \
+            polar-sandbox-worker-webhook \
+            polar-sandbox-worker-tinybird \
+            polar-sandbox-worker-invoices-receipts
+          do
             aws lambda update-function-code \
               --function-name "$function" \
               --image-uri "${{ steps.login-ecr.outputs.registry }}/polar-sandbox-lambda-worker:sha-${{ github.sha }}" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -294,19 +294,10 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
       - name: Update sandbox Lambda function code
         run: |
-          for function in \
-            polar-sandbox-worker-high-priority \
-            polar-sandbox-worker-medium-priority \
-            polar-sandbox-worker-low-priority \
-            polar-sandbox-worker-webhook \
-            polar-sandbox-worker-tinybird \
-            polar-sandbox-worker-invoices-receipts
-          do
-            aws lambda update-function-code \
-              --function-name "$function" \
-              --image-uri "${{ steps.login-ecr.outputs.registry }}/polar-sandbox-lambda-worker:sha-${{ github.sha }}" \
-              --publish
-          done
+          aws lambda update-function-code \
+            --function-name polar-sandbox-worker-default \
+            --image-uri "${{ steps.login-ecr.outputs.registry }}/polar-sandbox-lambda-worker:sha-${{ github.sha }}" \
+            --publish
 
   # deploy-lambda-production:
   #   name: "Deploy Lambda Worker to Production 🚀"

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -325,8 +325,8 @@ class Settings(BaseSettings):
     AWS_SIGNATURE_VERSION: str = "v4"
 
     # Worker SQS/Lambda execution engine (POC)
-    # When enabled, jobs enqueued for an allowlisted actor are routed to a
-    # per-actor SQS queue (consumed by a Lambda) instead of the Redis broker.
+    # When enabled, jobs enqueued for an allowlisted actor are routed to an
+    # SQS queue matching the actor's Dramatiq worker queue instead of Redis.
     WORKER_SQS_ENABLED: bool = False
     WORKER_SQS_ACTORS: set[str] = {"dummy"}
     WORKER_SQS_QUEUE_PREFIX: str = "polar-tasks"

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -326,7 +326,7 @@ class Settings(BaseSettings):
 
     # Worker SQS/Lambda execution engine (POC)
     # When enabled, jobs enqueued for an allowlisted actor are routed to an
-    # SQS queue matching the actor's Dramatiq worker queue instead of Redis.
+    # SQS queue consumed by the Lambda worker instead of Redis.
     WORKER_SQS_ENABLED: bool = False
     WORKER_SQS_ACTORS: set[str] = {"dummy"}
     WORKER_SQS_QUEUE_PREFIX: str = "polar-tasks"

--- a/server/polar/worker/_sqs.py
+++ b/server/polar/worker/_sqs.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
 import boto3
-import dramatiq
 import structlog
 from botocore.config import Config
 
@@ -56,14 +55,8 @@ def get_sqs_client() -> "SQSClient":
     )
 
 
-def worker_queue_to_sqs_queue_name(worker_queue_name: str) -> str:
-    sanitized = worker_queue_name.replace(".", "-")
-    return f"{settings.WORKER_SQS_QUEUE_PREFIX}-{sanitized}"
-
-
-def actor_to_queue_name(actor_name: str) -> str:
-    actor = dramatiq.get_broker().get_actor(actor_name)
-    return worker_queue_to_sqs_queue_name(actor.queue_name)
+def actor_to_queue_name(_actor_name: str) -> str:
+    return f"{settings.WORKER_SQS_QUEUE_PREFIX}-default"
 
 
 _queue_url_cache: dict[str, str] = {}
@@ -149,5 +142,4 @@ __all__ = [
     "get_sqs_client",
     "parse_envelope",
     "send_jobs",
-    "worker_queue_to_sqs_queue_name",
 ]

--- a/server/polar/worker/_sqs.py
+++ b/server/polar/worker/_sqs.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Any
 
 import boto3
+import dramatiq
 import structlog
 from botocore.config import Config
 
@@ -55,9 +56,14 @@ def get_sqs_client() -> "SQSClient":
     )
 
 
-def actor_to_queue_name(actor_name: str) -> str:
-    sanitized = actor_name.replace(".", "-").replace("_", "-")
+def worker_queue_to_sqs_queue_name(worker_queue_name: str) -> str:
+    sanitized = worker_queue_name.replace(".", "-")
     return f"{settings.WORKER_SQS_QUEUE_PREFIX}-{sanitized}"
+
+
+def actor_to_queue_name(actor_name: str) -> str:
+    actor = dramatiq.get_broker().get_actor(actor_name)
+    return worker_queue_to_sqs_queue_name(actor.queue_name)
 
 
 _queue_url_cache: dict[str, str] = {}
@@ -143,4 +149,5 @@ __all__ = [
     "get_sqs_client",
     "parse_envelope",
     "send_jobs",
+    "worker_queue_to_sqs_queue_name",
 ]

--- a/server/polar/worker/sqs.py
+++ b/server/polar/worker/sqs.py
@@ -33,12 +33,15 @@ def run(actor: str, body: str = typer.Argument("{}")) -> None:
 
 async def _poll_loop(actors: list[str], max_iterations: int) -> None:
     client = get_sqs_client()
-    queue_urls = {a: get_queue_url(client, actor_to_queue_name(a)) for a in actors}
+    queue_names = {actor_to_queue_name(actor) for actor in actors}
+    queue_urls = {
+        queue_name: get_queue_url(client, queue_name) for queue_name in queue_names
+    }
     iterations = 0
     try:
         while max_iterations == 0 or iterations < max_iterations:
             iterations += 1
-            for actor_name, url in queue_urls.items():
+            for url in queue_urls.values():
                 response = await asyncio.to_thread(
                     client.receive_message,
                     QueueUrl=url,

--- a/server/tests/worker/test_enqueue_gate.py
+++ b/server/tests/worker/test_enqueue_gate.py
@@ -9,6 +9,16 @@ from polar.config import settings
 from polar.logging import CorrelationID
 from polar.redis import Redis
 from polar.worker import JobQueueManager
+from polar.worker._sqs import actor_to_queue_name
+
+
+def test_actor_to_queue_name_uses_worker_queue(mocker: MockerFixture) -> None:
+    mocker.patch.object(settings, "WORKER_SQS_QUEUE_PREFIX", "polar-test-tasks")
+
+    assert actor_to_queue_name("customer.state_changed") == (
+        "polar-test-tasks-high_priority"
+    )
+    assert actor_to_queue_name("dummy") == "polar-test-tasks-low_priority"
 
 
 @pytest.mark.asyncio
@@ -26,7 +36,7 @@ class TestFlushGate:
         send_jobs.assert_not_called()
         assert await redis.llen("dramatiq:high_priority") == 1
 
-    async def test_allowlisted_actor_routes_to_sqs(
+    async def test_allowlisted_actor_routes_to_worker_queue_sqs(
         self, redis: Redis, mocker: MockerFixture
     ) -> None:
         mocker.patch.object(settings, "WORKER_SQS_ENABLED", True)

--- a/server/tests/worker/test_enqueue_gate.py
+++ b/server/tests/worker/test_enqueue_gate.py
@@ -12,13 +12,11 @@ from polar.worker import JobQueueManager
 from polar.worker._sqs import actor_to_queue_name
 
 
-def test_actor_to_queue_name_uses_worker_queue(mocker: MockerFixture) -> None:
+def test_actor_to_queue_name_uses_single_worker_queue(mocker: MockerFixture) -> None:
     mocker.patch.object(settings, "WORKER_SQS_QUEUE_PREFIX", "polar-test-tasks")
 
-    assert actor_to_queue_name("customer.state_changed") == (
-        "polar-test-tasks-high_priority"
-    )
-    assert actor_to_queue_name("dummy") == "polar-test-tasks-low_priority"
+    assert actor_to_queue_name("customer.state_changed") == "polar-test-tasks-default"
+    assert actor_to_queue_name("dummy") == "polar-test-tasks-default"
 
 
 @pytest.mark.asyncio
@@ -36,7 +34,7 @@ class TestFlushGate:
         send_jobs.assert_not_called()
         assert await redis.llen("dramatiq:high_priority") == 1
 
-    async def test_allowlisted_actor_routes_to_worker_queue_sqs(
+    async def test_allowlisted_actor_routes_to_sqs(
         self, redis: Redis, mocker: MockerFixture
     ) -> None:
         mocker.patch.object(settings, "WORKER_SQS_ENABLED", True)

--- a/terraform/modules/aws_task_worker/outputs.tf
+++ b/terraform/modules/aws_task_worker/outputs.tf
@@ -1,10 +1,10 @@
 output "queue_url" {
-  description = "Task SQS queue URL."
+  description = "Worker profile SQS queue URL."
   value       = aws_sqs_queue.task.url
 }
 
 output "queue_arn" {
-  description = "Task SQS queue ARN."
+  description = "Worker profile SQS queue ARN."
   value       = aws_sqs_queue.task.arn
 }
 

--- a/terraform/modules/aws_task_worker/variables.tf
+++ b/terraform/modules/aws_task_worker/variables.tf
@@ -9,7 +9,7 @@ variable "environment" {
 }
 
 variable "name" {
-  description = "Short task name used in the Lambda function name: polar-{environment}-worker-{name}."
+  description = "Short worker profile name used in the Lambda function name: polar-{environment}-worker-{name}."
   type        = string
 
   validation {
@@ -24,12 +24,12 @@ variable "name" {
 }
 
 variable "queue_name" {
-  description = "Full task SQS queue name. The producer addresses this queue by name, so the caller must match it."
+  description = "Full worker profile SQS queue name. The producer addresses this queue by name, so the caller must match it."
   type        = string
 }
 
 variable "image_uri" {
-  description = "Container image URI the task Lambda runs."
+  description = "Container image URI the worker Lambda runs."
   type        = string
 }
 

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -24,15 +24,27 @@ resource "aws_vpc_security_group_ingress_rule" "redis_lambda" {
   ip_protocol                  = "tcp"
 }
 
-module "dummy_lambda_worker" {
-  source = "../modules/aws_task_worker"
+locals {
+  lambda_workers = {
+    dummy = {
+      reserved_concurrency = null
+    }
+    "email-send" = {
+      reserved_concurrency = null
+    }
+  }
+}
+
+module "lambda_worker" {
+  source   = "../modules/aws_task_worker"
+  for_each = local.lambda_workers
 
   environment              = "sandbox"
-  name                     = "dummy"
-  queue_name               = "polar-sandbox-tasks-dummy"
+  name                     = each.key
+  queue_name               = "polar-sandbox-tasks-${each.key}"
   image_uri                = "${module.lambda_worker_ecr.repository_url}:latest"
   enabled                  = true
-  reserved_concurrency     = null
+  reserved_concurrency     = each.value.reserved_concurrency
   subnet_ids               = local.lambda_subnet_ids
   security_group_ids       = local.lambda_security_group_ids
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
@@ -69,6 +81,11 @@ module "dummy_lambda_worker" {
   }
 }
 
+moved {
+  from = module.dummy_lambda_worker
+  to   = module.lambda_worker["dummy"]
+}
+
 # =============================================================================
 # Task producer IAM user (SQS send-only, used by the Render backend)
 # =============================================================================
@@ -88,7 +105,7 @@ data "aws_iam_policy_document" "tasks_producer" {
       "sqs:SendMessage",
       "sqs:GetQueueUrl",
     ]
-    resources = [module.dummy_lambda_worker.queue_arn]
+    resources = [for worker in module.lambda_worker : worker.queue_arn]
   }
 }
 
@@ -126,9 +143,12 @@ data "aws_iam_policy_document" "lambda_worker_deploy" {
   }
 
   statement {
-    sid       = "UpdateFunctionCode"
-    actions   = ["lambda:UpdateFunctionCode"]
-    resources = ["arn:aws:lambda:us-east-2:${data.aws_caller_identity.current.account_id}:function:${module.dummy_lambda_worker.function_name}"]
+    sid     = "UpdateFunctionCode"
+    actions = ["lambda:UpdateFunctionCode"]
+    resources = [
+      for worker in module.lambda_worker :
+      "arn:aws:lambda:us-east-2:${data.aws_caller_identity.current.account_id}:function:${worker.function_name}"
+    ]
   }
 }
 

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -42,6 +42,9 @@ locals {
     POLAR_REDIS_PORT              = tostring(module.redis.port)
     POLAR_REDIS_DB                = "1"
     POLAR_AWS_REGION              = "us-east-2"
+    POLAR_EMAIL_SENDER            = "resend"
+    POLAR_EMAIL_FROM_NAME         = "[SANDBOX] Polar"
+    POLAR_EMAIL_FROM_DOMAIN       = "notifications.sandbox.polar.sh"
     POLAR_WORKER_SQS_ENABLED      = "true"
     POLAR_WORKER_SQS_QUEUE_PREFIX = "polar-sandbox-tasks"
   }
@@ -51,27 +54,36 @@ locals {
     POLAR_JWKS_CONTENT    = var.backend_jwks_sandbox
     POLAR_LOGFIRE_TOKEN   = var.logfire_token
     POLAR_POSTGRES_PWD    = local.db_password
+    POLAR_RESEND_API_KEY  = var.backend_resend_api_key_sandbox
     POLAR_SECRET          = var.backend_secret_sandbox
     POLAR_SENTRY_DSN      = var.backend_sentry_dsn_sandbox
     TAILSCALE_AUTHKEY     = var.lambda_worker_tailscale_token
   }
 
   lambda_workers = {
-    dummy = {
-      reserved_concurrency         = null
-      environment_variables        = {}
-      secret_environment_variables = {}
-    }
-    "email-send" = {
+    "high-priority" = {
+      queue_name           = "high_priority"
       reserved_concurrency = null
-      environment_variables = {
-        POLAR_EMAIL_SENDER      = "resend"
-        POLAR_EMAIL_FROM_NAME   = "[SANDBOX] Polar"
-        POLAR_EMAIL_FROM_DOMAIN = "notifications.sandbox.polar.sh"
-      }
-      secret_environment_variables = {
-        POLAR_RESEND_API_KEY = var.backend_resend_api_key_sandbox
-      }
+    }
+    "medium-priority" = {
+      queue_name           = "medium_priority"
+      reserved_concurrency = null
+    }
+    "low-priority" = {
+      queue_name           = "low_priority"
+      reserved_concurrency = null
+    }
+    webhook = {
+      queue_name           = "webhooks"
+      reserved_concurrency = null
+    }
+    tinybird = {
+      queue_name           = "tinybird"
+      reserved_concurrency = null
+    }
+    "invoices-receipts" = {
+      queue_name           = "invoices_and_receipts"
+      reserved_concurrency = null
     }
   }
 }
@@ -82,7 +94,7 @@ module "lambda_worker" {
 
   environment              = "sandbox"
   name                     = each.key
-  queue_name               = "polar-sandbox-tasks-${each.key}"
+  queue_name               = "polar-sandbox-tasks-${each.value.queue_name}"
   image_uri                = "${module.lambda_worker_ecr.repository_url}:latest"
   enabled                  = true
   reserved_concurrency     = each.value.reserved_concurrency
@@ -90,13 +102,13 @@ module "lambda_worker" {
   security_group_ids       = local.lambda_security_group_ids
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
 
-  environment_variables        = merge(local.lambda_worker_environment, each.value.environment_variables)
-  secret_environment_variables = merge(local.lambda_worker_secrets, each.value.secret_environment_variables)
+  environment_variables        = local.lambda_worker_environment
+  secret_environment_variables = local.lambda_worker_secrets
 }
 
 moved {
   from = module.dummy_lambda_worker
-  to   = module.lambda_worker["dummy"]
+  to   = module.lambda_worker["low-priority"]
 }
 
 # =============================================================================

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -60,44 +60,19 @@ locals {
     TAILSCALE_AUTHKEY     = var.lambda_worker_tailscale_token
   }
 
-  lambda_workers = {
-    "high-priority" = {
-      queue_name           = "high_priority"
-      reserved_concurrency = null
-    }
-    "medium-priority" = {
-      queue_name           = "medium_priority"
-      reserved_concurrency = null
-    }
-    "low-priority" = {
-      queue_name           = "low_priority"
-      reserved_concurrency = null
-    }
-    webhook = {
-      queue_name           = "webhooks"
-      reserved_concurrency = null
-    }
-    tinybird = {
-      queue_name           = "tinybird"
-      reserved_concurrency = null
-    }
-    "invoices-receipts" = {
-      queue_name           = "invoices_and_receipts"
-      reserved_concurrency = null
-    }
-  }
+  lambda_worker_name                 = "default"
+  lambda_worker_reserved_concurrency = null
 }
 
 module "lambda_worker" {
-  source   = "../modules/aws_task_worker"
-  for_each = local.lambda_workers
+  source = "../modules/aws_task_worker"
 
   environment              = "sandbox"
-  name                     = each.key
-  queue_name               = "polar-sandbox-tasks-${each.value.queue_name}"
+  name                     = local.lambda_worker_name
+  queue_name               = "polar-sandbox-tasks-${local.lambda_worker_name}"
   image_uri                = "${module.lambda_worker_ecr.repository_url}:latest"
   enabled                  = true
-  reserved_concurrency     = each.value.reserved_concurrency
+  reserved_concurrency     = local.lambda_worker_reserved_concurrency
   subnet_ids               = local.lambda_subnet_ids
   security_group_ids       = local.lambda_security_group_ids
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
@@ -109,6 +84,11 @@ module "lambda_worker" {
 moved {
   from = module.dummy_lambda_worker
   to   = module.lambda_worker["low-priority"]
+}
+
+moved {
+  from = module.lambda_worker["low-priority"]
+  to   = module.lambda_worker
 }
 
 # =============================================================================
@@ -130,7 +110,7 @@ data "aws_iam_policy_document" "tasks_producer" {
       "sqs:SendMessage",
       "sqs:GetQueueUrl",
     ]
-    resources = [for worker in module.lambda_worker : worker.queue_arn]
+    resources = [module.lambda_worker.queue_arn]
   }
 }
 
@@ -168,12 +148,9 @@ data "aws_iam_policy_document" "lambda_worker_deploy" {
   }
 
   statement {
-    sid     = "UpdateFunctionCode"
-    actions = ["lambda:UpdateFunctionCode"]
-    resources = [
-      for worker in module.lambda_worker :
-      "arn:aws:lambda:us-east-2:${data.aws_caller_identity.current.account_id}:function:${worker.function_name}"
-    ]
+    sid       = "UpdateFunctionCode"
+    actions   = ["lambda:UpdateFunctionCode"]
+    resources = ["arn:aws:lambda:us-east-2:${data.aws_caller_identity.current.account_id}:function:${module.lambda_worker.function_name}"]
   }
 }
 

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -25,31 +25,7 @@ resource "aws_vpc_security_group_ingress_rule" "redis_lambda" {
 }
 
 locals {
-  lambda_workers = {
-    dummy = {
-      reserved_concurrency = null
-    }
-    "email-send" = {
-      reserved_concurrency = null
-    }
-  }
-}
-
-module "lambda_worker" {
-  source   = "../modules/aws_task_worker"
-  for_each = local.lambda_workers
-
-  environment              = "sandbox"
-  name                     = each.key
-  queue_name               = "polar-sandbox-tasks-${each.key}"
-  image_uri                = "${module.lambda_worker_ecr.repository_url}:latest"
-  enabled                  = true
-  reserved_concurrency     = each.value.reserved_concurrency
-  subnet_ids               = local.lambda_subnet_ids
-  security_group_ids       = local.lambda_security_group_ids
-  permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
-
-  environment_variables = {
+  lambda_worker_environment = {
     POLAR_ENV                     = "sandbox"
     POLAR_BASE_URL                = "https://sandbox-api.polar.sh"
     POLAR_FRONTEND_BASE_URL       = "https://sandbox.polar.sh"
@@ -70,7 +46,7 @@ module "lambda_worker" {
     POLAR_WORKER_SQS_QUEUE_PREFIX = "polar-sandbox-tasks"
   }
 
-  secret_environment_variables = {
+  lambda_worker_secrets = {
     POLAR_CURRENT_JWK_KID = var.backend_current_jwk_kid_sandbox
     POLAR_JWKS_CONTENT    = var.backend_jwks_sandbox
     POLAR_LOGFIRE_TOKEN   = var.logfire_token
@@ -79,6 +55,43 @@ module "lambda_worker" {
     POLAR_SENTRY_DSN      = var.backend_sentry_dsn_sandbox
     TAILSCALE_AUTHKEY     = var.lambda_worker_tailscale_token
   }
+
+  lambda_workers = {
+    dummy = {
+      reserved_concurrency         = null
+      environment_variables        = {}
+      secret_environment_variables = {}
+    }
+    "email-send" = {
+      reserved_concurrency = null
+      environment_variables = {
+        POLAR_EMAIL_SENDER      = "resend"
+        POLAR_EMAIL_FROM_NAME   = "[SANDBOX] Polar"
+        POLAR_EMAIL_FROM_DOMAIN = "notifications.sandbox.polar.sh"
+      }
+      secret_environment_variables = {
+        POLAR_RESEND_API_KEY = var.backend_resend_api_key_sandbox
+      }
+    }
+  }
+}
+
+module "lambda_worker" {
+  source   = "../modules/aws_task_worker"
+  for_each = local.lambda_workers
+
+  environment              = "sandbox"
+  name                     = each.key
+  queue_name               = "polar-sandbox-tasks-${each.key}"
+  image_uri                = "${module.lambda_worker_ecr.repository_url}:latest"
+  enabled                  = true
+  reserved_concurrency     = each.value.reserved_concurrency
+  subnet_ids               = local.lambda_subnet_ids
+  security_group_ids       = local.lambda_security_group_ids
+  permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
+
+  environment_variables        = merge(local.lambda_worker_environment, each.value.environment_variables)
+  secret_environment_variables = merge(local.lambda_worker_secrets, each.value.secret_environment_variables)
 }
 
 moved {

--- a/terraform/sandbox/outputs.tf
+++ b/terraform/sandbox/outputs.tf
@@ -3,14 +3,14 @@ output "lambda_worker_ecr_repository_url" {
   value       = module.lambda_worker_ecr.repository_url
 }
 
-output "lambda_worker_function_names" {
-  description = "Sandbox Lambda worker function names, keyed by worker."
-  value       = { for key, worker in module.lambda_worker : key => worker.function_name }
+output "lambda_worker_function_name" {
+  description = "Sandbox Lambda worker function name."
+  value       = module.lambda_worker.function_name
 }
 
-output "lambda_worker_queue_urls" {
-  description = "Sandbox Lambda worker SQS queue URLs, keyed by worker."
-  value       = { for key, worker in module.lambda_worker : key => worker.queue_url }
+output "lambda_worker_queue_url" {
+  description = "Sandbox Lambda worker SQS queue URL."
+  value       = module.lambda_worker.queue_url
 }
 
 output "egress_ip" {

--- a/terraform/sandbox/outputs.tf
+++ b/terraform/sandbox/outputs.tf
@@ -3,14 +3,14 @@ output "lambda_worker_ecr_repository_url" {
   value       = module.lambda_worker_ecr.repository_url
 }
 
-output "dummy_lambda_worker_function_name" {
-  description = "Sandbox dummy Lambda worker function name."
-  value       = module.dummy_lambda_worker.function_name
+output "lambda_worker_function_names" {
+  description = "Sandbox Lambda worker function names, keyed by worker."
+  value       = { for key, worker in module.lambda_worker : key => worker.function_name }
 }
 
-output "dummy_lambda_worker_queue_url" {
-  description = "Sandbox dummy Lambda worker SQS queue URL."
-  value       = module.dummy_lambda_worker.queue_url
+output "lambda_worker_queue_urls" {
+  description = "Sandbox Lambda worker SQS queue URLs, keyed by worker."
+  value       = { for key, worker in module.lambda_worker : key => worker.queue_url }
 }
 
 output "egress_ip" {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch sandbox to a single Lambda worker with one SQS queue (`*-default`). All allowlisted `dramatiq` actors now route to this queue; Terraform and CI target this one worker.

- **New Features**
  - Route all allowed actors to `polar-<env>-tasks-default`; added test to confirm mapping.
  - Terraform defines one worker named `default`; shared env/secrets locals; added Resend email config.
  - CI deploys `polar-sandbox-worker-default`.

- **Migration**
  - Terraform: replace `module "dummy_lambda_worker"` with `module "lambda_worker"` (name `default`); state moved via `moved` blocks.
  - Outputs renamed to singular: use `lambda_worker_function_name` and `lambda_worker_queue_url`.
  - IAM policies updated to reference `module.lambda_worker.*`.

<sup>Written for commit dd917797934e0f0161d12d00bd9391ea29d50679. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

