### PR TITLE
fix(auth): persist context on authentication session update

### DIFF
--- a/server/polar/auth/authentication_session.py
+++ b/server/polar/auth/authentication_session.py
@@ -87,6 +87,7 @@ class AuthenticationSessionService(AuthenticationSessionServiceBase):
                 step=authentication_session.step,
                 authentication_method_references=authentication_session.amr,
                 used_factors=authentication_session.used_factors,
+                context=authentication_session.context,
                 identity_id=authentication_session.identity_id,
             )
         )

--- a/server/tests/auth/test_authentication_session.py
+++ b/server/tests/auth/test_authentication_session.py
@@ -1,0 +1,32 @@
+import pytest
+
+from polar.auth.authentication_session import AuthenticationSessionService
+from polar.models import AuthenticationSession
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+
+
+@pytest.mark.asyncio
+class TestUpdate:
+    async def test_persists_context(
+        self, session: AsyncSession, save_fixture: SaveFixture
+    ) -> None:
+        authentication_session = AuthenticationSession(
+            token_hash="a" * 64,
+            expires_at=9999999999,
+            step=0,
+            authentication_method_references=[],
+            used_factors=[],
+            context=None,
+            identity_id=None,
+        )
+        await save_fixture(authentication_session)
+
+        service = AuthenticationSessionService(session, set())
+        dataclass = authentication_session.to_dataclass()
+        dataclass.context = {"sso_organization_id": "org-123"}
+
+        await service.update(dataclass)
+        await session.refresh(authentication_session)
+
+        assert authentication_session.context == {"sso_organization_id": "org-123"}

--- a/server/tests/auth/test_authentication_session.py
+++ b/server/tests/auth/test_authentication_session.py
@@ -24,9 +24,9 @@ class TestUpdate:
 
         service = AuthenticationSessionService(session, set())
         dataclass = authentication_session.to_dataclass()
-        dataclass.context = {"sso_organization_id": "org-123"}
+        dataclass.context = {"foo": "bar"}
 
         await service.update(dataclass)
         await session.refresh(authentication_session)
 
-        assert authentication_session.context == {"sso_organization_id": "org-123"}
+        assert authentication_session.context == {"foo": "bar"}


### PR DESCRIPTION


## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing persistence of authentication session context during updates. Adds a test to ensure the `context` field is saved when `AuthenticationSessionService.update` is called.

<sup>Written for commit 7f7f4797a5c2faff0715239c0cdcc628003a7609. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

