### PR TITLE
feat(backoffice): show why an organization review was triggered

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/sections/_shared.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/_shared.py
@@ -24,6 +24,61 @@ VERDICT_BADGE: dict[str, str] = {
     "NEEDS_HUMAN_REVIEW": "badge-warning",
 }
 
+# Short label for each ReviewContext value (the review trigger)
+REVIEW_CONTEXT_LABELS: dict[str, str] = {
+    "submission": "Submission",
+    "threshold": "Threshold",
+    "manual": "Manual",
+    "appeal": "Appeal",
+    "product_changed": "Product Changed",
+}
+
+# Human-readable explanation of why each review trigger fires
+REVIEW_CONTEXT_REASONS: dict[str, str] = {
+    "submission": "First automated review, run when the organization submitted its details.",
+    "threshold": "Run after the organization crossed a payment volume threshold.",
+    "manual": "Triggered manually by a reviewer from the backoffice.",
+    "appeal": "Re-review requested through an appeal of a previous denial.",
+    "product_changed": (
+        "An active organization created or updated a product, "
+        "which can change its risk profile."
+    ),
+}
+
+
+def review_context_label(review_type: str | None) -> str | None:
+    """Short display label for a review trigger context."""
+    if not review_type:
+        return None
+    return REVIEW_CONTEXT_LABELS.get(review_type, review_type.replace("_", " ").title())
+
+
+def review_context_reason(review_type: str | None) -> str | None:
+    """Human-readable explanation of why the review was triggered."""
+    if not review_type:
+        return None
+    return REVIEW_CONTEXT_REASONS.get(review_type)
+
+
+def render_review_context_badge(review_type: str | None) -> None:
+    """Render the review trigger badge with the reason as a hover tooltip."""
+    label = review_context_label(review_type)
+    if label is None:
+        return
+    reason = review_context_reason(review_type)
+    if reason:
+        with tag.div(
+            classes="tooltip before:whitespace-pre-line before:text-left before:max-w-xs",
+            data_tip=reason,
+        ):
+            with tag.span(
+                classes="badge badge-ghost badge-sm badge-outline gap-1 cursor-help"
+            ):
+                text(label)
+    else:
+        with tag.div(classes="badge badge-ghost badge-sm badge-outline gap-1"):
+            text(label)
+
 
 def render_checklist_row(label: str, is_set: bool, value: str | None) -> None:
     """Render a single checklist row with a green/red status dot."""

--- a/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
@@ -27,6 +27,7 @@ from ._shared import (
     RISK_LEVEL_BADGE,
     ChecklistMixin,
     render_checklist_row,
+    render_review_context_badge,
 )
 
 
@@ -52,24 +53,6 @@ class OverviewSection(ChecklistMixin):
     # ------------------------------------------------------------------
     # Full-width: Organization Review card (primary content)
     # ------------------------------------------------------------------
-
-    _REVIEW_CONTEXT_LABELS: dict[str, str] = {
-        "submission": "Submission",
-        "setup_complete": "Setup Complete",
-        "threshold": "Threshold",
-        "manual": "Manual",
-        "product_changed": "Product Changed",
-    }
-
-    def _render_review_context_badge(self, review_type: str | None) -> None:
-        """Render a small badge showing the review trigger context."""
-        if not review_type:
-            return
-        label = self._REVIEW_CONTEXT_LABELS.get(
-            review_type, review_type.replace("_", " ").title()
-        )
-        with tag.div(classes="badge badge-ghost badge-sm badge-outline gap-1"):
-            text(label)
 
     @staticmethod
     def _render_dimension_card(dim: DimensionAssessment) -> None:
@@ -244,7 +227,7 @@ class OverviewSection(ChecklistMixin):
                 with tag.div(classes="flex items-center gap-2"):
                     with tag.h2(classes="text-lg font-bold"):
                         text("Organization Review")
-                    self._render_review_context_badge(ar.review_type)
+                    render_review_context_badge(ar.review_type)
                 if self.agent_reviewed_at:
                     with tag.span(classes="text-xs text-base-content/60"):
                         text(self.agent_reviewed_at.strftime("%Y-%m-%d %H:%M UTC"))

--- a/server/polar/backoffice/organizations_v2/views/sections/reviews_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/reviews_section.py
@@ -12,7 +12,12 @@ from polar.models.organization_agent_review import OrganizationAgentReview
 from polar.organization_review.schemas import ActorType
 
 from ....components import card
-from ._shared import RISK_LEVEL_BADGE, VERDICT_BADGE, render_dimension
+from ._shared import (
+    RISK_LEVEL_BADGE,
+    VERDICT_BADGE,
+    render_dimension,
+    render_review_context_badge,
+)
 
 # Badge classes for decision types
 DECISION_BADGE: dict[str, str] = {
@@ -74,6 +79,7 @@ class ReviewsSection:
                 with tag.div(classes="flex items-center gap-3"):
                     with tag.span(classes="text-sm font-medium"):
                         text(review.reviewed_at.strftime("%Y-%m-%d %H:%M UTC"))
+                    render_review_context_badge(parsed.review_type)
                     with tag.span(classes="text-xs text-base-content/60"):
                         text(review.model_used)
 


### PR DESCRIPTION
## Summary

Show the **review trigger context** (submission, threshold, manual, appeal, product changed) in the backoffice reviews tab

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included