### PR TITLE
fix(migration): do not backpopulate sso_enforced

### DIFF
--- a/server/migrations/versions/2026-07-01-1418_add_sso_enforced_to_organization.py
+++ b/server/migrations/versions/2026-07-01-1418_add_sso_enforced_to_organization.py
@@ -25,10 +25,6 @@ def upgrade() -> None:
         "organizations",
         sa.Column("sso_enforced", sa.Boolean(), nullable=True),
     )
-    op.execute("UPDATE organizations SET sso_enforced = false")
-    op.alter_column(
-        "organizations", "sso_enforced", existing_type=sa.Boolean(), nullable=False
-    )
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- issue number -->

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->

## Why

<!-- Explain why this change is needed -->

## How

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove backfilling and NOT NULL enforcement for `sso_enforced` in the migration. The upgrade now only adds the column as nullable to avoid a table-wide update and potential locks.

- **Migration**
  - Remove bulk UPDATE and `ALTER ... SET NOT NULL`; keep `sso_enforced` added as nullable.

<sup>Written for commit 996e3b17fc4f37010c9d3a0d01d802ba66a5a0a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

