### PR TITLE
fix(payout): block held payouts from triggering Stripe payouts

### DIFF
--- a/server/polar/backoffice/payouts/endpoints.py
+++ b/server/polar/backoffice/payouts/endpoints.py
@@ -277,7 +277,10 @@ async def get(
     if payout is None:
         raise HTTPException(status_code=404)
 
-    can_retry = payout.status != PayoutStatus.canceled and (
+    can_retry = payout.status not in (
+        PayoutStatus.canceled,
+        PayoutStatus.held,
+    ) and (
         payout.status == PayoutStatus.failed
         or len(payout.attempts) == 0
         or sum(
@@ -418,6 +421,12 @@ async def retry(
         raise HTTPException(
             status_code=400,
             detail="Cannot retry a canceled payout.",
+        )
+
+    if payout.status == PayoutStatus.held:
+        raise HTTPException(
+            status_code=400,
+            detail="Cannot retry a held payout while the organization is under review.",
         )
 
     remaining_amount = payout.account_amount - sum(

--- a/server/polar/payout/service.py
+++ b/server/polar/payout/service.py
@@ -224,6 +224,16 @@ class PayoutCanceled(PayoutError):
         super().__init__(message, 400)
 
 
+class PayoutHeld(PayoutError):
+    def __init__(self, payout: Payout) -> None:
+        self.payout = payout
+        message = (
+            f"Payout {payout.id} is held and cannot be triggered while the "
+            "organization is under review."
+        )
+        super().__init__(message, 400)
+
+
 class PayoutNotCancelable(PayoutError):
     def __init__(self, payout: Payout) -> None:
         self.payout = payout
@@ -663,6 +673,9 @@ class PayoutService:
         """
         if payout.status == PayoutStatus.canceled:
             raise PayoutCanceled(payout)
+
+        if payout.status == PayoutStatus.held:
+            raise PayoutHeld(payout)
 
         payout_account = payout.payout_account
         assert payout_account.stripe_id is not None

--- a/server/tests/payout/test_service.py
+++ b/server/tests/payout/test_service.py
@@ -26,6 +26,8 @@ from polar.payout.service import (
     InvoiceAlreadyExists,
     MissingInvoiceBillingDetails,
     OrganizationCannotPayout,
+    PayoutCanceled,
+    PayoutHeld,
     PayoutIntervalLimitReached,
     PayoutNotCancelable,
     PayoutNotSucceeded,
@@ -635,6 +637,64 @@ class TestTriggerStripePayouts:
         enqueue_job_mock.assert_any_call(
             "payout.trigger_stripe_payout", payout_id=payout_3.id
         )
+
+
+@pytest.mark.asyncio
+class TestTriggerStripePayout:
+    async def test_canceled_raises(
+        self,
+        stripe_service_mock: MagicMock,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        account = await create_account(save_fixture, user)
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        payout = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            status=PayoutStatus.canceled,
+            attempts=[],
+        )
+
+        with pytest.raises(PayoutCanceled):
+            await payout_service.trigger_stripe_payout(session, payout)
+
+        stripe_service_mock.retrieve_balance.assert_not_called()
+        stripe_service_mock.create_payout.assert_not_called()
+
+    async def test_held_raises(
+        self,
+        stripe_service_mock: MagicMock,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        # A held payout (org under review) must never reach Stripe, even through
+        # the manual retry/trigger path, or funds from other payouts in the same
+        # Connect account could be paid out against it.
+        account = await create_account(save_fixture, user)
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        payout = await create_payout(
+            save_fixture,
+            account=account,
+            payout_account=payout_account,
+            status=PayoutStatus.held,
+            attempts=[],
+        )
+
+        with pytest.raises(PayoutHeld):
+            await payout_service.trigger_stripe_payout(session, payout)
+
+        stripe_service_mock.retrieve_balance.assert_not_called()
+        stripe_service_mock.create_payout.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

**Related Issue**: #12228

Held payouts (created when an organization transitions to REVIEW) could still be pushed to Stripe through the manual backoffice retry path, this fix that.

## What

- `trigger_stripe_payout()` now rejects `held` payouts (new `PayoutHeld` error) before touching Stripe, in addition to the existing `canceled` check.
- Backoffice payout view: `can_retry` excludes `held` (hides the Retry button) and the retry endpoint rejects `held` with a 400.

## Why

Only `transfer()` guarded against `held`; the manual retry/trigger path did not, so a held payout could be paid out using funds from other pending payouts in the same Connect account while the ledger still showed it unfunded.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

