### PR TITLE
tf: Give admins access to all AWS accounts

### DIFF
--- a/terraform/organization/identity_center.tf
+++ b/terraform/organization/identity_center.tf
@@ -10,7 +10,7 @@ locals {
     identity   = local.identity_account.id
   }
 
-  staff_default_accounts = ["management", "production", "sandbox", "test"]
+  staff_default_accounts = setsubtract(keys(local.staff_target_accounts), ["identity"])
 
   identity_center_groups = {
     awsadmins    = { display_name = "AWS Access" }

--- a/terraform/organization/identity_center.tf
+++ b/terraform/organization/identity_center.tf
@@ -7,7 +7,10 @@ locals {
     production = local.workload_accounts.production.id
     sandbox    = local.workload_accounts.sandbox.id
     test       = local.workload_accounts.test.id
+    identity   = local.identity_account.id
   }
+
+  staff_default_accounts = ["management", "production", "sandbox", "test"]
 
   identity_center_groups = {
     awsadmins    = { display_name = "AWS Access" }
@@ -23,6 +26,7 @@ locals {
       managed_policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
       boundary           = false
       groups             = ["awsadmins"]
+      accounts           = keys(local.staff_target_accounts)
     }
     engineering = {
       base_name          = "PolarEngineering"
@@ -30,6 +34,7 @@ locals {
       managed_policy_arn = "arn:aws:iam::aws:policy/PowerUserAccess"
       boundary           = true
       groups             = ["awsengineers", "engineering"]
+      accounts           = local.staff_default_accounts
     }
     read_only = {
       base_name          = "PolarReadOnly"
@@ -37,19 +42,20 @@ locals {
       managed_policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
       boundary           = false
       groups             = ["awsaccess"]
+      accounts           = local.staff_default_accounts
     }
   }
 
   account_permission_sets = merge([
     for tier_key, tier in local.access_tiers : {
-      for account_key, account_id in local.staff_target_accounts :
+      for account_key in tier.accounts :
       "${tier_key}-${account_key}" => {
         name               = "${tier.base_name}${title(account_key)}"
         description        = tier.description
         managed_policy_arn = tier.managed_policy_arn
         boundary           = tier.boundary
         groups             = tier.groups
-        account_id         = account_id
+        account_id         = local.staff_target_accounts[account_key]
       }
     }
   ]...)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Give admins access to all AWS accounts via Identity Center; engineers and read-only stay limited to management, production, sandbox, and test. Adds the `identity` account and refactors permission set mapping to target accounts by key.

- **Refactors**
  - Added `identity` account and `staff_default_accounts` (excludes `identity`).
  - Admin tier targets all accounts; engineering/read_only use `staff_default_accounts`.
  - Build `account_permission_sets` from `tier.accounts`, resolving `account_id` via `local.staff_target_accounts[account_key]`.

<sup>Written for commit 6c1f7539506ddf706a4bbd88cca0781b608c5a6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

