### PR TITLE
tf/lambda: Bump memory limits for lambda

### DIFF
--- a/terraform/modules/aws_task_worker/variables.tf
+++ b/terraform/modules/aws_task_worker/variables.tf
@@ -42,7 +42,7 @@ variable "timeout_seconds" {
 variable "memory_size" {
   description = "Lambda memory in MB."
   type        = number
-  default     = 512
+  default     = 2048
 }
 
 variable "reserved_concurrency" {


### PR DESCRIPTION
Otherwise it becomes way too slow


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase default memory for the task worker Lambda in `terraform/modules/aws_task_worker` from 512 MB to 2048 MB. This speeds up execution by increasing CPU and memory, reducing slow runs.

<sup>Written for commit 53b00af029c26b3637fb5430589a3f6c302624fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

