### PR TITLE
IP resolution and rate limit improvements

### DIFF
--- a/server/polar/checkout_link/endpoints.py
+++ b/server/polar/checkout_link/endpoints.py
@@ -9,6 +9,7 @@ from polar.checkout import ip_geolocation
 from polar.checkout.service import checkout as checkout_service
 from polar.checkout_link.repository import CheckoutLinkRepository
 from polar.exceptions import ResourceNotFound
+from polar.kit.http import get_ip_address
 from polar.kit.pagination import ListResource, PaginationParamsQuery
 from polar.kit.schemas import MultipleQueryFilter
 from polar.models import CheckoutLink
@@ -186,7 +187,7 @@ async def redirect(
     if checkout_link is None:
         raise ResourceNotFound()
 
-    ip_address = request.client.host if request.client else None
+    ip_address = get_ip_address(request)
 
     # Build query_prefill dictionary from explicit parameters
     query_prefill: dict[str, str | UUID4 | dict[str, str] | None] = {

--- a/server/polar/customer_seat/endpoints.py
+++ b/server/polar/customer_seat/endpoints.py
@@ -8,6 +8,7 @@ from polar.authz.service import get_accessible_org_ids
 from polar.eventstream.endpoints import subscribe
 from polar.eventstream.service import Receivers
 from polar.exceptions import BadRequest, ResourceNotFound
+from polar.kit.http import get_ip_address
 from polar.models import CustomerSeat, Order, Subscription
 from polar.models.customer_seat import SeatStatus
 from polar.openapi import APITag
@@ -336,7 +337,7 @@ async def claim_seat(
     # Capture request metadata for audit logging
     request_metadata = {
         "user_agent": request.headers.get("user-agent"),
-        "ip": request.client.host if request.client else None,
+        "ip": get_ip_address(request),
     }
 
     seat, customer_session_token = await seat_service.claim_seat(

--- a/server/polar/kit/http.py
+++ b/server/polar/kit/http.py
@@ -218,3 +218,21 @@ def add_query_parameters(url: str, **kwargs: str | list[str]) -> str:
 
 def is_localhost(request: Request) -> bool:
     return request.url.hostname in {"127.0.0.1", "localhost"}
+
+
+def get_ip_address(request: Request) -> str | None:
+    """
+    Get the client's IP address.
+
+    Favor the highly trusted `True-Client-IP` header if present (set by Cloudflare),
+    otherwise fall back to the request's client host.
+    """
+    try:
+        return request.headers["True-Client-IP"]
+    except KeyError:
+        pass
+
+    if request.client:
+        return request.client.host
+
+    return None

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -48,7 +48,7 @@ from polar.integrations.polar.schemas import (
     organization_payment_method_from_sdk,
 )
 from polar.integrations.polar.service import polar_self as polar_self_service
-from polar.kit.http import check_url_reachable
+from polar.kit.http import check_url_reachable, get_ip_address
 from polar.kit.pagination import ListResource, Pagination, PaginationParamsQuery
 from polar.models import Account, Organization, UserOrganization
 from polar.models.support_case import (
@@ -946,7 +946,7 @@ async def start_subscription_checkout(
     session: AsyncReadSession = Depends(get_db_read_session),
 ) -> OrganizationCheckoutResponse:
     """Create a Polar checkout session for an initial paid subscription."""
-    customer_ip_address = request.client.host if request.client else None
+    customer_ip_address = get_ip_address(request)
     checkout = await polar_self_service.start_checkout(
         session=session,
         organization_id=authz.organization.id,
@@ -1044,7 +1044,7 @@ async def claim_startup_program(
     Caller passes ``success_url`` / ``return_url`` defensively; they're only
     used on the Free-plan branch.
     """
-    customer_ip_address = request.client.host if request.client else None
+    customer_ip_address = get_ip_address(request)
     try:
         subscription, checkout = await polar_self_service.claim_startup_program(
             session=session,

--- a/server/polar/rate_limit.py
+++ b/server/polar/rate_limit.py
@@ -5,12 +5,12 @@ from functools import partial
 from fastapi.security.utils import get_authorization_scheme_param
 from ratelimit import RateLimitMiddleware, Rule
 from ratelimit.auths import EmptyInformation
-from ratelimit.auths.ip import client_ip
 from ratelimit.backends.redis import RedisBackend
 from ratelimit.types import ASGIApp, Scope
 
 from polar.config import Environment, settings
 from polar.enums import RateLimitGroup
+from polar.kit.http import get_ip_address
 from polar.redis import Redis
 
 _IDENTITY_KEY_PREFIX = "rl:ident:"
@@ -99,6 +99,13 @@ async def clear_cached_identity(redis: Redis, token: str) -> None:
     await redis.delete(_identity_cache_key(token))
 
 
+def _get_ip(scope: Scope) -> tuple[str, RateLimitGroup]:
+    ip = get_ip_address(Request(scope))
+    if ip is None:
+        raise EmptyInformation(scope)
+    return ip, RateLimitGroup.default
+
+
 async def _authenticate(scope: Scope, *, redis: Redis) -> tuple[str, RateLimitGroup]:
     token = _bearer_token(scope)
     if token is not None:
@@ -115,8 +122,7 @@ async def _authenticate(scope: Scope, *, redis: Redis) -> tuple[str, RateLimitGr
         return f"cookie:{_token_hash(cookie)}", RateLimitGroup.pending_auth
 
     try:
-        ip, _ = await client_ip(scope)
-        return ip, RateLimitGroup.default
+        return _get_ip(scope)
     except (EmptyInformation, ValueError, TypeError):
         return _ANONYMOUS_IDENTITY, RateLimitGroup.default
 

--- a/server/polar/rate_limit.py
+++ b/server/polar/rate_limit.py
@@ -2,6 +2,7 @@ import hashlib
 from collections.abc import Sequence
 from functools import partial
 
+from fastapi.requests import Request
 from fastapi.security.utils import get_authorization_scheme_param
 from ratelimit import RateLimitMiddleware, Rule
 from ratelimit.auths import EmptyInformation
@@ -17,47 +18,40 @@ _IDENTITY_KEY_PREFIX = "rl:ident:"
 _IDENTITY_TTL_SECONDS = 300
 _ANONYMOUS_IDENTITY = "anonymous"
 
-_AUTHORIZATION_HEADER = b"authorization"
-_COOKIE_HEADER = b"cookie"
-
 
 def _bearer_token(scope: Scope) -> str | None:
     if scope.get("type") != "http":
         return None
-    for name, value in scope.get("headers", ()):
-        if name != _AUTHORIZATION_HEADER:
-            continue
-        try:
-            authorization = value.decode("ascii")
-        except UnicodeDecodeError:
-            return None
-        scheme, token = get_authorization_scheme_param(authorization)
-        if not scheme or scheme.lower() != "bearer" or not token:
-            return None
-        return token
-    return None
+
+    request = Request(scope)
+
+    authorization = request.headers.get("authorization")
+    if authorization is None:
+        return None
+
+    scheme, token = get_authorization_scheme_param(authorization)
+    if not scheme or scheme.lower() != "bearer" or not token:
+        return None
+
+    return token
 
 
 def _session_cookie(scope: Scope) -> str | None:
     if scope.get("type") != "http":
         return None
-    name_bytes = settings.USER_SESSION_COOKIE_KEY.encode("ascii")
-    for header_name, header_value in scope.get("headers", ()):
-        if header_name != _COOKIE_HEADER:
-            continue
-        for part in header_value.split(b";"):
-            part = part.strip()
-            equal = part.find(b"=")
-            if equal == -1:
-                continue
-            if part[:equal] != name_bytes:
-                continue
-            try:
-                value = part[equal + 1 :].decode("ascii")
-            except UnicodeDecodeError:
-                return None
-            return value or None
-    return None
+
+    request = Request(scope)
+    value = request.cookies.get(settings.USER_SESSION_COOKIE_KEY)
+    return value or None
+
+
+def _auth_session_cookie(scope: Scope) -> str | None:
+    if scope.get("type") != "http":
+        return None
+
+    request = Request(scope)
+    value = request.cookies.get(settings.AUTHENTICATION_SESSION_COOKIE_KEY)
+    return value or None
 
 
 def _token_hash(token: str) -> str:
@@ -120,6 +114,13 @@ async def _authenticate(scope: Scope, *, redis: Redis) -> tuple[str, RateLimitGr
         if cached is not None:
             return cached
         return f"cookie:{_token_hash(cookie)}", RateLimitGroup.pending_auth
+
+    auth_session_cookie = _auth_session_cookie(scope)
+    if auth_session_cookie is not None:
+        return (
+            f"auth_session_cookie:{_token_hash(auth_session_cookie)}",
+            RateLimitGroup.default,
+        )
 
     try:
         return _get_ip(scope)

--- a/server/polar/user/endpoints.py
+++ b/server/polar/user/endpoints.py
@@ -15,6 +15,7 @@ from polar.customer_portal.endpoints.license_keys import router as license_keys_
 from polar.customer_portal.endpoints.order import router as order_router
 from polar.customer_portal.endpoints.subscription import router as subscription_router
 from polar.exceptions import ResourceNotFound
+from polar.kit.http import get_ip_address
 from polar.models import User
 from polar.models.user import OAuthPlatform
 from polar.openapi import APITag
@@ -89,7 +90,7 @@ async def update_authenticated(
     auth_subject: AuthorizeWebUserWrite,
     session: AsyncSession = Depends(get_db_session),
 ) -> User:
-    ip_address = request.client.host if request.client else None
+    ip_address = get_ip_address(request)
     return await user_service.update(
         session, auth_subject.subject, user_update, ip_address=ip_address
     )

--- a/server/tests/test_rate_limit.py
+++ b/server/tests/test_rate_limit.py
@@ -60,10 +60,6 @@ class TestBearerToken:
         scope = _http_scope(headers=[(b"authorization", b"Bearer ")])
         assert _bearer_token(scope) is None
 
-    def test_non_ascii_header(self) -> None:
-        scope = _http_scope(headers=[(b"authorization", b"Bearer \xc3\xa9token")])
-        assert _bearer_token(scope) is None
-
     def test_non_http_scope(self) -> None:
         scope: dict[str, object] = {"type": "websocket", "headers": []}
         assert _bearer_token(scope) is None


### PR DESCRIPTION

- server/rate_limit: harden auth endpoints rate limit by identifying via auth session token
- server: factorize IP address resolution and use Cloudflare True-Client-IP first
  

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

