### PR TITLE
fix(subscription): batch org subscription cancellation to avoid 60s timeout

### DIFF
--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -127,6 +127,11 @@ from .update import generate_subscription_update
 
 log: Logger = structlog.get_logger()
 
+SUBSCRIPTION_CANCELLATION_BATCH_SIZE = 50
+"""Max subscriptions cancelled per ``cancel_for_organization`` job, so a large
+merchant winds down across several short jobs that each stay under the worker's
+60s time limit."""
+
 
 class SubscriptionError(PolarError): ...
 
@@ -1834,11 +1839,25 @@ class SubscriptionService:
                 )
 
     async def cancel_for_organization(
-        self, session: AsyncSession, organization_id: uuid.UUID
-    ) -> None:
-        """Immediately cancel all billable subscriptions of an organization,
-        without notifying its customers (the cancellation follows the merchant
-        being shut down, not a customer or merchant action).
+        self,
+        session: AsyncSession,
+        organization_id: uuid.UUID,
+        *,
+        batch_size: int = SUBSCRIPTION_CANCELLATION_BATCH_SIZE,
+    ) -> bool:
+        """Immediately cancel a batch of an organization's billable
+        subscriptions, without notifying its customers (the cancellation follows
+        the merchant being shut down, not a customer or merchant action).
+
+        Returns ``True`` when more subscriptions may remain and the caller should
+        re-enqueue the job, ``False`` once the organization is fully wound down.
+
+        Cancels at most ``batch_size`` subscriptions per call so a large merchant
+        completes across several short jobs instead of one long one: the worker
+        enforces a 60s time limit, and a single transaction exceeding it is
+        rolled back wholesale, making no progress on retry. Each cancelled
+        subscription leaves the billable set, so the next call naturally resumes
+        where this one stopped; the work is idempotent and resumable.
 
         Locks the org row (``for_update``) before re-checking its status, since
         this runs as a deferred job: it serializes against a concurrent admin
@@ -1846,11 +1865,8 @@ class SubscriptionService:
         copy of this job for the same org (which would otherwise duplicate
         cancellation side effects). If the org is no longer in a wind-down
         status, this is a no-op. ``include_blocked=True`` because ``blocked`` is
-        itself a wind-down status.
-
-        Streams the billable subscriptions so a large merchant doesn't
-        materialize its whole subscription set at once. An already-cancelled
-        subscription is skipped, not treated as an error.
+        itself a wind-down status. An already-cancelled subscription is skipped,
+        not treated as an error.
         """
         organization_repository = OrganizationRepository.from_session(session)
         organization = await organization_repository.get_by_id(
@@ -1860,13 +1876,18 @@ class SubscriptionService:
             organization is None
             or organization.status not in SUBSCRIPTION_CANCELLATION_STATUSES
         ):
-            return
+            return False
 
         subscription_repository = SubscriptionRepository.from_session(session)
-        statement = subscription_repository.get_billable_by_organization_statement(
-            organization_id, options=subscription_repository.get_eager_options()
+        statement = (
+            subscription_repository.get_billable_by_organization_statement(
+                organization_id, options=subscription_repository.get_eager_options()
+            )
+            .order_by(Subscription.created_at)
+            .limit(batch_size)
         )
-        async for subscription in subscription_repository.stream(statement):
+        subscriptions = await subscription_repository.get_all(statement)
+        for subscription in subscriptions:
             try:
                 async with SubscriptionUpdateContext(
                     session, subscription, self, notify_customer=False
@@ -1876,6 +1897,8 @@ class SubscriptionService:
                     )
             except AlreadyCanceledSubscription:
                 continue
+
+        return len(subscriptions) == batch_size
 
     async def _perform_cancellation(
         self,

--- a/server/polar/subscription/tasks.py
+++ b/server/polar/subscription/tasks.py
@@ -82,9 +82,20 @@ async def subscription_cycle(subscription_id: uuid.UUID, force: bool = False) ->
 async def subscription_cancel_for_organization(organization_id: uuid.UUID) -> None:
     """Cancel all billable subscriptions of a denied/blocked/offboarded org,
     enqueued per-organization by ``organization.cancel_expired_subscriptions``.
+
+    Cancels one batch per run and re-enqueues itself while subscriptions remain,
+    so a large org winds down across several short jobs instead of one that would
+    exceed the worker's 60s time limit and roll back without progress.
     """
     async with AsyncSessionMaker() as session:
-        await subscription_service.cancel_for_organization(session, organization_id)
+        has_more = await subscription_service.cancel_for_organization(
+            session, organization_id
+        )
+
+    if has_more:
+        enqueue_job(
+            "subscription.cancel_for_organization", organization_id=organization_id
+        )
 
 
 @actor(

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -7145,8 +7145,8 @@ class TestCancelForOrganization:
         customer: Customer,
         customer_second: Customer,
     ) -> None:
-        # Every billable subscription of the org is cancelled by the streaming
-        # loop, not just the first one.
+        # Every billable subscription of the org is cancelled in one batch when
+        # they all fit under the batch size, not just the first one.
         organization.status = OrganizationStatus.DENIED
         await save_fixture(organization)
         first = await create_active_subscription(
@@ -7156,7 +7156,7 @@ class TestCancelForOrganization:
             save_fixture, product=product, customer=customer_second
         )
 
-        await subscription_service.cancel_for_organization(
+        has_more = await subscription_service.cancel_for_organization(
             session, product.organization_id
         )
 
@@ -7164,6 +7164,59 @@ class TestCancelForOrganization:
         await session.refresh(second)
         assert first.status == SubscriptionStatus.canceled
         assert second.status == SubscriptionStatus.canceled
+        assert has_more is False
+
+    async def test_batches_and_signals_remaining_work(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+        customer_second: Customer,
+    ) -> None:
+        # With more billable subscriptions than the batch size, a single call
+        # cancels only a batch and reports that work remains, so the task
+        # re-enqueues itself instead of exceeding the worker time limit.
+        organization.status = OrganizationStatus.DENIED
+        await save_fixture(organization)
+        first = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        second = await create_active_subscription(
+            save_fixture, product=product, customer=customer_second
+        )
+
+        has_more = await subscription_service.cancel_for_organization(
+            session, product.organization_id, batch_size=1
+        )
+        assert has_more is True
+
+        await session.refresh(first)
+        await session.refresh(second)
+        cancelled = [
+            s for s in (first, second) if s.status == SubscriptionStatus.canceled
+        ]
+        assert len(cancelled) == 1
+
+        # The next run cancels the last subscription; it still reports remaining
+        # work because it processed a full batch, so one final confirming run
+        # follows.
+        has_more = await subscription_service.cancel_for_organization(
+            session, product.organization_id, batch_size=1
+        )
+        assert has_more is True
+
+        await session.refresh(first)
+        await session.refresh(second)
+        assert first.status == SubscriptionStatus.canceled
+        assert second.status == SubscriptionStatus.canceled
+
+        # Nothing billable remains, so the loop terminates.
+        has_more = await subscription_service.cancel_for_organization(
+            session, product.organization_id, batch_size=1
+        )
+        assert has_more is False
 
 
 @pytest.mark.asyncio

--- a/server/tests/subscription/test_tasks.py
+++ b/server/tests/subscription/test_tasks.py
@@ -47,6 +47,45 @@ class TestSubscriptionCancelForOrganization:
         assert refreshed is not None
         assert refreshed.status == SubscriptionStatus.canceled
 
+    async def test_reenqueues_when_work_remains(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+    ) -> None:
+        organization_id = uuid.uuid4()
+        mocker.patch.object(
+            subscription_service,
+            "cancel_for_organization",
+            return_value=True,
+        )
+        enqueue_job_mock = mocker.patch("polar.subscription.tasks.enqueue_job")
+
+        session.expunge_all()
+
+        await subscription_cancel_for_organization(organization_id)
+
+        enqueue_job_mock.assert_called_once_with(
+            "subscription.cancel_for_organization", organization_id=organization_id
+        )
+
+    async def test_does_not_reenqueue_when_done(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+    ) -> None:
+        mocker.patch.object(
+            subscription_service,
+            "cancel_for_organization",
+            return_value=False,
+        )
+        enqueue_job_mock = mocker.patch("polar.subscription.tasks.enqueue_job")
+
+        session.expunge_all()
+
+        await subscription_cancel_for_organization(uuid.uuid4())
+
+        enqueue_job_mock.assert_not_called()
+
 
 @pytest.mark.asyncio
 class TestSubscriptionUpdateProductBenefitsGrants:


### PR DESCRIPTION
## Summary

`subscription.cancel_for_organization` cancelled every billable subscription of an organization in one task within a single transaction committed only at the very end. For a large org the loop exceeded the worker's 60s time limit, the transaction rolled back without committing any progress, and each retry restarted from scratch and timed out again — looping indefinitely and never winding the org down.

## What

Cancel subscriptions in bounded batches (default 50) and re-enqueue the job while subscriptions remain, instead of processing the whole set in one long task.

## Why

A single transaction that exceeds the worker time limit is rolled back wholesale, so a large org made zero progress on every attempt. Batching keeps each run well under the limit and makes durable, incremental progress.

## How

- `cancel_for_organization` now takes a `batch_size`, limits the billable-subscriptions query, and returns whether work may remain.
- The task commits each batch and re-enqueues itself when subscriptions remain. Cancelled subscriptions drop out of the billable query, so each run resumes where the previous one stopped — idempotent and resumable.
- The org row lock is now held for one batch at a time rather than the full run.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

