### PR TITLE
feat: add nested customer member endpoints under /v1/customers/{id}/members

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -7043,6 +7043,17 @@ export interface components {
       /** Detail */
       detail: string
     }
+    /** AmbiguousExternalCustomerID */
+    AmbiguousExternalCustomerID: {
+      /**
+       * Error
+       * @example AmbiguousExternalCustomerID
+       * @constant
+       */
+      error: 'AmbiguousExternalCustomerID'
+      /** Detail */
+      detail: string
+    }
     /**
      * AppealDecision
      * @enum {string}
@@ -43759,6 +43770,15 @@ export interface operations {
           'application/json': components['schemas']['ResourceNotFound']
         }
       }
+      /** @description The external customer ID matches customers in several accessible organizations. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['AmbiguousExternalCustomerID']
+        }
+      }
       /** @description Validation Error */
       422: {
         headers: {
@@ -43930,6 +43950,15 @@ export interface operations {
           'application/json': components['schemas']['ResourceNotFound']
         }
       }
+      /** @description The external customer ID matches customers in several accessible organizations. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['AmbiguousExternalCustomerID']
+        }
+      }
       /** @description Validation Error */
       422: {
         headers: {
@@ -43969,6 +43998,15 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description The external customer ID matches customers in several accessible organizations. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['AmbiguousExternalCustomerID']
         }
       }
       /** @description Validation Error */
@@ -44016,6 +44054,15 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description The external customer ID matches customers in several accessible organizations. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['AmbiguousExternalCustomerID']
         }
       }
       /** @description Validation Error */

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -3528,6 +3528,7 @@ export interface paths {
     put?: never
     /**
      * Create Member
+     * @deprecated
      * @description Create a new member for a customer.
      *
      *     Only B2B customers with the member management feature enabled can add members.
@@ -3551,6 +3552,7 @@ export interface paths {
     }
     /**
      * Get Member
+     * @deprecated
      * @description Get a member by ID.
      *
      *     The authenticated user or organization must have access to the member's organization.
@@ -3562,6 +3564,7 @@ export interface paths {
     post?: never
     /**
      * Delete Member
+     * @deprecated
      * @description Delete a member.
      *
      *     The authenticated user or organization must have access to the member's organization.
@@ -3573,6 +3576,7 @@ export interface paths {
     head?: never
     /**
      * Update Member
+     * @deprecated
      * @description Update a member.
      *
      *     Only name, email and role can be updated.
@@ -3592,6 +3596,7 @@ export interface paths {
     }
     /**
      * Get Member by External ID
+     * @deprecated
      * @description Get a member by external ID. One of customer_id or external_customer_id must be specified.
      *
      *     **Scopes**: `members:read` `members:write`
@@ -3601,6 +3606,7 @@ export interface paths {
     post?: never
     /**
      * Delete Member by External ID
+     * @deprecated
      * @description Delete a member by external ID. One of customer_id or external_customer_id must be specified.
      *
      *     **Scopes**: `members:write`
@@ -3610,6 +3616,7 @@ export interface paths {
     head?: never
     /**
      * Update Member by External ID
+     * @deprecated
      * @description Update a member by external ID. One of customer_id or external_customer_id must be specified.
      *
      *     **Scopes**: `members:write`
@@ -3700,7 +3707,7 @@ export interface paths {
     patch: operations['customers:members:update']
     trace?: never
   }
-  '/v1/customers/external/{external_id}/members/external/{member_external_id}': {
+  '/v1/customers/external/{external_id}/members/{member_external_id}': {
     parameters: {
       query?: never
       header?: never

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -3617,6 +3617,123 @@ export interface paths {
     patch: operations['members:update_member_by_external_id']
     trace?: never
   }
+  '/v1/customers/{id}/members': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Create Member
+     * @description Create a new member for a customer.
+     *
+     *     Only B2B customers with the member management feature enabled can add members.
+     *     The authenticated user or organization must have access to the customer's organization.
+     *
+     *     **Scopes**: `members:write`
+     */
+    post: operations['customers:members:create']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v1/customers/external/{external_id}/members': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Create Member by Customer External ID
+     * @description Create a new member for a customer identified by its external ID.
+     *
+     *     **Scopes**: `members:write`
+     */
+    post: operations['customers:members:create_external']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v1/customers/{id}/members/{member_id}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get Member
+     * @description Get a member of a customer by its ID.
+     *
+     *     **Scopes**: `members:read` `members:write`
+     */
+    get: operations['customers:members:get']
+    put?: never
+    post?: never
+    /**
+     * Delete Member
+     * @description Delete a member of a customer.
+     *
+     *     **Scopes**: `members:write`
+     */
+    delete: operations['customers:members:delete']
+    options?: never
+    head?: never
+    /**
+     * Update Member
+     * @description Update a member of a customer.
+     *
+     *     Only name, email and role can be updated.
+     *
+     *     **Scopes**: `members:write`
+     */
+    patch: operations['customers:members:update']
+    trace?: never
+  }
+  '/v1/customers/external/{external_id}/members/external/{member_external_id}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get Member by External ID
+     * @description Get a member by external ID for a customer identified by its external ID.
+     *
+     *     **Scopes**: `members:read` `members:write`
+     */
+    get: operations['customers:members:get_external']
+    put?: never
+    post?: never
+    /**
+     * Delete Member by External ID
+     * @description Delete a member by external ID for a customer identified by its external ID.
+     *
+     *     **Scopes**: `members:write`
+     */
+    delete: operations['customers:members:delete_external']
+    options?: never
+    head?: never
+    /**
+     * Update Member by External ID
+     * @description Update a member by external ID for a customer identified by its external ID.
+     *
+     *     **Scopes**: `members:write`
+     */
+    patch: operations['customers:members:update_external']
+    trace?: never
+  }
   '/v1/customer-portal/benefit-grants/': {
     parameters: {
       query?: never
@@ -21551,15 +21668,46 @@ export interface components {
     }
     /**
      * MemberCreate
-     * @description Schema for creating a new member.
+     * @description Schema for creating a new member (deprecated; customer in the body).
      */
     MemberCreate: {
+      /**
+       * Email
+       * Format: email
+       * @description The email address of the member.
+       * @example member@example.com
+       */
+      email: string
+      /** Name */
+      name?: string | null
+      /**
+       * External Id
+       * @description The ID of the member in your system. This must be unique within the customer.
+       * @example usr_1337
+       */
+      external_id?: string | null
+      /**
+       * Role
+       * @description The role of the member within the customer. To assign or transfer ownership, use the member update endpoint.
+       * @default member
+       * @example member
+       * @enum {string}
+       */
+      role: 'member' | 'billing_manager'
       /**
        * Customer Id
        * Format: uuid4
        * @description The ID of the customer this member belongs to.
        */
       customer_id: string
+    }
+    /**
+     * MemberCreateFromCustomer
+     * @description Schema for creating a new member nested under a customer.
+     *
+     *     The customer is taken from the URL path, so it's not part of the body.
+     */
+    MemberCreateFromCustomer: {
       /**
        * Email
        * Format: email
@@ -43514,6 +43662,373 @@ export interface operations {
       }
     }
   }
+  'customers:members:create': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description The customer ID. */
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['MemberCreateFromCustomer']
+      }
+    }
+    responses: {
+      /** @description Member created. */
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Member']
+        }
+      }
+      /** @description Not permitted to add members. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['NotPermitted']
+        }
+      }
+      /** @description Customer not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'customers:members:create_external': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description The customer external ID. */
+        external_id: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['MemberCreateFromCustomer']
+      }
+    }
+    responses: {
+      /** @description Member created. */
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Member']
+        }
+      }
+      /** @description Not permitted to add members. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['NotPermitted']
+        }
+      }
+      /** @description Customer not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'customers:members:get': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description The customer ID. */
+        id: string
+        member_id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Member retrieved. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Member']
+        }
+      }
+      /** @description Member not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'customers:members:delete': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description The customer ID. */
+        id: string
+        member_id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Member deleted. */
+      204: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Member not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'customers:members:update': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description The customer ID. */
+        id: string
+        member_id: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['MemberUpdate']
+      }
+    }
+    responses: {
+      /** @description Member updated. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Member']
+        }
+      }
+      /** @description Member not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'customers:members:get_external': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description The customer external ID. */
+        external_id: string
+        /** @description The member external ID. */
+        member_external_id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Member retrieved. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Member']
+        }
+      }
+      /** @description Member not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'customers:members:delete_external': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description The customer external ID. */
+        external_id: string
+        /** @description The member external ID. */
+        member_external_id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Member deleted. */
+      204: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Member not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'customers:members:update_external': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description The customer external ID. */
+        external_id: string
+        /** @description The member external ID. */
+        member_external_id: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['MemberUpdate']
+      }
+    }
+    responses: {
+      /** @description Member updated. */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['Member']
+        }
+      }
+      /** @description Member not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
   'customer_portal:benefit-grants:list': {
     parameters: {
       query?: {
@@ -57847,6 +58362,9 @@ export const maintainerNewProductSaleNotificationTypeValues: ReadonlyArray<
 > = ['MaintainerNewProductSaleNotification']
 export const memberCreateRoleValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['MemberCreate']['role']
+> = ['member', 'billing_manager']
+export const memberCreateFromCustomerRoleValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['MemberCreateFromCustomer']['role']
 > = ['member', 'billing_manager']
 export const memberRoleValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['MemberRole']

--- a/server/polar/api.py
+++ b/server/polar/api.py
@@ -38,6 +38,7 @@ from polar.integrations.resend.endpoints import router as resend_router
 from polar.integrations.slack.endpoints import router as slack_router
 from polar.integrations.stripe.endpoints import router as stripe_router
 from polar.license_key.endpoints import router as license_key_router
+from polar.member.endpoints import customer_members_router
 from polar.member.endpoints import router as member_router
 from polar.meter.endpoints import router as meter_router
 from polar.metrics.endpoints import router as metrics_router
@@ -134,6 +135,8 @@ router.include_router(discount_router)
 router.include_router(customer_router)
 # /members
 router.include_router(member_router)
+# /customers/{id}/members (nested member CRUD; defined in the member module)
+router.include_router(customer_members_router)
 # /customer-portal
 router.include_router(customer_portal_router)
 # /seats

--- a/server/polar/member/endpoints.py
+++ b/server/polar/member/endpoints.py
@@ -2,8 +2,8 @@ from uuid import UUID
 
 from fastapi import Depends, Query
 
-from polar.customer.schemas.customer import ExternalCustomerID
-from polar.exceptions import PolarRequestValidationError, ResourceNotFound
+from polar.customer.schemas.customer import CustomerID, ExternalCustomerID
+from polar.exceptions import NotPermitted, PolarRequestValidationError, ResourceNotFound
 from polar.kit.pagination import ListResource, PaginationParamsQuery
 from polar.models.member import MemberRole
 from polar.openapi import APITag
@@ -16,7 +16,13 @@ from polar.postgres import (
 from polar.routing import APIRouter
 
 from . import auth, sorting
-from .schemas import ExternalMemberID, Member, MemberCreate, MemberUpdate
+from .schemas import (
+    ExternalMemberID,
+    Member,
+    MemberCreate,
+    MemberCreateFromCustomer,
+    MemberUpdate,
+)
 from .service import member_service
 
 router = APIRouter(
@@ -24,9 +30,27 @@ router = APIRouter(
     tags=["members", APITag.public],
 )
 
+# Nested router: the new customer-scoped member CRUD, mounted under
+# /v1/customers/{id}/members. Lives in the member module (logic ownership) but
+# is grouped under `customers.members` in the SDK via its tags.
+customer_members_router = APIRouter(
+    prefix="/customers",
+    tags=["customers", "members", APITag.public],
+)
+
 MemberNotFound = {
     "description": "Member not found.",
     "model": ResourceNotFound.schema(),
+}
+
+CustomerNotFound = {
+    "description": "Customer not found.",
+    "model": ResourceNotFound.schema(),
+}
+
+NotPermittedToAddMembers = {
+    "description": "Not permitted to add members.",
+    "model": NotPermitted.schema(),
 }
 
 
@@ -96,6 +120,256 @@ async def list_members(
         count,
         pagination,
     )
+
+
+# --- Nested customer-scoped endpoints ---------------------------------------
+
+
+@customer_members_router.post(
+    "/{id}/members",
+    response_model=Member,
+    status_code=201,
+    summary="Create Member",
+    responses={
+        201: {"description": "Member created."},
+        403: NotPermittedToAddMembers,
+        404: CustomerNotFound,
+    },
+)
+async def create(
+    id: CustomerID,
+    member_create: MemberCreateFromCustomer,
+    auth_subject: auth.MemberWrite,
+    session: AsyncSession = Depends(get_db_session),
+) -> Member:
+    """
+    Create a new member for a customer.
+
+    Only B2B customers with the member management feature enabled can add members.
+    The authenticated user or organization must have access to the customer's organization.
+    """
+    created_member = await member_service.create(
+        session,
+        auth_subject,
+        customer_id=id,
+        email=member_create.email,
+        name=member_create.name,
+        external_id=member_create.external_id,
+        role=member_create.role,
+    )
+
+    return Member.model_validate(created_member)
+
+
+@customer_members_router.post(
+    "/external/{external_id}/members",
+    response_model=Member,
+    status_code=201,
+    summary="Create Member by Customer External ID",
+    responses={
+        201: {"description": "Member created."},
+        403: NotPermittedToAddMembers,
+        404: CustomerNotFound,
+    },
+)
+async def create_external(
+    external_id: ExternalCustomerID,
+    member_create: MemberCreateFromCustomer,
+    auth_subject: auth.MemberWrite,
+    session: AsyncSession = Depends(get_db_session),
+) -> Member:
+    """Create a new member for a customer identified by its external ID."""
+    created_member = await member_service.create(
+        session,
+        auth_subject,
+        external_customer_id=external_id,
+        email=member_create.email,
+        name=member_create.name,
+        external_id=member_create.external_id,
+        role=member_create.role,
+    )
+
+    return Member.model_validate(created_member)
+
+
+@customer_members_router.get(
+    "/{id}/members/{member_id}",
+    summary="Get Member",
+    response_model=Member,
+    responses={
+        200: {"description": "Member retrieved."},
+        404: MemberNotFound,
+    },
+)
+async def get(
+    id: CustomerID,
+    member_id: UUID,
+    auth_subject: auth.MemberRead,
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> Member:
+    """Get a member of a customer by its ID."""
+    member = await member_service.get_for_customer(session, auth_subject, id, member_id)
+    if member is None:
+        raise ResourceNotFound("Member not found")
+
+    return Member.model_validate(member)
+
+
+@customer_members_router.get(
+    "/external/{external_id}/members/external/{member_external_id}",
+    summary="Get Member by External ID",
+    response_model=Member,
+    responses={
+        200: {"description": "Member retrieved."},
+        404: MemberNotFound,
+    },
+)
+async def get_external(
+    external_id: ExternalCustomerID,
+    member_external_id: ExternalMemberID,
+    auth_subject: auth.MemberRead,
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> Member:
+    """Get a member by external ID for a customer identified by its external ID."""
+    member = await member_service.get_by_external_id(
+        session,
+        auth_subject,
+        member_external_id,
+        external_customer_id=external_id,
+    )
+    if member is None:
+        raise ResourceNotFound("Member not found")
+
+    return Member.model_validate(member)
+
+
+@customer_members_router.patch(
+    "/{id}/members/{member_id}",
+    summary="Update Member",
+    response_model=Member,
+    responses={
+        200: {"description": "Member updated."},
+        404: MemberNotFound,
+    },
+)
+async def update(
+    id: CustomerID,
+    member_id: UUID,
+    member_update: MemberUpdate,
+    auth_subject: auth.MemberWrite,
+    session: AsyncSession = Depends(get_db_session),
+) -> Member:
+    """
+    Update a member of a customer.
+
+    Only name, email and role can be updated.
+    """
+    member = await member_service.get_for_customer(session, auth_subject, id, member_id)
+    if member is None:
+        raise ResourceNotFound("Member not found")
+
+    updated_member = await member_service.update(
+        session,
+        member,
+        name=member_update.name,
+        role=member_update.role,
+        email=member_update.email,
+        allow_ownership_transfer=True,
+    )
+
+    return Member.model_validate(updated_member)
+
+
+@customer_members_router.patch(
+    "/external/{external_id}/members/external/{member_external_id}",
+    summary="Update Member by External ID",
+    response_model=Member,
+    responses={
+        200: {"description": "Member updated."},
+        404: MemberNotFound,
+    },
+)
+async def update_external(
+    external_id: ExternalCustomerID,
+    member_external_id: ExternalMemberID,
+    member_update: MemberUpdate,
+    auth_subject: auth.MemberWrite,
+    session: AsyncSession = Depends(get_db_session),
+) -> Member:
+    """Update a member by external ID for a customer identified by its external ID."""
+    member = await member_service.get_by_external_id(
+        session,
+        auth_subject,
+        member_external_id,
+        external_customer_id=external_id,
+    )
+    if member is None:
+        raise ResourceNotFound("Member not found")
+
+    updated_member = await member_service.update(
+        session,
+        member,
+        name=member_update.name,
+        role=member_update.role,
+        email=member_update.email,
+        allow_ownership_transfer=True,
+    )
+
+    return Member.model_validate(updated_member)
+
+
+@customer_members_router.delete(
+    "/{id}/members/{member_id}",
+    status_code=204,
+    summary="Delete Member",
+    responses={
+        204: {"description": "Member deleted."},
+        404: MemberNotFound,
+    },
+)
+async def delete(
+    id: CustomerID,
+    member_id: UUID,
+    auth_subject: auth.MemberWrite,
+    session: AsyncSession = Depends(get_db_session),
+) -> None:
+    """Delete a member of a customer."""
+    member = await member_service.get_for_customer(session, auth_subject, id, member_id)
+    if member is None:
+        raise ResourceNotFound("Member not found")
+
+    await member_service.delete(session, member)
+
+
+@customer_members_router.delete(
+    "/external/{external_id}/members/external/{member_external_id}",
+    status_code=204,
+    summary="Delete Member by External ID",
+    responses={
+        204: {"description": "Member deleted."},
+        404: MemberNotFound,
+    },
+)
+async def delete_external(
+    external_id: ExternalCustomerID,
+    member_external_id: ExternalMemberID,
+    auth_subject: auth.MemberWrite,
+    session: AsyncSession = Depends(get_db_session),
+) -> None:
+    """Delete a member by external ID for a customer identified by its external ID."""
+    member = await member_service.get_by_external_id(
+        session,
+        auth_subject,
+        member_external_id,
+        external_customer_id=external_id,
+    )
+    if member is None:
+        raise ResourceNotFound("Member not found")
+
+    await member_service.delete(session, member)
+
+
+# --- Existing customer-scoped endpoints (unchanged) -------------------------
 
 
 @router.post(

--- a/server/polar/member/endpoints.py
+++ b/server/polar/member/endpoints.py
@@ -27,7 +27,7 @@ from .service import AmbiguousExternalCustomerID, member_service
 
 router = APIRouter(
     prefix="/members",
-    tags=["members", APITag.public],
+    tags=["members"],
 )
 
 # Nested router: the new customer-scoped member CRUD, mounted under
@@ -90,6 +90,7 @@ def _validate_customer_id_params(
 @router.get(
     "/",
     summary="List Members",
+    tags=[APITag.public],
     response_model=ListResource[Member],
 )
 async def list_members(
@@ -223,7 +224,7 @@ async def get(
 
 
 @customer_members_router.get(
-    "/external/{external_id}/members/external/{member_external_id}",
+    "/external/{external_id}/members/{member_external_id}",
     summary="Get Member by External ID",
     response_model=Member,
     responses={
@@ -289,7 +290,7 @@ async def update(
 
 
 @customer_members_router.patch(
-    "/external/{external_id}/members/external/{member_external_id}",
+    "/external/{external_id}/members/{member_external_id}",
     summary="Update Member by External ID",
     response_model=Member,
     responses={
@@ -351,7 +352,7 @@ async def delete(
 
 
 @customer_members_router.delete(
-    "/external/{external_id}/members/external/{member_external_id}",
+    "/external/{external_id}/members/{member_external_id}",
     status_code=204,
     summary="Delete Member by External ID",
     responses={
@@ -379,7 +380,9 @@ async def delete_external(
     await member_service.delete(session, member)
 
 
-# --- Existing customer-scoped endpoints (unchanged) -------------------------
+# --- Deprecated customer-scoped endpoints -----------------------------------
+# Superseded by the nested /v1/customers/{id}/members routes above. Kept for
+# backwards compatibility (APITag.private removes them from the public SDK).
 
 
 @router.post(
@@ -387,6 +390,8 @@ async def delete_external(
     response_model=Member,
     status_code=201,
     summary="Create Member",
+    tags=[APITag.private],
+    deprecated=True,
     responses={
         201: {"description": "Member created."},
         403: {"description": "Not permitted to add members."},
@@ -421,6 +426,8 @@ async def create_member(
     "/{id}",
     summary="Get Member",
     response_model=Member,
+    tags=[APITag.private],
+    deprecated=True,
     responses={
         200: {"description": "Member retrieved."},
         404: MemberNotFound,
@@ -448,6 +455,8 @@ async def get_member(
     "/external/{external_id}",
     summary="Get Member by External ID",
     response_model=Member,
+    tags=[APITag.private],
+    deprecated=True,
     responses={
         200: {"description": "Member retrieved."},
         404: MemberNotFound,
@@ -483,6 +492,8 @@ async def get_member_by_external_id(
     "/{id}",
     summary="Update Member",
     response_model=Member,
+    tags=[APITag.private],
+    deprecated=True,
     responses={
         200: {"description": "Member updated."},
         404: MemberNotFound,
@@ -521,6 +532,8 @@ async def update_member(
     "/external/{external_id}",
     summary="Update Member by External ID",
     response_model=Member,
+    tags=[APITag.private],
+    deprecated=True,
     responses={
         200: {"description": "Member updated."},
         404: MemberNotFound,
@@ -566,6 +579,8 @@ async def update_member_by_external_id(
     "/{id}",
     status_code=204,
     summary="Delete Member",
+    tags=[APITag.private],
+    deprecated=True,
     responses={
         204: {"description": "Member deleted."},
         404: MemberNotFound,
@@ -593,6 +608,8 @@ async def delete_member(
     "/external/{external_id}",
     status_code=204,
     summary="Delete Member by External ID",
+    tags=[APITag.private],
+    deprecated=True,
     responses={
         204: {"description": "Member deleted."},
         404: MemberNotFound,

--- a/server/polar/member/endpoints.py
+++ b/server/polar/member/endpoints.py
@@ -23,7 +23,7 @@ from .schemas import (
     MemberCreateFromCustomer,
     MemberUpdate,
 )
-from .service import member_service
+from .service import AmbiguousExternalCustomerID, member_service
 
 router = APIRouter(
     prefix="/members",
@@ -51,6 +51,12 @@ CustomerNotFound = {
 NotPermittedToAddMembers = {
     "description": "Not permitted to add members.",
     "model": NotPermitted.schema(),
+}
+
+AmbiguousExternalCustomer = {
+    "description": "The external customer ID matches customers in several "
+    "accessible organizations.",
+    "model": AmbiguousExternalCustomerID.schema(),
 }
 
 
@@ -170,6 +176,7 @@ async def create(
         201: {"description": "Member created."},
         403: NotPermittedToAddMembers,
         404: CustomerNotFound,
+        409: AmbiguousExternalCustomer,
     },
 )
 async def create_external(
@@ -222,6 +229,7 @@ async def get(
     responses={
         200: {"description": "Member retrieved."},
         404: MemberNotFound,
+        409: AmbiguousExternalCustomer,
     },
 )
 async def get_external(
@@ -287,6 +295,7 @@ async def update(
     responses={
         200: {"description": "Member updated."},
         404: MemberNotFound,
+        409: AmbiguousExternalCustomer,
     },
 )
 async def update_external(
@@ -348,6 +357,7 @@ async def delete(
     responses={
         204: {"description": "Member deleted."},
         404: MemberNotFound,
+        409: AmbiguousExternalCustomer,
     },
 )
 async def delete_external(

--- a/server/polar/member/schemas.py
+++ b/server/polar/member/schemas.py
@@ -46,12 +46,12 @@ class MemberOwnerCreate(Schema):
     )
 
 
-class MemberCreate(Schema):
-    """Schema for creating a new member."""
+class MemberCreateFromCustomer(Schema):
+    """Schema for creating a new member nested under a customer.
 
-    customer_id: UUID4 = Field(
-        description="The ID of the customer this member belongs to."
-    )
+    The customer is taken from the URL path, so it's not part of the body.
+    """
+
     email: EmailStrDNS = Field(
         description=_email_description, examples=[_email_example]
     )
@@ -70,6 +70,14 @@ class MemberCreate(Schema):
             "ownership, use the member update endpoint."
         ),
         examples=[MemberRole.member],
+    )
+
+
+class MemberCreate(MemberCreateFromCustomer):
+    """Schema for creating a new member (deprecated; customer in the body)."""
+
+    customer_id: UUID4 = Field(
+        description="The ID of the customer this member belongs to."
     )
 
 

--- a/server/polar/member/service.py
+++ b/server/polar/member/service.py
@@ -123,23 +123,28 @@ class MemberService:
         """Get a member by external ID if the auth subject has access to it."""
         repository = MemberRepository.from_session(session)
         org_ids = await get_accessible_org_ids(session, auth_subject)
+
+        # Resolve the customer first so an ambiguous external customer ID always
+        # surfaces as a 409, regardless of how many members happen to match.
+        if external_customer_id is not None:
+            customer_repository = CustomerRepository.from_session(session)
+            try:
+                customer = await customer_repository.get_readable_by_external_id(
+                    org_ids, external_customer_id
+                )
+            except MultipleResultsFound as e:
+                raise AmbiguousExternalCustomerID(external_customer_id) from e
+            if customer is None:
+                return None
+            customer_id = customer.id
+
         statement = repository.get_statement_by_org_ids(org_ids).where(
             Member.external_id == external_id
         )
-
-        if external_customer_id is not None:
-            statement = statement.join(Customer).where(
-                Customer.external_id == external_customer_id
-            )
         if customer_id is not None:
             statement = statement.where(Member.customer_id == customer_id)
 
-        try:
-            return await repository.get_one_or_none(statement)
-        except MultipleResultsFound as e:
-            if external_customer_id is not None:
-                raise AmbiguousExternalCustomerID(external_customer_id) from e
-            raise
+        return await repository.get_one_or_none(statement)
 
     async def delete(
         self,

--- a/server/polar/member/service.py
+++ b/server/polar/member/service.py
@@ -83,6 +83,19 @@ class MemberService:
         statement = repository.get_statement_by_org_ids(org_ids).where(Member.id == id)
         return await repository.get_one_or_none(statement)
 
+    async def get_for_customer(
+        self,
+        session: AsyncReadSession,
+        auth_subject: AuthSubject[User | Organization],
+        customer_id: UUID,
+        member_id: UUID,
+    ) -> Member | None:
+        """Get a member by ID, scoped to a customer the auth subject can access."""
+        member = await self.get(session, auth_subject, member_id)
+        if member is None or member.customer_id != customer_id:
+            return None
+        return member
+
     async def get_by_external_id(
         self,
         session: AsyncReadSession,
@@ -527,7 +540,8 @@ class MemberService:
         session: AsyncSession,
         auth_subject: AuthSubject[User | Organization],
         *,
-        customer_id: UUID,
+        customer_id: UUID | None = None,
+        external_customer_id: str | None = None,
         email: str,
         name: str | None = None,
         external_id: str | None = None,
@@ -537,10 +551,14 @@ class MemberService:
         """
         Create a new member for a customer.
 
+        The customer is resolved by either its internal ID (`customer_id`) or its
+        external ID (`external_customer_id`); exactly one must be provided.
+
         Args:
             session: Database session
             auth_subject: Authenticated user/organization
             customer_id: ID of the customer to add member to
+            external_customer_id: External ID of the customer to add member to
             email: Email address of the member
             name: Optional name of the member
             external_id: Optional external ID of the member
@@ -555,12 +573,23 @@ class MemberService:
         """
         customer_repository = CustomerRepository.from_session(session)
         org_ids = await get_accessible_org_ids(session, auth_subject)
-        customer = await customer_repository.get_readable_by_id(
-            org_ids, customer_id, options=(joinedload(Customer.organization),)
-        )
+        if customer_id is not None:
+            customer = await customer_repository.get_readable_by_id(
+                org_ids, customer_id, options=(joinedload(Customer.organization),)
+            )
+        elif external_customer_id is not None:
+            customer = await customer_repository.get_readable_by_external_id(
+                org_ids,
+                external_customer_id,
+                options=(joinedload(Customer.organization),),
+            )
+        else:
+            raise ResourceNotFound("Customer not found")
 
         if customer is None:
             raise ResourceNotFound("Customer not found")
+
+        customer_id = customer.id
 
         member_model = customer.organization.feature_settings.get(
             "member_model_enabled", False

--- a/server/polar/member/service.py
+++ b/server/polar/member/service.py
@@ -39,8 +39,9 @@ class AmbiguousExternalCustomerID(PolarError):
     def __init__(self, external_customer_id: str) -> None:
         self.external_customer_id = external_customer_id
         super().__init__(
-            "Several customers across your organizations share this external ID. "
-            "Use the customer ID instead.",
+            "Several customers across your organizations share this external "
+            "customer ID. Use an organization-scoped token, the Polar customer "
+            "ID, or a unique external ID to disambiguate.",
             409,
         )
 

--- a/server/polar/member/service.py
+++ b/server/polar/member/service.py
@@ -5,14 +5,19 @@ from uuid import UUID
 
 import structlog
 from sqlalchemy import UnaryExpression, asc, desc
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, MultipleResultsFound
 from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject, Organization, User
 from polar.authz.service import get_accessible_org_ids
 from polar.customer.repository import CustomerRepository
 from polar.customer_seat.repository import CustomerSeatRepository
-from polar.exceptions import NotPermitted, PolarRequestValidationError, ResourceNotFound
+from polar.exceptions import (
+    NotPermitted,
+    PolarError,
+    PolarRequestValidationError,
+    ResourceNotFound,
+)
 from polar.kit.pagination import PaginationParams
 from polar.kit.sorting import Sorting
 from polar.models.customer import Customer, CustomerType
@@ -28,6 +33,16 @@ from .repository import MemberRepository
 from .sorting import MemberSortProperty
 
 log = structlog.get_logger()
+
+
+class AmbiguousExternalCustomerID(PolarError):
+    def __init__(self, external_customer_id: str) -> None:
+        self.external_customer_id = external_customer_id
+        super().__init__(
+            "Several customers across your organizations share this external ID. "
+            "Use the customer ID instead.",
+            409,
+        )
 
 
 class MemberService:
@@ -119,7 +134,12 @@ class MemberService:
         if customer_id is not None:
             statement = statement.where(Member.customer_id == customer_id)
 
-        return await repository.get_one_or_none(statement)
+        try:
+            return await repository.get_one_or_none(statement)
+        except MultipleResultsFound as e:
+            if external_customer_id is not None:
+                raise AmbiguousExternalCustomerID(external_customer_id) from e
+            raise
 
     async def delete(
         self,
@@ -571,6 +591,11 @@ class MemberService:
             ResourceNotFound: If customer not found or not accessible
             NotPermitted: If feature flag disabled or no permission to add members
         """
+        if customer_id is not None and external_customer_id is not None:
+            raise ValueError(
+                "Provide either customer_id or external_customer_id, not both."
+            )
+
         customer_repository = CustomerRepository.from_session(session)
         org_ids = await get_accessible_org_ids(session, auth_subject)
         if customer_id is not None:
@@ -578,11 +603,14 @@ class MemberService:
                 org_ids, customer_id, options=(joinedload(Customer.organization),)
             )
         elif external_customer_id is not None:
-            customer = await customer_repository.get_readable_by_external_id(
-                org_ids,
-                external_customer_id,
-                options=(joinedload(Customer.organization),),
-            )
+            try:
+                customer = await customer_repository.get_readable_by_external_id(
+                    org_ids,
+                    external_customer_id,
+                    options=(joinedload(Customer.organization),),
+                )
+            except MultipleResultsFound as e:
+                raise AmbiguousExternalCustomerID(external_customer_id) from e
         else:
             raise ResourceNotFound("Customer not found")
 

--- a/server/tests/member/test_endpoints.py
+++ b/server/tests/member/test_endpoints.py
@@ -1815,6 +1815,49 @@ class TestGetCustomerMember:
         )
         assert response.status_code == 409
 
+    @pytest.mark.auth
+    async def test_external_ambiguous_customer_single_member(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user: User,
+    ) -> None:
+        # Two accessible customers share the external ID, but only one has a
+        # member with the requested member external ID. The ambiguity must still
+        # surface as 409 (resolved from the customer, not from member count).
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            external_id="cus_dup_single",
+            email="a@example.com",
+        )
+        await save_fixture(
+            Member(
+                customer_id=customer.id,
+                organization_id=organization.id,
+                email="m1@example.com",
+                external_id="mem_single",
+                role="owner",
+            )
+        )
+
+        other_account = await create_account(save_fixture, user)
+        other_org = await create_organization(save_fixture, other_account)
+        await save_fixture(UserOrganization(user=user, organization=other_org))
+        await create_customer(
+            save_fixture,
+            organization=other_org,
+            external_id="cus_dup_single",
+            email="b@example.com",
+        )
+
+        response = await client.get(
+            "/v1/customers/external/cus_dup_single/members/external/mem_single"
+        )
+        assert response.status_code == 409
+
 
 @pytest.mark.asyncio
 class TestUpdateCustomerMember:

--- a/server/tests/member/test_endpoints.py
+++ b/server/tests/member/test_endpoints.py
@@ -1521,6 +1521,52 @@ class TestCreateCustomerMember:
         )
         assert response.status_code == 404
 
+    @pytest.mark.auth
+    async def test_different_organization(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user: User,
+    ) -> None:
+        other_account = await create_account(save_fixture, user)
+        other_org = await create_organization(save_fixture, other_account)
+        other_org.feature_settings = {"member_model_enabled": True}
+        await save_fixture(other_org)
+        customer = await create_customer(
+            save_fixture, organization=other_org, email="customer@example.com"
+        )
+
+        # The customer exists but belongs to an org the subject can't access.
+        response = await client.post(
+            f"/v1/customers/{customer.id}/members",
+            json={"email": "member@example.com"},
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_external_different_organization(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user: User,
+    ) -> None:
+        other_account = await create_account(save_fixture, user)
+        other_org = await create_organization(save_fixture, other_account)
+        other_org.feature_settings = {"member_model_enabled": True}
+        await save_fixture(other_org)
+        await create_customer(
+            save_fixture,
+            organization=other_org,
+            external_id="cus_ext_other_org",
+            email="customer@example.com",
+        )
+
+        response = await client.post(
+            "/v1/customers/external/cus_ext_other_org/members",
+            json={"email": "member@example.com"},
+        )
+        assert response.status_code == 404
+
 
 @pytest.mark.asyncio
 class TestGetCustomerMember:

--- a/server/tests/member/test_endpoints.py
+++ b/server/tests/member/test_endpoints.py
@@ -1567,6 +1567,44 @@ class TestCreateCustomerMember:
         )
         assert response.status_code == 404
 
+    @pytest.mark.auth
+    async def test_external_ambiguous_across_organizations(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user: User,
+    ) -> None:
+        organization.feature_settings = {"member_model_enabled": True}
+        await save_fixture(organization)
+        await create_customer(
+            save_fixture,
+            organization=organization,
+            external_id="cus_dup",
+            email="a@example.com",
+        )
+
+        # A second org the same user belongs to has a customer with the same
+        # external ID, making the external lookup ambiguous.
+        other_account = await create_account(save_fixture, user)
+        other_org = await create_organization(save_fixture, other_account)
+        other_org.feature_settings = {"member_model_enabled": True}
+        await save_fixture(other_org)
+        await save_fixture(UserOrganization(user=user, organization=other_org))
+        await create_customer(
+            save_fixture,
+            organization=other_org,
+            external_id="cus_dup",
+            email="b@example.com",
+        )
+
+        response = await client.post(
+            "/v1/customers/external/cus_dup/members",
+            json={"email": "member@example.com"},
+        )
+        assert response.status_code == 409
+
 
 @pytest.mark.asyncio
 class TestGetCustomerMember:
@@ -1727,6 +1765,55 @@ class TestGetCustomerMember:
 
         response = await client.get(f"/v1/customers/{customer.id}/members/{member.id}")
         assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_external_ambiguous_across_organizations(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user: User,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            external_id="cus_dup_get",
+            email="a@example.com",
+        )
+        await save_fixture(
+            Member(
+                customer_id=customer.id,
+                organization_id=organization.id,
+                email="m1@example.com",
+                external_id="mem_dup",
+                role="owner",
+            )
+        )
+
+        other_account = await create_account(save_fixture, user)
+        other_org = await create_organization(save_fixture, other_account)
+        await save_fixture(UserOrganization(user=user, organization=other_org))
+        other_customer = await create_customer(
+            save_fixture,
+            organization=other_org,
+            external_id="cus_dup_get",
+            email="b@example.com",
+        )
+        await save_fixture(
+            Member(
+                customer_id=other_customer.id,
+                organization_id=other_org.id,
+                email="m2@example.com",
+                external_id="mem_dup",
+                role="owner",
+            )
+        )
+
+        response = await client.get(
+            "/v1/customers/external/cus_dup_get/members/external/mem_dup"
+        )
+        assert response.status_code == 409
 
 
 @pytest.mark.asyncio

--- a/server/tests/member/test_endpoints.py
+++ b/server/tests/member/test_endpoints.py
@@ -1654,7 +1654,7 @@ class TestGetCustomerMember:
 
         # Member's external id exists, but under a different customer's external id.
         response = await client.get(
-            "/v1/customers/external/cus_ext_w_b/members/external/mem_ext_w"
+            "/v1/customers/external/cus_ext_w_b/members/mem_ext_w"
         )
         assert response.status_code == 404
 
@@ -1709,7 +1709,7 @@ class TestGetCustomerMember:
         await save_fixture(member)
 
         response = await client.get(
-            "/v1/customers/external/cus_ext_2/members/external/mem_ext_2"
+            "/v1/customers/external/cus_ext_2/members/mem_ext_2"
         )
 
         assert response.status_code == 200
@@ -1811,7 +1811,7 @@ class TestGetCustomerMember:
         )
 
         response = await client.get(
-            "/v1/customers/external/cus_dup_get/members/external/mem_dup"
+            "/v1/customers/external/cus_dup_get/members/mem_dup"
         )
         assert response.status_code == 409
 
@@ -1854,7 +1854,7 @@ class TestGetCustomerMember:
         )
 
         response = await client.get(
-            "/v1/customers/external/cus_dup_single/members/external/mem_single"
+            "/v1/customers/external/cus_dup_single/members/mem_single"
         )
         assert response.status_code == 409
 
@@ -1931,7 +1931,7 @@ class TestUpdateCustomerMember:
         await save_fixture(member)
 
         response = await client.patch(
-            "/v1/customers/external/cus_ext_3/members/external/mem_ext_3",
+            "/v1/customers/external/cus_ext_3/members/mem_ext_3",
             json={"name": "New Name"},
         )
 
@@ -2036,7 +2036,7 @@ class TestDeleteCustomerMember:
         await save_fixture(member)
 
         response = await client.delete(
-            "/v1/customers/external/cus_ext_4/members/external/mem_ext_4"
+            "/v1/customers/external/cus_ext_4/members/mem_ext_4"
         )
         assert response.status_code == 204
 

--- a/server/tests/member/test_endpoints.py
+++ b/server/tests/member/test_endpoints.py
@@ -1387,3 +1387,506 @@ class TestDeleteMember:
         response = await client.delete(f"/v1/members/{member.id}")
 
         assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestCreateCustomerMember:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.post(
+            f"/v1/customers/{uuid.uuid4()}/members",
+            json={"email": "member@example.com"},
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes=set()))
+    async def test_missing_scope(
+        self, client: AsyncClient, user_organization: UserOrganization
+    ) -> None:
+        response = await client.post(
+            f"/v1/customers/{uuid.uuid4()}/members",
+            json={"email": "member@example.com"},
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.auth
+    async def test_feature_flag_disabled(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        organization.feature_settings = {"member_model_enabled": False}
+        await save_fixture(organization)
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+
+        response = await client.post(
+            f"/v1/customers/{customer.id}/members",
+            json={"email": "member@example.com"},
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.auth
+    async def test_rejects_owner_role(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        organization.feature_settings = {"member_model_enabled": True}
+        await save_fixture(organization)
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+
+        response = await client.post(
+            f"/v1/customers/{customer.id}/members",
+            json={"email": "member@example.com", "role": "owner"},
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.auth
+    async def test_success(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        organization.feature_settings = {"member_model_enabled": True}
+        await save_fixture(organization)
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+
+        response = await client.post(
+            f"/v1/customers/{customer.id}/members",
+            json={
+                "email": "newmember@example.com",
+                "name": "New Member",
+                "role": "member",
+            },
+        )
+
+        assert response.status_code == 201
+        json = response.json()
+        assert json["email"] == "newmember@example.com"
+        assert json["customer_id"] == str(customer.id)
+        assert json["role"] == "member"
+
+    @pytest.mark.auth
+    async def test_external_success(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        organization.feature_settings = {"member_model_enabled": True}
+        await save_fixture(organization)
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            external_id="cus_ext_1",
+            email="customer@example.com",
+        )
+
+        response = await client.post(
+            "/v1/customers/external/cus_ext_1/members",
+            json={"email": "newmember@example.com", "external_id": "mem_ext_1"},
+        )
+
+        assert response.status_code == 201
+        json = response.json()
+        assert json["customer_id"] == str(customer.id)
+        assert json["external_id"] == "mem_ext_1"
+
+    @pytest.mark.auth
+    async def test_customer_not_found(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        organization.feature_settings = {"member_model_enabled": True}
+        await save_fixture(organization)
+
+        response = await client.post(
+            f"/v1/customers/{uuid.uuid4()}/members",
+            json={"email": "member@example.com"},
+        )
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestGetCustomerMember:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get(
+            f"/v1/customers/{uuid.uuid4()}/members/{uuid.uuid4()}"
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes=set()))
+    async def test_missing_scope(
+        self, client: AsyncClient, user_organization: UserOrganization
+    ) -> None:
+        response = await client.get(
+            f"/v1/customers/{uuid.uuid4()}/members/{uuid.uuid4()}"
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.auth
+    async def test_external_wrong_customer(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            external_id="cus_ext_w_a",
+            email="customer@example.com",
+        )
+        await create_customer(
+            save_fixture,
+            organization=organization,
+            external_id="cus_ext_w_b",
+            email="other@example.com",
+        )
+        member = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="member@example.com",
+            external_id="mem_ext_w",
+            role="owner",
+        )
+        await save_fixture(member)
+
+        # Member's external id exists, but under a different customer's external id.
+        response = await client.get(
+            "/v1/customers/external/cus_ext_w_b/members/external/mem_ext_w"
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_success(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        member = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="member@example.com",
+            name="Test Member",
+            role="owner",
+        )
+        await save_fixture(member)
+
+        response = await client.get(f"/v1/customers/{customer.id}/members/{member.id}")
+
+        assert response.status_code == 200
+        json = response.json()
+        assert json["id"] == str(member.id)
+        assert json["customer_id"] == str(customer.id)
+
+    @pytest.mark.auth
+    async def test_external_success(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            external_id="cus_ext_2",
+            email="customer@example.com",
+        )
+        member = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="member@example.com",
+            external_id="mem_ext_2",
+            role="owner",
+        )
+        await save_fixture(member)
+
+        response = await client.get(
+            "/v1/customers/external/cus_ext_2/members/external/mem_ext_2"
+        )
+
+        assert response.status_code == 200
+        assert response.json()["id"] == str(member.id)
+
+    @pytest.mark.auth
+    async def test_wrong_customer(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        other_customer = await create_customer(
+            save_fixture, organization=organization, email="other@example.com"
+        )
+        member = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="member@example.com",
+            role="owner",
+        )
+        await save_fixture(member)
+
+        # Member exists but belongs to a different customer than the path's.
+        response = await client.get(
+            f"/v1/customers/{other_customer.id}/members/{member.id}"
+        )
+        assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_different_organization(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user: User,
+    ) -> None:
+        other_account = await create_account(save_fixture, user)
+        other_org = await create_organization(save_fixture, other_account)
+        customer = await create_customer(
+            save_fixture, organization=other_org, email="customer@example.com"
+        )
+        member = Member(
+            customer_id=customer.id,
+            organization_id=other_org.id,
+            email="member@example.com",
+            role="owner",
+        )
+        await save_fixture(member)
+
+        response = await client.get(f"/v1/customers/{customer.id}/members/{member.id}")
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestUpdateCustomerMember:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.patch(
+            f"/v1/customers/{uuid.uuid4()}/members/{uuid.uuid4()}",
+            json={"name": "X"},
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes=set()))
+    async def test_missing_scope(
+        self, client: AsyncClient, user_organization: UserOrganization
+    ) -> None:
+        response = await client.patch(
+            f"/v1/customers/{uuid.uuid4()}/members/{uuid.uuid4()}",
+            json={"name": "X"},
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.auth
+    async def test_success(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        member = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="member@example.com",
+            name="Old Name",
+            role="owner",
+        )
+        await save_fixture(member)
+
+        response = await client.patch(
+            f"/v1/customers/{customer.id}/members/{member.id}",
+            json={"name": "New Name"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["name"] == "New Name"
+
+    @pytest.mark.auth
+    async def test_external_success(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            external_id="cus_ext_3",
+            email="customer@example.com",
+        )
+        member = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="member@example.com",
+            external_id="mem_ext_3",
+            name="Old Name",
+            role="owner",
+        )
+        await save_fixture(member)
+
+        response = await client.patch(
+            "/v1/customers/external/cus_ext_3/members/external/mem_ext_3",
+            json={"name": "New Name"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["name"] == "New Name"
+
+    @pytest.mark.auth
+    async def test_wrong_customer(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        other_customer = await create_customer(
+            save_fixture, organization=organization, email="other@example.com"
+        )
+        member = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="member@example.com",
+            role="owner",
+        )
+        await save_fixture(member)
+
+        response = await client.patch(
+            f"/v1/customers/{other_customer.id}/members/{member.id}",
+            json={"name": "New Name"},
+        )
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestDeleteCustomerMember:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.delete(
+            f"/v1/customers/{uuid.uuid4()}/members/{uuid.uuid4()}"
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes=set()))
+    async def test_missing_scope(
+        self, client: AsyncClient, user_organization: UserOrganization
+    ) -> None:
+        response = await client.delete(
+            f"/v1/customers/{uuid.uuid4()}/members/{uuid.uuid4()}"
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.auth
+    async def test_success(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        customer.type = CustomerType.team
+        await save_fixture(customer)
+        member = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="member@example.com",
+            role="member",
+        )
+        await save_fixture(member)
+
+        response = await client.delete(
+            f"/v1/customers/{customer.id}/members/{member.id}"
+        )
+        assert response.status_code == 204
+
+    @pytest.mark.auth
+    async def test_external_success(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            external_id="cus_ext_4",
+            email="customer@example.com",
+        )
+        customer.type = CustomerType.team
+        await save_fixture(customer)
+        member = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="member@example.com",
+            external_id="mem_ext_4",
+            role="member",
+        )
+        await save_fixture(member)
+
+        response = await client.delete(
+            "/v1/customers/external/cus_ext_4/members/external/mem_ext_4"
+        )
+        assert response.status_code == 204
+
+    @pytest.mark.auth
+    async def test_wrong_customer(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        other_customer = await create_customer(
+            save_fixture, organization=organization, email="other@example.com"
+        )
+        member = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="member@example.com",
+            role="member",
+        )
+        await save_fixture(member)
+
+        response = await client.delete(
+            f"/v1/customers/{other_customer.id}/members/{member.id}"
+        )
+        assert response.status_code == 404

--- a/server/tests/member/test_service.py
+++ b/server/tests/member/test_service.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -530,6 +531,21 @@ class TestCreate:
         assert second_member is not None
         assert second_member.email == "second@example.com"
         assert second_member.role == MemberRole.member
+
+    @pytest.mark.auth
+    async def test_rejects_both_customer_identifiers(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+    ) -> None:
+        with pytest.raises(ValueError, match="not both"):
+            await member_service.create(
+                session,
+                auth_subject,
+                customer_id=uuid.uuid4(),
+                external_customer_id="ext_123",
+                email="member@example.com",
+            )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds member endpoints nested under `/v1/customers/{id}/members` and external variants. The current endpoints are unchanged, for now. 


SDK will look like:

```python
polar_sdk.customers.members.create()
polar_sdk.customers.members.update()
# ...
```

## What

New public endpoints, defined in the member module and registered under the `/customers` prefix:

- `POST /v1/customers/{id}/members` and `POST /v1/customers/external/{external_id}/members`
- `GET|PATCH|DELETE /v1/customers/{id}/members/{member_id}`
- `GET|PATCH|DELETE /v1/customers/external/{external_id}/members/external/{member_external_id}`

Supporting changes: a `MemberCreateFromCustomer` body schema (customer comes from the path), `member_service.create` now resolves the customer by internal or external id, and a new auth-scoped `member_service.get_for_customer` helper. The TS client is regenerated.

## How

- The route carries `tags=["customers", "members"]`, which writes both the `operationId` (`customers:members:*`) and the `x-speakeasy-group` (`customers.members`), so the SDKs nest the methods automatically. 
- New routes are set on members/endpoints.py to avoid many recursive imports issues




## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

