### PR TITLE
feat(slack): dual-write encrypted SlackApp secrets

### DIFF
--- a/server/migrations/versions/2026-07-02-1000_add_slack_app_encrypted_secrets.py
+++ b/server/migrations/versions/2026-07-02-1000_add_slack_app_encrypted_secrets.py
@@ -1,0 +1,42 @@
+"""add SlackApp encrypted secret columns
+
+Revision ID: b181f0be8208
+Revises: 31d662178679
+Create Date: 2026-07-02 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "b181f0be8208"
+down_revision = "31d662178679"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.add_column(
+        "slack_apps",
+        sa.Column("client_secret_encrypted", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "slack_apps",
+        sa.Column("signing_secret_encrypted", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "slack_apps",
+        sa.Column("bot_token_encrypted", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.drop_column("slack_apps", "bot_token_encrypted")
+    op.drop_column("slack_apps", "signing_secret_encrypted")
+    op.drop_column("slack_apps", "client_secret_encrypted")

--- a/server/polar/integrations/slack/service.py
+++ b/server/polar/integrations/slack/service.py
@@ -122,13 +122,26 @@ class SlackAppService:
                 client_secret=client_secret,
                 signing_secret=signing_secret,
             )
+            integration.id = SlackApp.generate_id()
+            integration.client_secret_encrypted = await SlackApp.encrypt_client_secret(
+                integration.id, client_secret
+            )
+            integration.signing_secret_encrypted = (
+                await SlackApp.encrypt_signing_secret(integration.id, signing_secret)
+            )
             return await repository.create(integration, flush=True)
 
         update_dict: dict[str, Any] = {
             "display_name": update.display_name,
             "client_id": update.client_id,
             "client_secret": client_secret,
+            "client_secret_encrypted": await SlackApp.encrypt_client_secret(
+                existing.id, client_secret
+            ),
             "signing_secret": signing_secret,
+            "signing_secret_encrypted": await SlackApp.encrypt_signing_secret(
+                existing.id, signing_secret
+            ),
         }
         # client_id identifies which Slack app the OAuth flow targets. If it
         # changes, the bot_token from the previous install is no longer valid
@@ -141,6 +154,7 @@ class SlackAppService:
                     "team_name": None,
                     "bot_user_id": None,
                     "bot_token": None,
+                    "bot_token_encrypted": None,
                     "authed_user_id": None,
                     "scopes": None,
                     "installed_at": None,
@@ -264,13 +278,17 @@ class SlackAppService:
             raise SlackIntegrationInvalidCredentials("app_id_mismatch")
 
         team = result.get("team") or {}
+        bot_token = result.get("access_token")
         return await repository.update(
             integration,
             update_dict={
                 "team_id": team.get("id"),
                 "team_name": team.get("name"),
                 "bot_user_id": result.get("bot_user_id"),
-                "bot_token": result.get("access_token"),
+                "bot_token": bot_token,
+                "bot_token_encrypted": await SlackApp.encrypt_bot_token(
+                    integration.id, bot_token
+                ),
                 "authed_user_id": (result.get("authed_user") or {}).get("id"),
                 "scopes": result["scope"].split(",") if result.get("scope") else None,
                 "installed_at": utc_now(),
@@ -301,6 +319,7 @@ class SlackAppService:
                 integration,
                 update_dict={
                     "bot_token": None,
+                    "bot_token_encrypted": None,
                     "revoked_at": utc_now(),
                 },
             )

--- a/server/polar/models/slack_app.py
+++ b/server/polar/models/slack_app.py
@@ -6,8 +6,22 @@ from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
 from polar.kit.db.models.base import RecordModel
+from polar.kit.encryption import EncryptedString, EncryptedStringType
 
 from .organization import Organization
+
+SLACK_APP_CLIENT_SECRET_CONTEXT = {
+    "table": "slack_apps",
+    "column": "client_secret",
+}
+SLACK_APP_SIGNING_SECRET_CONTEXT = {
+    "table": "slack_apps",
+    "column": "signing_secret",
+}
+SLACK_APP_BOT_TOKEN_CONTEXT = {
+    "table": "slack_apps",
+    "column": "bot_token",
+}
 
 
 class SlackApp(RecordModel):
@@ -30,8 +44,18 @@ class SlackApp(RecordModel):
     client_secret: Mapped[str | None] = mapped_column(
         String(255), nullable=True, default=None
     )
+    client_secret_encrypted: Mapped[EncryptedString | None] = mapped_column(
+        EncryptedStringType(SLACK_APP_CLIENT_SECRET_CONTEXT),
+        nullable=True,
+        default=None,
+    )
     signing_secret: Mapped[str | None] = mapped_column(
         String(255), nullable=True, default=None
+    )
+    signing_secret_encrypted: Mapped[EncryptedString | None] = mapped_column(
+        EncryptedStringType(SLACK_APP_SIGNING_SECRET_CONTEXT),
+        nullable=True,
+        default=None,
     )
 
     team_id: Mapped[str | None] = mapped_column(
@@ -45,6 +69,11 @@ class SlackApp(RecordModel):
     )
     bot_token: Mapped[str | None] = mapped_column(
         String(255), nullable=True, default=None
+    )
+    bot_token_encrypted: Mapped[EncryptedString | None] = mapped_column(
+        EncryptedStringType(SLACK_APP_BOT_TOKEN_CONTEXT),
+        nullable=True,
+        default=None,
     )
     authed_user_id: Mapped[str | None] = mapped_column(
         String(32), nullable=True, default=None
@@ -62,3 +91,36 @@ class SlackApp(RecordModel):
     @declared_attr
     def organization(cls) -> Mapped["Organization"]:
         return relationship(Organization, lazy="raise")
+
+    @classmethod
+    async def encrypt_client_secret(
+        cls, id: UUID, client_secret: str | None
+    ) -> EncryptedString | None:
+        if client_secret is None:
+            return None
+        return await EncryptedString.encrypt(
+            client_secret,
+            context={**SLACK_APP_CLIENT_SECRET_CONTEXT, "id": str(id)},
+        )
+
+    @classmethod
+    async def encrypt_signing_secret(
+        cls, id: UUID, signing_secret: str | None
+    ) -> EncryptedString | None:
+        if signing_secret is None:
+            return None
+        return await EncryptedString.encrypt(
+            signing_secret,
+            context={**SLACK_APP_SIGNING_SECRET_CONTEXT, "id": str(id)},
+        )
+
+    @classmethod
+    async def encrypt_bot_token(
+        cls, id: UUID, bot_token: str | None
+    ) -> EncryptedString | None:
+        if bot_token is None:
+            return None
+        return await EncryptedString.encrypt(
+            bot_token,
+            context={**SLACK_APP_BOT_TOKEN_CONTEXT, "id": str(id)},
+        )

--- a/server/tests/models/test_slack_app.py
+++ b/server/tests/models/test_slack_app.py
@@ -1,0 +1,112 @@
+import pytest
+from cryptography.exceptions import InvalidTag
+from sqlalchemy import select
+
+from polar.kit.encryption import EncryptedString
+from polar.models import Organization, SlackApp
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+
+
+def _build(organization: Organization) -> SlackApp:
+    return SlackApp(
+        organization_id=organization.id,
+        display_name="Test",
+        slack_app_id="A1",
+        client_id="100.200",
+    )
+
+
+@pytest.mark.asyncio
+class TestEncryptClassmethods:
+    """Covers the classmethods used by the create and ``update_dict`` write
+    paths in the Slack integration service."""
+
+    async def test_encrypt_client_secret(self, organization: Organization) -> None:
+        integration = _build(organization)
+        integration.id = SlackApp.generate_id()
+
+        encrypted = await SlackApp.encrypt_client_secret(integration.id, "cs-test")
+
+        assert isinstance(encrypted, EncryptedString)
+        assert await encrypted.decrypt(id=str(integration.id)) == "cs-test"
+
+    async def test_encrypt_signing_secret(self, organization: Organization) -> None:
+        integration = _build(organization)
+        integration.id = SlackApp.generate_id()
+
+        encrypted = await SlackApp.encrypt_signing_secret(integration.id, "ss-test")
+
+        assert isinstance(encrypted, EncryptedString)
+        assert await encrypted.decrypt(id=str(integration.id)) == "ss-test"
+
+    async def test_encrypt_bot_token(self, organization: Organization) -> None:
+        integration = _build(organization)
+        integration.id = SlackApp.generate_id()
+
+        encrypted = await SlackApp.encrypt_bot_token(integration.id, "xoxb-test")
+
+        assert isinstance(encrypted, EncryptedString)
+        assert await encrypted.decrypt(id=str(integration.id)) == "xoxb-test"
+
+    async def test_encrypt_none_returns_none(self, organization: Organization) -> None:
+        row_id = SlackApp.generate_id()
+        assert await SlackApp.encrypt_client_secret(row_id, None) is None
+        assert await SlackApp.encrypt_signing_secret(row_id, None) is None
+        assert await SlackApp.encrypt_bot_token(row_id, None) is None
+
+    async def test_binds_ciphertext_to_row_id(self, organization: Organization) -> None:
+        integration = _build(organization)
+        integration.id = SlackApp.generate_id()
+
+        encrypted = await SlackApp.encrypt_client_secret(integration.id, "cs-test")
+
+        assert isinstance(encrypted, EncryptedString)
+        with pytest.raises(InvalidTag):
+            await encrypted.decrypt(id="not-the-row-id")
+
+
+@pytest.mark.asyncio
+class TestPersistence:
+    async def test_round_trip_through_database(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        integration = _build(organization)
+        integration.id = SlackApp.generate_id()
+        integration.client_secret = "cs-test"
+        integration.client_secret_encrypted = await SlackApp.encrypt_client_secret(
+            integration.id, "cs-test"
+        )
+        integration.signing_secret = "ss-test"
+        integration.signing_secret_encrypted = await SlackApp.encrypt_signing_secret(
+            integration.id, "ss-test"
+        )
+        integration.bot_token = "xoxb-test"
+        integration.bot_token_encrypted = await SlackApp.encrypt_bot_token(
+            integration.id, "xoxb-test"
+        )
+        await save_fixture(integration)
+        integration_id = integration.id
+
+        session.expunge_all()
+        loaded = await session.scalar(
+            select(SlackApp).where(SlackApp.id == integration_id)
+        )
+
+        assert loaded is not None
+        assert isinstance(loaded.client_secret_encrypted, EncryptedString)
+        assert isinstance(loaded.signing_secret_encrypted, EncryptedString)
+        assert isinstance(loaded.bot_token_encrypted, EncryptedString)
+        assert (
+            await loaded.client_secret_encrypted.decrypt(id=str(loaded.id)) == "cs-test"
+        )
+        assert (
+            await loaded.signing_secret_encrypted.decrypt(id=str(loaded.id))
+            == "ss-test"
+        )
+        assert (
+            await loaded.bot_token_encrypted.decrypt(id=str(loaded.id)) == "xoxb-test"
+        )


### PR DESCRIPTION
## Summary

Step 1 (dual-write) of the secrets in `SlackApp` model, mirroring the earlier `OAuthAccount` change. 
## What

- Add nullable `client_secret_encrypted` / `signing_secret_encrypted` / `bot_token_encrypted` columns (thin migration, additive) plus per-column encryption contexts and `encrypt_*` classmethods on `SlackApp`.
- Dual-write the encrypted columns at every write site: credentials create + rotation, install completion, and revoke/client-id-change resets. Reads stay on the plaintext columns for now.

## Checklist

- [x] Lint passes
- [x] Type check passes
- [x] Tests added
- [x] Change is focused and small
- [ ] Backfill script (separate follow-up)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

