### PR TITLE
refactor(sso): scope login via /{slug}/start and /{slug}/complete

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -1677,6 +1677,23 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/auth/{slug}/start': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Auth.Sso.Start */
+    post: operations['auth:auth.sso.start']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/auth/logout': {
     parameters: {
       query?: never
@@ -38173,6 +38190,41 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['TaxSummary']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'auth:auth.sso.start': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        slug: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['AuthenticationSessionStart']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['AuthenticationSession']
         }
       }
       /** @description Validation Error */

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -38227,6 +38227,15 @@ export interface operations {
           'application/json': components['schemas']['AuthenticationSession']
         }
       }
+      /** @description Organization not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
       /** @description Validation Error */
       422: {
         headers: {

--- a/server/polar/auth/endpoints.py
+++ b/server/polar/auth/endpoints.py
@@ -1,5 +1,4 @@
 import typing
-from uuid import UUID
 
 from fastapi import Depends, Request, Response
 from fastapi.responses import RedirectResponse
@@ -35,7 +34,6 @@ from polar.postgres import AsyncSession, get_db_session
 from polar.routing import APIRouter
 from polar.user.repository import UserRepository
 from polar.user.service import user as user_service
-from polar.user_organization.repository import UserOrganizationRepository
 
 from .authentication_session import (
     AuthenticationSessionService,
@@ -148,33 +146,15 @@ async def complete(
         raise PolarAuthRedirectionError("User not found for authenticated identity")
 
     context = authentication_session.context or {}
-    return_to = context.get("return_to")
-
-    # An SSO login carries its organization in the session context; mint a
-    # session down-scoped to it (other login methods stay unrestricted).
-    sso_organization_id = context.get("sso_organization_id")
-    organization_ids: frozenset[UUID] | None = None
     factor: LoginMethod = typing.cast(
         LoginMethod, authentication_session.used_factors[0]
     )
-    if sso_organization_id is not None:
-        organization_id = UUID(sso_organization_id)
-        user_organization_repository = UserOrganizationRepository.from_session(session)
-        membership = await user_organization_repository.get_by_user_and_organization(
-            user.id, organization_id
-        )
-        if membership is None:
-            raise PolarAuthRedirectionError("You are not a member of this organization")
-        organization_ids = frozenset({organization_id})
-        factor = "sso"
-
     response = await auth_service.get_login_response(
         session,
         request,
         user,
-        return_to=return_to,
+        return_to=context.get("return_to"),
         factor=factor,
-        organization_ids=organization_ids,
     )
     await authentication_session_service.set_cookie(request, response, "", 0)
     return response

--- a/server/polar/auth/sso/endpoints.py
+++ b/server/polar/auth/sso/endpoints.py
@@ -2,10 +2,12 @@ import secrets
 import typing
 from uuid import UUID
 
-from fastapi import Depends, Query, Request
+from fastapi import Depends, Query, Request, Response
 from fastapi.responses import RedirectResponse
 from reauth.authentication_session import (
     AuthenticationSession,
+    FactorsRemainingException,
+    IdentityNotAttachedException,
 )
 from reauth.factors import FactorBase
 from reauth.factors.oauth2.base import (
@@ -19,6 +21,7 @@ from reauth.factors.oauth2.state import ExpiredStateException, InvalidStateExcep
 from polar.config import settings
 from polar.exceptions import ResourceNotFound
 from polar.models import OrganizationSSOConnection
+from polar.openapi import APITag
 from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncSession, get_db_session
 from polar.routing import APIRouter
@@ -34,6 +37,9 @@ from ..authentication_session import (
 from ..exceptions import PolarAuthRedirectionError
 from ..factors import get_org_factors
 from ..helpers import OIDC_ERROR_MESSAGE, check_factor, set_state_cookie
+from ..schemas import AuthenticationSession as AuthenticationSessionSchema
+from ..schemas import AuthenticationSessionStart
+from ..service import auth as auth_service
 
 SSO_SCOPE = ["openid", "email"]
 
@@ -69,10 +75,32 @@ async def get_sso_factor(
     raise ResourceNotFound()
 
 
-router = APIRouter(prefix="/{slug}", include_in_schema=False)
+router = APIRouter(prefix="/{slug}")
 
 
-@router.get("/sso/{connection_id}/authorize", name="auth.sso.authorize")
+@router.post("/start", name="auth.sso.start", status_code=201, tags=[APITag.private])
+async def start(
+    request: Request,
+    response: Response,
+    authentication_session_start: AuthenticationSessionStart,
+    authentication_session_service: AuthenticationSessionService = Depends(
+        get_org_authentication_session_service
+    ),
+) -> AuthenticationSessionSchema:
+    token, authentication_session = await authentication_session_service.start(
+        return_to=authentication_session_start.return_to
+    )
+    await authentication_session_service.set_cookie(
+        request, response, token, authentication_session.expires_at
+    )
+    return await authentication_session_service.to_schema(authentication_session)
+
+
+@router.get(
+    "/sso/{connection_id}/authorize",
+    name="auth.sso.authorize",
+    include_in_schema=False,
+)
 async def authorize(
     request: Request,
     slug: str,
@@ -106,7 +134,11 @@ async def authorize(
     return response
 
 
-@router.get("/sso/{connection_id}/callback", name="auth.sso.callback")
+@router.get(
+    "/sso/{connection_id}/callback",
+    name="auth.sso.callback",
+    include_in_schema=False,
+)
 async def callback(
     request: Request,
     connection: OrganizationSSOConnection = Depends(get_sso_connection),
@@ -171,19 +203,63 @@ async def callback(
     if membership is None:
         raise PolarAuthRedirectionError("You are not a member of this organization")
 
-    authentication_session.context = {
-        **(authentication_session.context or {}),
-        "sso_organization_id": str(connection.organization_id),
-    }
     await authentication_session_service.advance(
         authentication_session, user.id, factor
     )
 
     # Like the social login flow, hand off to the frontend so any remaining
-    # factors (e.g. TOTP) are challenged before the session is completed. The
-    # SSO organization is carried in the session context for scoped minting.
+    # factors (e.g. TOTP) are challenged before the session completes
     response = RedirectResponse(
         settings.generate_frontend_url("/auth"), status_code=303
     )
     set_state_cookie(request, response, "", 0)
+    return response
+
+
+@router.get("/complete", name="auth.sso.complete", include_in_schema=False)
+async def complete(
+    request: Request,
+    slug: str,
+    authentication_session: AuthenticationSession = Depends(get_authentication_session),
+    authentication_session_service: AuthenticationSessionService = Depends(
+        get_org_authentication_session_service
+    ),
+    session: AsyncSession = Depends(get_db_session),
+) -> RedirectResponse:
+    organization_repository = OrganizationRepository.from_session(session)
+    organization = await organization_repository.get_by_slug(slug)
+    if organization is None:
+        raise ResourceNotFound()
+
+    try:
+        identity_id, _ = await authentication_session_service.complete(
+            authentication_session
+        )
+    except (IdentityNotAttachedException, FactorsRemainingException) as e:
+        raise PolarAuthRedirectionError(
+            "Authentication session cannot be completed"
+        ) from e
+
+    user_repository = UserRepository.from_session(session)
+    user = await user_repository.get_by_id(identity_id)
+    if user is None:
+        raise PolarAuthRedirectionError("User not found for authenticated identity")
+
+    user_organization_repository = UserOrganizationRepository.from_session(session)
+    membership = await user_organization_repository.get_by_user_and_organization(
+        user.id, organization.id
+    )
+    if membership is None:
+        raise PolarAuthRedirectionError("You are not a member of this organization")
+
+    context = authentication_session.context or {}
+    response = await auth_service.get_login_response(
+        session,
+        request,
+        user,
+        return_to=context.get("return_to"),
+        factor="sso",
+        organization_ids=frozenset({organization.id}),
+    )
+    await authentication_session_service.set_cookie(request, response, "", 0)
     return response

--- a/server/polar/auth/sso/endpoints.py
+++ b/server/polar/auth/sso/endpoints.py
@@ -78,7 +78,18 @@ async def get_sso_factor(
 router = APIRouter(prefix="/{slug}")
 
 
-@router.post("/start", name="auth.sso.start", status_code=201, tags=[APITag.private])
+@router.post(
+    "/start",
+    name="auth.sso.start",
+    status_code=201,
+    tags=[APITag.private],
+    responses={
+        404: {
+            "description": "Organization not found",
+            "model": ResourceNotFound.schema(),
+        }
+    },
+)
 async def start(
     request: Request,
     response: Response,

--- a/server/polar/auth/sso/endpoints.py
+++ b/server/polar/auth/sso/endpoints.py
@@ -20,7 +20,7 @@ from reauth.factors.oauth2.state import ExpiredStateException, InvalidStateExcep
 
 from polar.config import settings
 from polar.exceptions import ResourceNotFound
-from polar.models import OrganizationSSOConnection
+from polar.models import Organization, OrganizationSSOConnection
 from polar.openapi import APITag
 from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncSession, get_db_session
@@ -75,6 +75,33 @@ async def get_sso_factor(
     raise ResourceNotFound()
 
 
+async def get_login_organization(
+    slug: str,
+    session: AsyncSession = Depends(get_db_session),
+) -> Organization:
+    organization = await OrganizationRepository.from_session(session).get_by_slug(slug)
+    if organization is None:
+        raise ResourceNotFound()
+    return organization
+
+
+async def get_org_authentication_session(
+    organization: Organization = Depends(get_login_organization),
+    authentication_session: AuthenticationSession = Depends(get_authentication_session),
+) -> AuthenticationSession:
+    """The authentication session, verified to belong to the URL's organization.
+
+    A session is bound to its organization at `/{slug}/start`; this rejects a
+    session that is then driven to a different organization's endpoints.
+    """
+    context = authentication_session.context or {}
+    if context.get("organization_id") != str(organization.id):
+        raise PolarAuthRedirectionError(
+            "This authentication session was not started for this organization"
+        )
+    return authentication_session
+
+
 router = APIRouter(prefix="/{slug}")
 
 
@@ -94,6 +121,7 @@ async def start(
     request: Request,
     response: Response,
     authentication_session_start: AuthenticationSessionStart,
+    organization: Organization = Depends(get_login_organization),
     authentication_session_service: AuthenticationSessionService = Depends(
         get_org_authentication_session_service
     ),
@@ -101,6 +129,12 @@ async def start(
     token, authentication_session = await authentication_session_service.start(
         return_to=authentication_session_start.return_to
     )
+    # Bind the session to this organization; slug-scoped endpoints verify it.
+    authentication_session.context = {
+        **(authentication_session.context or {}),
+        "organization_id": str(organization.id),
+    }
+    await authentication_session_service.update(authentication_session)
     await authentication_session_service.set_cookie(
         request, response, token, authentication_session.expires_at
     )
@@ -116,7 +150,9 @@ async def authorize(
     request: Request,
     slug: str,
     connection_id: UUID,
-    authentication_session: AuthenticationSession = Depends(get_authentication_session),
+    authentication_session: AuthenticationSession = Depends(
+        get_org_authentication_session
+    ),
     authentication_session_service: AuthenticationSessionService = Depends(
         get_org_authentication_session_service
     ),
@@ -159,7 +195,9 @@ async def callback(
     error_description: str | None = Query(None),
     error_uri: str | None = Query(None),
     state: str | None = Query(None),
-    authentication_session: AuthenticationSession = Depends(get_authentication_session),
+    authentication_session: AuthenticationSession = Depends(
+        get_org_authentication_session
+    ),
     authentication_session_service: AuthenticationSessionService = Depends(
         get_org_authentication_session_service
     ),
@@ -230,18 +268,15 @@ async def callback(
 @router.get("/complete", name="auth.sso.complete", include_in_schema=False)
 async def complete(
     request: Request,
-    slug: str,
-    authentication_session: AuthenticationSession = Depends(get_authentication_session),
+    organization: Organization = Depends(get_login_organization),
+    authentication_session: AuthenticationSession = Depends(
+        get_org_authentication_session
+    ),
     authentication_session_service: AuthenticationSessionService = Depends(
         get_org_authentication_session_service
     ),
     session: AsyncSession = Depends(get_db_session),
 ) -> RedirectResponse:
-    organization_repository = OrganizationRepository.from_session(session)
-    organization = await organization_repository.get_by_slug(slug)
-    if organization is None:
-        raise ResourceNotFound()
-
     try:
         identity_id, _ = await authentication_session_service.complete(
             authentication_session

--- a/server/tests/auth/sso/test_flow.py
+++ b/server/tests/auth/sso/test_flow.py
@@ -327,3 +327,17 @@ class TestSSOLoginFlow:
             assert "error=" in complete.headers["location"]
 
         assert await _user_session_count(session, user) == 0
+
+    async def test_rejects_session_bound_to_other_organization(
+        self,
+        sso_client: httpx.AsyncClient,
+        organization: Organization,
+        organization_second: Organization,
+    ) -> None:
+        # The session is bound to `organization` at start.
+        start = await sso_client.post(f"/v1/auth/{organization.slug}/start", json={})
+        assert start.status_code == 201
+
+        # Driving it to a different organization's endpoint is rejected.
+        complete = await sso_client.get(f"/v1/auth/{organization_second.slug}/complete")
+        assert "error=" in complete.headers["location"]

--- a/server/tests/auth/sso/test_flow.py
+++ b/server/tests/auth/sso/test_flow.py
@@ -144,7 +144,7 @@ async def drive_to_callback(
     email_verified: bool = True,
 ) -> httpx.Response:
     """Run start → authorize → callback against the mock IdP, returning the
-    callback response (a redirect to /complete on success, or an error
+    callback response (a redirect to the frontend on success, or an error
     redirect on rejection)."""
     mock.get(f"{ISSUER}/.well-known/openid-configuration").mock(
         return_value=httpx.Response(200, json=_discovery_document())
@@ -153,7 +153,7 @@ async def drive_to_callback(
         return_value=httpx.Response(200, json=_public_jwks(idp_key))
     )
 
-    start = await client.post("/v1/auth/start", json={})
+    start = await client.post(f"/v1/auth/{slug}/start", json={})
     assert start.status_code == 201
 
     authorize = await client.get(f"/v1/auth/{slug}/sso/{connection_id}/authorize")
@@ -218,7 +218,7 @@ class TestSSOLoginFlow:
             )
             assert callback.status_code == 303
 
-            await sso_client.get("/v1/auth/complete")
+            await sso_client.get(f"/v1/auth/{organization.slug}/complete")
 
         user_session = (
             (
@@ -323,7 +323,7 @@ class TestSSOLoginFlow:
             await session.delete(user_organization)
             await session.flush()
 
-            complete = await sso_client.get("/v1/auth/complete")
+            complete = await sso_client.get(f"/v1/auth/{organization.slug}/complete")
             assert "error=" in complete.headers["location"]
 
         assert await _user_session_count(session, user) == 0


### PR DESCRIPTION
## Summary

Move SSO org-scoping onto explicit slug-scoped endpoints instead of threading sso_organization_id through the session context. 

/{slug}/start issues a session scoped to the org's factors; 
/{slug}/complete resolves the org from the path, completes through the standard 2FA flow, and mints the org-scoped session.

The global /complete drops its SSO branch. 

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

