### PR TITLE
Fix so deploys work again

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -374,7 +374,6 @@ jobs:
     uses: ./.github/workflows/deploy-environment.yml
     with:
       environment: test
-      docker-digest: ${{ needs.build.outputs.digest }}
       render-api-service-id: "srv-d8ffbc42m8qs73e7lv30"
       render-worker-service-ids: "srv-d8ffbbvavr4c73a79u00"
       has-migrations: ${{ needs.changes.outputs.migrations-sandbox == 'true' || github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix deploys by removing the `docker-digest` input from the test environment call in `.github/workflows/deploy.yml`. The input is no longer accepted by `deploy-environment.yml`, and its presence was failing the job.

<sup>Written for commit 9eaec0b715c0eccb4aee016ca12895d5a7e9a0bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

