### PR TITLE
feat(sso): get email verified from profile if absent from token claims

### DIFF
--- a/server/polar/auth/sso/endpoints.py
+++ b/server/polar/auth/sso/endpoints.py
@@ -240,8 +240,20 @@ async def callback(
         raise PolarAuthRedirectionError(OIDC_ERROR_MESSAGE)
 
     claims = await factor.get_id_token_claims(oauth_account.id_token)
-    if claims.get("email_verified") is not True:
-        raise PolarAuthRedirectionError("The email address could not be verified")
+    email_verified = claims.get("email_verified")
+    if email_verified is not True:
+        if email_verified is False:
+            raise PolarAuthRedirectionError("The email address could not be verified")
+        try:
+            # Some providers (e.g. Okta) omit `email_verified` from the id_token but
+            # assert it at the userinfo endpoint. Fall back to the profile before failing.
+            profile = await factor.get_profile(oauth_account.access_token)
+        except (OAuth2GetProfileException, NotImplementedError) as e:
+            raise PolarAuthRedirectionError(
+                "The email address could not be verified"
+            ) from e
+        if profile.get("email_verified") is not True:
+            raise PolarAuthRedirectionError("The email address could not be verified")
 
     email = claims.get("email")
     if email is None:


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- issue number -->

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->

## Why

<!-- Explain why this change is needed -->

## How

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verify email via the user profile when `email_verified` is missing from the ID token in the SSO callback. This restores sign-in for providers like Okta that omit the claim.

- **Bug Fixes**
  - Still reject when the token sets `email_verified: false`.
  - If the claim is absent, fetch the profile and require `email_verified: true`; otherwise reject.
  - Fail gracefully when the profile endpoint is unsupported or errors.

<sup>Written for commit 1c0fa6937822f01ee85e45d35e7ed9d04674a4a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

