### PR TITLE
feat(oauth): read encrypted OAuthAccount tokens with plaintext fallback

### DIFF
--- a/server/polar/auth/oauth2/factor.py
+++ b/server/polar/auth/oauth2/factor.py
@@ -33,7 +33,7 @@ class OAuth2FactorMixin:
         enrollment_orm = result.scalar_one_or_none()
         if enrollment_orm is None:
             return None
-        return enrollment_orm.to_dataclass(self.SCOPE)
+        return await enrollment_orm.to_dataclass(self.SCOPE)
 
     async def insert(
         self: OAuth2FactorProtocol, enrollment: OAuth2EnrollmentDataclass
@@ -97,7 +97,7 @@ class OAuth2FactorMixin:
         enrollment_orm = result.scalar_one_or_none()
         if enrollment_orm is None:
             return None
-        return enrollment_orm.to_dataclass(self.SCOPE)
+        return await enrollment_orm.to_dataclass(self.SCOPE)
 
     async def get_email(
         self, callback_result: OAuth2EnrollmentDataclass | OAuth2Account

--- a/server/polar/integrations/github_repository_benefit/service.py
+++ b/server/polar/integrations/github_repository_benefit/service.py
@@ -133,7 +133,7 @@ class GitHubRepositoryBenefitUserService:
         )
         account.expires_at = oauth2_token_data["expires_at"]
 
-        client = github.get_client(access_token=account.access_token)
+        client = github.get_client(access_token=await account.get_access_token())
         user_data = await client.rest.users.async_get_authenticated()
         github.ensure_expected_response(user_data)
 
@@ -159,12 +159,13 @@ class GitHubRepositoryBenefitUserService:
             raise GitHubRepositoryBenefitAccountNotConnected(user)
 
         if account.is_access_token_expired():
-            if account.refresh_token is None:
+            refresh_token = await account.get_refresh_token()
+            if refresh_token is None:
                 raise GitHubRepositoryBenefitExpiredAccessToken(user)
 
             try:
                 refreshed_token_data = await github_oauth_client.refresh_token(
-                    account.refresh_token
+                    refresh_token
                 )
             except RefreshTokenError as e:
                 raise GitHubRepositoryRefreshTokenError() from e
@@ -188,7 +189,7 @@ class GitHubRepositoryBenefitUserService:
     async def list_user_installations(
         self, oauth: OAuthAccount
     ) -> list["types.Installation"]:
-        client = github.get_client(access_token=oauth.access_token)
+        client = github.get_client(access_token=await oauth.get_access_token())
 
         def map_installations_func(
             r: github.Response["types.UserInstallationsGetResponse200"],
@@ -246,7 +247,7 @@ class GitHubRepositoryBenefitUserService:
         ) = None
 
         if installation.target_type == "User":
-            user_client = github.get_client(access_token=oauth.access_token)
+            user_client = github.get_client(access_token=await oauth.get_access_token())
             user_response = await user_client.rest.users.async_get_authenticated()
             if user_response.parsed_data and user_response.parsed_data.plan:
                 plan = user_response.parsed_data.plan
@@ -296,7 +297,7 @@ class GitHubRepositoryBenefitUserService:
         oauth: OAuthAccount,
         installations: list["types.Installation"],
     ) -> list[GitHubInvitesBenefitRepository]:
-        client = github.get_client(access_token=oauth.access_token)
+        client = github.get_client(access_token=await oauth.get_access_token())
 
         """
         Load user accessible installations from GitHub API

--- a/server/polar/models/user.py
+++ b/server/polar/models/user.py
@@ -119,14 +119,24 @@ class OAuthAccount(RecordModel):
             return True
         return False
 
-    def to_dataclass(self, scope: list[str]) -> OAuth2EnrollmentDataclass:
+    async def get_access_token(self) -> str:
+        if self.access_token_encrypted is not None:
+            return await self.access_token_encrypted.decrypt(id=str(self.id))
+        return self.access_token
+
+    async def get_refresh_token(self) -> str | None:
+        if self.refresh_token_encrypted is not None:
+            return await self.refresh_token_encrypted.decrypt(id=str(self.id))
+        return self.refresh_token
+
+    async def to_dataclass(self, scope: list[str]) -> OAuth2EnrollmentDataclass:
         return OAuth2EnrollmentDataclass(
             id=self.id,
             provider=self.platform,
             scope=scope,
-            access_token=self.access_token,
+            access_token=await self.get_access_token(),
             expires_at=self.expires_at,
-            refresh_token=self.refresh_token,
+            refresh_token=await self.get_refresh_token(),
             refresh_token_expires_at=self.refresh_token_expires_at,
             account_id=self.account_id,
             identity_id=self.user_id,

--- a/server/tests/models/test_oauth_account.py
+++ b/server/tests/models/test_oauth_account.py
@@ -103,6 +103,46 @@ class TestEncryptClassmethods:
 
 
 @pytest.mark.asyncio
+class TestGetTokens:
+    async def test_prefers_encrypted(self, user: User) -> None:
+        oauth_account = await _build(user)
+        await oauth_account.set_tokens(
+            access_token="the-access-token", refresh_token="the-refresh-token"
+        )
+
+        assert await oauth_account.get_access_token() == "the-access-token"
+        assert await oauth_account.get_refresh_token() == "the-refresh-token"
+
+    async def test_falls_back_to_plain(self, user: User) -> None:
+        oauth_account = await _build(user)
+        oauth_account.id = OAuthAccount.generate_id()
+        oauth_account.access_token = "the-access-token"
+        oauth_account.refresh_token = "the-refresh-token"
+
+        assert await oauth_account.get_access_token() == "the-access-token"
+        assert await oauth_account.get_refresh_token() == "the-refresh-token"
+
+    async def test_refresh_token_none_without_encrypted(self, user: User) -> None:
+        oauth_account = await _build(user)
+        oauth_account.id = OAuthAccount.generate_id()
+        oauth_account.access_token = "the-access-token"
+        oauth_account.refresh_token = None
+
+        assert await oauth_account.get_refresh_token() is None
+
+    async def test_to_dataclass_decrypts_tokens(self, user: User) -> None:
+        oauth_account = await _build(user)
+        await oauth_account.set_tokens(
+            access_token="the-access-token", refresh_token="the-refresh-token"
+        )
+
+        enrollment = await oauth_account.to_dataclass(["scope"])
+
+        assert enrollment.access_token == "the-access-token"
+        assert enrollment.refresh_token == "the-refresh-token"
+
+
+@pytest.mark.asyncio
 class TestPersistence:
     async def test_round_trip_through_database(
         self, save_fixture: SaveFixture, session: AsyncSession, user: User


### PR DESCRIPTION
## Summary

Now, OAuthAccount will read the encrypted token if it exists, and if not fallback to the original value.


## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

