### PR TITLE
lambda: Route both cron and regular actors

### DIFF
--- a/server/polar/worker/_broker.py
+++ b/server/polar/worker/_broker.py
@@ -21,9 +21,11 @@ from polar.logfire import instrument_httpx
 from polar.logging import CorrelationID, Logger
 from polar.operational_errors import handle_operational_error
 
+from . import _sqs
 from ._asyncio import MonitoredAsyncIO
 from ._debounce import DebounceMiddleware
 from ._encoder import JSONEncoder
+from ._enqueue import should_route_to_sqs
 from ._health import HealthMiddleware
 from ._httpx import HTTPXMiddleware
 from ._metrics import PrometheusMiddleware
@@ -175,6 +177,26 @@ class LogfireMiddleware(dramatiq.Middleware):
         return self.after_process_message(broker, message)
 
 
+class RoutingRedisBroker(RedisBroker):
+    """RedisBroker that diverts SQS-allowlisted actors to SQS at enqueue time.
+
+    Native dramatiq dispatch (cron ``actor.send``, the subscription cycle,
+    retries, pipelines) all funnel through ``enqueue``, so the gate applied here
+    covers every scheduled path. The buffered ``enqueue_job`` path bypasses this
+    method and applies the same gate in ``JobQueueManager.flush``.
+    """
+
+    def enqueue(
+        self, message: dramatiq.Message[Any], *, delay: int | None = None
+    ) -> dramatiq.Message[Any]:
+        if should_route_to_sqs(message.actor_name):
+            _sqs.send_jobs_sync(
+                [(message.actor_name, message.args, message.kwargs, delay, None)]
+            )
+            return message
+        return super().enqueue(message, delay=delay)
+
+
 def get_broker(*, database: bool = True) -> dramatiq.Broker:
     redis_pool = redis.ConnectionPool.from_url(
         settings.redis_url,
@@ -216,7 +238,7 @@ def get_broker(*, database: bool = True) -> dramatiq.Broker:
         middleware.CurrentMessage(),
     ]
 
-    broker = RedisBroker(
+    broker = RoutingRedisBroker(
         connection_pool=redis_pool,
         middleware=middleware_list,
         dead_message_ttl=3600 * 1000,  # 1 hour in milliseconds

--- a/server/polar/worker/_broker.py
+++ b/server/polar/worker/_broker.py
@@ -191,7 +191,15 @@ class RoutingRedisBroker(RedisBroker):
     ) -> dramatiq.Message[Any]:
         if should_route_to_sqs(message.actor_name):
             _sqs.send_jobs_sync(
-                [(message.actor_name, message.args, message.kwargs, delay, None)]
+                [
+                    (
+                        message.actor_name,
+                        message.args,
+                        message.kwargs,
+                        delay,
+                        CorrelationID.get(),
+                    )
+                ]
             )
             return message
         return super().enqueue(message, delay=delay)

--- a/server/polar/worker/_enqueue.py
+++ b/server/polar/worker/_enqueue.py
@@ -40,6 +40,10 @@ _job_queue_manager: contextvars.ContextVar["JobQueueManager | None"] = (
 FLUSH_BATCH_SIZE = 50
 
 
+def should_route_to_sqs(actor_name: str) -> bool:
+    return settings.WORKER_SQS_ENABLED and actor_name in settings.WORKER_SQS_ACTORS
+
+
 class JobQueueManager:
     __slots__ = ("_enqueued_jobs", "_ingested_events")
 
@@ -75,20 +79,10 @@ class JobQueueManager:
             self.reset()
             return
 
-        if settings.WORKER_SQS_ENABLED and settings.WORKER_SQS_ACTORS:
-            sqs_jobs = [
-                job
-                for job in self._enqueued_jobs
-                if job[0] in settings.WORKER_SQS_ACTORS
-            ]
-            redis_jobs = [
-                job
-                for job in self._enqueued_jobs
-                if job[0] not in settings.WORKER_SQS_ACTORS
-            ]
-        else:
-            sqs_jobs = []
-            redis_jobs = self._enqueued_jobs
+        sqs_jobs = [job for job in self._enqueued_jobs if should_route_to_sqs(job[0])]
+        redis_jobs = [
+            job for job in self._enqueued_jobs if not should_route_to_sqs(job[0])
+        ]
 
         queue_messages = defaultdict[str, list[tuple[str, Any]]](list)
         all_messages: list[tuple[str, Any]] = []

--- a/server/polar/worker/_runner.py
+++ b/server/polar/worker/_runner.py
@@ -75,10 +75,6 @@ def validate_allowlist() -> None:
             raise ValueError(
                 f"Actor {actor_name!r} uses debounce, unsupported over SQS"
             )
-        if actor_obj.options.get("cron_trigger") is not None:
-            raise ValueError(
-                f"Actor {actor_name!r} is cron-scheduled; cron bypasses the SQS gate"
-            )
 
 
 @contextlib.contextmanager

--- a/server/polar/worker/_sqs.py
+++ b/server/polar/worker/_sqs.py
@@ -101,10 +101,12 @@ def parse_envelope(body: str) -> tuple[str, list[Any], dict[str, Any], str | Non
 async def send_jobs(jobs: list[Job]) -> None:
     if not jobs:
         return
-    await asyncio.to_thread(_send_jobs_sync, jobs)
+    await asyncio.to_thread(send_jobs_sync, jobs)
 
 
-def _send_jobs_sync(jobs: list[Job]) -> None:
+def send_jobs_sync(jobs: list[Job]) -> None:
+    if not jobs:
+        return
     client = get_sqs_client()
 
     by_queue: dict[str, list[SendMessageBatchRequestEntryTypeDef]] = defaultdict(list)
@@ -142,4 +144,5 @@ __all__ = [
     "get_sqs_client",
     "parse_envelope",
     "send_jobs",
+    "send_jobs_sync",
 ]

--- a/server/tests/worker/test_routing_broker.py
+++ b/server/tests/worker/test_routing_broker.py
@@ -1,0 +1,84 @@
+import dramatiq
+import pytest
+from dramatiq.brokers.redis import RedisBroker
+from pytest_mock import MockerFixture
+
+import polar.tasks  # noqa: F401  (registers actors with the broker)
+from polar.config import settings
+from polar.worker._runner import validate_allowlist
+
+CRON_ACTOR = "organization.unsnooze_expired"
+SUBSCRIPTION_ACTOR = "subscription.cycle"
+
+
+class TestRoutingBroker:
+    def test_disabled_routes_to_redis(self, mocker: MockerFixture) -> None:
+        mocker.patch.object(settings, "WORKER_SQS_ENABLED", False)
+        mocker.patch.object(settings, "WORKER_SQS_ACTORS", {CRON_ACTOR})
+        super_enqueue = mocker.patch.object(RedisBroker, "enqueue")
+        send_jobs_sync = mocker.patch("polar.worker._broker._sqs.send_jobs_sync")
+
+        broker = dramatiq.get_broker()
+        broker.enqueue(broker.get_actor(CRON_ACTOR).message())
+
+        send_jobs_sync.assert_not_called()
+        super_enqueue.assert_called_once()
+
+    def test_non_allowlisted_routes_to_redis(self, mocker: MockerFixture) -> None:
+        mocker.patch.object(settings, "WORKER_SQS_ENABLED", True)
+        mocker.patch.object(settings, "WORKER_SQS_ACTORS", {"dummy"})
+        super_enqueue = mocker.patch.object(RedisBroker, "enqueue")
+        send_jobs_sync = mocker.patch("polar.worker._broker._sqs.send_jobs_sync")
+
+        broker = dramatiq.get_broker()
+        broker.enqueue(broker.get_actor(CRON_ACTOR).message())
+
+        send_jobs_sync.assert_not_called()
+        super_enqueue.assert_called_once()
+
+    def test_allowlisted_cron_actor_routes_to_sqs(self, mocker: MockerFixture) -> None:
+        mocker.patch.object(settings, "WORKER_SQS_ENABLED", True)
+        mocker.patch.object(settings, "WORKER_SQS_ACTORS", {CRON_ACTOR})
+        super_enqueue = mocker.patch.object(RedisBroker, "enqueue")
+        send_jobs_sync = mocker.patch("polar.worker._broker._sqs.send_jobs_sync")
+
+        broker = dramatiq.get_broker()
+        broker.enqueue(broker.get_actor(CRON_ACTOR).message())
+
+        super_enqueue.assert_not_called()
+        send_jobs_sync.assert_called_once()
+        sent = send_jobs_sync.call_args.args[0]
+        assert [job[0] for job in sent] == [CRON_ACTOR]
+
+    def test_allowlisted_actor_forwards_kwargs_to_sqs(
+        self, mocker: MockerFixture
+    ) -> None:
+        mocker.patch.object(settings, "WORKER_SQS_ENABLED", True)
+        mocker.patch.object(settings, "WORKER_SQS_ACTORS", {SUBSCRIPTION_ACTOR})
+        mocker.patch.object(RedisBroker, "enqueue")
+        send_jobs_sync = mocker.patch("polar.worker._broker._sqs.send_jobs_sync")
+
+        broker = dramatiq.get_broker()
+        subscription_id = "00000000-0000-0000-0000-000000000000"
+        broker.enqueue(
+            broker.get_actor(SUBSCRIPTION_ACTOR).message(
+                subscription_id=subscription_id
+            )
+        )
+
+        sent = send_jobs_sync.call_args.args[0]
+        assert sent[0][0] == SUBSCRIPTION_ACTOR
+        assert sent[0][2] == {"subscription_id": subscription_id}
+
+
+class TestValidateAllowlist:
+    def test_accepts_cron_actor(self, mocker: MockerFixture) -> None:
+        mocker.patch.object(settings, "WORKER_SQS_ACTORS", {CRON_ACTOR})
+
+        validate_allowlist()
+
+    def test_rejects_debounced_actor(self, mocker: MockerFixture) -> None:
+        mocker.patch.object(settings, "WORKER_SQS_ACTORS", {"customer.webhook"})
+
+        with pytest.raises(ValueError, match="debounce"):
+            validate_allowlist()

--- a/server/tests/worker/test_routing_broker.py
+++ b/server/tests/worker/test_routing_broker.py
@@ -55,7 +55,7 @@ class TestRoutingBroker:
     ) -> None:
         mocker.patch.object(settings, "WORKER_SQS_ENABLED", True)
         mocker.patch.object(settings, "WORKER_SQS_ACTORS", {SUBSCRIPTION_ACTOR})
-        mocker.patch.object(RedisBroker, "enqueue")
+        super_enqueue = mocker.patch.object(RedisBroker, "enqueue")
         send_jobs_sync = mocker.patch("polar.worker._broker._sqs.send_jobs_sync")
 
         broker = dramatiq.get_broker()
@@ -66,6 +66,7 @@ class TestRoutingBroker:
             )
         )
 
+        super_enqueue.assert_not_called()
         sent = send_jobs_sync.call_args.args[0]
         assert sent[0][0] == SUBSCRIPTION_ACTOR
         assert sent[0][2] == {"subscription_id": subscription_id}


### PR DESCRIPTION
This enables us to use the lambda workers for cron jobs as well. All types of actors are routed to either Redis or SQS

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

