### PR TITLE
refactor(sso): use oauth2 state to store connection id

### DIFF
--- a/server/polar/auth/oauth2/state.py
+++ b/server/polar/auth/oauth2/state.py
@@ -1,6 +1,7 @@
 import uuid
 
 from fastapi import Depends
+from reauth.crypto import get_token_hash
 from reauth.factors.oauth2.state import (
     OAuth2State as OAuth2StateDataclass,
 )
@@ -48,6 +49,10 @@ class OAuth2StateService(OAuth2StateServiceBase):
         if oauth2_state_orm is None:
             return None
         return oauth2_state_orm.to_dataclass()
+
+    async def get_by_token(self, token: str) -> OAuth2StateDataclass | None:
+        state_hash = get_token_hash(token, secret=self.hash_secret)
+        return await self.get_by_state_hash(state_hash)
 
     async def delete(self, oauth2_state: OAuth2StateDataclass) -> None:
         statement = delete(OAuth2State).where(OAuth2State.id == oauth2_state.id)

--- a/server/polar/auth/sso/endpoints.py
+++ b/server/polar/auth/sso/endpoints.py
@@ -34,6 +34,7 @@ from ..authentication_session import (
 from ..exceptions import PolarAuthRedirectionError
 from ..factors import get_org_factors
 from ..helpers import OIDC_ERROR_MESSAGE, check_factor, set_state_cookie
+from ..oauth2.state import OAuth2StateService, get_oauth2_state_service
 
 SSO_SCOPE = ["openid", "email"]
 
@@ -88,15 +89,14 @@ async def authorize(
     )
     check_factor(factor, factors)
 
-    redirect_uri = str(
-        request.url_for("auth.sso.callback", slug=slug, connection_id=connection_id)
-    )
+    redirect_uri = str(request.url_for("auth.sso.callback", slug=slug))
     try:
         authorization_url, state, oauth2_state = await factor.start(
             redirect_uri=redirect_uri,
             scope=SSO_SCOPE,
             nonce=secrets.token_urlsafe(16),
             authentication_session_token_hash=authentication_session.token_hash,
+            sso_connection_id=str(connection_id),
         )
     except OIDCException as e:
         raise PolarAuthRedirectionError(OIDC_ERROR_MESSAGE) from e
@@ -106,11 +106,10 @@ async def authorize(
     return response
 
 
-@router.get("/sso/{connection_id}/callback", name="auth.sso.callback")
+@router.get("/sso/callback", name="auth.sso.callback")
 async def callback(
     request: Request,
-    connection: OrganizationSSOConnection = Depends(get_sso_connection),
-    factor: OIDCFactorBase = Depends(get_sso_factor),
+    slug: str,
     code: str | None = Query(None),
     error: str | None = Query(None),
     error_description: str | None = Query(None),
@@ -120,6 +119,8 @@ async def callback(
     authentication_session_service: AuthenticationSessionService = Depends(
         get_org_authentication_session_service
     ),
+    factors: set[FactorBase[typing.Any]] = Depends(get_org_factors),
+    state_service: OAuth2StateService = Depends(get_oauth2_state_service),
     session: AsyncSession = Depends(get_db_session),
 ) -> RedirectResponse:
     if state is None:
@@ -130,6 +131,16 @@ async def callback(
         raise PolarAuthRedirectionError("Missing OAuth2 state cookie")
     if state != state_cookie:
         raise PolarAuthRedirectionError("Invalid OAuth2 state")
+
+    oauth2_state = await state_service.get_by_token(state)
+    if oauth2_state is None or oauth2_state.context is None:
+        raise PolarAuthRedirectionError("Invalid OAuth2 state")
+    connection_id = oauth2_state.context.get("sso_connection_id")
+    if connection_id is None:
+        raise PolarAuthRedirectionError("Invalid OAuth2 state")
+
+    connection = await get_sso_connection(slug, UUID(connection_id), session)
+    factor = await get_sso_factor(connection, factors)
 
     try:
         _, oauth_account, _ = await factor.callback(

--- a/server/tests/auth/sso/test_flow.py
+++ b/server/tests/auth/sso/test_flow.py
@@ -180,7 +180,7 @@ async def drive_to_callback(
     )
 
     return await client.get(
-        f"/v1/auth/{slug}/sso/{connection_id}/callback",
+        f"/v1/auth/{slug}/sso/callback",
         params={"code": "the-code", "state": state},
     )
 


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- issue number -->

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->

## Why

<!-- Explain why this change is needed -->

## How

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Store the SSO connection ID in the OAuth2 state and resolve it during callback, removing the `connection_id` from the callback URL. This simplifies the flow and avoids exposing the connection ID in the URL.

- **Refactors**
  - Callback route changed to `/sso/callback`; it now takes `slug` and resolves the connection and factor from OAuth2 state.
  - `authorize` passes `sso_connection_id` in the state context and no longer embeds `connection_id` in the redirect URI.
  - Added `get_by_token` to the OAuth2 state service to resolve state via hashed token.

- **Migration**
  - Update any hardcoded or IdP-registered redirect URIs to use `/v1/auth/{slug}/sso/callback`.

<sup>Written for commit 52f870b955505876c06e38c8b58ba0d847046877. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

