### PR TITLE
fx: Only lookup FX if it makes a difference (non zero)

### DIFF
--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -2772,16 +2772,17 @@ class OrderService:
             if order.product_id is not None:
                 credit_metadata["product_id"] = str(order.product_id)
 
-            event_repository = EventRepository.from_session(session)
-            exchange_rate = (
-                await event_repository.get_recent_balance_order_exchange_rate(
-                    organization.id,
-                    order.currency,
-                    before=order.created_at,
+            if order.net_amount != 0:
+                event_repository = EventRepository.from_session(session)
+                exchange_rate = (
+                    await event_repository.get_recent_balance_order_exchange_rate(
+                        organization.id,
+                        order.currency,
+                        before=order.created_at,
+                    )
                 )
-            )
-            if exchange_rate is not None:
-                credit_metadata["exchange_rate"] = exchange_rate
+                if exchange_rate is not None:
+                    credit_metadata["exchange_rate"] = exchange_rate
 
             credit_event = build_system_event(
                 SystemEvent.balance_credit_order,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Skip FX rate lookup for zero net amount orders in balance credit events. This avoids unnecessary DB queries and prevents adding exchange_rate metadata when it has no effect.

<sup>Written for commit 91c43ff42d0b42be9ad842d6fe84901172ad1785. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

