### PR TITLE
Add "Why you should win" and "Merchant attachments" section to disputes

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/disputes/[id]/DisputeDetailPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/disputes/[id]/DisputeDetailPage.tsx
@@ -50,11 +50,16 @@ interface Props {
 }
 
 const DisputeDetailPage = ({ organization, disputeId }: Props) => {
-  const { data: dispute, isLoading } = useDispute(disputeId)
-  const { data: order } = useOrder(dispute?.order_id)
+  const { data: dispute, isLoading: disputeLoading } = useDispute(disputeId)
+  const { data: order, isLoading: orderLoading } = useOrder(dispute?.order_id)
   const { data: thread, isLoading: threadLoading } = useSupportCase(
     dispute?.case_id ?? undefined,
   )
+
+  const isLoading =
+    disputeLoading ||
+    (dispute != null && orderLoading) ||
+    (dispute?.case_id != null && threadLoading)
 
   if (isLoading) {
     return (
@@ -112,8 +117,6 @@ const DisputeDetailPage = ({ organization, disputeId }: Props) => {
         )}
       </Box>
     )
-  } else if (dispute.case_id != null && threadLoading) {
-    body = <Spinner />
   } else if (hasResponded && dispute.case_id) {
     bodyClassName = 'min-h-0 flex-1'
     body = (

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/disputes/[id]/respond/DisputeRespondView.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/disputes/[id]/respond/DisputeRespondView.tsx
@@ -11,14 +11,35 @@ import { useReplyToSupportCase } from '@/hooks/queries/org'
 import { useOrder } from '@/hooks/queries/orders'
 import { getDisputeReasonExplanation } from '@/utils/dispute'
 import { schemas } from '@polar-sh/client'
-import { Button, Text } from '@polar-sh/orbit'
+import { Button, Input, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { Textarea } from '@polar-sh/orbit/ui/textarea'
+import { Label } from '@polar-sh/ui/components/ui/label'
+import {
+  RadioGroup,
+  RadioGroupItem,
+} from '@polar-sh/ui/components/ui/radio-group'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
 const MIN_EXPLANATION_LENGTH = 20
+
+const REASON_OPTIONS = [
+  {
+    value: 'cardholder_withdrew',
+    label: 'The cardholder withdrew the dispute',
+  },
+  { value: 'cardholder_refunded', label: 'The cardholder was refunded' },
+  {
+    value: 'rightful_cardholder',
+    label: 'The purchase was made by the rightful cardholder',
+  },
+  { value: 'other', label: 'Other' },
+] as const satisfies readonly {
+  value: schemas['DisputeWinReason']
+  label: string
+}[]
 
 interface Props {
   organization: schemas['Organization']
@@ -31,6 +52,8 @@ export const DisputeRespondView = ({ organization, dispute }: Props) => {
   const caseId = dispute.case_id
   const { data: order } = useOrder(dispute.order_id)
 
+  const [reason, setReason] = useState<schemas['DisputeWinReason'] | ''>('')
+  const [otherReason, setOtherReason] = useState('')
   const [explanation, setExplanation] = useState('')
   const [evidence, setEvidence] = useState<DisputeEvidenceState>({
     fileIds: [],
@@ -38,8 +61,13 @@ export const DisputeRespondView = ({ organization, dispute }: Props) => {
   })
   const reply = useReplyToSupportCase()
 
-  const isValid =
-    explanation.trim().length >= MIN_EXPLANATION_LENGTH && caseId != null
+  const hasReason = reason !== ''
+  const otherReasonProvided =
+    reason === 'other' ? otherReason.trim().length > 0 : true
+  const hasExplanation = explanation.trim().length >= MIN_EXPLANATION_LENGTH
+  const hasCase = caseId != null
+
+  const isValid = hasReason && otherReasonProvided && hasExplanation && hasCase
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault()
@@ -50,6 +78,8 @@ export const DisputeRespondView = ({ organization, dispute }: Props) => {
       caseId,
       body: explanation.trim(),
       file_ids: evidence.fileIds,
+      dispute_win_reason: reason || null,
+      dispute_win_reason_other: reason === 'other' ? otherReason.trim() : null,
     })
     if (result.error) {
       toast({
@@ -84,6 +114,49 @@ export const DisputeRespondView = ({ organization, dispute }: Props) => {
       <div className="w-full">
         <form onSubmit={handleSubmit}>
           <Box flexDirection="column" rowGap="xl">
+            <Box flexDirection="column" rowGap="xs">
+              <Box flexDirection="column" rowGap="xs" marginBottom="s">
+                <Text variant="heading-xxs" as="h3">
+                  Why should you win this dispute?
+                </Text>
+                <Text variant="caption" color="muted">
+                  Choose the reason that best describes your case.
+                </Text>
+              </Box>
+              <RadioGroup
+                value={reason}
+                onValueChange={(value) =>
+                  setReason(value as schemas['DisputeWinReason'])
+                }
+              >
+                {REASON_OPTIONS.map((option) => (
+                  <Box key={option.value} alignItems="center" columnGap="m">
+                    <RadioGroupItem
+                      value={option.value}
+                      id={`reason-${option.value}`}
+                    />
+                    <Label
+                      htmlFor={`reason-${option.value}`}
+                      className="cursor-pointer"
+                    >
+                      {option.label}
+                    </Label>
+                  </Box>
+                ))}
+              </RadioGroup>
+              {reason === 'other' && (
+                <Box marginTop="s">
+                  <Input
+                    value={otherReason}
+                    onChange={(event) => setOtherReason(event.target.value)}
+                    placeholder="Tell us why you should win"
+                    maxLength={500}
+                    autoFocus
+                  />
+                </Box>
+              )}
+            </Box>
+
             <Box flexDirection="column" rowGap="xs">
               <Box flexDirection="column" rowGap="xs" marginBottom="s">
                 <Text variant="heading-xxs" as="h3">

--- a/clients/apps/web/src/hooks/queries/org.ts
+++ b/clients/apps/web/src/hooks/queries/org.ts
@@ -435,14 +435,23 @@ export const useReplyToSupportCase = () =>
       caseId,
       body,
       file_ids,
+      dispute_win_reason,
+      dispute_win_reason_other,
     }: {
       caseId: string
       body?: string
       file_ids?: string[]
+      dispute_win_reason?: schemas['DisputeWinReason'] | null
+      dispute_win_reason_other?: string | null
     }) =>
       api.POST('/v1/support-cases/{id}/messages', {
         params: { path: { id: caseId } },
-        body: { body: body || null, file_ids },
+        body: {
+          body: body || null,
+          file_ids,
+          dispute_win_reason,
+          dispute_win_reason_other,
+        },
       }),
     onSuccess: async (result, { caseId }) => {
       if (result.error) return

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -19958,6 +19958,19 @@ export interface components {
       | 'lost'
       | 'won'
     /**
+     * DisputeWinReason
+     * @description Why the merchant believes they should win the chargeback.
+     *
+     *     Collected on their counter submission to help support gather the right
+     *     evidence before submitting to the card network.
+     * @enum {string}
+     */
+    DisputeWinReason:
+      | 'cardholder_withdrew'
+      | 'cardholder_refunded'
+      | 'rightful_cardholder'
+      | 'other'
+    /**
      * DownloadableFileCreate
      * @description Schema to create a file to be associated with the downloadables benefit.
      */
@@ -32410,6 +32423,13 @@ export interface components {
       body?: string | null
       /** File Ids */
       file_ids?: string[]
+      /** @description For a dispute case, the merchant's stated grounds for contesting. Set on the counter submission; ignored for other case types. */
+      dispute_win_reason?: components['schemas']['DisputeWinReason'] | null
+      /**
+       * Dispute Win Reason Other
+       * @description Free-text detail when `dispute_win_reason` is `other`.
+       */
+      dispute_win_reason_other?: string | null
     }
     /**
      * SupportCaseMessageType
@@ -59601,6 +59621,14 @@ export const disputeStatusValues: ReadonlyArray<
   'under_review',
   'lost',
   'won',
+]
+export const disputeWinReasonValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['DisputeWinReason']
+> = [
+  'cardholder_withdrew',
+  'cardholder_refunded',
+  'rightful_cardholder',
+  'other',
 ]
 export const downloadableFileCreateServiceValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['DownloadableFileCreate']['service']

--- a/server/polar/backoffice/middlewares.py
+++ b/server/polar/backoffice/middlewares.py
@@ -1,8 +1,30 @@
 import functools
+from urllib.parse import urlsplit
 
 from starlette.datastructures import MutableHeaders
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from tagflow import document
+
+from polar.file.s3 import S3_SERVICES
+from polar.models.file import FileServiceTypes
+
+
+@functools.cache
+def _content_security_policy() -> str:
+    """The backoffice CSP."""
+    s3_service = S3_SERVICES[FileServiceTypes.support_case_attachment]
+    url, _ = s3_service.generate_presigned_download_url(
+        path="csp-origin-probe",
+        filename="probe",
+        mime_type="application/octet-stream",
+    )
+    parts = urlsplit(url)
+    attachments_origin = f"{parts.scheme}://{parts.netloc}"
+    return (
+        "default-src 'self'; script-src 'self'; object-src 'none'; "
+        "base-uri 'self'; style-src 'self' 'unsafe-inline'; "
+        f"img-src 'self' data: {attachments_origin};"
+    )
 
 
 class TagflowMiddleware:
@@ -38,11 +60,9 @@ class SecurityHeadersMiddleware:
         headers = MutableHeaders(scope=message)
 
         # Add Content-Security-Policy
-        # Restricts sources of content to only the same origin, but allows inline CSS and data:image
-        headers["Content-Security-Policy"] = (
-            "default-src 'self'; script-src 'self'; object-src 'none'; base-uri 'self'; "
-            "style-src 'self' 'unsafe-inline'; img-src 'self' data:;"
-        )
+        # Restricts sources of content to only the same origin, but allows
+        # inline CSS, data:image and presigned attachment images.
+        headers["Content-Security-Policy"] = _content_security_policy()
 
         # Add X-Content-Type-Options
         # Prevents MIME type sniffing

--- a/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
@@ -14,6 +14,8 @@ from tagflow import attr, tag, text
 from polar.enums import PaymentProcessor
 from polar.models import Dispute, Organization
 from polar.models.support_case import (
+    DisputeSupportCase,
+    DisputeWinReason,
     SupportCase,
     SupportCaseAttachment,
     SupportCaseMessage,
@@ -36,6 +38,15 @@ _AUTHOR_LABELS: dict[SupportCaseMessageAuthorKind, str] = {
 _CASE_TITLES: dict[SupportCaseType, str] = {
     SupportCaseType.review_appeal: "Appeal Support Case",
     SupportCaseType.dispute: "Dispute Support Case",
+}
+
+_WIN_REASON_LABELS: dict[DisputeWinReason, str] = {
+    DisputeWinReason.cardholder_withdrew: "The cardholder withdrew the dispute",
+    DisputeWinReason.cardholder_refunded: "The cardholder was refunded",
+    DisputeWinReason.rightful_cardholder: (
+        "The purchase was made by the rightful cardholder"
+    ),
+    DisputeWinReason.other: "Other",
 }
 
 # The "opened" milestone reads differently per case type (a merchant-requested
@@ -124,6 +135,7 @@ class SupportCaseSection:
         author_emails: dict[UUID, str] | None = None,
         current_user_id: UUID | None = None,
         attachments_by_message: dict[UUID, list[SupportCaseAttachment]] | None = None,
+        attachments: Sequence[SupportCaseAttachment] | None = None,
         dispute: Dispute | None = None,
         return_to: str | None = None,
     ) -> None:
@@ -132,6 +144,7 @@ class SupportCaseSection:
         self.author_emails = author_emails or {}
         self.current_user_id = current_user_id
         self.attachments_by_message = attachments_by_message or {}
+        self.attachments = attachments or []
         # The dispute behind a dispute case, surfaced as a read-only facts panel.
         self.dispute = dispute
         # Origin to come back to after an action (e.g. the org page), threaded
@@ -305,10 +318,10 @@ class SupportCaseSection:
     def _render_dispute_details(self, request: Request, dispute: Dispute) -> None:
         """Read-only facts about the chargeback: what is owed, why, and by when."""
         order_url = str(request.url_for("orders:get", id=dispute.order_id))
-        with tag.div(classes="mb-8 rounded-xl border border-base-200"):
+        with tag.div(classes="mb-8 rounded-xl border border-base-300"):
             with tag.div(
                 classes="flex items-center justify-between gap-2 px-4 py-3 "
-                "border-b border-base-200"
+                "border-b border-base-300"
             ):
                 with tag.div(classes="flex items-center gap-2"):
                     with tag.span(classes="icon-gavel text-base-content/60"):
@@ -341,6 +354,56 @@ class SupportCaseSection:
                 if dispute.payment_processor_id:
                     with self._fact("Processor dispute ID"):
                         self._render_processor_id(dispute)
+                with self._fact("Why they should win"):
+                    self._render_win_reason()
+            self._render_evidence_files(request)
+
+    def _render_win_reason(self) -> None:
+        case = self.thread[0] if self.thread else None
+        if not isinstance(case, DisputeSupportCase) or case.win_reason is None:
+            with tag.span(classes="text-base-content/50"):
+                text("Not provided")
+            return
+        label = _WIN_REASON_LABELS.get(case.win_reason, case.win_reason.value)
+        if case.win_reason == DisputeWinReason.other and case.win_reason_other:
+            text(f"{label} — {case.win_reason_other}")
+        else:
+            text(label)
+
+    def _merchant_attachments(self) -> list[SupportCaseAttachment]:
+        """Attachments carried by merchant-authored messages.
+
+        The case can also hold platform/internal attachments; those must not
+        appear under a "merchant submitted" heading."""
+        if self.thread is None:
+            return []
+        _case, _is_open, messages = self.thread
+        merchant_message_ids = {
+            message.id
+            for message in messages
+            if message.author_kind == SupportCaseMessageAuthorKind.merchant
+        }
+        return [
+            attachment
+            for attachment in self.attachments
+            if attachment.message_id in merchant_message_ids
+        ]
+
+    def _render_evidence_files(self, request: Request) -> None:
+        """The merchant's evidence — the counter submission and any files sent
+        later in the chat — consolidated so support always has the full set."""
+        attachments = self._merchant_attachments()
+        if not attachments:
+            return
+        with tag.div(
+            classes="flex flex-col gap-2 px-4 pb-4 border-t border-base-300 pt-4"
+        ):
+            with tag.div(
+                classes="text-xs uppercase tracking-wide text-base-content/40"
+            ):
+                text(f"Merchant submitted files ({len(attachments)})")
+            for attachment in attachments:
+                self._render_attachment(request, attachment)
 
     @contextlib.contextmanager
     def _fact(self, label: str) -> Generator[None]:
@@ -510,11 +573,25 @@ class SupportCaseSection:
         with tag.a(
             href=url,
             target="_blank",
-            classes="flex items-center gap-2 max-w-md rounded-lg border "
-            "border-base-200 bg-base-100 px-3 py-2 hover:bg-base-200",
+            classes="flex items-center gap-3 max-w-md rounded-lg border "
+            "border-base-300 bg-base-100 px-3 py-2 hover:bg-base-200",
         ):
-            with tag.span(classes="icon-paperclip text-base-content/40"):
-                pass
+            if file.mime_type.startswith("image/"):
+                with tag.img(
+                    src=url,
+                    alt=file.name,
+                    loading="lazy",
+                    classes="h-12 w-12 flex-none rounded-md object-cover bg-base-200",
+                ):
+                    pass
+            else:
+                with tag.div(
+                    classes="flex h-12 w-12 flex-none items-center "
+                    "justify-center rounded-md bg-base-200 "
+                    "text-base-content/40"
+                ):
+                    with tag.span(classes="icon-paperclip"):
+                        pass
             with tag.div(classes="min-w-0"):
                 with tag.div(classes="text-sm font-medium truncate"):
                     text(file.name)
@@ -554,7 +631,7 @@ class SupportCaseSection:
         )
         # A closed case only takes internal follow-ups after the decision.
         internal_only = not is_open
-        with tag.div(classes="mt-8 pt-6 border-t border-base-200"):
+        with tag.div(classes="mt-8 pt-6 border-t border-base-300"):
             if not is_open:
                 with tag.div(
                     classes="flex items-center gap-2 mb-3 text-sm text-base-content/60"

--- a/server/polar/backoffice/support_cases/endpoints.py
+++ b/server/polar/backoffice/support_cases/endpoints.py
@@ -370,6 +370,7 @@ async def case_detail(
         author_emails=author_emails,
         current_user_id=user_session.user_id,
         attachments_by_message=attachments_by_message,
+        attachments=attachments,
         dispute=dispute,
         return_to=return_to if is_safe_return_to(return_to) else None,
     )

--- a/server/polar/dispute/dispute_case.py
+++ b/server/polar/dispute/dispute_case.py
@@ -5,6 +5,7 @@ from polar.exceptions import PolarError
 from polar.models import Dispute, File, Organization, User
 from polar.models.support_case import (
     DisputeSupportCase,
+    DisputeWinReason,
     SupportCaseAudience,
     SupportCaseMessage,
     SupportCaseMessageAuthorKind,
@@ -140,14 +141,22 @@ class DisputeCaseService:
         body: str | None = None,
         files: Sequence[File] = (),
         internal: bool = False,
+        win_reason: DisputeWinReason | None = None,
+        win_reason_other: str | None = None,
     ) -> SupportCaseMessage:
         """Post a reply to the dispute thread, optionally carrying files.
 
         This is the merchant ↔ support conversation channel: the merchant's
         evidence and any back-and-forth live here as ``chat`` messages, which
-        support reviews and submits to the processor.
+        support reviews and submits to the processor. ``win_reason`` records the
+        merchant's stated grounds for contesting, set on their counter;
+        ``win_reason_other`` carries their free-text detail for ``other``.
         """
         await self._assert_open(session, case)
+
+        if win_reason is not None:
+            case.win_reason = win_reason
+            case.win_reason_other = win_reason_other
 
         is_first_merchant_reply = (
             author_kind == SupportCaseMessageAuthorKind.merchant

--- a/server/polar/support_case/endpoints.py
+++ b/server/polar/support_case/endpoints.py
@@ -137,6 +137,8 @@ async def reply_to_support_case(
             author_user=auth_subject.subject,
             body=message.body,
             files=files,
+            win_reason=message.dispute_win_reason,
+            win_reason_other=message.dispute_win_reason_other,
         )
     raise CaseRepliesNotSupportedError(case)
 

--- a/server/polar/support_case/schemas.py
+++ b/server/polar/support_case/schemas.py
@@ -6,6 +6,7 @@ from pydantic import UUID4, Field, model_validator
 from polar.exceptions import ResourceNotFound
 from polar.kit.schemas import IDSchema, Schema, TimestampedSchema
 from polar.models.support_case import (
+    DisputeWinReason,
     SupportCaseMessageAuthorKind,
     SupportCaseMessageType,
     SupportCaseType,
@@ -55,11 +56,43 @@ class SupportCaseMessageCreate(Schema):
 
     body: str | None = Field(default=None, min_length=1, max_length=5000)
     file_ids: list[UUID4] = Field(default_factory=list, max_length=10)
+    dispute_win_reason: DisputeWinReason | None = Field(
+        default=None,
+        description=(
+            "For a dispute case, the merchant's stated grounds for contesting. "
+            "Set on the counter submission; ignored for other case types."
+        ),
+    )
+    dispute_win_reason_other: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=500,
+        description="Free-text detail when `dispute_win_reason` is `other`.",
+    )
 
     @model_validator(mode="after")
     def _require_content(self) -> Self:
         if not self.body and not self.file_ids:
             raise ValueError("A reply needs a body, an attachment, or both.")
+        return self
+
+    @model_validator(mode="after")
+    def _validate_win_reason(self) -> Self:
+        if (
+            self.dispute_win_reason_other is not None
+            and self.dispute_win_reason != DisputeWinReason.other
+        ):
+            raise ValueError(
+                "dispute_win_reason_other is only allowed when "
+                "dispute_win_reason is `other`."
+            )
+        if (
+            self.dispute_win_reason == DisputeWinReason.other
+            and not self.dispute_win_reason_other
+        ):
+            raise ValueError(
+                "dispute_win_reason `other` requires dispute_win_reason_other."
+            )
         return self
 
 

--- a/server/tests/support_case/test_endpoints.py
+++ b/server/tests/support_case/test_endpoints.py
@@ -1,10 +1,13 @@
 import pytest
 from httpx import AsyncClient
 from pytest_mock import MockerFixture
+from sqlalchemy import select
 
 from polar.dispute.dispute_case import DISPUTE_GREETING_DELAY_MS
 from polar.models import Customer, Organization, Product
 from polar.models.support_case import (
+    DisputeSupportCase,
+    DisputeWinReason,
     SupportCaseAudience,
     SupportCaseMessageAuthorKind,
 )
@@ -220,6 +223,107 @@ class TestReplyToSupportCase:
         )
         assert response.status_code == 201
         assert response.json()["body"] == "my evidence"
+
+    @pytest.mark.auth
+    async def test_dispute_reply_records_win_reason(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+        user_organization: UserOrganization,
+    ) -> None:
+        case = await create_dispute_case(save_fixture, organization, customer, product)
+        assert case.win_reason is None
+
+        response = await client.post(
+            f"/v1/support-cases/{case.id}/messages",
+            json={
+                "body": "my evidence",
+                "dispute_win_reason": "cardholder_withdrew",
+            },
+        )
+        assert response.status_code == 201
+
+        win_reason = await session.scalar(
+            select(DisputeSupportCase.win_reason).where(
+                DisputeSupportCase.id == case.id
+            )
+        )
+        assert win_reason == DisputeWinReason.cardholder_withdrew
+
+    @pytest.mark.auth
+    async def test_dispute_reply_records_win_reason_other(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+        user_organization: UserOrganization,
+    ) -> None:
+        case = await create_dispute_case(save_fixture, organization, customer, product)
+
+        response = await client.post(
+            f"/v1/support-cases/{case.id}/messages",
+            json={
+                "body": "my evidence",
+                "dispute_win_reason": "other",
+                "dispute_win_reason_other": "The subscription was reactivated",
+            },
+        )
+        assert response.status_code == 201
+
+        row = (
+            await session.execute(
+                select(
+                    DisputeSupportCase.win_reason,
+                    DisputeSupportCase.win_reason_other,
+                ).where(DisputeSupportCase.id == case.id)
+            )
+        ).one()
+        assert row.win_reason == DisputeWinReason.other
+        assert row.win_reason_other == "The subscription was reactivated"
+
+    @pytest.mark.auth
+    async def test_win_reason_other_without_other_reason_rejected(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+        user_organization: UserOrganization,
+    ) -> None:
+        case = await create_dispute_case(save_fixture, organization, customer, product)
+        response = await client.post(
+            f"/v1/support-cases/{case.id}/messages",
+            json={
+                "body": "my evidence",
+                "dispute_win_reason_other": "would be silently lost",
+            },
+        )
+        assert response.status_code == 422
+
+    @pytest.mark.auth
+    async def test_win_reason_other_required_for_other(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+        user_organization: UserOrganization,
+    ) -> None:
+        case = await create_dispute_case(save_fixture, organization, customer, product)
+        response = await client.post(
+            f"/v1/support-cases/{case.id}/messages",
+            json={"body": "my evidence", "dispute_win_reason": "other"},
+        )
+        assert response.status_code == 422
 
     @pytest.mark.auth
     async def test_dispute_first_reply_enqueues_greeting(


### PR DESCRIPTION
## Summary

This PR will:

* add a `Why you should win` section to our disputes, similar to what Stripe does, which will be shown in the Backoffice for easier disputes.
* Add a `Merchant submitted files` section in the backoffice, which updates for every new attachment the merchant sends. 
* Add a new endpoint so that we can show a preview of merchant attachments
* add some UI polish to the dashboard (loading state) and Backoffice (border colors).

## Screenshots

| Dashboard | Backoffice  |
|--------|--------|
| <img width="1840" height="1133" alt="Screenshot 2026-07-03 at 11 45 23" src="https://github.com/user-attachments/assets/9c403743-23f0-4231-bc75-037905dce64a" /> | <img width="3680" height="2268" alt="Screenshot 2026-07-03 at 12 06 06" src="https://github.com/user-attachments/assets/4a897c00-e4ee-4148-9443-6964798f27dd" /> |






