### PR TITLE
feat(sso): expose connection name

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -1677,23 +1677,6 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  '/v1/auth/{slug}/sso/connections': {
-    parameters: {
-      query?: never
-      header?: never
-      path?: never
-      cookie?: never
-    }
-    /** Auth.Sso.Connections */
-    get: operations['auth:auth.sso.connections']
-    put?: never
-    post?: never
-    delete?: never
-    options?: never
-    head?: never
-    patch?: never
-    trace?: never
-  }
   '/v1/auth/{slug}/start': {
     parameters: {
       query?: never
@@ -26385,25 +26368,6 @@ export interface components {
       enabled: boolean
     }
     /**
-     * OrganizationSSOConnectionLogin
-     * @description Public, login-facing view of an enabled SSO connection.
-     */
-    OrganizationSSOConnectionLogin: {
-      /**
-       * Id
-       * Format: uuid4
-       * @description The ID of the object.
-       */
-      id: string
-      /**
-       * Name
-       * @description Human-friendly label for the connection, shown on the login page.
-       */
-      name: string | null
-      /** @description Type of the SSO connection. */
-      type: components['schemas']['OrganizationSSOConnectionType']
-    }
-    /**
      * OrganizationSSOConnectionType
      * @enum {string}
      */
@@ -29706,6 +29670,11 @@ export interface components {
       connection_id: string
       /** Organization Slug */
       organization_slug: string
+      /**
+       * Name
+       * @description Human-friendly label for the connection, shown on the login page.
+       */
+      name: string | null
     }
     /**
      * Scope
@@ -38241,37 +38210,6 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['TaxSummary']
-        }
-      }
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['HTTPValidationError']
-        }
-      }
-    }
-  }
-  'auth:auth.sso.connections': {
-    parameters: {
-      query?: never
-      header?: never
-      path: {
-        slug: string
-      }
-      cookie?: never
-    }
-    requestBody?: never
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json': components['schemas']['OrganizationSSOConnectionLogin'][]
         }
       }
       /** @description Validation Error */

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -1677,6 +1677,23 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/auth/{slug}/sso/connections': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Auth.Sso.Connections */
+    get: operations['auth:auth.sso.connections']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/auth/{slug}/start': {
     parameters: {
       query?: never
@@ -26324,6 +26341,11 @@ export interface components {
        * @description ID of the organization the connection belongs to.
        */
       organization_id: string
+      /**
+       * Name
+       * @description Human-friendly label for the connection, shown on the login page.
+       */
+      name: string | null
       /** @description Type of the SSO connection. */
       type: components['schemas']['OrganizationSSOConnectionType']
       /** @description Provider-specific configuration of the connection. */
@@ -26336,6 +26358,11 @@ export interface components {
     }
     /** OrganizationSSOConnectionCreate */
     OrganizationSSOConnectionCreate: {
+      /**
+       * Name
+       * @description Human-friendly label for the connection, shown on the login page.
+       */
+      name?: string | null
       /**
        * Type
        * @description Type of the SSO connection.
@@ -26358,12 +26385,36 @@ export interface components {
       enabled: boolean
     }
     /**
+     * OrganizationSSOConnectionLogin
+     * @description Public, login-facing view of an enabled SSO connection.
+     */
+    OrganizationSSOConnectionLogin: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the object.
+       */
+      id: string
+      /**
+       * Name
+       * @description Human-friendly label for the connection, shown on the login page.
+       */
+      name: string | null
+      /** @description Type of the SSO connection. */
+      type: components['schemas']['OrganizationSSOConnectionType']
+    }
+    /**
      * OrganizationSSOConnectionType
      * @enum {string}
      */
     OrganizationSSOConnectionType: 'oidc'
     /** OrganizationSSOConnectionUpdate */
     OrganizationSSOConnectionUpdate: {
+      /**
+       * Name
+       * @description Human-friendly label for the connection, shown on the login page.
+       */
+      name?: string | null
       /**
        * Configuration
        * @description Provider-specific configuration of the connection.
@@ -38190,6 +38241,37 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['TaxSummary']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'auth:auth.sso.connections': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        slug: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['OrganizationSSOConnectionLogin'][]
         }
       }
       /** @description Validation Error */

--- a/server/polar/auth/schemas.py
+++ b/server/polar/auth/schemas.py
@@ -28,6 +28,9 @@ class SSOFactor(Schema):
     type: typing.Literal["sso"] = "sso"
     connection_id: UUID4
     organization_slug: str
+    name: str | None = Field(
+        description="Human-friendly label for the connection, shown on the login page."
+    )
 
 
 Factor = typing.Annotated[BaseFactor | SSOFactor, Field(discriminator="type")]
@@ -38,6 +41,7 @@ def _factor_to_schema(factor: FactorBase[typing.Any]) -> BaseFactor | SSOFactor:
         return SSOFactor(
             connection_id=factor.connection_id,
             organization_slug=factor.organization_slug,
+            name=factor.name,
         )
     return BaseFactor.model_validate({"type": factor.identifier})
 

--- a/server/polar/auth/sso/endpoints.py
+++ b/server/polar/auth/sso/endpoints.py
@@ -20,18 +20,12 @@ from reauth.factors.oauth2.state import ExpiredStateException, InvalidStateExcep
 
 from polar.config import settings
 from polar.exceptions import ResourceNotFound
-from polar.kit.db.postgres import AsyncReadSession
 from polar.models import Organization, OrganizationSSOConnection
 from polar.openapi import APITag
 from polar.organization.repository import OrganizationRepository
-from polar.postgres import (
-    AsyncSession,
-    get_db_read_session,
-    get_db_session,
-)
+from polar.postgres import AsyncSession, get_db_session
 from polar.routing import APIRouter
 from polar.sso.repository import OrganizationSSOConnectionRepository
-from polar.sso.schemas import OrganizationSSOConnectionLogin
 from polar.user.repository import UserRepository
 from polar.user_organization.repository import UserOrganizationRepository
 
@@ -109,25 +103,6 @@ async def get_org_authentication_session(
 
 
 router = APIRouter(prefix="/{slug}")
-
-
-@router.get(
-    "/sso/connections",
-    name="auth.sso.connections",
-    response_model=list[OrganizationSSOConnectionLogin],
-    tags=[APITag.private],
-)
-async def list_sso_connections(
-    slug: str,
-    session: AsyncReadSession = Depends(get_db_read_session),
-) -> typing.Sequence[OrganizationSSOConnection]:
-    organization_repository = OrganizationRepository.from_session(session)
-    organization = await organization_repository.get_by_slug(slug)
-    if organization is None:
-        raise ResourceNotFound()
-
-    sso_repository = OrganizationSSOConnectionRepository.from_session(session)
-    return await sso_repository.get_enabled_by_organization(organization.id)
 
 
 @router.post(

--- a/server/polar/auth/sso/endpoints.py
+++ b/server/polar/auth/sso/endpoints.py
@@ -20,12 +20,18 @@ from reauth.factors.oauth2.state import ExpiredStateException, InvalidStateExcep
 
 from polar.config import settings
 from polar.exceptions import ResourceNotFound
+from polar.kit.db.postgres import AsyncReadSession
 from polar.models import Organization, OrganizationSSOConnection
 from polar.openapi import APITag
 from polar.organization.repository import OrganizationRepository
-from polar.postgres import AsyncSession, get_db_session
+from polar.postgres import (
+    AsyncSession,
+    get_db_read_session,
+    get_db_session,
+)
 from polar.routing import APIRouter
 from polar.sso.repository import OrganizationSSOConnectionRepository
+from polar.sso.schemas import OrganizationSSOConnectionLogin
 from polar.user.repository import UserRepository
 from polar.user_organization.repository import UserOrganizationRepository
 
@@ -103,6 +109,25 @@ async def get_org_authentication_session(
 
 
 router = APIRouter(prefix="/{slug}")
+
+
+@router.get(
+    "/sso/connections",
+    name="auth.sso.connections",
+    response_model=list[OrganizationSSOConnectionLogin],
+    tags=[APITag.private],
+)
+async def list_sso_connections(
+    slug: str,
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> typing.Sequence[OrganizationSSOConnection]:
+    organization_repository = OrganizationRepository.from_session(session)
+    organization = await organization_repository.get_by_slug(slug)
+    if organization is None:
+        raise ResourceNotFound()
+
+    sso_repository = OrganizationSSOConnectionRepository.from_session(session)
+    return await sso_repository.get_enabled_by_organization(organization.id)
 
 
 @router.post(

--- a/server/polar/auth/sso/factor.py
+++ b/server/polar/auth/sso/factor.py
@@ -33,6 +33,7 @@ class SSOFactorMixin:
 
     connection_id: uuid.UUID
     organization_slug: str
+    name: str | None
     _discovery_endpoint: str
 
     @property
@@ -66,6 +67,7 @@ class SSOClientSecretFactor(SSOFactorMixin, OIDCFactor):
         *,
         connection_id: uuid.UUID,
         organization_slug: str,
+        name: str | None,
         issuer: str,
         client_id: str,
         client_secret: str,
@@ -79,6 +81,7 @@ class SSOClientSecretFactor(SSOFactorMixin, OIDCFactor):
         )
         self.connection_id = connection_id
         self.organization_slug = organization_slug
+        self.name = name
         self.DISCOVERY_ENDPOINT = _discovery_endpoint(issuer)
 
 
@@ -88,6 +91,7 @@ class SSOPrivateKeyJWTFactor(SSOFactorMixin, PrivateKeyJWTOIDCFactor):
         *,
         connection_id: uuid.UUID,
         organization_slug: str,
+        name: str | None,
         issuer: str,
         client_id: str,
         state_service: OAuth2StateService,
@@ -101,6 +105,7 @@ class SSOPrivateKeyJWTFactor(SSOFactorMixin, PrivateKeyJWTOIDCFactor):
         )
         self.connection_id = connection_id
         self.organization_slug = organization_slug
+        self.name = name
         self.DISCOVERY_ENDPOINT = _discovery_endpoint(issuer)
 
 
@@ -119,6 +124,7 @@ def build_sso_factor(
         return SSOClientSecretFactor(
             connection_id=connection.id,
             organization_slug=organization_slug,
+            name=connection.name,
             issuer=configuration["issuer"],
             client_id=configuration["client_id"],
             client_secret=client_secret,
@@ -127,6 +133,7 @@ def build_sso_factor(
     return SSOPrivateKeyJWTFactor(
         connection_id=connection.id,
         organization_slug=organization_slug,
+        name=connection.name,
         issuer=configuration["issuer"],
         client_id=configuration["client_id"],
         state_service=state_service,

--- a/server/polar/sso/schemas.py
+++ b/server/polar/sso/schemas.py
@@ -65,17 +65,6 @@ class OrganizationSSOConnection(IDSchema, TimestampedSchema):
     enabled: bool = Field(description="Whether the connection can be used to sign in.")
 
 
-class OrganizationSSOConnectionLogin(IDSchema):
-    """Public, login-facing view of an enabled SSO connection."""
-
-    name: str | None = Field(
-        description="Human-friendly label for the connection, shown on the login page."
-    )
-    type: OrganizationSSOConnectionType = Field(
-        description="Type of the SSO connection."
-    )
-
-
 class OrganizationSSOConnectionCreate(Schema):
     name: NonEmptyStr | None = Field(
         default=None,

--- a/server/polar/sso/schemas.py
+++ b/server/polar/sso/schemas.py
@@ -53,6 +53,9 @@ class OrganizationSSOConnection(IDSchema, TimestampedSchema):
     organization_id: UUID4 = Field(
         description="ID of the organization the connection belongs to."
     )
+    name: str | None = Field(
+        description="Human-friendly label for the connection, shown on the login page."
+    )
     type: OrganizationSSOConnectionType = Field(
         description="Type of the SSO connection."
     )
@@ -62,7 +65,22 @@ class OrganizationSSOConnection(IDSchema, TimestampedSchema):
     enabled: bool = Field(description="Whether the connection can be used to sign in.")
 
 
+class OrganizationSSOConnectionLogin(IDSchema):
+    """Public, login-facing view of an enabled SSO connection."""
+
+    name: str | None = Field(
+        description="Human-friendly label for the connection, shown on the login page."
+    )
+    type: OrganizationSSOConnectionType = Field(
+        description="Type of the SSO connection."
+    )
+
+
 class OrganizationSSOConnectionCreate(Schema):
+    name: NonEmptyStr | None = Field(
+        default=None,
+        description="Human-friendly label for the connection, shown on the login page.",
+    )
     type: Literal[OrganizationSSOConnectionType.oidc] = Field(
         default=OrganizationSSOConnectionType.oidc,
         description="Type of the SSO connection.",
@@ -76,6 +94,10 @@ class OrganizationSSOConnectionCreate(Schema):
 
 
 class OrganizationSSOConnectionUpdate(Schema):
+    name: NonEmptyStr | None = Field(
+        default=None,
+        description="Human-friendly label for the connection, shown on the login page.",
+    )
     configuration: OIDCConfiguration | None = Field(
         default=None, description="Provider-specific configuration of the connection."
     )

--- a/server/tests/auth/sso/test_endpoints.py
+++ b/server/tests/auth/sso/test_endpoints.py
@@ -100,12 +100,12 @@ class TestGetSSOConnection:
 
 
 @pytest.mark.asyncio
-class TestListSSOConnections:
+class TestStart:
     async def test_unknown_slug(self, client: AsyncClient) -> None:
-        response = await client.get("/v1/auth/does-not-exist/sso/connections")
+        response = await client.post("/v1/auth/does-not-exist/start", json={})
         assert response.status_code == 404
 
-    async def test_returns_enabled_connections(
+    async def test_exposes_enabled_sso_connections(
         self,
         client: AsyncClient,
         save_fixture: SaveFixture,
@@ -116,10 +116,13 @@ class TestListSSOConnections:
         )
         await create_sso_connection(save_fixture, organization, enabled=False)
 
-        response = await client.get(f"/v1/auth/{organization.slug}/sso/connections")
+        response = await client.post(f"/v1/auth/{organization.slug}/start", json={})
 
-        assert response.status_code == 200
-        data = response.json()
-        assert [c["id"] for c in data] == [str(enabled.id)]
-        assert data[0]["name"] == "Acme SSO"
-        assert data[0]["type"] == "oidc"
+        assert response.status_code == 201
+        sso_factors = [
+            factor
+            for factor in response.json()["available_factors"]
+            if factor["type"] == "sso"
+        ]
+        assert [factor["connection_id"] for factor in sso_factors] == [str(enabled.id)]
+        assert sso_factors[0]["name"] == "Acme SSO"

--- a/server/tests/auth/sso/test_endpoints.py
+++ b/server/tests/auth/sso/test_endpoints.py
@@ -1,6 +1,7 @@
 import uuid
 
 import pytest
+from httpx import AsyncClient
 
 from polar.auth.sso.endpoints import get_sso_connection
 from polar.exceptions import ResourceNotFound
@@ -19,6 +20,7 @@ async def create_sso_connection(
     organization: Organization,
     *,
     enabled: bool = True,
+    name: str | None = None,
 ) -> OrganizationSSOConnection:
     configuration: OIDCConfiguration = {
         "issuer": "https://idp.example.com",
@@ -31,6 +33,7 @@ async def create_sso_connection(
         type=OrganizationSSOConnectionType.oidc,
         configuration=configuration,
         enabled=enabled,
+        name=name,
     )
     await save_fixture(connection)
     return connection
@@ -94,3 +97,29 @@ class TestGetSSOConnection:
         )
 
         assert result.id == connection.id
+
+
+@pytest.mark.asyncio
+class TestListSSOConnections:
+    async def test_unknown_slug(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/auth/does-not-exist/sso/connections")
+        assert response.status_code == 404
+
+    async def test_returns_enabled_connections(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        enabled = await create_sso_connection(
+            save_fixture, organization, name="Acme SSO"
+        )
+        await create_sso_connection(save_fixture, organization, enabled=False)
+
+        response = await client.get(f"/v1/auth/{organization.slug}/sso/connections")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert [c["id"] for c in data] == [str(enabled.id)]
+        assert data[0]["name"] == "Acme SSO"
+        assert data[0]["type"] == "oidc"


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- issue number -->

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->

## Why

<!-- Explain why this change is needed -->

## How

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose human-friendly names on SSO connections and return them from the auth start flow so the login page can show labeled SSO options. No dedicated list endpoint; use `POST /v1/auth/{slug}/start`.

- **New Features**
  - Expose optional `name` on SSO connections (create/update/read) and include it on SSO factors.
  - `POST /v1/auth/{slug}/start` now lists enabled SSO options in `available_factors` with `{type: 'sso', connection_id, name}`; returns 404 for unknown slugs. Updated client and server schemas to include `name` across connection and SSO factor types.

<sup>Written for commit b1822e4c59768a2bc3bcba40ea6a758008685db1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

