### PR TITLE
feat(polar-self): add failure-path subscription emails (past due, revoked, canceled)

### DIFF
--- a/server/emails/src/emails/index.ts
+++ b/server/emails/src/emails/index.ts
@@ -18,6 +18,8 @@ import { PersonalAccessTokenLeaked } from './personal_access_token_leaked'
 import { PolarSelfStartupProgramWelcome } from './polar_self_startup_program_welcome'
 import { PolarSelfSubscriptionConfirmation } from './polar_self_subscription_confirmation'
 import { PolarSelfSubscriptionCycled } from './polar_self_subscription_cycled'
+import { PolarSelfSubscriptionPastDue } from './polar_self_subscription_past_due'
+import { PolarSelfSubscriptionRevoked } from './polar_self_subscription_revoked'
 import { SeatInvitation } from './seat_invitation'
 import { SubscriptionCancellation } from './subscription_cancellation'
 import { SubscriptionConfirmation } from './subscription_confirmation'
@@ -67,6 +69,8 @@ const TEMPLATES: Record<string, React.FC<never>> = {
   chargeback_prevention_refund: ChargebackPreventionRefund,
   polar_self_subscription_confirmation: PolarSelfSubscriptionConfirmation,
   polar_self_subscription_cycled: PolarSelfSubscriptionCycled,
+  polar_self_subscription_past_due: PolarSelfSubscriptionPastDue,
+  polar_self_subscription_revoked: PolarSelfSubscriptionRevoked,
   polar_self_startup_program_welcome: PolarSelfStartupProgramWelcome,
 }
 

--- a/server/emails/src/emails/index.ts
+++ b/server/emails/src/emails/index.ts
@@ -16,6 +16,7 @@ import { OrganizationInvite } from './organization_invite'
 import { OrganizationOffboarded } from './organization_offboarded'
 import { PersonalAccessTokenLeaked } from './personal_access_token_leaked'
 import { PolarSelfStartupProgramWelcome } from './polar_self_startup_program_welcome'
+import { PolarSelfSubscriptionCancellation } from './polar_self_subscription_cancellation'
 import { PolarSelfSubscriptionConfirmation } from './polar_self_subscription_confirmation'
 import { PolarSelfSubscriptionCycled } from './polar_self_subscription_cycled'
 import { PolarSelfSubscriptionPastDue } from './polar_self_subscription_past_due'
@@ -67,6 +68,7 @@ const TEMPLATES: Record<string, React.FC<never>> = {
   notification_new_subscription: NotificationNewSubscription,
   notification_credits_granted: NotificationCreditsGranted,
   chargeback_prevention_refund: ChargebackPreventionRefund,
+  polar_self_subscription_cancellation: PolarSelfSubscriptionCancellation,
   polar_self_subscription_confirmation: PolarSelfSubscriptionConfirmation,
   polar_self_subscription_cycled: PolarSelfSubscriptionCycled,
   polar_self_subscription_past_due: PolarSelfSubscriptionPastDue,

--- a/server/emails/src/emails/polar_self_subscription_cancellation.tsx
+++ b/server/emails/src/emails/polar_self_subscription_cancellation.tsx
@@ -1,0 +1,46 @@
+import { Footer, Intro, Text, WrapperPolar } from '../components/foundation'
+import type { schemas } from '../types'
+
+export function PolarSelfSubscriptionCancellation({
+  email,
+  product_name,
+  ends_at,
+}: schemas['PolarSelfSubscriptionCancellationProps']) {
+  const endDate = ends_at
+    ? new Date(ends_at).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      })
+    : null
+
+  return (
+    <WrapperPolar
+      preview={`Your ${product_name} subscription has been canceled`}
+    >
+      <Intro headline="Your subscription has been canceled">
+        Your{' '}
+        <Text as="span" weight="medium">
+          {product_name}
+        </Text>{' '}
+        subscription has been canceled.{' '}
+        {endDate
+          ? `You'll keep full access until ${endDate}.`
+          : "You'll keep full access until the end of your current billing period."}
+      </Intro>
+      <Text>
+        If you change your mind, you can resubscribe anytime from your billing
+        settings.
+      </Text>
+      <Footer email={email} />
+    </WrapperPolar>
+  )
+}
+
+PolarSelfSubscriptionCancellation.PreviewProps = {
+  email: 'john@example.com',
+  product_name: 'Polar Pro',
+  ends_at: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+} satisfies schemas['PolarSelfSubscriptionCancellationProps']
+
+export default PolarSelfSubscriptionCancellation

--- a/server/emails/src/emails/polar_self_subscription_past_due.tsx
+++ b/server/emails/src/emails/polar_self_subscription_past_due.tsx
@@ -1,0 +1,34 @@
+import { Footer, Intro, Text, WrapperPolar } from '../components/foundation'
+import type { schemas } from '../types'
+
+export function PolarSelfSubscriptionPastDue({
+  email,
+  product_name,
+}: schemas['PolarSelfSubscriptionPastDueProps']) {
+  return (
+    <WrapperPolar
+      preview={`Action needed: we couldn't process your payment for ${product_name}`}
+    >
+      <Intro headline="We couldn&rsquo;t process your payment">
+        We tried to charge your payment method for your{' '}
+        <Text as="span" weight="medium">
+          {product_name}
+        </Text>{' '}
+        subscription, but it didn&rsquo;t go through. This can happen for a
+        number of reasons, like an expired card or a temporary bank hold.
+      </Intro>
+      <Text>
+        Please update your payment method in your billing settings to keep your
+        subscription active. We&rsquo;ll automatically retry the payment.
+      </Text>
+      <Footer email={email} />
+    </WrapperPolar>
+  )
+}
+
+PolarSelfSubscriptionPastDue.PreviewProps = {
+  email: 'john@example.com',
+  product_name: 'Polar Pro',
+} satisfies schemas['PolarSelfSubscriptionPastDueProps']
+
+export default PolarSelfSubscriptionPastDue

--- a/server/emails/src/emails/polar_self_subscription_revoked.tsx
+++ b/server/emails/src/emails/polar_self_subscription_revoked.tsx
@@ -1,0 +1,33 @@
+import { Footer, Intro, Text, WrapperPolar } from '../components/foundation'
+import type { schemas } from '../types'
+
+export function PolarSelfSubscriptionRevoked({
+  email,
+  product_name,
+}: schemas['PolarSelfSubscriptionRevokedProps']) {
+  return (
+    <WrapperPolar preview={`Your ${product_name} subscription has ended`}>
+      <Intro headline={`Your ${product_name} subscription has ended`}>
+        Your{' '}
+        <Text as="span" weight="medium">
+          {product_name}
+        </Text>{' '}
+        subscription has ended, and the associated benefits are no longer
+        active.
+      </Intro>
+      <Text>
+        You can resubscribe anytime from your billing settings. If this
+        wasn&rsquo;t expected, please get in touch and we&rsquo;ll help sort it
+        out.
+      </Text>
+      <Footer email={email} />
+    </WrapperPolar>
+  )
+}
+
+PolarSelfSubscriptionRevoked.PreviewProps = {
+  email: 'john@example.com',
+  product_name: 'Polar Pro',
+} satisfies schemas['PolarSelfSubscriptionRevokedProps']
+
+export default PolarSelfSubscriptionRevoked

--- a/server/emails/src/types/openapi.ts
+++ b/server/emails/src/types/openapi.ts
@@ -2208,6 +2208,28 @@ export interface components {
       /** Billing Url */
       billing_url: string
     }
+    /** PolarSelfSubscriptionCancellationEmail */
+    PolarSelfSubscriptionCancellationEmail: {
+      /**
+       * Template
+       * @default polar_self_subscription_cancellation
+       * @constant
+       */
+      template: 'polar_self_subscription_cancellation'
+      props: components['schemas']['PolarSelfSubscriptionCancellationProps']
+    }
+    /** PolarSelfSubscriptionCancellationProps */
+    PolarSelfSubscriptionCancellationProps: {
+      /** Email */
+      email: string
+      /** Product Name */
+      product_name: string
+      /**
+       * Ends At
+       * @default null
+       */
+      ends_at: string | null
+    }
     /** PolarSelfSubscriptionConfirmationEmail */
     PolarSelfSubscriptionConfirmationEmail: {
       /**

--- a/server/emails/src/types/openapi.ts
+++ b/server/emails/src/types/openapi.ts
@@ -2242,6 +2242,40 @@ export interface components {
       /** Product Name */
       product_name: string
     }
+    /** PolarSelfSubscriptionPastDueEmail */
+    PolarSelfSubscriptionPastDueEmail: {
+      /**
+       * Template
+       * @default polar_self_subscription_past_due
+       * @constant
+       */
+      template: 'polar_self_subscription_past_due'
+      props: components['schemas']['PolarSelfSubscriptionPastDueProps']
+    }
+    /** PolarSelfSubscriptionPastDueProps */
+    PolarSelfSubscriptionPastDueProps: {
+      /** Email */
+      email: string
+      /** Product Name */
+      product_name: string
+    }
+    /** PolarSelfSubscriptionRevokedEmail */
+    PolarSelfSubscriptionRevokedEmail: {
+      /**
+       * Template
+       * @default polar_self_subscription_revoked
+       * @constant
+       */
+      template: 'polar_self_subscription_revoked'
+      props: components['schemas']['PolarSelfSubscriptionRevokedProps']
+    }
+    /** PolarSelfSubscriptionRevokedProps */
+    PolarSelfSubscriptionRevokedProps: {
+      /** Email */
+      email: string
+      /** Product Name */
+      product_name: string
+    }
     /** ProductEmail */
     ProductEmail: {
       /**

--- a/server/polar/email/schemas.py
+++ b/server/polar/email/schemas.py
@@ -59,6 +59,8 @@ class EmailTemplate(StrEnum):
     chargeback_prevention_refund = "chargeback_prevention_refund"
     polar_self_subscription_confirmation = "polar_self_subscription_confirmation"
     polar_self_subscription_cycled = "polar_self_subscription_cycled"
+    polar_self_subscription_past_due = "polar_self_subscription_past_due"
+    polar_self_subscription_revoked = "polar_self_subscription_revoked"
     polar_self_startup_program_welcome = "polar_self_startup_program_welcome"
 
 
@@ -457,6 +459,28 @@ class PolarSelfSubscriptionCycledEmail(BaseModel):
     props: PolarSelfSubscriptionCycledProps
 
 
+class PolarSelfSubscriptionPastDueProps(EmailProps):
+    product_name: str
+
+
+class PolarSelfSubscriptionPastDueEmail(BaseModel):
+    template: Literal[EmailTemplate.polar_self_subscription_past_due] = (
+        EmailTemplate.polar_self_subscription_past_due
+    )
+    props: PolarSelfSubscriptionPastDueProps
+
+
+class PolarSelfSubscriptionRevokedProps(EmailProps):
+    product_name: str
+
+
+class PolarSelfSubscriptionRevokedEmail(BaseModel):
+    template: Literal[EmailTemplate.polar_self_subscription_revoked] = (
+        EmailTemplate.polar_self_subscription_revoked
+    )
+    props: PolarSelfSubscriptionRevokedProps
+
+
 class PolarSelfStartupProgramWelcomeProps(EmailProps):
     organization_name: str
     billing_url: str
@@ -527,6 +551,8 @@ Email = Annotated[
     | ChargebackPreventionRefundEmail
     | PolarSelfSubscriptionConfirmationEmail
     | PolarSelfSubscriptionCycledEmail
+    | PolarSelfSubscriptionPastDueEmail
+    | PolarSelfSubscriptionRevokedEmail
     | PolarSelfStartupProgramWelcomeEmail,
     Discriminator("template"),
 ]

--- a/server/polar/email/schemas.py
+++ b/server/polar/email/schemas.py
@@ -57,6 +57,7 @@ class EmailTemplate(StrEnum):
     notification_new_subscription = "notification_new_subscription"
     notification_credits_granted = "notification_credits_granted"
     chargeback_prevention_refund = "chargeback_prevention_refund"
+    polar_self_subscription_cancellation = "polar_self_subscription_cancellation"
     polar_self_subscription_confirmation = "polar_self_subscription_confirmation"
     polar_self_subscription_cycled = "polar_self_subscription_cycled"
     polar_self_subscription_past_due = "polar_self_subscription_past_due"
@@ -459,6 +460,18 @@ class PolarSelfSubscriptionCycledEmail(BaseModel):
     props: PolarSelfSubscriptionCycledProps
 
 
+class PolarSelfSubscriptionCancellationProps(EmailProps):
+    product_name: str
+    ends_at: str | None = None
+
+
+class PolarSelfSubscriptionCancellationEmail(BaseModel):
+    template: Literal[EmailTemplate.polar_self_subscription_cancellation] = (
+        EmailTemplate.polar_self_subscription_cancellation
+    )
+    props: PolarSelfSubscriptionCancellationProps
+
+
 class PolarSelfSubscriptionPastDueProps(EmailProps):
     product_name: str
 
@@ -549,6 +562,7 @@ Email = Annotated[
     | NotificationNewSubscriptionEmail
     | NotificationCreditsGrantedEmail
     | ChargebackPreventionRefundEmail
+    | PolarSelfSubscriptionCancellationEmail
     | PolarSelfSubscriptionConfirmationEmail
     | PolarSelfSubscriptionCycledEmail
     | PolarSelfSubscriptionPastDueEmail

--- a/server/polar/integrations/polar/endpoints.py
+++ b/server/polar/integrations/polar/endpoints.py
@@ -24,6 +24,7 @@ IMPLEMENTED_WEBHOOKS = {
     "benefit_grant.updated",
     "benefit_grant.revoked",
     "order.created",
+    "subscription.canceled",
     "subscription.past_due",
     "subscription.revoked",
 }

--- a/server/polar/integrations/polar/endpoints.py
+++ b/server/polar/integrations/polar/endpoints.py
@@ -24,6 +24,8 @@ IMPLEMENTED_WEBHOOKS = {
     "benefit_grant.updated",
     "benefit_grant.revoked",
     "order.created",
+    "subscription.past_due",
+    "subscription.revoked",
 }
 
 # Defer order.created handling so payment settlement and invoice generation

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -16,6 +16,8 @@ from polar_sdk.models import (
     WebhookBenefitGrantRevokedPayload,
     WebhookBenefitGrantUpdatedPayload,
     WebhookOrderCreatedPayload,
+    WebhookSubscriptionPastDuePayload,
+    WebhookSubscriptionRevokedPayload,
 )
 
 from polar.account.repository import AccountRepository
@@ -24,6 +26,8 @@ from polar.email.schemas import (
     EmailAdapter,
     PolarSelfSubscriptionConfirmationProps,
     PolarSelfSubscriptionCycledProps,
+    PolarSelfSubscriptionPastDueProps,
+    PolarSelfSubscriptionRevokedProps,
 )
 from polar.email.sender import Attachment, enqueue_email_template
 from polar.integrations.plain.service import plain as plain_service
@@ -782,6 +786,88 @@ class PolarSelfService:
                     subject=subject,
                     attachments=attachments,
                 )
+
+    async def handle_subscription_past_due_event(
+        self, payload: WebhookSubscriptionPastDuePayload
+    ) -> None:
+        subscription = payload.data
+        context = await self._resolve_subscription_email_context(subscription)
+        if context is None:
+            return
+        recipients, product_name = context
+
+        with logfire.span(
+            "polar_self.webhook.subscription_past_due",
+            subscription_id=subscription.id,
+        ):
+            for recipient in recipients:
+                email = EmailAdapter.validate_python(
+                    {
+                        "template": "polar_self_subscription_past_due",
+                        "props": PolarSelfSubscriptionPastDueProps(
+                            email=recipient,
+                            product_name=product_name,
+                        ).model_dump(),
+                    }
+                )
+                enqueue_email_template(
+                    email,
+                    to_email_addr=recipient,
+                    subject=f"Your {product_name} subscription payment failed",
+                )
+
+    async def handle_subscription_revoked_event(
+        self, payload: WebhookSubscriptionRevokedPayload
+    ) -> None:
+        subscription = payload.data
+        context = await self._resolve_subscription_email_context(subscription)
+        if context is None:
+            return
+        recipients, product_name = context
+
+        with logfire.span(
+            "polar_self.webhook.subscription_revoked",
+            subscription_id=subscription.id,
+        ):
+            for recipient in recipients:
+                email = EmailAdapter.validate_python(
+                    {
+                        "template": "polar_self_subscription_revoked",
+                        "props": PolarSelfSubscriptionRevokedProps(
+                            email=recipient,
+                            product_name=product_name,
+                        ).model_dump(),
+                    }
+                )
+                enqueue_email_template(
+                    email,
+                    to_email_addr=recipient,
+                    subject=f"Your {product_name} subscription has ended",
+                )
+
+    async def _resolve_subscription_email_context(
+        self, subscription: "Subscription"
+    ) -> tuple[list[str], str] | None:
+        """Resolve ``(recipients, product_name)`` for a subscription email.
+
+        Returns ``None`` when no email should be sent: free ($0) subscriptions
+        never have a payment to fail, and a subscription with no billing
+        contacts has nobody to notify.
+        """
+        if subscription.amount == 0:
+            return None
+
+        contacts = await get_client().list_billing_contacts(
+            customer_id=subscription.customer_id
+        )
+        recipients = sorted({contact.email for contact in contacts if contact.email})
+        if not recipients:
+            return None
+
+        product_name = (
+            subscription.product.name if subscription.product is not None else "Polar"
+        )
+        return recipients, product_name
 
     async def _require_approval(
         self,

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -16,6 +16,7 @@ from polar_sdk.models import (
     WebhookBenefitGrantRevokedPayload,
     WebhookBenefitGrantUpdatedPayload,
     WebhookOrderCreatedPayload,
+    WebhookSubscriptionCanceledPayload,
     WebhookSubscriptionPastDuePayload,
     WebhookSubscriptionRevokedPayload,
 )
@@ -24,6 +25,7 @@ from polar.account.repository import AccountRepository
 from polar.config import settings
 from polar.email.schemas import (
     EmailAdapter,
+    PolarSelfSubscriptionCancellationProps,
     PolarSelfSubscriptionConfirmationProps,
     PolarSelfSubscriptionCycledProps,
     PolarSelfSubscriptionPastDueProps,
@@ -785,6 +787,37 @@ class PolarSelfService:
                     to_email_addr=recipient,
                     subject=subject,
                     attachments=attachments,
+                )
+
+    async def handle_subscription_canceled_event(
+        self, payload: WebhookSubscriptionCanceledPayload
+    ) -> None:
+        subscription = payload.data
+        context = await self._resolve_subscription_email_context(subscription)
+        if context is None:
+            return
+        recipients, product_name = context
+        ends_at = subscription.ends_at.isoformat() if subscription.ends_at else None
+
+        with logfire.span(
+            "polar_self.webhook.subscription_canceled",
+            subscription_id=subscription.id,
+        ):
+            for recipient in recipients:
+                email = EmailAdapter.validate_python(
+                    {
+                        "template": "polar_self_subscription_cancellation",
+                        "props": PolarSelfSubscriptionCancellationProps(
+                            email=recipient,
+                            product_name=product_name,
+                            ends_at=ends_at,
+                        ).model_dump(),
+                    }
+                )
+                enqueue_email_template(
+                    email,
+                    to_email_addr=recipient,
+                    subject=f"Your {product_name} subscription has been canceled",
                 )
 
     async def handle_subscription_past_due_event(

--- a/server/polar/integrations/polar/tasks.py
+++ b/server/polar/integrations/polar/tasks.py
@@ -9,6 +9,7 @@ from polar_sdk.models import (
     WebhookBenefitGrantRevokedPayload,
     WebhookBenefitGrantUpdatedPayload,
     WebhookOrderCreatedPayload,
+    WebhookSubscriptionCanceledPayload,
     WebhookSubscriptionPastDuePayload,
     WebhookSubscriptionRevokedPayload,
 )
@@ -246,6 +247,16 @@ async def webhook_order_created(event_id: uuid.UUID) -> None:
                 if can_retry():
                     raise Retry() from e
                 raise
+
+
+@actor(actor_name="polar_self.webhook.subscription.canceled", priority=TaskPriority.LOW)
+async def webhook_subscription_canceled(event_id: uuid.UUID) -> None:
+    async with AsyncSessionMaker() as session:
+        async with external_event_service.handle(
+            session, ExternalEventSource.polar, event_id
+        ) as event:
+            payload = WebhookSubscriptionCanceledPayload.model_validate(event.data)
+            await polar_self.handle_subscription_canceled_event(payload)
 
 
 @actor(actor_name="polar_self.webhook.subscription.past_due", priority=TaskPriority.LOW)

--- a/server/polar/integrations/polar/tasks.py
+++ b/server/polar/integrations/polar/tasks.py
@@ -9,6 +9,8 @@ from polar_sdk.models import (
     WebhookBenefitGrantRevokedPayload,
     WebhookBenefitGrantUpdatedPayload,
     WebhookOrderCreatedPayload,
+    WebhookSubscriptionPastDuePayload,
+    WebhookSubscriptionRevokedPayload,
 )
 
 from polar.config import settings
@@ -244,3 +246,23 @@ async def webhook_order_created(event_id: uuid.UUID) -> None:
                 if can_retry():
                     raise Retry() from e
                 raise
+
+
+@actor(actor_name="polar_self.webhook.subscription.past_due", priority=TaskPriority.LOW)
+async def webhook_subscription_past_due(event_id: uuid.UUID) -> None:
+    async with AsyncSessionMaker() as session:
+        async with external_event_service.handle(
+            session, ExternalEventSource.polar, event_id
+        ) as event:
+            payload = WebhookSubscriptionPastDuePayload.model_validate(event.data)
+            await polar_self.handle_subscription_past_due_event(payload)
+
+
+@actor(actor_name="polar_self.webhook.subscription.revoked", priority=TaskPriority.LOW)
+async def webhook_subscription_revoked(event_id: uuid.UUID) -> None:
+    async with AsyncSessionMaker() as session:
+        async with external_event_service.handle(
+            session, ExternalEventSource.polar, event_id
+        ) as event:
+            payload = WebhookSubscriptionRevokedPayload.model_validate(event.data)
+            await polar_self.handle_subscription_revoked_event(payload)

--- a/server/tests/integrations/polar/test_endpoints.py
+++ b/server/tests/integrations/polar/test_endpoints.py
@@ -332,15 +332,29 @@ class TestWebhook:
         assert call.args[2] == "polar_self.webhook.order.created"
         assert call.kwargs["delay"] == 60_000
 
-    async def test_subscription_revoked_is_ignored(
+    @pytest.mark.parametrize(
+        "event_type",
+        [
+            "subscription.past_due",
+            "subscription.revoked",
+        ],
+    )
+    async def test_subscription_event_is_enqueued_without_delay(
         self,
         client: AsyncClient,
         enqueue_mock: AsyncMock,
+        event_type: str,
     ) -> None:
-        payload = _subscription_event("subscription.revoked")
-        body, headers = _sign(payload, msg_id="msg_subscription.revoked")
+        payload = _subscription_event(event_type)
+        body, headers = _sign(payload, msg_id=f"msg_{event_type}")
 
         response = await client.post(WEBHOOK_URL, content=body, headers=headers)
 
         assert response.status_code == 202
-        enqueue_mock.assert_not_awaited()
+        enqueue_mock.assert_awaited_once()
+        call = enqueue_mock.await_args
+        assert call is not None
+        assert call.args[2] == f"polar_self.webhook.{event_type}"
+        assert call.args[3] == f"msg_{event_type}"
+        assert call.args[4] == payload
+        assert call.kwargs["delay"] is None

--- a/server/tests/integrations/polar/test_endpoints.py
+++ b/server/tests/integrations/polar/test_endpoints.py
@@ -264,9 +264,9 @@ class TestWebhook:
     async def test_unhandled_event_type_is_ignored(
         self, client: AsyncClient, enqueue_mock: AsyncMock
     ) -> None:
-        # subscription.canceled is a valid (parseable) Polar event type, but
+        # subscription.uncanceled is a valid (parseable) Polar event type, but
         # not in IMPLEMENTED_WEBHOOKS.
-        body, headers = _sign(_subscription_event("subscription.canceled"))
+        body, headers = _sign(_subscription_event("subscription.uncanceled"))
 
         response = await client.post(WEBHOOK_URL, content=body, headers=headers)
 
@@ -335,6 +335,7 @@ class TestWebhook:
     @pytest.mark.parametrize(
         "event_type",
         [
+            "subscription.canceled",
             "subscription.past_due",
             "subscription.revoked",
         ],

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -15,6 +15,8 @@ from polar_sdk.models import (
     WebhookBenefitGrantRevokedPayload,
     WebhookBenefitGrantUpdatedPayload,
     WebhookOrderCreatedPayload,
+    WebhookSubscriptionPastDuePayload,
+    WebhookSubscriptionRevokedPayload,
 )
 from pytest_mock import MockerFixture
 
@@ -2262,3 +2264,132 @@ class TestHandleOrderCreatedEvent:
 
         order_webhook_client_mock.get_order.assert_awaited_once_with(order_id="ord_1")
         enqueue_email_mock.assert_not_called()
+
+
+def _make_subscription_past_due_payload(
+    **kwargs: Any,
+) -> WebhookSubscriptionPastDuePayload:
+    return WebhookSubscriptionPastDuePayload.model_validate(
+        {
+            "type": "subscription.past_due",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "data": _make_subscription(**kwargs).model_dump(mode="json"),
+        }
+    )
+
+
+def _make_subscription_revoked_payload(
+    **kwargs: Any,
+) -> WebhookSubscriptionRevokedPayload:
+    return WebhookSubscriptionRevokedPayload.model_validate(
+        {
+            "type": "subscription.revoked",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "data": _make_subscription(**kwargs).model_dump(mode="json"),
+        }
+    )
+
+
+@pytest.fixture
+def subscription_webhook_client_mock(mocker: MockerFixture) -> MagicMock:
+    client = MagicMock()
+    client.list_billing_contacts = AsyncMock(
+        return_value=[_make_contact("billing@example.com")]
+    )
+    mocker.patch("polar.integrations.polar.service.get_client", return_value=client)
+    return client
+
+
+@pytest.mark.asyncio
+class TestHandleSubscriptionPastDueEvent:
+    async def test_skips_free_subscription(
+        self,
+        subscription_webhook_client_mock: MagicMock,
+        enqueue_email_mock: MagicMock,
+    ) -> None:
+        # A $0 subscription has no payment to fail, so there's nothing to notify.
+        payload = _make_subscription_past_due_payload(amount=0)
+
+        await polar_self.handle_subscription_past_due_event(payload)
+
+        subscription_webhook_client_mock.list_billing_contacts.assert_not_awaited()
+        enqueue_email_mock.assert_not_called()
+
+    async def test_skips_when_no_billing_contacts(
+        self,
+        subscription_webhook_client_mock: MagicMock,
+        enqueue_email_mock: MagicMock,
+    ) -> None:
+        subscription_webhook_client_mock.list_billing_contacts.return_value = []
+        payload = _make_subscription_past_due_payload(amount=2000)
+
+        await polar_self.handle_subscription_past_due_event(payload)
+
+        enqueue_email_mock.assert_not_called()
+
+    async def test_sends_email_to_billing_contacts(
+        self,
+        subscription_webhook_client_mock: MagicMock,
+        enqueue_email_mock: MagicMock,
+    ) -> None:
+        payload = _make_subscription_past_due_payload(amount=2000)
+
+        await polar_self.handle_subscription_past_due_event(payload)
+
+        subscription_webhook_client_mock.list_billing_contacts.assert_awaited_once_with(
+            customer_id=_CUSTOMER_ID
+        )
+        enqueue_email_mock.assert_called_once()
+        email = enqueue_email_mock.call_args.args[0]
+        assert email.template == "polar_self_subscription_past_due"
+        assert email.props.product_name == "Pro"
+        kwargs = enqueue_email_mock.call_args.kwargs
+        assert kwargs["to_email_addr"] == "billing@example.com"
+        assert kwargs["subject"] == "Your Pro subscription payment failed"
+
+
+@pytest.mark.asyncio
+class TestHandleSubscriptionRevokedEvent:
+    async def test_skips_free_subscription(
+        self,
+        subscription_webhook_client_mock: MagicMock,
+        enqueue_email_mock: MagicMock,
+    ) -> None:
+        payload = _make_subscription_revoked_payload(amount=0)
+
+        await polar_self.handle_subscription_revoked_event(payload)
+
+        subscription_webhook_client_mock.list_billing_contacts.assert_not_awaited()
+        enqueue_email_mock.assert_not_called()
+
+    async def test_skips_when_no_billing_contacts(
+        self,
+        subscription_webhook_client_mock: MagicMock,
+        enqueue_email_mock: MagicMock,
+    ) -> None:
+        subscription_webhook_client_mock.list_billing_contacts.return_value = []
+        payload = _make_subscription_revoked_payload(amount=2000)
+
+        await polar_self.handle_subscription_revoked_event(payload)
+
+        enqueue_email_mock.assert_not_called()
+
+    async def test_sends_email_to_billing_contacts(
+        self,
+        subscription_webhook_client_mock: MagicMock,
+        enqueue_email_mock: MagicMock,
+    ) -> None:
+        payload = _make_subscription_revoked_payload(amount=2000)
+
+        await polar_self.handle_subscription_revoked_event(payload)
+
+        subscription_webhook_client_mock.list_billing_contacts.assert_awaited_once_with(
+            customer_id=_CUSTOMER_ID
+        )
+        enqueue_email_mock.assert_called_once()
+        email = enqueue_email_mock.call_args.args[0]
+        assert email.template == "polar_self_subscription_revoked"
+        assert email.props.product_name == "Pro"
+        kwargs = enqueue_email_mock.call_args.kwargs
+        assert kwargs["to_email_addr"] == "billing@example.com"
+        assert kwargs["subject"] == "Your Pro subscription has ended"

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -15,6 +15,7 @@ from polar_sdk.models import (
     WebhookBenefitGrantRevokedPayload,
     WebhookBenefitGrantUpdatedPayload,
     WebhookOrderCreatedPayload,
+    WebhookSubscriptionCanceledPayload,
     WebhookSubscriptionPastDuePayload,
     WebhookSubscriptionRevokedPayload,
 )
@@ -2266,6 +2267,20 @@ class TestHandleOrderCreatedEvent:
         enqueue_email_mock.assert_not_called()
 
 
+def _make_subscription_canceled_payload(
+    *, ends_at: str | None = "2026-02-01T00:00:00Z", **kwargs: Any
+) -> WebhookSubscriptionCanceledPayload:
+    data = _make_subscription(**kwargs).model_dump(mode="json")
+    data["ends_at"] = ends_at
+    return WebhookSubscriptionCanceledPayload.model_validate(
+        {
+            "type": "subscription.canceled",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "data": data,
+        }
+    )
+
+
 def _make_subscription_past_due_payload(
     **kwargs: Any,
 ) -> WebhookSubscriptionPastDuePayload:
@@ -2298,6 +2313,70 @@ def subscription_webhook_client_mock(mocker: MockerFixture) -> MagicMock:
     )
     mocker.patch("polar.integrations.polar.service.get_client", return_value=client)
     return client
+
+
+@pytest.mark.asyncio
+class TestHandleSubscriptionCanceledEvent:
+    async def test_skips_free_subscription(
+        self,
+        subscription_webhook_client_mock: MagicMock,
+        enqueue_email_mock: MagicMock,
+    ) -> None:
+        payload = _make_subscription_canceled_payload(amount=0)
+
+        await polar_self.handle_subscription_canceled_event(payload)
+
+        subscription_webhook_client_mock.list_billing_contacts.assert_not_awaited()
+        enqueue_email_mock.assert_not_called()
+
+    async def test_skips_when_no_billing_contacts(
+        self,
+        subscription_webhook_client_mock: MagicMock,
+        enqueue_email_mock: MagicMock,
+    ) -> None:
+        subscription_webhook_client_mock.list_billing_contacts.return_value = []
+        payload = _make_subscription_canceled_payload(amount=2000)
+
+        await polar_self.handle_subscription_canceled_event(payload)
+
+        enqueue_email_mock.assert_not_called()
+
+    async def test_sends_email_with_end_date(
+        self,
+        subscription_webhook_client_mock: MagicMock,
+        enqueue_email_mock: MagicMock,
+    ) -> None:
+        payload = _make_subscription_canceled_payload(
+            amount=2000, ends_at="2026-02-01T00:00:00Z"
+        )
+
+        await polar_self.handle_subscription_canceled_event(payload)
+
+        subscription_webhook_client_mock.list_billing_contacts.assert_awaited_once_with(
+            customer_id=_CUSTOMER_ID
+        )
+        enqueue_email_mock.assert_called_once()
+        email = enqueue_email_mock.call_args.args[0]
+        assert email.template == "polar_self_subscription_cancellation"
+        assert email.props.product_name == "Pro"
+        assert email.props.ends_at is not None
+        assert email.props.ends_at.startswith("2026-02-01")
+        kwargs = enqueue_email_mock.call_args.kwargs
+        assert kwargs["to_email_addr"] == "billing@example.com"
+        assert kwargs["subject"] == "Your Pro subscription has been canceled"
+
+    async def test_sends_email_without_end_date(
+        self,
+        subscription_webhook_client_mock: MagicMock,
+        enqueue_email_mock: MagicMock,
+    ) -> None:
+        payload = _make_subscription_canceled_payload(amount=2000, ends_at=None)
+
+        await polar_self.handle_subscription_canceled_event(payload)
+
+        enqueue_email_mock.assert_called_once()
+        email = enqueue_email_mock.call_args.args[0]
+        assert email.props.ends_at is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The Polar self-integration only emailed the happy path — subscription confirmation and renewal, both driven off `order.created`. This adds the three failure/lifecycle emails so Polar's own customers (organizations subscribing to Polar plans) are notified when billing goes wrong:

| Email | Webhook | Subject |
|---|---|---|
| `polar_self_subscription_past_due` | `subscription.past_due` | "Your {product} subscription payment failed" |
| `polar_self_subscription_revoked` | `subscription.revoked` | "Your {product} subscription has ended" |
| `polar_self_subscription_cancellation` | `subscription.canceled` | "Your {product} subscription has been canceled" |

### Notes on scope
- **Past due covers both originally-requested cases.** A failed charge and a renewal that cycled without a successful payment are the same event in Polar's model — both land in `past_due`.
- **Revoked is the terminal companion** to past-due: when dunning never succeeds, the subscription is revoked and access is lost.
- **Cancellation** confirms a customer-initiated cancel-at-period-end and surfaces the access-until date (`ends_at`).

## Implementation

All three handlers are modeled on the existing `handle_order_created_event`: resolve billing contacts via the Polar API and enqueue one email per recipient — no DB session, no org lookup. Free ($0) subscriptions and subscriptions with no billing contacts are skipped via a shared `_resolve_subscription_email_context` helper.

- `email/schemas.py` — new template enum values, Props/Email models, union entries
- `emails/src/emails/*.tsx` — three React Email templates (cloned from `polar_self_subscription_cycled.tsx`) + registered in `index.ts`
- `emails/src/types/openapi.ts` — regenerated-style type entries (see caveat)
- `integrations/polar/endpoints.py` — three events added to `IMPLEMENTED_WEBHOOKS` (no 60s delay, unlike `order.created`)
- `integrations/polar/tasks.py` — three Dramatiq actors
- `integrations/polar/service.py` — three handlers + shared context helper
- Tests — endpoint enqueue tests + service handler tests (free-skip, no-contacts-skip, sends-to-contacts, end-date passthrough)

## Caveats for the reviewer
- **Couldn't run backend tests/lint in the dev sandbox** — its `uv` is older than the `uv.lock`/`pyproject.toml` feature set, so the venv wouldn't build. All Python is `py_compile`-checked and mirrors existing fixtures/patterns; please let CI be the gate.
- **`emails/src/types/openapi.ts` is normally generated** (`pnpm run types`). I hand-wrote the new entries to match the generator's output since I couldn't run it — worth a quick `pnpm run types` to confirm a zero diff.

## Still uncovered (deliberately, lower priority)
`subscription.uncanceled` and proactive renewal reminders. Easy follow-ups if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LE1z9bepfsS8yD58FEYv1B

---
_Generated by [Claude Code](https://claude.ai/code/session_01LE1z9bepfsS8yD58FEYv1B)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

