### PR TITLE
Respect past due subscriptions, ask for payment method update

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/BillingPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/BillingPage.tsx
@@ -10,6 +10,7 @@ import { BillingBenefitGrants } from '@/components/Settings/Billing/BillingBenef
 import { BillingOrdersTable } from '@/components/Settings/Billing/BillingOrdersTable'
 import { BillingPaymentMethods } from '@/components/Settings/Billing/BillingPaymentMethods'
 import { BillingSubscriptionCard } from '@/components/Settings/Billing/BillingSubscriptionCard'
+import { PastDueSubscriptionCallout } from '@/components/Settings/Billing/PastDueSubscriptionCallout'
 import { SandboxPreviewAccessNotice } from '@/components/Settings/Billing/SandboxPreviewAccessNotice'
 import { StartupProgramCallout } from '@/components/Settings/Billing/StartupProgramCallout'
 import { Section, SectionDescription } from '@/components/Settings/Section'
@@ -153,6 +154,9 @@ export default function BillingPage({
                 organization={organization}
                 subscription={subscriptionQuery.data}
                 plans={plansQuery.data ?? []}
+              />
+              <PastDueSubscriptionCallout
+                subscription={subscriptionQuery.data}
               />
               <BillingSubscriptionCard
                 subscription={subscriptionQuery.data}

--- a/clients/apps/web/src/components/Settings/Billing/PastDueSubscriptionCallout.tsx
+++ b/clients/apps/web/src/components/Settings/Billing/PastDueSubscriptionCallout.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { schemas } from '@polar-sh/client'
+import { Alert } from '@polar-sh/orbit/Alert'
+
+export const PastDueSubscriptionCallout = ({
+  subscription,
+}: {
+  subscription: schemas['OrganizationSubscription']
+}) => {
+  if (subscription.status !== 'past_due') {
+    return null
+  }
+
+  return (
+    <Alert
+      variant="warning"
+      title="Renewal payment failed"
+      description="We couldn't process your latest subscription renewal. Update your default payment method to retry the payment and keep your plan active."
+    />
+  )
+}

--- a/server/polar/integrations/polar/client.py
+++ b/server/polar/integrations/polar/client.py
@@ -46,6 +46,7 @@ from polar_sdk.models import (
     Subscription,
     SubscriptionCancel,
     SubscriptionProrationBehavior,
+    SubscriptionStatus,
     SubscriptionUpdateBase,
 )
 from polar_sdk.models.membercreate import Role as MemberCreateRole
@@ -302,7 +303,11 @@ class PolarSelfClient:
             try:
                 response = await self._sdk.subscriptions.list_async(
                     external_customer_id=external_customer_id,
-                    active=True,
+                    status=[
+                        SubscriptionStatus.TRIALING,
+                        SubscriptionStatus.ACTIVE,
+                        SubscriptionStatus.PAST_DUE,
+                    ],
                     page=1,
                     limit=1,
                 )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show a warning on the Billing page when a subscription is past due and prompt users to update their default payment method. The server now includes past-due subscriptions when fetching the current org subscription so the callout can appear.

- **New Features**
  - Added `PastDueSubscriptionCallout` to Billing settings.
  - Displays a warning when `subscription.status === 'past_due'`.
  - Uses `@polar-sh/client` types and `@polar-sh/orbit/Alert`.

- **Bug Fixes**
  - Server `get_active_subscription` now requests `status=[TRIALING, ACTIVE, PAST_DUE]` instead of `active=True`.
  - Ensures past-due subscriptions are returned so users can update payment methods.

<sup>Written for commit 7e256faf20ce327d2ca9f8ac563fb354981b344a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

