### PR TITLE
fix strong weight in prose

### DIFF
--- a/clients/apps/orbit-demo/next-env.d.ts
+++ b/clients/apps/orbit-demo/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/clients/apps/orbit-demo/next-env.d.ts
+++ b/clients/apps/orbit-demo/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/dev/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/clients/apps/web/src/components/MDX/ProseWrapper.tsx
+++ b/clients/apps/web/src/components/MDX/ProseWrapper.tsx
@@ -12,7 +12,7 @@ const ProseWrapper = ({
         'prose dark:prose-invert prose-p:text-lg text-black dark:text-white',
         'prose-p:tracking-normal prose-p:leading-relaxed prose-hr:border-gray-300 dark:prose-hr:border-polar-600',
         'prose-img:rounded-lg prose-img:shadow-xs prose-img:border prose-img:border-gray-200 dark:prose-img:border-polar-800',
-        'prose-headings:text-black prose-h1:text-5xl prose-h2:text-3xl prose-h3:text-2xl prose-h4:text-xl prose-h5:text-lg prose-h6:text-md dark:prose-headings:text-white prose-headings:font-medium prose-headings:font-display',
+        'prose-headings:text-black prose-h1:text-5xl prose-h2:text-3xl prose-h3:text-2xl prose-h4:text-xl prose-h5:text-lg prose-h6:text-md dark:prose-headings:text-white prose-headings:font-medium prose-strong:font-medium prose-headings:font-display',
         'prose-pre:whitespace-pre-wrap dark:prose-pre:bg-polar-800 dark:prose-pre:border-polar-700 prose-pre:border prose-pre:border-transparent prose-pre:bg-gray-100 prose-pre:rounded-2xl prose-pre:text-gray-600 dark:prose-pre:text-polar-200',
         'prose-code:before:content-none prose-code:after:content-none prose-code:bg-gray-100 dark:prose-code:bg-polar-800 prose-code:font-normal prose-code:rounded-xs prose-code:px-1.5 prose-code:py-1',
       )}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adjust MDX prose so strong text uses medium weight for better readability. Remove `clients/apps/orbit-demo/next-env.d.ts` as it's not needed.

<sup>Written for commit 729b2274900d1f508cddf74655a829ba2d43e8b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

