### PR TITLE
server/order: do not emit a balance credit order event for free orders

### DIFF
--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -2754,6 +2754,9 @@ class OrderService:
         order: Order,
         organization: Organization,
     ) -> None:
+        if order.net_amount == 0:
+            return
+
         try:
             credit_metadata: BalanceCreditOrderMetadata = {
                 "order_id": str(order.id),


### PR DESCRIPTION
- server/order: do not emit a balance credit order event for free orders

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

