### PR TITLE
Show hovered X-axis value as chart tooltip title

### DIFF
--- a/clients/apps/web/src/components/Charts/GenericChart.tsx
+++ b/clients/apps/web/src/components/Charts/GenericChart.tsx
@@ -69,6 +69,8 @@ interface GenericChartProps<T extends Record<string, unknown>> {
   xAxisKey: keyof T
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   xAxisFormatter?: (value: any) => string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  labelFormatter?: (value: any) => string
   valueFormatter?: (value: number, seriesKey: string) => React.ReactNode
   height?: number
   width?: number
@@ -88,6 +90,7 @@ export const GenericChart = <T extends Record<string, unknown>>({
   series,
   xAxisKey,
   xAxisFormatter,
+  labelFormatter,
   valueFormatter,
   height,
   width,
@@ -215,6 +218,19 @@ export const GenericChart = <T extends Record<string, unknown>>({
     [valueFormatter],
   )
 
+  // Tooltip title = the formatted value of the hovered X-axis point (e.g. the
+  // date), read straight from the data row so it works whether the axis value
+  // is a string or a Date. Falls back to the axis tick formatter.
+  const tooltipLabelFormatter = useMemo(() => {
+    const fmt = labelFormatter ?? xAxisFormatter
+    if (!fmt) return undefined
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (value: any, items: any) => {
+      const raw = items?.[0]?.payload?.[xAxisKey as string]
+      return fmt(raw ?? value)
+    }
+  }, [labelFormatter, xAxisFormatter, xAxisKey])
+
   const primarySeries = series[0]
   const gradientInfo = useMemo(() => {
     if (!primarySeries) return { type: 'positive' as const, zeroOffset: 1 }
@@ -306,7 +322,7 @@ export const GenericChart = <T extends Record<string, unknown>>({
             activeIndex={activeIndex}
             className="text-black dark:text-white"
             indicator="dot"
-            labelKey={primarySeries?.key}
+            labelFormatter={tooltipLabelFormatter}
             formatter={formatter}
           />
         )}
@@ -462,6 +478,7 @@ export const GenericChart = <T extends Record<string, unknown>>({
     ticks,
     xAxisKey,
     xAxisFormatter,
+    tooltipLabelFormatter,
     formatter,
     series,
     primarySeries,

--- a/clients/apps/web/src/components/Costs/Chart.tsx
+++ b/clients/apps/web/src/components/Costs/Chart.tsx
@@ -33,6 +33,7 @@ export const Chart = <T extends Record<string, unknown>>({
   xAxisKey,
   xAxisFormatter,
   yAxisFormatter,
+  labelFormatter,
   showGrid = true,
   showLegend = true,
   showYAxis = false,
@@ -62,6 +63,11 @@ export const Chart = <T extends Record<string, unknown>>({
           xAxisFormatter={
             xAxisFormatter
               ? (value) => xAxisFormatter(value as T[keyof T])
+              : undefined
+          }
+          labelFormatter={
+            labelFormatter
+              ? (value) => labelFormatter(value as T[keyof T])
               : undefined
           }
           valueFormatter={yAxisFormatter}


### PR DESCRIPTION
The chart tooltip title was hardcoded to the primary series label (e.g.
"Current Period") via labelKey. Instead, format the tooltip title from the
hovered X-axis data point so it reflects the actual date/label being
inspected. The value is read straight from the data row so it works whether
the axis value is a string or a Date, falling back to the axis tick
formatter. Also forward the previously-dropped labelFormatter prop through
the Costs Chart wrapper.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MsUjtkUyEGwSG9Pshdh88G

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

