### PR TITLE
Switch to `langcodes` for locale parsing

### DIFF
--- a/server/polar/kit/locale.py
+++ b/server/polar/kit/locale.py
@@ -1,27 +1,29 @@
 from typing import Annotated
 
+import langcodes
 from pydantic import AfterValidator, Field
 
 
-def _normalize_locale(value: str) -> str:
-    """Normalize locale to lowercase-UPPERCASE format (e.g. en-us → en-US)."""
-    parts = value.split("-", 1)
-    parts[0] = parts[0].lower()
-    if len(parts) == 2:
-        parts[1] = parts[1].upper()
-    return "-".join(parts)
+def _validate_locale(value: str) -> str:
+    if not langcodes.tag_is_valid(value):
+        raise ValueError("Invalid IETF BCP 47 language tag")
+    locale = langcodes.Language.get(value)
+    # Tags without a real language subtag (`und`, private-use `x-…`) are valid
+    # BCP 47, but carry no language and `Intl` rejects the `x-…` form.
+    if locale.language is None or len(locale.language) > 3:
+        raise ValueError("Invalid IETF BCP 47 language tag")
+    return langcodes.standardize_tag(value)
 
 
 Locale = Annotated[
     str,
     Field(
-        pattern=r"^[a-zA-Z]{2,3}(-[a-zA-Z]{2}|-[0-9]{3})?$",
         description=(
-            "Locale of the customer, given as an IETF BCP 47 language tag. "
-            "Supported: language code (e.g. `en`) or language + region (e.g. `en-US`). "
+            "Locale of the customer, given as an IETF BCP 47 language tag, "
+            "e.g. `en`, `en-US` or `en-GB-oxendict`. "
             "If `null` or unsupported, the locale will default to `en`."
         ),
         examples=["en", "en-US", "fr", "fr-CA"],
     ),
-    AfterValidator(_normalize_locale),
+    AfterValidator(_validate_locale),
 ]

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -66,6 +66,7 @@ dependencies = [
   "markdown-it-py>=4.2.0",
   "tzdata>=2026.2",
   "reauth==0.2.0",
+  "langcodes>=3.5.1",
 ]
 
 [dependency-groups]

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -1600,6 +1600,15 @@ wheels = [
 ]
 
 [[package]]
+name = "langcodes"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/75/f9edc5d72945019312f359e69ded9f82392a81d49c5051ed3209b100c0d2/langcodes-3.5.1.tar.gz", hash = "sha256:40bff315e01b01d11c2ae3928dd4f5cbd74dd38f9bd912c12b9a3606c143f731", size = 191084, upload-time = "2025-12-02T16:22:01.627Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/c1/d10b371bcba7abce05e2b33910e39c33cfa496a53f13640b7b8e10bb4d2b/langcodes-3.5.1-py3-none-any.whl", hash = "sha256:b6a9c25c603804e2d169165091d0cdb23934610524a21d226e4f463e8e958a72", size = 183050, upload-time = "2025-12-02T16:21:59.954Z" },
+]
+
+[[package]]
 name = "librt"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2421,6 +2430,7 @@ dependencies = [
     { name = "httpx-oauth" },
     { name = "ipinfo-db" },
     { name = "itsdangerous" },
+    { name = "langcodes" },
     { name = "logfire", extra = ["fastapi", "httpx", "redis", "sqlalchemy"] },
     { name = "makefun" },
     { name = "markdown-it-py" },
@@ -2516,6 +2526,7 @@ requires-dist = [
     { name = "httpx-oauth", specifier = ">=0.17.0" },
     { name = "ipinfo-db", specifier = ">=0.0.4" },
     { name = "itsdangerous", specifier = ">=2.2.0" },
+    { name = "langcodes", specifier = ">=3.5.1" },
     { name = "logfire", extras = ["fastapi", "httpx", "sqlalchemy", "redis"], specifier = ">=4.36.0" },
     { name = "makefun", specifier = ">=1.15.6" },
     { name = "markdown-it-py", specifier = ">=4.2.0" },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch locale parsing to `langcodes` for real BCP 47 validation and standardized tags. This blocks invalid locales from hitting `Intl` and adds support for extended tags (e.g., `en-GB-oxendict`).

- **Bug Fixes**
  - Reject tags without a real language (`und`) and private-use `x-…` forms.
  - Standardize output (e.g., `en-us` → `en-US`).

- **Dependencies**
  - Added `langcodes>=3.5.1`.

<sup>Written for commit 72872edc0f5be43f260618b2e1f5b51661bce4da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

