### PR TITLE
Add ESLint rules against link patterns

### DIFF
--- a/clients/apps/web/eslint-rules/index.mjs
+++ b/clients/apps/web/eslint-rules/index.mjs
@@ -1,5 +1,6 @@
 import noClassnameBox from './no-classname-box.mjs'
 import noClassnameText from './no-classname-text.mjs'
+import noExternalLinkComponent from './no-external-link-component.mjs'
 import noMerchantApiCallsInCustomerPortal from './no-merchant-api-calls-in-customer-portal.mjs'
 import noMerchantQueriesInCustomerPortal from './no-merchant-queries-in-customer-portal.mjs'
 import noNextImage from './no-next-image.mjs'
@@ -8,6 +9,7 @@ import noStyleBox from './no-style-box.mjs'
 import noStyleText from './no-style-text.mjs'
 import noToastErrorDetail from './no-toast-error-detail.mjs'
 import requireCustomerPortalPage from './require-customer-portal-page.mjs'
+import requireExternalLinkRel from './require-external-link-rel.mjs'
 
 /** @type {import('eslint').ESLint.Plugin} */
 const polarPlugin = {
@@ -17,6 +19,7 @@ const polarPlugin = {
   rules: {
     'no-classname-box': noClassnameBox,
     'no-classname-text': noClassnameText,
+    'no-external-link-component': noExternalLinkComponent,
     'no-merchant-api-calls-in-customer-portal':
       noMerchantApiCallsInCustomerPortal,
     'no-merchant-queries-in-customer-portal': noMerchantQueriesInCustomerPortal,
@@ -26,6 +29,7 @@ const polarPlugin = {
     'no-style-text': noStyleText,
     'no-toast-error-detail': noToastErrorDetail,
     'require-customer-portal-page': requireCustomerPortalPage,
+    'require-external-link-rel': requireExternalLinkRel,
   },
 }
 

--- a/clients/apps/web/eslint-rules/no-external-link-component.mjs
+++ b/clients/apps/web/eslint-rules/no-external-link-component.mjs
@@ -1,0 +1,67 @@
+function getStaticHref(attr) {
+  if (
+    attr.type !== 'JSXAttribute' ||
+    attr.name.type !== 'JSXIdentifier' ||
+    attr.name.name !== 'href'
+  ) {
+    return null
+  }
+
+  const { value } = attr
+
+  if (value?.type === 'Literal' && typeof value.value === 'string') {
+    return value.value
+  }
+
+  if (value?.type === 'JSXExpressionContainer') {
+    const { expression } = value
+    if (expression.type === 'Literal' && typeof expression.value === 'string') {
+      return expression.value
+    }
+    if (
+      expression.type === 'TemplateLiteral' &&
+      expression.expressions.length === 0
+    ) {
+      return expression.quasis[0].value.cooked
+    }
+  }
+
+  return null
+}
+
+function isExternalHref(href) {
+  return href.startsWith('http') || href.startsWith('/docs')
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+const noExternalLinkComponent = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow the next/link <Link /> component for external URLs',
+    },
+    schema: [],
+    messages: {
+      noExternalLinkComponent:
+        'Use a native <a> element instead of <Link> for external URLs. next/link is for internal navigation only.',
+    },
+  },
+  create(context) {
+    return {
+      JSXOpeningElement(node) {
+        if (node.name.type !== 'JSXIdentifier' || node.name.name !== 'Link') {
+          return
+        }
+        for (const attr of node.attributes) {
+          const href = getStaticHref(attr)
+          if (href !== null && isExternalHref(href)) {
+            context.report({ node: attr, messageId: 'noExternalLinkComponent' })
+          }
+        }
+      },
+    }
+  },
+}
+
+export default noExternalLinkComponent

--- a/clients/apps/web/eslint-rules/no-external-link-component.mjs
+++ b/clients/apps/web/eslint-rules/no-external-link-component.mjs
@@ -30,7 +30,7 @@ function getStaticHref(attr) {
 }
 
 function isExternalHref(href) {
-  return href.startsWith('http') || href.startsWith('/docs')
+  return /^https?:\/\//.test(href) || href.startsWith('/docs')
 }
 
 /** @type {import('eslint').Rule.RuleModule} */
@@ -48,9 +48,22 @@ const noExternalLinkComponent = {
     },
   },
   create(context) {
+    const nextLinkLocalNames = new Set()
+
     return {
+      ImportDeclaration(node) {
+        if (node.source.value !== 'next/link') return
+        for (const specifier of node.specifiers) {
+          if (specifier.type === 'ImportDefaultSpecifier') {
+            nextLinkLocalNames.add(specifier.local.name)
+          }
+        }
+      },
       JSXOpeningElement(node) {
-        if (node.name.type !== 'JSXIdentifier' || node.name.name !== 'Link') {
+        if (
+          node.name.type !== 'JSXIdentifier' ||
+          !nextLinkLocalNames.has(node.name.name)
+        ) {
           return
         }
         for (const attr of node.attributes) {

--- a/clients/apps/web/eslint-rules/require-external-link-rel.mjs
+++ b/clients/apps/web/eslint-rules/require-external-link-rel.mjs
@@ -1,0 +1,78 @@
+function getStaticAttrValue(attr) {
+  const { value } = attr
+
+  if (value?.type === 'Literal' && typeof value.value === 'string') {
+    return value.value
+  }
+
+  if (value?.type === 'JSXExpressionContainer') {
+    const { expression } = value
+    if (expression.type === 'Literal' && typeof expression.value === 'string') {
+      return expression.value
+    }
+    if (
+      expression.type === 'TemplateLiteral' &&
+      expression.expressions.length === 0
+    ) {
+      return expression.quasis[0].value.cooked
+    }
+  }
+
+  return null
+}
+
+function findAttr(node, name) {
+  return node.attributes.find(
+    (attr) =>
+      attr.type === 'JSXAttribute' &&
+      attr.name.type === 'JSXIdentifier' &&
+      attr.name.name === name,
+  )
+}
+
+function isExternalHref(href) {
+  return href.startsWith('http') || href.startsWith('/docs')
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+const requireExternalLinkRel = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Require rel="noopener noreferrer" on external <a> links',
+    },
+    schema: [],
+    messages: {
+      requireExternalLinkRel:
+        'External <a> links must set rel="noopener noreferrer".',
+    },
+  },
+  create(context) {
+    return {
+      JSXOpeningElement(node) {
+        if (node.name.type !== 'JSXIdentifier' || node.name.name !== 'a') {
+          return
+        }
+
+        const hrefAttr = findAttr(node, 'href')
+        if (!hrefAttr) return
+
+        const href = getStaticAttrValue(hrefAttr)
+        if (href === null || !isExternalHref(href)) return
+
+        const relAttr = findAttr(node, 'rel')
+        const rel = relAttr ? getStaticAttrValue(relAttr) : null
+        const tokens = rel ? rel.split(/\s+/) : []
+
+        if (!tokens.includes('noopener') || !tokens.includes('noreferrer')) {
+          context.report({
+            node: relAttr ?? node,
+            messageId: 'requireExternalLinkRel',
+          })
+        }
+      },
+    }
+  },
+}
+
+export default requireExternalLinkRel

--- a/clients/apps/web/eslint-rules/require-external-link-rel.mjs
+++ b/clients/apps/web/eslint-rules/require-external-link-rel.mjs
@@ -31,7 +31,7 @@ function findAttr(node, name) {
 }
 
 function isExternalHref(href) {
-  return href.startsWith('http') || href.startsWith('/docs')
+  return /^https?:\/\//.test(href) || href.startsWith('/docs')
 }
 
 /** @type {import('eslint').Rule.RuleModule} */

--- a/clients/apps/web/eslint.config.mjs
+++ b/clients/apps/web/eslint.config.mjs
@@ -43,6 +43,8 @@ export default [
       'polar/no-style-box': 'error',
       'polar/no-style-text': 'error',
       'polar/no-next-image': 'error',
+      'polar/no-external-link-component': 'error',
+      'polar/require-external-link-rel': 'error',
     },
   },
   {

--- a/clients/apps/web/src/app/(main)/oauth2/authorize/components/CreateOrganizationForm.tsx
+++ b/clients/apps/web/src/app/(main)/oauth2/authorize/components/CreateOrganizationForm.tsx
@@ -217,7 +217,7 @@ const CreateOrganizationForm = ({
                           href="https://polar.sh/docs/merchant-of-record/account-reviews"
                           className="text-blue-600 hover:underline dark:text-blue-400"
                           target="_blank"
-                          rel="noreferrer"
+                          rel="noopener noreferrer"
                         >
                           Account Reviews Policy
                         </a>
@@ -229,7 +229,7 @@ const CreateOrganizationForm = ({
                           href="https://polar.sh/legal/master-services-terms"
                           className="text-blue-600 hover:underline dark:text-blue-400"
                           target="_blank"
-                          rel="noreferrer"
+                          rel="noopener noreferrer"
                         >
                           Terms of Service
                         </a>
@@ -239,7 +239,7 @@ const CreateOrganizationForm = ({
                           href="https://polar.sh/legal/privacy-policy"
                           className="text-blue-600 hover:underline dark:text-blue-400"
                           target="_blank"
-                          rel="noreferrer"
+                          rel="noopener noreferrer"
                         >
                           Privacy Policy
                         </a>

--- a/clients/apps/web/src/app/(main)/oauth2/authorize/components/SupportedUseCases.tsx
+++ b/clients/apps/web/src/app/(main)/oauth2/authorize/components/SupportedUseCases.tsx
@@ -36,7 +36,7 @@ export default function SupportedUseCases() {
                 href="https://polar.sh/legal/acceptable-use-policy"
                 className="text-blue-500 underline dark:text-blue-400"
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
               >
                 prohibited products
               </a>

--- a/clients/apps/web/src/components/Auth/Auth.tsx
+++ b/clients/apps/web/src/components/Auth/Auth.tsx
@@ -124,6 +124,7 @@ const Auth = ({
         <a
           className="dark:text-polar-300 text-gray-600"
           href="https://polar.sh/legal/master-services-terms"
+          rel="noopener noreferrer"
         >
           Terms of Service
         </a>{' '}
@@ -131,6 +132,7 @@ const Auth = ({
         <a
           className="dark:text-polar-300 text-gray-600"
           href="https://polar.sh/legal/privacy-policy"
+          rel="noopener noreferrer"
         >
           Privacy Policy
         </a>

--- a/clients/apps/web/src/components/Landing/resources/WhyPolarPage.tsx
+++ b/clients/apps/web/src/components/Landing/resources/WhyPolarPage.tsx
@@ -187,14 +187,15 @@ export const WhyPolarPage = () => {
             believe that the best way to build a great developer experience is
             to build it with the community.
           </p>
-          <Link
+          <a
             href="https://github.com/polarsource/polar"
             target="_blank"
+            rel="noopener noreferrer"
             className="w-fit border-b border-black pb-0.5 dark:border-white"
           >
             Follow the development on GitHub
             <ArrowOutwardOutlined className="ml-2" fontSize="inherit" />
-          </Link>
+          </a>
         </div>
       </ResourceSection>
 

--- a/clients/apps/web/src/components/Onboarding/AUPBlocker.tsx
+++ b/clients/apps/web/src/components/Onboarding/AUPBlocker.tsx
@@ -24,7 +24,7 @@ export function AUPBlocker({ categories }: { categories: string[] }) {
           href="https://polar.sh/legal/acceptable-use-policy"
           className="underline"
           target="_blank"
-          rel="noreferrer"
+          rel="noopener noreferrer"
         >
           Acceptable Use Policy
         </a>

--- a/clients/apps/web/src/components/Onboarding/SandboxFormFields.tsx
+++ b/clients/apps/web/src/components/Onboarding/SandboxFormFields.tsx
@@ -177,7 +177,7 @@ export function SandboxFormFields({
                     href="https://polar.sh/legal/terms"
                     className="text-gray-900 underline dark:text-white"
                     target="_blank"
-                    rel="noreferrer"
+                    rel="noopener noreferrer"
                   >
                     Terms
                   </a>
@@ -186,7 +186,7 @@ export function SandboxFormFields({
                     href="https://polar.sh/legal/privacy"
                     className="text-gray-900 underline dark:text-white"
                     target="_blank"
-                    rel="noreferrer"
+                    rel="noopener noreferrer"
                   >
                     Privacy Policy
                   </a>{' '}
@@ -195,7 +195,7 @@ export function SandboxFormFields({
                     href="https://polar.sh/docs/merchant-of-record/account-reviews"
                     className="text-gray-900 underline dark:text-white"
                     target="_blank"
-                    rel="noreferrer"
+                    rel="noopener noreferrer"
                   >
                     AUP
                   </a>

--- a/clients/apps/web/src/components/Onboarding/TermsCheckbox.tsx
+++ b/clients/apps/web/src/components/Onboarding/TermsCheckbox.tsx
@@ -49,7 +49,7 @@ export function TermsCheckbox<T extends FieldValues>({
                       href="https://polar.sh/legal/master-services-terms"
                       className="text-gray-900 underline dark:text-white"
                       target="_blank"
-                      rel="noreferrer"
+                      rel="noopener noreferrer"
                     >
                       Terms
                     </a>
@@ -58,7 +58,7 @@ export function TermsCheckbox<T extends FieldValues>({
                       href="https://polar.sh/legal/privacy-policy"
                       className="text-gray-900 underline dark:text-white"
                       target="_blank"
-                      rel="noreferrer"
+                      rel="noopener noreferrer"
                     >
                       Privacy Policy
                     </a>{' '}
@@ -67,7 +67,7 @@ export function TermsCheckbox<T extends FieldValues>({
                       href="https://polar.sh/legal/acceptable-use-policy"
                       className="text-gray-900 underline dark:text-white"
                       target="_blank"
-                      rel="noreferrer"
+                      rel="noopener noreferrer"
                     >
                       AUP
                     </a>

--- a/clients/apps/web/src/components/Sandbox/SandboxBanner.tsx
+++ b/clients/apps/web/src/components/Sandbox/SandboxBanner.tsx
@@ -28,6 +28,7 @@ const SandboxBanner = () => {
         <a
           href="https://polar.sh/start"
           className="font-medium transition-colors hover:text-yellow-600 dark:hover:text-yellow-400"
+          rel="noopener noreferrer"
         >
           Exit sandbox
         </a>

--- a/clients/apps/web/src/components/Shared/InternalServerError.tsx
+++ b/clients/apps/web/src/components/Shared/InternalServerError.tsx
@@ -32,6 +32,7 @@ export default function InternalServerError({ digest }: { digest?: string }) {
           <a
             href="https://polar.sh/docs"
             className="dark:hover:text-polar-300 block p-1 hover:text-gray-700 hover:underline"
+            rel="noopener noreferrer"
           >
             Documentation
           </a>

--- a/clients/apps/web/src/components/Shared/PageNotFound.tsx
+++ b/clients/apps/web/src/components/Shared/PageNotFound.tsx
@@ -32,6 +32,7 @@ const PageNotFound = () => {
           <a
             href="https://polar.sh/docs"
             className="dark:hover:text-polar-300 block p-1 hover:text-gray-700 hover:underline"
+            rel="noopener noreferrer"
           >
             Documentation
           </a>


### PR DESCRIPTION
## Summary

This PR will add two ESLint rules that:

* Prevents using `<Link />` from Next on external URL's (see https://github.com/polarsource/polar/pull/12787)
* Enforces us to use `rel="noopener noreferrer"` on external links

<img width="1728" height="779" alt="Screenshot 2026-06-30 at 11 08 16" src="https://github.com/user-attachments/assets/7f0ea0e5-6c5e-4219-b1b2-868f66613bea" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

