### PR TITLE
feat(sso): organization SSO login page

### DIFF
--- a/clients/apps/web/src/app/(main)/auth/sso/[slug]/page.tsx
+++ b/clients/apps/web/src/app/(main)/auth/sso/[slug]/page.tsx
@@ -1,0 +1,60 @@
+import OrgAuth from '@/components/Auth/OrgAuth'
+import { PolarLogotype } from '@/components/Layout/Public/PolarLogotype'
+import { Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Sign in with SSO to Polar',
+}
+
+export default async function Page(props: {
+  params: Promise<{ slug: string }>
+  searchParams: Promise<{ error?: string; return_to?: string }>
+}) {
+  const { slug } = await props.params
+  const { error, return_to } = await props.searchParams
+  // Land on the SSO organization's dashboard by default — the scoped session
+  // can't access the user's other organizations.
+  const returnTo = return_to ?? `/dashboard/${slug}`
+
+  return (
+    <Box
+      height="100vh"
+      width="100%"
+      flexGrow={1}
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Box
+        flexDirection="column"
+        gap="2xl"
+        width="100%"
+        maxWidth={448}
+        backgroundColor="background-secondary"
+        borderRadius="xl"
+        padding="3xl"
+      >
+        <Box flexDirection="column" gap="l">
+          <PolarLogotype logoVariant="icon" size={60} />
+          <Text variant="heading-s" as="h2">
+            Sign in
+          </Text>
+          {error && (
+            <Box
+              borderRadius="m"
+              backgroundColor="background-warning"
+              borderWidth={1}
+              borderStyle="solid"
+              borderColor="border-warning"
+              padding="l"
+            >
+              <Text>{error}</Text>
+            </Box>
+          )}
+        </Box>
+        <OrgAuth slug={slug} returnTo={returnTo} />
+      </Box>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/components/Auth/OrgAuth.tsx
+++ b/clients/apps/web/src/components/Auth/OrgAuth.tsx
@@ -1,0 +1,179 @@
+'use client'
+
+import {
+  getAuthenticationSessionRedirectPath,
+  getOrgAuthenticationSessionCompleteURL,
+} from '@/utils/auth'
+import { api } from '@/utils/client'
+import { schemas } from '@polar-sh/client'
+import { SpinnerNoMargin, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { useRouter } from 'next/navigation'
+import { useEffect, useRef, useState } from 'react'
+import AppleLoginButton from './AppleLoginButton'
+import EmailOTPForm from './EmailOTPForm'
+import GitHubLoginButton from './GitHubLoginButton'
+import GoogleLoginButton from './GoogleLoginButton'
+import SSOLoginButton from './SSOLoginButton'
+
+type AuthenticationSession = schemas['AuthenticationSession']
+type Factor = AuthenticationSession['available_factors'][number]
+type SSOFactor = Extract<Factor, { type: 'sso' }>
+
+const OrDivider = () => (
+  <Box alignItems="center" gap="l">
+    <Box
+      flexGrow={1}
+      borderTopWidth={1}
+      borderStyle="solid"
+      borderColor="border-primary"
+    />
+    <Text variant="caption" color="muted">
+      or
+    </Text>
+    <Box
+      flexGrow={1}
+      borderTopWidth={1}
+      borderStyle="solid"
+      borderColor="border-primary"
+    />
+  </Box>
+)
+
+const OrgAuth = ({ slug, returnTo }: { slug: string; returnTo?: string }) => {
+  const router = useRouter()
+  const [session, setSession] = useState<AuthenticationSession | null>(null)
+  const [status, setStatus] = useState<
+    'loading' | 'completing' | 'ready' | 'error'
+  >('loading')
+  const initialized = useRef(false)
+
+  useEffect(() => {
+    if (initialized.current) {
+      return
+    }
+    initialized.current = true
+
+    const init = async () => {
+      const { data: existing, response } = await api.GET('/v1/auth/status')
+
+      // /status is global and omits org SSO factors, so only trust it after an
+      // identity is attached (return-from-callback): advance or complete.
+      if (response.ok && existing && existing.identity_id) {
+        if (existing.available_factors.length === 0) {
+          setStatus('completing')
+          window.location.href = getOrgAuthenticationSessionCompleteURL(slug)
+          return
+        }
+        const redirectPath = getAuthenticationSessionRedirectPath(existing)
+        if (redirectPath) {
+          setStatus('completing')
+          router.push(redirectPath)
+          return
+        }
+        setSession(existing)
+        setStatus('ready')
+        return
+      }
+
+      // Start an org-scoped session to get this org's factors (SSO + base).
+      const { data: started, error } = await api.POST('/v1/auth/{slug}/start', {
+        params: { path: { slug } },
+        body: { return_to: returnTo },
+      })
+      if (error || !started) {
+        setStatus('error')
+        return
+      }
+      setSession(started)
+      setStatus('ready')
+    }
+
+    init()
+  }, [slug, returnTo, router])
+
+  if (status === 'error') {
+    return (
+      <Box
+        borderRadius="m"
+        backgroundColor="background-warning"
+        borderWidth={1}
+        borderStyle="solid"
+        borderColor="border-warning"
+        padding="l"
+      >
+        <Text>
+          Could not load single sign-on for this organization. Please try again.
+        </Text>
+      </Box>
+    )
+  }
+
+  if (status === 'completing' || status === 'loading' || !session) {
+    return (
+      <Box
+        flexDirection="column"
+        alignItems="center"
+        gap="m"
+        paddingVertical="2xl"
+      >
+        <SpinnerNoMargin />
+        <Text color="muted">
+          {status === 'completing'
+            ? 'Signing you in…'
+            : 'Loading sign-in options…'}
+        </Text>
+      </Box>
+    )
+  }
+
+  const factors = session.available_factors
+  const ssoFactors = factors.filter((f): f is SSOFactor => f.type === 'sso')
+  const hasApple = factors.some((f) => f.type === 'apple')
+  const hasGithub = factors.some((f) => f.type === 'github')
+  const hasGoogle = factors.some((f) => f.type === 'google')
+  const hasEmail = factors.some((f) => f.type === 'email_otp')
+  const hasBaseFactor = hasApple || hasGithub || hasGoogle || hasEmail
+
+  return (
+    <Box flexDirection="column" gap="l">
+      {ssoFactors.map((factor) => (
+        <SSOLoginButton
+          key={factor.connection_id}
+          organizationSlug={slug}
+          connection={{ id: factor.connection_id, name: factor.name }}
+          authenticationSession={session}
+          returnTo={returnTo}
+          variant="default"
+        />
+      ))}
+      {ssoFactors.length > 0 && hasBaseFactor && <OrDivider />}
+      {hasApple && (
+        <AppleLoginButton
+          authenticationSession={session}
+          returnTo={returnTo}
+          variant="secondary"
+        />
+      )}
+      {hasGithub && (
+        <GitHubLoginButton
+          authenticationSession={session}
+          returnTo={returnTo}
+          variant="secondary"
+        />
+      )}
+      {hasGoogle && (
+        <GoogleLoginButton
+          authenticationSession={session}
+          returnTo={returnTo}
+          variant="secondary"
+        />
+      )}
+      {hasEmail && (
+        <EmailOTPForm authenticationSession={session} returnTo={returnTo} />
+      )}
+    </Box>
+  )
+}
+
+export default OrgAuth

--- a/clients/apps/web/src/components/Auth/SSOLoginButton.tsx
+++ b/clients/apps/web/src/components/Auth/SSOLoginButton.tsx
@@ -1,0 +1,62 @@
+import { useToast } from '@/components/Toast/use-toast'
+import { useOrgAuthSessionStart } from '@/hooks'
+import { usePostHog } from '@/hooks/posthog'
+import { getSSOAuthorizeLoginURL } from '@/utils/auth'
+import Key from '@mui/icons-material/Key'
+import { schemas } from '@polar-sh/client'
+import { Button, type ButtonProps } from '@polar-sh/orbit'
+
+interface SSOLoginButtonProps {
+  organizationSlug: string
+  connection: { id: string; name: string | null }
+  authenticationSession: schemas['AuthenticationSession'] | null
+  returnTo?: string
+  variant?: ButtonProps['variant']
+}
+
+const SSOLoginButton = ({
+  organizationSlug,
+  connection,
+  authenticationSession,
+  returnTo,
+  variant,
+}: SSOLoginButtonProps) => {
+  const posthog = usePostHog()
+  const authSessionStart = useOrgAuthSessionStart(organizationSlug)
+  const { toast } = useToast()
+
+  const onClick = async () => {
+    posthog.capture('global:user:login:submit', { method: 'sso' })
+
+    if (!authenticationSession) {
+      try {
+        await authSessionStart.mutateAsync(returnTo)
+      } catch {
+        toast({
+          title: 'Sign in failed',
+          description:
+            'Could not start authentication session. Please try again.',
+        })
+        return
+      }
+    }
+
+    window.location.href = getSSOAuthorizeLoginURL(
+      organizationSlug,
+      connection.id,
+    )
+  }
+
+  return (
+    <a onClick={onClick}>
+      <Button variant={variant} wrapperClassNames="space-x-2 p-2.5 px-5" fullWidth>
+        <Key fontSize="small" />
+        <div className="w-32 text-left">
+          {connection.name ?? 'Sign in with SSO'}
+        </div>
+      </Button>
+    </a>
+  )
+}
+
+export default SSOLoginButton

--- a/clients/apps/web/src/components/Auth/SSOLoginButton.tsx
+++ b/clients/apps/web/src/components/Auth/SSOLoginButton.tsx
@@ -49,7 +49,11 @@ const SSOLoginButton = ({
 
   return (
     <a onClick={onClick}>
-      <Button variant={variant} wrapperClassNames="space-x-2 p-2.5 px-5" fullWidth>
+      <Button
+        variant={variant}
+        wrapperClassNames="space-x-2 p-2.5 px-5"
+        fullWidth
+      >
         <Key fontSize="small" />
         <div className="w-32 text-left">
           {connection.name ?? 'Sign in with SSO'}

--- a/clients/apps/web/src/hooks/auth.ts
+++ b/clients/apps/web/src/hooks/auth.ts
@@ -56,6 +56,15 @@ export const useAuthSessionStart = () =>
       api.POST('/v1/auth/start', { body: { return_to } }),
   })
 
+export const useOrgAuthSessionStart = (slug: string) =>
+  useMutation({
+    mutationFn: (return_to?: string) =>
+      api.POST('/v1/auth/{slug}/start', {
+        params: { path: { slug } },
+        body: { return_to },
+      }),
+  })
+
 export const useEmailOTPRequest = () =>
   useMutation({
     mutationFn: (email: string) =>

--- a/clients/apps/web/src/utils/auth.ts
+++ b/clients/apps/web/src/utils/auth.ts
@@ -40,6 +40,19 @@ export const getAppleAuthorizeURL = (): string => {
   return `${getPublicServerURL()}/v1/auth/apple/authorize`
 }
 
+export const getSSOAuthorizeLoginURL = (
+  organizationSlug: string,
+  connectionId: string,
+): string => {
+  return `${getPublicServerURL()}/v1/auth/${organizationSlug}/sso/${connectionId}/authorize`
+}
+
+export const getOrgAuthenticationSessionCompleteURL = (
+  organizationSlug: string,
+): string => {
+  return `${getPublicServerURL()}/v1/auth/${organizationSlug}/complete`
+}
+
 export const getSSOCallbackURL = (organizationSlug: string): string => {
   return `${getPublicServerURL()}/v1/auth/${organizationSlug}/sso/callback`
 }

--- a/server/polar/auth/endpoints.py
+++ b/server/polar/auth/endpoints.py
@@ -1,4 +1,5 @@
 import typing
+from uuid import UUID
 
 from fastapi import Depends, Request, Response
 from fastapi.responses import RedirectResponse
@@ -34,6 +35,7 @@ from polar.postgres import AsyncSession, get_db_session
 from polar.routing import APIRouter
 from polar.user.repository import UserRepository
 from polar.user.service import user as user_service
+from polar.user_organization.repository import UserOrganizationRepository
 
 from .authentication_session import (
     AuthenticationSessionService,
@@ -146,15 +148,32 @@ async def complete(
         raise PolarAuthRedirectionError("User not found for authenticated identity")
 
     context = authentication_session.context or {}
-    factor: LoginMethod = typing.cast(
-        LoginMethod, authentication_session.used_factors[0]
-    )
+
+    # An SSO-authenticated session stays scoped to its organization, whichever
+    # completion path (including the global 2FA pages) it reaches.
+    organization_ids: frozenset[UUID] | None = None
+    factor: LoginMethod
+    sso_organization_id = context.get("sso_organization_id")
+    if sso_organization_id is not None:
+        organization_id = UUID(sso_organization_id)
+        user_organization_repository = UserOrganizationRepository.from_session(session)
+        membership = await user_organization_repository.get_by_user_and_organization(
+            user.id, organization_id
+        )
+        if membership is None:
+            raise PolarAuthRedirectionError("You are not a member of this organization")
+        organization_ids = frozenset({organization_id})
+        factor = "sso"
+    else:
+        factor = typing.cast(LoginMethod, authentication_session.used_factors[0])
+
     response = await auth_service.get_login_response(
         session,
         request,
         user,
         return_to=context.get("return_to"),
         factor=factor,
+        organization_ids=organization_ids,
     )
     await authentication_session_service.set_cookie(request, response, "", 0)
     return response

--- a/server/polar/auth/sso/endpoints.py
+++ b/server/polar/auth/sso/endpoints.py
@@ -259,6 +259,13 @@ async def callback(
     if membership is None:
         raise PolarAuthRedirectionError("You are not a member of this organization")
 
+    # Mark that SSO authenticated this session for the organization, so any
+    # completion path (including the global 2FA pages) mints an org-scoped
+    # session and never falls back to an unscoped login.
+    authentication_session.context = {
+        **(authentication_session.context or {}),
+        "sso_organization_id": str(connection.organization_id),
+    }
     await authentication_session_service.advance(
         authentication_session, user.id, factor
     )

--- a/server/polar/auth/sso/endpoints.py
+++ b/server/polar/auth/sso/endpoints.py
@@ -263,10 +263,11 @@ async def callback(
         authentication_session, user.id, factor
     )
 
-    # Like the social login flow, hand off to the frontend so any remaining
-    # factors (e.g. TOTP) are challenged before the session completes
+    # Hand off to the organization login page so any remaining factors (e.g.
+    # TOTP) are challenged and the org-scoped session is completed via
+    # `/{slug}/complete` rather than the global, unscoped completion.
     response = RedirectResponse(
-        settings.generate_frontend_url("/auth"), status_code=303
+        settings.generate_frontend_url(f"/auth/sso/{slug}"), status_code=303
     )
     set_state_cookie(request, response, "", 0)
     return response

--- a/server/tests/auth/sso/test_flow.py
+++ b/server/tests/auth/sso/test_flow.py
@@ -217,11 +217,60 @@ class TestSSOLoginFlow:
                 email=user.email,
             )
             assert callback.status_code == 303
-            assert (
-                f"/auth/sso/{organization.slug}" in callback.headers["location"]
-            )
+            assert f"/auth/sso/{organization.slug}" in callback.headers["location"]
 
             await sso_client.get(f"/v1/auth/{organization.slug}/complete")
+
+        user_session = (
+            (
+                await session.execute(
+                    select(UserSession).where(UserSession.user_id == user.id)
+                )
+            )
+            .scalars()
+            .unique()
+            .one()
+        )
+        scopes = (
+            (
+                await session.execute(
+                    select(UserSessionOrganization).where(
+                        UserSessionOrganization.user_session_id == user_session.id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert [scope.organization_id for scope in scopes] == [organization.id]
+
+    async def test_global_complete_keeps_sso_session_scoped(
+        self,
+        sso_client: httpx.AsyncClient,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+        user_organization: UserOrganization,
+        idp_key: rsa.RSAPrivateKey,
+    ) -> None:
+        # Completing through the global /complete (as the shared TOTP/backup-codes
+        # pages do) must still mint an org-scoped session for an SSO login.
+        connection = await create_sso_connection(save_fixture, organization)
+
+        with respx.mock(assert_all_mocked=False) as mock:
+            callback = await drive_to_callback(
+                sso_client,
+                session,
+                mock,
+                idp_key,
+                slug=organization.slug,
+                connection_id=connection.id,
+                email=user.email,
+            )
+            assert callback.status_code == 303
+
+            await sso_client.get("/v1/auth/complete")
 
         user_session = (
             (

--- a/server/tests/auth/sso/test_flow.py
+++ b/server/tests/auth/sso/test_flow.py
@@ -217,6 +217,9 @@ class TestSSOLoginFlow:
                 email=user.email,
             )
             assert callback.status_code == 303
+            assert (
+                f"/auth/sso/{organization.slug}" in callback.headers["location"]
+            )
 
             await sso_client.get(f"/v1/auth/{organization.slug}/complete")
 


### PR DESCRIPTION
## Summary

Adds `/auth/sso/[slug]` — the login page for an organization.

It starts an org-scoped session (`POST /{slug}/start`) and renders one button per returned `available_factors`: the org's SSO connections **plus** the base factors (Apple/GitHub/Google + email OTP). 
It's fully driven by `available_factors`, so once "forced SSO" ships (base factors dropped server-side) the page shows only SSO buttons with no change here.

The SSO callback now redirects to `/auth/sso/{slug}` (instead of the global `/auth`) so the org-scoped session completes via `/{slug}/complete` and stays scoped to the organization.

Base factors on this page do a normal global login (SSO is the only org-scoped path) — acceptable since forced-SSO will hide them.


https://github.com/user-attachments/assets/1a3b8074-fb1b-46a4-b60a-b93c0a542c2b



## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

