### PR TITLE
feat: add envelope-encryption primitives for secrets at rest

### DIFF
--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -324,6 +324,12 @@ class Settings(BaseSettings):
     AWS_REGION: str = "us-east-2"
     AWS_SIGNATURE_VERSION: str = "v4"
 
+    # Secrets encryption. Production and sandbox wrap data keys with a KMS key
+    # (AWS_KMS_KEY_ID); local and CI use a static key instead, so tests make no
+    # cloud calls.
+    AWS_KMS_KEY_ID: str | None = None
+    ENCRYPTION_LOCAL_KEY: str = "super secret encryption key"
+
     # Worker SQS/Lambda execution engine (POC)
     # When enabled, jobs enqueued for an allowlisted actor are routed to a
     # per-actor SQS queue (consumed by a Lambda) instead of the Redis broker.

--- a/server/polar/kit/encryption.py
+++ b/server/polar/kit/encryption.py
@@ -1,0 +1,189 @@
+"""Envelope encryption for secrets stored at rest.
+
+Each secret is stored as ciphertext wrapped in an :class:`EncryptedString`. The
+column is mapped with a wrap-only :class:`EncryptedStringType` that does no
+crypto and no I/O: on load it boxes the stored ciphertext into an
+:class:`EncryptedString`; on save it unboxes it. Encryption and decryption are
+explicit ``await`` calls that go through a :class:`KeyProvider` chosen by config.
+
+See the design document for the full rationale:
+``handbook/engineering/design-documents/secrets-encryption.mdx``.
+"""
+
+import asyncio
+import base64
+import functools
+import hashlib
+import json
+import os
+from typing import Any, Protocol
+
+import sqlalchemy as sa
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from sqlalchemy.engine.interfaces import Dialect
+
+from polar.config import settings
+from polar.kit.extensions.sqlalchemy.types import TypeDecorator
+
+VERSION = "v1"
+NONCE_SIZE = 12
+DATA_KEY_SIZE = 32
+
+
+def _encode_context(context: dict[str, str]) -> bytes:
+    return json.dumps(context, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _b64encode(value: bytes) -> str:
+    return base64.b64encode(value).decode("ascii")
+
+
+def _b64decode(value: str) -> bytes:
+    return base64.b64decode(value)
+
+
+class KeyProvider(Protocol):
+    """Wraps and unwraps the per-secret data key. The plaintext secret never
+    reaches the provider."""
+
+    async def generate_data_key(self, context: dict[str, str]) -> tuple[bytes, bytes]:
+        """Return a fresh ``(plaintext_data_key, wrapped_data_key)`` pair."""
+        ...
+
+    async def decrypt_data_key(self, wrapped: bytes, context: dict[str, str]) -> bytes:
+        """Unwrap a previously wrapped data key."""
+        ...
+
+
+class LocalKeyProvider:
+    """Wraps the data key with a static key. Used for local development and CI,
+    so tests need no cloud access."""
+
+    def __init__(self, key: str) -> None:
+        self._key = AESGCM(hashlib.sha256(key.encode("utf-8")).digest())
+
+    async def generate_data_key(self, context: dict[str, str]) -> tuple[bytes, bytes]:
+        data_key = os.urandom(DATA_KEY_SIZE)
+        nonce = os.urandom(NONCE_SIZE)
+        wrapped = nonce + self._key.encrypt(nonce, data_key, _encode_context(context))
+        return data_key, wrapped
+
+    async def decrypt_data_key(self, wrapped: bytes, context: dict[str, str]) -> bytes:
+        nonce, ciphertext = wrapped[:NONCE_SIZE], wrapped[NONCE_SIZE:]
+        return self._key.decrypt(nonce, ciphertext, _encode_context(context))
+
+
+class KMSKeyProvider:
+    """Wraps the data key with a KMS master key. Used in production and sandbox."""
+
+    def __init__(self, key_id: str) -> None:
+        self._key_id = key_id
+
+    @functools.cached_property
+    def _client(self) -> Any:
+        import boto3
+
+        return boto3.client(
+            "kms",
+            region_name=settings.AWS_REGION,
+            aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+        )
+
+    async def generate_data_key(self, context: dict[str, str]) -> tuple[bytes, bytes]:
+        response = await asyncio.to_thread(
+            self._client.generate_data_key,
+            KeyId=self._key_id,
+            KeySpec="AES_256",
+            EncryptionContext=context,
+        )
+        return response["Plaintext"], response["CiphertextBlob"]
+
+    async def decrypt_data_key(self, wrapped: bytes, context: dict[str, str]) -> bytes:
+        response = await asyncio.to_thread(
+            self._client.decrypt, CiphertextBlob=wrapped, EncryptionContext=context
+        )
+        return response["Plaintext"]
+
+
+@functools.cache
+def get_key_provider() -> KeyProvider:
+    if settings.is_production() or settings.is_sandbox():
+        key_id = settings.AWS_KMS_KEY_ID
+        if key_id is None:
+            raise RuntimeError("POLAR_AWS_KMS_KEY_ID is required in this environment")
+        return KMSKeyProvider(key_id)
+    return LocalKeyProvider(settings.ENCRYPTION_LOCAL_KEY)
+
+
+class EncryptedString:
+    """Holds the ciphertext of a secret and owns the only paths that touch the
+    key provider. Immutable: any new value is a fresh instance, so ORM change
+    tracking works without ``sqlalchemy.ext.mutable``."""
+
+    __slots__ = ("context", "encrypted_value")
+
+    def __init__(self, encrypted_value: str, context: dict[str, str]) -> None:
+        self.encrypted_value = encrypted_value
+        self.context = dict(context)
+
+    @classmethod
+    async def encrypt(
+        cls, plaintext: str, *, context: dict[str, str]
+    ) -> "EncryptedString":
+        provider = get_key_provider()
+        data_key, wrapped = await provider.generate_data_key(context)
+        nonce = os.urandom(NONCE_SIZE)
+        ciphertext = AESGCM(data_key).encrypt(
+            nonce, plaintext.encode("utf-8"), _encode_context(context)
+        )
+        encoded = ".".join(
+            (VERSION, _b64encode(wrapped), _b64encode(nonce), _b64encode(ciphertext))
+        )
+        return cls(encoded, context)
+
+    async def decrypt(self, *, id: str | None = None) -> str:
+        context = {**self.context, "id": id} if id is not None else self.context
+        version, wrapped, nonce, ciphertext = self.encrypted_value.split(".")
+        if version != VERSION:
+            raise ValueError(f"Unsupported encryption version: {version}")
+        provider = get_key_provider()
+        data_key = await provider.decrypt_data_key(_b64decode(wrapped), context)
+        plaintext = AESGCM(data_key).decrypt(
+            _b64decode(nonce), _b64decode(ciphertext), _encode_context(context)
+        )
+        return plaintext.decode("utf-8")
+
+    def __repr__(self) -> str:
+        return f'{self.__class__.__name__}("***", {self.context!r})'
+
+    def __str__(self) -> str:
+        return "<encrypted>"
+
+
+class EncryptedStringType(TypeDecorator):
+    """Wrap-only column type: no crypto, no I/O. Boxes the stored ciphertext
+    into an :class:`EncryptedString` on load and unboxes it on save."""
+
+    impl = sa.Text
+    cache_ok = True
+
+    def __init__(self, context: dict[str, str]) -> None:
+        super().__init__()
+        self.context = tuple(sorted(context.items()))
+
+    def process_bind_param(
+        self, value: EncryptedString | None, dialect: Dialect
+    ) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, EncryptedString):
+            return value.encrypted_value
+        raise ValueError("encrypt the value before assigning it")
+
+    def process_result_value(
+        self, value: str | None, dialect: Dialect
+    ) -> EncryptedString | None:
+        if value is None:
+            return None
+        return EncryptedString(value, dict(self.context))

--- a/server/tests/kit/test_encryption.py
+++ b/server/tests/kit/test_encryption.py
@@ -1,0 +1,135 @@
+import pytest
+from cryptography.exceptions import InvalidTag
+
+from polar.config import Environment, settings
+from polar.kit import encryption
+from polar.kit.encryption import (
+    EncryptedString,
+    EncryptedStringType,
+    LocalKeyProvider,
+)
+
+CONTEXT = {"table": "slack_apps", "column": "bot_token"}
+
+
+@pytest.mark.asyncio
+async def test_encrypt_decrypt_roundtrip() -> None:
+    secret = await EncryptedString.encrypt("xoxb-1234", context=CONTEXT)
+    assert secret.encrypted_value.startswith("v1.")
+    assert "xoxb-1234" not in secret.encrypted_value
+    assert await secret.decrypt() == "xoxb-1234"
+
+
+@pytest.mark.asyncio
+async def test_each_encryption_uses_a_fresh_data_key() -> None:
+    first = await EncryptedString.encrypt("same", context=CONTEXT)
+    second = await EncryptedString.encrypt("same", context=CONTEXT)
+    assert first.encrypted_value != second.encrypted_value
+
+
+@pytest.mark.asyncio
+async def test_context_binds_ciphertext_to_its_row() -> None:
+    encrypted = await EncryptedString.encrypt(
+        "xoxb-1234", context={**CONTEXT, "id": "row-1"}
+    )
+    # A loaded row only carries the static context; the caller supplies the id.
+    loaded = EncryptedString(encrypted.encrypted_value, CONTEXT)
+
+    assert await loaded.decrypt(id="row-1") == "xoxb-1234"
+
+    with pytest.raises(InvalidTag):
+        await loaded.decrypt(id="row-2")
+
+    with pytest.raises(InvalidTag):
+        await loaded.decrypt()
+
+
+@pytest.mark.asyncio
+async def test_tampered_ciphertext_fails_closed() -> None:
+    secret = await EncryptedString.encrypt("xoxb-1234", context=CONTEXT)
+    version, wrapped, nonce, ciphertext = secret.encrypted_value.split(".")
+    tampered = EncryptedString(
+        ".".join((version, wrapped, nonce, ciphertext[:-4] + "AAAA")), CONTEXT
+    )
+    with pytest.raises(InvalidTag):
+        await tampered.decrypt()
+
+
+@pytest.mark.asyncio
+async def test_unsupported_version_raises() -> None:
+    secret = await EncryptedString.encrypt("xoxb-1234", context=CONTEXT)
+    _, rest = secret.encrypted_value.split(".", 1)
+    with pytest.raises(ValueError, match="Unsupported encryption version"):
+        await EncryptedString(f"v2.{rest}", CONTEXT).decrypt()
+
+
+def test_str_never_leaks_and_repr_hides_the_secret() -> None:
+    secret = EncryptedString("v1.aaa.bbb.ccc", CONTEXT)
+    assert str(secret) == "<encrypted>"
+    assert repr(secret) == f'EncryptedString("***", {CONTEXT!r})'
+    assert "aaa.bbb.ccc" not in str(secret)
+    assert "aaa.bbb.ccc" not in repr(secret)
+
+
+def test_context_is_copied_not_aliased() -> None:
+    context = {"table": "t", "column": "c"}
+    secret = EncryptedString("v1.a.b.c", context)
+    context["column"] = "mutated"
+    assert secret.context == {"table": "t", "column": "c"}
+
+
+@pytest.mark.asyncio
+async def test_local_key_provider_rejects_wrong_context() -> None:
+    provider = LocalKeyProvider("local-key")
+    _, wrapped = await provider.generate_data_key(CONTEXT)
+    with pytest.raises(InvalidTag):
+        await provider.decrypt_data_key(wrapped, {**CONTEXT, "id": "other"})
+
+
+def test_type_unboxes_encrypted_string_on_write() -> None:
+    type_ = EncryptedStringType(CONTEXT)
+    secret = EncryptedString("v1.a.b.c", CONTEXT)
+    assert type_.process_bind_param(secret, None) == "v1.a.b.c"  # type: ignore[arg-type]
+    assert type_.process_bind_param(None, None) is None  # type: ignore[arg-type]
+
+
+def test_type_rejects_raw_string_on_write() -> None:
+    type_ = EncryptedStringType(CONTEXT)
+    with pytest.raises(ValueError, match="encrypt the value before assigning it"):
+        type_.process_bind_param("plaintext", None)  # type: ignore[arg-type]
+
+
+def test_type_boxes_ciphertext_on_read() -> None:
+    type_ = EncryptedStringType(CONTEXT)
+    boxed = type_.process_result_value("v1.a.b.c", None)  # type: ignore[arg-type]
+    assert isinstance(boxed, EncryptedString)
+    assert boxed.encrypted_value == "v1.a.b.c"
+    assert boxed.context == CONTEXT
+    assert type_.process_result_value(None, None) is None  # type: ignore[arg-type]
+
+
+def test_type_context_distinguishes_statement_cache_keys() -> None:
+    # The per-column context must be part of the SQLAlchemy statement cache
+    # key; otherwise two encrypted columns collide and decrypt with the wrong
+    # context.
+    a = EncryptedStringType({"table": "t", "column": "a"})
+    b = EncryptedStringType({"table": "t", "column": "b"})
+    assert a.cache_ok is True
+    assert (
+        a._static_cache_key
+        == EncryptedStringType({"table": "t", "column": "a"})._static_cache_key
+    )
+    assert a._static_cache_key != b._static_cache_key
+
+
+def test_get_key_provider_requires_kms_key_in_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(settings, "ENV", Environment.production)
+    monkeypatch.setattr(settings, "AWS_KMS_KEY_ID", None)
+    encryption.get_key_provider.cache_clear()
+    try:
+        with pytest.raises(RuntimeError, match="POLAR_AWS_KMS_KEY_ID"):
+            encryption.get_key_provider()
+    finally:
+        encryption.get_key_provider.cache_clear()


### PR DESCRIPTION
## Summary

First step of the secrets-at-rest encryption RFC (`handbook/engineering/design-documents/secrets-encryption.mdx`): the foundational encryption layer. No model columns or migrations change yet, so this is self-contained and unblocks the per-column rollout.

## What

- `KeyProvider` protocol with two implementations: a KMS-backed provider (production/sandbox) and a static-key provider (local/CI, so tests make no cloud calls).
- `EncryptedString`: holds ciphertext and owns the only paths that touch the provider `__str__`/`__repr__` return `<encrypted>` so secrets don't leak into logs.
- `EncryptedStringType`: a wrap-only SQLAlchemy `TypeDecorator` that does no crypto or I/O — it boxes stored ciphertext into an `EncryptedString` on load and unboxes it on save, so listing rows fires zero provider calls.
- Config: `AWS_KMS_KEY_ID` and `ENCRYPTION_LOCAL_KEY`.

## Why

Secrets (OAuth tokens, client secrets, Slack tokens) are stored in plain text today. Envelope encryption means a leaked DB dump, backup, or read replica no longer exposes them, while the master key stays out of the app and database.

## How

Envelope encryption with AES-256-GCM: each secret gets a fresh data key wrapped by the provider; the per-row encryption context is bound as associated data so a ciphertext copied to another row (or decrypted without its id) fails closed. `cache_ok=True` is kept safe by storing the context as a sorted tuple (verified to produce distinct statement-cache keys per column).

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

