### PR TITLE
Improve event type selector

### DIFF
--- a/clients/apps/web/src/components/Customer/CustomerEventsView.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerEventsView.tsx
@@ -2,7 +2,8 @@ import { useInfiniteEvents } from '@/hooks/queries/events'
 import { schemas } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
 import { TabsContent } from '@polar-sh/orbit'
-import { parseAsString, useQueryState } from 'nuqs'
+import { parseAsArrayOf, parseAsString, useQueryState } from 'nuqs'
+import { useMemo } from 'react'
 import { Events } from '../Events/Events'
 import EventSelect from '../Events/EventSelect'
 import MeterSelector from '../Meter/MeterSelector'
@@ -19,9 +20,13 @@ export const CustomerEventsView = ({
   dateRange: { startDate: Date; endDate: Date }
 }) => {
   const [meterId, setMeterId] = useQueryState('meterId', parseAsString)
-  const [eventName, setEventName] = useQueryState(
+  const [eventNamesRaw, setEventNames] = useQueryState(
     'eventName',
-    parseAsString.withDefault('all'),
+    parseAsArrayOf(parseAsString).withDefault([]),
+  )
+  const eventNames = useMemo(
+    () => eventNamesRaw.filter((name) => name !== 'all'),
+    [eventNamesRaw],
   )
 
   const {
@@ -33,7 +38,7 @@ export const CustomerEventsView = ({
     limit: 50,
     customer_id: customer.id,
     ...(meterId ? { meter_id: meterId } : {}),
-    ...(eventName !== 'all' ? { name: eventName } : {}),
+    ...(eventNames.length ? { name: eventNames } : {}),
     ...(dateRange?.startDate
       ? { start_timestamp: dateRange.startDate.toISOString() }
       : {}),
@@ -48,15 +53,8 @@ export const CustomerEventsView = ({
         <EventSelect
           className="w-auto min-w-64"
           organizationId={customer.organization_id}
-          allOption
-          value={eventName}
-          onValueChange={(eventName) => {
-            if (eventName === 'all') {
-              setEventName(null)
-            } else {
-              setEventName(eventName)
-            }
-          }}
+          value={eventNames}
+          onChange={(names) => setEventNames(names.length ? names : null)}
         />
         <MeterSelector
           className="min-w-64"

--- a/clients/apps/web/src/components/Customer/CustomerEventsView.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerEventsView.tsx
@@ -3,7 +3,6 @@ import { schemas } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
 import { TabsContent } from '@polar-sh/orbit'
 import { parseAsArrayOf, parseAsString, useQueryState } from 'nuqs'
-import { useMemo } from 'react'
 import { Events } from '../Events/Events'
 import EventSelect from '../Events/EventSelect'
 import MeterSelector from '../Meter/MeterSelector'
@@ -20,13 +19,9 @@ export const CustomerEventsView = ({
   dateRange: { startDate: Date; endDate: Date }
 }) => {
   const [meterId, setMeterId] = useQueryState('meterId', parseAsString)
-  const [eventNamesRaw, setEventNames] = useQueryState(
+  const [eventNames, setEventNames] = useQueryState(
     'eventName',
     parseAsArrayOf(parseAsString).withDefault([]),
-  )
-  const eventNames = useMemo(
-    () => eventNamesRaw.filter((name) => name !== 'all'),
-    [eventNamesRaw],
   )
 
   const {

--- a/clients/apps/web/src/components/Events/EventSelect.tsx
+++ b/clients/apps/web/src/components/Events/EventSelect.tsx
@@ -1,40 +1,232 @@
 import { useEventNames } from '@/hooks/queries/events'
-import ShortTextOutlined from '@mui/icons-material/ShortTextOutlined'
+import { schemas } from '@polar-sh/client'
+import { Button } from '@polar-sh/orbit/ui/button'
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@polar-sh/orbit'
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '@polar-sh/ui/components/ui/command'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@polar-sh/ui/components/ui/popover'
+import { Check, ChevronsUpDown } from 'lucide-react'
+import React, { useCallback, useMemo, useState } from 'react'
+import { twMerge } from 'tailwind-merge'
 
-const EventSelect: React.FC<
-  React.ComponentProps<typeof Select> & {
-    className?: string
-    organizationId: string
-    allOption?: boolean
+const EVENT_SOURCE_LABELS: Record<schemas['EventSource'], string> = {
+  system: 'System Events',
+  user: 'Custom Events',
+}
+
+const EventsCommandGroup = ({
+  source,
+  eventNames,
+  value,
+  onSelectEvent,
+  onSelectAll,
+}: {
+  source: schemas['EventSource']
+  eventNames: schemas['EventName'][]
+  value: string[]
+  onSelectEvent: (name: string) => void
+  onSelectAll: (names: string[]) => void
+}) => {
+  const names = useMemo(() => eventNames.map(({ name }) => name), [eventNames])
+  const areAllSelected = useMemo(
+    () => names.length > 0 && names.every((name) => value.includes(name)),
+    [names, value],
+  )
+
+  if (eventNames.length === 0) {
+    return null
   }
-> = ({ organizationId, allOption, className, ...props }) => {
-  const { data } = useEventNames(organizationId)
-  const eventNames = data?.pages.flatMap((page) => page.items) ?? []
 
   return (
-    <Select {...props}>
-      <SelectTrigger className={className}>
-        <div className="flex flex-row items-center gap-x-2">
-          <ShortTextOutlined fontSize="inherit" />
-          <SelectValue placeholder="Select an event" />
-        </div>
-      </SelectTrigger>
-      <SelectContent>
-        {allOption && <SelectItem value="all">All Events</SelectItem>}
-        {eventNames.map((eventName) => (
-          <SelectItem key={eventName.name} value={eventName.name}>
-            {eventName.name}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+    <CommandGroup>
+      <CommandItem
+        className="flex flex-row items-center justify-between py-2 text-black dark:text-white"
+        value={source}
+        onSelect={() => onSelectAll(names)}
+      >
+        <span className="font-medium">{EVENT_SOURCE_LABELS[source]}</span>
+        <span className="text-xs opacity-70">
+          {areAllSelected ? 'Deselect all' : `Select all ${names.length}`}
+        </span>
+      </CommandItem>
+      {eventNames.map((eventName) => (
+        <CommandItem
+          className="flex flex-row items-center justify-between text-black dark:text-white"
+          key={eventName.name}
+          value={eventName.name}
+          onSelect={() => onSelectEvent(eventName.name)}
+        >
+          {eventName.label}
+          <Check
+            className={twMerge(
+              'ml-auto h-4 w-4',
+              value.includes(eventName.name) ? 'opacity-100' : 'opacity-0',
+            )}
+          />
+        </CommandItem>
+      ))}
+    </CommandGroup>
+  )
+}
+
+interface EventSelectProps {
+  organizationId: string
+  value: string[]
+  onChange: (value: string[]) => void
+  emptyLabel?: string
+  className?: string
+}
+
+const EventSelect: React.FC<EventSelectProps> = ({
+  organizationId,
+  value,
+  onChange,
+  emptyLabel,
+  className,
+}) => {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+
+  const { data } = useEventNames(organizationId, {
+    limit: 100,
+    sorting: ['name'],
+  })
+
+  const eventNames = useMemo(
+    () => data?.pages.flatMap((page) => page.items) ?? [],
+    [data],
+  )
+
+  const groupedEventNames = useMemo<
+    Record<schemas['EventSource'], schemas['EventName'][]>
+  >(() => {
+    const normalizedQuery = query.trim().toLowerCase()
+    return eventNames.reduce<
+      Record<schemas['EventSource'], schemas['EventName'][]>
+    >(
+      (acc, eventName) => {
+        if (
+          normalizedQuery &&
+          !eventName.name.toLowerCase().includes(normalizedQuery) &&
+          !eventName.label.toLowerCase().includes(normalizedQuery)
+        ) {
+          return acc
+        }
+        return {
+          ...acc,
+          [eventName.source]: [...acc[eventName.source], eventName],
+        }
+      },
+      { system: [], user: [] },
+    )
+  }, [eventNames, query])
+
+  const hasResults =
+    groupedEventNames.system.length > 0 || groupedEventNames.user.length > 0
+
+  const buttonLabel = useMemo(() => {
+    if (value.length === 0) {
+      return emptyLabel || 'All events'
+    }
+    if (value.length === 1) {
+      const selected = eventNames.find(({ name }) => name === value[0])
+      return selected?.label ?? value[0]
+    }
+    return `${value.length} events`
+  }, [value, emptyLabel, eventNames])
+
+  const onSelectEvent = useCallback(
+    (name: string) => {
+      if (value.includes(name)) {
+        onChange(value.filter((selected) => selected !== name))
+      } else {
+        onChange([...value, name])
+      }
+    },
+    [onChange, value],
+  )
+
+  const onSelectAll = useCallback(
+    (names: string[]) => {
+      const allSelected = names.every((name) => value.includes(name))
+      if (allSelected) {
+        onChange(value.filter((selected) => !names.includes(selected)))
+      } else {
+        onChange([
+          ...value,
+          ...names.filter((name) => !value.includes(name)),
+        ])
+      }
+    },
+    [onChange, value],
+  )
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className={twMerge(
+            'dark:bg-polar-800 dark:hover:bg-polar-700 dark:hover:border-polar-700 dark:border-polar-700 flex w-full flex-row justify-between gap-x-2 rounded-lg border border-gray-200 bg-white px-3 font-normal shadow-xs transition-colors hover:bg-gray-50 hover:text-black dark:hover:text-white',
+            className,
+          )}
+        >
+          <span className="overflow-hidden text-ellipsis whitespace-nowrap">
+            {buttonLabel}
+          </span>
+          <ChevronsUpDown className="opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-(--radix-popover-trigger-width) rounded-xl p-0"
+      >
+        <Command shouldFilter={false} className="rounded-xl">
+          <CommandInput
+            className="h-9 border-0 focus:ring-0 focus:outline-0"
+            placeholder="Search events…"
+            value={query}
+            onValueChange={setQuery}
+          />
+          <CommandList>
+            {hasResults ? (
+              <>
+                <EventsCommandGroup
+                  source="system"
+                  eventNames={groupedEventNames.system}
+                  value={value}
+                  onSelectEvent={onSelectEvent}
+                  onSelectAll={onSelectAll}
+                />
+                {groupedEventNames.system.length > 0 &&
+                  groupedEventNames.user.length > 0 && <CommandSeparator />}
+                <EventsCommandGroup
+                  source="user"
+                  eventNames={groupedEventNames.user}
+                  value={value}
+                  onSelectEvent={onSelectEvent}
+                  onSelectAll={onSelectAll}
+                />
+              </>
+            ) : (
+              <CommandEmpty>No events found</CommandEmpty>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
   )
 }
 

--- a/clients/apps/web/src/components/Events/EventSelect.tsx
+++ b/clients/apps/web/src/components/Events/EventSelect.tsx
@@ -162,10 +162,7 @@ const EventSelect: React.FC<EventSelectProps> = ({
       if (allSelected) {
         onChange(value.filter((selected) => !names.includes(selected)))
       } else {
-        onChange([
-          ...value,
-          ...names.filter((name) => !value.includes(name)),
-        ])
+        onChange([...value, ...names.filter((name) => !value.includes(name))])
       }
     },
     [onChange, value],

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -20132,6 +20132,11 @@ export interface components {
        * @description The name of the event.
        */
       name: string
+      /**
+       * Label
+       * @description Human readable label of the event.
+       */
+      label: string
       /** @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API. */
       source: components['schemas']['EventSource']
       /**

--- a/server/polar/event/schemas.py
+++ b/server/polar/event/schemas.py
@@ -660,6 +660,7 @@ EventTypeAdapter: TypeAdapter[Event] = TypeAdapter(Event)
 
 class EventName(Schema):
     name: str = Field(description="The name of the event.")
+    label: str = Field(description="Human readable label of the event.")
     source: EventSource = Field(description=_SOURCE_DESCRIPTION)
     occurrences: int = Field(description="Number of times the event has occurred.")
     first_seen: datetime = Field(description="The first time the event occurred.")

--- a/server/polar/event/service.py
+++ b/server/polar/event/service.py
@@ -66,7 +66,7 @@ from .schemas import (
     VarianceEvent,
 )
 from .sorting import EventNamesSortProperty, EventSortProperty
-from .system import SystemEvent
+from .system import SYSTEM_EVENT_LABELS, SystemEvent
 
 log: Logger = structlog.get_logger()
 
@@ -779,9 +779,25 @@ class EventService:
         end = start + pagination.limit
         paginated_stats = tinybird_stats[start:end]
 
+        event_type_repository = EventTypeRepository.from_session(session)
+        event_types_by_name = await event_type_repository.get_by_names_and_organization(
+            [name for name, *_ in paginated_stats], list(organization_ids)
+        )
+        event_type_labels = {
+            name: event_type.label
+            for (_, name), event_type in event_types_by_name.items()
+        }
+
+        def _resolve_label(name: str, event_source: EventSource) -> str:
+            fallback = event_type_labels.get(name, name)
+            if event_source == EventSource.system:
+                return SYSTEM_EVENT_LABELS.get(name, fallback)
+            return fallback
+
         event_names = [
             EventName(
                 name=name,
+                label=_resolve_label(name, event_source),
                 source=event_source,
                 occurrences=occurrences,
                 first_seen=first_seen,

--- a/server/polar/event/service.py
+++ b/server/polar/event/service.py
@@ -783,9 +783,14 @@ class EventService:
         event_types_by_name = await event_type_repository.get_by_names_and_organization(
             [name for name, *_ in paginated_stats], list(organization_ids)
         )
+        labels_by_name: dict[str, set[str]] = {}
+        for (_, name), event_type in event_types_by_name.items():
+            labels_by_name.setdefault(name, set()).add(event_type.label)
+        # Fall back to the event name when accessible orgs disagree on the label
         event_type_labels = {
-            name: event_type.label
-            for (_, name), event_type in event_types_by_name.items()
+            name: next(iter(labels))
+            for name, labels in labels_by_name.items()
+            if len(labels) == 1
         }
 
         def _resolve_label(name: str, event_source: EventSource) -> str:

--- a/server/tests/event/test_service.py
+++ b/server/tests/event/test_service.py
@@ -42,6 +42,7 @@ from polar.models.discount import DiscountDuration, DiscountType
 from polar.models.event import EventSource
 from polar.models.order import OrderStatus
 from polar.models.subscription import CustomerCancellationReason
+from polar.models.user_organization import OrganizationRole
 from polar.order.service import order as order_service
 from polar.postgres import AsyncSession
 from polar.subscription.service import SubscriptionUpdateContext
@@ -476,6 +477,126 @@ class TestListNames:
         assert labels["customer.created"] == "Customer Created"
         assert labels["api.request"] == "API Request"
         assert labels["custom.event"] == "custom.event"
+
+    @pytest.mark.auth(AuthSubjectFixture(subject="user"))
+    async def test_resolves_conflicting_labels_across_organizations(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user: User,
+        organization: Organization,
+        organization_second: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await save_fixture(
+            UserOrganization(
+                user=user,
+                organization=organization_second,
+                role=OrganizationRole.owner,
+            )
+        )
+        await save_fixture(
+            EventType(
+                name="custom.event",
+                label="Custom Event",
+                organization=organization,
+            )
+        )
+        await save_fixture(
+            EventType(
+                name="custom.event",
+                label="Bespoke Event",
+                organization=organization_second,
+            )
+        )
+
+        now = utc_now()
+        mocker.patch(
+            "polar.event.tinybird_repository.TinybirdEventsQuery.get_event_type_stats",
+            new_callable=AsyncMock,
+            return_value=[
+                TinybirdEventTypeStats(
+                    organization_id=organization.id,
+                    name="custom.event",
+                    source=EventSource.user,
+                    occurrences=5,
+                    first_seen=now,
+                    last_seen=now,
+                ),
+            ],
+        )
+
+        event_names, _ = await event_service.list_names(
+            session,
+            auth_subject,
+            pagination=PaginationParams(1, 10),
+            sorting=[(EventNamesSortProperty.event_name, False)],
+        )
+
+        labels = {event_name.name: event_name.label for event_name in event_names}
+        assert labels["custom.event"] == "custom.event"
+
+    @pytest.mark.auth(AuthSubjectFixture(subject="user"))
+    async def test_resolves_matching_labels_across_organizations(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user: User,
+        organization: Organization,
+        organization_second: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await save_fixture(
+            UserOrganization(
+                user=user,
+                organization=organization_second,
+                role=OrganizationRole.owner,
+            )
+        )
+        await save_fixture(
+            EventType(
+                name="custom.event",
+                label="Custom Event",
+                organization=organization,
+            )
+        )
+        await save_fixture(
+            EventType(
+                name="custom.event",
+                label="Custom Event",
+                organization=organization_second,
+            )
+        )
+
+        now = utc_now()
+        mocker.patch(
+            "polar.event.tinybird_repository.TinybirdEventsQuery.get_event_type_stats",
+            new_callable=AsyncMock,
+            return_value=[
+                TinybirdEventTypeStats(
+                    organization_id=organization.id,
+                    name="custom.event",
+                    source=EventSource.user,
+                    occurrences=5,
+                    first_seen=now,
+                    last_seen=now,
+                ),
+            ],
+        )
+
+        event_names, _ = await event_service.list_names(
+            session,
+            auth_subject,
+            pagination=PaginationParams(1, 10),
+            sorting=[(EventNamesSortProperty.event_name, False)],
+        )
+
+        labels = {event_name.name: event_name.label for event_name in event_names}
+        assert labels["custom.event"] == "Custom Event"
 
 
 @pytest.mark.asyncio

--- a/server/tests/event/test_service.py
+++ b/server/tests/event/test_service.py
@@ -417,6 +417,66 @@ class TestListNames:
         assert count == 2
         query_mock.assert_awaited_once()
 
+    @pytest.mark.auth(AuthSubjectFixture(subject="organization"))
+    async def test_resolves_labels(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Organization],
+    ) -> None:
+        now = utc_now()
+        organization = auth_subject.subject
+        event_type = EventType(
+            name="api.request",
+            label="API Request",
+            organization=organization,
+        )
+        await save_fixture(event_type)
+
+        mocker.patch(
+            "polar.event.tinybird_repository.TinybirdEventsQuery.get_event_type_stats",
+            new_callable=AsyncMock,
+            return_value=[
+                TinybirdEventTypeStats(
+                    organization_id=organization.id,
+                    name="customer.created",
+                    source=EventSource.system,
+                    occurrences=1,
+                    first_seen=now,
+                    last_seen=now,
+                ),
+                TinybirdEventTypeStats(
+                    organization_id=organization.id,
+                    name="api.request",
+                    source=EventSource.user,
+                    occurrences=2,
+                    first_seen=now,
+                    last_seen=now,
+                ),
+                TinybirdEventTypeStats(
+                    organization_id=organization.id,
+                    name="custom.event",
+                    source=EventSource.user,
+                    occurrences=3,
+                    first_seen=now,
+                    last_seen=now,
+                ),
+            ],
+        )
+
+        event_names, _ = await event_service.list_names(
+            session,
+            auth_subject,
+            pagination=PaginationParams(1, 10),
+            sorting=[(EventNamesSortProperty.event_name, False)],
+        )
+
+        labels = {event_name.name: event_name.label for event_name in event_names}
+        assert labels["customer.created"] == "Customer Created"
+        assert labels["api.request"] == "API Request"
+        assert labels["custom.event"] == "custom.event"
+
 
 @pytest.mark.asyncio
 class TestIngest:


### PR DESCRIPTION
<img width="350" height="436" alt="image" src="https://github.com/user-attachments/assets/7af3d10e-f1e6-47de-bd83-8ce549026803" />

Allow to select all custom events & all system events, and use the friendly event labels instead of the system names.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

