### PR TITLE
Tighten embedded checkout spacings and dimensions

### DIFF
--- a/clients/apps/web/src/components/Checkout/Checkout.tsx
+++ b/clients/apps/web/src/components/Checkout/Checkout.tsx
@@ -265,6 +265,7 @@ const Checkout = ({
           disabled={disableCheckout}
           isUpdatePending={isUpdatePending}
           locale={locale}
+          embed
           beforeSubmit={
             hasProductCheckout(checkout) && !checkout.is_free_product_price ? (
               <div className="flex flex-col gap-4">

--- a/clients/apps/web/src/components/Checkout/Embed/CheckoutEmbedLayout.tsx
+++ b/clients/apps/web/src/components/Checkout/Embed/CheckoutEmbedLayout.tsx
@@ -15,8 +15,8 @@ const CheckoutEmbedLayout = ({
       className={theme === 'dark' ? 'dark' : 'light'}
       id="polar-embed-layout"
     >
-      <div className="flex h-full w-full items-center justify-center p-0 md:p-12 dark:text-white">
-        <div className="h-full w-full max-w-2xl" id="polar-embed-content">
+      <div className="flex h-full w-full items-center justify-center p-0 md:p-6 dark:text-white">
+        <div className="h-full w-full max-w-lg" id="polar-embed-content">
           {children}
         </div>
       </div>

--- a/clients/packages/checkout/src/components/CheckoutForm.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.tsx
@@ -80,6 +80,7 @@ interface BaseCheckoutFormProps {
   locale?: AcceptedLocale
   isWalletPayment?: boolean
   beforeSubmit?: React.ReactNode
+  embed?: boolean
 }
 
 const BaseCheckoutForm = ({
@@ -95,6 +96,7 @@ const BaseCheckoutForm = ({
   locale: localeProp,
   isWalletPayment,
   beforeSubmit,
+  embed,
 }: React.PropsWithChildren<BaseCheckoutFormProps>) => {
   const interval = hasProductCheckout(checkout)
     ? isLegacyRecurringProductPrice(checkout.product_price)
@@ -274,12 +276,17 @@ const BaseCheckoutForm = ({
   }, [checkout, interval, t])
 
   return (
-    <div className="flex flex-col justify-between gap-y-24">
-      <div className="flex flex-col gap-y-12">
+    <div
+      className={cn(
+        'flex flex-col justify-between',
+        embed ? 'gap-y-8' : 'gap-y-24',
+      )}
+    >
+      <div className={cn('flex flex-col', embed ? 'gap-y-8' : 'gap-y-12')}>
         <Form {...form}>
           <form
             onSubmit={handleSubmit(onSubmit)}
-            className="flex flex-col gap-y-12"
+            className={cn('flex flex-col', embed ? 'gap-y-8' : 'gap-y-12')}
           >
             <div className="flex flex-col gap-y-6">
               <FormField
@@ -745,6 +752,7 @@ interface CheckoutFormProps {
   themePreset: ThemingPresetProps
   locale?: AcceptedLocale
   beforeSubmit?: React.ReactNode
+  embed?: boolean
 }
 
 const StripeCheckoutForm = (props: CheckoutFormProps) => {


### PR DESCRIPTION
## Summary
Tighten spacing for the embedded checkout

## Screenshots
| Before | After  |
|--------|--------|
| <img width="1840" height="1134" alt="Screenshot 2026-07-01 at 21 57 20" src="https://github.com/user-attachments/assets/b7192f47-39d9-4d98-932a-7b97c1c77ecc" /> | <img width="1840" height="1134" alt="Screenshot 2026-07-01 at 21 58 54" src="https://github.com/user-attachments/assets/9412ec73-de8d-4c02-9fd6-fa38f556d0fb" /> |






<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

