### PR TITLE
Allow plan changes while in review

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/change-plan/ChangePlanPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/change-plan/ChangePlanPage.tsx
@@ -31,6 +31,14 @@ const FREE_PLAN_KEY = '__free__'
 const planKey = (plan: schemas['OrganizationPlan']) =>
   plan.product_id ?? FREE_PLAN_KEY
 
+// Statuses for which plan changes are available: active orgs and orgs still
+// pending approval (under review or snoozed).
+const PLAN_CHANGE_STATUSES: schemas['OrganizationStatus'][] = [
+  'active',
+  'review',
+  'snoozed',
+]
+
 export default function ChangePlanPage({
   organization,
 }: {
@@ -54,7 +62,7 @@ export default function ChangePlanPage({
   const cancelSubscription = useCancelSubscription(organization.id)
   const startCheckout = useStartSubscriptionCheckout(organization.id)
 
-  const blockChanges = organization.status !== 'active'
+  const blockChanges = !PLAN_CHANGE_STATUSES.includes(organization.status)
 
   const [selectedPlanId, setSelectedPlanId] = useState<string | null>(null)
   const {

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -912,7 +912,7 @@ class PolarSelfService:
         organization = await organization_repository.get_by_id(
             organization_id, include_blocked=True
         )
-        if organization is None or not organization.is_active():
+        if organization is None or not organization.can_change_plan():
             raise PolarSelfNotApproved(organization_id)
 
     async def _ensure_plan(self, product_id: str) -> "Product":

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -861,8 +861,13 @@ class Organization(RateLimitGroupMixin, RecordModel):
     def is_blocked(self) -> bool:
         return self.status == OrganizationStatus.BLOCKED
 
-    def is_active(self) -> bool:
-        return self.status == OrganizationStatus.ACTIVE
+    def can_change_plan(self) -> bool:
+        # Active organizations and organizations under silent review (review or
+        # snoozed) may change their plan; all other statuses are blocked.
+        return (
+            self.status == OrganizationStatus.ACTIVE
+            or self.status in OrganizationStatus.review_statuses()
+        )
 
     def statement_descriptor(self, suffix: str = "") -> str:
         max_length = settings.stripe_descriptor_suffix_max_length

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -223,7 +223,7 @@ def read_session_mock() -> AsyncReadSession:
 def organization_repository_mock(mocker: MockerFixture) -> MagicMock:
     repository = MagicMock()
     active_organization = MagicMock(spec=Organization)
-    active_organization.is_active.return_value = True
+    active_organization.can_change_plan.return_value = True
     repository.get_by_id = AsyncMock(return_value=active_organization)
     mocker.patch(
         "polar.integrations.polar.service.OrganizationRepository.from_session",
@@ -1523,7 +1523,7 @@ class TestChangePlan:
             _make_product(id="prod_2", metadata={"order": 2}),
         ]
         inactive = MagicMock(spec=Organization)
-        inactive.is_active.return_value = False
+        inactive.can_change_plan.return_value = False
         organization_repository_mock.get_by_id.return_value = inactive
 
         with pytest.raises(PolarSelfNotApproved):

--- a/server/tests/models/test_organization.py
+++ b/server/tests/models/test_organization.py
@@ -3,9 +3,38 @@ from sqlalchemy.orm import joinedload
 
 from polar.kit.utils import utc_now
 from polar.models import Organization, OrganizationReview
+from polar.models.organization import OrganizationStatus
 from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
+
+
+class TestCanChangePlan:
+    @pytest.mark.parametrize(
+        "status",
+        [
+            OrganizationStatus.ACTIVE,
+            OrganizationStatus.REVIEW,
+            OrganizationStatus.SNOOZED,
+        ],
+    )
+    def test_allowed_statuses(self, status: OrganizationStatus) -> None:
+        organization = Organization(status=status)
+        assert organization.can_change_plan() is True
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            OrganizationStatus.CREATED,
+            OrganizationStatus.DENIED,
+            OrganizationStatus.BLOCKED,
+            OrganizationStatus.OFFBOARDING,
+            OrganizationStatus.OFFBOARDED,
+        ],
+    )
+    def test_blocked_statuses(self, status: OrganizationStatus) -> None:
+        organization = Organization(status=status)
+        assert organization.can_change_plan() is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
After being initially approved, organizations don't know if they're active or under review (e.g. catalog change or threshold trigger), and they should be allowed to upgrade regardless.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow organizations to change plans while under review or snoozed, not just when active. Aligns the UI and backend to prevent 403s during checkout for pending-approval orgs.

- **Bug Fixes**
  - Frontend: use `PLAN_CHANGE_STATUSES` (`active`, `review`, `snoozed`) to allow plan changes.
  - Backend: gate plan changes with `Organization.can_change_plan()` in `_require_approval` instead of `is_active`.
  - Tests: add model tests for allowed/blocked statuses and update service tests/mocks to use `can_change_plan`.

<sup>Written for commit 695cc1b9855c5e7402fc8c7052654fbe6ecea312. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

