### PR TITLE
feat: provision KMS keys and IAM grants for secrets encryption

### DIFF
--- a/server/polar/kit/encryption.py
+++ b/server/polar/kit/encryption.py
@@ -83,12 +83,7 @@ class KMSKeyProvider:
     def _client(self) -> Any:
         import boto3
 
-        return boto3.client(
-            "kms",
-            region_name=settings.AWS_REGION,
-            aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
-            aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
-        )
+        return boto3.client("kms", region_name=settings.AWS_REGION)
 
     async def generate_data_key(self, context: dict[str, str]) -> tuple[bytes, bytes]:
         response = await asyncio.to_thread(

--- a/terraform/modules/render_secrets_kms/main.tf
+++ b/terraform/modules/render_secrets_kms/main.tf
@@ -1,0 +1,124 @@
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.43"
+    }
+  }
+}
+
+# KMS key that envelope-encrypts the app's secrets at rest, plus the IAM role
+# the Render backend assumes via OIDC to use it (no long-lived AWS keys).
+# Design: handbook/engineering/design-documents/secrets-encryption.mdx.
+
+variable "environment" {
+  description = "Workload environment this runs in."
+  type        = string
+
+  validation {
+    condition     = contains(["production", "sandbox", "test"], var.environment)
+    error_message = "Must be \"production\", \"sandbox\" or \"test\"."
+  }
+}
+
+variable "render_owner_id" {
+  description = "Render workspace (owner) id, e.g. tea-xxxx. Used as the OIDC issuer host."
+  type        = string
+}
+
+variable "render_environment_id" {
+  description = "Render environment id (evm-xxxx). The role trusts every service in this environment."
+  type        = string
+}
+
+variable "permissions_boundary_arn" {
+  description = "Permission boundary that IAM roles in workload accounts must carry."
+  type        = string
+}
+
+locals {
+  oidc_host = "oidc.render.com/${var.render_owner_id}"
+}
+
+resource "aws_kms_key" "secrets" {
+  description             = "Envelope encryption master key for polar-${var.environment} secrets at rest"
+  enable_key_rotation     = true
+  deletion_window_in_days = 30
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_kms_alias" "secrets" {
+  name          = "alias/polar-${var.environment}-secrets"
+  target_key_id = aws_kms_key.secrets.key_id
+}
+
+# thumbprint_list is omitted: AWS retrieves it from the issuer (aws provider
+# >= 5.43). See render.com/docs/oidc.
+resource "aws_iam_openid_connect_provider" "render" {
+  url            = "https://${local.oidc_host}"
+  client_id_list = ["sts.amazonaws.com"]
+}
+
+data "aws_iam_policy_document" "assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.render.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "${local.oidc_host}:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    # sub is "workspace:{owner}:environment:{env}:service:{service}"; trust every
+    # service in this environment only. https://render.com/docs/oidc
+    condition {
+      test     = "StringLike"
+      variable = "${local.oidc_host}:sub"
+      values   = ["workspace:${var.render_owner_id}:environment:${var.render_environment_id}:service:*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "secrets" {
+  name                 = "polar-${var.environment}-secrets"
+  assume_role_policy   = data.aws_iam_policy_document.assume.json
+  permissions_boundary = var.permissions_boundary_arn
+}
+
+data "aws_iam_policy_document" "secrets" {
+  statement {
+    sid = "EnvelopeEncryption"
+    actions = [
+      "kms:GenerateDataKey",
+      "kms:Decrypt",
+    ]
+    resources = [aws_kms_key.secrets.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "secrets" {
+  name   = "polar-${var.environment}-secrets"
+  role   = aws_iam_role.secrets.id
+  policy = data.aws_iam_policy_document.secrets.json
+}
+
+output "key_arn" {
+  description = "Full ARN of the secrets KMS key. Passed to the app as POLAR_AWS_KMS_KEY_ID."
+  value       = aws_kms_key.secrets.arn
+}
+
+output "role_arn" {
+  description = "ARN of the role the Render backend assumes via OIDC. Passed to the app as AWS_ROLE_ARN."
+  value       = aws_iam_role.secrets.arn
+}

--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -127,6 +127,17 @@ resource "render_env_group" "aws_s3" {
   }
 }
 
+# Setting AWS_ROLE_ARN makes Render inject a web-identity token, so boto3
+# assumes the role via OIDC and needs no static keys.
+resource "render_env_group" "secrets_kms" {
+  environment_id = var.render_environment_id
+  name           = "secrets-kms-${var.environment}"
+  env_vars = {
+    POLAR_AWS_KMS_KEY_ID = { value = var.aws_kms_config.key_id }
+    AWS_ROLE_ARN         = { value = var.aws_kms_config.role_arn }
+  }
+}
+
 resource "render_env_group" "worker_sqs" {
   count          = var.worker_sqs_config != null ? 1 : 0
   environment_id = var.render_environment_id
@@ -443,6 +454,11 @@ resource "render_env_group_link" "redis" {
 
 resource "render_env_group_link" "aws_s3" {
   env_group_id = render_env_group.aws_s3.id
+  service_ids  = local.all_service_ids
+}
+
+resource "render_env_group_link" "secrets_kms" {
+  env_group_id = render_env_group.secrets_kms.id
   service_ids  = local.all_service_ids
 }
 

--- a/terraform/modules/render_service/variables.tf
+++ b/terraform/modules/render_service/variables.tf
@@ -191,6 +191,14 @@ variable "aws_s3_secrets" {
   sensitive = true
 }
 
+variable "aws_kms_config" {
+  description = "Secrets-encryption KMS key ARN and the OIDC role the backend assumes to use it (both in the workload account)."
+  type = object({
+    key_id   = string # full key ARN -> POLAR_AWS_KMS_KEY_ID
+    role_arn = string # OIDC role -> AWS_ROLE_ARN
+  })
+}
+
 variable "worker_sqs_config" {
   description = "Worker SQS execution engine config and producer credentials (optional). null skips the env group."
   type = object({

--- a/terraform/production/aws.tf
+++ b/terraform/production/aws.tf
@@ -1,20 +1,12 @@
-module "lambda_worker_ecr" {
-  count  = local.test_enabled ? 1 : 0
-  source = "../modules/ecr_repository"
-
-  name = "polar-test-lambda-worker"
-}
-
 data "aws_iam_policy" "permission_boundary" {
   name = "PolarPermissionBoundary"
 }
 
 module "secrets_kms" {
-  count  = local.test_enabled ? 1 : 0
   source = "../modules/render_secrets_kms"
 
-  environment              = "test"
+  environment              = "production"
   render_owner_id          = "tea-ch0f74hjvhtkjjvvhnr0"
-  render_environment_id    = local.environment_id
+  render_environment_id    = render_project.polar.environments["Production"].id
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
 }

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -336,6 +336,11 @@ module "production" {
     files_download_secret = var.s3_files_download_secret_production
   }
 
+  aws_kms_config = {
+    key_id   = module.secrets_kms.key_arn
+    role_arn = module.secrets_kms.role_arn
+  }
+
   github_secrets = {
     client_id                           = var.github_client_id_production
     client_secret                       = var.github_client_secret_production

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -2,6 +2,15 @@ data "aws_iam_policy" "permission_boundary" {
   name = "PolarPermissionBoundary"
 }
 
+module "secrets_kms" {
+  source = "../modules/render_secrets_kms"
+
+  environment              = "sandbox"
+  render_owner_id          = "tea-ch0f74hjvhtkjjvvhnr0"
+  render_environment_id    = data.tfe_outputs.production.values.sandbox_environment_id
+  permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
+}
+
 module "lambda_worker_ecr" {
   source = "../modules/ecr_repository"
 

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -234,6 +234,11 @@ module "sandbox" {
     files_download_secret = var.s3_files_download_secret_sandbox
   }
 
+  aws_kms_config = {
+    key_id   = module.secrets_kms.key_arn
+    role_arn = module.secrets_kms.role_arn
+  }
+
   worker_sqs_config = {
     enabled               = "true"
     actors                = var.worker_sqs_actors

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -219,6 +219,11 @@ module "test" {
     files_download_secret = var.s3_files_download_secret
   }
 
+  aws_kms_config = {
+    key_id   = one(module.secrets_kms[*].key_arn)
+    role_arn = one(module.secrets_kms[*].role_arn)
+  }
+
   github_secrets = {
     client_id                           = var.github_client_id
     client_secret                       = var.github_client_secret


### PR DESCRIPTION
## Summary

Provisions the KMS key for each environemtn

## What

- One AWS KMS master key + alias `alias/polar-{env}-secrets` per environment with automatic key rotation enabled.
- Grants the backend IAM user (`polar-{env}-files` - not the best name 🥲) `kms:GenerateDataKey` + `kms:Decrypt`
- Sets `POLAR_AWS_KMS_KEY_ID` on the Render side

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

