### PR TITLE
Allow expired license keys backed by subscriptions to remain valid

### DIFF
--- a/server/polar/license_key/repository.py
+++ b/server/polar/license_key/repository.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from sqlalchemy import Select
+from sqlalchemy import Select, select
 from sqlalchemy.orm import joinedload
 
 from polar.auth.models import (
@@ -16,7 +16,7 @@ from polar.kit.repository import (
     RepositorySoftDeletionIDMixin,
     RepositorySoftDeletionMixin,
 )
-from polar.models import LicenseKey
+from polar.models import BenefitGrant, LicenseKey
 
 
 class LicenseKeyRepository(
@@ -80,6 +80,21 @@ class LicenseKeyRepository(
             .options(*options)
         )
         return await self.get_one_or_none(statement)
+
+    async def is_granted_through_subscription(self, license_key: LicenseKey) -> bool:
+        statement = (
+            select(BenefitGrant.id)
+            .where(
+                BenefitGrant.benefit_id == license_key.benefit_id,
+                BenefitGrant.customer_id == license_key.customer_id,
+                BenefitGrant.member_id == license_key.member_id,
+                BenefitGrant.subscription_id.is_not(None),
+                BenefitGrant.deleted_at.is_(None),
+            )
+            .limit(1)
+        )
+        result = await self.session.execute(statement)
+        return result.first() is not None
 
     def get_eager_options(self) -> Options:
         return (

--- a/server/polar/license_key/service.py
+++ b/server/polar/license_key/service.py
@@ -172,8 +172,9 @@ class LicenseKeyService:
             bound_logger.info("license_key.validate.invalid_status")
             raise ResourceNotFound("License key is no longer active.")
 
-        if license_key.expires_at:
-            if utc_now() >= license_key.expires_at:
+        if license_key.expires_at and utc_now() >= license_key.expires_at:
+            repository = LicenseKeyRepository.from_session(session)
+            if not await repository.is_granted_through_subscription(license_key):
                 bound_logger.info("license_key.validate.invalid_ttl")
                 raise ResourceNotFound("License key has expired.")
 
@@ -251,8 +252,9 @@ class LicenseKeyService:
                 "This license key can not be activated."
             )
 
-        if license_key.expires_at:
-            if utc_now() >= license_key.expires_at:
+        if license_key.expires_at and utc_now() >= license_key.expires_at:
+            repository = LicenseKeyRepository.from_session(session)
+            if not await repository.is_granted_through_subscription(license_key):
                 raise NotPermitted("License key has expired.")
 
         if not license_key.limit_activations:

--- a/server/tests/fixtures/license_key.py
+++ b/server/tests/fixtures/license_key.py
@@ -16,6 +16,7 @@ from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_benefit,
     create_benefit_grant,
+    create_order,
     create_subscription,
 )
 
@@ -68,6 +69,29 @@ class TestLicenseKey:
             customer,
             benefit,
             subscription=subscription,
+        )
+        return await cls.run_grant_task(session, redis, benefit, customer)
+
+    @classmethod
+    async def create_order_grant(
+        cls,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        benefit: Benefit,
+        customer: Customer,
+        product: Product,
+    ) -> tuple[Benefit, BenefitGrantLicenseKeysProperties]:
+        order = await create_order(
+            save_fixture,
+            customer=customer,
+            product=product,
+        )
+        await create_benefit_grant(
+            save_fixture,
+            customer,
+            benefit,
+            order=order,
         )
         return await cls.run_grant_task(session, redis, benefit, customer)
 

--- a/server/tests/license_key/test_endpoints.py
+++ b/server/tests/license_key/test_endpoints.py
@@ -23,12 +23,14 @@ from polar.models import (
     User,
     UserOrganization,
 )
+from polar.models.benefit import BenefitType
 from polar.models.license_key import LicenseKeyStatus
 from polar.postgres import AsyncSession
 from polar.redis import Redis
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.license_key import TestLicenseKey
+from tests.fixtures.random_objects import create_benefit
 
 
 @pytest.mark.asyncio
@@ -472,7 +474,7 @@ class TestLicenseKeyEndpoints:
         AuthSubjectFixture(subject="user"),
         AuthSubjectFixture(subject="organization"),
     )
-    async def test_activate_expired_license_key_should_fail(
+    async def test_activate_expired_order_license_key_should_fail(
         self,
         activate_path: str,
         session: AsyncSession,
@@ -484,7 +486,63 @@ class TestLicenseKeyEndpoints:
         product: Product,
         customer: Customer,
     ) -> None:
-        """Test that activating an expired license key should fail."""
+        """An expired license key not backed by a subscription should fail."""
+        benefit = await create_benefit(
+            save_fixture,
+            type=BenefitType.license_keys,
+            organization=organization,
+            properties=BenefitLicenseKeysCreateProperties(
+                prefix="testing",
+                activations=BenefitLicenseKeyActivationCreateProperties(
+                    limit=2, enable_customer_admin=True
+                ),
+            ).model_dump(mode="json"),
+        )
+        _, granted = await TestLicenseKey.create_order_grant(
+            session,
+            redis,
+            save_fixture,
+            benefit,
+            customer=customer,
+            product=product,
+        )
+        repository = LicenseKeyRepository.from_session(session)
+        lk = await repository.get_by_id(UUID(granted["license_key_id"]))
+        assert lk is not None
+
+        lk.expires_at = utc_now() - relativedelta(days=1)
+        session.add(lk)
+        await session.flush()
+
+        activate = await client.post(
+            activate_path,
+            json={
+                "key": lk.key,
+                "organization_id": str(organization.id),
+                "label": "testing activation of expired key",
+            },
+        )
+
+        assert activate.status_code == 403, (
+            f"Expected 403 but got {activate.status_code}. Response: {activate.json()}"
+        )
+
+    async def test_activate_expired_subscription_license_key_succeeds(
+        self,
+        activate_path: str,
+        session: AsyncSession,
+        redis: Redis,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        user_organization: UserOrganization,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        """
+        An expired license key backed by an active subscription should still
+        activate: the TTL is ignored in favor of the subscription status.
+        """
         benefit, granted = await TestLicenseKey.create_benefit_and_grant(
             session,
             redis,
@@ -516,8 +574,8 @@ class TestLicenseKeyEndpoints:
             },
         )
 
-        assert activate.status_code == 403, (
-            f"Expected 403 but got {activate.status_code}. Response: {activate.json()}"
+        assert activate.status_code == 200, (
+            f"Expected 200 but got {activate.status_code}. Response: {activate.json()}"
         )
 
 
@@ -699,6 +757,96 @@ class TestValidateLicenseKey:
         )
 
         assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_validate_expired_order_license_key_should_fail(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        user_organization: UserOrganization,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        """An expired license key not backed by a subscription should fail."""
+        benefit = await create_benefit(
+            save_fixture,
+            type=BenefitType.license_keys,
+            organization=organization,
+            properties=BenefitLicenseKeysCreateProperties(
+                prefix="testing"
+            ).model_dump(mode="json"),
+        )
+        _, granted = await TestLicenseKey.create_order_grant(
+            session,
+            redis,
+            save_fixture,
+            benefit,
+            customer=customer,
+            product=product,
+        )
+        repository = LicenseKeyRepository.from_session(session)
+        lk = await repository.get_by_id(UUID(granted["license_key_id"]))
+        assert lk is not None
+
+        lk.expires_at = utc_now() - relativedelta(days=1)
+        session.add(lk)
+        await session.flush()
+
+        response = await client.post(
+            "/v1/license-keys/validate",
+            json={
+                "key": lk.key,
+                "organization_id": str(lk.organization_id),
+            },
+        )
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_validate_expired_subscription_license_key_succeeds(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        user_organization: UserOrganization,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        """
+        An expired license key backed by an active subscription should still
+        validate: the TTL is ignored in favor of the subscription status.
+        """
+        _, granted = await TestLicenseKey.create_benefit_and_grant(
+            session,
+            redis,
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            product=product,
+            properties=BenefitLicenseKeysCreateProperties(prefix="testing"),
+        )
+        repository = LicenseKeyRepository.from_session(session)
+        lk = await repository.get_by_id(UUID(granted["license_key_id"]))
+        assert lk is not None
+
+        lk.expires_at = utc_now() - relativedelta(days=1)
+        session.add(lk)
+        await session.flush()
+
+        response = await client.post(
+            "/v1/license-keys/validate",
+            json={
+                "key": lk.key,
+                "organization_id": str(lk.organization_id),
+            },
+        )
+
+        assert response.status_code == 200
 
     @pytest.mark.auth
     async def test_negative_increment_usage_rejected(


### PR DESCRIPTION
## Summary

License keys that are backed by active subscriptions should remain valid even after their TTL expires. Only license keys granted through one-time orders should respect the expiration date.

## What

- Added `is_granted_through_subscription()` method to `LicenseKeyRepository` to check if a license key is backed by an active subscription
- Updated `validate()` and `activate()` methods in `LicenseKeyService` to skip expiration checks for subscription-backed license keys
- Added comprehensive test coverage for both expired order-based and subscription-based license keys in both activation and validation flows

## Why

License keys granted as part of a subscription benefit should be valid as long as the subscription is active, regardless of any TTL set on the key itself. The expiration date should only apply to one-time order-based license keys. This allows organizations to manage license key validity through subscription status rather than manual TTL management.

## How

1. Added a repository method that queries for a `BenefitGrant` with a non-null `subscription_id` for the given license key
2. Modified the expiration check logic in both `validate()` and `activate()` to call this method before rejecting expired keys
3. Added four new test cases:
   - `test_activate_expired_order_license_key_should_fail`: Verifies order-based expired keys are rejected
   - `test_activate_expired_subscription_license_key_succeeds`: Verifies subscription-based expired keys are accepted
   - `test_validate_expired_order_license_key_should_fail`: Verifies order-based expired keys fail validation
   - `test_validate_expired_subscription_license_key_succeeds`: Verifies subscription-based expired keys pass validation
4. Added `create_order_grant()` helper method to `TestLicenseKey` fixture for creating order-based license key grants

## Checklist

- [x] This PR addresses a single concern (distinguishing expiration handling for subscription vs order-based license keys)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests (4 new test cases added)
- [x] No unrelated changes or drive-by fixes are included

https://claude.ai/code/session_012neVzkYXantd74AvaostP2

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

