### PR TITLE
feat(terraform): declare Stripe App OAuth vars for backend

### DIFF
--- a/terraform/global/production.tf
+++ b/terraform/global/production.tf
@@ -584,3 +584,19 @@ resource "tfe_variable" "worker_sqs_actors_production" {
     ignore_changes = [value]
   }
 }
+
+resource "tfe_variable" "stripe_app_client_id_production" {
+  key             = "stripe_app_client_id"
+  category        = "terraform"
+  description     = "Stripe App OAuth client ID for production"
+  sensitive       = false
+  variable_set_id = tfe_variable_set.production.id
+}
+
+resource "tfe_variable" "stripe_app_client_link_id_production" {
+  key             = "stripe_app_client_link_id"
+  category        = "terraform"
+  description     = "Stripe App OAuth client link ID for production"
+  sensitive       = false
+  variable_set_id = tfe_variable_set.production.id
+}

--- a/terraform/global/sandbox.tf
+++ b/terraform/global/sandbox.tf
@@ -502,3 +502,19 @@ resource "tfe_variable" "worker_sqs_actors_sandbox" {
     ignore_changes = [value]
   }
 }
+
+resource "tfe_variable" "stripe_app_client_id_sandbox" {
+  key             = "stripe_app_client_id"
+  category        = "terraform"
+  description     = "Stripe App OAuth client ID for sandbox"
+  sensitive       = false
+  variable_set_id = tfe_variable_set.sandbox.id
+}
+
+resource "tfe_variable" "stripe_app_client_link_id_sandbox" {
+  key             = "stripe_app_client_link_id"
+  category        = "terraform"
+  description     = "Stripe App OAuth client link ID for sandbox"
+  sensitive       = false
+  variable_set_id = tfe_variable_set.sandbox.id
+}

--- a/terraform/global/test.tf
+++ b/terraform/global/test.tf
@@ -488,3 +488,19 @@ resource "tfe_variable" "worker_sqs_actors_test" {
     ignore_changes = [value]
   }
 }
+
+resource "tfe_variable" "stripe_app_client_id_test" {
+  key             = "stripe_app_client_id"
+  category        = "terraform"
+  description     = "Stripe App OAuth client ID for test"
+  sensitive       = false
+  variable_set_id = tfe_variable_set.test.id
+}
+
+resource "tfe_variable" "stripe_app_client_link_id_test" {
+  key             = "stripe_app_client_link_id"
+  category        = "terraform"
+  description     = "Stripe App OAuth client link ID for test"
+  sensitive       = false
+  variable_set_id = tfe_variable_set.test.id
+}

--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -172,6 +172,8 @@ resource "render_env_group" "stripe" {
     POLAR_STRIPE_CONNECT_WEBHOOK_SECRET = { value = var.stripe_secrets.connect_webhook_secret }
     POLAR_STRIPE_SECRET_KEY             = { value = var.stripe_secrets.secret_key }
     POLAR_STRIPE_WEBHOOK_SECRET         = { value = var.stripe_secrets.webhook_secret }
+    POLAR_STRIPE_APP_CLIENT_ID          = { value = var.stripe_secrets.app_client_id }
+    POLAR_STRIPE_APP_CLIENT_LINK_ID     = { value = var.stripe_secrets.app_client_link_id }
   }
 }
 

--- a/terraform/modules/render_service/variables.tf
+++ b/terraform/modules/render_service/variables.tf
@@ -232,6 +232,8 @@ variable "stripe_secrets" {
     connect_webhook_secret = string
     secret_key             = string
     webhook_secret         = string
+    app_client_id          = optional(string, "")
+    app_client_link_id     = optional(string, "")
   })
   sensitive = true
 }

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -355,6 +355,8 @@ module "production" {
     connect_webhook_secret = var.stripe_connect_webhook_secret_production
     secret_key             = var.stripe_secret_key_production
     webhook_secret         = var.stripe_webhook_secret_production
+    app_client_id          = var.stripe_app_client_id
+    app_client_link_id     = var.stripe_app_client_link_id
   }
 
   logfire_config = {

--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -512,9 +512,11 @@ variable "next_public_stripe_payment_method_configuration" {
 variable "stripe_app_client_id" {
   description = "Stripe App OAuth client ID"
   type        = string
+  default     = ""
 }
 
 variable "stripe_app_client_link_id" {
   description = "Stripe App OAuth client link ID"
   type        = string
+  default     = ""
 }

--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -508,3 +508,13 @@ variable "next_public_stripe_payment_method_configuration" {
   type        = string
   sensitive   = true
 }
+
+variable "stripe_app_client_id" {
+  description = "Stripe App OAuth client ID"
+  type        = string
+}
+
+variable "stripe_app_client_link_id" {
+  description = "Stripe App OAuth client link ID"
+  type        = string
+}

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -261,6 +261,8 @@ module "sandbox" {
     connect_webhook_secret = var.stripe_connect_webhook_secret_sandbox
     secret_key             = var.stripe_secret_key_sandbox
     webhook_secret         = var.stripe_webhook_secret_sandbox
+    app_client_id          = var.stripe_app_client_id
+    app_client_link_id     = var.stripe_app_client_link_id
   }
 
   apple_secrets = {

--- a/terraform/sandbox/variables.tf
+++ b/terraform/sandbox/variables.tf
@@ -429,9 +429,11 @@ variable "worker_sqs_actors" {
 variable "stripe_app_client_id" {
   description = "Stripe App OAuth client ID"
   type        = string
+  default     = ""
 }
 
 variable "stripe_app_client_link_id" {
   description = "Stripe App OAuth client link ID"
   type        = string
+  default     = ""
 }

--- a/terraform/sandbox/variables.tf
+++ b/terraform/sandbox/variables.tf
@@ -425,3 +425,13 @@ variable "worker_sqs_actors" {
   type        = string
   default     = "[\"dummy\"]"
 }
+
+variable "stripe_app_client_id" {
+  description = "Stripe App OAuth client ID"
+  type        = string
+}
+
+variable "stripe_app_client_link_id" {
+  description = "Stripe App OAuth client link ID"
+  type        = string
+}

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -236,6 +236,8 @@ module "test" {
     connect_webhook_secret = var.stripe_connect_webhook_secret
     secret_key             = var.stripe_secret_key
     webhook_secret         = var.stripe_webhook_secret
+    app_client_id          = var.stripe_app_client_id
+    app_client_link_id     = var.stripe_app_client_link_id
   }
 
   logfire_config = {

--- a/terraform/test/variables.tf
+++ b/terraform/test/variables.tf
@@ -403,3 +403,15 @@ variable "next_public_stripe_payment_method_configuration" {
   type        = string
   sensitive   = true
 }
+
+variable "stripe_app_client_id" {
+  description = "Stripe App OAuth client ID"
+  type        = string
+  default     = ""
+}
+
+variable "stripe_app_client_link_id" {
+  description = "Stripe App OAuth client link ID"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

Add the `stripe_app_client_id` and `stripe_app_client_link_id` Terraform Cloud variables for production + sandbox


## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

