### PR TITLE
ci: Add Slack warning on DB backup failure

### DIFF
--- a/.github/workflows/database_backup.yml
+++ b/.github/workflows/database_backup.yml
@@ -21,3 +21,25 @@ jobs:
           --fail \
           --silent \
           --output /dev/null
+
+    - name: Notify Slack on failure
+      if: failure()
+      uses: slackapi/slack-github-action@v3.0.3
+      with:
+        method: chat.postMessage
+        token: ${{ secrets.E2E_SLACK_BOT_TOKEN }}
+        errors: true
+        payload: |
+          {
+            "channel": "C093CJXJXPT",
+            "text": "Database backup trigger failed",
+            "blocks": [
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": ":rotating_light: *Database backup trigger failed* — the daily Render PITR snapshot could not be triggered.\n*<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>*"
+                }
+              }
+            ]
+          }

--- a/.github/workflows/database_backup_upload.yml
+++ b/.github/workflows/database_backup_upload.yml
@@ -71,3 +71,25 @@ jobs:
         run: |
           # Remove any sensitive files regardless of whether steps succeeded
           rm -rf backups/
+
+      - name: Notify Slack on failure
+        if: failure()
+        uses: slackapi/slack-github-action@v3.0.3
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.E2E_SLACK_BOT_TOKEN }}
+          errors: true
+          payload: |
+            {
+              "channel": "C093CJXJXPT",
+              "text": "Database backup upload to S3 failed",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":rotating_light: *Database backup upload to S3 failed* — the daily PostgreSQL backup could not be downloaded from Render or uploaded to s3://polar-sh-backups. The off-provider backup copy may be missing for today.\n*<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View workflow run>*"
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Slack alerts when the daily database backup trigger or S3 upload fails, with a direct link to the workflow run for quick triage. Implemented using `slackapi/slack-github-action@v3.0.3` in `database_backup.yml` and `database_backup_upload.yml`.

<sup>Written for commit e51261366e80b7387d1a84b3522c56f930690519. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

