### PR TITLE
feat(sso): enforce Force SSO on organization access

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/layout.tsx
@@ -1,20 +1,25 @@
 import { AccountSetupProvider } from '@/providers/accountSetup'
 import { OrganizationContextProvider } from '@/providers/maintainerOrganization'
 import { getServerSideAPI } from '@/utils/client/serverside'
-import { getOrganizationBySlugOrNotFound } from '@/utils/organization'
-import { getUserOrganizations } from '@/utils/user'
+import {
+  getOrganizationBySlug,
+  getOrganizationBySlugOrNotFound,
+} from '@/utils/organization'
+import { getAuthenticatedUser } from '@/utils/user'
 import { Metadata } from 'next'
-import { redirect } from 'next/navigation'
+import { notFound, redirect } from 'next/navigation'
 
 export async function generateMetadata(props: {
   params: Promise<{ organization: string }>
 }): Promise<Metadata> {
   const params = await props.params
   const api = await getServerSideAPI()
-  const organization = await getOrganizationBySlugOrNotFound(
-    api,
-    params.organization,
-  )
+  // Non-throwing: access is enforced in the layout, so metadata must not 404 a
+  // member who needs to re-authenticate through SSO.
+  const organization = await getOrganizationBySlug(api, params.organization)
+  if (!organization) {
+    return { title: 'Polar' }
+  }
   return {
     title: {
       template: `%s | ${organization.name} | Polar`,
@@ -28,31 +33,33 @@ export default async function Layout(props: {
   children: React.ReactNode
 }) {
   const params = await props.params
-
   const { children } = props
+  const slug = params.organization
+
+  const user = await getAuthenticatedUser()
+  const organizations = user?.organizations ?? []
+  const memberOrganizations = user?.member_organizations ?? []
+
+  if (!organizations.some((org) => org.slug === slug)) {
+    // Not accessible in this session. A member of an org that enforces SSO must
+    // re-authenticate through SSO; a non-member gets a 404 (no leak).
+    const membership = memberOrganizations.find((org) => org.slug === slug)
+    if (membership?.requires_sso) {
+      redirect(`/auth/sso/${slug}`)
+    }
+    if (!membership) {
+      notFound()
+    }
+    redirect('/dashboard')
+  }
 
   const api = await getServerSideAPI()
-  const organization = await getOrganizationBySlugOrNotFound(
-    api,
-    params.organization,
-  )
-
-  const userOrganizations = await getUserOrganizations()
-
-  if (!userOrganizations.some((org) => org.id === organization.id)) {
-    // An org that enforces SSO is only reachable through an SSO-scoped session,
-    // so send the user to re-authenticate via SSO rather than bouncing them to
-    // the dashboard root.
-    if (organization.sso_enforced) {
-      return redirect(`/auth/sso/${organization.slug}`)
-    }
-    return redirect('/dashboard')
-  }
+  const organization = await getOrganizationBySlugOrNotFound(api, slug)
 
   return (
     <OrganizationContextProvider
       organization={organization}
-      organizations={userOrganizations}
+      organizations={organizations}
     >
       <AccountSetupProvider>{children}</AccountSetupProvider>
     </OrganizationContextProvider>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/layout.tsx
@@ -40,6 +40,12 @@ export default async function Layout(props: {
   const userOrganizations = await getUserOrganizations()
 
   if (!userOrganizations.some((org) => org.id === organization.id)) {
+    // An org that enforces SSO is only reachable through an SSO-scoped session,
+    // so send the user to re-authenticate via SSO rather than bouncing them to
+    // the dashboard root.
+    if (organization.sso_enforced) {
+      return redirect(`/auth/sso/${organization.slug}`)
+    }
     return redirect('/dashboard')
   }
 

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -24416,6 +24416,11 @@ export interface components {
        */
       details_submitted_at: string | null
       /**
+       * Sso Enforced
+       * @description Whether members must access this organization through its SSO connection.
+       */
+      sso_enforced: boolean
+      /**
        * Default Presentment Currency
        * @description Default presentment currency. Used as fallback in checkout and customer portal, if the customer's local currency is not available.
        */
@@ -25629,6 +25634,11 @@ export interface components {
        * @description When the business details were submitted for review.
        */
       details_submitted_at: string | null
+      /**
+       * Sso Enforced
+       * @description Whether members must access this organization through its SSO connection.
+       */
+      sso_enforced: boolean
       /**
        * Default Presentment Currency
        * @description Default presentment currency. Used as fallback in checkout and customer portal, if the customer's local currency is not available.
@@ -27019,6 +27029,11 @@ export interface components {
        * @description When the business details were submitted for review.
        */
       details_submitted_at: string | null
+      /**
+       * Sso Enforced
+       * @description Whether members must access this organization through its SSO connection.
+       */
+      sso_enforced: boolean
       /**
        * Default Presentment Currency
        * @description Default presentment currency. Used as fallback in checkout and customer portal, if the customer's local currency is not available.

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -22053,6 +22053,21 @@ export interface components {
        */
       role: 'member' | 'billing_manager'
     }
+    /** MemberOrganization */
+    MemberOrganization: {
+      /**
+       * Id
+       * Format: uuid4
+       */
+      id: string
+      /** Slug */
+      slug: string
+      /**
+       * Requires Sso
+       * @description Whether this organization enforces SSO.
+       */
+      requires_sso: boolean
+    }
     /**
      * MemberOwnerCreate
      * @description Schema for creating an owner member during customer creation.
@@ -33034,9 +33049,14 @@ export interface components {
       oauth_accounts: components['schemas']['OAuthAccountRead'][]
       /**
        * Organizations
-       * @description Organizations the user is a member of, with their role on each. Populated by `GET /v1/users/me`; empty otherwise.
+       * @description Organizations the user is a member of and can access in the current session, with their role on each. Populated by `GET /v1/users/me`; empty otherwise.
        */
       organizations?: components['schemas']['OrganizationWithRole'][]
+      /**
+       * Member Organizations
+       * @description All organizations the user is a member of, regardless of whether they're accessible in the current session. Compare with `organizations` (the accessible subset) to determine access. Populated by `GET /v1/users/me`.
+       */
+      member_organizations?: components['schemas']['MemberOrganization'][]
       /** Email Hash */
       readonly email_hash: string | null
     }

--- a/server/polar/authz/repository.py
+++ b/server/polar/authz/repository.py
@@ -5,7 +5,7 @@ from sqlalchemy import Select, select
 
 from polar.auth.models import AuthSubject, User, is_organization, is_user
 from polar.auth.permission import OrganizationPermission, roles_with_permission
-from polar.models import Organization, UserOrganization
+from polar.models import Organization, UserOrganization, UserSession
 from polar.postgres import AsyncReadSession
 
 
@@ -53,8 +53,13 @@ def select_accessible_org_ids(
     Takes the full ``AuthSubject`` so the session/token down-scope
     (``organization_ids``) travels with the subject and can't be forgotten or
     mismatched with a stray ``user_id``: results are the user's memberships
-    (optionally narrowed by ``permission``) intersected with that scope. An
-    unscoped subject (``organization_ids is None``) is not narrowed.
+    (optionally narrowed by ``permission``) intersected with that scope.
+
+    A subject scoped to specific organizations (``organization_ids``) is
+    narrowed to them. An unscoped **user session** additionally cannot reach
+    organizations that enforce SSO (``sso_enforced``) — those are only
+    accessible through an SSO-scoped session. Token credentials (PAT / OAuth)
+    are exempt from SSO enforcement.
     """
     # Composes the raw helper, then applies the session down-scope right below.
     stmt = select_user_org_ids(auth_subject.subject.id, permission=permission)  # noqa: org-scope
@@ -62,6 +67,8 @@ def select_accessible_org_ids(
         stmt = stmt.where(
             UserOrganization.organization_id.in_(auth_subject.organization_ids)
         )
+    elif isinstance(auth_subject.session, UserSession):
+        stmt = stmt.where(Organization.sso_enforced.is_not(True))
     return stmt
 
 

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -415,8 +415,7 @@ class Organization(OrganizationBase):
     )
     sso_enforced: bool = Field(
         description=(
-            "Whether members must access this organization through its SSO "
-            "connection."
+            "Whether members must access this organization through its SSO connection."
         ),
     )
 

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -413,6 +413,12 @@ class Organization(OrganizationBase):
     details_submitted_at: datetime | None = Field(
         description="When the business details were submitted for review.",
     )
+    sso_enforced: bool = Field(
+        description=(
+            "Whether members must access this organization through its SSO "
+            "connection."
+        ),
+    )
 
     default_presentment_currency: str = Field(
         description=(

--- a/server/polar/user/endpoints.py
+++ b/server/polar/user/endpoints.py
@@ -10,6 +10,7 @@ from polar.authz.dependencies import (
     AuthorizeWebUserRead,
     AuthorizeWebUserWrite,
 )
+from polar.authz.repository import AuthzRepository
 from polar.customer_portal.endpoints.downloadables import router as downloadables_router
 from polar.customer_portal.endpoints.license_keys import router as license_keys_router
 from polar.customer_portal.endpoints.order import router as order_router
@@ -65,14 +66,15 @@ async def get_authenticated(
 ) -> UserRead:
     user = auth_subject.subject
     repository = UserOrganizationRepository.from_session(session)
-    # Raw membership, intersected below with the session's organization scope.
+    # Raw membership, filtered below to the session's accessible organizations
+    # (session scope + SSO enforcement) via the shared authz chokepoint.
     org_with_roles = await repository.get_organizations_with_role(user.id)  # noqa: org-scope
-    if auth_subject.organization_ids is not None:
-        org_with_roles = [
-            (org, role)
-            for org, role in org_with_roles
-            if org.id in auth_subject.organization_ids
-        ]
+    accessible_ids = await AuthzRepository.from_session(session).get_user_org_ids(
+        auth_subject
+    )
+    org_with_roles = [
+        (org, role) for org, role in org_with_roles if org.id in accessible_ids
+    ]
     return UserRead.model_validate(user).model_copy(
         update={
             "organizations": [

--- a/server/polar/user/endpoints.py
+++ b/server/polar/user/endpoints.py
@@ -43,6 +43,7 @@ from polar.user_organization.service import (
 )
 
 from .schemas import (
+    MemberOrganization,
     UserDeletionResponse,
     UserIdentityVerification,
     UserRead,
@@ -66,21 +67,27 @@ async def get_authenticated(
 ) -> UserRead:
     user = auth_subject.subject
     repository = UserOrganizationRepository.from_session(session)
-    # Raw membership, filtered below to the session's accessible organizations
-    # (session scope + SSO enforcement) via the shared authz chokepoint.
+    # Raw membership; `organizations` is narrowed to the session's accessible
+    # set (session scope + SSO enforcement) via the shared authz chokepoint,
+    # while `member_organizations` exposes every membership so the frontend can
+    # tell "no access" apart from "not a member".
     org_with_roles = await repository.get_organizations_with_role(user.id)  # noqa: org-scope
     accessible_ids = await AuthzRepository.from_session(session).get_user_org_ids(
         auth_subject
     )
-    org_with_roles = [
-        (org, role) for org, role in org_with_roles if org.id in accessible_ids
-    ]
     return UserRead.model_validate(user).model_copy(
         update={
             "organizations": [
                 OrganizationWithRole.from_organization(org, role)
                 for org, role in org_with_roles
-            ]
+                if org.id in accessible_ids
+            ],
+            "member_organizations": [
+                MemberOrganization(
+                    id=org.id, slug=org.slug, requires_sso=org.sso_enforced
+                )
+                for org, _ in org_with_roles
+            ],
         }
     )
 

--- a/server/polar/user/schemas.py
+++ b/server/polar/user/schemas.py
@@ -29,6 +29,14 @@ class OAuthAccountRead(TimestampedSchema):
     account_username: str | None
 
 
+class MemberOrganization(Schema):
+    id: UUID4
+    slug: str
+    requires_sso: bool = Field(
+        description="Whether this organization enforces SSO.",
+    )
+
+
 class UserRead(UserBase, TimestampedSchema):
     id: uuid.UUID
     accepted_terms_of_service: bool
@@ -43,8 +51,18 @@ class UserRead(UserBase, TimestampedSchema):
     organizations: list[OrganizationWithRole] = Field(
         default_factory=list,
         description=(
-            "Organizations the user is a member of, with their role on each. "
-            "Populated by `GET /v1/users/me`; empty otherwise."
+            "Organizations the user is a member of and can access in the "
+            "current session, with their role on each. Populated by "
+            "`GET /v1/users/me`; empty otherwise."
+        ),
+    )
+    member_organizations: list[MemberOrganization] = Field(
+        default_factory=list,
+        description=(
+            "All organizations the user is a member of, regardless of whether "
+            "they're accessible in the current session. Compare with "
+            "`organizations` (the accessible subset) to determine access. "
+            "Populated by `GET /v1/users/me`."
         ),
     )
 

--- a/server/tests/authz/test_service.py
+++ b/server/tests/authz/test_service.py
@@ -1,10 +1,11 @@
+from unittest.mock import MagicMock
 from uuid import UUID
 
 import pytest
 
 from polar.auth.models import AuthSubject
 from polar.authz.service import get_accessible_org_ids, get_accessible_organization
-from polar.models import Organization, User
+from polar.models import Organization, PersonalAccessToken, User
 from polar.models.organization import OrganizationStatus
 from polar.models.user_organization import UserOrganization
 from polar.postgres import AsyncSession
@@ -128,6 +129,70 @@ class TestGetAccessibleOrgIds:
 
         result = await get_accessible_org_ids(session, auth_subject)
         assert result == set()
+
+
+@pytest.mark.asyncio
+class TestGetAccessibleOrgIdsSSOEnforced:
+    """A non-SSO user session cannot reach organizations that enforce SSO."""
+
+    @pytest.mark.auth
+    async def test_global_session_denied_enforced_org(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        organization.sso_enforced = True
+        await session.flush()
+
+        result = await get_accessible_org_ids(session, auth_subject)
+        assert result == set()
+
+    @pytest.mark.auth
+    async def test_global_session_allowed_non_enforced_org(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        organization.sso_enforced = False
+        await session.flush()
+
+        result = await get_accessible_org_ids(session, auth_subject)
+        assert result == {organization.id}
+
+    @pytest.mark.auth
+    async def test_sso_scoped_session_allowed_enforced_org(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        organization.sso_enforced = True
+        await session.flush()
+        auth_subject.organization_ids = frozenset({organization.id})
+
+        result = await get_accessible_org_ids(session, auth_subject)
+        assert result == {organization.id}
+
+    @pytest.mark.auth
+    async def test_token_credential_exempt(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        organization.sso_enforced = True
+        await session.flush()
+        # PAT / OAuth credentials are not user sessions and stay exempt.
+        auth_subject.session = MagicMock(spec=PersonalAccessToken)
+
+        result = await get_accessible_org_ids(session, auth_subject)
+        assert result == {organization.id}
 
 
 @pytest.mark.asyncio

--- a/server/tests/user/test_endpoints.py
+++ b/server/tests/user/test_endpoints.py
@@ -1,6 +1,7 @@
 import pytest
 from httpx import AsyncClient
 
+from polar.auth.models import AuthSubject
 from polar.auth.scope import READ_ONLY_SCOPES
 from polar.kit.utils import utc_now
 from polar.models import Organization, User, UserOrganization
@@ -61,6 +62,47 @@ async def test_get_users_me_excludes_blocked_organizations(
 
     assert response.status_code == 200
     assert response.json()["organizations"] == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.auth
+async def test_get_users_me_excludes_sso_enforced_org_for_global_session(
+    client: AsyncClient,
+    save_fixture: SaveFixture,
+    organization: Organization,
+    user_organization: UserOrganization,
+) -> None:
+    # A non-SSO session cannot reach an org that enforces SSO, so it must not
+    # appear in the org list either — otherwise the dashboard lets the user in
+    # and every scoped query then comes back empty.
+    organization.sso_enforced = True
+    await save_fixture(organization)
+
+    response = await client.get("/v1/users/me")
+
+    assert response.status_code == 200
+    assert response.json()["organizations"] == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.auth
+async def test_get_users_me_includes_sso_enforced_org_for_sso_session(
+    client: AsyncClient,
+    save_fixture: SaveFixture,
+    auth_subject: AuthSubject[User],
+    organization: Organization,
+    user_organization: UserOrganization,
+) -> None:
+    organization.sso_enforced = True
+    await save_fixture(organization)
+    auth_subject.organization_ids = frozenset({organization.id})
+
+    response = await client.get("/v1/users/me")
+
+    assert response.status_code == 200
+    organizations = response.json()["organizations"]
+    assert len(organizations) == 1
+    assert organizations[0]["id"] == str(organization.id)
 
 
 @pytest.mark.asyncio

--- a/server/tests/user/test_endpoints.py
+++ b/server/tests/user/test_endpoints.py
@@ -72,16 +72,25 @@ async def test_get_users_me_excludes_sso_enforced_org_for_global_session(
     organization: Organization,
     user_organization: UserOrganization,
 ) -> None:
-    # A non-SSO session cannot reach an org that enforces SSO, so it must not
-    # appear in the org list either — otherwise the dashboard lets the user in
-    # and every scoped query then comes back empty.
+    # A non-SSO session cannot reach an org that enforces SSO, so it's excluded
+    # from the accessible `organizations` list but still surfaced under
+    # `member_organizations` (flagged `requires_sso`) so the dashboard can
+    # redirect the member to SSO rather than 404.
     organization.sso_enforced = True
     await save_fixture(organization)
 
     response = await client.get("/v1/users/me")
 
     assert response.status_code == 200
-    assert response.json()["organizations"] == []
+    json = response.json()
+    assert json["organizations"] == []
+    assert json["member_organizations"] == [
+        {
+            "id": str(organization.id),
+            "slug": organization.slug,
+            "requires_sso": True,
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -100,9 +109,18 @@ async def test_get_users_me_includes_sso_enforced_org_for_sso_session(
     response = await client.get("/v1/users/me")
 
     assert response.status_code == 200
-    organizations = response.json()["organizations"]
+    json = response.json()
+    organizations = json["organizations"]
     assert len(organizations) == 1
     assert organizations[0]["id"] == str(organization.id)
+    # It's accessible in an SSO-scoped session and still listed as a membership.
+    assert json["member_organizations"] == [
+        {
+            "id": str(organization.id),
+            "slug": organization.slug,
+            "requires_sso": True,
+        }
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Enforces an organization's Force SSO (`sso_enforced`) setting: 
a user session that wasn't established through the org's SSO connection can no longer access that organization, and the dashboard redirects such users to re-authenticate via SSO.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

