### PR TITLE
feat(oauth): dual-write encrypted OAuthAccount tokens at rest

### DIFF
--- a/server/migrations/versions/2026-07-01-0900_add_oauth_account_encrypted_tokens.py
+++ b/server/migrations/versions/2026-07-01-0900_add_oauth_account_encrypted_tokens.py
@@ -1,0 +1,37 @@
+"""add OAuthAccount encrypted token columns
+
+Revision ID: 42886ceacac8
+Revises: f159733f3ae6
+Create Date: 2026-07-01 09:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "42886ceacac8"
+down_revision = "f159733f3ae6"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.add_column(
+        "oauth_accounts",
+        sa.Column("access_token_encrypted", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "oauth_accounts",
+        sa.Column("refresh_token_encrypted", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.drop_column("oauth_accounts", "refresh_token_encrypted")
+    op.drop_column("oauth_accounts", "access_token_encrypted")

--- a/server/polar/auth/oauth2/apple.py
+++ b/server/polar/auth/oauth2/apple.py
@@ -40,20 +40,23 @@ class AppleFactor(OAuth2FactorMixin, AppleOAuth2FactorBase):
         claims = await self.get_id_token_claims(enrollment.id_token)
         enrollment_orm = OAuthAccount(
             platform=OAuthPlatform.apple,
-            access_token=enrollment.access_token,
             expires_at=enrollment.expires_at,
-            refresh_token=enrollment.refresh_token,
             refresh_token_expires_at=enrollment.refresh_token_expires_at,
             account_id=enrollment.account_id,
             account_email=claims["email"],
             account_username=claims.get("name"),
             user_id=enrollment.identity_id,
         )
+        await enrollment_orm.set_tokens(
+            access_token=enrollment.access_token,
+            refresh_token=enrollment.refresh_token,
+        )
         self.session.add(enrollment_orm)
         await self.session.flush()
         return enrollment_orm.id
 
     async def update(self, enrollment: OAuth2EnrollmentDataclass) -> None:
+        assert enrollment.id is not None
         statement = (
             update(OAuthAccount)
             .where(
@@ -61,8 +64,14 @@ class AppleFactor(OAuth2FactorMixin, AppleOAuth2FactorBase):
             )
             .values(
                 access_token=enrollment.access_token,
+                access_token_encrypted=await OAuthAccount.encrypt_access_token(
+                    enrollment.id, enrollment.access_token
+                ),
                 expires_at=enrollment.expires_at,
                 refresh_token=enrollment.refresh_token,
+                refresh_token_encrypted=await OAuthAccount.encrypt_refresh_token(
+                    enrollment.id, enrollment.refresh_token
+                ),
                 refresh_token_expires_at=enrollment.refresh_token_expires_at,
                 # Apple doesn't provide profile information on subsequent login,
                 # so we don't update account_email and account_username on update.

--- a/server/polar/auth/oauth2/factor.py
+++ b/server/polar/auth/oauth2/factor.py
@@ -42,14 +42,16 @@ class OAuth2FactorMixin:
         email = await typing.cast(OAuth2FactorMixin, self).get_email(enrollment)
         enrollment_orm = OAuthAccount(
             platform=OAuthPlatform(self.identifier),
-            access_token=enrollment.access_token,
             expires_at=enrollment.expires_at,
-            refresh_token=enrollment.refresh_token,
             refresh_token_expires_at=enrollment.refresh_token_expires_at,
             account_id=enrollment.account_id,
             account_email=email,
             account_username=profile.get("name"),
             user_id=enrollment.identity_id,
+        )
+        await enrollment_orm.set_tokens(
+            access_token=enrollment.access_token,
+            refresh_token=enrollment.refresh_token,
         )
         self.session.add(enrollment_orm)
         await self.session.flush()
@@ -58,6 +60,7 @@ class OAuth2FactorMixin:
     async def update(
         self: OAuth2FactorProtocol, enrollment: OAuth2EnrollmentDataclass
     ) -> None:
+        assert enrollment.id is not None
         profile = await self.get_profile(enrollment.access_token)
         email = await typing.cast(OAuth2FactorMixin, self).get_email(enrollment)
         statement = (
@@ -67,8 +70,14 @@ class OAuth2FactorMixin:
             )
             .values(
                 access_token=enrollment.access_token,
+                access_token_encrypted=await OAuthAccount.encrypt_access_token(
+                    enrollment.id, enrollment.access_token
+                ),
                 expires_at=enrollment.expires_at,
                 refresh_token=enrollment.refresh_token,
+                refresh_token_encrypted=await OAuthAccount.encrypt_refresh_token(
+                    enrollment.id, enrollment.refresh_token
+                ),
                 refresh_token_expires_at=enrollment.refresh_token_expires_at,
                 account_email=email,
                 account_username=profile.get("name"),

--- a/server/polar/integrations/github_repository_benefit/service.py
+++ b/server/polar/integrations/github_repository_benefit/service.py
@@ -98,13 +98,15 @@ class GitHubRepositoryBenefitUserService:
 
         oauth_account = OAuthAccount(
             platform=OAuthPlatform.github_repository_benefit,
-            access_token=access_token,
             expires_at=oauth2_token_data["expires_at"],
-            refresh_token=oauth2_token_data["refresh_token"],
             account_id=str(account_id),
             account_email=account_email,
             account_username=account_username,
             user=user,
+        )
+        await oauth_account.set_tokens(
+            access_token=access_token,
+            refresh_token=oauth2_token_data["refresh_token"],
         )
 
         nested = await session.begin_nested()
@@ -125,9 +127,11 @@ class GitHubRepositoryBenefitUserService:
         if account is None:
             raise GitHubRepositoryBenefitAccountNotConnected(user)
 
-        account.access_token = oauth2_token_data["access_token"]
+        await account.set_tokens(
+            access_token=oauth2_token_data["access_token"],
+            refresh_token=oauth2_token_data["refresh_token"],
+        )
         account.expires_at = oauth2_token_data["expires_at"]
-        account.refresh_token = oauth2_token_data["refresh_token"]
 
         client = github.get_client(access_token=account.access_token)
         user_data = await client.rest.users.async_get_authenticated()
@@ -165,9 +169,11 @@ class GitHubRepositoryBenefitUserService:
             except RefreshTokenError as e:
                 raise GitHubRepositoryRefreshTokenError() from e
 
-            account.access_token = refreshed_token_data["access_token"]
+            await account.set_tokens(
+                access_token=refreshed_token_data["access_token"],
+                refresh_token=refreshed_token_data["refresh_token"],
+            )
             account.expires_at = refreshed_token_data["expires_at"]
-            account.refresh_token = refreshed_token_data["refresh_token"]
             session.add(account)
             await session.flush()
 

--- a/server/polar/models/user.py
+++ b/server/polar/models/user.py
@@ -25,10 +25,20 @@ from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 from sqlalchemy.schema import Index, UniqueConstraint
 
 from polar.kit.db.models import RecordModel
+from polar.kit.encryption import EncryptedString, EncryptedStringType
 from polar.kit.extensions.sqlalchemy.types import StringEnum
 from polar.kit.schemas import Schema
 
 from .account import Account
+
+OAUTH_ACCOUNT_ACCESS_TOKEN_CONTEXT = {
+    "table": "oauth_accounts",
+    "column": "access_token",
+}
+OAUTH_ACCOUNT_REFRESH_TOKEN_CONTEXT = {
+    "table": "oauth_accounts",
+    "column": "refresh_token",
+}
 
 
 class OAuthPlatform(StrEnum):
@@ -66,9 +76,19 @@ class OAuthAccount(RecordModel):
 
     platform: Mapped[OAuthPlatform] = mapped_column(String(32), nullable=False)
     access_token: Mapped[str] = mapped_column(String(1024), nullable=False)
+    access_token_encrypted: Mapped[EncryptedString | None] = mapped_column(
+        EncryptedStringType(OAUTH_ACCOUNT_ACCESS_TOKEN_CONTEXT),
+        nullable=True,
+        default=None,
+    )
     expires_at: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
     refresh_token: Mapped[str | None] = mapped_column(
         String(1024), nullable=True, default=None
+    )
+    refresh_token_encrypted: Mapped[EncryptedString | None] = mapped_column(
+        EncryptedStringType(OAUTH_ACCOUNT_REFRESH_TOKEN_CONTEXT),
+        nullable=True,
+        default=None,
     )
     refresh_token_expires_at: Mapped[int | None] = mapped_column(
         Integer, nullable=True, default=None
@@ -110,6 +130,36 @@ class OAuthAccount(RecordModel):
             refresh_token_expires_at=self.refresh_token_expires_at,
             account_id=self.account_id,
             identity_id=self.user_id,
+        )
+
+    @classmethod
+    async def encrypt_access_token(cls, id: UUID, access_token: str) -> EncryptedString:
+        return await EncryptedString.encrypt(
+            access_token,
+            context={**OAUTH_ACCOUNT_ACCESS_TOKEN_CONTEXT, "id": str(id)},
+        )
+
+    @classmethod
+    async def encrypt_refresh_token(
+        cls, id: UUID, refresh_token: str | None
+    ) -> EncryptedString | None:
+        if refresh_token is None:
+            return None
+        return await EncryptedString.encrypt(
+            refresh_token,
+            context={**OAUTH_ACCOUNT_REFRESH_TOKEN_CONTEXT, "id": str(id)},
+        )
+
+    async def set_tokens(self, *, access_token: str, refresh_token: str | None) -> None:
+        if self.id is None:
+            self.id = self.generate_id()
+        self.access_token = access_token
+        self.refresh_token = refresh_token
+        self.access_token_encrypted = await self.encrypt_access_token(
+            self.id, access_token
+        )
+        self.refresh_token_encrypted = await self.encrypt_refresh_token(
+            self.id, refresh_token
         )
 
 

--- a/server/tests/models/test_oauth_account.py
+++ b/server/tests/models/test_oauth_account.py
@@ -1,0 +1,155 @@
+import pytest
+from cryptography.exceptions import InvalidTag
+from sqlalchemy import select
+
+from polar.kit.encryption import EncryptedString
+from polar.models import User
+from polar.models.user import OAuthAccount, OAuthPlatform
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+
+
+async def _build(user: User) -> OAuthAccount:
+    return OAuthAccount(
+        platform=OAuthPlatform.github,
+        account_id="account-id",
+        account_email="foo@bar.com",
+        account_username="foo",
+        user=user,
+    )
+
+
+@pytest.mark.asyncio
+class TestSetTokens:
+    async def test_dual_writes_plain_and_encrypted(self, user: User) -> None:
+        oauth_account = await _build(user)
+
+        await oauth_account.set_tokens(
+            access_token="the-access-token", refresh_token="the-refresh-token"
+        )
+
+        assert oauth_account.access_token == "the-access-token"
+        assert oauth_account.refresh_token == "the-refresh-token"
+        assert isinstance(oauth_account.access_token_encrypted, EncryptedString)
+        assert isinstance(oauth_account.refresh_token_encrypted, EncryptedString)
+        assert (
+            await oauth_account.access_token_encrypted.decrypt(id=str(oauth_account.id))
+            == "the-access-token"
+        )
+        assert (
+            await oauth_account.refresh_token_encrypted.decrypt(
+                id=str(oauth_account.id)
+            )
+            == "the-refresh-token"
+        )
+
+    async def test_binds_ciphertext_to_row_id(self, user: User) -> None:
+        oauth_account = await _build(user)
+
+        await oauth_account.set_tokens(
+            access_token="the-access-token", refresh_token="the-refresh-token"
+        )
+
+        assert isinstance(oauth_account.access_token_encrypted, EncryptedString)
+        with pytest.raises(InvalidTag):
+            await oauth_account.access_token_encrypted.decrypt(id="not-the-row-id")
+
+    async def test_clears_encrypted_when_refresh_none(self, user: User) -> None:
+        oauth_account = await _build(user)
+        await oauth_account.set_tokens(
+            access_token="the-access-token", refresh_token="the-refresh-token"
+        )
+
+        await oauth_account.set_tokens(
+            access_token="the-access-token", refresh_token=None
+        )
+
+        assert oauth_account.refresh_token is None
+        assert oauth_account.refresh_token_encrypted is None
+
+
+@pytest.mark.asyncio
+class TestEncryptClassmethods:
+    """Covers the classmethods used by the Core ``update().values()`` write
+    paths in factor.py / apple.py, which don't go through the instance setters."""
+
+    async def test_encrypt_access_token(self, user: User) -> None:
+        oauth_account = await _build(user)
+        oauth_account.id = OAuthAccount.generate_id()
+
+        encrypted = await OAuthAccount.encrypt_access_token(
+            oauth_account.id, "the-access-token"
+        )
+
+        assert isinstance(encrypted, EncryptedString)
+        assert await encrypted.decrypt(id=str(oauth_account.id)) == "the-access-token"
+
+    async def test_encrypt_refresh_token_with_value(self, user: User) -> None:
+        oauth_account = await _build(user)
+        oauth_account.id = OAuthAccount.generate_id()
+
+        encrypted = await OAuthAccount.encrypt_refresh_token(
+            oauth_account.id, "the-refresh-token"
+        )
+
+        assert isinstance(encrypted, EncryptedString)
+        assert await encrypted.decrypt(id=str(oauth_account.id)) == "the-refresh-token"
+
+    async def test_encrypt_refresh_token_none_returns_none(self, user: User) -> None:
+        assert (
+            await OAuthAccount.encrypt_refresh_token(OAuthAccount.generate_id(), None)
+            is None
+        )
+
+
+@pytest.mark.asyncio
+class TestPersistence:
+    async def test_round_trip_through_database(
+        self, save_fixture: SaveFixture, session: AsyncSession, user: User
+    ) -> None:
+        oauth_account = await _build(user)
+        await oauth_account.set_tokens(
+            access_token="the-access-token", refresh_token="the-refresh-token"
+        )
+        await save_fixture(oauth_account)
+        oauth_account_id = oauth_account.id
+
+        session.expunge_all()
+        loaded = await session.scalar(
+            select(OAuthAccount).where(OAuthAccount.id == oauth_account_id)
+        )
+        assert loaded is not None
+
+        assert isinstance(loaded.access_token_encrypted, EncryptedString)
+        assert (
+            await loaded.access_token_encrypted.decrypt(id=str(loaded.id))
+            == "the-access-token"
+        )
+        assert isinstance(loaded.refresh_token_encrypted, EncryptedString)
+        assert (
+            await loaded.refresh_token_encrypted.decrypt(id=str(loaded.id))
+            == "the-refresh-token"
+        )
+
+    async def test_clearing_refresh_token_persists_null(
+        self, save_fixture: SaveFixture, session: AsyncSession, user: User
+    ) -> None:
+        oauth_account = await _build(user)
+        await oauth_account.set_tokens(
+            access_token="the-access-token", refresh_token="the-refresh-token"
+        )
+        await save_fixture(oauth_account)
+        oauth_account_id = oauth_account.id
+
+        await oauth_account.set_tokens(
+            access_token="the-access-token", refresh_token=None
+        )
+        await save_fixture(oauth_account)
+
+        session.expunge_all()
+        loaded = await session.scalar(
+            select(OAuthAccount).where(OAuthAccount.id == oauth_account_id)
+        )
+        assert loaded is not None
+        assert loaded.refresh_token is None
+        assert loaded.refresh_token_encrypted is None


### PR DESCRIPTION
## Summary

First rollout step of the secrets-encryption RFC: encrypt OAuth tokens at rest. We add a new column and we dual-write it

## What

- New `access_token_encrypted` / `refresh_token_encrypted` columns (`EncryptedStringType`, nullable) on `OAuthAccount`
- `set_access_token` / `set_refresh_token` helpers and `encrypt_*` classmethods that envelope-encrypt the value, binding the ciphertext to the row id.
- Dual-write wired into all write paths

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

