### PR TITLE
fix(dispute): derive support case org from order, not payment

### DIFF
--- a/server/polar/dispute/repository.py
+++ b/server/polar/dispute/repository.py
@@ -92,7 +92,7 @@ class DisputeRepository(
 
     def get_eager_options(self) -> Options:
         return (
-            joinedload(Dispute.payment).joinedload(Payment.organization),
+            joinedload(Dispute.order).joinedload(Order.organization),
             joinedload(Dispute.order).joinedload(Order.customer),
         )
 

--- a/server/polar/dispute/service.py
+++ b/server/polar/dispute/service.py
@@ -227,7 +227,7 @@ class DisputeService:
         if dispute.status == DisputeStatus.needs_response:
             if case is None:
                 await dispute_case_service.open_case(
-                    session, dispute, organization=dispute.payment.organization
+                    session, dispute, organization=dispute.order.organization
                 )
             elif not await dispute_case_service.is_open(session, case):
                 # Dispute reopened after we'd closed the case (e.g. a prevented

--- a/server/polar/dispute/service.py
+++ b/server/polar/dispute/service.py
@@ -320,7 +320,10 @@ class DisputeService:
         payment = await payment_repository.get_by_processor_id(
             PaymentProcessor.stripe,
             processor_id,
-            options=(joinedload(Payment.order), joinedload(Payment.organization)),
+            options=(
+                joinedload(Payment.order).joinedload(Order.organization),
+                joinedload(Payment.organization),
+            ),
         )
         if payment is None or payment.order is None:
             raise DisputePaymentNotFoundError(processor, processor_id)


### PR DESCRIPTION
## Summary

**Related Issue**: polarsource/feedback#188.

Dispute support cases stored their owning org from `dispute.payment.organization`, while the model contract and backfill migration both derive it from the order.
Switch case creation to `dispute.order.organization` and eager-load `order.organization` accordingly.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

