### PR TITLE
Show chargeback prevention banner on refunded orders

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/[id]/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/[id]/SalesPage.tsx
@@ -2,6 +2,7 @@
 
 import { CustomerContextView } from '@/components/Customer/CustomerContextView'
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
+import { ChargebackPreventionBanner } from '@/components/Orders/ChargebackPreventionBanner'
 import { OrderSecondaryDetails } from '@/components/Orders/OrderSecondaryDetails'
 import { OrderCalloutBanner } from '@/components/Orders/OrderCalloutBanner'
 import { OrderDetails } from '@/components/Orders/OrderDetails'
@@ -18,7 +19,9 @@ import { toast } from '@/components/Toast/use-toast'
 import { useCustomFields, useProduct, useSubscription } from '@/hooks/queries'
 import { useOrder } from '@/hooks/queries/orders'
 import { usePayments } from '@/hooks/queries/payments'
+import { useRefunds } from '@/hooks/queries/refunds'
 import {
+  getChargebackPreventionRefund,
   isOrderDunningFailed,
   isOrderInDunning,
   isOrderInDunningLifecycle,
@@ -51,6 +54,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
     organization.id,
     { order_id: _order.id },
   )
+  const { data: refunds } = useRefunds(_order.id)
 
   const orderPayments = payments?.items ?? []
   const inDunningLifecycle =
@@ -67,6 +71,10 @@ const ClientPage: React.FC<ClientPageProps> = ({
     !!dunningSubscription &&
     (isOrderInDunning(order, orderPayments) ||
       isOrderDunningFailed(order, dunningSubscription, orderPayments))
+
+  const chargebackPreventionRefund = order
+    ? getChargebackPreventionRefund(order, refunds?.items ?? [])
+    : null
 
   if (!order) {
     return null
@@ -150,6 +158,10 @@ const ClientPage: React.FC<ClientPageProps> = ({
           subscription={dunningSubscription}
           payments={orderPayments}
         />
+      ) : null}
+
+      {chargebackPreventionRefund ? (
+        <ChargebackPreventionBanner refund={chargebackPreventionRefund} />
       ) : null}
 
       <OrderDetails

--- a/clients/apps/web/src/components/Orders/ChargebackPreventionBanner.tsx
+++ b/clients/apps/web/src/components/Orders/ChargebackPreventionBanner.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import { schemas } from '@polar-sh/client'
+import { formatCurrency } from '@polar-sh/currency'
+import { Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
+import { ExternalLinkIcon } from 'lucide-react'
+import type { ReactNode } from 'react'
+
+const REFUNDS_DOCS_URL = 'https://docs.polar.sh/features/refunds'
+
+const BannerColumn = ({
+  divided = false,
+  children,
+}: {
+  divided?: boolean
+  children: ReactNode
+}) => (
+  <Box
+    flexDirection="column"
+    rowGap="m"
+    paddingVertical="xl"
+    paddingHorizontal="2xl"
+    borderTopWidth={divided ? { base: 1, lg: 0 } : undefined}
+    borderLeftWidth={divided ? { base: 0, lg: 1 } : undefined}
+    borderStyle={divided ? 'solid' : undefined}
+    borderColor={divided ? 'border-primary' : undefined}
+  >
+    {children}
+  </Box>
+)
+
+interface ChargebackPreventionBannerProps {
+  refund: schemas['Refund']
+}
+
+export const ChargebackPreventionBanner = ({
+  refund,
+}: ChargebackPreventionBannerProps) => {
+  return (
+    <Box
+      flexDirection="column"
+      overflow="hidden"
+      borderRadius="l"
+      borderWidth={1}
+      borderStyle="solid"
+      borderColor="border-primary"
+    >
+      <Box
+        alignItems="center"
+        columnGap="m"
+        paddingHorizontal="2xl"
+        paddingVertical="l"
+      >
+        <Text variant="body">We prevented a chargeback for this order</Text>
+      </Box>
+
+      <Box
+        display="grid"
+        gridTemplateColumns={{ base: '1fr', lg: 'repeat(2, 1fr)' }}
+        borderTopWidth={1}
+        borderStyle="solid"
+        borderColor="border-primary"
+      >
+        <BannerColumn>
+          <Box flexDirection="column" rowGap="xs">
+            <Text color="muted">Refund issued</Text>
+            <Text variant="body">
+              <FormattedDateTime
+                resolution="day"
+                datetime={refund.created_at}
+              />
+            </Text>
+          </Box>
+          <Box flexDirection="column" rowGap="xs">
+            <Text color="muted">Amount refunded</Text>
+            <Text variant="body">
+              {formatCurrency('standard')(refund.amount, refund.currency)}
+            </Text>
+          </Box>
+        </BannerColumn>
+
+        <BannerColumn divided>
+          <Text color="muted">Why this happened</Text>
+          <Box flexDirection="column" rowGap="m" maxWidth={512}>
+            <Text>
+              Our early-warning system detected that the customer started to
+              file a chargeback for this transaction. To help you avoid the fees
+              and risks of a formal dispute, we refunded the payment before it
+              was officially filed.
+            </Text>
+            <Text>
+              A formal chargeback can mean losing the transaction amount on top
+              of extra dispute fees, and a rising dispute ratio can hurt your
+              account over time. Refunding proactively is usually the least
+              costly outcome.
+            </Text>
+          </Box>
+          <a
+            href={REFUNDS_DOCS_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="w-fit"
+          >
+            <Box
+              as="span"
+              display="inline-flex"
+              alignItems="center"
+              columnGap="xs"
+            >
+              <Text as="span">
+                <span className="underline">Learn more</span>
+              </Text>
+              <ExternalLinkIcon className="h-3.5 w-3.5 shrink-0" />
+            </Box>
+          </a>
+        </BannerColumn>
+      </Box>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/utils/order.ts
+++ b/clients/apps/web/src/utils/order.ts
@@ -132,3 +132,23 @@ export function isOrderNonRecoverable(
     latestFailedPayment !== null && isPaymentNonRecoverable(latestFailedPayment)
   )
 }
+
+/**
+ * Returns the succeeded refund that was issued to prevent a chargeback, if the
+ * order was (partially) refunded for that reason. This is the signal we use to
+ * surface the chargeback prevention banner and derived status.
+ */
+export function getChargebackPreventionRefund(
+  order: schemas['Order'],
+  refunds: schemas['Refund'][],
+): schemas['Refund'] | null {
+  if (order.status !== 'refunded' && order.status !== 'partially_refunded') {
+    return null
+  }
+  return (
+    refunds.find(
+      (refund) =>
+        refund.reason === 'dispute_prevention' && refund.status === 'succeeded',
+    ) ?? null
+  )
+}


### PR DESCRIPTION

<img width="1330" height="434" alt="image" src="https://github.com/user-attachments/assets/0e51acc5-195f-4c77-b0fc-abb405e8c162" />

When an order is refunded to prevent a chargeback (refund reason
dispute_prevention), surface a merchant-facing banner on the order
detail page explaining why Polar issued the refund on their behalf,
along with a derived "Chargeback Prevented" status badge.

The copy is adapted from the chargeback prevention email so merchants
understand the refund was proactive risk mitigation, reducing support
questions from sellers who would otherwise be surprised by it.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CmNvqCXt8HNskQKrwubeDF

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

