### PR TITLE
fix: prevent duplicate benefit grant tasks and IntegrityError on grant

### DIFF
--- a/server/migrations/versions/2026-06-29-1011_drop_legacy_benefit_grants_smb_key_.py
+++ b/server/migrations/versions/2026-06-29-1011_drop_legacy_benefit_grants_smb_key_.py
@@ -1,0 +1,41 @@
+"""drop legacy benefit_grants_smb_key constraint
+
+Revision ID: 66438a5cfc91
+Revises: e7118c4ae5d8
+Create Date: 2026-06-29 10:11:48.340279
+
+"""
+
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "66438a5cfc91"
+down_revision = "e7118c4ae5d8"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+CONSTRAINT = "benefit_grants_smb_key"
+COLUMNS = ["subscription_id", "member_id", "benefit_id"]
+
+
+def upgrade() -> None:
+    # benefit_grants_smb_key (subscription_id, member_id, benefit_id) is a legacy
+    # non-partial unique constraint that contradicts ix_benefit_grants_scope_unique
+    # (the member-aware, deleted-aware partial index that already prevents duplicate
+    # grants). Because smb_key ignores customer_id/order_id and still applies to
+    # revoked/soft-deleted rows, it rejected legitimate re-grants (after soft-delete,
+    # or for seat/customer reassignment) and lost concurrent-grant races, raising
+    # IntegrityError. Drop it and rely on ix_benefit_grants_scope_unique.
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.drop_constraint(CONSTRAINT, "benefit_grants", type_="unique")
+
+
+def downgrade() -> None:
+    # Rarely-run rollback. Recreating the constraint fails loudly if duplicate
+    # (subscription, member, benefit) rows have accumulated since the drop, rather
+    # than silently dropping grants. Runs in a single transaction so a failure
+    # leaves ix_benefit_grants_scope_unique in place as the uniqueness guard.
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.create_unique_constraint(CONSTRAINT, "benefit_grants", COLUMNS)

--- a/server/migrations/versions/2026-06-29-1011_drop_legacy_benefit_grants_smb_key_.py
+++ b/server/migrations/versions/2026-06-29-1011_drop_legacy_benefit_grants_smb_key_.py
@@ -21,21 +21,14 @@ COLUMNS = ["subscription_id", "member_id", "benefit_id"]
 
 
 def upgrade() -> None:
-    # benefit_grants_smb_key (subscription_id, member_id, benefit_id) is a legacy
-    # non-partial unique constraint that contradicts ix_benefit_grants_scope_unique
-    # (the member-aware, deleted-aware partial index that already prevents duplicate
-    # grants). Because smb_key ignores customer_id/order_id and still applies to
-    # revoked/soft-deleted rows, it rejected legitimate re-grants (after soft-delete,
-    # or for seat/customer reassignment) and lost concurrent-grant races, raising
-    # IntegrityError. Drop it and rely on ix_benefit_grants_scope_unique.
+    # Legacy non-partial constraint superseded by ix_benefit_grants_scope_unique
+    # (member- and soft-delete-aware); it wrongly rejected legitimate re-grants.
     op.execute("SET LOCAL lock_timeout = '5s'")
     op.drop_constraint(CONSTRAINT, "benefit_grants", type_="unique")
 
 
 def downgrade() -> None:
-    # Rarely-run rollback. Recreating the constraint fails loudly if duplicate
-    # (subscription, member, benefit) rows have accumulated since the drop, rather
-    # than silently dropping grants. Runs in a single transaction so a failure
-    # leaves ix_benefit_grants_scope_unique in place as the uniqueness guard.
+    # Rarely-run rollback; fails loudly if duplicate (subscription, member, benefit)
+    # rows accumulated since the drop rather than silently dropping grants.
     op.execute("SET LOCAL lock_timeout = '5s'")
     op.create_unique_constraint(CONSTRAINT, "benefit_grants", COLUMNS)

--- a/server/polar/benefit/grant/repository.py
+++ b/server/polar/benefit/grant/repository.py
@@ -3,6 +3,7 @@ from typing import Unpack
 from uuid import UUID
 
 from sqlalchemy import Select, func, select
+from sqlalchemy.exc import IntegrityError
 
 from polar.authz.types import AccessibleOrganizationID
 from polar.kit.repository import (
@@ -59,6 +60,42 @@ class BenefitGrantRepository(
             BenefitGrant.scope == scope,
         )
         return await self.get_one_or_none(statement)
+
+    async def get_or_create_by_benefit_and_scope(
+        self,
+        customer: Customer,
+        benefit: Benefit,
+        member: Member | None = None,
+        **scope: Unpack[BenefitGrantScope],
+    ) -> BenefitGrant:
+        grant = await self.get_by_benefit_and_scope(
+            customer, benefit, member=member, **scope
+        )
+        if grant is not None:
+            return grant
+
+        grant = BenefitGrant(
+            customer=customer,
+            benefit=benefit,
+            member=member,
+            properties={},
+            **scope,
+        )
+        # Two grant tasks can be enqueued for the same (subscription, member,
+        # benefit) and race this check-then-insert; flush in a savepoint so the
+        # losing insert is a recoverable IntegrityError and reuse the winner's row.
+        nested = await self.session.begin_nested()
+        try:
+            self.session.add(grant)
+            await self.session.flush()
+        except IntegrityError:
+            await nested.rollback()
+            grant = await self.get_by_benefit_and_scope(
+                customer, benefit, member=member, **scope
+            )
+            if grant is None:
+                raise
+        return grant
 
     async def list_granted_by_scope(
         self, **scope: Unpack[BenefitGrantScope]

--- a/server/polar/benefit/grant/service.py
+++ b/server/polar/benefit/grant/service.py
@@ -213,20 +213,11 @@ class BenefitGrantService(ResourceServiceReader[BenefitGrant]):
         )
 
         repository = BenefitGrantRepository.from_session(session)
-        grant = await repository.get_by_benefit_and_scope(
+        grant = await repository.get_or_create_by_benefit_and_scope(
             customer, benefit, member=member, **scope
         )
 
-        if grant is None:
-            grant = BenefitGrant(
-                customer=customer,
-                benefit=benefit,
-                member=member,
-                properties={},
-                **scope,
-            )
-            session.add(grant)
-        elif grant.is_granted:
+        if grant.is_granted:
             return grant
 
         previous_properties = grant.properties

--- a/server/polar/models/benefit_grant.py
+++ b/server/polar/models/benefit_grant.py
@@ -8,7 +8,6 @@ from sqlalchemy import (
     ColumnElement,
     ForeignKey,
     Index,
-    UniqueConstraint,
     Uuid,
     and_,
     text,
@@ -81,21 +80,15 @@ class BenefitGrant(RecordModel):
     """
     Represents a benefit granted to a customer or member.
 
-    Unique constraints:
-    - benefit_grants_sbc_key: Ensures one grant per (subscription, customer, benefit)
-    - benefit_grants_smb_key: Ensures one grant per (subscription, member, benefit)
-
-    These constraints allow both customer-level and member-level benefit grants.
+    Uniqueness is enforced by ix_benefit_grants_scope_unique, a partial index over
+    (customer_id, benefit_id, member_id, subscription_id, order_id) where the grant
+    is not soft-deleted. NULLS NOT DISTINCT keeps customer-level (member_id IS NULL)
+    grants idempotent, while still allowing one grant per member for member-level
+    (seat-based) grants.
     """
 
     __tablename__ = "benefit_grants"
     __table_args__ = (
-        UniqueConstraint(
-            "subscription_id",
-            "member_id",
-            "benefit_id",
-            name="benefit_grants_smb_key",
-        ),
         Index(
             "ix_benefit_grants_scope_unique",
             "customer_id",

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1326,12 +1326,10 @@ class SubscriptionService:
                 await self.enqueue_benefits_grants(session, subscription)
 
                 # Seat-based subscriptions short-circuit enqueue_benefits_grants
-                # while active, so existing claimed seats won't pick up the new
-                # product's benefits without an explicit re-sync.
-                # On an initial seat transition the only claimed seat is the one
-                # just claimed above via `assign_seat(immediate_claim=True)`, which
-                # already enqueued its grant; re-syncing here would enqueue a second
-                # grant task for the same (subscription, member, benefit) and race it.
+                # while active, so existing claimed seats need an explicit re-sync.
+                # Skip it on the initial transition: the seat just claimed above via
+                # assign_seat(immediate_claim=True) already enqueued its grant, so
+                # re-syncing would only enqueue a redundant duplicate grant task.
                 if (
                     product.has_seat_based_price
                     and subscription.active

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1328,7 +1328,15 @@ class SubscriptionService:
                 # Seat-based subscriptions short-circuit enqueue_benefits_grants
                 # while active, so existing claimed seats won't pick up the new
                 # product's benefits without an explicit re-sync.
-                if product.has_seat_based_price and subscription.active:
+                # On an initial seat transition the only claimed seat is the one
+                # just claimed above via `assign_seat(immediate_claim=True)`, which
+                # already enqueued its grant; re-syncing here would enqueue a second
+                # grant task for the same (subscription, member, benefit) and race it.
+                if (
+                    product.has_seat_based_price
+                    and subscription.active
+                    and not is_initial_seat_transition
+                ):
                     await seat_service.update_subscription_benefits_grants(
                         session, subscription
                     )

--- a/server/tests/benefit/grant/test_service.py
+++ b/server/tests/benefit/grant/test_service.py
@@ -117,6 +117,55 @@ class TestGrantBenefit:
         assert updated_grant.is_granted
         benefit_strategy_mock.grant.assert_not_called()
 
+    async def test_concurrent_grant_recovers_from_integrity_error(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        subscription: Subscription,
+        customer: Customer,
+        benefit_organization: Benefit,
+        benefit_strategy_mock: MagicMock,
+        mocker: MockerFixture,
+    ) -> None:
+        # Simulate the race: a concurrent task already inserted and granted the
+        # grant for this (subscription, member, benefit), but our initial lookup
+        # doesn't see it yet. Our insert then hits the unique index;
+        # grant_benefit must recover by reusing the existing grant, not raise.
+        existing = BenefitGrant(
+            subscription=subscription, customer=customer, benefit=benefit_organization
+        )
+        existing.set_granted()
+        await save_fixture(existing)
+
+        real_lookup = BenefitGrantRepository.get_by_benefit_and_scope
+        calls = 0
+
+        async def lookup_side_effect(
+            self: BenefitGrantRepository, *args: Any, **kwargs: Any
+        ) -> BenefitGrant | None:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return None
+            return await real_lookup(self, *args, **kwargs)
+
+        mocker.patch.object(
+            BenefitGrantRepository,
+            "get_by_benefit_and_scope",
+            autospec=True,
+            side_effect=lookup_side_effect,
+        )
+
+        grant = await benefit_grant_service.grant_benefit(
+            session, redis, customer, benefit_organization, subscription=subscription
+        )
+
+        assert grant.id == existing.id
+        assert grant.is_granted
+        # The recovered grant was already granted, so we must not grant again.
+        benefit_strategy_mock.grant.assert_not_called()
+
     async def test_action_required_error(
         self,
         session: AsyncSession,

--- a/server/tests/benefit/grant/test_service.py
+++ b/server/tests/benefit/grant/test_service.py
@@ -138,23 +138,12 @@ class TestGrantBenefit:
         existing.set_granted()
         await save_fixture(existing)
 
-        real_lookup = BenefitGrantRepository.get_by_benefit_and_scope
-        calls = 0
-
-        async def lookup_side_effect(
-            self: BenefitGrantRepository, *args: Any, **kwargs: Any
-        ) -> BenefitGrant | None:
-            nonlocal calls
-            calls += 1
-            if calls == 1:
-                return None
-            return await real_lookup(self, *args, **kwargs)
-
+        # First lookup misses (race), so our insert conflicts on the unique index;
+        # the recovery lookup then finds the existing grant.
         mocker.patch.object(
             BenefitGrantRepository,
             "get_by_benefit_and_scope",
-            autospec=True,
-            side_effect=lookup_side_effect,
+            side_effect=[None, existing],
         )
 
         grant = await benefit_grant_service.grant_benefit(

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -4052,6 +4052,63 @@ class TestUpdateProduct:
         assert len(claimed) == 1
         assert claimed[0].customer_id == customer.id
 
+    async def test_non_seat_to_seat_upgrade_enqueues_single_benefit_grant(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        mocker.patch.object(
+            subscription_service, "_create_subscription_update_order", new=AsyncMock()
+        )
+        organization.feature_settings = {
+            **organization.feature_settings,
+            "seat_based_pricing_enabled": True,
+        }
+        await save_fixture(organization)
+
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        seat_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[("seat", 1500, "usd")],
+        )
+
+        enqueue_job_mock = mocker.patch("polar.customer_seat.service.enqueue_job")
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=seat_product.id,
+                proration_behavior=SubscriptionProrationBehavior.invoice,
+            )
+
+        # The auto-claimed billing-customer seat must enqueue exactly one grant
+        # job. A second enqueue would race two benefit.grant tasks on the same
+        # (subscription, member, benefit) and raise a duplicate-key IntegrityError.
+        benefit_grant_calls = [
+            c
+            for c in enqueue_job_mock.call_args_list
+            if c.args and c.args[0] == "benefit.enqueue_benefits_grants"
+        ]
+        assert len(benefit_grant_calls) == 1
+        call_kwargs = benefit_grant_calls[0].kwargs
+        assert call_kwargs["task"] == "grant"
+        assert call_kwargs["customer_id"] == customer.id
+        assert call_kwargs["product_id"] == seat_product.id
+        assert call_kwargs["subscription_id"] == updated.id
+
     async def test_non_seat_to_seat_upgrade_promotes_customer_to_team(
         self,
         session: AsyncSession,

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -4095,8 +4095,8 @@ class TestUpdateProduct:
             )
 
         # The auto-claimed billing-customer seat must enqueue exactly one grant
-        # job. A second enqueue would race two benefit.grant tasks on the same
-        # (subscription, member, benefit) and raise a duplicate-key IntegrityError.
+        # job; a second enqueue would spawn a redundant benefit.grant task for the
+        # same (subscription, member, benefit).
         benefit_grant_calls = [
             c
             for c in enqueue_job_mock.call_args_list


### PR DESCRIPTION
## Summary

Fixes a `UniqueViolationError` on the `benefit_grants` unique index raised from the `benefit.grant` worker task. The error had two independent causes: a single subscription update enqueued the same grant twice and they raced, and a legacy unique constraint contradicted the canonical scope index, rejecting legitimate re-grants.

## What

- Initial seat transitions no longer enqueue the same `(subscription, member, benefit)` grant twice. The auto-claimed seat already enqueues its grant, so the redundant per-seat resync is skipped on the initial transition.
- Benefit grant creation is now idempotent: it lives in `BenefitGrantRepository.get_or_create_by_benefit_and_scope`, which inserts within a savepoint and, on a unique violation, reuses the existing grant instead of crashing.
- Dropped the legacy `benefit_grants_smb_key` unique constraint. The partial `ix_benefit_grants_scope_unique` index already enforces member-aware, soft-delete-aware uniqueness; the legacy constraint was stricter and rejected legitimate re-grants (after soft-delete or seat reassignment).

## Why

The legacy constraint ignored `customer_id`/`order_id` and applied to soft-deleted rows, so it both lost concurrent-grant races and deterministically blocked valid re-grants. The duplicate enqueue made the race common. Together these produced recurring failed grant tasks.

## How

The get-or-create follows the established `begin_nested` + `IntegrityError` recovery idiom (matching the `event_type` repository). The constraint drop follows the same migration pattern used to make downloadables member-aware, with a bounded `lock_timeout` and a loud-failing downgrade.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

