### PR TITLE
tf/aws: Look up staff groups instead of creating them

### DIFF
--- a/terraform/organization/identity_center.tf
+++ b/terraform/organization/identity_center.tf
@@ -10,10 +10,10 @@ locals {
   }
 
   identity_center_groups = {
-    awsadmins    = { display_name = "awsadmins@polar.sh" }
-    awsengineers = { display_name = "awsengineers@polar.sh" }
-    engineering  = { display_name = "engineering@polar.sh" }
-    awsaccess    = { display_name = "awsaccess@polar.sh" }
+    awsadmins    = { display_name = "AWS Access" }
+    awsengineers = { display_name = "AWS Engineers" }
+    engineering  = { display_name = "Engineering" }
+    awsaccess    = { display_name = "AWS Read Only Access" }
   }
 
   access_tiers = {
@@ -59,6 +59,16 @@ locals {
     key => permission_set if permission_set.boundary
   }
 
+  identity_store_groups_by_name = {
+    for group in data.aws_identitystore_groups.all.groups :
+    group.display_name => group.group_id
+  }
+
+  staff_group_ids = {
+    for key, group in local.identity_center_groups :
+    key => lookup(local.identity_store_groups_by_name, group.display_name, null)
+  }
+
   account_permission_set_assignments = merge([
     for key, permission_set in local.account_permission_sets : {
       for group in permission_set.groups :
@@ -66,16 +76,13 @@ locals {
         permission_set = key
         account_id     = permission_set.account_id
         group          = group
-      }
+      } if local.staff_group_ids[group] != null
     }
   ]...)
 }
 
-resource "aws_identitystore_group" "staff" {
-  for_each = local.identity_center_groups
-
+data "aws_identitystore_groups" "all" {
   identity_store_id = local.sso_identity_store_id
-  display_name      = each.value.display_name
 }
 
 resource "aws_ssoadmin_permission_set" "account" {
@@ -121,7 +128,7 @@ resource "aws_ssoadmin_account_assignment" "account" {
 
   instance_arn       = local.sso_instance_arn
   permission_set_arn = aws_ssoadmin_permission_set.account[each.value.permission_set].arn
-  principal_id       = aws_identitystore_group.staff[each.value.group].group_id
+  principal_id       = local.staff_group_ids[each.value.group]
   principal_type     = "GROUP"
   target_id          = each.value.account_id
   target_type        = "AWS_ACCOUNT"


### PR DESCRIPTION
This allows the groups to be created and managed by ssosync, without us having a circular dependency on if terraform or ssosync runs first


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

