### PR TITLE
fix(auth): enforce down scoped session on read paths

### DIFF
--- a/server/polar/authz/repository.py
+++ b/server/polar/authz/repository.py
@@ -56,7 +56,8 @@ def select_accessible_org_ids(
     (optionally narrowed by ``permission``) intersected with that scope. An
     unscoped subject (``organization_ids is None``) is not narrowed.
     """
-    stmt = select_user_org_ids(auth_subject.subject.id, permission=permission)
+    # Composes the raw helper, then applies the session down-scope right below.
+    stmt = select_user_org_ids(auth_subject.subject.id, permission=permission)  # noqa: org-scope
     if auth_subject.organization_ids is not None:
         stmt = stmt.where(
             UserOrganization.organization_id.in_(auth_subject.organization_ids)

--- a/server/polar/feedback/service.py
+++ b/server/polar/feedback/service.py
@@ -27,7 +27,11 @@ class FeedbackService:
         membership = await user_organization_service.get_by_user_and_org(
             session, user.id, create_schema.organization_id
         )
-        if membership is None:
+        out_of_scope = (
+            auth_subject.organization_ids is not None
+            and create_schema.organization_id not in auth_subject.organization_ids
+        )
+        if membership is None or out_of_scope:
             raise PolarRequestValidationError(
                 [
                     {

--- a/server/polar/oauth2/grants/authorization_code.py
+++ b/server/polar/oauth2/grants/authorization_code.py
@@ -153,7 +153,10 @@ class AuthorizationCodeGrant(SubTypeGrantMixin, _AuthorizationCodeGrant):
         down-scope, so a token can never be broader than its session.
         """
         member_organization_ids = set(
-            self.server.session.execute(select_user_org_ids(user.id)).scalars().all()
+            # Intersected with the session's down-scope just below.
+            self.server.session.execute(select_user_org_ids(user.id))  # noqa: org-scope
+            .scalars()
+            .all()
         )
         if self.session_organization_ids is not None:
             member_organization_ids &= self.session_organization_ids

--- a/server/polar/oauth2/grants/web.py
+++ b/server/polar/oauth2/grants/web.py
@@ -105,7 +105,8 @@ class WebGrant(BaseGrant, TokenEndpointMixin):
             # be one the user is a member of, within the session's own down-scope,
             # so the token can never be broader than its session.
             member_organization_ids = set(
-                self.server.session.execute(select_user_org_ids(user.id))
+                # Intersected with session_organization_ids just below.
+                self.server.session.execute(select_user_org_ids(user.id))  # noqa: org-scope
                 .scalars()
                 .all()
             )

--- a/server/polar/user/endpoints.py
+++ b/server/polar/user/endpoints.py
@@ -64,7 +64,14 @@ async def get_authenticated(
 ) -> UserRead:
     user = auth_subject.subject
     repository = UserOrganizationRepository.from_session(session)
-    org_with_roles = await repository.get_organizations_with_role(user.id)
+    # Raw membership, intersected below with the session's organization scope.
+    org_with_roles = await repository.get_organizations_with_role(user.id)  # noqa: org-scope
+    if auth_subject.organization_ids is not None:
+        org_with_roles = [
+            (org, role)
+            for org, role in org_with_roles
+            if org.id in auth_subject.organization_ids
+        ]
     return UserRead.model_validate(user).model_copy(
         update={
             "organizations": [
@@ -105,6 +112,11 @@ async def update_authenticated_notification_settings(
     session: AsyncSession = Depends(get_db_session),
 ) -> UserOrganizationNotificationSettings:
     """Update the authenticated user's notification settings for an organization."""
+    if (
+        auth_subject.organization_ids is not None
+        and organization_id not in auth_subject.organization_ids
+    ):
+        raise ResourceNotFound()
     try:
         user_org = await user_organization_service.update_notification_settings(
             session,
@@ -134,6 +146,11 @@ async def get_authenticated_notification_settings(
     session: AsyncReadSession = Depends(get_db_read_session),
 ) -> UserOrganizationNotificationSettings:
     """Get the authenticated user's notification settings for an organization."""
+    if (
+        auth_subject.organization_ids is not None
+        and organization_id not in auth_subject.organization_ids
+    ):
+        raise ResourceNotFound()
 
     user_org = await user_organization_service.get_by_user_and_org(
         session, auth_subject.subject.id, organization_id

--- a/server/scripts/lint_org_scope.py
+++ b/server/scripts/lint_org_scope.py
@@ -1,23 +1,27 @@
-"""Flag hand-rolled `UserOrganization` membership expansion.
+"""Flag membership resolution that bypasses the session org down-scope.
 
 Resolving "which organizations can this subject access?" must go through the
-canonical helpers so a single definition stays enforceable — `select_user_org_ids`
-(`polar.authz.repository`) for subquery use, or `get_accessible_org_ids`
-(`polar.authz.service`). This matters ahead of session/token organization
-scoping: those helpers are the one place the down-scope restriction is applied,
-so a hand-rolled subquery silently bypasses it.
+**scope-aware** helpers so the session/token down-scope (`organization_ids`) is
+always applied: `select_accessible_org_ids(auth_subject)` (subquery) or
+`get_accessible_org_ids(...)` (service), and `get_accessible_organization(...)`
+for a single org. The *raw* helpers (`select_user_org_ids`,
+`get_organizations_with_role`) answer plain membership with **no** down-scope, so
+using them where an `auth_subject` is in play silently leaks other orgs (see the
+`/me` org-switcher regression).
 
 Rules:
-- Flag `select(UserOrganization.organization_id)` — building the
-  user→accessible-orgs subquery by hand. The canonical helper is the sole
-  blessed exception and marks itself with `# noqa: org-scope`.
+- Flag `select(UserOrganization.organization_id)` — hand-building the
+  user→accessible-orgs subquery. `select_user_org_ids` is the sole blessed
+  definition and marks itself with `# noqa: org-scope`.
 - Flag a comparison where one operand is `UserOrganization.<col>` and another
-  references `auth_subject` (e.g. `UserOrganization.user_id ==
-  auth_subject.subject.id`) — the join-form bypass that doesn't project
-  `organization_id` directly.
+  references `auth_subject` — the join-form bypass.
+- Flag a **call** to a raw membership helper (`select_user_org_ids`,
+  `get_organizations_with_role`). Prefer the scope-aware helpers; if the raw use
+  is intentional (composing the scope-aware helper, manual intersection, or
+  membership management on a plain `user_id`), mark it `# noqa: org-scope`.
 - Membership *management* code (filtering by a plain `user_id`/`user.id`
   parameter, not `auth_subject`, and not projecting `organization_id`) is NOT
-  flagged.
+  flagged by the first two rules.
 - `# noqa: org-scope` on the offending line is an explicit escape.
 
 Exits 1 on any violation.
@@ -34,6 +38,25 @@ from typing import TypeGuard
 NOQA_MARKER = "org-scope"
 MODEL_NAME = "UserOrganization"
 SUBJECT_NAME = "auth_subject"
+
+# Raw membership helpers that answer plain membership without applying the
+# session/token down-scope. Calls to them must be scope-aware or acknowledged.
+RAW_MEMBERSHIP_CALLS = frozenset({"select_user_org_ids", "get_organizations_with_role"})
+
+EXPANSION_MESSAGE = (
+    "hand-rolled UserOrganization membership expansion bypasses org-scope "
+    "enforcement. Use select_accessible_org_ids(auth_subject) from "
+    "polar.authz.repository (or get_accessible_org_ids). Escape with "
+    "`# noqa: org-scope` if intentional."
+)
+
+RAW_CALL_MESSAGE = (
+    "call to a raw membership helper bypasses the session org down-scope. Prefer "
+    "select_accessible_org_ids / get_accessible_org_ids / "
+    "get_accessible_organization. If the raw use is intentional (composing the "
+    "scope-aware helper, manual intersection, or membership management), mark it "
+    "`# noqa: org-scope`."
+)
 
 # Matches `# noqa` optionally followed by `: code1, code2`. A bare `# noqa`
 # suppresses everything; a coded form only suppresses the listed codes.
@@ -82,6 +105,17 @@ def _is_membership_expansion(node: ast.AST) -> bool:
     )
 
 
+def _is_raw_membership_call(node: ast.Call) -> bool:
+    """True for a call to a raw membership helper — `select_user_org_ids(...)` or
+    `<repo>.get_organizations_with_role(...)`."""
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id in RAW_MEMBERSHIP_CALLS
+    if isinstance(func, ast.Attribute):
+        return func.attr in RAW_MEMBERSHIP_CALLS
+    return False
+
+
 def _line_has_noqa(source_lines: list[str], lineno: int) -> bool:
     idx = lineno - 1
     if not (0 <= idx < len(source_lines)):
@@ -108,8 +142,13 @@ def check_file(path: Path) -> list[tuple[Path, int, str]]:
     seen_lines: set[int] = set()
 
     for node in ast.walk(tree):
+        message: str | None = None
         if isinstance(node, ast.Call):
-            if not _is_membership_expansion(node):
+            if _is_membership_expansion(node):
+                message = EXPANSION_MESSAGE
+            elif _is_raw_membership_call(node):
+                message = RAW_CALL_MESSAGE
+            else:
                 continue
         elif isinstance(node, ast.Compare):
             operands = [node.left, *node.comparators]
@@ -117,27 +156,18 @@ def check_file(path: Path) -> list[tuple[Path, int, str]]:
                 continue
             if not any(_references_subject(op) for op in operands):
                 continue
+            message = EXPANSION_MESSAGE
         else:
             continue
 
         if _line_has_noqa(source_lines, node.lineno):
             continue
 
-        if node.lineno in seen_lines:  # one query can match both branches
+        if node.lineno in seen_lines:  # one query can match multiple branches
             continue
         seen_lines.add(node.lineno)
 
-        violations.append(
-            (
-                path,
-                node.lineno,
-                "hand-rolled UserOrganization membership expansion bypasses "
-                "org-scope enforcement. Use select_user_org_ids("
-                "auth_subject.subject.id) from polar.authz.repository (or "
-                "get_accessible_org_ids). Escape with `# noqa: org-scope` if "
-                "intentional.",
-            )
-        )
+        violations.append((path, node.lineno, message))
 
     return violations
 


### PR DESCRIPTION
## Summary

Several read paths resolved a user's organizations from raw membership, ignoring the session's organization down-scope — so an SSO-scoped session could see or touch orgs outside its scope. Scopes /users/me organizations, per-org notification-settings, and feedback submission to auth_subject.organization_ids. Also tightens lint_org_scope to flag calls to the raw membership helpers (select_user_org_ids, get_organizations_with_role) so the class can't silently return; legitimate raw uses are marked # noqa: org-scope.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

