### PR TITLE
fix(refund): forbid dispute_prevention as a user-supplied refund reason

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -28855,7 +28855,18 @@ export interface components {
        * Format: uuid4
        */
       order_id: string
-      reason: components['schemas']['RefundReason']
+      /**
+       * Reason
+       * @description Reason for the refund.
+       * @enum {string}
+       */
+      reason:
+        | 'duplicate'
+        | 'fraudulent'
+        | 'customer_request'
+        | 'service_disruption'
+        | 'satisfaction_guarantee'
+        | 'other'
       /**
        * Amount
        * @description Amount to refund in cents. Minimum is 1.
@@ -59748,6 +59759,16 @@ export const propertyAggregationFuncValues: ReadonlyArray<
 export const recurringIntervalValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['RecurringInterval']
 > = ['day', 'week', 'month', 'year']
+export const refundCreateReasonValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['RefundCreate']['reason']
+> = [
+  'duplicate',
+  'fraudulent',
+  'customer_request',
+  'service_disruption',
+  'satisfaction_guarantee',
+  'other',
+]
 export const refundReasonValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['RefundReason']
 > = [

--- a/server/polar/backoffice/forms.py
+++ b/server/polar/backoffice/forms.py
@@ -3,7 +3,7 @@ import re
 from collections.abc import Generator
 from enum import StrEnum
 from inspect import isclass
-from typing import Any, Self
+from typing import Any, Literal, Self, get_args, get_origin
 
 from fastapi.datastructures import FormData
 from pydantic import AfterValidator, BaseModel, StringConstraints, ValidationError
@@ -521,6 +521,12 @@ def _get_input_field(field: FieldInfo) -> FormField:
             if issubclass(field.annotation, StrEnum):
                 return SelectField(
                     options=[(item.value, item.name) for item in field.annotation]
+                )
+        if get_origin(field.annotation) is Literal:
+            members = get_args(field.annotation)
+            if all(isinstance(member, StrEnum) for member in members):
+                return SelectField(
+                    options=[(member.value, member.name) for member in members]
                 )
 
     return InputField(**_string_constraint_attrs(field))

--- a/server/polar/backoffice/orders/forms.py
+++ b/server/polar/backoffice/orders/forms.py
@@ -4,13 +4,13 @@ from typing import Annotated
 from pydantic import Field
 
 from polar.kit.schemas import EmptyStrToNone
-from polar.models.refund import RefundReason
+from polar.models.refund import ManualRefundReason
 
 from .. import forms
 
 
 class RefundForm(forms.BaseForm):
-    reason: Annotated[RefundReason, Field(title="Refund reason")]
+    reason: Annotated[ManualRefundReason, Field(title="Refund reason")]
     amount: Annotated[Decimal, Field(title="Amount to refund", gt=0, decimal_places=2)]
     comment: Annotated[EmptyStrToNone, Field(default=None, title="Internal comment")]
     revoke_benefits: Annotated[bool, Field(default=False, title="Revoke benefits")]

--- a/server/polar/models/refund.py
+++ b/server/polar/models/refund.py
@@ -86,6 +86,18 @@ class RefundReason(StrEnum):
         return "requested_by_customer"
 
 
+# Reasons a human may pick when creating a refund. `dispute_prevention` is
+# excluded: it's reserved for system-generated refunds.
+ManualRefundReason = Literal[
+    RefundReason.duplicate,
+    RefundReason.fraudulent,
+    RefundReason.customer_request,
+    RefundReason.service_disruption,
+    RefundReason.satisfaction_guarantee,
+    RefundReason.other,
+]
+
+
 class RefundFailureReason(StrEnum):
     unknown = "unknown"
     declined = "declined"

--- a/server/polar/refund/schemas.py
+++ b/server/polar/refund/schemas.py
@@ -2,7 +2,7 @@ import inspect
 from typing import Annotated
 
 from fastapi import Path
-from pydantic import UUID4, Field
+from pydantic import UUID4, Field, field_validator
 
 from polar.dispute.schemas import DisputeBase
 from polar.kit.currency import format_currency
@@ -63,3 +63,12 @@ class RefundCreate(MetadataInputMixin, Schema):
             """
         ),
     )
+
+    @field_validator("reason")
+    @classmethod
+    def reason_must_not_be_system_only(cls, value: RefundReason) -> RefundReason:
+        if value == RefundReason.dispute_prevention:
+            raise ValueError(
+                "dispute_prevention is reserved for system-generated refunds."
+            )
+        return value

--- a/server/polar/refund/schemas.py
+++ b/server/polar/refund/schemas.py
@@ -2,7 +2,7 @@ import inspect
 from typing import Annotated
 
 from fastapi import Path
-from pydantic import UUID4, Field, field_validator
+from pydantic import UUID4, Field
 
 from polar.dispute.schemas import DisputeBase
 from polar.kit.currency import format_currency
@@ -12,6 +12,7 @@ from polar.kit.metadata import (
 )
 from polar.kit.schemas import IDSchema, Schema, TimestampedSchema
 from polar.models.refund import (
+    ManualRefundReason,
     RefundReason,
     RefundStatus,
 )
@@ -45,7 +46,7 @@ class Refund(MetadataOutputMixin, IDSchema, TimestampedSchema):
 
 class RefundCreate(MetadataInputMixin, Schema):
     order_id: UUID4
-    reason: RefundReason
+    reason: ManualRefundReason = Field(description="Reason for the refund.")
     amount: int = Field(description="Amount to refund in cents. Minimum is 1.", gt=0)
     comment: str | None = Field(
         None, description="An internal comment about the refund."
@@ -63,12 +64,3 @@ class RefundCreate(MetadataInputMixin, Schema):
             """
         ),
     )
-
-    @field_validator("reason")
-    @classmethod
-    def reason_must_not_be_system_only(cls, value: RefundReason) -> RefundReason:
-        if value == RefundReason.dispute_prevention:
-            raise ValueError(
-                "dispute_prevention is reserved for system-generated refunds."
-            )
-        return value

--- a/server/tests/refund/test_endpoints.py
+++ b/server/tests/refund/test_endpoints.py
@@ -527,6 +527,43 @@ class TestCreateRefunds(StripeRefund):
         )
         assert order.status == OrderStatus.refunded
 
+    @pytest.mark.auth(
+        AuthSubjectFixture(scopes={Scope.refunds_write}),
+    )
+    async def test_reject_dispute_prevention_reason(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        order, payment, transaction = await create_order_and_payment(
+            save_fixture,
+            product=product,
+            customer=customer,
+            amount=2000,
+            tax_amount=500,
+        )
+
+        response = await client.post(
+            "/v1/refunds/",
+            json={
+                "order_id": str(order.id),
+                "reason": RefundReason.dispute_prevention.value,
+                "amount": 500,
+            },
+        )
+        assert response.status_code == 422
+
+        order_repository = OrderRepository.from_session(session)
+        updated = await order_repository.get_by_id(order.id)
+        assert updated is not None
+        assert updated.refunded_amount == 0
+        assert updated.status == OrderStatus.paid
+
 
 @pytest.mark.asyncio
 class TestCreateRefundsAndRevokeBenefits(StripeRefund):


### PR DESCRIPTION
## Summary

Reject `dispute_prevention` as a user-supplied refund reason

Fixes polarsource/feedback#182

### Problem
`POST /v1/refunds/` (and the backoffice refund form) accept the full`RefundReason` enum, including `dispute_prevention`. That reason is meant to be system-only — set exclusively by `create_from_stripe` (chargeback early-warning alert) and `create_from_dispute`, both of which also link a `Dispute`.

A merchant could pass `reason=dispute_prevention` directly, producing:
1. A semantically invalid refund — `dispute_prevention` with no linked dispute — exposed as-is through the public API.
2. A misleading "Chargeback prevented" email to org owners/admins, claiming an early-warning alert fired when none did.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

