### PR TITLE
fix(subscription): handle archived prices when applying scheduled product update

### DIFF
--- a/server/polar/models/subscription_update.py
+++ b/server/polar/models/subscription_update.py
@@ -121,11 +121,15 @@ class SubscriptionUpdate(RecordModel):
 
         if self.product is not None:
             assert is_recurring_product(self.product)
-            subscription.product = self.product
-            subscription.subscription_product_prices = [
+            # Resolve new product prices before updating the subscription to
+            # avoid inconsistent states if PriceSet.from_product raises, e.g.
+            # NoPricesForCurrencies.
+            subscription_product_prices = [
                 SubscriptionProductPrice.from_price(price, seats=subscription.seats)
                 for price in PriceSet.from_product(self.product, subscription.currency)
             ]
+            subscription.product = self.product
+            subscription.subscription_product_prices = subscription_product_prices
             subscription.recurring_interval = self.product.recurring_interval
             subscription.recurring_interval_count = (
                 self.product.recurring_interval_count

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -806,13 +806,30 @@ class SubscriptionService:
                     )
                 else:
                     pending_update.discount = None
-                # Check before apply_update() changes subscription.product
-                pending_update_changed_interval = pending_update.is_interval_changed()
-                pending_update.apply_update()
                 subscription_update_repository = (
                     SubscriptionUpdateRepository.from_session(session)
                 )
-                await subscription_update_repository.update(pending_update)
+                # Check before apply_update() changes subscription.product
+                pending_update_changed_interval = pending_update.is_interval_changed()
+                try:
+                    pending_update.apply_update()
+                except NoPricesForCurrencies:
+                    # The target product's prices in the subscription's currency
+                    # were archived after this update was scheduled. Discard the
+                    # stale update and cycle on the current product rather than
+                    # leaving the subscription permanently locked.
+                    log.warning(
+                        "Skipping scheduled subscription update: "
+                        "target product has no price for the subscription currency",
+                        subscription_id=subscription.id,
+                        subscription_update_id=pending_update.id,
+                        product_id=pending_update.product_id,
+                        currency=subscription.currency,
+                    )
+                    pending_update_changed_interval = False
+                    await subscription_update_repository.soft_delete(pending_update)
+                else:
+                    await subscription_update_repository.update(pending_update)
                 subscription.pending_update = None
 
             if update_cycle_dates and not pending_update_changed_interval:

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -1829,6 +1829,87 @@ class TestCycle:
         assert updated_subscription_update is not None
         assert updated_subscription_update.applied_at is not None
 
+    async def test_pending_update_product_prices_archived(
+        self,
+        session: AsyncSession,
+        enqueue_job_mock: MagicMock,
+        enqueue_email_mock: MagicMock,
+        save_fixture: SaveFixture,
+        product: Product,
+        product_second: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            scheduler_locked_at=utc_now(),
+        )
+        subscription_update, _ = generate_subscription_update(
+            subscription,
+            SubscriptionProrationBehavior.prorate,
+            product=product_second,
+        )
+        await save_fixture(subscription_update)
+        subscription.pending_update = subscription_update
+        await save_fixture(subscription)
+
+        # Archive the target product's prices in the subscription's currency
+        # after the update was scheduled but before it's applied. Expire the
+        # relationship so the cycle re-reads the filtered prices, as it would in
+        # a fresh worker session.
+        for price in product_second.prices:
+            price.is_archived = True
+            await save_fixture(price)
+        session.expire(product_second, ["prices"])
+
+        previous_current_period_end = subscription.current_period_end
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.cycle(
+                session, ctx, subscription
+            )
+
+        # The stale update is discarded and the subscription cycles normally on
+        # its current product instead of becoming permanently locked.
+        assert updated_subscription.product == product
+        assert updated_subscription.ended_at is None
+        assert updated_subscription.current_period_start == previous_current_period_end
+        assert updated_subscription.current_period_end is not None
+        assert previous_current_period_end is not None
+        assert updated_subscription.current_period_end > previous_current_period_end
+        assert updated_subscription.scheduler_locked_at is None
+        assert updated_subscription.pending_update is None
+
+        price = product.prices[0]
+        assert is_fixed_price(price)
+        billing_entry_repository = BillingEntryRepository.from_session(session)
+        billing_entries = await billing_entry_repository.get_pending_by_subscription(
+            subscription.id
+        )
+        assert len(billing_entries) == 1
+        assert billing_entries[0].product_price_id == price.id
+
+        enqueue_job_mock.assert_any_call(
+            "order.create_subscription_order",
+            subscription.id,
+            OrderBillingReasonInternal.subscription_cycle,
+        )
+
+        # The scheduled update is soft-deleted, not applied.
+        subscription_update_repository = SubscriptionUpdateRepository.from_session(
+            session
+        )
+        stale_update = await subscription_update_repository.get_by_id(
+            subscription_update.id,
+            include_deleted=True,
+        )
+        assert stale_update is not None
+        assert stale_update.applied_at is None
+        assert stale_update.deleted_at is not None
+
     async def test_pending_update_seats(
         self,
         session: AsyncSession,


### PR DESCRIPTION
Addresses https://github.com/polarsource/polar/issues/12020

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes subscriptions getting stuck when a scheduled product change targets a product with archived prices in the subscription’s currency. We now validate prices before updating and discard stale updates so cycles continue on the current product.

- **Bug Fixes**
  - In apply_update, resolve new product prices before mutating the subscription; leave it unchanged if prices are missing.
  - In cycle, catch NoPricesForCurrencies, soft-delete the pending update, log a warning, clear the lock, and continue the cycle on the current product.
  - Add tests covering the archived-prices scenario and normal billing entry creation.

<sup>Written for commit 51b8c5bf43888c364d5fb926f912c7d8e586013f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

