### PR TITLE
Add a scoped "finance" organization role

### DIFF
--- a/server/polar/auth/permission.py
+++ b/server/polar/auth/permission.py
@@ -13,6 +13,11 @@ maps each `OrganizationRole` to the set of permissions it grants. `owner` and
 invariants (singularity per org, member-removal exemption), not by additional
 permissions. The `organizations:transfer_ownership` permission is reserved
 for a future self-serve transfer flow and will be owner-only when introduced.
+
+`finance` is a scoped role: read + write on sales, read-only on the data
+models sales depend on (finance, customers, products, custom fields,
+analytics), and nothing else — no member, organization, or write access
+beyond sales.
 """
 
 from enum import StrEnum
@@ -80,10 +85,24 @@ _MEMBER_PERMISSIONS: set[OrganizationPermission] = {
     OrganizationPermission.events_ingest,
 }
 
+# `finance` role: read + write on sales, read-only on the data models sales
+# relate to, and no other permissions (no member/org management, no writes
+# outside sales, no event ingestion).
+_FINANCE_PERMISSIONS: set[OrganizationPermission] = {
+    OrganizationPermission.sales_read,
+    OrganizationPermission.sales_manage,
+    OrganizationPermission.finance_read,
+    OrganizationPermission.customers_read,
+    OrganizationPermission.products_read,
+    OrganizationPermission.custom_fields_read,
+    OrganizationPermission.analytics_read,
+}
+
 ROLE_PERMISSIONS: dict[OrganizationRole, set[OrganizationPermission]] = {
     OrganizationRole.member: _MEMBER_PERMISSIONS,
     OrganizationRole.admin: _MEMBER_PERMISSIONS | _ADMIN_ONLY,
     OrganizationRole.owner: _MEMBER_PERMISSIONS | _ADMIN_ONLY,
+    OrganizationRole.finance: _FINANCE_PERMISSIONS,
 }
 
 

--- a/server/polar/models/user_organization.py
+++ b/server/polar/models/user_organization.py
@@ -16,6 +16,7 @@ class OrganizationRole(StrEnum):
     owner = "owner"
     admin = "admin"
     member = "member"
+    finance = "finance"
 
 
 class OrganizationNotificationSettings(TypedDict):

--- a/server/polar/user_organization/schemas.py
+++ b/server/polar/user_organization/schemas.py
@@ -32,7 +32,11 @@ class OrganizationMemberInvite(Schema):
 
 
 class OrganizationMemberRoleUpdate(Schema):
-    role: Literal[OrganizationRole.admin, OrganizationRole.member] = Field(
+    role: Literal[
+        OrganizationRole.admin,
+        OrganizationRole.member,
+        OrganizationRole.finance,
+    ] = Field(
         description=(
             "The role to assign. `owner` is rejected — ownership transfers "
             "go through a separate flow."

--- a/server/tests/auth/test_permission.py
+++ b/server/tests/auth/test_permission.py
@@ -1,0 +1,54 @@
+from polar.auth.permission import (
+    ROLE_PERMISSIONS,
+    OrganizationPermission,
+    roles_with_permission,
+)
+from polar.models.user_organization import OrganizationRole
+
+
+class TestFinanceRolePermissions:
+    """The `finance` role: read + write on sales, read-only on related data
+    models, and no permissions for anything else."""
+
+    def test_has_read_and_write_on_sales(self) -> None:
+        permissions = ROLE_PERMISSIONS[OrganizationRole.finance]
+        assert OrganizationPermission.sales_read in permissions
+        assert OrganizationPermission.sales_manage in permissions
+
+    def test_has_read_only_on_related_models(self) -> None:
+        permissions = ROLE_PERMISSIONS[OrganizationRole.finance]
+        assert OrganizationPermission.finance_read in permissions
+        assert OrganizationPermission.customers_read in permissions
+        assert OrganizationPermission.products_read in permissions
+        assert OrganizationPermission.custom_fields_read in permissions
+        assert OrganizationPermission.analytics_read in permissions
+
+    def test_has_no_write_outside_sales(self) -> None:
+        permissions = ROLE_PERMISSIONS[OrganizationRole.finance]
+        manage_permissions = {
+            p for p in OrganizationPermission if p.value.endswith(":manage")
+        }
+        assert manage_permissions & permissions == {
+            OrganizationPermission.sales_manage
+        }
+
+    def test_has_no_unrelated_permissions(self) -> None:
+        permissions = ROLE_PERMISSIONS[OrganizationRole.finance]
+        assert OrganizationPermission.organization_manage not in permissions
+        assert OrganizationPermission.members_read not in permissions
+        assert OrganizationPermission.members_manage not in permissions
+        assert OrganizationPermission.events_ingest not in permissions
+        assert OrganizationPermission.finance_manage not in permissions
+
+    def test_grants_sales_access(self) -> None:
+        assert OrganizationRole.finance in roles_with_permission(
+            OrganizationPermission.sales_read
+        )
+        assert OrganizationRole.finance in roles_with_permission(
+            OrganizationPermission.sales_manage
+        )
+
+    def test_does_not_grant_member_management(self) -> None:
+        assert OrganizationRole.finance not in roles_with_permission(
+            OrganizationPermission.members_manage
+        )

--- a/server/tests/authz/test_policies.py
+++ b/server/tests/authz/test_policies.py
@@ -65,6 +65,35 @@ class TestFinanceCanRead:
         assert isinstance(result, str)
         assert "permission" in result.lower()
 
+    @pytest.mark.auth
+    async def test_finance_allowed(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await _set_role(save_fixture, user_organization, OrganizationRole.finance)
+
+        result = await finance_policy.can_read(session, auth_subject, organization)
+        assert result is True
+
+    @pytest.mark.auth
+    async def test_finance_denied_manage(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await _set_role(save_fixture, user_organization, OrganizationRole.finance)
+
+        result = await finance_policy.can_manage(session, auth_subject, organization)
+        assert isinstance(result, str)
+        assert "permission" in result.lower()
+
     @pytest.mark.auth(AuthSubjectFixture(subject="organization"))
     async def test_organization_subject_allowed(
         self,
@@ -134,6 +163,20 @@ class TestMembersCanManage:
         user_organization: UserOrganization,
     ) -> None:
         await _set_role(save_fixture, user_organization, OrganizationRole.member)
+
+        result = await members.can_manage(session, auth_subject, organization)
+        assert result == "You don't have permission to manage members"
+
+    @pytest.mark.auth
+    async def test_finance_denied(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await _set_role(save_fixture, user_organization, OrganizationRole.finance)
 
         result = await members.can_manage(session, auth_subject, organization)
         assert result == "You don't have permission to manage members"


### PR DESCRIPTION
(Still need to test locally how the dashboard behaves)

Prototype a Finance role in the organization RBAC system: read + write on sales, read-only on the data models sales relate to (finance, customers, products, custom fields, analytics), and no other permissions.

- Add `OrganizationRole.finance` (StringEnum column → no migration needed).
- Map the role to its permission set in `ROLE_PERMISSIONS`; `roles_with_permission` derives endpoint access from this map, so sales endpoints accept the role and member/org/finance-management endpoints reject it automatically.
- Allow assigning `finance` via the member role-update endpoint.
- Cover the role contract with unit and policy tests.


Claude-Session: https://claude.ai/code/session_0116Zpm4mjd5reDCzQtiQDWN


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

