### PR TITLE
feat: auto-cancel subscriptions for wound-down organizations

### DIFF
--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -248,9 +248,8 @@ class Settings(BaseSettings):
     # (not fully refunded) order, i.e. the post-chargeback-risk wind-down window.
     ORGANIZATION_OFFBOARDING_PERIOD: timedelta = timedelta(days=120)
 
-    # How long an organization stays denied, blocked, or offboarded before its
-    # customers' subscriptions are automatically cancelled (silently, without
-    # notifying the customers). Measured from when the org entered the status.
+    # Delay after an org becomes denied/blocked/offboarded before its customers'
+    # subscriptions are auto-cancelled — silently, without notifying customers.
     ORGANIZATION_SUBSCRIPTION_CANCELLATION_DELAY: timedelta = timedelta(days=7)
 
     # Stripe

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -248,6 +248,11 @@ class Settings(BaseSettings):
     # (not fully refunded) order, i.e. the post-chargeback-risk wind-down window.
     ORGANIZATION_OFFBOARDING_PERIOD: timedelta = timedelta(days=120)
 
+    # How long an organization stays denied, blocked, or offboarded before its
+    # customers' subscriptions are automatically cancelled (silently, without
+    # notifying the customers). Measured from when the org entered the status.
+    ORGANIZATION_SUBSCRIPTION_CANCELLATION_DELAY: timedelta = timedelta(days=7)
+
     # Stripe
     STRIPE_SECRET_KEY: str = ""
     STRIPE_PUBLISHABLE_KEY: str = ""

--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -275,6 +275,8 @@ class OrganizationRepository(
 
         The ``EXISTS`` gate makes the scan idempotent: once an org's
         subscriptions are all cancelled it drops out and is not re-enqueued.
+        Falls back to ``created_at`` when ``status_updated_at`` is unset, so a
+        terminal org with a legacy null timestamp is still wound down.
         """
         has_billable_subscription = (
             select(Subscription.id)
@@ -287,15 +289,17 @@ class OrganizationRepository(
             .correlate(Organization)
             .exists()
         )
+        status_entered_at = func.coalesce(
+            Organization.status_updated_at, Organization.created_at
+        )
         statement = (
             self.get_base_statement()
             .where(
                 Organization.status.in_(SUBSCRIPTION_CANCELLATION_STATUSES),
-                Organization.status_updated_at.is_not(None),
-                Organization.status_updated_at <= cutoff,
+                status_entered_at <= cutoff,
                 has_billable_subscription,
             )
-            .order_by(Organization.status_updated_at.asc())
+            .order_by(status_entered_at.asc())
             .limit(limit)
         )
         return await self.get_all(statement)

--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -52,11 +52,8 @@ OFFBOARD_EXPIRED_BATCH_SIZE = 500
 # Maximum orgs the subscription-cancellation cron processes per run.
 CANCEL_SUBSCRIPTIONS_BATCH_SIZE = 500
 
-# Statuses after which an org's customer subscriptions are auto-cancelled
-# once the cancellation delay has elapsed. ``offboarded`` (not ``offboarding``)
-# is the terminal state: ``offboarding`` is the graceful wind-down period during
-# which renewals intentionally continue, so subscriptions are only cancelled once
-# that period has completed.
+# ``offboarded``, not ``offboarding``: offboarding intentionally keeps renewals
+# on during the wind-down, so subscriptions are only cancelled once it completes.
 SUBSCRIPTION_CANCELLATION_STATUSES = (
     OrganizationStatus.DENIED,
     OrganizationStatus.BLOCKED,
@@ -273,13 +270,11 @@ class OrganizationRepository(
     async def get_status_cancellation_expired(
         self, cutoff: datetime, *, limit: int = CANCEL_SUBSCRIPTIONS_BATCH_SIZE
     ) -> Sequence[Organization]:
-        """Orgs that have been denied, blocked, or offboarded past the cutoff
-        and still have at least one billable subscription to cancel.
+        """Orgs denied, blocked, or offboarded past the cutoff that still have a
+        billable subscription to cancel.
 
-        Anchored on ``status_updated_at``, which records when the org last
-        changed status. The ``EXISTS`` gate keeps the scan idempotent: once an
-        org's subscriptions are all cancelled it falls out of the result set,
-        so it is not re-enqueued on subsequent runs.
+        The ``EXISTS`` gate makes the scan idempotent: once an org's
+        subscriptions are all cancelled it drops out and is not re-enqueued.
         """
         has_billable_subscription = (
             select(Subscription.id)

--- a/server/polar/organization/repository.py
+++ b/server/polar/organization/repository.py
@@ -49,6 +49,20 @@ UNSNOOZE_EXPIRED_BATCH_SIZE = 500
 # Maximum orgs the auto-offboard cron processes per run.
 OFFBOARD_EXPIRED_BATCH_SIZE = 500
 
+# Maximum orgs the subscription-cancellation cron processes per run.
+CANCEL_SUBSCRIPTIONS_BATCH_SIZE = 500
+
+# Statuses after which an org's customer subscriptions are auto-cancelled
+# once the cancellation delay has elapsed. ``offboarded`` (not ``offboarding``)
+# is the terminal state: ``offboarding`` is the graceful wind-down period during
+# which renewals intentionally continue, so subscriptions are only cancelled once
+# that period has completed.
+SUBSCRIPTION_CANCELLATION_STATUSES = (
+    OrganizationStatus.DENIED,
+    OrganizationStatus.BLOCKED,
+    OrganizationStatus.OFFBOARDED,
+)
+
 
 class OrganizationRepository(
     RepositorySortingMixin[Organization, OrganizationSortProperty],
@@ -253,6 +267,41 @@ class OrganizationRepository(
             .order_by(anchor.asc())
             .limit(limit)
             .with_for_update(of=Organization)
+        )
+        return await self.get_all(statement)
+
+    async def get_status_cancellation_expired(
+        self, cutoff: datetime, *, limit: int = CANCEL_SUBSCRIPTIONS_BATCH_SIZE
+    ) -> Sequence[Organization]:
+        """Orgs that have been denied, blocked, or offboarded past the cutoff
+        and still have at least one billable subscription to cancel.
+
+        Anchored on ``status_updated_at``, which records when the org last
+        changed status. The ``EXISTS`` gate keeps the scan idempotent: once an
+        org's subscriptions are all cancelled it falls out of the result set,
+        so it is not re-enqueued on subsequent runs.
+        """
+        has_billable_subscription = (
+            select(Subscription.id)
+            .where(
+                Subscription.organization_id == Organization.id,
+                Subscription.status.in_(SubscriptionStatus.billable_statuses()),
+                Subscription.ended_at.is_(None),
+                Subscription.deleted_at.is_(None),
+            )
+            .correlate(Organization)
+            .exists()
+        )
+        statement = (
+            self.get_base_statement()
+            .where(
+                Organization.status.in_(SUBSCRIPTION_CANCELLATION_STATUSES),
+                Organization.status_updated_at.is_not(None),
+                Organization.status_updated_at <= cutoff,
+                has_billable_subscription,
+            )
+            .order_by(Organization.status_updated_at.asc())
+            .limit(limit)
         )
         return await self.get_all(statement)
 

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1457,13 +1457,9 @@ class OrganizationService:
     async def cancel_expired_organizations_subscriptions(
         self, session: AsyncSession
     ) -> Sequence[Organization]:
-        """Cancel customer subscriptions of orgs stuck in a terminal-bad status.
-
-        Run periodically by a worker. Picks up organizations that have been
-        denied, blocked, or offboarded for longer than the cancellation delay
-        and still have billable subscriptions, then enqueues a per-org job that
-        cancels them without notifying the customers. Returns the orgs whose
-        cancellation was enqueued.
+        """Enqueue a per-org cancellation job for each organization denied,
+        blocked, or offboarded past the cancellation delay that still has
+        billable subscriptions. Returns the organizations enqueued.
         """
         repository = OrganizationRepository.from_session(session)
         cutoff = (

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1454,6 +1454,29 @@ class OrganizationService:
             transitioned.append(organization)
         return transitioned
 
+    async def cancel_expired_organizations_subscriptions(
+        self, session: AsyncSession
+    ) -> Sequence[Organization]:
+        """Cancel customer subscriptions of orgs stuck in a terminal-bad status.
+
+        Run periodically by a worker. Picks up organizations that have been
+        denied, blocked, or offboarded for longer than the cancellation delay
+        and still have billable subscriptions, then enqueues a per-org job that
+        cancels them without notifying the customers. Returns the orgs whose
+        cancellation was enqueued.
+        """
+        repository = OrganizationRepository.from_session(session)
+        cutoff = (
+            datetime.now(UTC) - settings.ORGANIZATION_SUBSCRIPTION_CANCELLATION_DELAY
+        )
+        organizations = await repository.get_status_cancellation_expired(cutoff)
+        for organization in organizations:
+            enqueue_job(
+                "subscription.cancel_for_organization",
+                organization_id=organization.id,
+            )
+        return organizations
+
     async def set_organization_offboarded(
         self, session: AsyncSession, organization: Organization
     ) -> Organization:

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -97,6 +97,19 @@ async def organization_offboard_expired() -> None:
         await organization_service.offboard_expired_organizations(session)
 
 
+@actor(
+    actor_name="organization.cancel_expired_subscriptions",
+    cron_trigger=CronTrigger.from_crontab("0 5 * * *"),
+    priority=TaskPriority.LOW,
+    max_retries=0,
+)
+async def organization_cancel_expired_subscriptions() -> None:
+    """Cancel customer subscriptions of orgs denied/blocked/offboarded past the
+    cancellation delay. Customers are not notified."""
+    async with AsyncSessionMaker() as session:
+        await organization_service.cancel_expired_organizations_subscriptions(session)
+
+
 @actor(actor_name="organization.offboarded", priority=TaskPriority.LOW)
 async def organization_offboarded(organization_id: uuid.UUID) -> None:
     """Notify an organization's members that it has been offboarded."""

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -106,6 +106,20 @@ class SubscriptionRepository(
         )
         return await self.get_all(statement)
 
+    async def list_billable_by_organization(
+        self, organization_id: UUID, *, options: Options = ()
+    ) -> Sequence[Subscription]:
+        statement = (
+            self.get_base_statement()
+            .where(
+                Subscription.organization_id == organization_id,
+                Subscription.status.in_(SubscriptionStatus.billable_statuses()),
+                Subscription.ended_at.is_(None),
+            )
+            .options(*options)
+        )
+        return await self.get_all(statement)
+
     async def get_all_by_customer(
         self, customer_id: UUID, *, options: Options = ()
     ) -> Sequence[Subscription]:

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -106,23 +106,18 @@ class SubscriptionRepository(
         )
         return await self.get_all(statement)
 
-    async def list_billable_by_organization(
-        self,
-        organization_id: UUID,
-        *,
-        options: Options = (),
-        limit: int | None = None,
-        after_id: UUID | None = None,
-    ) -> Sequence[Subscription]:
-        statement = self.get_base_statement().where(
-            Subscription.organization_id == organization_id,
-            Subscription.status.in_(SubscriptionStatus.billable_statuses()),
-            Subscription.ended_at.is_(None),
+    def get_billable_by_organization_statement(
+        self, organization_id: UUID, *, options: Options = ()
+    ) -> Select[tuple[Subscription]]:
+        return (
+            self.get_base_statement()
+            .where(
+                Subscription.organization_id == organization_id,
+                Subscription.status.in_(SubscriptionStatus.billable_statuses()),
+                Subscription.ended_at.is_(None),
+            )
+            .options(*options)
         )
-        if after_id is not None:
-            statement = statement.where(Subscription.id > after_id)
-        statement = statement.order_by(Subscription.id).options(*options).limit(limit)
-        return await self.get_all(statement)
 
     async def get_all_by_customer(
         self, customer_id: UUID, *, options: Options = ()

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -107,17 +107,21 @@ class SubscriptionRepository(
         return await self.get_all(statement)
 
     async def list_billable_by_organization(
-        self, organization_id: UUID, *, options: Options = ()
+        self,
+        organization_id: UUID,
+        *,
+        options: Options = (),
+        limit: int | None = None,
+        after_id: UUID | None = None,
     ) -> Sequence[Subscription]:
-        statement = (
-            self.get_base_statement()
-            .where(
-                Subscription.organization_id == organization_id,
-                Subscription.status.in_(SubscriptionStatus.billable_statuses()),
-                Subscription.ended_at.is_(None),
-            )
-            .options(*options)
+        statement = self.get_base_statement().where(
+            Subscription.organization_id == organization_id,
+            Subscription.status.in_(SubscriptionStatus.billable_statuses()),
+            Subscription.ended_at.is_(None),
         )
+        if after_id is not None:
+            statement = statement.where(Subscription.id > after_id)
+        statement = statement.order_by(Subscription.id).options(*options).limit(limit)
         return await self.get_all(statement)
 
     async def get_all_by_customer(

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -90,7 +90,10 @@ from polar.notifications.notification import (
 )
 from polar.notifications.service import PartialNotification
 from polar.notifications.service import notifications as notifications_service
-from polar.organization.repository import OrganizationRepository
+from polar.organization.repository import (
+    SUBSCRIPTION_CANCELLATION_STATUSES,
+    OrganizationRepository,
+)
 from polar.product.guard import (
     is_custom_price,
     is_recurring_product,
@@ -240,6 +243,8 @@ class SubscriptionUpdateContext:
         session: AsyncSession,
         subscription: Subscription,
         service: "SubscriptionService",
+        *,
+        notify_customer: bool = True,
     ) -> None:
         self.session = session
         self.service = service
@@ -247,6 +252,7 @@ class SubscriptionUpdateContext:
         self.subscription = subscription
         self._previous_status = subscription.status
         self._previous_is_canceled = subscription.canceled
+        self._notify_customer = notify_customer
 
         self._billing_effect: Literal["invoice", "cycle"] | None = None
         self._event_metadata: SubscriptionUpdatedMetadataFields = {}
@@ -291,6 +297,7 @@ class SubscriptionUpdateContext:
             self.subscription,
             previous_status=self._previous_status,
             previous_is_canceled=self._previous_is_canceled,
+            notify_customer=self._notify_customer,
         )
 
     def set_billing_effect(self, effect: Literal["invoice", "cycle"]) -> None:
@@ -1816,6 +1823,55 @@ class SubscriptionService:
                     revoke_benefits=False,
                 )
 
+    async def cancel_for_organization(
+        self, session: AsyncSession, organization_id: uuid.UUID
+    ) -> None:
+        """Immediately cancel all billable subscriptions of an organization,
+        without notifying its customers.
+
+        Used when an organization has been denied, blocked, or offboarded for
+        long enough that its customers' subscriptions must be wound down. The
+        customers are intentionally not emailed, as the cancellation results
+        from the merchant being shut down rather than a customer-initiated or
+        merchant-initiated action.
+
+        Re-checks the organization status at execution time: this runs as a
+        deferred job enqueued by a daily scan, so an admin may have reactivated
+        the org in between. If it is no longer in a wind-down status, this is a
+        no-op — we must not cancel subscriptions of a reinstated org.
+        ``include_blocked=True`` is required because ``blocked`` is itself one
+        of the wind-down statuses.
+
+        Idempotent at the subscription level: a duplicate or concurrent run
+        (e.g. the cron firing from more than one scheduler replica) may have
+        already cancelled some subscriptions. Such a subscription is skipped
+        rather than aborting the whole batch.
+        """
+        organization_repository = OrganizationRepository.from_session(session)
+        organization = await organization_repository.get_by_id(
+            organization_id, include_blocked=True
+        )
+        if (
+            organization is None
+            or organization.status not in SUBSCRIPTION_CANCELLATION_STATUSES
+        ):
+            return
+
+        subscription_repository = SubscriptionRepository.from_session(session)
+        subscriptions = await subscription_repository.list_billable_by_organization(
+            organization_id, options=subscription_repository.get_eager_options()
+        )
+        for subscription in subscriptions:
+            try:
+                async with SubscriptionUpdateContext(
+                    session, subscription, self, notify_customer=False
+                ) as ctx:
+                    await self._perform_cancellation(
+                        session, ctx, subscription, immediately=True
+                    )
+            except AlreadyCanceledSubscription:
+                continue
+
     async def _perform_cancellation(
         self,
         session: AsyncSession,
@@ -2042,6 +2098,7 @@ class SubscriptionService:
         *,
         previous_status: SubscriptionStatus,
         previous_is_canceled: bool,
+        notify_customer: bool = True,
     ) -> None:
         await self._on_subscription_updated(session, subscription)
 
@@ -2074,12 +2131,18 @@ class SubscriptionService:
 
         if became_canceled or (became_revoked and previous_is_canceled):
             await self._on_subscription_canceled(
-                session, subscription, revoked=became_revoked
+                session,
+                subscription,
+                revoked=became_revoked,
+                notify_customer=notify_customer,
             )
 
         if became_revoked:
             await self._on_subscription_revoked(
-                session, subscription, past_due=became_past_due
+                session,
+                subscription,
+                past_due=became_past_due,
+                notify_customer=notify_customer,
             )
 
         enqueue_job("customer.state_changed", subscription.customer_id)
@@ -2187,6 +2250,7 @@ class SubscriptionService:
         session: AsyncSession,
         subscription: Subscription,
         revoked: bool,
+        notify_customer: bool = True,
     ) -> None:
         await self._send_webhook(
             session, subscription, WebhookEventType.subscription_canceled
@@ -2226,7 +2290,7 @@ class SubscriptionService:
 
         # Only send cancellation email if the subscription is not revoked,
         # as revocation has its own email.
-        if not revoked:
+        if not revoked and notify_customer:
             await self.send_cancellation_email(session, subscription)
 
     async def _on_subscription_revoked(
@@ -2234,6 +2298,7 @@ class SubscriptionService:
         session: AsyncSession,
         subscription: Subscription,
         past_due: bool,
+        notify_customer: bool = True,
     ) -> None:
         await self._send_webhook(
             session, subscription, WebhookEventType.subscription_revoked
@@ -2257,7 +2322,7 @@ class SubscriptionService:
         )
         # Only send revoked email if the subscription is not past due,
         # as past due has its own email.
-        if not past_due:
+        if not past_due and notify_customer:
             await self.send_revoked_email(session, subscription)
 
         # Void all pending orders for this subscription

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -127,10 +127,6 @@ from .update import generate_subscription_update
 
 log: Logger = structlog.get_logger()
 
-# How many subscriptions the org wind-down cancels per batch, so a large
-# merchant doesn't materialize its entire subscription set in one go.
-ORGANIZATION_CANCELLATION_BATCH_SIZE = 100
-
 
 class SubscriptionError(PolarError): ...
 
@@ -1842,9 +1838,9 @@ class SubscriptionService:
         status, this is a no-op. ``include_blocked=True`` because ``blocked`` is
         itself a wind-down status.
 
-        Subscriptions are cancelled in bounded batches so a large merchant
-        doesn't materialize its whole subscription set at once. An
-        already-cancelled subscription is skipped, not treated as an error.
+        Streams the billable subscriptions so a large merchant doesn't
+        materialize its whole subscription set at once. An already-cancelled
+        subscription is skipped, not treated as an error.
         """
         organization_repository = OrganizationRepository.from_session(session)
         organization = await organization_repository.get_by_id(
@@ -1857,31 +1853,19 @@ class SubscriptionService:
             return
 
         subscription_repository = SubscriptionRepository.from_session(session)
-        # Keyset pagination by id: advances past each batch regardless of whether
-        # a subscription was cancelled, so the loop always terminates (even if a
-        # subscription is skipped) and never re-materializes the whole set.
-        after_id: uuid.UUID | None = None
-        while True:
-            subscriptions = await subscription_repository.list_billable_by_organization(
-                organization_id,
-                options=subscription_repository.get_eager_options(),
-                limit=ORGANIZATION_CANCELLATION_BATCH_SIZE,
-                after_id=after_id,
-            )
-            if not subscriptions:
-                break
-            for subscription in subscriptions:
-                try:
-                    async with SubscriptionUpdateContext(
-                        session, subscription, self, notify_customer=False
-                    ) as ctx:
-                        await self._perform_cancellation(
-                            session, ctx, subscription, immediately=True
-                        )
-                except AlreadyCanceledSubscription:
-                    continue
-            after_id = subscriptions[-1].id
-            await session.flush()
+        statement = subscription_repository.get_billable_by_organization_statement(
+            organization_id, options=subscription_repository.get_eager_options()
+        )
+        async for subscription in subscription_repository.stream(statement):
+            try:
+                async with SubscriptionUpdateContext(
+                    session, subscription, self, notify_customer=False
+                ) as ctx:
+                    await self._perform_cancellation(
+                        session, ctx, subscription, immediately=True
+                    )
+            except AlreadyCanceledSubscription:
+                continue
 
     async def _perform_cancellation(
         self,

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -127,6 +127,10 @@ from .update import generate_subscription_update
 
 log: Logger = structlog.get_logger()
 
+# How many subscriptions the org wind-down cancels per batch, so a large
+# merchant doesn't materialize its entire subscription set in one go.
+ORGANIZATION_CANCELLATION_BATCH_SIZE = 100
+
 
 class SubscriptionError(PolarError): ...
 
@@ -1830,17 +1834,21 @@ class SubscriptionService:
         without notifying its customers (the cancellation follows the merchant
         being shut down, not a customer or merchant action).
 
-        Re-checks the org status, since this runs as a deferred job: an admin
-        may have reactivated the org after the scan enqueued it, in which case
-        this is a no-op. ``include_blocked=True`` because ``blocked`` is itself
-        a wind-down status.
+        Locks the org row (``for_update``) before re-checking its status, since
+        this runs as a deferred job: it serializes against a concurrent admin
+        reactivation (we must not cancel a reinstated org) and against another
+        copy of this job for the same org (which would otherwise duplicate
+        cancellation side effects). If the org is no longer in a wind-down
+        status, this is a no-op. ``include_blocked=True`` because ``blocked`` is
+        itself a wind-down status.
 
-        Idempotent at the subscription level: an already-cancelled subscription
-        (from a duplicate or concurrent run) is skipped, not treated as an error.
+        Subscriptions are cancelled in bounded batches so a large merchant
+        doesn't materialize its whole subscription set at once. An
+        already-cancelled subscription is skipped, not treated as an error.
         """
         organization_repository = OrganizationRepository.from_session(session)
         organization = await organization_repository.get_by_id(
-            organization_id, include_blocked=True
+            organization_id, include_blocked=True, for_update=True
         )
         if (
             organization is None
@@ -1849,19 +1857,31 @@ class SubscriptionService:
             return
 
         subscription_repository = SubscriptionRepository.from_session(session)
-        subscriptions = await subscription_repository.list_billable_by_organization(
-            organization_id, options=subscription_repository.get_eager_options()
-        )
-        for subscription in subscriptions:
-            try:
-                async with SubscriptionUpdateContext(
-                    session, subscription, self, notify_customer=False
-                ) as ctx:
-                    await self._perform_cancellation(
-                        session, ctx, subscription, immediately=True
-                    )
-            except AlreadyCanceledSubscription:
-                continue
+        # Keyset pagination by id: advances past each batch regardless of whether
+        # a subscription was cancelled, so the loop always terminates (even if a
+        # subscription is skipped) and never re-materializes the whole set.
+        after_id: uuid.UUID | None = None
+        while True:
+            subscriptions = await subscription_repository.list_billable_by_organization(
+                organization_id,
+                options=subscription_repository.get_eager_options(),
+                limit=ORGANIZATION_CANCELLATION_BATCH_SIZE,
+                after_id=after_id,
+            )
+            if not subscriptions:
+                break
+            for subscription in subscriptions:
+                try:
+                    async with SubscriptionUpdateContext(
+                        session, subscription, self, notify_customer=False
+                    ) as ctx:
+                        await self._perform_cancellation(
+                            session, ctx, subscription, immediately=True
+                        )
+                except AlreadyCanceledSubscription:
+                    continue
+            after_id = subscriptions[-1].id
+            await session.flush()
 
     async def _perform_cancellation(
         self,

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1827,25 +1827,16 @@ class SubscriptionService:
         self, session: AsyncSession, organization_id: uuid.UUID
     ) -> None:
         """Immediately cancel all billable subscriptions of an organization,
-        without notifying its customers.
+        without notifying its customers (the cancellation follows the merchant
+        being shut down, not a customer or merchant action).
 
-        Used when an organization has been denied, blocked, or offboarded for
-        long enough that its customers' subscriptions must be wound down. The
-        customers are intentionally not emailed, as the cancellation results
-        from the merchant being shut down rather than a customer-initiated or
-        merchant-initiated action.
+        Re-checks the org status, since this runs as a deferred job: an admin
+        may have reactivated the org after the scan enqueued it, in which case
+        this is a no-op. ``include_blocked=True`` because ``blocked`` is itself
+        a wind-down status.
 
-        Re-checks the organization status at execution time: this runs as a
-        deferred job enqueued by a daily scan, so an admin may have reactivated
-        the org in between. If it is no longer in a wind-down status, this is a
-        no-op — we must not cancel subscriptions of a reinstated org.
-        ``include_blocked=True`` is required because ``blocked`` is itself one
-        of the wind-down statuses.
-
-        Idempotent at the subscription level: a duplicate or concurrent run
-        (e.g. the cron firing from more than one scheduler replica) may have
-        already cancelled some subscriptions. Such a subscription is skipped
-        rather than aborting the whole batch.
+        Idempotent at the subscription level: an already-cancelled subscription
+        (from a duplicate or concurrent run) is skipped, not treated as an error.
         """
         organization_repository = OrganizationRepository.from_session(session)
         organization = await organization_repository.get_by_id(

--- a/server/polar/subscription/tasks.py
+++ b/server/polar/subscription/tasks.py
@@ -76,6 +76,20 @@ async def subscription_cycle(subscription_id: uuid.UUID, force: bool = False) ->
 
 
 @actor(
+    actor_name="subscription.cancel_for_organization",
+    priority=TaskPriority.LOW,
+)
+async def subscription_cancel_for_organization(organization_id: uuid.UUID) -> None:
+    """Cancel all billable subscriptions of a denied/blocked/offboarded org.
+
+    Enqueued per-organization by ``organization.cancel_expired_subscriptions``.
+    Customers are intentionally not emailed about the cancellation.
+    """
+    async with AsyncSessionMaker() as session:
+        await subscription_service.cancel_for_organization(session, organization_id)
+
+
+@actor(
     actor_name="subscription.subscription.update_product_benefits_grants",
     priority=TaskPriority.MEDIUM,
 )

--- a/server/polar/subscription/tasks.py
+++ b/server/polar/subscription/tasks.py
@@ -80,10 +80,8 @@ async def subscription_cycle(subscription_id: uuid.UUID, force: bool = False) ->
     priority=TaskPriority.LOW,
 )
 async def subscription_cancel_for_organization(organization_id: uuid.UUID) -> None:
-    """Cancel all billable subscriptions of a denied/blocked/offboarded org.
-
-    Enqueued per-organization by ``organization.cancel_expired_subscriptions``.
-    Customers are intentionally not emailed about the cancellation.
+    """Cancel all billable subscriptions of a denied/blocked/offboarded org,
+    enqueued per-organization by ``organization.cancel_expired_subscriptions``.
     """
     async with AsyncSessionMaker() as session:
         await subscription_service.cancel_for_organization(session, organization_id)

--- a/server/tests/organization/test_repository.py
+++ b/server/tests/organization/test_repository.py
@@ -1,6 +1,9 @@
+from datetime import UTC, datetime, timedelta
+
 import pytest
 
-from polar.models import Organization, User, UserOrganization
+from polar.models import Customer, Organization, Product, User, UserOrganization
+from polar.models.organization import OrganizationStatus
 from polar.models.user_organization import OrganizationRole
 from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncSession
@@ -8,6 +11,10 @@ from polar.user_organization.service import (
     user_organization as user_organization_service,
 )
 from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import (
+    create_active_subscription,
+    create_canceled_subscription,
+)
 
 
 @pytest.mark.asyncio
@@ -47,3 +54,161 @@ class TestGetOwnerUser:
         repo = OrganizationRepository.from_session(session)
         owner_after_removal = await repo.get_owner_user(organization)
         assert owner_after_removal is None
+
+
+async def _set_status(
+    save_fixture: SaveFixture,
+    organization: Organization,
+    status: OrganizationStatus,
+    status_updated_at: datetime,
+) -> None:
+    organization.status = status
+    organization.status_updated_at = status_updated_at
+    await save_fixture(organization)
+
+
+@pytest.mark.asyncio
+class TestGetStatusCancellationExpired:
+    async def test_returns_expired_org_with_billable_subscription(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        await _set_status(
+            save_fixture,
+            organization,
+            OrganizationStatus.DENIED,
+            datetime.now(UTC) - timedelta(days=8),
+        )
+        await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        repo = OrganizationRepository.from_session(session)
+        results = await repo.get_status_cancellation_expired(
+            datetime.now(UTC) - timedelta(days=7)
+        )
+
+        assert organization.id in {org.id for org in results}
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            OrganizationStatus.DENIED,
+            OrganizationStatus.BLOCKED,
+            OrganizationStatus.OFFBOARDED,
+        ],
+    )
+    async def test_includes_all_cancellation_statuses(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+        status: OrganizationStatus,
+    ) -> None:
+        await _set_status(
+            save_fixture,
+            organization,
+            status,
+            datetime.now(UTC) - timedelta(days=8),
+        )
+        await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        repo = OrganizationRepository.from_session(session)
+        results = await repo.get_status_cancellation_expired(
+            datetime.now(UTC) - timedelta(days=7)
+        )
+
+        assert organization.id in {org.id for org in results}
+
+    async def test_excludes_recent_status_change(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        await _set_status(
+            save_fixture,
+            organization,
+            OrganizationStatus.DENIED,
+            datetime.now(UTC) - timedelta(days=1),
+        )
+        await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        repo = OrganizationRepository.from_session(session)
+        results = await repo.get_status_cancellation_expired(
+            datetime.now(UTC) - timedelta(days=7)
+        )
+
+        assert organization.id not in {org.id for org in results}
+
+    async def test_excludes_org_without_billable_subscription(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        await _set_status(
+            save_fixture,
+            organization,
+            OrganizationStatus.DENIED,
+            datetime.now(UTC) - timedelta(days=8),
+        )
+        await create_canceled_subscription(
+            save_fixture, product=product, customer=customer, revoke=True
+        )
+
+        repo = OrganizationRepository.from_session(session)
+        results = await repo.get_status_cancellation_expired(
+            datetime.now(UTC) - timedelta(days=7)
+        )
+
+        assert organization.id not in {org.id for org in results}
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            OrganizationStatus.ACTIVE,
+            # `offboarding` is the in-progress wind-down (renewals still on);
+            # only the terminal `offboarded` status triggers cancellation.
+            OrganizationStatus.OFFBOARDING,
+        ],
+    )
+    async def test_excludes_non_cancellation_status(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+        status: OrganizationStatus,
+    ) -> None:
+        await _set_status(
+            save_fixture,
+            organization,
+            status,
+            datetime.now(UTC) - timedelta(days=8),
+        )
+        await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        repo = OrganizationRepository.from_session(session)
+        results = await repo.get_status_cancellation_expired(
+            datetime.now(UTC) - timedelta(days=7)
+        )
+
+        assert organization.id not in {org.id for org in results}

--- a/server/tests/organization/test_repository.py
+++ b/server/tests/organization/test_repository.py
@@ -212,3 +212,28 @@ class TestGetStatusCancellationExpired:
         )
 
         assert organization.id not in {org.id for org in results}
+
+    async def test_falls_back_to_created_at_when_status_updated_at_null(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        # Legacy terminal org with no status_updated_at must still be picked up,
+        # anchored on created_at.
+        organization.status = OrganizationStatus.DENIED
+        organization.status_updated_at = None
+        organization.created_at = datetime.now(UTC) - timedelta(days=8)
+        await save_fixture(organization)
+        await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        repo = OrganizationRepository.from_session(session)
+        results = await repo.get_status_cancellation_expired(
+            datetime.now(UTC) - timedelta(days=7)
+        )
+
+        assert organization.id in {org.id for org in results}

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -66,6 +66,7 @@ from polar.user_organization.service import (
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
+    create_active_subscription,
     create_benefit,
     create_checkout_link,
     create_dispute,
@@ -4919,3 +4920,57 @@ class TestAddUser:
             role=expected_member_role,
             delay=None,
         )
+
+
+@pytest.mark.asyncio
+class TestCancelExpiredOrganizationsSubscriptions:
+    async def test_enqueues_for_expired_org(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+        organization.status = OrganizationStatus.DENIED
+        organization.status_updated_at = datetime.now(UTC) - timedelta(days=8)
+        await save_fixture(organization)
+        await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        result = await organization_service.cancel_expired_organizations_subscriptions(
+            session
+        )
+
+        assert organization.id in {org.id for org in result}
+        enqueue_job_mock.assert_called_once_with(
+            "subscription.cancel_for_organization",
+            organization_id=organization.id,
+        )
+
+    async def test_skips_recent_org(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+        organization.status = OrganizationStatus.DENIED
+        organization.status_updated_at = datetime.now(UTC) - timedelta(days=1)
+        await save_fixture(organization)
+        await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        result = await organization_service.cancel_expired_organizations_subscriptions(
+            session
+        )
+
+        assert organization.id not in {org.id for org in result}
+        enqueue_job_mock.assert_not_called()

--- a/server/tests/organization/test_tasks.py
+++ b/server/tests/organization/test_tasks.py
@@ -8,6 +8,7 @@ from polar.models import Organization, User, UserOrganization
 from polar.models.organization import OrganizationStatus
 from polar.organization.tasks import (
     OrganizationDoesNotExist,
+    organization_cancel_expired_subscriptions,
     organization_created,
     organization_offboarded,
     organization_under_review,
@@ -120,3 +121,20 @@ class TestOrganizationOffboarded:
         assert organization.name in kwargs["subject"]
         email = args[0]
         assert email.props.account_url == organization.account_url
+
+
+@pytest.mark.asyncio
+class TestOrganizationCancelExpiredSubscriptions:
+    async def test_invokes_service(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+    ) -> None:
+        cancel_mock = mocker.patch(
+            "polar.organization.tasks.organization_service."
+            "cancel_expired_organizations_subscriptions"
+        )
+
+        await organization_cancel_expired_subscriptions()
+
+        cancel_mock.assert_called_once()

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -7056,9 +7056,8 @@ class TestCancelForOrganization:
             session, product.organization_id
         )
 
-    async def test_cancels_across_batches(
+    async def test_cancels_multiple_subscriptions(
         self,
-        mocker: MockerFixture,
         session: AsyncSession,
         save_fixture: SaveFixture,
         organization: Organization,
@@ -7066,11 +7065,8 @@ class TestCancelForOrganization:
         customer: Customer,
         customer_second: Customer,
     ) -> None:
-        # Batch size of 1 forces the keyset drain to span multiple iterations;
-        # every billable subscription must still be cancelled.
-        mocker.patch(
-            "polar.subscription.service.ORGANIZATION_CANCELLATION_BATCH_SIZE", 1
-        )
+        # Every billable subscription of the org is cancelled by the streaming
+        # loop, not just the first one.
         organization.status = OrganizationStatus.DENIED
         await save_fixture(organization)
         first = await create_active_subscription(

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -6930,9 +6930,13 @@ class TestCancelForOrganization:
         # No customer-facing email is sent for an org-driven cancellation.
         enqueue_email_mock.assert_not_called()
 
-        # Merchant side effects still happen (pending orders are voided).
+        # Merchant side effects still happen (pending orders are voided and the
+        # customer state is recomputed).
         enqueue_job_mock.assert_any_call(
             "order.void_pending_orders_for_subscription", subscription.id
+        )
+        enqueue_job_mock.assert_any_call(
+            "customer.state_changed", subscription.customer_id
         )
 
     async def test_skips_already_ended_subscriptions(
@@ -7051,6 +7055,39 @@ class TestCancelForOrganization:
         await subscription_service.cancel_for_organization(
             session, product.organization_id
         )
+
+    async def test_cancels_across_batches(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+        customer_second: Customer,
+    ) -> None:
+        # Batch size of 1 forces the keyset drain to span multiple iterations;
+        # every billable subscription must still be cancelled.
+        mocker.patch(
+            "polar.subscription.service.ORGANIZATION_CANCELLATION_BATCH_SIZE", 1
+        )
+        organization.status = OrganizationStatus.DENIED
+        await save_fixture(organization)
+        first = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        second = await create_active_subscription(
+            save_fixture, product=product, customer=customer_second
+        )
+
+        await subscription_service.cancel_for_organization(
+            session, product.organization_id
+        )
+
+        await session.refresh(first)
+        await session.refresh(second)
+        assert first.status == SubscriptionStatus.canceled
+        assert second.status == SubscriptionStatus.canceled
 
 
 @pytest.mark.asyncio

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -58,6 +58,7 @@ from polar.models.customer import CustomerType
 from polar.models.customer_seat import SeatStatus
 from polar.models.discount import DiscountDuration, DiscountType
 from polar.models.order import OrderBillingReasonInternal, OrderStatus
+from polar.models.organization import OrganizationStatus
 from polar.models.product_price import ProductPriceAmountType, ProductPriceSeatUnit
 from polar.models.subscription import SubscriptionStatus
 from polar.models.webhook_endpoint import WebhookEventType
@@ -6894,6 +6895,161 @@ class TestCancelCustomer:
         assert len(void_calls) == 1, (
             "Expected the past_due subscription's pending orders to be voided, "
             f"but found {len(void_calls)} void call(s)"
+        )
+
+
+@pytest.mark.asyncio
+class TestCancelForOrganization:
+    async def test_cancels_billable_without_email(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        enqueue_email_mock: MagicMock,
+        enqueue_job_mock: MagicMock,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        organization.status = OrganizationStatus.DENIED
+        await save_fixture(organization)
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+        )
+
+        await subscription_service.cancel_for_organization(
+            session, product.organization_id
+        )
+
+        await session.refresh(subscription)
+        assert subscription.status == SubscriptionStatus.canceled
+        assert subscription.canceled_at is not None
+        assert subscription.ended_at is not None
+
+        # No customer-facing email is sent for an org-driven cancellation.
+        enqueue_email_mock.assert_not_called()
+
+        # Merchant side effects still happen (pending orders are voided).
+        enqueue_job_mock.assert_any_call(
+            "order.void_pending_orders_for_subscription", subscription.id
+        )
+
+    async def test_skips_already_ended_subscriptions(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        enqueue_email_mock: MagicMock,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        organization.status = OrganizationStatus.DENIED
+        await save_fixture(organization)
+        subscription = await create_canceled_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            revoke=True,
+        )
+        ended_at = subscription.ended_at
+
+        await subscription_service.cancel_for_organization(
+            session, product.organization_id
+        )
+
+        await session.refresh(subscription)
+        assert subscription.ended_at == ended_at
+        enqueue_email_mock.assert_not_called()
+
+    async def test_skips_org_not_in_cancellation_status(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        enqueue_email_mock: MagicMock,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        # The org was reactivated (ACTIVE) after the daily scan enqueued the
+        # job: the deferred cancellation must be a no-op.
+        organization.status = OrganizationStatus.ACTIVE
+        await save_fixture(organization)
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        await subscription_service.cancel_for_organization(
+            session, product.organization_id
+        )
+
+        await session.refresh(subscription)
+        assert subscription.status == SubscriptionStatus.active
+        enqueue_email_mock.assert_not_called()
+
+    async def test_only_cancels_target_organization(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        organization_second: Organization,
+        product: Product,
+        product_organization_second: Product,
+        customer: Customer,
+    ) -> None:
+        # Both orgs are denied; only the targeted org's subscriptions are
+        # cancelled, proving the scoping is by organization id.
+        organization.status = OrganizationStatus.DENIED
+        organization_second.status = OrganizationStatus.DENIED
+        await save_fixture(organization)
+        await save_fixture(organization_second)
+        other_customer = await create_customer(
+            save_fixture,
+            organization=organization_second,
+        )
+        target_subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        other_subscription = await create_active_subscription(
+            save_fixture,
+            product=product_organization_second,
+            customer=other_customer,
+        )
+
+        await subscription_service.cancel_for_organization(
+            session, product.organization_id
+        )
+
+        await session.refresh(target_subscription)
+        await session.refresh(other_subscription)
+        assert target_subscription.status == SubscriptionStatus.canceled
+        assert other_subscription.status == SubscriptionStatus.active
+
+    async def test_skips_concurrently_canceled_subscription(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        # A duplicate/concurrent run already cancelled the subscription, so
+        # _perform_cancellation raises: the batch must skip it, not abort.
+        organization.status = OrganizationStatus.DENIED
+        await save_fixture(organization)
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        mocker.patch.object(
+            subscription_service,
+            "_perform_cancellation",
+            side_effect=AlreadyCanceledSubscription(subscription),
+        )
+
+        # Must not raise.
+        await subscription_service.cancel_for_organization(
+            session, product.organization_id
         )
 
 

--- a/server/tests/subscription/test_tasks.py
+++ b/server/tests/subscription/test_tasks.py
@@ -3,18 +3,49 @@ import uuid
 import pytest
 from pytest_mock import MockerFixture
 
-from polar.models import Customer, Product
+from polar.models import Customer, Organization, Product, Subscription
+from polar.models.organization import OrganizationStatus
+from polar.models.subscription import SubscriptionStatus
 from polar.postgres import AsyncSession
 from polar.subscription.service import SubscriptionService
 from polar.subscription.tasks import (  # type: ignore[attr-defined]
     SubscriptionDoesNotExist,
     SubscriptionTierDoesNotExist,
+    subscription_cancel_for_organization,
     subscription_enqueue_benefits_grants,
     subscription_service,
     subscription_update_product_benefits_grants,
 )
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_subscription
+from tests.fixtures.random_objects import (
+    create_active_subscription,
+    create_subscription,
+)
+
+
+@pytest.mark.asyncio
+class TestSubscriptionCancelForOrganization:
+    async def test_cancels_organization_subscriptions(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        organization.status = OrganizationStatus.DENIED
+        await save_fixture(organization)
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        session.expunge_all()
+
+        await subscription_cancel_for_organization(product.organization_id)
+
+        refreshed = await session.get(Subscription, subscription.id)
+        assert refreshed is not None
+        assert refreshed.status == SubscriptionStatus.canceled
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Automatically cancel customers' subscriptions once a merchant organization has been wound down, without emailing those customers.

## What

- New daily cron `organization.cancel_expired_subscriptions` scans for orgs in a terminal-bad status (`denied`, `blocked`, `offboarded`) for longer than `ORGANIZATION_SUBSCRIPTION_CANCELLATION_DELAY` (7 days) that still have billable subscriptions, and fans out a per-org job.
- `subscription.cancel_for_organization` immediately cancels each billable subscription with customer email suppressed (a new `notify_customer` flag threaded through the cancellation path).

## Why

When a merchant is shut down, their customers' subscriptions should stop, but those customers should not receive cancellation emails.

## How

- `notify_customer` defaults to `True`, so all existing cancellation/revocation paths are unchanged; only the org wind-down path passes `False`, which gates solely the customer emails (webhooks, events, benefit revocation and pending-order voiding still fire).
- `offboarded` (the terminal state) triggers cancellation
- The per-org job re-checks the org status at execution time (with `include_blocked=True`) so a reactivated org is a no-op, and is idempotent at the subscription level so duplicate/concurrent runs are safe.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

