### PR TITLE
access token: Add a toast on error

### DIFF
--- a/clients/apps/web/src/components/Settings/CreateAccessTokenModal.tsx
+++ b/clients/apps/web/src/components/Settings/CreateAccessTokenModal.tsx
@@ -7,6 +7,8 @@ import { Button } from '@polar-sh/orbit'
 import { Form } from '@polar-sh/ui/components/ui/form'
 import { useCallback } from 'react'
 import { useForm } from 'react-hook-form'
+import { extractApiErrorMessage } from '@/utils/api/errors'
+import { toast } from '../Toast/use-toast'
 import {
   AccessTokenForm,
   type AccessTokenCreate,
@@ -37,7 +39,7 @@ export const CreateAccessTokenModal = ({
 
   const onCreate = useCallback(
     async (data: AccessTokenCreate) => {
-      const { data: created } = await createToken.mutateAsync({
+      const { data: created, error } = await createToken.mutateAsync({
         comment: data.comment ? data.comment : '',
         expires_in:
           data.expires_in === 'no-expiration' ? null : data.expires_in,
@@ -47,6 +49,11 @@ export const CreateAccessTokenModal = ({
         onSuccess(created)
         reset({ scopes: [] })
         createToken.reset()
+      } else if (error) {
+        toast({
+          title: 'Could not create access token',
+          description: extractApiErrorMessage(error),
+        })
       }
     },
     [createToken, onSuccess, reset],


### PR DESCRIPTION
Otherwise errors are completely silent


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an error toast to the Create Access Token modal so failures are visible and actionable. When token creation fails, users now see a clear message with the API error.

- **Bug Fixes**
  - Show a toast if `createToken.mutateAsync` returns an `error`, with title "Could not create access token" and description from `extractApiErrorMessage(error)`.

<sup>Written for commit 860eedacfee1190d217fc76c7e400cc3eb72f3ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

