### PR TITLE
feat(organization): make sso_enforced not nullable

### DIFF
--- a/server/migrations/versions/2026-07-01-1721_enforce_organizations_sso_enforced_not_.py
+++ b/server/migrations/versions/2026-07-01-1721_enforce_organizations_sso_enforced_not_.py
@@ -1,0 +1,36 @@
+"""enforce organizations.sso_enforced NOT NULL
+
+Revision ID: 31d662178679
+Revises: 6cd2cda5a8a0
+Create Date: 2026-07-01 17:21:13.325483
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "31d662178679"
+down_revision = "6cd2cda5a8a0"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Run scripts.backfill_organization_sso_enforced --execute before this
+    # migration so no NULL rows remain when enforcing NOT NULL.
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.alter_column(
+        "organizations", "sso_enforced", existing_type=sa.Boolean(), nullable=False
+    )
+
+
+def downgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.alter_column(
+        "organizations", "sso_enforced", existing_type=sa.Boolean(), nullable=True
+    )

--- a/server/migrations/versions/2026-07-01-1721_enforce_organizations_sso_enforced_not_.py
+++ b/server/migrations/versions/2026-07-01-1721_enforce_organizations_sso_enforced_not_.py
@@ -19,10 +19,15 @@ depends_on: tuple[str] | None = None
 
 
 def upgrade() -> None:
-    # Run scripts.backfill_organization_sso_enforced --execute before this
-    # migration so no NULL rows remain when enforcing NOT NULL.
     # Ensures we don't break app by applying a deadlock-inducing migration
     op.execute("SET LOCAL lock_timeout = '5s'")
+    # Backfill remaining NULLs so the migration is self-contained (fresh/local DBs
+    # and any stragglers). In production, run
+    # scripts.backfill_organization_sso_enforced --execute first so this UPDATE
+    # matches no rows and doesn't rewrite the table under lock.
+    op.execute(
+        "UPDATE organizations SET sso_enforced = false WHERE sso_enforced IS NULL"
+    )
     op.alter_column(
         "organizations", "sso_enforced", existing_type=sa.Boolean(), nullable=False
     )

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -635,7 +635,7 @@ class Organization(RateLimitGroupMixin, RecordModel):
     def is_sso_enabled(self) -> bool:
         return self.feature_settings.get("sso_enabled", False)
 
-    sso_enforced: Mapped[bool] = mapped_column(Boolean, nullable=True, default=False)
+    sso_enforced: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     #
     # Currency and tax settings


### PR DESCRIPTION
## Summary

draft until backfill ran 

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `organizations.sso_enforced` NOT NULL and set the model to `nullable=False` (default stays `False`) to remove nullable states and improve data integrity.

- **Migration**
  - Apply the Alembic migration; it is self-contained and requires no manual backfill.

<sup>Written for commit e6a110a5f70f010ab1fc738d5c3fc1ae610d2bf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

