### PR TITLE
Fix opaque backdrop in dark mode

### DIFF
--- a/clients/apps/web/src/styles/globals.css
+++ b/clients/apps/web/src/styles/globals.css
@@ -246,6 +246,10 @@
     @apply text-gray-200;
   }
 
+  #polar-embed-layout {
+    color-scheme: normal;
+  }
+
   html:not(.dark) {
     --lightningcss-light: initial;
     --lightningcss-dark: ;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Sets `color-scheme: normal` on `#polar-embed-layout` so the embed backdrop keeps its transparency in dark mode. Fixes the opaque backdrop issue when the host page uses dark theme.

<sup>Written for commit c503f72c32a792d429f997ef1ada91b73b4f9c12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

