### PR TITLE
feat(terraform): add Cloudflare IP ranges module for forwarded_allow_ips

### DIFF
--- a/terraform/modules/cloudflare_ips/main.tf
+++ b/terraform/modules/cloudflare_ips/main.tf
@@ -13,8 +13,8 @@ data "http" "cloudflare_ips_v4" {
 
   lifecycle {
     postcondition {
-      condition     = self.response_body != ""
-      error_message = "Cloudflare IPv4 ranges endpoint returned empty content. Check https://www.cloudflare.com/ips-v4"
+      condition     = self.response_body != "" && self.status_code == 200
+      error_message = "Cloudflare IPv4 ranges endpoint failed. Check https://www.cloudflare.com/ips-v4"
     }
   }
 }
@@ -28,8 +28,8 @@ data "http" "cloudflare_ips_v6" {
 
   lifecycle {
     postcondition {
-      condition     = self.response_body != ""
-      error_message = "Cloudflare IPv6 ranges endpoint returned empty content. Check https://www.cloudflare.com/ips-v6"
+      condition     = self.response_body != "" && self.status_code == 200
+      error_message = "Cloudflare IPv6 ranges endpoint failed. Check https://www.cloudflare.com/ips-v6"
     }
   }
 }

--- a/terraform/modules/cloudflare_ips/main.tf
+++ b/terraform/modules/cloudflare_ips/main.tf
@@ -8,14 +8,16 @@
 # https://www.cloudflare.com/ips-v4
 # Returns a plain text file with one IP range per line
 data "http" "cloudflare_ips_v4" {
-  url = "https://www.cloudflare.com/ips-v4"
+  url                = "https://www.cloudflare.com/ips-v4"
+  request_timeout_ms = 30000
 }
 
 # Fetch Cloudflare IPv6 ranges
 # https://www.cloudflare.com/ips-v6
 # Returns a plain text file with one IP range per line
 data "http" "cloudflare_ips_v6" {
-  url = "https://www.cloudflare.com/ips-v6"
+  url                = "https://www.cloudflare.com/ips-v6"
+  request_timeout_ms = 30000
 }
 
 locals {

--- a/terraform/modules/cloudflare_ips/main.tf
+++ b/terraform/modules/cloudflare_ips/main.tf
@@ -10,6 +10,13 @@
 data "http" "cloudflare_ips_v4" {
   url                = "https://www.cloudflare.com/ips-v4"
   request_timeout_ms = 30000
+
+  lifecycle {
+    postcondition {
+      condition     = self.response_body != ""
+      error_message = "Cloudflare IPv4 ranges endpoint returned empty content. Check https://www.cloudflare.com/ips-v4"
+    }
+  }
 }
 
 # Fetch Cloudflare IPv6 ranges
@@ -18,6 +25,13 @@ data "http" "cloudflare_ips_v4" {
 data "http" "cloudflare_ips_v6" {
   url                = "https://www.cloudflare.com/ips-v6"
   request_timeout_ms = 30000
+
+  lifecycle {
+    postcondition {
+      condition     = self.response_body != ""
+      error_message = "Cloudflare IPv6 ranges endpoint returned empty content. Check https://www.cloudflare.com/ips-v6"
+    }
+  }
 }
 
 locals {
@@ -35,15 +49,4 @@ locals {
 
   # Combine all ranges into a single comma-separated string
   all_ranges = join(",", concat(local.ipv4_ranges, local.ipv6_ranges))
-}
-
-# Validate that we successfully fetched at least one IP range
-# If Cloudflare's endpoints return empty (transient outage), this will fail
-# the Terraform plan rather than silently setting forwarded_allow_ips to ""
-# which would block all traffic.
-check "cloudflare_ranges_not_empty" {
-  assert {
-    condition     = length(local.ipv4_ranges) > 0 || length(local.ipv6_ranges) > 0
-    error_message = "Cloudflare IP ranges are empty. Check if https://www.cloudflare.com/ips-v4 and https://www.cloudflare.com/ips-v6 are accessible."
-  }
 }

--- a/terraform/modules/cloudflare_ips/main.tf
+++ b/terraform/modules/cloudflare_ips/main.tf
@@ -34,3 +34,14 @@ locals {
   # Combine all ranges into a single comma-separated string
   all_ranges = join(",", concat(local.ipv4_ranges, local.ipv6_ranges))
 }
+
+# Validate that we successfully fetched at least one IP range
+# If Cloudflare's endpoints return empty (transient outage), this will fail
+# the Terraform plan rather than silently setting forwarded_allow_ips to ""
+# which would block all traffic.
+check "cloudflare_ranges_not_empty" {
+  assert {
+    condition     = length(local.ipv4_ranges) > 0 || length(local.ipv6_ranges) > 0
+    error_message = "Cloudflare IP ranges are empty. Check if https://www.cloudflare.com/ips-v4 and https://www.cloudflare.com/ips-v6 are accessible."
+  }
+}

--- a/terraform/modules/cloudflare_ips/main.tf
+++ b/terraform/modules/cloudflare_ips/main.tf
@@ -1,0 +1,36 @@
+# Cloudflare IP Ranges Module
+#
+# Fetches Cloudflare's published IP ranges (IPv4 and IPv6) and outputs them
+# as a comma-separated string suitable for use with forwarded_allow_ips
+# configuration.
+
+# Fetch Cloudflare IPv4 ranges
+# https://www.cloudflare.com/ips-v4
+# Returns a plain text file with one IP range per line
+data "http" "cloudflare_ips_v4" {
+  url = "https://www.cloudflare.com/ips-v4"
+}
+
+# Fetch Cloudflare IPv6 ranges
+# https://www.cloudflare.com/ips-v6
+# Returns a plain text file with one IP range per line
+data "http" "cloudflare_ips_v6" {
+  url = "https://www.cloudflare.com/ips-v6"
+}
+
+locals {
+  # Parse IPv4 ranges: split by newlines, trim whitespace, filter empty lines
+  ipv4_ranges = [
+    for ip in split("\n", data.http.cloudflare_ips_v4.response_body) :
+    trimspace(ip) if trimspace(ip) != ""
+  ]
+
+  # Parse IPv6 ranges: split by newlines, trim whitespace, filter empty lines
+  ipv6_ranges = [
+    for ip in split("\n", data.http.cloudflare_ips_v6.response_body) :
+    trimspace(ip) if trimspace(ip) != ""
+  ]
+
+  # Combine all ranges into a single comma-separated string
+  all_ranges = join(",", concat(local.ipv4_ranges, local.ipv6_ranges))
+}

--- a/terraform/modules/cloudflare_ips/outputs.tf
+++ b/terraform/modules/cloudflare_ips/outputs.tf
@@ -1,0 +1,19 @@
+output "ipv4_ranges" {
+  description = "List of Cloudflare IPv4 CIDR ranges."
+  value       = local.ipv4_ranges
+}
+
+output "ipv6_ranges" {
+  description = "List of Cloudflare IPv6 CIDR ranges."
+  value       = local.ipv6_ranges
+}
+
+output "all_ranges" {
+  description = "All Cloudflare IP ranges (IPv4 and IPv6) as a comma-separated string."
+  value       = local.all_ranges
+}
+
+output "all_ranges_list" {
+  description = "All Cloudflare IP ranges (IPv4 and IPv6) as a list."
+  value       = concat(local.ipv4_ranges, local.ipv6_ranges)
+}

--- a/terraform/modules/cloudflare_ips/terraform.tf
+++ b/terraform/modules/cloudflare_ips/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 3.0"
+    }
+  }
+}

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -112,6 +112,14 @@ resource "render_redis" "redis" {
 }
 
 # =============================================================================
+# Cloudflare IP Ranges
+# =============================================================================
+
+module "cloudflare_ips" {
+  source = "../modules/cloudflare_ips"
+}
+
+# =============================================================================
 # Production
 # =============================================================================
 
@@ -145,6 +153,7 @@ module "production" {
     custom_domains         = [{ name = "api.polar.sh" }, { name = "api-alt.polar.sh" }, { name = "buy.polar.sh" }, { name = "backoffice.polar.sh" }]
     plan                   = "pro_plus"
     web_concurrency        = "6"
+    forwarded_allow_ips    = module.cloudflare_ips.all_ranges
   }
 
   postgres_config = {

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -71,6 +71,14 @@ locals {
 }
 
 # =============================================================================
+# Cloudflare IP Ranges
+# =============================================================================
+
+module "cloudflare_ips" {
+  source = "../modules/cloudflare_ips"
+}
+
+# =============================================================================
 # Sandbox
 # =============================================================================
 
@@ -123,7 +131,7 @@ module "sandbox" {
     cors_origins           = "[\"https://sandbox.polar.sh\", \"https://github.com\", \"https://docs.polar.sh\"]"
     custom_domains         = [{ name = "sandbox-api.polar.sh" }]
     web_concurrency        = "2"
-    forwarded_allow_ips    = "*"
+    forwarded_allow_ips    = module.cloudflare_ips.all_ranges
     database_pool_size     = "10"
     postgres_database      = "polar_sandbox"
     postgres_read_database = "polar_sandbox"

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -74,6 +74,14 @@ resource "render_redis" "redis" {
 }
 
 # =============================================================================
+# Cloudflare IP Ranges
+# =============================================================================
+
+module "cloudflare_ips" {
+  source = "../modules/cloudflare_ips"
+}
+
+# =============================================================================
 # Test
 # =============================================================================
 locals {
@@ -131,7 +139,7 @@ module "test" {
     cors_origins           = "[\"https://test.polar.sh\", \"https://github.com\", \"https://docs.polar.sh\"]"
     custom_domains         = [{ name = "test-api.polar.sh" }]
     web_concurrency        = "2"
-    forwarded_allow_ips    = "*"
+    forwarded_allow_ips    = module.cloudflare_ips.all_ranges
     database_pool_size     = "10"
     postgres_database      = local.db_name
     postgres_read_database = local.db_name


### PR DESCRIPTION
## Summary

**Related Issue**: N/A

Add Cloudflare IP ranges module to restrict `forwarded_allow_ips` to Cloudflare's published IP ranges instead of allowing all IPs.

## What

- Created a new Terraform module `cloudflare_ips` in `terraform/modules/cloudflare_ips/` that:
  - Fetches Cloudflare's IPv4 ranges from `https://www.cloudflare.com/ips-v4`
  - Fetches Cloudflare's IPv6 ranges from `https://www.cloudflare.com/ips-v6`
  - Processes and combines them into a comma-separated string
  - Outputs the ranges in multiple formats for flexibility

- Integrated the module into all three environments:
  - `terraform/production/render.tf`
  - `terraform/sandbox/render.tf`
  - `terraform/test/render.tf`

- Changed `forwarded_allow_ips` from `"*"` (allow all) to `module.cloudflare_ips.all_ranges` (Cloudflare IPs only)

## Why

Currently, all environments have `forwarded_allow_ips` set to `"*"`, which allows traffic from any IP address. Since the service is behind Cloudflare proxy, we should restrict this to only Cloudflare's published IP ranges for security. This prevents direct access to the origin from non-Cloudflare IPs.

## How

The module uses Terraform's `http` data source to fetch the plain text files published by Cloudflare. It then:
1. Splits the response by newlines
2. Trims whitespace from each entry
3. Filters out empty lines
4. Joins all ranges with commas using `join(",", concat(ipv4_ranges, ipv6_ranges))`

To refresh the IP ranges when Cloudflare updates them: `terraform apply -refresh-only`

## Checklist

- [x] This PR addresses a single concern (security improvement for forwarded_allow_ips)
- [x] The diff is reasonably sized and easy to review (6 files changed, 92 insertions, 2 deletions)
- [ ] New functionality is covered by tests (N/A - infrastructure change)
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`) (to be verified)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

