### PR TITLE
Improve proration behavior labels for clarity

### DIFF
--- a/clients/apps/app/app/(authenticated)/subscriptions/[id]/update/index.tsx
+++ b/clients/apps/app/app/(authenticated)/subscriptions/[id]/update/index.tsx
@@ -213,10 +213,10 @@ const PRORATION_BEHAVIOR_LABELS: Record<
   schemas['SubscriptionProrationBehavior'],
   string
 > = {
-  invoice: 'Invoice Immediately',
-  prorate: 'Prorate next Invoice',
-  next_period: 'Apply on Next Period',
-  reset: 'Invoice Immediately without Proration and Reset Cycle',
+  invoice: 'Prorate & charge now',
+  prorate: 'Prorate on next invoice',
+  next_period: 'Schedule for next cycle',
+  reset: 'Charge full amount & reset cycle',
 }
 
 const ProrationBehaviorSelector = ({

--- a/clients/apps/web/src/components/Settings/ProrationBehavior.tsx
+++ b/clients/apps/web/src/components/Settings/ProrationBehavior.tsx
@@ -12,10 +12,10 @@ const PRORATION_BEHAVIOR_LABELS: Record<
   schemas['SubscriptionProrationBehavior'],
   string
 > = {
-  invoice: 'Invoice Immediately',
-  prorate: 'Next Invoice',
-  next_period: 'Apply on Next Period',
-  reset: 'Invoice Immediately without Proration and Reset Cycle',
+  invoice: 'Prorate & charge now',
+  prorate: 'Prorate on next invoice',
+  next_period: 'Schedule for next cycle',
+  reset: 'Charge full amount & reset cycle',
 }
 
 export interface ProrationBehaviorProps {

--- a/docs/features/subscriptions/proration.mdx
+++ b/docs/features/subscriptions/proration.mdx
@@ -12,13 +12,13 @@ You pick the proration behavior either at the organization level (as the default
 
 Polar supports three standard proration behaviors:
 
-### Invoice Immediately (`invoice`)
+### Prorate and charge now (`invoice`)
 
 The subscription is updated **immediately** and Polar invoices the prorated difference right away. If the update is an upgrade the customer is charged; if it's a downgrade they're credited on the new invoice.
 
 Use this when you want money to change hands at the same time as the change — for example, on upgrades where you want to collect the extra revenue now.
 
-### Next Invoice (`prorate`)
+### Prorate on next invoice (`prorate`)
 
 The subscription is updated **immediately**, but the prorated difference is carried over and applied on the **next scheduled invoice** instead of triggering a charge now. The customer's billing cycle is unchanged.
 
@@ -35,7 +35,7 @@ This is typically the smoothest experience for the customer: their plan changes 
   unchanged.
 </Warning>
 
-### Next Period (`next_period`)
+### Schedule for next cycle (`next_period`)
 
 The change is **not applied immediately**. It's scheduled as a pending update and applied at the start of the next billing period. No proration charge or credit is issued — the new plan simply takes effect on renewal.
 
@@ -43,7 +43,7 @@ While a `next_period` update is pending, the subscription's `pending_update` fie
 
 This behavior is the safer default for downgrades where you don't want to issue credits, and for any case where you want the current period's terms to stay intact.
 
-### Opting out of proration (`reset`)
+### Charge full amount and reset cycle (`reset`)
 
 The subscription switches to the new plan **immediately**, Polar invoices the **full price of the new plan** right away, and the **billing cycle is reset** to start now. No proration is applied: the customer isn't credited for the unused portion of the old period, and they aren't charged a prorated amount — they pay the full new price and begin a fresh billing period.
 

--- a/docs/merchant-of-record/fees.mdx
+++ b/docs/merchant-of-record/fees.mdx
@@ -33,7 +33,7 @@ Below your plan's threshold, a lower tier is the better deal. Above it, the paid
 Paid plans also unlock early access to features that are still in preview. While in preview, each of these is available only on paid plans:
 
 - [Shared Slack Channel benefit](/features/benefits/slack-shared-channel) — automatically give each customer a shared Slack channel via Slack Connect.
-- [`reset` proration behavior](/features/subscriptions/proration#opting-out-of-proration-reset) — on a plan change, charge the full new-plan price and restart the billing cycle, with no proration.
+- [`reset` proration behavior](/features/subscriptions/proration#charge-full-amount-and-reset-cycle-reset) — on a plan change, charge the full new-plan price and restart the billing cycle, with no proration.
 - [Off-session charges](/features/orders#arbitrary-charges) — charge a customer's saved payment method for an arbitrary amount, outside of a checkout or renewal.
 
 ## Early Member


### PR DESCRIPTION
## Summary

Updates proration behavior labels across the codebase to be more concise and user-friendly, improving clarity around subscription update options.

## What

Updated the display labels for subscription proration behaviors in three locations:

1. **App subscription update UI** (`clients/apps/app/app/(authenticated)/subscriptions/[id]/update/index.tsx`)
2. **Web settings component** (`clients/apps/web/src/components/Settings/ProrationBehavior.tsx`)
3. **Documentation** (`docs/features/subscriptions/proration.mdx` and `docs/merchant-of-record/fees.mdx`)

The labels were changed to be more descriptive and action-oriented:
- `invoice`: "Invoice Immediately" → "Prorate & charge now"
- `prorate`: "Prorate next Invoice" / "Next Invoice" → "Prorate on next invoice"
- `next_period`: "Apply on Next Period" → "Schedule for next cycle"
- `reset`: "Invoice Immediately without Proration and Reset Cycle" → "Charge full amount & reset cycle"

## Why

The previous labels were verbose and sometimes unclear about what would actually happen to the customer's billing. The new labels are:
- More concise and scannable
- Clearer about the financial impact (e.g., "charge now" vs "schedule")
- More consistent in tone and terminology across the UI and documentation
- Better aligned with how customers think about billing changes

## How

Synchronized label updates across all UI components and documentation to ensure consistency. The underlying behavior and API remain unchanged—only the user-facing labels were updated.

## Checklist

- [x] This PR addresses a single concern (improving label clarity)
- [x] The diff is reasonably sized and easy to review
- [x] No new functionality or tests needed (label-only changes)
- [x] No unrelated changes included

https://claude.ai/code/session_01XEiuAwbrtc73sAsmQwCBmc

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

