### PR TITLE
feat(sso): allow admins to toggle sso_enforced

### DIFF
--- a/clients/apps/web/src/components/Settings/SSO/SSOSettings.tsx
+++ b/clients/apps/web/src/components/Settings/SSO/SSOSettings.tsx
@@ -101,7 +101,9 @@ const SSOSettings = ({ org }: { org: schemas['Organization'] }) => {
             variant="secondary"
             onClick={toggleEnforced}
             loading={updateOrganization.isPending}
-            disabled={!org.sso_enforced && !canEnforce}
+            disabled={
+              !org.sso_enforced && (!canEnforce || !hasEnabledConnection)
+            }
           >
             {org.sso_enforced ? 'Stop enforcing' : 'Enforce'}
           </Button>

--- a/clients/apps/web/src/components/Settings/SSO/SSOSettings.tsx
+++ b/clients/apps/web/src/components/Settings/SSO/SSOSettings.tsx
@@ -4,6 +4,7 @@ import { toast } from '@/components/Toast/use-toast'
 import {
   useDeleteSSOConnection,
   useSSOConnections,
+  useUpdateOrganization,
   useUpdateSSOConnection,
 } from '@/hooks/queries'
 import { extractApiErrorMessage } from '@/utils/api/errors'
@@ -19,6 +20,24 @@ import NewSSOConnectionModal from './NewSSOConnectionModal'
 const SSOSettings = ({ org }: { org: schemas['Organization'] }) => {
   const { isShown, show, hide } = useModal()
   const connections = useSSOConnections(org.id)
+  const updateOrganization = useUpdateOrganization()
+
+  const hasEnabledConnection = connections.data?.items?.some(
+    (connection) => connection.enabled,
+  )
+
+  const toggleEnforced = async () => {
+    const { error } = await updateOrganization.mutateAsync({
+      id: org.id,
+      body: { sso_enforced: !org.sso_enforced },
+    })
+    if (error) {
+      toast({
+        title: 'Update failed',
+        description: extractApiErrorMessage(error),
+      })
+    }
+  }
 
   return (
     <>
@@ -52,6 +71,33 @@ const SSOSettings = ({ org }: { org: schemas['Organization'] }) => {
             <Button onClick={show}>Add connection</Button>
           </ListGroup.Item>
         </ListGroup>
+        <Box alignItems="center" justifyContent="between" width="100%">
+          <Box flexDirection="column" gap="xs">
+            <Box alignItems="center" gap="s">
+              <Text variant="label">Enforce SSO</Text>
+              <Status
+                status={org.sso_enforced ? 'Enforced' : 'Not enforced'}
+                color={org.sso_enforced ? 'green' : 'gray'}
+                size="small"
+              />
+            </Box>
+            <Text variant="caption" color="muted">
+              {org.sso_enforced
+                ? 'Members must sign in through SSO to access this organization.'
+                : hasEnabledConnection
+                  ? 'Require members to sign in through SSO to access this organization.'
+                  : 'Add and enable an SSO connection before enforcing SSO.'}
+            </Text>
+          </Box>
+          <Button
+            variant="secondary"
+            onClick={toggleEnforced}
+            loading={updateOrganization.isPending}
+            disabled={!org.sso_enforced && !hasEnabledConnection}
+          >
+            {org.sso_enforced ? 'Stop enforcing' : 'Enforce'}
+          </Button>
+        </Box>
       </Box>
       <InlineModal
         isShown={isShown}

--- a/clients/apps/web/src/components/Settings/SSO/SSOSettings.tsx
+++ b/clients/apps/web/src/components/Settings/SSO/SSOSettings.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { toast } from '@/components/Toast/use-toast'
+import { useAuth } from '@/hooks'
 import {
   useDeleteSSOConnection,
   useSSOConnections,
@@ -19,12 +20,17 @@ import NewSSOConnectionModal from './NewSSOConnectionModal'
 
 const SSOSettings = ({ org }: { org: schemas['Organization'] }) => {
   const { isShown, show, hide } = useModal()
+  const { currentUser } = useAuth()
   const connections = useSSOConnections(org.id)
   const updateOrganization = useUpdateOrganization()
 
   const hasEnabledConnection = connections.data?.items?.some(
     (connection) => connection.enabled,
   )
+  // Enforcing is only allowed from a session already authenticated through
+  // this organization's SSO — a scoped session can only reach this org, so
+  // `organization_scoped` here means "signed in via this org's SSO".
+  const canEnforce = currentUser?.organization_scoped ?? false
 
   const toggleEnforced = async () => {
     const { error } = await updateOrganization.mutateAsync({
@@ -84,16 +90,18 @@ const SSOSettings = ({ org }: { org: schemas['Organization'] }) => {
             <Text variant="caption" color="muted">
               {org.sso_enforced
                 ? 'Members must sign in through SSO to access this organization.'
-                : hasEnabledConnection
-                  ? 'Require members to sign in through SSO to access this organization.'
-                  : 'Add and enable an SSO connection before enforcing SSO.'}
+                : !hasEnabledConnection
+                  ? 'Add and enable an SSO connection before enforcing SSO.'
+                  : !canEnforce
+                    ? 'Sign in through this organization’s SSO to enforce it.'
+                    : 'Require members to sign in through SSO to access this organization.'}
             </Text>
           </Box>
           <Button
             variant="secondary"
             onClick={toggleEnforced}
             loading={updateOrganization.isPending}
-            disabled={!org.sso_enforced && !hasEnabledConnection}
+            disabled={!org.sso_enforced && !canEnforce}
           >
             {org.sso_enforced ? 'Stop enforcing' : 'Enforce'}
           </Button>

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -27024,7 +27024,7 @@ export interface components {
       default_tax_behavior?: components['schemas']['TaxBehaviorOption'] | null
       /**
        * Sso Enforced
-       * @description Whether members must access this organization through its SSO connection. Requires an enabled SSO connection to turn on.
+       * @description Whether members must access this organization through its SSO connection. Turning this on requires an active SSO session for this organization and at least one enabled SSO connection.
        */
       sso_enforced?: boolean | null
     }
@@ -29774,6 +29774,17 @@ export interface components {
       headers: {
         [key: string]: string
       }
+    }
+    /** SSOEnforcementRequiresConnection */
+    SSOEnforcementRequiresConnection: {
+      /**
+       * Error
+       * @example SSOEnforcementRequiresConnection
+       * @constant
+       */
+      error: 'SSOEnforcementRequiresConnection'
+      /** Detail */
+      detail: string
     }
     /** SSOFactor */
     SSOFactor: {
@@ -36056,6 +36067,15 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Cannot enforce SSO without an enabled connection. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['SSOEnforcementRequiresConnection']
         }
       }
       /** @description Validation Error */

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -27011,6 +27011,11 @@ export interface components {
         | null
       /** @description Default tax behavior applied on products. */
       default_tax_behavior?: components['schemas']['TaxBehaviorOption'] | null
+      /**
+       * Sso Enforced
+       * @description Whether members must access this organization through its SSO connection. Requires an enabled SSO connection to turn on.
+       */
+      sso_enforced?: boolean | null
     }
     /** OrganizationValidateWebsiteRequest */
     OrganizationValidateWebsiteRequest: {

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -20924,6 +20924,17 @@ export interface components {
        */
       total_tokens: number
     }
+    /** LastSSOConnectionRequired */
+    LastSSOConnectionRequired: {
+      /**
+       * Error
+       * @example LastSSOConnectionRequired
+       * @constant
+       */
+      error: 'LastSSOConnectionRequired'
+      /** Detail */
+      detail: string
+    }
     /**
      * LegacyOrganizationStatus
      * @description Legacy organization status values kept for backward compatibility in schemas
@@ -37786,6 +37797,15 @@ export interface operations {
           'application/json': components['schemas']['ResourceNotFound']
         }
       }
+      /** @description Cannot remove the last enabled connection while SSO is enforced. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['LastSSOConnectionRequired']
+        }
+      }
       /** @description Validation Error */
       422: {
         headers: {
@@ -37838,6 +37858,15 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Cannot remove the last enabled connection while SSO is enforced. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['LastSSOConnectionRequired']
         }
       }
       /** @description Validation Error */

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -313,6 +313,24 @@ async def update(
     session: AsyncSession = Depends(get_db_session),
 ) -> Organization:
     """Update an organization."""
+    if organization_update.sso_enforced and (
+        authz.auth_subject.organization_ids is None
+        or authz.organization.id not in authz.auth_subject.organization_ids
+    ):
+        # Only allow enforcing SSO from a session already authenticated through
+        # this organization's SSO — proof it works, so an admin can't lock
+        # themselves (and everyone else) out.
+        raise PolarRequestValidationError(
+            [
+                {
+                    "loc": ("body", "sso_enforced"),
+                    "msg": "You must be signed in through SSO for this "
+                    "organization to enforce it.",
+                    "type": "value_error",
+                    "input": True,
+                }
+            ]
+        )
     return await organization_service.update(
         session, authz.organization, organization_update
     )

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -74,6 +74,7 @@ from polar.postgres import (
     get_db_session,
 )
 from polar.routing import APIRouter
+from polar.sso.repository import OrganizationSSOConnectionRepository
 from polar.startup_program.service import (
     StartupProgramError,
 )
@@ -123,7 +124,7 @@ from .schemas import (
     OrganizationValidateWebsiteRequest,
     OrganizationValidateWebsiteResponse,
 )
-from .service import CannotCreateOrganizationError
+from .service import CannotCreateOrganizationError, SSOEnforcementRequiresConnection
 from .service import organization as organization_service
 
 router = APIRouter(prefix="/organizations", tags=["organizations"])
@@ -304,6 +305,10 @@ async def check_slug(
             "model": NotPermitted.schema(),
         },
         404: OrganizationNotFound,
+        409: {
+            "description": "Cannot enforce SSO without an enabled connection.",
+            "model": SSOEnforcementRequiresConnection.schema(),
+        },
     },
     tags=[APITag.public],
 )
@@ -313,24 +318,24 @@ async def update(
     session: AsyncSession = Depends(get_db_session),
 ) -> Organization:
     """Update an organization."""
-    if organization_update.sso_enforced and (
-        authz.auth_subject.organization_ids is None
-        or authz.organization.id not in authz.auth_subject.organization_ids
-    ):
+    if organization_update.sso_enforced:
         # Only allow enforcing SSO from a session already authenticated through
-        # this organization's SSO — proof it works, so an admin can't lock
-        # themselves (and everyone else) out.
-        raise PolarRequestValidationError(
-            [
-                {
-                    "loc": ("body", "sso_enforced"),
-                    "msg": "You must be signed in through SSO for this "
-                    "organization to enforce it.",
-                    "type": "value_error",
-                    "input": True,
-                }
-            ]
+        # this organization's SSO — proof it works — and only while an enabled
+        # connection exists, so an admin can't lock everyone out.
+        if (
+            authz.auth_subject.organization_ids is None
+            or authz.organization.id not in authz.auth_subject.organization_ids
+        ):
+            raise NotPermitted(
+                "You must be signed in through SSO for this organization to enforce it."
+            )
+        connection_repository = OrganizationSSOConnectionRepository.from_session(
+            session
         )
+        if not await connection_repository.get_enabled_by_organization(
+            authz.organization.id
+        ):
+            raise SSOEnforcementRequiresConnection()
     return await organization_service.update(
         session, authz.organization, organization_update
     )

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -582,7 +582,8 @@ class OrganizationUpdate(Schema):
         None,
         description=(
             "Whether members must access this organization through its SSO "
-            "connection. Requires an enabled SSO connection to turn on."
+            "connection. Turning this on requires an active SSO session for "
+            "this organization and at least one enabled SSO connection."
         ),
     )
 

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -578,6 +578,13 @@ class OrganizationUpdate(Schema):
     default_tax_behavior: TaxBehaviorOption | None = Field(
         None, description="Default tax behavior applied on products."
     )
+    sso_enforced: bool | None = Field(
+        None,
+        description=(
+            "Whether members must access this organization through its SSO "
+            "connection. Requires an enabled SSO connection to turn on."
+        ),
+    )
 
 
 class OrganizationReviewSubmissionDetails(Schema):

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -77,7 +77,6 @@ from polar.payout_account.service import payout_account as payout_account_servic
 from polar.postgres import AsyncReadSession, AsyncSession, sql
 from polar.posthog import posthog
 from polar.product.repository import ProductRepository
-from polar.sso.repository import OrganizationSSOConnectionRepository
 from polar.transaction.service.transaction import transaction as transaction_service
 from polar.user_organization.service import (
     user_organization as user_organization_service,
@@ -539,28 +538,6 @@ class OrganizationService:
             await self._validate_currency_change(
                 session, organization, update_schema.default_presentment_currency
             )
-
-        if update_schema.sso_enforced:
-            connection_repository = (
-                OrganizationSSOConnectionRepository.from_session(session)
-            )
-            enabled_connections = (
-                await connection_repository.get_enabled_by_organization(
-                    organization.id
-                )
-            )
-            if not enabled_connections:
-                raise PolarRequestValidationError(
-                    [
-                        {
-                            "loc": ("body", "sso_enforced"),
-                            "msg": "An enabled SSO connection is required "
-                            "before enforcing SSO.",
-                            "type": "value_error",
-                            "input": True,
-                        }
-                    ]
-                )
 
         update_dict = update_schema.model_dump(
             by_alias=True,

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -77,6 +77,7 @@ from polar.payout_account.service import payout_account as payout_account_servic
 from polar.postgres import AsyncReadSession, AsyncSession, sql
 from polar.posthog import posthog
 from polar.product.repository import ProductRepository
+from polar.sso.repository import OrganizationSSOConnectionRepository
 from polar.transaction.service.transaction import transaction as transaction_service
 from polar.user_organization.service import (
     user_organization as user_organization_service,
@@ -538,6 +539,28 @@ class OrganizationService:
             await self._validate_currency_change(
                 session, organization, update_schema.default_presentment_currency
             )
+
+        if update_schema.sso_enforced:
+            connection_repository = (
+                OrganizationSSOConnectionRepository.from_session(session)
+            )
+            enabled_connections = (
+                await connection_repository.get_enabled_by_organization(
+                    organization.id
+                )
+            )
+            if not enabled_connections:
+                raise PolarRequestValidationError(
+                    [
+                        {
+                            "loc": ("body", "sso_enforced"),
+                            "msg": "An enabled SSO connection is required "
+                            "before enforcing SSO.",
+                            "type": "value_error",
+                            "input": True,
+                        }
+                    ]
+                )
 
         update_dict = update_schema.model_dump(
             by_alias=True,

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -239,6 +239,15 @@ class CannotCreateOrganizationError(OrganizationError):
         )
 
 
+class SSOEnforcementRequiresConnection(OrganizationError):
+    def __init__(self) -> None:
+        super().__init__(
+            "This organization must have an enabled SSO connection before SSO "
+            "can be enforced.",
+            409,
+        )
+
+
 class OrganizationService:
     async def list(
         self,

--- a/server/polar/sso/endpoints.py
+++ b/server/polar/sso/endpoints.py
@@ -22,6 +22,7 @@ from .schemas import (
     OrganizationSSOConnectionCreate,
     OrganizationSSOConnectionUpdate,
 )
+from .service import LastSSOConnectionRequired
 from .service import (
     organization_sso_connection as organization_sso_connection_service,
 )
@@ -44,6 +45,11 @@ SSOConnectionNotFound = {
 NotPermittedResponse = {
     "description": "The user doesn't have the permission to manage the organization.",
     "model": NotPermitted.schema(),
+}
+
+LastSSOConnectionResponse = {
+    "description": "Cannot remove the last enabled connection while SSO is enforced.",
+    "model": LastSSOConnectionRequired.schema(),
 }
 
 
@@ -108,7 +114,11 @@ async def create_sso_connection(
     "/{connection_id}",
     summary="Update SSO Connection",
     response_model=OrganizationSSOConnectionSchema,
-    responses={403: NotPermittedResponse, 404: SSOConnectionNotFound},
+    responses={
+        403: NotPermittedResponse,
+        404: SSOConnectionNotFound,
+        409: LastSSOConnectionResponse,
+    },
 )
 async def update_sso_connection(
     connection_id: UUID,
@@ -121,14 +131,20 @@ async def update_sso_connection(
     )
     if connection is None:
         raise ResourceNotFound()
-    return await organization_sso_connection_service.update(session, connection, update)
+    return await organization_sso_connection_service.update(
+        session, authz.organization, connection, update
+    )
 
 
 @router.delete(
     "/{connection_id}",
     summary="Delete SSO Connection",
     status_code=204,
-    responses={403: NotPermittedResponse, 404: SSOConnectionNotFound},
+    responses={
+        403: NotPermittedResponse,
+        404: SSOConnectionNotFound,
+        409: LastSSOConnectionResponse,
+    },
 )
 async def delete_sso_connection(
     connection_id: UUID,
@@ -140,4 +156,6 @@ async def delete_sso_connection(
     )
     if connection is None:
         raise ResourceNotFound()
-    await organization_sso_connection_service.delete(session, connection)
+    await organization_sso_connection_service.delete(
+        session, authz.organization, connection
+    )

--- a/server/polar/sso/service.py
+++ b/server/polar/sso/service.py
@@ -22,6 +22,15 @@ class SSONotEnabled(PolarError):
         )
 
 
+class LastSSOConnectionRequired(PolarError):
+    def __init__(self) -> None:
+        super().__init__(
+            "This organization enforces SSO. Disable SSO enforcement before "
+            "removing its last enabled connection.",
+            409,
+        )
+
+
 class OrganizationSSOConnectionService:
     async def list(
         self,
@@ -67,9 +76,18 @@ class OrganizationSSOConnectionService:
     async def update(
         self,
         session: AsyncSession,
+        organization: Organization,
         connection: OrganizationSSOConnection,
         update: OrganizationSSOConnectionUpdate,
     ) -> OrganizationSSOConnection:
+        if (
+            update.enabled is False
+            and organization.sso_enforced
+            and not await self._has_other_enabled_connection(
+                session, organization, connection
+            )
+        ):
+            raise LastSSOConnectionRequired()
         repository = OrganizationSSOConnectionRepository.from_session(session)
         update_dict = update.model_dump(exclude_none=True)
         return await repository.update(connection, update_dict=update_dict)
@@ -77,10 +95,29 @@ class OrganizationSSOConnectionService:
     async def delete(
         self,
         session: AsyncSession,
+        organization: Organization,
         connection: OrganizationSSOConnection,
     ) -> OrganizationSSOConnection:
+        if (
+            connection.enabled
+            and organization.sso_enforced
+            and not await self._has_other_enabled_connection(
+                session, organization, connection
+            )
+        ):
+            raise LastSSOConnectionRequired()
         repository = OrganizationSSOConnectionRepository.from_session(session)
         return await repository.soft_delete(connection)
+
+    async def _has_other_enabled_connection(
+        self,
+        session: AsyncReadSession,
+        organization: Organization,
+        connection: OrganizationSSOConnection,
+    ) -> bool:
+        repository = OrganizationSSOConnectionRepository.from_session(session)
+        enabled = await repository.get_enabled_by_organization(organization.id)
+        return any(other.id != connection.id for other in enabled)
 
 
 organization_sso_connection = OrganizationSSOConnectionService()

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -8,9 +8,14 @@ from pytest_mock import MockerFixture
 from polar.auth.models import AuthSubject
 from polar.config import settings
 from polar.integrations.polar.service import PolarSelfService
-from polar.models import Product, User
+from polar.models import OrganizationSSOConnection, Product, User
 from polar.models.account import Account
 from polar.models.organization import Organization, OrganizationStatus
+from polar.models.organization_sso_connection import (
+    OIDCAuthMethod,
+    OIDCConfiguration,
+    OrganizationSSOConnectionType,
+)
 from polar.models.subscription import SubscriptionStatus
 from polar.models.user_organization import OrganizationRole, UserOrganization
 from polar.payout_account.service import PayoutAccountServiceError
@@ -1366,29 +1371,70 @@ class TestGetReviewStatus:
 
 @pytest.mark.asyncio
 class TestUpdateSSOEnforced:
+    async def _create_connection(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> OrganizationSSOConnection:
+        configuration: OIDCConfiguration = {
+            "issuer": "https://idp.example.com",
+            "client_id": "client-id",
+            "auth_method": OIDCAuthMethod.client_secret,
+            "client_secret": "secret",
+        }
+        connection = OrganizationSSOConnection(
+            organization=organization,
+            type=OrganizationSSOConnectionType.oidc,
+            configuration=configuration,
+            enabled=True,
+        )
+        await save_fixture(connection)
+        return connection
+
     @pytest.mark.auth
     async def test_enable_from_global_session_forbidden(
         self,
         client: AsyncClient,
+        save_fixture: SaveFixture,
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
         # A non-SSO session must not be able to turn on enforcement.
+        await self._create_connection(save_fixture, organization)
+
         response = await client.patch(
             f"/v1/organizations/{organization.id}",
             json={"sso_enforced": True},
         )
 
-        assert response.status_code == 422
+        assert response.status_code == 403
 
     @pytest.mark.auth
-    async def test_enable_from_scoped_session(
+    async def test_enable_without_connection_forbidden(
         self,
         client: AsyncClient,
         auth_subject: AuthSubject[User],
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
+        # Scoped session but no enabled connection would lock the org out.
+        auth_subject.organization_ids = frozenset({organization.id})
+
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={"sso_enforced": True},
+        )
+
+        assert response.status_code == 409
+
+    @pytest.mark.auth
+    async def test_enable_from_scoped_session(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await self._create_connection(save_fixture, organization)
         auth_subject.organization_ids = frozenset({organization.id})
 
         response = await client.patch(

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -5,6 +5,7 @@ import pytest
 from httpx import AsyncClient
 from pytest_mock import MockerFixture
 
+from polar.auth.models import AuthSubject
 from polar.config import settings
 from polar.integrations.polar.service import PolarSelfService
 from polar.models import Product, User
@@ -1361,3 +1362,60 @@ class TestGetReviewStatus:
 
         assert response.status_code == 200
         assert response.json()["appeal_case_id"] is None
+
+
+@pytest.mark.asyncio
+class TestUpdateSSOEnforced:
+    @pytest.mark.auth
+    async def test_enable_from_global_session_forbidden(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        # A non-SSO session must not be able to turn on enforcement.
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={"sso_enforced": True},
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.auth
+    async def test_enable_from_scoped_session(
+        self,
+        client: AsyncClient,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        auth_subject.organization_ids = frozenset({organization.id})
+
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={"sso_enforced": True},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["sso_enforced"] is True
+
+    @pytest.mark.auth
+    async def test_disable_from_scoped_session(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        organization.sso_enforced = True
+        await save_fixture(organization)
+        auth_subject.organization_ids = frozenset({organization.id})
+
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={"sso_enforced": False},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["sso_enforced"] is False

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -21,7 +21,6 @@ from polar.kit.http import UrlReachability
 from polar.models import (
     Customer,
     Organization,
-    OrganizationSSOConnection,
     Product,
     User,
     UserOrganization,
@@ -42,11 +41,6 @@ from polar.models.organization import (
 )
 from polar.models.organization_access_token import OrganizationAccessToken
 from polar.models.organization_review import OrganizationReview
-from polar.models.organization_sso_connection import (
-    OIDCAuthMethod,
-    OIDCConfiguration,
-    OrganizationSSOConnectionType,
-)
 from polar.models.user import IdentityVerificationStatus
 from polar.models.user_organization import OrganizationRole
 from polar.organization.repository import OrganizationRepository
@@ -327,78 +321,6 @@ class TestCreate:
         assert (
             organization.capabilities == STATUS_CAPABILITIES[OrganizationStatus.CREATED]
         )
-
-
-@pytest.mark.asyncio
-class TestUpdateSSOEnforced:
-    async def _create_connection(
-        self,
-        save_fixture: SaveFixture,
-        organization: Organization,
-        *,
-        enabled: bool,
-    ) -> OrganizationSSOConnection:
-        configuration: OIDCConfiguration = {
-            "issuer": "https://idp.example.com",
-            "client_id": "client-id",
-            "auth_method": OIDCAuthMethod.client_secret,
-            "client_secret": "secret",
-        }
-        connection = OrganizationSSOConnection(
-            organization=organization,
-            type=OrganizationSSOConnectionType.oidc,
-            configuration=configuration,
-            enabled=enabled,
-        )
-        await save_fixture(connection)
-        return connection
-
-    async def test_enable_requires_enabled_connection(
-        self, session: AsyncSession, organization: Organization
-    ) -> None:
-        with pytest.raises(PolarRequestValidationError):
-            await organization_service.update(
-                session, organization, OrganizationUpdate(sso_enforced=True)
-            )
-
-    async def test_enable_ignores_disabled_connection(
-        self,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        organization: Organization,
-    ) -> None:
-        await self._create_connection(save_fixture, organization, enabled=False)
-
-        with pytest.raises(PolarRequestValidationError):
-            await organization_service.update(
-                session, organization, OrganizationUpdate(sso_enforced=True)
-            )
-
-    async def test_enable_with_enabled_connection(
-        self,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        organization: Organization,
-    ) -> None:
-        await self._create_connection(save_fixture, organization, enabled=True)
-
-        result = await organization_service.update(
-            session, organization, OrganizationUpdate(sso_enforced=True)
-        )
-
-        assert result.sso_enforced is True
-
-    async def test_disable_does_not_require_connection(
-        self, session: AsyncSession, organization: Organization
-    ) -> None:
-        organization.sso_enforced = True
-        await session.flush()
-
-        result = await organization_service.update(
-            session, organization, OrganizationUpdate(sso_enforced=False)
-        )
-
-        assert result.sso_enforced is False
 
 
 @pytest.mark.asyncio

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -18,7 +18,14 @@ from polar.enums import (
 )
 from polar.exceptions import PolarRequestValidationError
 from polar.kit.http import UrlReachability
-from polar.models import Customer, Organization, Product, User, UserOrganization
+from polar.models import (
+    Customer,
+    Organization,
+    OrganizationSSOConnection,
+    Product,
+    User,
+    UserOrganization,
+)
 from polar.models.account import Account
 from polar.models.benefit import BenefitType
 from polar.models.member import MemberRole
@@ -35,6 +42,11 @@ from polar.models.organization import (
 )
 from polar.models.organization_access_token import OrganizationAccessToken
 from polar.models.organization_review import OrganizationReview
+from polar.models.organization_sso_connection import (
+    OIDCAuthMethod,
+    OIDCConfiguration,
+    OrganizationSSOConnectionType,
+)
 from polar.models.user import IdentityVerificationStatus
 from polar.models.user_organization import OrganizationRole
 from polar.organization.repository import OrganizationRepository
@@ -315,6 +327,78 @@ class TestCreate:
         assert (
             organization.capabilities == STATUS_CAPABILITIES[OrganizationStatus.CREATED]
         )
+
+
+@pytest.mark.asyncio
+class TestUpdateSSOEnforced:
+    async def _create_connection(
+        self,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        *,
+        enabled: bool,
+    ) -> OrganizationSSOConnection:
+        configuration: OIDCConfiguration = {
+            "issuer": "https://idp.example.com",
+            "client_id": "client-id",
+            "auth_method": OIDCAuthMethod.client_secret,
+            "client_secret": "secret",
+        }
+        connection = OrganizationSSOConnection(
+            organization=organization,
+            type=OrganizationSSOConnectionType.oidc,
+            configuration=configuration,
+            enabled=enabled,
+        )
+        await save_fixture(connection)
+        return connection
+
+    async def test_enable_requires_enabled_connection(
+        self, session: AsyncSession, organization: Organization
+    ) -> None:
+        with pytest.raises(PolarRequestValidationError):
+            await organization_service.update(
+                session, organization, OrganizationUpdate(sso_enforced=True)
+            )
+
+    async def test_enable_ignores_disabled_connection(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        await self._create_connection(save_fixture, organization, enabled=False)
+
+        with pytest.raises(PolarRequestValidationError):
+            await organization_service.update(
+                session, organization, OrganizationUpdate(sso_enforced=True)
+            )
+
+    async def test_enable_with_enabled_connection(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        await self._create_connection(save_fixture, organization, enabled=True)
+
+        result = await organization_service.update(
+            session, organization, OrganizationUpdate(sso_enforced=True)
+        )
+
+        assert result.sso_enforced is True
+
+    async def test_disable_does_not_require_connection(
+        self, session: AsyncSession, organization: Organization
+    ) -> None:
+        organization.sso_enforced = True
+        await session.flush()
+
+        result = await organization_service.update(
+            session, organization, OrganizationUpdate(sso_enforced=False)
+        )
+
+        assert result.sso_enforced is False
 
 
 @pytest.mark.asyncio

--- a/server/tests/sso/test_endpoints.py
+++ b/server/tests/sso/test_endpoints.py
@@ -4,7 +4,13 @@ import pytest
 import pytest_asyncio
 from httpx import AsyncClient
 
-from polar.models import Organization, OrganizationSSOConnection, UserOrganization
+from polar.auth.models import AuthSubject
+from polar.models import (
+    Organization,
+    OrganizationSSOConnection,
+    User,
+    UserOrganization,
+)
 from polar.models.organization_sso_connection import (
     OIDCAuthMethod,
     OIDCConfiguration,
@@ -391,6 +397,51 @@ class TestUpdateSSOConnection:
         )
         assert response.status_code == 404
 
+    @pytest.mark.auth
+    async def test_disable_last_connection_rejected_when_enforced(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        sso_enabled_organization: Organization,
+        user_organization: UserOrganization,
+        sso_connection: OrganizationSSOConnection,
+    ) -> None:
+        organization.sso_enforced = True
+        await save_fixture(organization)
+        auth_subject.organization_ids = frozenset({organization.id})
+
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}/sso-connections/{sso_connection.id}",
+            json={"enabled": False},
+        )
+
+        assert response.status_code == 409
+
+    @pytest.mark.auth
+    async def test_disable_connection_allowed_when_another_enabled(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        sso_enabled_organization: Organization,
+        user_organization: UserOrganization,
+        sso_connection: OrganizationSSOConnection,
+    ) -> None:
+        await create_sso_connection(save_fixture, organization)
+        organization.sso_enforced = True
+        await save_fixture(organization)
+        auth_subject.organization_ids = frozenset({organization.id})
+
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}/sso-connections/{sso_connection.id}",
+            json={"enabled": False},
+        )
+
+        assert response.status_code == 200
+
 
 @pytest.mark.asyncio
 class TestDeleteSSOConnection:
@@ -464,6 +515,27 @@ class TestDeleteSSOConnection:
             f"/v1/organizations/{organization.id}/sso-connections/{uuid.uuid4()}"
         )
         assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_delete_last_connection_rejected_when_enforced(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        sso_enabled_organization: Organization,
+        user_organization: UserOrganization,
+        sso_connection: OrganizationSSOConnection,
+    ) -> None:
+        organization.sso_enforced = True
+        await save_fixture(organization)
+        auth_subject.organization_ids = frozenset({organization.id})
+
+        response = await client.delete(
+            f"/v1/organizations/{organization.id}/sso-connections/{sso_connection.id}"
+        )
+
+        assert response.status_code == 409
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Allow admins to toggle `sso_enforced`.

<img width="1913" height="945" alt="Screenshot 2026-07-02 at 14 39 44" src="https://github.com/user-attachments/assets/5e431c1f-c60a-4d9b-a3f1-e9e6267f3ac3" />

## What

Adds a dashboard toggle for an org's `sso_enforced` setting, with guards that make it impossible to lock the org out.

## How

- **Toggle** on the SSO settings page (`OrganizationUpdate.sso_enforced`).
- **Enabling requires an active SSO session** for the org — you can only enforce SSO you've just successfully used, so you can't lock yourself out. Button is disabled otherwise.
- **Can't remove the last enabled connection** while enforced (409) — disable enforcement first. Rotation still works (add before remove).

Disabling enforcement is always allowed. Break-glass for a truly locked-out org stays backoffice-only.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Enforce SSO toggle in organization SSO settings so admins can require members to sign in via SSO. Enabling requires an SSO-scoped session and at least one enabled connection; enforcement blocks removing the last enabled connection.

- **New Features**
  - Dashboard: Added “Enforce SSO” toggle with status badge and clear copy; enabling is disabled unless signed in via this org’s SSO and at least one connection is enabled; shows loading and error toast on failure.
  - API/Schema/Service: Added `sso_enforced` on organization; enabling requires an SSO-scoped session (403 `NotPermitted`) and at least one enabled connection (409 `SSOEnforcementRequiresConnection`); SSO connection update/delete reject removing the last enabled connection while enforced (409 `LastSSOConnectionRequired`); regenerated client `v1` types; tests cover these guards.

<sup>Written for commit 11c47783ee2feef1fc20f0ff6a0e19816d4c5614. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



