### PR TITLE
fix(customer_seat): read blocked orgs in seat feature check

### DIFF
--- a/server/polar/customer_seat/service.py
+++ b/server/polar/customer_seat/service.py
@@ -223,7 +223,9 @@ class SeatService:
         from polar.organization.repository import OrganizationRepository
 
         organization_repository = OrganizationRepository.from_session(session)
-        organization = await organization_repository.get_by_id(organization_id)
+        organization = await organization_repository.get_by_id(
+            organization_id, include_blocked=True
+        )
         if not organization:
             raise FeatureNotEnabled()
         if not organization.feature_settings.get("seat_based_pricing_enabled", False):

--- a/server/tests/customer_seat/test_service.py
+++ b/server/tests/customer_seat/test_service.py
@@ -29,6 +29,7 @@ from polar.models import (
     UserOrganization,
 )
 from polar.models.customer_seat import CustomerSeat, SeatStatus
+from polar.models.organization import OrganizationStatus
 from polar.models.webhook_endpoint import WebhookEventType
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
@@ -2656,6 +2657,50 @@ class TestRevokeAllSeatsForSubscription:
                 assert call[1]["subscription_id"] == subscription_with_seats.id
                 # Customer ID should be either customer1 or customer2
                 assert call[1]["customer_id"] in [customer1.id, customer2.id]
+
+    @pytest.mark.asyncio
+    async def test_revoke_all_seats_for_blocked_organization(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        subscription_with_seats: Subscription,
+    ) -> None:
+        """Seats are revoked even when the organization is blocked.
+
+        This happens when a wound-down organization's subscriptions are
+        auto-cancelled: the organization is blocked, and the feature check must
+        still be able to read it, otherwise it raises FeatureNotEnabled and
+        breaks the cancellation.
+        """
+        customer = await create_customer(
+            save_fixture,
+            organization=subscription_with_seats.product.organization,
+            email="customer@example.com",
+        )
+        seat = await create_customer_seat(
+            save_fixture,
+            subscription=subscription_with_seats,
+            customer=customer,
+            status=SeatStatus.claimed,
+            claimed_at=utc_now(),
+        )
+
+        subscription_with_seats.product.organization.status = OrganizationStatus.BLOCKED
+        await save_fixture(subscription_with_seats.product.organization)
+
+        await session.refresh(subscription_with_seats, ["product"])
+        await session.refresh(subscription_with_seats.product, ["organization"])
+
+        revoked_count = await seat_service.revoke_all_seats_for_subscription(
+            session, subscription_with_seats
+        )
+
+        assert revoked_count == 1
+
+        await session.refresh(seat)
+        assert seat.status == SeatStatus.revoked
+        assert seat.revoked_at is not None
+        assert seat.customer_id is None
 
 
 class TestAssignSeatToDeletedMember:


### PR DESCRIPTION
## Summary

Fixes Sentry issue [SERVER-4T5](https://polar-sh.sentry.io/issues/7582321496/) — `FeatureNotEnabled: Seat-based pricing is not enabled for this organization`, raised from the `subscription.cancel_for_organization` task.

## What

`SeatService.check_seat_feature_enabled` now looks up the organization with `include_blocked=True`.

## How

- `check_seat_feature_enabled` passes `include_blocked=True` to `get_by_id`.
- Added a test that revokes all seats for a **blocked** organization that still has the feature enabled.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)