### PR TITLE
tf/lambda: Add image_config

### DIFF
--- a/terraform/modules/aws_task_worker/main.tf
+++ b/terraform/modules/aws_task_worker/main.tf
@@ -158,6 +158,10 @@ resource "aws_lambda_function" "task" {
   package_type  = "Image"
   image_uri     = var.image_uri
 
+  image_config {
+    command = var.image_command
+  }
+
   timeout     = var.timeout_seconds
   memory_size = var.memory_size
 

--- a/terraform/modules/aws_task_worker/variables.tf
+++ b/terraform/modules/aws_task_worker/variables.tf
@@ -33,6 +33,12 @@ variable "image_uri" {
   type        = string
 }
 
+variable "image_command" {
+  description = "Container image CMD override the worker Lambda runs."
+  type        = list(string)
+  default     = ["polar.worker.aws_lambda.handler"]
+}
+
 variable "timeout_seconds" {
   description = "Lambda function timeout. Must stay below the queue visibility timeout."
   type        = number


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `image_config` to the task worker Lambda and expose `image_command` (default `polar.worker.aws_lambda.handler`) to set the container command. This ensures image-based deployments invoke the intended handler while allowing overrides.

<sup>Written for commit 5385afde487d2f6d3aa596c09fddfc553eddc130. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

