### PR TITLE
feat: issue license keys without expiration when granted by subscriptions

### DIFF
--- a/server/polar/benefit/grant/service.py
+++ b/server/polar/benefit/grant/service.py
@@ -238,6 +238,7 @@ class BenefitGrantService(ResourceServiceReader[BenefitGrant]):
                 grant.properties,
                 attempt=attempt,
                 member=member,
+                **scope_to_args(scope),
             )
         except BenefitActionRequiredError as e:
             if e.grant_properties is not None:
@@ -521,6 +522,7 @@ class BenefitGrantService(ResourceServiceReader[BenefitGrant]):
                 update=True,
                 attempt=attempt,
                 member=member,
+                **grant.scope,
             )
         except BenefitActionRequiredError as e:
             if e.grant_properties is not None:

--- a/server/polar/benefit/strategies/base/service.py
+++ b/server/polar/benefit/strategies/base/service.py
@@ -1,8 +1,9 @@
-from typing import Any, Protocol, cast
+from typing import Any, Protocol, Unpack, cast
 
 from polar.auth.models import AuthSubject
 from polar.exceptions import PolarError, PolarRequestValidationError, ValidationError
 from polar.models import Benefit, Customer, Member, Organization, User
+from polar.models.benefit_grant import BenefitGrantScopeArgs
 from polar.postgres import AsyncSession
 from polar.redis import Redis
 
@@ -97,6 +98,7 @@ class BenefitServiceProtocol[BP: BenefitProperties, BGP: BenefitGrantProperties]
         update: bool = False,
         attempt: int = 1,
         member: Member | None = None,
+        **scope: Unpack[BenefitGrantScopeArgs],
     ) -> BGP:
         """
         Executes the logic to grant a benefit to a customer.
@@ -110,6 +112,9 @@ class BenefitServiceProtocol[BP: BenefitProperties, BGP: BenefitGrantProperties]
             update: Whether we are updating an already granted benefit.
             attempt: Number of times we attempted to grant the benefit.
             Useful for the worker to implement retry logic.
+            member: The member the benefit is granted to, if any.
+            scope: The scope backing the grant, i.e. the `subscription_id` and/or
+            `order_id` it originates from.
 
         Returns:
             A dictionary with data to store for this specific benefit and customer.

--- a/server/polar/benefit/strategies/custom/service.py
+++ b/server/polar/benefit/strategies/custom/service.py
@@ -1,7 +1,8 @@
-from typing import Any, cast
+from typing import Any, Unpack, cast
 
 from polar.auth.models import AuthSubject
 from polar.models import Benefit, Customer, Member, Organization, User
+from polar.models.benefit_grant import BenefitGrantScopeArgs
 
 from ..base.service import BenefitServiceProtocol
 from .properties import BenefitCustomProperties, BenefitGrantCustomProperties
@@ -19,6 +20,7 @@ class BenefitCustomService(
         update: bool = False,
         attempt: int = 1,
         member: Member | None = None,
+        **scope: Unpack[BenefitGrantScopeArgs],
     ) -> BenefitGrantCustomProperties:
         return {}
 

--- a/server/polar/benefit/strategies/discord/service.py
+++ b/server/polar/benefit/strategies/discord/service.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import Any, Unpack, cast
 
 import httpx
 import structlog
@@ -12,6 +12,7 @@ from polar.integrations.discord.service import discord_bot as discord_bot_servic
 from polar.logging import Logger
 from polar.member.repository import MemberRepository
 from polar.models import Benefit, Customer, Member, Organization, User
+from polar.models.benefit_grant import BenefitGrantScopeArgs
 from polar.models.customer import CustomerOAuthAccount, CustomerOAuthPlatform
 
 from ..base.service import (
@@ -37,6 +38,7 @@ class BenefitDiscordService(
         update: bool = False,
         attempt: int = 1,
         member: Member | None = None,
+        **scope: Unpack[BenefitGrantScopeArgs],
     ) -> BenefitGrantDiscordProperties:
         bound_logger = log.bind(
             benefit_id=str(benefit.id),

--- a/server/polar/benefit/strategies/downloadables/service.py
+++ b/server/polar/benefit/strategies/downloadables/service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, Unpack, cast
 from uuid import UUID
 
 import structlog
@@ -13,6 +13,7 @@ from polar.exceptions import ValidationError
 from polar.file.repository import FileRepository
 from polar.logging import Logger
 from polar.models import Benefit, Customer, File, Member, Organization, User
+from polar.models.benefit_grant import BenefitGrantScopeArgs
 
 from ..base.service import BenefitPropertiesValidationError, BenefitServiceProtocol
 from . import schemas
@@ -43,6 +44,7 @@ class BenefitDownloadablesService(
         update: bool = False,
         attempt: int = 1,
         member: Member | None = None,
+        **scope: Unpack[BenefitGrantScopeArgs],
     ) -> BenefitGrantDownloadablesProperties:
         properties = self._get_properties(benefit)
         file_ids = get_active_file_ids(properties)

--- a/server/polar/benefit/strategies/feature_flag/service.py
+++ b/server/polar/benefit/strategies/feature_flag/service.py
@@ -1,7 +1,8 @@
-from typing import Any, cast
+from typing import Any, Unpack, cast
 
 from polar.auth.models import AuthSubject
 from polar.models import Benefit, Customer, Member, Organization, User
+from polar.models.benefit_grant import BenefitGrantScopeArgs
 
 from ..base.service import BenefitServiceProtocol
 from .properties import BenefitFeatureFlagProperties, BenefitGrantFeatureFlagProperties
@@ -21,6 +22,7 @@ class BenefitFeatureFlagService(
         update: bool = False,
         attempt: int = 1,
         member: Member | None = None,
+        **scope: Unpack[BenefitGrantScopeArgs],
     ) -> BenefitGrantFeatureFlagProperties:
         return {}
 

--- a/server/polar/benefit/strategies/github_repository/service.py
+++ b/server/polar/benefit/strategies/github_repository/service.py
@@ -1,6 +1,6 @@
 import contextlib
 from collections.abc import AsyncIterator
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Unpack, cast
 
 import structlog
 from githubkit.exception import (
@@ -18,6 +18,7 @@ from polar.integrations.github_repository_benefit.service import (
 )
 from polar.logging import Logger
 from polar.models import Benefit, Customer, Member, Organization, User
+from polar.models.benefit_grant import BenefitGrantScopeArgs
 from polar.models.customer import CustomerOAuthPlatform
 
 from ..base.service import (
@@ -53,6 +54,7 @@ class BenefitGitHubRepositoryService(
         update: bool = False,
         attempt: int = 1,
         member: Member | None = None,
+        **scope: Unpack[BenefitGrantScopeArgs],
     ) -> BenefitGrantGitHubRepositoryProperties:
         bound_logger = log.bind(
             benefit_id=str(benefit.id),

--- a/server/polar/benefit/strategies/license_keys/service.py
+++ b/server/polar/benefit/strategies/license_keys/service.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, Unpack, cast
 from uuid import UUID
 
 import structlog
@@ -9,6 +9,7 @@ from polar.auth.models import AuthSubject
 from polar.license_key.service import license_key as license_key_service
 from polar.logging import Logger
 from polar.models import Benefit, Customer, Member, Organization, User
+from polar.models.benefit_grant import BenefitGrantScopeArgs
 
 from ..base.service import BenefitServiceProtocol
 from .properties import BenefitGrantLicenseKeysProperties, BenefitLicenseKeysProperties
@@ -32,6 +33,7 @@ class BenefitLicenseKeysService(
         update: bool = False,
         attempt: int = 1,
         member: Member | None = None,
+        **scope: Unpack[BenefitGrantScopeArgs],
     ) -> BenefitGrantLicenseKeysProperties:
         current_lk_id = None
         if update and "license_key_id" in grant_properties:
@@ -48,6 +50,8 @@ class BenefitLicenseKeysService(
             license_key_id=current_lk_id,
             key=user_provided_key,
             member_id=member.id if member else None,
+            # Subscription-backed keys never expire; they follow the subscription.
+            set_expiration=scope.get("subscription_id") is None,
         )
         return {
             **grant_properties,

--- a/server/polar/benefit/strategies/meter_credit/service.py
+++ b/server/polar/benefit/strategies/meter_credit/service.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime
-from typing import Any, cast
+from typing import Any, Unpack, cast
 
 from polar.auth.models import AuthSubject
 from polar.authz.types import AccessibleOrganizationID
@@ -11,6 +11,7 @@ from polar.event.system import SystemEvent, build_system_event
 from polar.kit.utils import utc_now
 from polar.meter.repository import MeterRepository
 from polar.models import Benefit, Customer, Member, Organization, User
+from polar.models.benefit_grant import BenefitGrantScopeArgs
 
 from ..base.service import BenefitPropertiesValidationError, BenefitServiceProtocol
 from .properties import BenefitGrantMeterCreditProperties, BenefitMeterCreditProperties
@@ -30,6 +31,7 @@ class BenefitMeterCreditService(
         update: bool = False,
         attempt: int = 1,
         member: Member | None = None,
+        **scope: Unpack[BenefitGrantScopeArgs],
     ) -> BenefitGrantMeterCreditProperties:
         properties = self._get_properties(benefit)
         meter_id = uuid.UUID(properties["meter_id"])

--- a/server/polar/benefit/strategies/slack_shared_channel/service.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/service.py
@@ -1,5 +1,5 @@
 import secrets
-from typing import Any, cast
+from typing import Any, Unpack, cast
 from uuid import UUID
 
 import httpx
@@ -19,6 +19,7 @@ from polar.models import (
     SlackApp,
     User,
 )
+from polar.models.benefit_grant import BenefitGrantScopeArgs
 
 from ..base.service import (
     BenefitActionRequiredError,
@@ -66,6 +67,7 @@ class BenefitSlackSharedChannelService(
         update: bool = False,
         attempt: int = 1,
         member: Member | None = None,
+        **scope: Unpack[BenefitGrantScopeArgs],
     ) -> BenefitGrantSlackSharedChannelProperties:
         bound_logger = log.bind(
             benefit_id=str(benefit.id), customer_id=str(customer.id)

--- a/server/polar/license_key/service.py
+++ b/server/polar/license_key/service.py
@@ -328,8 +328,10 @@ class LicenseKeyService:
         license_key_id: UUID | None = None,
         key: str | None = None,
         member_id: UUID | None = None,
+        set_expiration: bool = True,
     ) -> LicenseKey:
         props = cast(BenefitLicenseKeysProperties, benefit.properties)
+        expires = props.get("expires", None) if set_expiration else None
         if key is not None:
             create_schema = LicenseKeyCreate.build(
                 organization_id=benefit.organization_id,
@@ -338,7 +340,7 @@ class LicenseKeyService:
                 key=key,
                 limit_usage=props.get("limit_usage", None),
                 activations=props.get("activations", None),
-                expires=props.get("expires", None),
+                expires=expires,
             )
         else:
             create_schema = LicenseKeyCreate.build(
@@ -348,7 +350,7 @@ class LicenseKeyService:
                 prefix=props.get("prefix", None),
                 limit_usage=props.get("limit_usage", None),
                 activations=props.get("activations", None),
-                expires=props.get("expires", None),
+                expires=expires,
             )
 
         log.info(

--- a/server/scripts/unset_subscription_license_key_expiration.py
+++ b/server/scripts/unset_subscription_license_key_expiration.py
@@ -1,0 +1,63 @@
+import typer
+from sqlalchemy import String, select, update
+
+from polar.models import BenefitGrant, LicenseKey, Subscription
+from polar.models.subscription import SubscriptionStatus
+from scripts.helper import (
+    configure_script_logging,
+    limit_bindparam,
+    run_batched_update,
+    typer_async,
+)
+
+cli = typer.Typer()
+
+configure_script_logging()
+
+
+@cli.command()
+@typer_async
+async def unset_subscription_license_key_expiration(
+    batch_size: int = typer.Option(5000, help="Number of rows to process per batch"),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+) -> None:
+    """Unset `expires_at` on license keys granted through an active subscription.
+
+    License keys backed by a subscription stay valid as long as the subscription
+    is active, so they should never carry an expiration date. This backfills
+    existing keys that were granted with a TTL before that rule was introduced.
+
+    "Active" here means billable — active, trialing, or past due (still in the
+    grace period) — matching `SubscriptionStatus.billable_statuses()`.
+    """
+    subscription_license_key_ids = (
+        select(LicenseKey.id)
+        .join(
+            BenefitGrant,
+            LicenseKey.id.cast(String)
+            == BenefitGrant.properties["license_key_id"].as_string(),
+        )
+        .join(Subscription, Subscription.id == BenefitGrant.subscription_id)
+        .where(
+            LicenseKey.expires_at.is_not(None),
+            LicenseKey.deleted_at.is_(None),
+            BenefitGrant.is_deleted.is_(False),
+            Subscription.status.in_(SubscriptionStatus.billable_statuses()),
+        )
+        .order_by(LicenseKey.id)
+        .limit(limit_bindparam())
+    )
+
+    await run_batched_update(
+        (
+            update(LicenseKey)
+            .values(expires_at=None)
+            .where(LicenseKey.id.in_(subscription_license_key_ids))
+        ),
+        batch_size=batch_size,
+        sleep_seconds=sleep_seconds,
+    )
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/tests/benefit/strategies/test_license_keys.py
+++ b/server/tests/benefit/strategies/test_license_keys.py
@@ -1,0 +1,127 @@
+from typing import cast
+from uuid import UUID
+
+import pytest
+from dateutil.relativedelta import relativedelta
+
+from polar.benefit.grant.service import benefit_grant as benefit_grant_service
+from polar.benefit.strategies.license_keys.properties import (
+    BenefitGrantLicenseKeysProperties,
+)
+from polar.benefit.strategies.license_keys.schemas import (
+    BenefitLicenseKeyExpirationProperties,
+    BenefitLicenseKeysCreateProperties,
+)
+from polar.kit.utils import utc_now
+from polar.license_key.repository import LicenseKeyRepository
+from polar.models import BenefitGrant, Customer, LicenseKey, Organization, Product
+from polar.models.benefit import BenefitType
+from polar.postgres import AsyncSession
+from polar.redis import Redis
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import (
+    create_benefit,
+    create_order,
+    create_subscription,
+)
+
+EXPIRING_PROPERTIES = BenefitLicenseKeysCreateProperties(
+    prefix="testing",
+    expires=BenefitLicenseKeyExpirationProperties(ttl=1, timeframe="year"),
+).model_dump(mode="json")
+
+
+async def _get_license_key(session: AsyncSession, grant: BenefitGrant) -> LicenseKey:
+    properties = cast(BenefitGrantLicenseKeysProperties, grant.properties)
+    repository = LicenseKeyRepository.from_session(session)
+    license_key = await repository.get_by_id(UUID(properties["license_key_id"]))
+    assert license_key is not None
+    return license_key
+
+
+@pytest.mark.asyncio
+class TestGrantExpiration:
+    async def test_subscription_grant_never_sets_expiration(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            type=BenefitType.license_keys,
+            organization=organization,
+            properties=EXPIRING_PROPERTIES,
+        )
+        subscription = await create_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        grant = await benefit_grant_service.grant_benefit(
+            session, redis, customer, benefit, subscription=subscription
+        )
+
+        license_key = await _get_license_key(session, grant)
+        assert license_key.expires_at is None
+
+    async def test_order_grant_sets_expiration(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            type=BenefitType.license_keys,
+            organization=organization,
+            properties=EXPIRING_PROPERTIES,
+        )
+        order = await create_order(save_fixture, customer=customer, product=product)
+
+        grant = await benefit_grant_service.grant_benefit(
+            session, redis, customer, benefit, order=order
+        )
+
+        license_key = await _get_license_key(session, grant)
+        assert license_key.expires_at is not None
+
+    async def test_update_subscription_grant_unsets_expiration(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            type=BenefitType.license_keys,
+            organization=organization,
+            properties=EXPIRING_PROPERTIES,
+        )
+        subscription = await create_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        grant = await benefit_grant_service.grant_benefit(
+            session, redis, customer, benefit, subscription=subscription
+        )
+
+        license_key = await _get_license_key(session, grant)
+        # Simulate a key granted with an expiration before the rule was introduced.
+        license_key.expires_at = utc_now() + relativedelta(days=30)
+        session.add(license_key)
+        await session.flush()
+
+        loaded_grant = await benefit_grant_service.get(session, grant.id, loaded=True)
+        assert loaded_grant is not None
+        await benefit_grant_service.update_benefit_grant(session, redis, loaded_grant)
+
+        license_key = await _get_license_key(session, grant)
+        assert license_key.expires_at is None


### PR DESCRIPTION
An alternative approach to https://github.com/polarsource/polar/pull/12707


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Issue license keys without expiration when granted through subscriptions; one‑time order grants still use TTL. Propagates grant scope to benefit strategies and clears existing expirations on subscription-backed keys.

- **New Features**
  - Threads grant scope (`subscription_id`/`order_id`) into all benefit strategies; `license_keys` skips setting `expires_at` when a subscription is present.
  - On benefit grant updates, unsets `expires_at` for subscription-backed license keys.

- **Migration**
  - Run `python server/scripts/unset_subscription_license_key_expiration.py` to remove `expires_at` from license keys granted through billable subscriptions.

<sup>Written for commit 26576a0545be08870d3a30a263106aaaf98b7b4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



