### PR TITLE
feat(oauth): backfill encrypted OAuthAccount tokens

### DIFF
--- a/handbook/engineering/design-documents/secrets-encryption.mdx
+++ b/handbook/engineering/design-documents/secrets-encryption.mdx
@@ -3,7 +3,7 @@
 
 **Created**: 2026-06-23
 
-**Last Updated**: 2026-06-25
+**Last Updated**: 2026-07-01
 
 **Author**: Petru Rares Sincraian
 </Info>
@@ -79,7 +79,7 @@ There is no separate "data key rotation" step: each secret already gets its own 
 We migrate one column at a time, without losing data, in this order:
 
 1. Add the encrypted column and write both (plain and encrypted) while reading plain.
-2. Backfill existing rows with a background job (see `server/polar/meter/tasks.py` for the pattern).
+2. Backfill existing rows with a batched script (see `server/scripts/backfill_oauth_account_encrypted_tokens.py`).
 3. Switch reads to the encrypted column, then drop the plain column in a later migration.
 
 The full migration plan is in [Appendix C](#appendix-c-migration-plan).
@@ -271,7 +271,7 @@ We migrate each secret column on its own, so a problem with one never blocks the
 
 1. Add `X_encrypted` (a new column holding ciphertext). Keep the plain `X` for now.
 2. Dual-write. On every write, set the plain `X` and also `X_encrypted = await EncryptedString.encrypt(value, context=...)`. On read, prefer `await obj.X_encrypted.decrypt()` and fall back to `X`. The app behaves exactly as before.
-3. Backfill. A batched script reads each row, encrypts `X`, and fills `X_encrypted` (one KMS `GenerateDataKey` call per row, so pace the batches within the KMS request-rate quota). The pattern to copy is `meter.backfill_events` in `server/polar/meter/tasks.py`. Migrations stay thin (add the column only); the data work happens in the task.
+3. Backfill. A batched script reads each row, encrypts `X`, and fills `X_encrypted` (one KMS `GenerateDataKey` call per row, so pace the batches within the KMS request-rate quota). Encryption is per-row Python work through the key provider, so it cannot be a set-based SQL update; the script loops on the `X_encrypted IS NULL` predicate, which drains as rows are filled and makes the script safe to rerun. See `server/scripts/backfill_oauth_account_encrypted_tokens.py`. Migrations stay thin (add the column only); the data work happens in the script.
 4. Cut over. Once the backfill is done, switch reads to `X_encrypted` only.
 5. Drop the plain column in a later migration, after we are confident.
 

--- a/server/scripts/backfill_oauth_account_encrypted_tokens.py
+++ b/server/scripts/backfill_oauth_account_encrypted_tokens.py
@@ -7,7 +7,7 @@ from rich.progress import (
     TextColumn,
     TimeElapsedColumn,
 )
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from polar.config import settings
 from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
@@ -22,6 +22,7 @@ cli = typer.Typer()
 async def run_backfill(
     batch_size: int = 500,
     sleep_seconds: float = 0.1,
+    dry_run: bool = False,
     session: AsyncSession | None = None,
 ) -> int:
     """
@@ -52,6 +53,18 @@ async def run_backfill(
     batch_number = 0
 
     try:
+        if dry_run:
+            count = (
+                await session.scalar(
+                    select(func.count())
+                    .select_from(OAuthAccount)
+                    .where(OAuthAccount.access_token_encrypted.is_(None))
+                )
+                or 0
+            )
+            typer.echo(f"[dry-run] {count} oauth accounts would be encrypted")
+            return count
+
         with Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
@@ -120,13 +133,17 @@ async def run_backfill(
 async def backfill(
     batch_size: int = typer.Option(500, help="Number of rows to process per batch"),
     sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Count rows that would be encrypted without writing"
+    ),
 ) -> None:
     """Encrypt OAuthAccount tokens written before dual-write."""
     configure_script_logging()
     total_encrypted = await run_backfill(
-        batch_size=batch_size, sleep_seconds=sleep_seconds
+        batch_size=batch_size, sleep_seconds=sleep_seconds, dry_run=dry_run
     )
-    typer.echo(f"Encrypted {total_encrypted} oauth accounts")
+    if not dry_run:
+        typer.echo(f"Encrypted {total_encrypted} oauth accounts")
 
 
 if __name__ == "__main__":

--- a/server/scripts/backfill_oauth_account_encrypted_tokens.py
+++ b/server/scripts/backfill_oauth_account_encrypted_tokens.py
@@ -1,0 +1,133 @@
+import asyncio
+
+import typer
+from rich.progress import (
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeElapsedColumn,
+)
+from sqlalchemy import select
+
+from polar.config import settings
+from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
+from polar.kit.db.postgres import create_async_engine as _create_async_engine
+from polar.models import OAuthAccount
+
+from .helper import configure_script_logging, typer_async
+
+cli = typer.Typer()
+
+
+async def run_backfill(
+    batch_size: int = 500,
+    sleep_seconds: float = 0.1,
+    session: AsyncSession | None = None,
+) -> int:
+    """
+    Encrypt OAuthAccount tokens written before dual-write (rollout step 3; see
+    the design document, Appendix C).
+
+    Encryption calls the key provider once per row, so this loops in Python
+    rather than a set-based SQL update. Encrypted rows fall out of the `IS NULL`
+    predicate, so the loop terminates and reruns are safe.
+    """
+    engine = None
+    own_session = False
+
+    if session is None:
+        engine = _create_async_engine(
+            dsn=str(settings.get_postgres_dsn("asyncpg")),
+            application_name=f"{settings.ENV.value}.script",
+            debug=False,
+            pool_size=settings.DATABASE_POOL_SIZE,
+            pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
+            command_timeout=settings.DATABASE_COMMAND_TIMEOUT_SECONDS,
+        )
+        sessionmaker = create_async_sessionmaker(engine)
+        session = sessionmaker()
+        own_session = True
+
+    total_encrypted = 0
+    batch_number = 0
+
+    try:
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            TimeElapsedColumn(),
+            transient=False,
+        ) as progress:
+            task = progress.add_task("[cyan]Batch 0: 0 rows encrypted", total=None)
+
+            while True:
+                statement = (
+                    select(OAuthAccount)
+                    .where(OAuthAccount.access_token_encrypted.is_(None))
+                    .order_by(OAuthAccount.id)
+                    .limit(batch_size)
+                )
+                result = await session.execute(statement)
+                oauth_accounts = list(result.scalars().all())
+
+                if not oauth_accounts:
+                    progress.update(
+                        task,
+                        description=(
+                            f"[green]✓ Complete: {total_encrypted} rows encrypted"
+                        ),
+                    )
+                    break
+
+                for oauth_account in oauth_accounts:
+                    oauth_account.access_token_encrypted = (
+                        await OAuthAccount.encrypt_access_token(
+                            oauth_account.id, oauth_account.access_token
+                        )
+                    )
+                    oauth_account.refresh_token_encrypted = (
+                        await OAuthAccount.encrypt_refresh_token(
+                            oauth_account.id, oauth_account.refresh_token
+                        )
+                    )
+
+                await session.commit()
+                session.expunge_all()
+
+                batch_number += 1
+                total_encrypted += len(oauth_accounts)
+                progress.update(
+                    task,
+                    description=(
+                        f"[cyan]Batch {batch_number}: {total_encrypted} rows encrypted"
+                    ),
+                )
+
+                if sleep_seconds > 0:
+                    await asyncio.sleep(sleep_seconds)
+
+        return total_encrypted
+
+    finally:
+        if own_session:
+            await session.close()
+        if engine is not None:
+            await engine.dispose()
+
+
+@cli.command()
+@typer_async
+async def backfill(
+    batch_size: int = typer.Option(500, help="Number of rows to process per batch"),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+) -> None:
+    """Encrypt OAuthAccount tokens written before dual-write."""
+    configure_script_logging()
+    total_encrypted = await run_backfill(
+        batch_size=batch_size, sleep_seconds=sleep_seconds
+    )
+    typer.echo(f"Encrypted {total_encrypted} oauth accounts")
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/tests/scripts/test_backfill_oauth_account_encrypted_tokens.py
+++ b/server/tests/scripts/test_backfill_oauth_account_encrypted_tokens.py
@@ -137,3 +137,22 @@ class TestBackfillOAuthAccountEncryptedTokens:
         loaded = await _reload(session, oauth_account)
         assert isinstance(loaded.access_token_encrypted, EncryptedString)
         assert loaded.access_token_encrypted.encrypted_value == first_ciphertext
+
+    async def test_dry_run_counts_without_writing(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        oauth_account = await _create_legacy_oauth_account(
+            save_fixture,
+            user,
+            account_id="dry-run",
+            access_token="the-access-token",
+        )
+
+        count = await run_backfill(dry_run=True, session=session)
+
+        assert count == 1
+        loaded = await _reload(session, oauth_account)
+        assert loaded.access_token_encrypted is None

--- a/server/tests/scripts/test_backfill_oauth_account_encrypted_tokens.py
+++ b/server/tests/scripts/test_backfill_oauth_account_encrypted_tokens.py
@@ -1,0 +1,139 @@
+import pytest
+from sqlalchemy import select
+
+from polar.kit.db.postgres import AsyncSession
+from polar.kit.encryption import EncryptedString
+from polar.models import User
+from polar.models.user import OAuthAccount, OAuthPlatform
+from scripts.backfill_oauth_account_encrypted_tokens import run_backfill
+from tests.fixtures.database import SaveFixture
+
+
+async def _create_legacy_oauth_account(
+    save_fixture: SaveFixture,
+    user: User,
+    *,
+    account_id: str,
+    access_token: str,
+    refresh_token: str | None = None,
+) -> OAuthAccount:
+    """A row written before dual-write: plaintext tokens, NULL encrypted columns."""
+    oauth_account = OAuthAccount(
+        platform=OAuthPlatform.github,
+        account_id=account_id,
+        account_email=f"{account_id}@example.com",
+        account_username=account_id,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        user=user,
+    )
+    await save_fixture(oauth_account)
+    return oauth_account
+
+
+async def _reload(session: AsyncSession, oauth_account: OAuthAccount) -> OAuthAccount:
+    session.expunge_all()
+    loaded = await session.scalar(
+        select(OAuthAccount).where(OAuthAccount.id == oauth_account.id)
+    )
+    assert loaded is not None
+    return loaded
+
+
+@pytest.mark.asyncio
+class TestBackfillOAuthAccountEncryptedTokens:
+    async def test_encrypts_legacy_rows(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        oauth_account = await _create_legacy_oauth_account(
+            save_fixture,
+            user,
+            account_id="legacy",
+            access_token="the-access-token",
+            refresh_token="the-refresh-token",
+        )
+        assert oauth_account.access_token_encrypted is None
+        assert oauth_account.refresh_token_encrypted is None
+
+        encrypted = await run_backfill(batch_size=10, sleep_seconds=0, session=session)
+
+        assert encrypted == 1
+        loaded = await _reload(session, oauth_account)
+        assert isinstance(loaded.access_token_encrypted, EncryptedString)
+        assert (
+            await loaded.access_token_encrypted.decrypt(id=str(loaded.id))
+            == "the-access-token"
+        )
+        assert isinstance(loaded.refresh_token_encrypted, EncryptedString)
+        assert (
+            await loaded.refresh_token_encrypted.decrypt(id=str(loaded.id))
+            == "the-refresh-token"
+        )
+
+    async def test_leaves_null_refresh_token_null(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        oauth_account = await _create_legacy_oauth_account(
+            save_fixture,
+            user,
+            account_id="no-refresh",
+            access_token="the-access-token",
+            refresh_token=None,
+        )
+
+        await run_backfill(batch_size=10, sleep_seconds=0, session=session)
+
+        loaded = await _reload(session, oauth_account)
+        assert isinstance(loaded.access_token_encrypted, EncryptedString)
+        assert loaded.refresh_token_encrypted is None
+
+    async def test_processes_multiple_batches(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        for i in range(5):
+            await _create_legacy_oauth_account(
+                save_fixture,
+                user,
+                account_id=f"acc-{i}",
+                access_token=f"token-{i}",
+            )
+
+        encrypted = await run_backfill(batch_size=2, sleep_seconds=0, session=session)
+
+        assert encrypted == 5
+        remaining = await session.execute(
+            select(OAuthAccount).where(OAuthAccount.access_token_encrypted.is_(None))
+        )
+        assert remaining.scalars().first() is None
+
+    async def test_is_idempotent(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        oauth_account = await _create_legacy_oauth_account(
+            save_fixture,
+            user,
+            account_id="rerun",
+            access_token="the-access-token",
+        )
+
+        assert await run_backfill(batch_size=10, sleep_seconds=0, session=session) == 1
+        loaded = await _reload(session, oauth_account)
+        assert isinstance(loaded.access_token_encrypted, EncryptedString)
+        first_ciphertext = loaded.access_token_encrypted.encrypted_value
+
+        assert await run_backfill(batch_size=10, sleep_seconds=0, session=session) == 0
+        loaded = await _reload(session, oauth_account)
+        assert isinstance(loaded.access_token_encrypted, EncryptedString)
+        assert loaded.access_token_encrypted.encrypted_value == first_ciphertext


### PR DESCRIPTION
## Summary

Backfill the encrypted token columns for `OAuthAccount` rows written

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

