### PR TITLE
Replace Next.js Link with native anchors for external URLs

### DIFF
--- a/clients/apps/web/src/components/Events/EventCostCreationGuideModal.tsx
+++ b/clients/apps/web/src/components/Events/EventCostCreationGuideModal.tsx
@@ -1,6 +1,5 @@
 import ArrowOutwardOutlined from '@mui/icons-material/ArrowOutwardOutlined'
 import { Button } from '@polar-sh/orbit'
-import Link from 'next/link'
 import { Well } from '../Shared/Well'
 import {
   SyntaxHighlighterClient,
@@ -46,16 +45,17 @@ const result = await polar.events.ingest({
           />
         </Well>
         <div className="flex flex-row items-center gap-x-4">
-          <Link
+          <a
             href="https://docs.polar.sh/features/cost-insights/cost-events"
             target="_blank"
+            rel="noopener noreferrer"
             className="flex flex-row items-center"
           >
             <Button variant="secondary">
               <span>Learn more</span>
               <ArrowOutwardOutlined fontSize="inherit" className="ml-2" />
             </Button>
-          </Link>
+          </a>
         </div>
       </div>
     </SyntaxHighlighterProvider>

--- a/clients/apps/web/src/components/Landing/NavPopover.tsx
+++ b/clients/apps/web/src/components/Landing/NavPopover.tsx
@@ -79,22 +79,44 @@ export const NavPopover = ({
                   : '',
               )}
             >
-              {section.items.map(({ href, label, subtitle, target }) => (
-                <Link
-                  key={href + label}
-                  href={href}
-                  prefetch
-                  target={target}
-                  className="dark:hover:bg-polar-800 flex flex-col rounded-md px-4 py-2 text-sm transition-colors hover:bg-gray-100"
-                >
-                  <span className="font-medium">{label}</span>
-                  {subtitle && (
-                    <span className="dark:text-polar-500 text-gray-500">
-                      {subtitle}
-                    </span>
-                  )}
-                </Link>
-              ))}
+              {section.items.map(({ href, label, subtitle, target }) => {
+                const className =
+                  'dark:hover:bg-polar-800 flex flex-col rounded-md px-4 py-2 text-sm transition-colors hover:bg-gray-100'
+                const content = (
+                  <>
+                    <span className="font-medium">{label}</span>
+                    {subtitle && (
+                      <span className="dark:text-polar-500 text-gray-500">
+                        {subtitle}
+                      </span>
+                    )}
+                  </>
+                )
+                const isExternal =
+                  href.startsWith('/docs') || href.startsWith('http')
+
+                return isExternal ? (
+                  <a
+                    key={href + label}
+                    href={href}
+                    target={target}
+                    rel="noopener noreferrer"
+                    className={className}
+                  >
+                    {content}
+                  </a>
+                ) : (
+                  <Link
+                    key={href + label}
+                    href={href}
+                    prefetch
+                    target={target}
+                    className={className}
+                  >
+                    {content}
+                  </Link>
+                )
+              })}
             </div>
           </div>
         ))}

--- a/clients/apps/web/src/components/Landing/UseCases.tsx
+++ b/clients/apps/web/src/components/Landing/UseCases.tsx
@@ -8,7 +8,6 @@ import { Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { Button } from '@polar-sh/orbit'
 import { SectionHeader } from './SectionHeader'
-import Link from 'next/link'
 import { useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 
@@ -142,11 +141,11 @@ export const UseCases = () => {
                 </Text>
               </Box>
               <Box display="block" paddingTop="xs">
-                <Link href={active.docsHref}>
+                <a href={active.docsHref}>
                   <Button className="dark:hover:bg-polar-50 rounded-full border-none bg-black hover:bg-gray-900 dark:bg-white dark:text-black">
                     Read the docs
                   </Button>
-                </Link>
+                </a>
               </Box>
             </Box>
 

--- a/clients/apps/web/src/components/Landing/features/FeaturePageLayout.tsx
+++ b/clients/apps/web/src/components/Landing/features/FeaturePageLayout.tsx
@@ -3,7 +3,6 @@
 import GetStartedButton from '@/components/Auth/GetStartedButton'
 import { Button } from '@polar-sh/orbit'
 import { motion } from 'motion/react'
-import Link from 'next/link'
 import { ComponentType, PropsWithChildren, ReactNode } from 'react'
 import { Section } from '../Section'
 
@@ -56,11 +55,11 @@ export const FeaturePageHeader = ({
       >
         <GetStartedButton size="lg" text="Get Started" />
         {docsHref ? (
-          <Link href={docsHref}>
+          <a href={docsHref}>
             <Button variant="ghost" className="rounded-full" size="lg">
               View Documentation
             </Button>
-          </Link>
+          </a>
         ) : null}
       </motion.div>
     </motion.section>

--- a/clients/apps/web/src/components/Layout/Dashboard/DashboardSidebar.tsx
+++ b/clients/apps/web/src/components/Layout/Dashboard/DashboardSidebar.tsx
@@ -172,7 +172,7 @@ export const DashboardSidebar = ({
         {type === 'organization' && organization && (
           <SupportButton organization={organization} />
         )}
-        <Link
+        <a
           className={twMerge(
             'flex flex-row items-center rounded-lg border border-transparent text-sm transition-colors dark:border-transparent',
             'dark:text-polar-500 dark:hover:text-polar-200 text-gray-500 hover:text-black',
@@ -180,12 +180,13 @@ export const DashboardSidebar = ({
           )}
           href="https://polar.sh/docs"
           target="_blank"
+          rel="noopener noreferrer"
         >
           <ArrowOutwardOutlined className="ml-2" fontSize="inherit" />
           {!isCollapsed && (
             <span className="ml-4 font-medium">Documentation</span>
           )}
-        </Link>
+        </a>
         <Separator />
         {type === 'organization' && organization && (
           <SidebarMenu>

--- a/clients/apps/web/src/components/Onboarding/IntegrateStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/IntegrateStep.tsx
@@ -5,7 +5,6 @@ import { schemas } from '@polar-sh/client'
 import { Box } from '@polar-sh/orbit/Box'
 import { Button } from '@polar-sh/orbit'
 import { Tabs, TabsList, TabsTrigger } from '@polar-sh/orbit'
-import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useContext, useEffect, useMemo, useState } from 'react'
 import slugify from 'slugify'
@@ -238,16 +237,17 @@ export const IntegrateStep = ({ products }: IntegrateStepProps) => {
             ))}
           </Box>
           <Box flexDirection="column" rowGap="l">
-            <Link
+            <a
               href={`https://polar.sh/docs/integrate/sdk/adapters/nextjs`}
               target="_blank"
+              rel="noopener noreferrer"
               className="w-full"
             >
               <Button size="lg" fullWidth variant="secondary">
                 <Box as="span">Explore All Adapters</Box>
                 <ArrowOutwardOutlined className="ml-2" fontSize="small" />
               </Button>
-            </Link>
+            </a>
             <Button size="lg" fullWidth onClick={handleGoToDashboard}>
               Go to Dashboard
             </Button>
@@ -337,12 +337,16 @@ POLAR_SUCCESS_URL=https://example.com/success?checkout_id={CHECKOUT_ID}`}
                   code={currentFramework?.code ?? ''}
                 />
               </CodeWrapper>
-              <Link href={currentFramework?.link ?? ''} target="_blank">
+              <a
+                href={currentFramework?.link ?? ''}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 <Button size="lg" variant="secondary" fullWidth>
                   <Box as="span">View Documentation</Box>
                   <ArrowOutwardOutlined className="ml-2" fontSize="small" />
                 </Button>
-              </Link>
+              </a>
             </Box>
           </Box>
         </Box>

--- a/clients/apps/web/src/components/Payouts/WithdrawModal.tsx
+++ b/clients/apps/web/src/components/Payouts/WithdrawModal.tsx
@@ -6,7 +6,6 @@ import { isValidationError, schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
 import { Button } from '@polar-sh/orbit'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
-import Link from 'next/link'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { Modal } from '@polar-sh/orbit'
 import { DetailRow } from '../Shared/DetailRow'
@@ -145,7 +144,7 @@ const WithdrawModal: React.FC<WithdrawModalProps> = ({
                 you have any questions, please reach out to our support team.
               </p>
               <p>
-                <Link
+                <a
                   href="https://polar.sh/docs/merchant-of-record/account-reviews"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -157,7 +156,7 @@ const WithdrawModal: React.FC<WithdrawModalProps> = ({
                     <span>Learn more</span>
                     <ArrowOutwardOutlined className="ml-2" fontSize="inherit" />
                   </Button>
-                </Link>
+                </a>
               </p>
             </div>
           )}

--- a/clients/apps/web/src/components/Settings/OAuth/OAuthForm.tsx
+++ b/clients/apps/web/src/components/Settings/OAuth/OAuthForm.tsx
@@ -20,7 +20,6 @@ import ImageUpload from '@/components/Form/ImageUpload'
 import AddOutlined from '@mui/icons-material/AddOutlined'
 import ClearOutlined from '@mui/icons-material/ClearOutlined'
 import { enums } from '@polar-sh/client'
-import Link from 'next/link'
 import { useFieldArray, useFormContext } from 'react-hook-form'
 import { TreeMultiSelect } from '../TreeMultiSelect'
 import { EnhancedOAuth2ClientConfiguration } from './NewOAuthClientModal'
@@ -81,14 +80,14 @@ export const FieldClientType = () => {
             If you intend to perform authentication on public clients, like SPA
             or mobile app, select <em>Public Client</em>. Otherwise, choose{' '}
             <em>Confidential Client</em>.{' '}
-            <Link
+            <a
               className="text-blue-500 hover:text-blue-400 dark:text-blue-400 dark:hover:text-blue-300"
               href="https://polar.sh/docs/documentation/integration-guides/authenticating-with-polar"
               target="_blank"
               rel="noopener noreferrer"
             >
               Read more
-            </Link>
+            </a>
             .
           </FormDescription>
         </FormItem>
@@ -128,14 +127,14 @@ export const FieldClientSecret = ({
       <FormDescription>
         This is a sensitive value. Don&apos;t embed it in a public client like a
         SPA or mobile app.{' '}
-        <Link
+        <a
           className="text-blue-500 hover:text-blue-400 dark:text-blue-400 dark:hover:text-blue-300"
           href="https://polar.sh/docs/documentation/integration-guides/authenticating-with-polar"
           target="_blank"
           rel="noopener noreferrer"
         >
           Read more
-        </Link>
+        </a>
         .
       </FormDescription>
     </FormItem>

--- a/clients/apps/web/src/components/Settings/Webhook/WebhookForm.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookForm.tsx
@@ -191,6 +191,7 @@ export const FieldEvents = () => {
                   className="text-xs text-blue-400"
                   href={`https://polar.sh/docs/api-reference/webhooks/${event}`}
                   target="_blank"
+                  prefetch={false}
                 >
                   Schema
                 </Link>

--- a/clients/apps/web/src/components/Settings/Webhook/WebhookForm.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookForm.tsx
@@ -14,7 +14,6 @@ import {
   FormLabel,
   FormMessage,
 } from '@polar-sh/ui/components/ui/form'
-import Link from 'next/link'
 import { useEffect } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { TreeMultiSelect } from '../TreeMultiSelect'
@@ -187,14 +186,14 @@ export const FieldEvents = () => {
               onChange={field.onChange}
               separator="."
               renderOptionSuffix={(event) => (
-                <Link
+                <a
                   className="text-xs text-blue-400"
                   href={`https://polar.sh/docs/api-reference/webhooks/${event}`}
                   target="_blank"
-                  prefetch={false}
+                  rel="noopener noreferrer"
                 >
                   Schema
-                </Link>
+                </a>
               )}
             />
           </FormControl>

--- a/clients/apps/web/src/components/Settings/Webhook/WebhookSettings.tsx
+++ b/clients/apps/web/src/components/Settings/Webhook/WebhookSettings.tsx
@@ -47,15 +47,17 @@ const WebhookSettings = (props: { org: schemas['Organization'] }) => {
             <Button asChild onClick={showNewWebhookModal}>
               Add Endpoint
             </Button>
-            <Link
+            <a
               href="https://polar.sh/docs/integrate/webhooks/endpoints"
+              target="_blank"
+              rel="noopener noreferrer"
               className="shrink-0"
             >
               <Button className="gap-x-2" asChild variant="ghost">
                 <span>Documentation</span>
                 <ArrowUpRightIcon className="h-4 w-4" />
               </Button>
-            </Link>
+            </a>
           </div>
         </ListGroup.Item>
       </ListGroup>


### PR DESCRIPTION
## Summary

Replace Next.js `Link` components with native HTML `<a>` elements for external URLs and documentation links across the web client.

## What

This PR systematically replaces `next/link` imports and `Link` components with standard HTML `<a>` tags in the following scenarios:
- External URLs (starting with `http`)
- Documentation links (starting with `/docs`)
- Links to external domains like `polar.sh/docs`

Changes made in:
- `NavPopover.tsx` - Conditional rendering of `<a>` vs `Link` based on URL type
- `IntegrateStep.tsx` - External documentation links
- `OAuthForm.tsx` - External documentation links
- `EventCostCreationGuideModal.tsx` - External documentation link
- `WebhookForm.tsx` - External documentation links
- `WebhookSettings.tsx` - External documentation link
- `UseCases.tsx` - External documentation link
- `FeaturePageLayout.tsx` - External documentation link
- `DashboardSidebar.tsx` - External documentation link
- `WithdrawModal.tsx` - External documentation link

All external `<a>` tags include `rel="noopener noreferrer"` for security.

## Why

Next.js `Link` components are optimized for internal navigation within the application. Using them for external URLs is unnecessary and adds overhead. Native `<a>` elements are more appropriate for external links and provide better semantics.

## How

1. Identified all `Link` components pointing to external URLs or documentation
2. Replaced with native `<a>` elements
3. Added `rel="noopener noreferrer"` to external links for security
4. Removed unused `next/link` imports
5. In `NavPopover.tsx`, added conditional logic to use `<a>` for external URLs and `Link` for internal routes

## Checklist

- [x] This PR addresses a single concern (refactor external link handling)
- [x] The diff is reasonably sized and easy to review
- [x] No new functionality or tests needed (refactor only)
- [x] No unrelated changes included

https://claude.ai/code/session_01KKcBg1FBr4mMRCxUtJD4Nc

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

