### PR TITLE
tf: Add pgBouncer

### DIFF
--- a/infra/pgbouncer/Dockerfile
+++ b/infra/pgbouncer/Dockerfile
@@ -1,0 +1,23 @@
+FROM debian:trixie-slim
+
+RUN apt-get -qq update \
+  && apt-get -qq install -y --no-install-recommends \
+    ca-certificates \
+    postgresql-common \
+  > /dev/null \
+  && /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y \
+  && apt-get -qq install -y --no-install-recommends pgbouncer > /dev/null \
+  && apt-get -qq clean \
+  && rm -rf \
+    /var/lib/apt/lists/* \
+    /tmp/* \
+    /var/tmp/*
+
+COPY --chmod=755 entrypoint.sh /usr/local/bin/pgbouncer-entrypoint
+
+RUN chown -R postgres:postgres /etc/pgbouncer
+
+USER postgres
+EXPOSE 5432
+
+CMD ["/usr/local/bin/pgbouncer-entrypoint"]

--- a/infra/pgbouncer/Dockerfile
+++ b/infra/pgbouncer/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:trixie-slim
-
+ARG PGBOUNCER_APT_VERSION=1.25.2-1.pgdg13+1
 RUN apt-get -qq update \
   && apt-get -qq install -y --no-install-recommends \
     ca-certificates \

--- a/infra/pgbouncer/Dockerfile
+++ b/infra/pgbouncer/Dockerfile
@@ -1,3 +1,5 @@
+# Dockerfile inspired by https://github.com/edoburu/docker-pgbouncer
+
 FROM debian:trixie-slim
 ARG PGBOUNCER_APT_VERSION=1.25.2-1.pgdg13+1
 RUN apt-get -qq update \

--- a/infra/pgbouncer/Dockerfile
+++ b/infra/pgbouncer/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get -qq update \
     postgresql-common \
   > /dev/null \
   && /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y \
-  && apt-get -qq install -y --no-install-recommends pgbouncer > /dev/null \
+  && apt-get -qq install -y --no-install-recommends pgbouncer="${PGBOUNCER_APT_VERSION}" > /dev/null \
   && apt-get -qq clean \
   && rm -rf \
     /var/lib/apt/lists/* \

--- a/infra/pgbouncer/entrypoint.sh
+++ b/infra/pgbouncer/entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -e
+
+: "${DB_HOST:?DB_HOST is required}"
+: "${DB_USER:?DB_USER is required}"
+: "${DB_PASSWORD:?DB_PASSWORD is required}"
+
+cat > /etc/pgbouncer/userlist.txt <<EOF
+"${DB_USER}" "${DB_PASSWORD}"
+EOF
+chmod 600 /etc/pgbouncer/userlist.txt
+
+cat > /etc/pgbouncer/pgbouncer.ini <<EOF
+[databases]
+* = host=${DB_HOST} port=${DB_PORT:-5432}
+
+[pgbouncer]
+listen_addr = 0.0.0.0
+listen_port = ${LISTEN_PORT:-5432}
+unix_socket_dir =
+auth_type = ${AUTH_TYPE:-scram-sha-256}
+auth_file = /etc/pgbouncer/userlist.txt
+admin_users = ${ADMIN_USERS:-${DB_USER}}
+stats_users = ${STATS_USERS:-${DB_USER}}
+pool_mode = ${POOL_MODE:-transaction}
+max_client_conn = ${MAX_CLIENT_CONN:-1000}
+default_pool_size = ${DEFAULT_POOL_SIZE:-20}
+min_pool_size = ${MIN_POOL_SIZE:-0}
+reserve_pool_size = ${RESERVE_POOL_SIZE:-0}
+reserve_pool_timeout = ${RESERVE_POOL_TIMEOUT:-5}
+max_prepared_statements = ${MAX_PREPARED_STATEMENTS:-200}
+server_tls_sslmode = ${SERVER_TLS_SSLMODE:-prefer}
+ignore_startup_parameters = ${IGNORE_STARTUP_PARAMETERS:-extra_float_digits}
+EOF
+
+exec pgbouncer /etc/pgbouncer/pgbouncer.ini

--- a/terraform/modules/pgbouncer/main.tf
+++ b/terraform/modules/pgbouncer/main.tf
@@ -1,0 +1,32 @@
+locals {
+  env_suffix = var.environment == "production" ? "" : "-${var.environment}"
+}
+
+resource "render_private_service" "pgbouncer" {
+  environment_id = var.render_environment_id
+  name           = "${var.name}${local.env_suffix}"
+  plan           = var.plan
+  region         = "ohio"
+  num_instances  = var.num_instances
+
+  runtime_source = {
+    image = {
+      image_url              = var.image_url
+      tag                    = var.image_tag
+      registry_credential_id = var.registry_credential_id
+    }
+  }
+
+  env_vars = {
+    DB_HOST                 = { value = var.database.host }
+    DB_PORT                 = { value = var.database.port }
+    DB_USER                 = { value = var.database.user }
+    DB_PASSWORD             = { value = var.database.password }
+    POOL_MODE               = { value = var.pool_config.pool_mode }
+    MAX_CLIENT_CONN         = { value = var.pool_config.max_client_conn }
+    DEFAULT_POOL_SIZE       = { value = var.pool_config.default_pool_size }
+    MIN_POOL_SIZE           = { value = var.pool_config.min_pool_size }
+    RESERVE_POOL_SIZE       = { value = var.pool_config.reserve_pool_size }
+    MAX_PREPARED_STATEMENTS = { value = var.pool_config.max_prepared_statements }
+  }
+}

--- a/terraform/modules/pgbouncer/outputs.tf
+++ b/terraform/modules/pgbouncer/outputs.tf
@@ -1,0 +1,14 @@
+output "service_id" {
+  description = "The ID of the PgBouncer service"
+  value       = render_private_service.pgbouncer.id
+}
+
+output "host" {
+  description = "Private-network hostname of the PgBouncer service"
+  value       = render_private_service.pgbouncer.slug
+}
+
+output "port" {
+  description = "Port PgBouncer listens on"
+  value       = "5432"
+}

--- a/terraform/modules/pgbouncer/terraform.tf
+++ b/terraform/modules/pgbouncer/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    render = {
+      source  = "render-oss/render"
+      version = ">= 1.8.0"
+    }
+  }
+
+  required_version = ">= 1.2"
+}

--- a/terraform/modules/pgbouncer/variables.tf
+++ b/terraform/modules/pgbouncer/variables.tf
@@ -1,0 +1,74 @@
+variable "environment" {
+  description = "Environment name (production, sandbox, test)"
+  type        = string
+
+  validation {
+    condition     = contains(["production", "sandbox", "test"], var.environment)
+    error_message = "Must be one of \"production\", \"sandbox\" or \"test\"."
+  }
+}
+
+variable "name" {
+  description = "Service name, environment suffix is appended"
+  type        = string
+  default     = "pgbouncer"
+}
+
+variable "render_environment_id" {
+  description = "The environment ID in Render"
+  type        = string
+}
+
+variable "registry_credential_id" {
+  description = "Render registry credential ID for GHCR"
+  type        = string
+  sensitive   = true
+}
+
+variable "image_url" {
+  description = "Docker image URL for PgBouncer"
+  type        = string
+  default     = "ghcr.io/polarsource/polar-pgbouncer"
+}
+
+variable "image_tag" {
+  description = "Docker image tag"
+  type        = string
+  default     = "latest"
+}
+
+variable "plan" {
+  description = "Render service plan"
+  type        = string
+  default     = "starter"
+}
+
+variable "num_instances" {
+  description = "Number of PgBouncer instances"
+  type        = number
+  default     = 1
+}
+
+variable "database" {
+  description = "Postgres endpoint PgBouncer proxies to"
+  type = object({
+    host     = string
+    port     = string
+    user     = string
+    password = string
+  })
+  sensitive = true
+}
+
+variable "pool_config" {
+  description = "PgBouncer pooling configuration"
+  type = object({
+    pool_mode               = optional(string, "transaction")
+    max_client_conn         = optional(string, "1000")
+    default_pool_size       = optional(string, "20")
+    min_pool_size           = optional(string, "0")
+    reserve_pool_size       = optional(string, "0")
+    max_prepared_statements = optional(string, "200")
+  })
+  default = {}
+}

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -433,26 +433,38 @@ module "pgbouncer" {
   depends_on = [render_registry_credential.ghcr, render_project.polar, render_postgres.db]
 }
 
-module "pgbouncer_read" {
-  source = "../modules/pgbouncer"
+locals {
+  pgbouncer_read_pool_configs = {
+    "polar-read" = {
+      max_client_conn   = "5000"
+      default_pool_size = "50"
+      reserve_pool_size = "10"
+    }
+    "polar-replica" = {
+      max_client_conn   = "1000"
+      default_pool_size = "20"
+      reserve_pool_size = "0"
+    }
+  }
+}
 
-  name                   = "pgbouncer-read"
+module "pgbouncer_read" {
+  source   = "../modules/pgbouncer"
+  for_each = { for replica in render_postgres.db.read_replicas : replica.name => replica }
+
+  name                   = "pgbouncer-${trimprefix(each.key, "polar-")}"
   environment            = "production"
   render_environment_id  = render_project.polar.environments["Production"].id
   registry_credential_id = render_registry_credential.ghcr.id
 
   database = {
-    host     = local.read_replica.id
+    host     = each.value.id
     port     = local.db_port
     user     = local.db_user
     password = local.db_password
   }
 
-  pool_config = {
-    max_client_conn   = "5000"
-    default_pool_size = "50"
-    reserve_pool_size = "10"
-  }
+  pool_config = local.pgbouncer_read_pool_configs[each.key]
 
   depends_on = [render_registry_credential.ghcr, render_project.polar, render_postgres.db]
 }

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -407,6 +407,57 @@ module "production" {
 }
 
 # =============================================================================
+# PgBouncer
+# =============================================================================
+
+module "pgbouncer" {
+  source = "../modules/pgbouncer"
+
+  environment            = "production"
+  render_environment_id  = render_project.polar.environments["Production"].id
+  registry_credential_id = render_registry_credential.ghcr.id
+
+  database = {
+    host     = local.db_internal_host
+    port     = local.db_port
+    user     = local.db_user
+    password = local.db_password
+  }
+
+  pool_config = {
+    max_client_conn   = "5000"
+    default_pool_size = "50"
+    reserve_pool_size = "10"
+  }
+
+  depends_on = [render_registry_credential.ghcr, render_project.polar, render_postgres.db]
+}
+
+module "pgbouncer_read" {
+  source = "../modules/pgbouncer"
+
+  name                   = "pgbouncer-read"
+  environment            = "production"
+  render_environment_id  = render_project.polar.environments["Production"].id
+  registry_credential_id = render_registry_credential.ghcr.id
+
+  database = {
+    host     = local.read_replica.id
+    port     = local.db_port
+    user     = local.db_user
+    password = local.db_password
+  }
+
+  pool_config = {
+    max_client_conn   = "5000"
+    default_pool_size = "50"
+    reserve_pool_size = "10"
+  }
+
+  depends_on = [render_registry_credential.ghcr, render_project.polar, render_postgres.db]
+}
+
+# =============================================================================
 # Tailscale Subnet Router
 # =============================================================================
 

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -307,6 +307,55 @@ module "sandbox" {
 }
 
 # =============================================================================
+# PgBouncer
+# =============================================================================
+
+module "pgbouncer" {
+  source = "../modules/pgbouncer"
+
+  environment            = "sandbox"
+  render_environment_id  = data.tfe_outputs.production.values.sandbox_environment_id
+  registry_credential_id = render_registry_credential.ghcr.id
+
+  database = {
+    host     = local.db_internal_host
+    port     = local.db_port
+    user     = local.db_user
+    password = local.db_password
+  }
+
+  pool_config = {
+    max_client_conn   = "1000"
+    default_pool_size = "20"
+  }
+
+  depends_on = [render_registry_credential.ghcr, data.render_postgres.db]
+}
+
+module "pgbouncer_read" {
+  source = "../modules/pgbouncer"
+
+  name                   = "pgbouncer-read"
+  environment            = "sandbox"
+  render_environment_id  = data.tfe_outputs.production.values.sandbox_environment_id
+  registry_credential_id = render_registry_credential.ghcr.id
+
+  database = {
+    host     = local.read_replica.id
+    port     = local.db_port
+    user     = local.db_user
+    password = local.db_password
+  }
+
+  pool_config = {
+    max_client_conn   = "1000"
+    default_pool_size = "20"
+  }
+
+  depends_on = [render_registry_credential.ghcr, data.render_postgres.db]
+}
+
+# =============================================================================
 # Cloudflare DNS
 # =============================================================================
 import {

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -278,6 +278,57 @@ module "test" {
 }
 
 # =============================================================================
+# PgBouncer
+# =============================================================================
+
+module "pgbouncer" {
+  count  = local.test_enabled ? 1 : 0
+  source = "../modules/pgbouncer"
+
+  environment            = "test"
+  render_environment_id  = local.environment_id
+  registry_credential_id = render_registry_credential.ghcr.id
+
+  database = {
+    host     = local.db_internal_host
+    port     = local.db_port
+    user     = local.db_user
+    password = local.db_password
+  }
+
+  pool_config = {
+    max_client_conn   = "1000"
+    default_pool_size = "20"
+  }
+
+  depends_on = [render_registry_credential.ghcr, render_postgres.db]
+}
+
+module "pgbouncer_read" {
+  count  = local.test_enabled ? 1 : 0
+  source = "../modules/pgbouncer"
+
+  name                   = "pgbouncer-read"
+  environment            = "test"
+  render_environment_id  = local.environment_id
+  registry_credential_id = render_registry_credential.ghcr.id
+
+  database = {
+    host     = local.read_replica.id
+    port     = local.db_port
+    user     = local.db_user
+    password = local.db_password
+  }
+
+  pool_config = {
+    max_client_conn   = "1000"
+    default_pool_size = "20"
+  }
+
+  depends_on = [render_registry_credential.ghcr, render_postgres.db]
+}
+
+# =============================================================================
 # Cloudflare DNS
 # =============================================================================
 


### PR DESCRIPTION
This adds pgbouncer services to all environments, mapped to each replica of the db.

The initial step here is to roll it out, and the follow up is to start using it for the different services.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

