### PR TITLE
refactor: break out subscription order creation into private helper method

### DIFF
--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1311,181 +1311,202 @@ class OrderService:
             if len(items) == 0:
                 raise NoPendingBillingEntries(subscription)
 
-            order_id = uuid.uuid4()
-            customer = subscription.customer
-
-            subtotal_amount = sum(item.amount for item in items)
-
-            discount = subscription.discount
-            discount_amount = 0
-            if discount is not None:
-                # Discount only applies to cycle and meter items, as prorations
-                # use "last month's" discount and so this month's discount
-                # shouldn't apply to those.
-                discountable_amount = sum(
-                    item.amount for item in items if item.discountable
-                )
-                discount_amount = discount.get_discount_amount(
-                    discountable_amount, subscription.currency
-                )
-
-            billing_address = customer.billing_address
-            tax_id = customer.tax_id
-            product = subscription.product
-
-            tax_behavior_option = (
-                subscription.tax_behavior.to_option()
-                if subscription.tax_behavior is not None
-                else customer.organization.default_tax_behavior
-            )
-            # Calculate tax
-            (
-                tax_processor,
-                tax_behavior,
-                tax_calculation_processor_id,
-                tax_amount,
-                tax_breakdown,
-            ) = await self._calculate_tax(
-                reference=str(order_id),
-                taxable_amount=subtotal_amount - discount_amount,
-                tax_behavior_option=tax_behavior_option,
-                currency=subscription.currency,
-                customer=customer,
-                product=product,
-                tax_exempted=subscription.tax_exempted,
+            return await self._create_order(
+                session,
+                subscription,
+                list(items),
+                billing_reason,
+                payment_mode=payment_mode,
             )
 
-            invoice_number = await organization_service.get_next_invoice_number(
-                session, subscription.organization, customer
+    async def _create_order(
+        self,
+        session: AsyncSession,
+        subscription: Subscription,
+        items: Sequence[OrderItem],
+        billing_reason: OrderBillingReasonInternal,
+        *,
+        payment_mode: PaymentMode = PaymentMode.background,
+    ) -> Order:
+        """
+        Finalize a subscription order from already-built line items: compute the
+        discount, tax, balance and totals, persist the order, optionally reset
+        meters, and settle or trigger payment. Callers are responsible for
+        building ``items`` (from pending billing entries, carried overage, …).
+        """
+        order_id = uuid.uuid4()
+        customer = subscription.customer
+
+        subtotal_amount = sum(item.amount for item in items)
+
+        discount = subscription.discount
+        discount_amount = 0
+        if discount is not None:
+            # Discount only applies to cycle and meter items, as prorations
+            # use "last month's" discount and so this month's discount
+            # shouldn't apply to those.
+            discountable_amount = sum(
+                item.amount for item in items if item.discountable
+            )
+            discount_amount = discount.get_discount_amount(
+                discountable_amount, subscription.currency
             )
 
-            net_amount = (
-                subtotal_amount
-                - discount_amount
-                - (tax_amount if tax_behavior == TaxBehavior.inclusive else 0)
-            )
-            total_amount = net_amount + tax_amount
-            customer_balance = await wallet_service.get_billing_wallet_balance(
-                session, customer, subscription.currency, for_update=True
-            )
+        billing_address = customer.billing_address
+        tax_id = customer.tax_id
+        product = subscription.product
 
-            # Calculate balance change and applied amount
-            if total_amount >= 0:
-                # Order is a charge: use customer balance if available
-                balance_change = -min(total_amount, customer_balance)
-                applied_balance_amount = balance_change
+        tax_behavior_option = (
+            subscription.tax_behavior.to_option()
+            if subscription.tax_behavior is not None
+            else customer.organization.default_tax_behavior
+        )
+        # Calculate tax
+        (
+            tax_processor,
+            tax_behavior,
+            tax_calculation_processor_id,
+            tax_amount,
+            tax_breakdown,
+        ) = await self._calculate_tax(
+            reference=str(order_id),
+            taxable_amount=subtotal_amount - discount_amount,
+            tax_behavior_option=tax_behavior_option,
+            currency=subscription.currency,
+            customer=customer,
+            product=product,
+            tax_exempted=subscription.tax_exempted,
+        )
+
+        invoice_number = await organization_service.get_next_invoice_number(
+            session, subscription.organization, customer
+        )
+
+        net_amount = (
+            subtotal_amount
+            - discount_amount
+            - (tax_amount if tax_behavior == TaxBehavior.inclusive else 0)
+        )
+        total_amount = net_amount + tax_amount
+        customer_balance = await wallet_service.get_billing_wallet_balance(
+            session, customer, subscription.currency, for_update=True
+        )
+
+        # Calculate balance change and applied amount
+        if total_amount >= 0:
+            # Order is a charge: use customer balance if available
+            balance_change = -min(total_amount, customer_balance)
+            applied_balance_amount = balance_change
+        else:
+            # Order is a credit: always add to balance
+            balance_change = -total_amount
+            # Track how much existing debt was cleared
+            if customer_balance < 0:
+                applied_balance_amount = min(-total_amount, -customer_balance)
             else:
-                # Order is a credit: always add to balance
-                balance_change = -total_amount
-                # Track how much existing debt was cleared
-                if customer_balance < 0:
-                    applied_balance_amount = min(-total_amount, -customer_balance)
-                else:
-                    applied_balance_amount = 0
+                applied_balance_amount = 0
 
-            repository = OrderRepository.from_session(session)
-            order = await repository.create(
-                Order(
-                    id=order_id,
-                    status=OrderStatus.pending,
-                    subtotal_amount=subtotal_amount,
-                    discount_amount=discount_amount,
-                    tax_amount=tax_amount,
-                    net_amount=net_amount,
-                    applied_balance_amount=applied_balance_amount,
-                    currency=subscription.currency,
-                    billing_reason=billing_reason,
-                    billing_name=customer.billing_name,
-                    billing_address=billing_address,
-                    tax_behavior=tax_behavior,
-                    tax_id=tax_id,
-                    tax_breakdown=tax_breakdown or None,
-                    tax_processor=tax_processor,
-                    tax_calculation_processor_id=tax_calculation_processor_id,
-                    invoice_number=invoice_number,
-                    organization=subscription.organization,
-                    customer=customer,
-                    product=subscription.product,
-                    discount=discount,
-                    subscription=subscription,
-                    checkout=None,
-                    items=items,
-                    user_metadata=subscription.user_metadata,
-                    custom_field_data=subscription.custom_field_data,
-                ),
-                flush=True,
+        repository = OrderRepository.from_session(session)
+        order = await repository.create(
+            Order(
+                id=order_id,
+                status=OrderStatus.pending,
+                subtotal_amount=subtotal_amount,
+                discount_amount=discount_amount,
+                tax_amount=tax_amount,
+                net_amount=net_amount,
+                applied_balance_amount=applied_balance_amount,
+                currency=subscription.currency,
+                billing_reason=billing_reason,
+                billing_name=customer.billing_name,
+                billing_address=billing_address,
+                tax_behavior=tax_behavior,
+                tax_id=tax_id,
+                tax_breakdown=tax_breakdown or None,
+                tax_processor=tax_processor,
+                tax_calculation_processor_id=tax_calculation_processor_id,
+                invoice_number=invoice_number,
+                organization=subscription.organization,
+                customer=customer,
+                product=subscription.product,
+                discount=discount,
+                subscription=subscription,
+                checkout=None,
+                items=items,
+                user_metadata=subscription.user_metadata,
+                custom_field_data=subscription.custom_field_data,
+            ),
+            flush=True,
+        )
+
+        subscription.update_net_amount_from(order)
+
+        # Impact customer's balance
+        if balance_change != 0:
+            await wallet_service.create_balance_transaction(
+                session,
+                customer,
+                balance_change,
+                subscription.currency,
+                order=order,
             )
 
-            subscription.update_net_amount_from(order)
+        # Reset the associated meters, if any
+        # Note: subscription_update is intentionally excluded - meter credits from
+        # benefit grants should persist within a billing cycle. Subscription updates
+        # are for prorations, not new billing periods.
+        if billing_reason in {
+            OrderBillingReasonInternal.subscription_cycle,
+            OrderBillingReasonInternal.subscription_cycle_after_trial,
+            OrderBillingReasonInternal.subscription_cancel,
+        }:
+            await subscription_service.reset_meters(session, subscription)
 
-            # Impact customer's balance
-            if balance_change != 0:
-                await wallet_service.create_balance_transaction(
-                    session,
-                    customer,
-                    balance_change,
-                    subscription.currency,
-                    order=order,
-                )
-
-            # Reset the associated meters, if any
-            # Note: subscription_update is intentionally excluded - meter credits from
-            # benefit grants should persist within a billing cycle. Subscription updates
-            # are for prorations, not new billing periods.
-            if billing_reason in {
-                OrderBillingReasonInternal.subscription_cycle,
-                OrderBillingReasonInternal.subscription_cycle_after_trial,
-                OrderBillingReasonInternal.subscription_cancel,
-            }:
-                await subscription_service.reset_meters(session, subscription)
-
-            # If the due amount is less or equal than zero, mark it as paid immediately
-            if order.due_amount <= 0:
-                order = await repository.update(
-                    order, update_dict={"status": OrderStatus.paid}
-                )
-                await self._emit_balance_credit_order_event(
-                    session, order, subscription.organization
-                )
-            # Sync mode, attempt payment immediately and raise if it fails
-            elif payment_mode == PaymentMode.sync:
-                payment_method_id = (
-                    subscription.payment_method_id or customer.default_payment_method_id
-                )
-                if payment_method_id is None:
-                    raise PaymentFailed(PaymentFailedReason.missing_payment_method)
-                payment_method_repository = PaymentMethodRepository.from_session(
-                    session
-                )
-                payment_method = await payment_method_repository.get_by_id(
-                    payment_method_id
-                )
-                assert payment_method is not None
-                await self.trigger_payment(
-                    session,
-                    order,
-                    payment_method,
-                    payment_mode=payment_mode,
+        # If the due amount is less or equal than zero, mark it as paid immediately
+        if order.due_amount <= 0:
+            order = await repository.update(
+                order, update_dict={"status": OrderStatus.paid}
+            )
+            await self._emit_balance_credit_order_event(
+                session, order, subscription.organization
+            )
+        # Sync mode, attempt payment immediately and raise if it fails
+        elif payment_mode == PaymentMode.sync:
+            payment_method_id = (
+                subscription.payment_method_id or customer.default_payment_method_id
+            )
+            if payment_method_id is None:
+                raise PaymentFailed(PaymentFailedReason.missing_payment_method)
+            payment_method_repository = PaymentMethodRepository.from_session(session)
+            payment_method = await payment_method_repository.get_by_id(
+                payment_method_id
+            )
+            assert payment_method is not None
+            await self.trigger_payment(
+                session,
+                order,
+                payment_method,
+                payment_mode=payment_mode,
+                payment_trigger=PaymentTrigger.subscription_cycle,
+            )
+        # Async mode, allow payment to fail and be retried later
+        else:
+            payment_method_id = (
+                subscription.payment_method_id or customer.default_payment_method_id
+            )
+            if payment_method_id is None:
+                order = await self.handle_payment_failure(session, order)
+            else:
+                enqueue_job(
+                    "order.trigger_payment",
+                    order_id=order.id,
+                    payment_method_id=payment_method_id,
                     payment_trigger=PaymentTrigger.subscription_cycle,
                 )
-            # Async mode, allow payment to fail and be retried later
-            else:
-                payment_method_id = (
-                    subscription.payment_method_id or customer.default_payment_method_id
-                )
-                if payment_method_id is None:
-                    order = await self.handle_payment_failure(session, order)
-                else:
-                    enqueue_job(
-                        "order.trigger_payment",
-                        order_id=order.id,
-                        payment_method_id=payment_method_id,
-                        payment_trigger=PaymentTrigger.subscription_cycle,
-                    )
 
-            await self._on_order_created(session, order)
+        await self._on_order_created(session, order)
 
-            return order
+        return order
 
     async def create_trial_order(
         self,


### PR DESCRIPTION
Preparation for #12510

Easiest to review in "hide whitespace" mode.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Extracted subscription order finalization into a reusable private helper to simplify `create_subscription_order` and enable reuse for other item sources. No behavior change; discount, tax, balance, and payment logic remain the same.

- **Refactors**
  - Added `_create_order(session, subscription, items, billing_reason, payment_mode)` to finalize orders from pre-built line items.
  - `create_subscription_order` now delegates to `_create_order`; prepares for a future caller to settle meter-cycle overage.

<sup>Written for commit 910a0e6402d0a5a8b5e31c8cf0a44cf76e4f6622. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

