### PR TITLE
feat(organization): block organization creation from a scoped session

### DIFF
--- a/clients/apps/web/src/app/(main)/oauth2/authorize/components/CreateOrganizationForm.tsx
+++ b/clients/apps/web/src/app/(main)/oauth2/authorize/components/CreateOrganizationForm.tsx
@@ -2,10 +2,11 @@
 
 import revalidate from '@/app/actions'
 import { CurrencySelector } from '@/components/CurrencySelector'
+import { useToast } from '@/components/Toast/use-toast'
 import { useAuth } from '@/hooks'
 import { useCreateOrganization } from '@/hooks/queries'
 import { setValidationErrors } from '@/utils/api/errors'
-import { schemas } from '@polar-sh/client'
+import { isValidationError, schemas } from '@polar-sh/client'
 import { Button, Checkbox, Input } from '@polar-sh/orbit'
 import {
   Form,
@@ -42,6 +43,7 @@ const CreateOrganizationForm = ({
 }) => {
   const { currentUser, setUserOrganizations } = useAuth()
   const createOrganization = useCreateOrganization()
+  const { toast } = useToast()
   const [editedSlug, setEditedSlug] = useState(false)
 
   const form = useForm<FormSchema>({
@@ -81,8 +83,13 @@ const CreateOrganizationForm = ({
       await createOrganization.mutateAsync(data)
 
     if (error) {
-      if (error.detail) {
+      if (isValidationError(error.detail)) {
         setValidationErrors(error.detail, setError)
+      } else if (error.detail) {
+        toast({
+          title: 'Organization creation failed',
+          description: error.detail,
+        })
       }
       return
     }

--- a/clients/apps/web/src/components/Layout/Dashboard/DashboardSidebar.tsx
+++ b/clients/apps/web/src/components/Layout/Dashboard/DashboardSidebar.tsx
@@ -1,4 +1,5 @@
 import { SupportButton } from '@/components/Feedback/SupportButton'
+import { useAuth } from '@/hooks/auth'
 import { NotificationsPopover } from '@/components/Notifications/NotificationsPopover'
 import { OmniSearch } from '@/components/Search/OmniSearch'
 import { CONFIG } from '@/utils/config'
@@ -50,6 +51,7 @@ export const DashboardSidebar = ({
 }) => {
   const router = useRouter()
   const { state } = useSidebar()
+  const { currentUser } = useAuth()
 
   const isCollapsed = state === 'collapsed'
   const [searchOpen, setSearchOpen] = useState(false)
@@ -232,15 +234,17 @@ export const DashboardSidebar = ({
                     </DropdownMenuItem>
                   ))}
                   <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    onClick={() =>
-                      CONFIG.IS_SANDBOX
-                        ? router.push('/onboarding/sandbox')
-                        : router.push('/onboarding/business')
-                    }
-                  >
-                    New Organization
-                  </DropdownMenuItem>
+                  {!currentUser?.organization_scoped && (
+                    <DropdownMenuItem
+                      onClick={() =>
+                        CONFIG.IS_SANDBOX
+                          ? router.push('/onboarding/sandbox')
+                          : router.push('/onboarding/business')
+                      }
+                    >
+                      New Organization
+                    </DropdownMenuItem>
+                  )}
                   <DropdownMenuItem
                     onClick={() => router.push('/dashboard/account')}
                   >

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -11219,6 +11219,17 @@ export interface components {
        */
       action: 'allow' | 'deny'
     }
+    /** CannotCreateOrganizationError */
+    CannotCreateOrganizationError: {
+      /**
+       * Error
+       * @example CannotCreateOrganizationError
+       * @constant
+       */
+      error: 'CannotCreateOrganizationError'
+      /** Detail */
+      detail: string
+    }
     /**
      * CardPayment
      * @description Schema of a payment with a card payment method.
@@ -33022,6 +33033,12 @@ export interface components {
        * @description Organizations the user is a member of, with their role on each. Populated by `GET /v1/users/me`; empty otherwise.
        */
       organizations?: components['schemas']['OrganizationWithRole'][]
+      /**
+       * Organization Scoped
+       * @description Whether the current session is restricted to a specific organization. Such sessions cannot access other organizations or create new ones. Populated by `GET /v1/users/me`.
+       * @default false
+       */
+      organization_scoped: boolean
       /** Email Hash */
       readonly email_hash: string | null
     }
@@ -35786,6 +35803,15 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['Organization']
+        }
+      }
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['CannotCreateOrganizationError']
         }
       }
       /** @description Validation Error */

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -123,6 +123,7 @@ from .schemas import (
     OrganizationValidateWebsiteRequest,
     OrganizationValidateWebsiteResponse,
 )
+from .service import CannotCreateOrganizationError
 from .service import organization as organization_service
 
 router = APIRouter(prefix="/organizations", tags=["organizations"])
@@ -262,7 +263,10 @@ async def get_kyc(
     response_model=OrganizationSchema,
     status_code=201,
     summary="Create Organization",
-    responses={201: {"description": "Organization created."}},
+    responses={
+        201: {"description": "Organization created."},
+        403: {"model": CannotCreateOrganizationError.schema()},
+    },
     tags=[APITag.public],
 )
 async def create(

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -230,6 +230,15 @@ class CannotChangeOwnerError(OrganizationError):
         super().__init__(f"Cannot change organization owner: {reason}")
 
 
+class CannotCreateOrganizationError(OrganizationError):
+    def __init__(self) -> None:
+        super().__init__(
+            "You cannot create an organization from a session restricted to a "
+            "specific organization.",
+            403,
+        )
+
+
 class OrganizationService:
     async def list(
         self,
@@ -316,6 +325,9 @@ class OrganizationService:
         create_schema: OrganizationCreate,
         auth_subject: AuthSubject[User],
     ) -> Organization:
+        if auth_subject.organization_ids is not None:
+            raise CannotCreateOrganizationError()
+
         repository = OrganizationRepository.from_session(session)
         if await repository.slug_exists(create_schema.slug):
             raise PolarRequestValidationError(

--- a/server/polar/user/endpoints.py
+++ b/server/polar/user/endpoints.py
@@ -77,7 +77,8 @@ async def get_authenticated(
             "organizations": [
                 OrganizationWithRole.from_organization(org, role)
                 for org, role in org_with_roles
-            ]
+            ],
+            "organization_scoped": auth_subject.organization_ids is not None,
         }
     )
 

--- a/server/polar/user/schemas.py
+++ b/server/polar/user/schemas.py
@@ -47,6 +47,14 @@ class UserRead(UserBase, TimestampedSchema):
             "Populated by `GET /v1/users/me`; empty otherwise."
         ),
     )
+    organization_scoped: bool = Field(
+        default=False,
+        description=(
+            "Whether the current session is restricted to a specific "
+            "organization. Such sessions cannot access other organizations or "
+            "create new ones. Populated by `GET /v1/users/me`."
+        ),
+    )
 
     @computed_field
     def email_hash(self) -> str | None:

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -54,7 +54,10 @@ from polar.organization.schemas import (
     OrganizationSocialPlatforms,
     OrganizationUpdate,
 )
-from polar.organization.service import OrganizationError
+from polar.organization.service import (
+    CannotCreateOrganizationError,
+    OrganizationError,
+)
 from polar.organization.service import organization as organization_service
 from polar.organization_review.appeal_case import appeal_case as appeal_case_service
 from polar.organization_review.schemas import ReviewContext, ReviewVerdict
@@ -100,6 +103,23 @@ class TestCreate:
             await organization_service.create(
                 session,
                 OrganizationCreate(name="My New Organization", slug=slug),
+                auth_subject,
+            )
+
+    @pytest.mark.auth
+    async def test_organization_scoped_session_forbidden(
+        self,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        auth_subject.organization_ids = frozenset({organization.id})
+        with pytest.raises(CannotCreateOrganizationError):
+            await organization_service.create(
+                session,
+                OrganizationCreate(
+                    name="My New Organization", slug="scoped-session-org"
+                ),
                 auth_subject,
             )
 


### PR DESCRIPTION
## Summary

Block organization creation from a scoped session (backend + UI)

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

