### PR TITLE
feat(dashboard): add Download Receipt button to order detail page

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/[id]/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/[id]/SalesPage.tsx
@@ -86,19 +86,19 @@ const ClientPage: React.FC<ClientPageProps> = ({
         <Box alignItems="center" columnGap="l">
           {order.paid && (
             <>
+              <DownloadInvoiceDashboard
+                order={order}
+                organization={organization}
+                onInvoiceGenerated={refetchOrder}
+              />
               {order.receipt_number != null && (
                 <DownloadReceiptDashboard
                   organization={organization}
                   order={order}
                   className="w-auto"
+                  variant="secondary"
                 />
               )}
-              <DownloadInvoiceDashboard
-                order={order}
-                organization={organization}
-                onInvoiceGenerated={refetchOrder}
-                variant={order.receipt_number != null ? 'secondary' : undefined}
-              />
             </>
           )}
           <DropdownMenu>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/[id]/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/[id]/SalesPage.tsx
@@ -12,6 +12,7 @@ import { OrderSeatsSection } from '@/components/Orders/OrderSeatsSection'
 import { OrderSection } from '@/components/Orders/OrderSection'
 import { OrderStatus } from '@/components/Orders/OrderStatus'
 import { DownloadInvoiceDashboard } from '@/components/Orders/DownloadInvoice'
+import { DownloadReceiptDashboard } from '@/components/Orders/DownloadReceipt'
 import { InvoicePreview } from '@/components/Orders/InvoicePreview'
 import { toast } from '@/components/Toast/use-toast'
 import { useCustomFields, useProduct, useSubscription } from '@/hooks/queries'
@@ -84,11 +85,21 @@ const ClientPage: React.FC<ClientPageProps> = ({
       header={
         <Box alignItems="center" columnGap="l">
           {order.paid && (
-            <DownloadInvoiceDashboard
-              order={order}
-              organization={organization}
-              onInvoiceGenerated={refetchOrder}
-            />
+            <>
+              {order.receipt_number != null && (
+                <DownloadReceiptDashboard
+                  organization={organization}
+                  order={order}
+                  className="w-auto"
+                />
+              )}
+              <DownloadInvoiceDashboard
+                order={order}
+                organization={organization}
+                onInvoiceGenerated={refetchOrder}
+                variant={order.receipt_number != null ? 'secondary' : undefined}
+              />
+            </>
           )}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>

--- a/clients/apps/web/src/components/Orders/DownloadReceipt.tsx
+++ b/clients/apps/web/src/components/Orders/DownloadReceipt.tsx
@@ -8,6 +8,9 @@ import type EventEmitter from 'eventemitter3'
 import { useCallback, useRef, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { useCustomerPortalContext } from '../CustomerPortal/CustomerPortalProvider'
+import { buttonVariants } from '@polar-sh/orbit/ui/button'
+
+type Variant = NonNullable<Parameters<typeof buttonVariants>[0]>['variant']
 
 const RECEIPT_GENERATED_EVENT = 'order.receipt_generated'
 const RENDER_TIMEOUT_MS = 30_000
@@ -47,6 +50,7 @@ const DownloadReceipt = ({
   eventEmitter,
   receiptURL,
   className,
+  variant,
 }: {
   order: schemas['Order'] | schemas['CustomerOrder']
   api: Client
@@ -55,6 +59,7 @@ const DownloadReceipt = ({
     | '/v1/orders/{id}/receipt'
     | '/v1/customer-portal/orders/{id}/receipt'
   className?: string
+  variant?: Variant
 }) => {
   const [loading, setLoading] = useState(false)
   const [failed, setFailed] = useState(false)
@@ -140,6 +145,7 @@ const DownloadReceipt = ({
       loading={loading}
       disabled={loading}
       className={twMerge('w-full', className)}
+      variant={variant}
     >
       Download Receipt
     </Button>
@@ -150,10 +156,12 @@ export const DownloadReceiptDashboard = ({
   organization,
   order,
   className,
+  variant,
 }: {
   organization: schemas['Organization']
   order: schemas['Order']
   className?: string
+  variant?: Variant
 }) => {
   const eventEmitter = useOrganizationSSE(organization.id)
   return (
@@ -163,6 +171,7 @@ export const DownloadReceiptDashboard = ({
       eventEmitter={eventEmitter}
       receiptURL="/v1/orders/{id}/receipt"
       className={className}
+      variant={variant}
     />
   )
 }

--- a/clients/apps/web/src/components/Orders/DownloadReceipt.tsx
+++ b/clients/apps/web/src/components/Orders/DownloadReceipt.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { useOrganizationSSE } from '@/hooks/sse'
+import { api } from '@/utils/client'
 import type { Client, schemas } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
 import type EventEmitter from 'eventemitter3'
@@ -141,6 +143,27 @@ const DownloadReceipt = ({
     >
       Download Receipt
     </Button>
+  )
+}
+
+export const DownloadReceiptDashboard = ({
+  organization,
+  order,
+  className,
+}: {
+  organization: schemas['Organization']
+  order: schemas['Order']
+  className?: string
+}) => {
+  const eventEmitter = useOrganizationSSE(organization.id)
+  return (
+    <DownloadReceipt
+      order={order}
+      api={api}
+      eventEmitter={eventEmitter}
+      receiptURL="/v1/orders/{id}/receipt"
+      className={className}
+    />
   )
 }
 


### PR DESCRIPTION
Add a merchant-facing DownloadReceiptDashboard wrapper (mirroring
DownloadInvoiceDashboard) that uses the organization SSE stream and the
`/v1/orders/{id}/receipt` endpoint, and render it in the sales order
detail header when the order has a receipt number.

When a receipt is available the receipt button becomes the primary action
and the invoice button becomes secondary, matching the customer portal's
OrderDownloadActions hierarchy.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MD5C3FGWS18rMoLT1hrVbf

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

