### PR TITLE
fix(checkout): populate customer name from cardholder name when unset

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -2634,12 +2634,15 @@ class CheckoutService:
                 stripe_customer_id, tax_id=tax_id, **update_params
             )
 
-        # Only populate customer.name when creating a new customer. For existing
-        # customers (linked via customer_id or matched by email),
-        # checkout.customer_name may be the cardholder name on a wallet/payment
-        # method — e.g. a CFO or office manager paying on behalf of a company
-        # customer — and must not overwrite the company's name.
-        if created and customer_name is not None:
+        # Populate customer.name when it's not already set, even for existing
+        # customers (linked via customer_id or matched by email). We only avoid
+        # *overwriting* an existing name: checkout.customer_name may be the
+        # cardholder name on a wallet/payment method — e.g. a CFO or office
+        # manager paying on behalf of a company customer — and must not clobber
+        # the company's name. But an existing customer with no name at all
+        # (e.g. created through the API without one) should still get an initial
+        # value so invoices can be generated.
+        if customer.name is None and customer_name is not None:
             customer.name = customer_name
         if checkout.customer_billing_name is not None:
             customer.billing_name = checkout.customer_billing_name

--- a/server/scripts/backfill_customer_name.py
+++ b/server/scripts/backfill_customer_name.py
@@ -1,0 +1,171 @@
+import asyncio
+from typing import Any, cast
+
+import typer
+from rich.progress import (
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeElapsedColumn,
+)
+from sqlalchemy import (
+    ColumnElement,
+    CursorResult,
+    func,
+    select,
+    update,
+)
+
+from polar.config import settings
+from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
+from polar.kit.db.postgres import create_async_engine as _create_async_engine
+from polar.models import Checkout, Customer
+from polar.models.checkout import CheckoutStatus
+
+from .helper import configure_script_logging, typer_async
+
+cli = typer.Typer()
+
+
+def _computed_name() -> ColumnElement[str | None]:
+    """
+    Name derived from the customer's earliest succeeded checkout.
+
+    Mirrors what checkout confirmation now does for a nameless customer:
+    ``customer.name = checkout.customer_billing_name or checkout.customer_name``.
+    We coalesce to the customer's current ``name``, so customers that already
+    have a name (or have no succeeded checkout carrying one) compute to their
+    existing value and drop out of the update predicate — idempotent, and never
+    writes NULL.
+    """
+    checkout_name = func.coalesce(
+        Checkout.customer_billing_name, Checkout.customer_name
+    )
+    earliest_checkout_name = (
+        select(checkout_name)
+        .where(
+            Checkout.customer_id == Customer.id,
+            Checkout.status == CheckoutStatus.succeeded,
+            Checkout.deleted_at.is_(None),
+            checkout_name.is_not(None),
+        )
+        .order_by(Checkout.created_at.asc(), Checkout.id.asc())
+        .limit(1)
+        .correlate(Customer)
+        .scalar_subquery()
+    )
+    return func.coalesce(Customer.name, earliest_checkout_name)
+
+
+async def run_backfill(
+    batch_size: int = 5000,
+    sleep_seconds: float = 0.1,
+    session: AsyncSession | None = None,
+) -> int:
+    """
+    Backfill ``customer.name`` from the earliest succeeded checkout that carried
+    a name, for customers that don't have one yet.
+
+    A nameless customer leaves ``billing_name`` (which falls back to ``name``)
+    null, so its orders get a null ``billing_name`` and can never produce an
+    invoice. This sets an initial name without ever overwriting an existing one.
+
+    Set-based and batched: each batch updates up to ``batch_size`` customers
+    whose stored ``name`` differs from the computed value, so already-named
+    customers (and those with no qualifying checkout) drop out of the predicate.
+    This gives the loop its termination condition and makes the script safe to
+    rerun.
+    """
+    engine = None
+    own_session = False
+
+    if session is None:
+        engine = _create_async_engine(
+            dsn=str(settings.get_postgres_dsn("asyncpg")),
+            application_name=f"{settings.ENV.value}.script",
+            debug=False,
+            pool_size=settings.DATABASE_POOL_SIZE,
+            pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
+            command_timeout=settings.DATABASE_COMMAND_TIMEOUT_SECONDS,
+        )
+        sessionmaker = create_async_sessionmaker(engine)
+        session = sessionmaker()
+        own_session = True
+
+    total_updated = 0
+    batch_number = 0
+
+    try:
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            TimeElapsedColumn(),
+            transient=False,
+        ) as progress:
+            task = progress.add_task("[cyan]Batch 0: 0 rows updated", total=None)
+
+            while True:
+                batch = (
+                    select(Customer.id)
+                    .where(
+                        Customer.deleted_at.is_(None),
+                        Customer.name.is_(None),
+                        Customer.name.is_distinct_from(_computed_name()),
+                    )
+                    .limit(batch_size)
+                )
+                result = await session.execute(
+                    update(Customer)
+                    .where(Customer.id.in_(batch))
+                    .values(name=_computed_name())
+                    .execution_options(synchronize_session=False)
+                )
+                await session.commit()
+
+                rows_updated = cast(CursorResult[Any], result).rowcount
+                if rows_updated == 0:
+                    progress.update(
+                        task,
+                        description=(
+                            f"[green]✓ Complete: {total_updated} rows updated"
+                        ),
+                    )
+                    break
+
+                batch_number += 1
+                total_updated += rows_updated
+                progress.update(
+                    task,
+                    description=(
+                        f"[cyan]Batch {batch_number}: {total_updated} rows updated"
+                    ),
+                )
+
+                if sleep_seconds > 0:
+                    await asyncio.sleep(sleep_seconds)
+
+        return total_updated
+
+    finally:
+        if own_session:
+            await session.close()
+        if engine is not None:
+            await engine.dispose()
+
+
+@cli.command()
+@typer_async
+async def backfill(
+    batch_size: int = typer.Option(5000, help="Number of rows to process per batch"),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+) -> None:
+    """Backfill customer.name from the earliest succeeded checkout."""
+    configure_script_logging()
+    total_updated = await run_backfill(
+        batch_size=batch_size, sleep_seconds=sleep_seconds
+    )
+    typer.echo(f"Updated {total_updated} customers")
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/scripts/backfill_customer_name.py
+++ b/server/scripts/backfill_customer_name.py
@@ -1,28 +1,16 @@
-import asyncio
-from typing import Any, cast
-
 import typer
-from rich.progress import (
-    Progress,
-    SpinnerColumn,
-    TextColumn,
-    TimeElapsedColumn,
-)
-from sqlalchemy import (
-    ColumnElement,
-    CursorResult,
-    func,
-    select,
-    update,
-)
+from sqlalchemy import ColumnElement, func, select, update
 
-from polar.config import settings
-from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
-from polar.kit.db.postgres import create_async_engine as _create_async_engine
+from polar.kit.db.postgres import AsyncSession
 from polar.models import Checkout, Customer
 from polar.models.checkout import CheckoutStatus
 
-from .helper import configure_script_logging, typer_async
+from .helper import (
+    configure_script_logging,
+    limit_bindparam,
+    run_batched_update,
+    typer_async,
+)
 
 cli = typer.Typer()
 
@@ -35,8 +23,8 @@ def _computed_name() -> ColumnElement[str | None]:
     ``customer.name = checkout.customer_billing_name or checkout.customer_name``.
     We coalesce to the customer's current ``name``, so customers that already
     have a name (or have no succeeded checkout carrying one) compute to their
-    existing value and drop out of the update predicate — idempotent, and never
-    writes NULL.
+    existing value and are excluded by the ``is_distinct_from`` predicate below
+    — idempotent, and never writes NULL.
     """
     checkout_name = func.coalesce(
         Checkout.customer_billing_name, Checkout.customer_name
@@ -70,87 +58,31 @@ async def run_backfill(
     null, so its orders get a null ``billing_name`` and can never produce an
     invoice. This sets an initial name without ever overwriting an existing one.
 
-    Set-based and batched: each batch updates up to ``batch_size`` customers
-    whose stored ``name`` differs from the computed value, so already-named
-    customers (and those with no qualifying checkout) drop out of the predicate.
-    This gives the loop its termination condition and makes the script safe to
-    rerun.
+    ``name IS DISTINCT FROM COALESCE(name, <checkout name>)`` is only true when
+    ``name`` is null and a checkout name exists, so already-named customers (and
+    those with no qualifying checkout) drop out of the predicate. This gives the
+    batched loop its termination condition and makes the script safe to rerun.
     """
-    engine = None
-    own_session = False
-
-    if session is None:
-        engine = _create_async_engine(
-            dsn=str(settings.get_postgres_dsn("asyncpg")),
-            application_name=f"{settings.ENV.value}.script",
-            debug=False,
-            pool_size=settings.DATABASE_POOL_SIZE,
-            pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
-            command_timeout=settings.DATABASE_COMMAND_TIMEOUT_SECONDS,
+    batch = (
+        select(Customer.id)
+        .where(
+            Customer.deleted_at.is_(None),
+            Customer.name.is_distinct_from(_computed_name()),
         )
-        sessionmaker = create_async_sessionmaker(engine)
-        session = sessionmaker()
-        own_session = True
-
-    total_updated = 0
-    batch_number = 0
-
-    try:
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            TimeElapsedColumn(),
-            transient=False,
-        ) as progress:
-            task = progress.add_task("[cyan]Batch 0: 0 rows updated", total=None)
-
-            while True:
-                batch = (
-                    select(Customer.id)
-                    .where(
-                        Customer.deleted_at.is_(None),
-                        Customer.name.is_(None),
-                        Customer.name.is_distinct_from(_computed_name()),
-                    )
-                    .limit(batch_size)
-                )
-                result = await session.execute(
-                    update(Customer)
-                    .where(Customer.id.in_(batch))
-                    .values(name=_computed_name())
-                    .execution_options(synchronize_session=False)
-                )
-                await session.commit()
-
-                rows_updated = cast(CursorResult[Any], result).rowcount
-                if rows_updated == 0:
-                    progress.update(
-                        task,
-                        description=(
-                            f"[green]✓ Complete: {total_updated} rows updated"
-                        ),
-                    )
-                    break
-
-                batch_number += 1
-                total_updated += rows_updated
-                progress.update(
-                    task,
-                    description=(
-                        f"[cyan]Batch {batch_number}: {total_updated} rows updated"
-                    ),
-                )
-
-                if sleep_seconds > 0:
-                    await asyncio.sleep(sleep_seconds)
-
-        return total_updated
-
-    finally:
-        if own_session:
-            await session.close()
-        if engine is not None:
-            await engine.dispose()
+        .limit(limit_bindparam())
+    )
+    update_statement = (
+        update(Customer)
+        .where(Customer.id.in_(batch))
+        .values(name=_computed_name())
+        .execution_options(synchronize_session=False)
+    )
+    return await run_batched_update(
+        update_statement,
+        batch_size=batch_size,
+        sleep_seconds=sleep_seconds,
+        session=session,
+    )
 
 
 @cli.command()

--- a/server/scripts/backfill_order_billing_name.py
+++ b/server/scripts/backfill_order_billing_name.py
@@ -1,0 +1,170 @@
+import asyncio
+from typing import Any, cast
+
+import typer
+from rich.progress import (
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeElapsedColumn,
+)
+from sqlalchemy import (
+    ColumnElement,
+    CursorResult,
+    func,
+    select,
+    update,
+)
+
+from polar.config import settings
+from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
+from polar.kit.db.postgres import create_async_engine as _create_async_engine
+from polar.models import Customer, Order
+
+from .helper import configure_script_logging, typer_async
+
+cli = typer.Typer()
+
+
+def _computed_billing_name() -> ColumnElement[str | None]:
+    """
+    Billing name derived from the order's customer.
+
+    ``order.billing_name`` is a snapshot of ``customer.billing_name`` (the
+    ``_billing_name`` column falling back to ``name``) taken at order creation.
+    Orders created for a nameless customer got a null snapshot and can never
+    produce an invoice. We re-derive it from the customer, coalescing to the
+    order's current ``billing_name`` so already-filled orders (and orders whose
+    customer still has no name) compute to their existing value and drop out of
+    the update predicate — idempotent, and never writes NULL.
+
+    ``Customer._billing_name`` is the mapped column behind the read-only
+    ``billing_name`` property; the property isn't queryable, so we read the
+    column directly.
+
+    Run *after* ``backfill_customer_name`` so the customer name is populated
+    first — otherwise the source it reads is still null.
+    """
+    customer_billing_name = (
+        select(func.coalesce(Customer._billing_name, Customer.name))
+        .where(Customer.id == Order.customer_id)
+        .correlate(Order)
+        .scalar_subquery()
+    )
+    return func.coalesce(Order.billing_name, customer_billing_name)
+
+
+async def run_backfill(
+    batch_size: int = 5000,
+    sleep_seconds: float = 0.1,
+    session: AsyncSession | None = None,
+) -> int:
+    """
+    Backfill ``order.billing_name`` from the order's customer, for paid-through
+    orders that never got one.
+
+    Invoice generation is hard-gated on ``order.billing_name`` (and
+    ``billing_address``) being non-null, so orders snapshotted from a nameless
+    customer can never produce an invoice. This re-derives the name from the
+    customer without overwriting orders that already have one. Orders still
+    missing a ``billing_address`` remain un-invoiceable — that's a separate gate.
+
+    Set-based and batched: each batch updates up to ``batch_size`` orders whose
+    stored ``billing_name`` differs from the computed value, so already-filled
+    orders (and orders whose customer has no name) drop out of the predicate.
+    This gives the loop its termination condition and makes the script safe to
+    rerun.
+    """
+    engine = None
+    own_session = False
+
+    if session is None:
+        engine = _create_async_engine(
+            dsn=str(settings.get_postgres_dsn("asyncpg")),
+            application_name=f"{settings.ENV.value}.script",
+            debug=False,
+            pool_size=settings.DATABASE_POOL_SIZE,
+            pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
+            command_timeout=settings.DATABASE_COMMAND_TIMEOUT_SECONDS,
+        )
+        sessionmaker = create_async_sessionmaker(engine)
+        session = sessionmaker()
+        own_session = True
+
+    total_updated = 0
+    batch_number = 0
+
+    try:
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            TimeElapsedColumn(),
+            transient=False,
+        ) as progress:
+            task = progress.add_task("[cyan]Batch 0: 0 rows updated", total=None)
+
+            while True:
+                batch = (
+                    select(Order.id)
+                    .where(
+                        Order.deleted_at.is_(None),
+                        Order.billing_name.is_(None),
+                        Order.billing_name.is_distinct_from(_computed_billing_name()),
+                    )
+                    .limit(batch_size)
+                )
+                result = await session.execute(
+                    update(Order)
+                    .where(Order.id.in_(batch))
+                    .values(billing_name=_computed_billing_name())
+                    .execution_options(synchronize_session=False)
+                )
+                await session.commit()
+
+                rows_updated = cast(CursorResult[Any], result).rowcount
+                if rows_updated == 0:
+                    progress.update(
+                        task,
+                        description=(
+                            f"[green]✓ Complete: {total_updated} rows updated"
+                        ),
+                    )
+                    break
+
+                batch_number += 1
+                total_updated += rows_updated
+                progress.update(
+                    task,
+                    description=(
+                        f"[cyan]Batch {batch_number}: {total_updated} rows updated"
+                    ),
+                )
+
+                if sleep_seconds > 0:
+                    await asyncio.sleep(sleep_seconds)
+
+        return total_updated
+
+    finally:
+        if own_session:
+            await session.close()
+        if engine is not None:
+            await engine.dispose()
+
+
+@cli.command()
+@typer_async
+async def backfill(
+    batch_size: int = typer.Option(5000, help="Number of rows to process per batch"),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+) -> None:
+    """Backfill order.billing_name from the order's customer."""
+    configure_script_logging()
+    total_updated = await run_backfill(
+        batch_size=batch_size, sleep_seconds=sleep_seconds
+    )
+    typer.echo(f"Updated {total_updated} orders")
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/scripts/backfill_order_billing_name.py
+++ b/server/scripts/backfill_order_billing_name.py
@@ -1,27 +1,15 @@
-import asyncio
-from typing import Any, cast
-
 import typer
-from rich.progress import (
-    Progress,
-    SpinnerColumn,
-    TextColumn,
-    TimeElapsedColumn,
-)
-from sqlalchemy import (
-    ColumnElement,
-    CursorResult,
-    func,
-    select,
-    update,
-)
+from sqlalchemy import ColumnElement, func, select, update
 
-from polar.config import settings
-from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
-from polar.kit.db.postgres import create_async_engine as _create_async_engine
+from polar.kit.db.postgres import AsyncSession
 from polar.models import Customer, Order
 
-from .helper import configure_script_logging, typer_async
+from .helper import (
+    configure_script_logging,
+    limit_bindparam,
+    run_batched_update,
+    typer_async,
+)
 
 cli = typer.Typer()
 
@@ -35,8 +23,8 @@ def _computed_billing_name() -> ColumnElement[str | None]:
     Orders created for a nameless customer got a null snapshot and can never
     produce an invoice. We re-derive it from the customer, coalescing to the
     order's current ``billing_name`` so already-filled orders (and orders whose
-    customer still has no name) compute to their existing value and drop out of
-    the update predicate — idempotent, and never writes NULL.
+    customer still has no name) compute to their existing value and are excluded
+    by the ``is_distinct_from`` predicate below — idempotent, never writes NULL.
 
     ``Customer._billing_name`` is the mapped column behind the read-only
     ``billing_name`` property; the property isn't queryable, so we read the
@@ -69,87 +57,32 @@ async def run_backfill(
     customer without overwriting orders that already have one. Orders still
     missing a ``billing_address`` remain un-invoiceable — that's a separate gate.
 
-    Set-based and batched: each batch updates up to ``batch_size`` orders whose
-    stored ``billing_name`` differs from the computed value, so already-filled
-    orders (and orders whose customer has no name) drop out of the predicate.
-    This gives the loop its termination condition and makes the script safe to
-    rerun.
+    ``billing_name IS DISTINCT FROM COALESCE(billing_name, <customer name>)`` is
+    only true when ``billing_name`` is null and the customer has a name, so
+    already-filled orders (and orders whose customer has no name) drop out of the
+    predicate. This gives the batched loop its termination condition and makes
+    the script safe to rerun.
     """
-    engine = None
-    own_session = False
-
-    if session is None:
-        engine = _create_async_engine(
-            dsn=str(settings.get_postgres_dsn("asyncpg")),
-            application_name=f"{settings.ENV.value}.script",
-            debug=False,
-            pool_size=settings.DATABASE_POOL_SIZE,
-            pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
-            command_timeout=settings.DATABASE_COMMAND_TIMEOUT_SECONDS,
+    batch = (
+        select(Order.id)
+        .where(
+            Order.deleted_at.is_(None),
+            Order.billing_name.is_distinct_from(_computed_billing_name()),
         )
-        sessionmaker = create_async_sessionmaker(engine)
-        session = sessionmaker()
-        own_session = True
-
-    total_updated = 0
-    batch_number = 0
-
-    try:
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            TimeElapsedColumn(),
-            transient=False,
-        ) as progress:
-            task = progress.add_task("[cyan]Batch 0: 0 rows updated", total=None)
-
-            while True:
-                batch = (
-                    select(Order.id)
-                    .where(
-                        Order.deleted_at.is_(None),
-                        Order.billing_name.is_(None),
-                        Order.billing_name.is_distinct_from(_computed_billing_name()),
-                    )
-                    .limit(batch_size)
-                )
-                result = await session.execute(
-                    update(Order)
-                    .where(Order.id.in_(batch))
-                    .values(billing_name=_computed_billing_name())
-                    .execution_options(synchronize_session=False)
-                )
-                await session.commit()
-
-                rows_updated = cast(CursorResult[Any], result).rowcount
-                if rows_updated == 0:
-                    progress.update(
-                        task,
-                        description=(
-                            f"[green]✓ Complete: {total_updated} rows updated"
-                        ),
-                    )
-                    break
-
-                batch_number += 1
-                total_updated += rows_updated
-                progress.update(
-                    task,
-                    description=(
-                        f"[cyan]Batch {batch_number}: {total_updated} rows updated"
-                    ),
-                )
-
-                if sleep_seconds > 0:
-                    await asyncio.sleep(sleep_seconds)
-
-        return total_updated
-
-    finally:
-        if own_session:
-            await session.close()
-        if engine is not None:
-            await engine.dispose()
+        .limit(limit_bindparam())
+    )
+    update_statement = (
+        update(Order)
+        .where(Order.id.in_(batch))
+        .values(billing_name=_computed_billing_name())
+        .execution_options(synchronize_session=False)
+    )
+    return await run_batched_update(
+        update_statement,
+        batch_size=batch_size,
+        sleep_seconds=sleep_seconds,
+        session=session,
+    )
 
 
 @cli.command()

--- a/server/scripts/helper.py
+++ b/server/scripts/helper.py
@@ -8,7 +8,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 from sqlalchemy import CursorResult, Update, bindparam
 from sqlalchemy.sql.elements import BindParameter
 
-from polar.kit.db.postgres import create_async_sessionmaker
+from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
 from polar.postgres import create_async_engine
 
 
@@ -76,6 +76,7 @@ async def run_batched_update(
     *,
     batch_size: int = 5000,
     sleep_seconds: float = 0.1,
+    session: AsyncSession | None = None,
 ) -> int:
     """
     Execute a batched update migration to avoid long locks on large tables.
@@ -108,12 +109,17 @@ async def run_batched_update(
             subset of rows.
         batch_size: Number of rows to process per batch.
         sleep_seconds: Seconds to sleep between batches to reduce database load.
+        session: Optional session to run every batch on (used by tests). When
+            omitted, each batch opens its own session on a dedicated engine.
 
     Returns:
         Total number of rows updated.
     """
-    engine = create_async_engine("script")
-    sessionmaker = create_async_sessionmaker(engine)
+    engine = None
+    sessionmaker = None
+    if session is None:
+        engine = create_async_engine("script")
+        sessionmaker = create_async_sessionmaker(engine)
 
     total_updated = 0
     batch_number = 0
@@ -128,30 +134,37 @@ async def run_batched_update(
             task = progress.add_task("[cyan]Batch 0: 0 rows updated", total=None)
 
             while True:
-                async with sessionmaker() as session:
+                if session is not None:
                     result = await session.execute(
                         update_statement, {"limit": batch_size}
                     )
                     await session.commit()
-
-                    # https://github.com/sqlalchemy/sqlalchemy/commit/67f62aac5b49b6d048ca39019e5bd123d3c9cfb2
-                    rows_updated = cast(CursorResult[Any], result).rowcount
-
-                    if rows_updated == 0:
-                        progress.update(
-                            task,
-                            description=f"[green]✓ Complete: {total_updated} rows updated",
+                else:
+                    assert sessionmaker is not None
+                    async with sessionmaker() as batch_session:
+                        result = await batch_session.execute(
+                            update_statement, {"limit": batch_size}
                         )
-                        break
+                        await batch_session.commit()
 
-                    batch_number += 1
-                    total_updated += rows_updated
+                # https://github.com/sqlalchemy/sqlalchemy/commit/67f62aac5b49b6d048ca39019e5bd123d3c9cfb2
+                rows_updated = cast(CursorResult[Any], result).rowcount
+
+                if rows_updated == 0:
                     progress.update(
                         task,
-                        description=(
-                            f"[cyan]Batch {batch_number}: {total_updated} rows updated"
-                        ),
+                        description=f"[green]✓ Complete: {total_updated} rows updated",
                     )
+                    break
+
+                batch_number += 1
+                total_updated += rows_updated
+                progress.update(
+                    task,
+                    description=(
+                        f"[cyan]Batch {batch_number}: {total_updated} rows updated"
+                    ),
+                )
 
                 if sleep_seconds > 0:
                     await asyncio.sleep(sleep_seconds)
@@ -159,4 +172,5 @@ async def run_batched_update(
         return total_updated
 
     finally:
-        await engine.dispose()
+        if engine is not None:
+            await engine.dispose()

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -5077,6 +5077,50 @@ class TestConfirm:
         update_call = stripe_service_mock.update_customer.call_args
         assert update_call.kwargs.get("name") == "ACME Corp Inc."
 
+    async def test_existing_customer_without_name_gets_cardholder_name(
+        self,
+        save_fixture: SaveFixture,
+        stripe_service_mock: MagicMock,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Anonymous],
+        organization: Organization,
+        checkout_one_time_fixed: Checkout,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            stripe_customer_id="CHECKOUT_CUSTOMER_ID",
+        )
+        customer.name = None
+        await save_fixture(customer)
+        checkout_one_time_fixed.customer = customer
+        checkout_one_time_fixed.customer_email = customer.email
+        await save_fixture(checkout_one_time_fixed)
+
+        stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
+            client_secret="CLIENT_SECRET", status="succeeded"
+        )
+
+        checkout = await checkout_service.confirm(
+            session,
+            auth_subject,
+            checkout_one_time_fixed,
+            CheckoutConfirmStripe.model_validate(
+                {
+                    "confirmation_token_id": "CONFIRMATION_TOKEN_ID",
+                    "customer_name": "John Smith",
+                    "customer_billing_address": {"country": "FR"},
+                }
+            ),
+        )
+
+        assert checkout.status == CheckoutStatus.confirmed
+        assert checkout.customer is not None
+        # An existing customer with no name yet gets an initial value from the
+        # cardholder name, so billing_name resolves and invoices can generate.
+        assert checkout.customer.name == "John Smith"
+        assert checkout.customer.billing_name == "John Smith"
+
     async def test_valid_stripe_existing_customer_email(
         self,
         save_fixture: SaveFixture,

--- a/server/tests/scripts/test_backfill_customer_name.py
+++ b/server/tests/scripts/test_backfill_customer_name.py
@@ -1,0 +1,192 @@
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import select
+
+from polar.kit.db.postgres import AsyncSession
+from polar.models import Checkout, Customer, Organization, Product
+from polar.models.checkout import CheckoutStatus
+from scripts.backfill_customer_name import run_backfill
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_checkout, create_customer
+
+
+async def _nameless_customer(
+    save_fixture: SaveFixture,
+    organization: Organization,
+    *,
+    billing_name: str | None = None,
+) -> Customer:
+    customer = await create_customer(
+        save_fixture, organization=organization, billing_name=billing_name
+    )
+    customer.name = None
+    await save_fixture(customer)
+    return customer
+
+
+async def _checkout(
+    save_fixture: SaveFixture,
+    product: Product,
+    customer: Customer,
+    *,
+    status: CheckoutStatus = CheckoutStatus.succeeded,
+    customer_name: str | None = None,
+    customer_billing_name: str | None = None,
+    created_at: datetime | None = None,
+) -> Checkout:
+    checkout = await create_checkout(
+        save_fixture,
+        products=[product],
+        customer=customer,
+        status=status,
+        created_at=created_at,
+    )
+    checkout.customer_name = customer_name
+    checkout.customer_billing_name = customer_billing_name
+    await save_fixture(checkout)
+    return checkout
+
+
+async def _get_name(session: AsyncSession, customer: Customer) -> str | None:
+    result = await session.execute(
+        select(Customer.name).where(Customer.id == customer.id)
+    )
+    return result.scalar_one()
+
+
+@pytest.mark.asyncio
+class TestBackfillCustomerName:
+    async def test_backfills_name_from_succeeded_checkout(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        organization: Organization,
+    ) -> None:
+        customer = await _nameless_customer(save_fixture, organization)
+        await _checkout(save_fixture, product, customer, customer_name="John Doe")
+
+        updated = await run_backfill(batch_size=10, session=session)
+
+        assert updated == 1
+        assert await _get_name(session, customer) == "John Doe"
+
+    async def test_prefers_billing_name_over_cardholder_name(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        organization: Organization,
+    ) -> None:
+        customer = await _nameless_customer(save_fixture, organization)
+        await _checkout(
+            save_fixture,
+            product,
+            customer,
+            customer_name="Cardholder Name",
+            customer_billing_name="ACME Corp Inc.",
+        )
+
+        updated = await run_backfill(batch_size=10, session=session)
+
+        assert updated == 1
+        assert await _get_name(session, customer) == "ACME Corp Inc."
+
+    async def test_uses_earliest_succeeded_checkout(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        organization: Organization,
+    ) -> None:
+        customer = await _nameless_customer(save_fixture, organization)
+        await _checkout(
+            save_fixture,
+            product,
+            customer,
+            customer_name="Later Name",
+            created_at=datetime(2026, 2, 1, tzinfo=UTC),
+        )
+        await _checkout(
+            save_fixture,
+            product,
+            customer,
+            customer_name="Earliest Name",
+            created_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+
+        updated = await run_backfill(batch_size=10, session=session)
+
+        assert updated == 1
+        assert await _get_name(session, customer) == "Earliest Name"
+
+    async def test_does_not_overwrite_existing_name(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        organization: Organization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture, organization=organization, name="Existing Person"
+        )
+        await _checkout(save_fixture, product, customer, customer_name="Cardholder")
+
+        updated = await run_backfill(batch_size=10, session=session)
+
+        assert updated == 0
+        assert await _get_name(session, customer) == "Existing Person"
+
+    async def test_ignores_non_succeeded_checkout(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        organization: Organization,
+    ) -> None:
+        customer = await _nameless_customer(save_fixture, organization)
+        await _checkout(
+            save_fixture,
+            product,
+            customer,
+            status=CheckoutStatus.open,
+            customer_name="Never Paid",
+        )
+
+        updated = await run_backfill(batch_size=10, session=session)
+
+        assert updated == 0
+        assert await _get_name(session, customer) is None
+
+    async def test_ignores_checkout_without_name(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        organization: Organization,
+    ) -> None:
+        customer = await _nameless_customer(save_fixture, organization)
+        await _checkout(save_fixture, product, customer, customer_name=None)
+
+        updated = await run_backfill(batch_size=10, session=session)
+
+        assert updated == 0
+        assert await _get_name(session, customer) is None
+
+    async def test_is_idempotent(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        organization: Organization,
+    ) -> None:
+        customer = await _nameless_customer(save_fixture, organization)
+        await _checkout(save_fixture, product, customer, customer_name="John Doe")
+
+        first_run = await run_backfill(batch_size=10, session=session)
+        second_run = await run_backfill(batch_size=10, session=session)
+
+        assert first_run == 1
+        assert second_run == 0
+        assert await _get_name(session, customer) == "John Doe"

--- a/server/tests/scripts/test_backfill_order_billing_name.py
+++ b/server/tests/scripts/test_backfill_order_billing_name.py
@@ -2,7 +2,7 @@ import pytest
 from sqlalchemy import select
 
 from polar.kit.db.postgres import AsyncSession
-from polar.models import Customer, Order, Organization, Product
+from polar.models import Order, Organization, Product
 from scripts.backfill_order_billing_name import run_backfill
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_customer, create_order

--- a/server/tests/scripts/test_backfill_order_billing_name.py
+++ b/server/tests/scripts/test_backfill_order_billing_name.py
@@ -1,0 +1,121 @@
+import pytest
+from sqlalchemy import select
+
+from polar.kit.db.postgres import AsyncSession
+from polar.models import Customer, Order, Organization, Product
+from scripts.backfill_order_billing_name import run_backfill
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_customer, create_order
+
+
+async def _get_billing_name(session: AsyncSession, order: Order) -> str | None:
+    result = await session.execute(
+        select(Order.billing_name).where(Order.id == order.id)
+    )
+    return result.scalar_one()
+
+
+@pytest.mark.asyncio
+class TestBackfillOrderBillingName:
+    async def test_backfills_from_customer_name(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        organization: Organization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture, organization=organization, name="John Doe"
+        )
+        order = await create_order(
+            save_fixture, customer=customer, product=product, billing_name=None
+        )
+
+        updated = await run_backfill(batch_size=10, session=session)
+
+        assert updated == 1
+        assert await _get_billing_name(session, order) == "John Doe"
+
+    async def test_prefers_customer_billing_name(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        organization: Organization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            name="John Doe",
+            billing_name="ACME Corp Inc.",
+        )
+        order = await create_order(
+            save_fixture, customer=customer, product=product, billing_name=None
+        )
+
+        updated = await run_backfill(batch_size=10, session=session)
+
+        assert updated == 1
+        assert await _get_billing_name(session, order) == "ACME Corp Inc."
+
+    async def test_does_not_overwrite_existing_billing_name(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        organization: Organization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture, organization=organization, name="John Doe"
+        )
+        order = await create_order(
+            save_fixture,
+            customer=customer,
+            product=product,
+            billing_name="Already Set",
+        )
+
+        updated = await run_backfill(batch_size=10, session=session)
+
+        assert updated == 0
+        assert await _get_billing_name(session, order) == "Already Set"
+
+    async def test_skips_order_when_customer_has_no_name(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        organization: Organization,
+    ) -> None:
+        customer = await create_customer(save_fixture, organization=organization)
+        customer.name = None
+        await save_fixture(customer)
+        order = await create_order(
+            save_fixture, customer=customer, product=product, billing_name=None
+        )
+
+        updated = await run_backfill(batch_size=10, session=session)
+
+        assert updated == 0
+        assert await _get_billing_name(session, order) is None
+
+    async def test_is_idempotent(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        organization: Organization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture, organization=organization, name="John Doe"
+        )
+        order = await create_order(
+            save_fixture, customer=customer, product=product, billing_name=None
+        )
+
+        first_run = await run_backfill(batch_size=10, session=session)
+        second_run = await run_backfill(batch_size=10, session=session)
+
+        assert first_run == 1
+        assert second_run == 0
+        assert await _get_billing_name(session, order) == "John Doe"


### PR DESCRIPTION
An existing customer without a name (e.g. created through the API without
one, or matched by email) never received a name during checkout, because
customer.name was only written for newly created customers. As a result
billing_name — which falls back to name — stayed null, so orders had no
billing name and invoices could neither auto-generate nor be created via
the API.

Set customer.name from the checkout/cardholder name whenever the customer
has no name yet, regardless of whether it was just created. Existing
customers that already have a name are still protected from being
overwritten by the cardholder name (e.g. a company customer paid for by an
employee), preserving the previous team-name fix.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UxtYmEsYmo9vkpmm3bNr9C

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

