### PR TITLE
feat(payouts): show created-at and processor id to disambiguate account

### DIFF
--- a/clients/apps/web/src/components/Payouts/ManagePayoutAccountModal.tsx
+++ b/clients/apps/web/src/components/Payouts/ManagePayoutAccountModal.tsx
@@ -6,7 +6,13 @@ import {
 import { toast } from '@/components/Toast/use-toast'
 import { api } from '@/utils/client'
 import { schemas, unwrap } from '@polar-sh/client'
-import { Button } from '@polar-sh/orbit'
+import {
+  Button,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@polar-sh/orbit'
+import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import { ExternalLink, Plus, Trash2 } from 'lucide-react'
 import React, { useCallback, useState } from 'react'
 import { useOrganization } from '@/hooks/queries'
@@ -153,9 +159,24 @@ const ManagePayoutAccountModal: React.FC<ManagePayoutAccountModalProps> = ({
               >
                 <div className="flex flex-row items-center justify-between gap-x-4">
                   <div className="flex flex-row items-center gap-x-3">
-                    <span className="font-medium capitalize">
-                      {account.type}
-                    </span>
+                    {account.processor_id ? (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="font-medium capitalize">
+                            {account.type}
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <span className="font-mono text-xs">
+                            {account.processor_id}
+                          </span>
+                        </TooltipContent>
+                      </Tooltip>
+                    ) : (
+                      <span className="font-medium capitalize">
+                        {account.type}
+                      </span>
+                    )}
                     {isActive && (
                       <span className="dark:bg-polar-700 rounded-full bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-600 dark:text-blue-300">
                         Active
@@ -202,7 +223,8 @@ const ManagePayoutAccountModal: React.FC<ManagePayoutAccountModalProps> = ({
                 <div className="dark:border-polar-700 flex flex-row items-center gap-x-4 border-t border-gray-100 pt-3">
                   <span className="dark:text-polar-400 text-xs text-gray-500">
                     {account.country.toUpperCase()} ·{' '}
-                    {account.currency.toUpperCase()}
+                    {account.currency.toUpperCase()} · Added{' '}
+                    <FormattedDateTime datetime={account.created_at} />
                   </span>
                   <span
                     className={`inline-flex items-center gap-x-1.5 text-xs ${

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -27038,6 +27038,8 @@ export interface components {
        */
       modified_at: string | null
       type: components['schemas']['PayoutAccountType']
+      /** Processor Id */
+      processor_id: string | null
       /** Country */
       country: string
       /** Currency */

--- a/server/polar/payout_account/schemas.py
+++ b/server/polar/payout_account/schemas.py
@@ -140,6 +140,7 @@ class PayoutAccountCreate(Schema):
 
 class PayoutAccount(TimestampedSchema, IDSchema):
     type: PayoutAccountType
+    processor_id: str | None = Field(validation_alias="stripe_id")
     country: str
     currency: str
     is_payout_ready: bool


### PR DESCRIPTION
The Manage Payout Accounts modal renders every account identically — each row just says "Stripe" with a `NO · NOK · Ready` line. A merchant with multiple Stripe accounts has no way to tell them apart, so "Make Active" and "Delete"
become a guessing game. Reported on X (and by Emil, who suggested a created-at timestamp).

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

