### PR TITLE
add dunning banner on subscription page

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/[id]/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/[id]/SalesPage.tsx
@@ -29,11 +29,6 @@ import {
   DisputeStatusDisplayTitle,
 } from '@/utils/dispute'
 import { formatCountry } from '@/utils/formatters'
-import {
-  isOrderDunningFailed,
-  isOrderInDunning,
-  isOrderInDunningLifecycle,
-} from '@/utils/order'
 import ArrowOutwardOutlined from '@mui/icons-material/ArrowOutwardOutlined'
 import { ArrowUpRightIcon } from 'lucide-react'
 import { schemas } from '@polar-sh/client'
@@ -69,6 +64,11 @@ const ClientPage: React.FC<ClientPageProps> = ({
     organization.id,
     { order_id: _order.id },
   )
+  const { data: subscription, isLoading: subscriptionLoading } = useSubscription(
+    _order.subscription_id ?? '',
+    undefined,
+    { enabled: !!_order.subscription_id }
+  )
 
   const {
     isShown: isRefundModalShown,
@@ -93,22 +93,6 @@ const ClientPage: React.FC<ClientPageProps> = ({
   const totalSeats = seatsData?.total_seats || 0
   const availableSeats = seatsData?.available_seats || 0
   const seats = seatsData?.seats || []
-
-  const orderPayments = payments?.items ?? []
-  const inDunningLifecycle =
-    !!order && isOrderInDunningLifecycle(order, orderPayments)
-
-  const { data: dunningSubscription } = useSubscription(
-    order?.subscription_id ?? '',
-    undefined,
-    { enabled: inDunningLifecycle },
-  )
-
-  const showDunningBanner =
-    !!order &&
-    !!dunningSubscription &&
-    (isOrderInDunning(order, orderPayments) ||
-      isOrderDunningFailed(order, dunningSubscription, orderPayments))
 
   if (!order) {
     return null
@@ -143,14 +127,9 @@ const ClientPage: React.FC<ClientPageProps> = ({
       }
       contextViewClassName="bg-transparent dark:bg-transparent border-none rounded-none md:shadow-none"
     >
-      {showDunningBanner && dunningSubscription ? (
-        <OrderCalloutBanner
-          organization={organization}
-          order={order}
-          subscription={dunningSubscription}
-          payments={orderPayments}
-        />
-      ) : null}
+      {subscription && (
+        <OrderCalloutBanner organization={organization} order={order} subscription={subscription} />
+      )}
 
       <ShadowBox className="dark:divide-polar-700 flex flex-col divide-y divide-gray-200 border-gray-200 bg-transparent p-0 md:rounded-3xl!">
         <div className="flex flex-col gap-6 p-4 md:p-8">
@@ -264,9 +243,9 @@ const ClientPage: React.FC<ClientPageProps> = ({
               value={
                 order.discount_amount
                   ? formatCurrency('accounting')(
-                      -order.discount_amount,
-                      order.currency,
-                    )
+                    -order.discount_amount,
+                    order.currency,
+                  )
                   : '—'
               }
             />
@@ -311,8 +290,8 @@ const ClientPage: React.FC<ClientPageProps> = ({
             )}
 
             {order.billing_address ||
-            order.billing_name ||
-            order.customer.tax_id ? (
+              order.billing_name ||
+              order.customer.tax_id ? (
               <>
                 <Separator className="dark:bg-polar-700 my-4 h-px bg-gray-300" />
                 {order.billing_name ? (
@@ -380,8 +359,8 @@ const ClientPage: React.FC<ClientPageProps> = ({
                       value={
                         order.custom_field_data
                           ? order.custom_field_data[
-                              field.slug as keyof typeof order.custom_field_data
-                            ]
+                          field.slug as keyof typeof order.custom_field_data
+                          ]
                           : undefined
                       }
                     />
@@ -451,22 +430,22 @@ const ClientPage: React.FC<ClientPageProps> = ({
             },
             ...(hasDeclinedPayment
               ? ([
-                  {
-                    accessorKey: 'decline_reason',
-                    header: 'Bank Decline Reason',
-                    cell: ({ row: { original } }) => {
-                      const reason =
-                        original.decline_message || original.decline_reason
-                      return reason ? (
-                        <Truncated>
-                          <span className="text-sm">{reason}</span>
-                        </Truncated>
-                      ) : (
-                        '—'
-                      )
-                    },
+                {
+                  accessorKey: 'decline_reason',
+                  header: 'Bank Decline Reason',
+                  cell: ({ row: { original } }) => {
+                    const reason =
+                      original.decline_message || original.decline_reason
+                    return reason ? (
+                      <Truncated>
+                        <span className="text-sm">{reason}</span>
+                      </Truncated>
+                    ) : (
+                      '—'
+                    )
                   },
-                ] satisfies DataTableColumnDef<schemas['Payment']>[])
+                },
+              ] satisfies DataTableColumnDef<schemas['Payment']>[])
               : []),
           ]}
           data={payments?.items ?? []}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/[id]/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/[id]/SalesPage.tsx
@@ -64,11 +64,10 @@ const ClientPage: React.FC<ClientPageProps> = ({
     organization.id,
     { order_id: _order.id },
   )
-  const { data: subscription, isLoading: subscriptionLoading } = useSubscription(
-    _order.subscription_id ?? '',
-    undefined,
-    { enabled: !!_order.subscription_id }
-  )
+  const { data: subscription, isLoading: subscriptionLoading } =
+    useSubscription(_order.subscription_id ?? '', undefined, {
+      enabled: !!_order.subscription_id,
+    })
 
   const {
     isShown: isRefundModalShown,
@@ -127,9 +126,13 @@ const ClientPage: React.FC<ClientPageProps> = ({
       }
       contextViewClassName="bg-transparent dark:bg-transparent border-none rounded-none md:shadow-none"
     >
-      {subscription && (
-        <OrderCalloutBanner organization={organization} order={order} subscription={subscription} />
-      )}
+      {subscription && !subscriptionLoading ? (
+        <OrderCalloutBanner
+          organization={organization}
+          order={order}
+          subscription={subscription}
+        />
+      ) : null}
 
       <ShadowBox className="dark:divide-polar-700 flex flex-col divide-y divide-gray-200 border-gray-200 bg-transparent p-0 md:rounded-3xl!">
         <div className="flex flex-col gap-6 p-4 md:p-8">
@@ -243,9 +246,9 @@ const ClientPage: React.FC<ClientPageProps> = ({
               value={
                 order.discount_amount
                   ? formatCurrency('accounting')(
-                    -order.discount_amount,
-                    order.currency,
-                  )
+                      -order.discount_amount,
+                      order.currency,
+                    )
                   : '—'
               }
             />
@@ -290,8 +293,8 @@ const ClientPage: React.FC<ClientPageProps> = ({
             )}
 
             {order.billing_address ||
-              order.billing_name ||
-              order.customer.tax_id ? (
+            order.billing_name ||
+            order.customer.tax_id ? (
               <>
                 <Separator className="dark:bg-polar-700 my-4 h-px bg-gray-300" />
                 {order.billing_name ? (
@@ -359,8 +362,8 @@ const ClientPage: React.FC<ClientPageProps> = ({
                       value={
                         order.custom_field_data
                           ? order.custom_field_data[
-                          field.slug as keyof typeof order.custom_field_data
-                          ]
+                              field.slug as keyof typeof order.custom_field_data
+                            ]
                           : undefined
                       }
                     />
@@ -430,22 +433,22 @@ const ClientPage: React.FC<ClientPageProps> = ({
             },
             ...(hasDeclinedPayment
               ? ([
-                {
-                  accessorKey: 'decline_reason',
-                  header: 'Bank Decline Reason',
-                  cell: ({ row: { original } }) => {
-                    const reason =
-                      original.decline_message || original.decline_reason
-                    return reason ? (
-                      <Truncated>
-                        <span className="text-sm">{reason}</span>
-                      </Truncated>
-                    ) : (
-                      '—'
-                    )
+                  {
+                    accessorKey: 'decline_reason',
+                    header: 'Bank Decline Reason',
+                    cell: ({ row: { original } }) => {
+                      const reason =
+                        original.decline_message || original.decline_reason
+                      return reason ? (
+                        <Truncated>
+                          <span className="text-sm">{reason}</span>
+                        </Truncated>
+                      ) : (
+                        '—'
+                      )
+                    },
                   },
-                },
-              ] satisfies DataTableColumnDef<schemas['Payment']>[])
+                ] satisfies DataTableColumnDef<schemas['Payment']>[])
               : []),
           ]}
           data={payments?.items ?? []}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/[id]/SubscriptionsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/[id]/SubscriptionsPage.tsx
@@ -5,6 +5,7 @@ import CustomFieldValue from '@/components/CustomFields/CustomFieldValue'
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import { InlineModal } from '@polar-sh/orbit'
 import { useModal } from '@/components/Modal/useModal'
+import { OrderCalloutBanner } from '@/components/Orders/OrderCalloutBanner'
 import { SeatViewOnlyTable } from '@/components/Seats/SeatViewOnlyTable'
 import { DetailRow } from '@/components/Shared/DetailRow'
 import CancelSubscriptionModal from '@/components/Subscriptions/CancelSubscriptionModal'
@@ -20,6 +21,7 @@ import {
 } from '@/hooks/queries'
 import { extractApiErrorMessage } from '@/utils/api/errors'
 import { useOrganizationSeats } from '@/hooks/queries/seats'
+import { useOrders } from '@/hooks/queries/orders'
 import SubscriptionOrdersSection from '@/components/Subscriptions/SubscriptionOrdersSection'
 import { schemas } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
@@ -61,6 +63,15 @@ const ClientPage: React.FC<ClientPageProps> = ({
   } = useModal()
 
   const uncancelSubscription = useUncancelSubscription(_subscription.id)
+
+  const { data: orders } = useOrders(organization.id, {
+    subscription_id: [_subscription.id],
+    sorting: ['-created_at'],
+    limit: 100,
+  })
+
+  const pendingOrder =
+    orders?.items.findLast((order) => order.status === 'pending') ?? null
 
   const hasSeatBasedSubscription =
     !!subscription?.seats && subscription.seats > 0
@@ -147,6 +158,14 @@ const ClientPage: React.FC<ClientPageProps> = ({
         />
       }
     >
+      {pendingOrder && (
+        <OrderCalloutBanner
+          organization={organization}
+          order={pendingOrder}
+          subscription={subscription}
+        />
+      )}
+
       <ShadowBox className="dark:divide-polar-700 flex flex-col divide-y divide-gray-200 border-gray-200 bg-transparent p-0 md:rounded-3xl!">
         <div className="flex flex-col gap-6 p-8">
           <div className="flex flex-col gap-2">

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/[id]/SubscriptionsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/[id]/SubscriptionsPage.tsx
@@ -158,13 +158,13 @@ const ClientPage: React.FC<ClientPageProps> = ({
         />
       }
     >
-      {pendingOrder && (
+      {pendingOrder ? (
         <OrderCalloutBanner
           organization={organization}
           order={pendingOrder}
           subscription={subscription}
         />
-      )}
+      ) : null}
 
       <ShadowBox className="dark:divide-polar-700 flex flex-col divide-y divide-gray-200 border-gray-200 bg-transparent p-0 md:rounded-3xl!">
         <div className="flex flex-col gap-6 p-8">

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/[id]/SubscriptionsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/[id]/SubscriptionsPage.tsx
@@ -71,7 +71,9 @@ const ClientPage: React.FC<ClientPageProps> = ({
   })
 
   const pendingOrder =
-    orders?.items.findLast((order) => order.status === 'pending') ?? null
+    orders?.items.findLast(
+      (order) => order.status === 'pending' || order.status === 'void',
+    ) ?? null
 
   const hasSeatBasedSubscription =
     !!subscription?.seats && subscription.seats > 0

--- a/clients/apps/web/src/components/Orders/OrderCalloutBanner.tsx
+++ b/clients/apps/web/src/components/Orders/OrderCalloutBanner.tsx
@@ -9,6 +9,7 @@ import { schemas } from '@polar-sh/client'
 import { Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
+import { parseISO } from 'date-fns'
 import { ExternalLinkIcon } from 'lucide-react'
 import type { ReactNode } from 'react'
 

--- a/clients/apps/web/src/components/Orders/OrderCalloutBanner.tsx
+++ b/clients/apps/web/src/components/Orders/OrderCalloutBanner.tsx
@@ -1,16 +1,16 @@
 'use client'
 
-import { useSubscription } from '@/hooks/queries'
 import { usePayments } from '@/hooks/queries/payments'
-import { getOrderDunningState, getBenefitsRevocationSchedule } from '@/utils/order'
+import {
+  getOrderDunningState,
+  getBenefitsRevocationSchedule,
+} from '@/utils/order'
 import { schemas } from '@polar-sh/client'
 import { Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
-import { addDays, isPast, min, parseISO } from 'date-fns'
 import { ExternalLinkIcon } from 'lucide-react'
 import type { ReactNode } from 'react'
-
 
 const FAILED_PAYMENTS_DOCS_URL =
   'https://docs.polar.sh/features/subscriptions/failed-payments'
@@ -55,8 +55,6 @@ const ColumnHeading = ({
   </Box>
 )
 
-
-
 const BenefitsRevocationText = ({
   benefitsRevocationDate,
   benefitsRevoked,
@@ -75,7 +73,6 @@ const BenefitsRevocationText = ({
     .
   </Text>
 )
-
 
 interface OrderCalloutBannerProps {
   organization: schemas['Organization']
@@ -115,7 +112,6 @@ export const OrderCalloutBanner = ({
     return null
   }
 
-
   return (
     <Box
       flexDirection="column"
@@ -132,7 +128,9 @@ export const OrderCalloutBanner = ({
         paddingVertical="l"
       >
         <Text variant="body">
-          {dunningState === 'failed' ? "Payment couldn't be recovered" : 'Payment Failed'}
+          {dunningState === 'failed'
+            ? "Payment couldn't be recovered"
+            : 'Payment Failed'}
         </Text>
       </Box>
 
@@ -187,7 +185,8 @@ export const OrderCalloutBanner = ({
                 datetime={order.next_payment_attempt_at ?? null}
               />
               <Text>
-                Polar always tries to recover failed subscription payments for you.
+                Polar always tries to recover failed subscription payments for
+                you.
               </Text>
               <a
                 href={FAILED_PAYMENTS_DOCS_URL}
@@ -210,9 +209,13 @@ export const OrderCalloutBanner = ({
             </BannerColumn>
 
             <BannerColumn divided>
-              <ColumnHeading label="What happens next" datetime={revocationDeadline} />
+              <ColumnHeading
+                label="What happens next"
+                datetime={revocationDeadline}
+              />
               <Text>
-                If we can&apos;t recover the payment, the subscription will be canceled
+                If we can&apos;t recover the payment, the subscription will be
+                canceled
                 {revocationDeadline ? (
                   <>
                     {' on '}

--- a/clients/apps/web/src/components/Orders/OrderCalloutBanner.tsx
+++ b/clients/apps/web/src/components/Orders/OrderCalloutBanner.tsx
@@ -1,6 +1,8 @@
 'use client'
 
-import { isOrderDunningFailed } from '@/utils/order'
+import { useSubscription } from '@/hooks/queries'
+import { usePayments } from '@/hooks/queries/payments'
+import { getOrderDunningState, getBenefitsRevocationSchedule } from '@/utils/order'
 import { schemas } from '@polar-sh/client'
 import { Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
@@ -9,7 +11,6 @@ import { addDays, isPast, min, parseISO } from 'date-fns'
 import { ExternalLinkIcon } from 'lucide-react'
 import type { ReactNode } from 'react'
 
-const DUNNING_TOTAL_RETRY_DAYS = 21
 
 const FAILED_PAYMENTS_DOCS_URL =
   'https://docs.polar.sh/features/subscriptions/failed-payments'
@@ -54,108 +55,50 @@ const ColumnHeading = ({
   </Box>
 )
 
-const CanceledColumn = ({
-  endedAt,
+
+
+const BenefitsRevocationText = ({
   benefitsRevocationDate,
   benefitsRevoked,
 }: {
-  endedAt: string | null
   benefitsRevocationDate: Date | null
   benefitsRevoked: boolean
 }) => (
-  <BannerColumn divided>
-    <ColumnHeading label="Subscription canceled" datetime={endedAt} />
-    <Text>
-      Benefits {benefitsRevoked ? 'were revoked' : 'will be revoked'}
-      {benefitsRevocationDate ? (
-        <>
-          {' on '}
-          <FormattedDateTime
-            resolution="day"
-            datetime={benefitsRevocationDate}
-          />
-        </>
-      ) : null}
-      .
-    </Text>
-  </BannerColumn>
+  <Text>
+    Benefits {benefitsRevoked ? 'were revoked' : 'will be revoked'}
+    {benefitsRevocationDate ? (
+      <>
+        {' on '}
+        <FormattedDateTime resolution="day" datetime={benefitsRevocationDate} />
+      </>
+    ) : null}
+    .
+  </Text>
 )
 
-const RecoveringColumns = ({
-  nextAttemptAt,
-  revocationDeadline,
-  benefitsRevocationDate,
-  benefitsRevoked,
-}: {
-  nextAttemptAt: string | null
-  revocationDeadline: Date | null
-  benefitsRevocationDate: Date | null
-  benefitsRevoked: boolean
-}) => (
-  <>
-    <BannerColumn divided>
-      <ColumnHeading label="Next attempt" datetime={nextAttemptAt} />
-      <Text>
-        Polar always tries to recover failed subscription payments for you.
-      </Text>
-      <a
-        href={FAILED_PAYMENTS_DOCS_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="w-fit"
-      >
-        <Box as="span" display="inline-flex" alignItems="center" columnGap="xs">
-          <Text as="span">
-            <span className="underline">Learn more</span>
-          </Text>
-          <ExternalLinkIcon className="h-3.5 w-3.5 shrink-0" />
-        </Box>
-      </a>
-    </BannerColumn>
-
-    <BannerColumn divided>
-      <ColumnHeading label="What happens next" datetime={revocationDeadline} />
-      <Text>
-        If we can&apos;t recover the payment, the subscription will be canceled
-        {revocationDeadline ? (
-          <>
-            {' on '}
-            <FormattedDateTime resolution="day" datetime={revocationDeadline} />
-          </>
-        ) : null}
-        .
-      </Text>
-      <Text>
-        Benefits {benefitsRevoked ? 'were revoked' : 'will be revoked'}
-        {benefitsRevocationDate ? (
-          <>
-            {' on '}
-            <FormattedDateTime
-              resolution="day"
-              datetime={benefitsRevocationDate}
-            />
-          </>
-        ) : null}
-        .
-      </Text>
-    </BannerColumn>
-  </>
-)
 
 interface OrderCalloutBannerProps {
   organization: schemas['Organization']
-  order: schemas['Order']
   subscription: schemas['Subscription']
-  payments: schemas['Payment'][]
+  order: schemas['Order']
 }
 
 export const OrderCalloutBanner = ({
   organization,
-  order,
   subscription,
-  payments,
+  order,
 }: OrderCalloutBannerProps) => {
-  const dunningFailed = isOrderDunningFailed(order, subscription, payments)
+  const { data: paymentsData } = usePayments(
+    organization.id,
+    { order_id: order.id },
+    { enabled: !!order.subscription_id },
+  )
+  const payments = paymentsData?.items ?? []
+
+  const dunningState = getOrderDunningState(order, subscription, payments)
+
+  const { benefitsRevocationDate, benefitsRevoked, revocationDeadline } =
+    getBenefitsRevocationSchedule(organization, subscription)
 
   const latestFailedPayment =
     payments
@@ -165,31 +108,13 @@ export const OrderCalloutBanner = ({
           parseISO(b.created_at).getTime() - parseISO(a.created_at).getTime(),
       )[0] ?? null
 
-  const pastDueAt = subscription.past_due_at
-    ? parseISO(subscription.past_due_at)
-    : null
-
-  const revocationDeadline = pastDueAt
-    ? addDays(pastDueAt, DUNNING_TOTAL_RETRY_DAYS)
-    : null
-
-  const gracePeriodDays =
-    organization.subscription_settings.benefit_revocation_grace_period
-
-  const benefitsRevocationDate = pastDueAt
-    ? min(
-        [addDays(pastDueAt, gracePeriodDays), revocationDeadline].filter(
-          (date) => date !== null,
-        ),
-      )
-    : null
-
   const failedPaymentDisplayMessage =
     latestFailedPayment?.decline_message ?? latestFailedPayment?.decline_reason
 
-  const benefitsRevokedInPast = benefitsRevocationDate
-    ? isPast(benefitsRevocationDate)
-    : false
+  if (!dunningState) {
+    return null
+  }
+
 
   return (
     <Box
@@ -207,7 +132,7 @@ export const OrderCalloutBanner = ({
         paddingVertical="l"
       >
         <Text variant="body">
-          {dunningFailed ? "Payment couldn't be recovered" : 'Payment Failed'}
+          {dunningState === 'failed' ? "Payment couldn't be recovered" : 'Payment Failed'}
         </Text>
       </Box>
 
@@ -215,7 +140,7 @@ export const OrderCalloutBanner = ({
         display="grid"
         gridTemplateColumns={{
           base: '1fr',
-          lg: dunningFailed ? 'repeat(2, 1fr)' : 'repeat(3, 1fr)',
+          lg: dunningState === 'failed' ? 'repeat(2, 1fr)' : 'repeat(3, 1fr)',
         }}
         borderTopWidth={1}
         borderStyle="solid"
@@ -223,7 +148,7 @@ export const OrderCalloutBanner = ({
       >
         <BannerColumn>
           <ColumnHeading
-            label={dunningFailed ? 'Final attempt' : 'Last attempt'}
+            label={dunningState === 'failed' ? 'Final attempt' : 'Last attempt'}
             datetime={latestFailedPayment?.created_at ?? null}
             resolution="time"
           />
@@ -243,19 +168,68 @@ export const OrderCalloutBanner = ({
           ) : null}
         </BannerColumn>
 
-        {dunningFailed ? (
-          <CanceledColumn
-            endedAt={subscription.ended_at}
-            benefitsRevocationDate={benefitsRevocationDate}
-            benefitsRevoked={benefitsRevokedInPast}
-          />
+        {dunningState === 'failed' ? (
+          <BannerColumn divided>
+            <ColumnHeading
+              label="Subscription canceled"
+              datetime={subscription.ended_at}
+            />
+            <BenefitsRevocationText
+              benefitsRevocationDate={benefitsRevocationDate}
+              benefitsRevoked={benefitsRevoked}
+            />
+          </BannerColumn>
         ) : (
-          <RecoveringColumns
-            nextAttemptAt={order.next_payment_attempt_at ?? null}
-            revocationDeadline={revocationDeadline}
-            benefitsRevocationDate={benefitsRevocationDate}
-            benefitsRevoked={benefitsRevokedInPast}
-          />
+          <>
+            <BannerColumn divided>
+              <ColumnHeading
+                label="Next attempt"
+                datetime={order.next_payment_attempt_at ?? null}
+              />
+              <Text>
+                Polar always tries to recover failed subscription payments for you.
+              </Text>
+              <a
+                href={FAILED_PAYMENTS_DOCS_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="w-fit"
+              >
+                <Box
+                  as="span"
+                  display="inline-flex"
+                  alignItems="center"
+                  columnGap="xs"
+                >
+                  <Text as="span">
+                    <span className="underline">Learn more</span>
+                  </Text>
+                  <ExternalLinkIcon className="h-3.5 w-3.5 shrink-0" />
+                </Box>
+              </a>
+            </BannerColumn>
+
+            <BannerColumn divided>
+              <ColumnHeading label="What happens next" datetime={revocationDeadline} />
+              <Text>
+                If we can&apos;t recover the payment, the subscription will be canceled
+                {revocationDeadline ? (
+                  <>
+                    {' on '}
+                    <FormattedDateTime
+                      resolution="day"
+                      datetime={revocationDeadline}
+                    />
+                  </>
+                ) : null}
+                .
+              </Text>
+              <BenefitsRevocationText
+                benefitsRevocationDate={benefitsRevocationDate}
+                benefitsRevoked={benefitsRevoked}
+              />
+            </BannerColumn>
+          </>
         )}
       </Box>
     </Box>

--- a/clients/apps/web/src/hooks/queries/payments.ts
+++ b/clients/apps/web/src/hooks/queries/payments.ts
@@ -9,6 +9,7 @@ export const usePayments = (
     NonNullable<operations['payments:list']['parameters']['query']>,
     'organization_id'
   >,
+  options?: { enabled?: boolean },
 ) => {
   return useQuery({
     queryKey: ['payments', organizationId, { ...(parameters || {}) }],
@@ -21,5 +22,6 @@ export const usePayments = (
         }),
       ),
     retry: defaultRetry,
+    enabled: options?.enabled ?? true,
   })
 }

--- a/clients/apps/web/src/utils/order.ts
+++ b/clients/apps/web/src/utils/order.ts
@@ -1,4 +1,5 @@
 import { Client, schemas, unwrap } from '@polar-sh/client'
+import { addDays, isPast, min, parseISO } from 'date-fns'
 import { notFound } from 'next/navigation'
 import { cache } from 'react'
 
@@ -21,6 +22,7 @@ const _getOrderById = async (
   )
 }
 
+
 // Tell React to memoize it for the duration of the request
 export const getOrderById = cache(_getOrderById)
 
@@ -37,36 +39,65 @@ export const canRetryOrderPayment = (
   )
 }
 
-export function isOrderInDunningLifecycle(
-  order: schemas['Order'],
-  payments: schemas['Payment'][],
-): boolean {
-  return (
-    !order.paid &&
-    order.subscription_id !== null &&
-    payments.some((payment) => payment.status === 'failed')
-  )
-}
+const DUNNING_TOTAL_RETRY_DAYS = 21
+export type OrderDunningState = 'recovering' | 'failed'
 
-export function isOrderInDunning(
-  order: schemas['Order'],
-  payments: schemas['Payment'][],
-): boolean {
-  return (
-    isOrderInDunningLifecycle(order, payments) &&
-    order.next_payment_attempt_at !== null
-  )
-}
-
-export function isOrderDunningFailed(
+/**
+ * Where a subscription order sits in the dunningflow:
+ * - `recovering`: Polar is still retrying it.
+ * - `failed`: retries are exhausted and the subscription was ended by Polar.
+ * - `null`: the order isn't in dunning
+ */
+export function getOrderDunningState(
   order: schemas['Order'],
   subscription: schemas['Subscription'],
   payments: schemas['Payment'][],
-): boolean {
-  return (
-    isOrderInDunningLifecycle(order, payments) &&
-    order.next_payment_attempt_at === null &&
+): OrderDunningState | null {
+  if (
+    order.paid ||
+    order.subscription_id === null ||
+    !payments.some((payment) => payment.status === 'failed')
+  ) {
+    return null
+  }
+
+  if (order.next_payment_attempt_at !== null) {
+    return 'recovering'
+  }
+
+  const endedByPolar =
     subscription.ended_at !== null &&
     subscription.customer_cancellation_reason === null
-  )
+
+  return endedByPolar ? 'failed' : null
+}
+
+export function getBenefitsRevocationSchedule(
+  organization: schemas['Organization'],
+  subscription: schemas['Subscription'],
+) {
+  const pastDueAt = subscription.past_due_at
+    ? parseISO(subscription.past_due_at)
+    : null
+
+  const revocationDeadline = pastDueAt
+    ? addDays(pastDueAt, DUNNING_TOTAL_RETRY_DAYS)
+    : null
+
+  const gracePeriodDays =
+    organization.subscription_settings.benefit_revocation_grace_period
+
+  const benefitsRevocationDate = pastDueAt
+    ? min(
+      [addDays(pastDueAt, gracePeriodDays), revocationDeadline].filter(
+        (date) => date !== null,
+      ),
+    )
+    : null
+
+  const benefitsRevoked = benefitsRevocationDate
+    ? isPast(benefitsRevocationDate)
+    : false
+
+  return { revocationDeadline, benefitsRevocationDate, benefitsRevoked }
 }

--- a/clients/apps/web/src/utils/order.ts
+++ b/clients/apps/web/src/utils/order.ts
@@ -22,7 +22,6 @@ const _getOrderById = async (
   )
 }
 
-
 // Tell React to memoize it for the duration of the request
 export const getOrderById = cache(_getOrderById)
 
@@ -89,10 +88,10 @@ export function getBenefitsRevocationSchedule(
 
   const benefitsRevocationDate = pastDueAt
     ? min(
-      [addDays(pastDueAt, gracePeriodDays), revocationDeadline].filter(
-        (date) => date !== null,
-      ),
-    )
+        [addDays(pastDueAt, gracePeriodDays), revocationDeadline].filter(
+          (date) => date !== null,
+        ),
+      )
     : null
 
   const benefitsRevoked = benefitsRevocationDate


### PR DESCRIPTION
## Summary

Adds the OrderCalloutBanner component to the subscription detail page. Checks for 'pending' or 'void' orders tied to that subscription and shows the dunning process.

Also refactored the fetching pattern on it.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [X] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [X] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [X] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [X] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

