### PR TITLE
feat: allow denied organizations to be sent to offboarding

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -426,7 +426,9 @@ class OrganizationDetailView:
                                 text("Unblock & Approve")
 
                     elif self.org.status == OrganizationStatus.DENIED:
-                        # Denied organizations can be approved
+                        # Denied organizations can be approved or, for merchants
+                        # winding down after the fact, sent straight to
+                        # offboarding to release their remaining balance.
                         with tag.div(classes="w-full"):
                             with button(
                                 variant="secondary",
@@ -441,6 +443,21 @@ class OrganizationDetailView:
                                 hx_target="#modal",
                             ):
                                 text("Approve")
+
+                        with tag.div(classes="w-full"):
+                            with button(
+                                variant="secondary",
+                                size="sm",
+                                outline=True,
+                                hx_get=str(
+                                    request.url_for(
+                                        "organizations:offboard_dialog",
+                                        organization_id=self.org.id,
+                                    )
+                                ),
+                                hx_target="#modal",
+                            ):
+                                text("Set Offboarding")
 
                         # Show "Deny Appeal" when there's a pending appeal
                         if (

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -425,6 +425,7 @@ ALLOWED_STATUS_TRANSITIONS: dict[OrganizationStatus, frozenset[OrganizationStatu
         {
             OrganizationStatus.CREATED,
             OrganizationStatus.ACTIVE,
+            OrganizationStatus.OFFBOARDING,
             OrganizationStatus.BLOCKED,
         }
     ),

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -1510,9 +1510,12 @@ class OrganizationService:
         *,
         reason: str | None = None,
     ) -> Organization:
-        if organization.status != OrganizationStatus.REVIEW:
+        if organization.status not in (
+            OrganizationStatus.REVIEW,
+            OrganizationStatus.DENIED,
+        ):
             raise OrganizationError(
-                "Only organizations under review can be set to offboarding.",
+                "Only organizations under review or denied can be set to offboarding.",
                 403,
             )
         organization.set_status(OrganizationStatus.OFFBOARDING)

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -3733,16 +3733,29 @@ class TestSetOrganizationOffboarding:
         assert result.status == OrganizationStatus.OFFBOARDING
         assert result.status_updated_at is not None
 
+    async def test_from_denied(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.DENIED
+
+        result = await organization_service.set_organization_offboarding(
+            session, organization
+        )
+
+        assert result.status == OrganizationStatus.OFFBOARDING
+        assert result.status_updated_at is not None
+
     @pytest.mark.parametrize(
         "status",
         [
             OrganizationStatus.SNOOZED,
             OrganizationStatus.ACTIVE,
-            OrganizationStatus.DENIED,
             OrganizationStatus.CREATED,
         ],
     )
-    async def test_from_non_review_raises(
+    async def test_from_invalid_status_raises(
         self,
         status: OrganizationStatus,
         session: AsyncSession,
@@ -4513,17 +4526,24 @@ class TestStatusTransitions:
         organization.set_status(OrganizationStatus.REVIEW)
         assert organization.status == OrganizationStatus.REVIEW
 
+    async def test_denied_can_go_to_offboarding(
+        self,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.DENIED
+        organization.set_status(OrganizationStatus.OFFBOARDING)
+        assert organization.status == OrganizationStatus.OFFBOARDING
+
     @pytest.mark.parametrize(
         "current",
         [
             OrganizationStatus.CREATED,
             OrganizationStatus.SNOOZED,
             OrganizationStatus.ACTIVE,
-            OrganizationStatus.DENIED,
             OrganizationStatus.BLOCKED,
         ],
     )
-    async def test_only_review_can_go_to_offboarding(
+    async def test_only_review_or_denied_can_go_to_offboarding(
         self,
         current: OrganizationStatus,
         organization: Organization,


### PR DESCRIPTION
## Summary

Let denied organizations be sent straight to offboarding,

## What

- Add the `DENIED → OFFBOARDING` transition to `ALLOWED_STATUS_TRANSITIONS`.
- Surface a **Set Offboarding** action on denied orgs in the backoffice detail view.

## Why

Some merchants were denied before offboarding existed. Now that the 120-day period has passed and they want their funds. This allows  Denied → Offboarding → Offboarded.


## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

