### PR TITLE
feat(sso): polish the org SSO login page

### DIFF
--- a/clients/apps/web/src/app/(main)/auth/page.tsx
+++ b/clients/apps/web/src/app/(main)/auth/page.tsx
@@ -1,8 +1,7 @@
-import { PolarLogotype } from '@/components/Layout/Public/PolarLogotype'
-import { CONFIG } from '@/utils/config'
 import { Metadata } from 'next'
 import { cookies } from 'next/headers'
 import Auth from '@/components/Auth/Auth'
+import AuthHeader from '@/components/Auth/AuthHeader'
 import { getServerSideAPI } from '@/utils/client/serverside'
 import {
   checkAuthenticationSession,
@@ -42,31 +41,7 @@ export default async function Page(props: {
   return (
     <div className="flex h-screen w-full grow items-center justify-center">
       <div className="dark:bg-polar-900 flex w-full max-w-md flex-col justify-between gap-8 rounded-3xl bg-gray-50 p-12">
-        <div className="flex flex-col gap-y-4">
-          <PolarLogotype logoVariant="icon" size={60} />
-          <div className="flex flex-col gap-4">
-            <h2 className="text-2xl text-black dark:text-white">
-              {CONFIG.IS_SANDBOX
-                ? 'Welcome to the Polar Sandbox'
-                : 'Welcome to Polar'}
-            </h2>
-            <span className="dark:text-polar-400 text-lg text-balance text-gray-500">
-              {CONFIG.IS_SANDBOX ? (
-                <>
-                  This is a testing environment. Changes here won&rsquo;t affect
-                  your live account and payments are not processed.
-                </>
-              ) : (
-                'Monetize your software'
-              )}
-            </span>
-          </div>
-          {searchParams.error && (
-            <div className="rounded-lg bg-red-50 p-4 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
-              {searchParams.error}
-            </div>
-          )}
-        </div>
+        <AuthHeader error={searchParams.error} />
         <Auth
           authenticationSession={authenticationSession}
           lastLoginMethod={lastLoginMethod as LoginMethod | null}

--- a/clients/apps/web/src/app/(main)/auth/sso/[slug]/page.tsx
+++ b/clients/apps/web/src/app/(main)/auth/sso/[slug]/page.tsx
@@ -1,6 +1,6 @@
+import AuthHeader from '@/components/Auth/AuthHeader'
+import AuthTermsFooter from '@/components/Auth/AuthTermsFooter'
 import OrgAuth from '@/components/Auth/OrgAuth'
-import { PolarLogotype } from '@/components/Layout/Public/PolarLogotype'
-import { Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { Metadata } from 'next'
 
@@ -35,25 +35,9 @@ export default async function Page(props: {
         borderRadius="xl"
         padding="3xl"
       >
-        <Box flexDirection="column" gap="l">
-          <PolarLogotype logoVariant="icon" size={60} />
-          <Text variant="heading-s" as="h2">
-            Sign in
-          </Text>
-          {error && (
-            <Box
-              borderRadius="m"
-              backgroundColor="background-warning"
-              borderWidth={1}
-              borderStyle="solid"
-              borderColor="border-warning"
-              padding="l"
-            >
-              <Text>{error}</Text>
-            </Box>
-          )}
-        </Box>
+        <AuthHeader error={error} />
         <OrgAuth slug={slug} returnTo={returnTo} />
+        <AuthTermsFooter />
       </Box>
     </Box>
   )

--- a/clients/apps/web/src/components/Auth/Auth.tsx
+++ b/clients/apps/web/src/components/Auth/Auth.tsx
@@ -7,6 +7,7 @@ import { Fragment } from 'react'
 import GoogleLoginButton from './GoogleLoginButton'
 import EmailOTPForm from './EmailOTPForm'
 import AppleLoginButton from './AppleLoginButton'
+import AuthTermsFooter from './AuthTermsFooter'
 import GitHubLoginButton from './GitHubLoginButton'
 import { usePathname, useSearchParams } from 'next/navigation'
 import { useImpressionEvent } from '@/hooks/useImpressionEvent'
@@ -120,25 +121,7 @@ const Auth = ({
           />
         </LastUsedWrapper>
       </div>
-      <div className="dark:text-polar-500 mt-6 text-center text-xs text-balance text-gray-400">
-        By using Polar, you agree to our{' '}
-        <a
-          className="dark:text-polar-300 text-gray-600"
-          href="https://polar.sh/legal/master-services-terms"
-          rel="noopener noreferrer"
-        >
-          Terms of Service
-        </a>{' '}
-        &amp;{' '}
-        <a
-          className="dark:text-polar-300 text-gray-600"
-          href="https://polar.sh/legal/privacy-policy"
-          rel="noopener noreferrer"
-        >
-          Privacy Policy
-        </a>
-        .
-      </div>
+      <AuthTermsFooter />
     </div>
   )
 }

--- a/clients/apps/web/src/components/Auth/AuthHeader.tsx
+++ b/clients/apps/web/src/components/Auth/AuthHeader.tsx
@@ -1,0 +1,34 @@
+import { PolarLogotype } from '@/components/Layout/Public/PolarLogotype'
+import { CONFIG } from '@/utils/config'
+
+const AuthHeader = ({ error }: { error?: string }) => {
+  return (
+    <div className="flex flex-col gap-y-4">
+      <PolarLogotype logoVariant="icon" size={60} />
+      <div className="flex flex-col gap-4">
+        <h2 className="text-2xl text-black dark:text-white">
+          {CONFIG.IS_SANDBOX
+            ? 'Welcome to the Polar Sandbox'
+            : 'Welcome to Polar'}
+        </h2>
+        <span className="dark:text-polar-400 text-lg text-balance text-gray-500">
+          {CONFIG.IS_SANDBOX ? (
+            <>
+              This is a testing environment. Changes here won&rsquo;t affect
+              your live account and payments are not processed.
+            </>
+          ) : (
+            'Monetize your software'
+          )}
+        </span>
+      </div>
+      {error && (
+        <div className="rounded-lg bg-red-50 p-4 text-sm text-red-600 dark:bg-red-900/20 dark:text-red-400">
+          {error}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default AuthHeader

--- a/clients/apps/web/src/components/Auth/AuthTermsFooter.tsx
+++ b/clients/apps/web/src/components/Auth/AuthTermsFooter.tsx
@@ -1,0 +1,23 @@
+const AuthTermsFooter = () => (
+  <div className="dark:text-polar-500 mt-6 text-center text-xs text-balance text-gray-400">
+    By using Polar, you agree to our{' '}
+    <a
+      className="dark:text-polar-300 text-gray-600"
+      href="https://polar.sh/legal/master-services-terms"
+      rel="noopener noreferrer"
+    >
+      Terms of Service
+    </a>{' '}
+    &amp;{' '}
+    <a
+      className="dark:text-polar-300 text-gray-600"
+      href="https://polar.sh/legal/privacy-policy"
+      rel="noopener noreferrer"
+    >
+      Privacy Policy
+    </a>
+    .
+  </div>
+)
+
+export default AuthTermsFooter

--- a/server/polar/auth/factors.py
+++ b/server/polar/auth/factors.py
@@ -311,8 +311,7 @@ async def get_org_factors(
     sso_repository = OrganizationSSOConnectionRepository.from_session(session)
     connections = await sso_repository.get_enabled_by_organization(organization.id)
 
-    # todo (maxime) : once we implement org enforce sso, we should remove the base factors and only return the sso factors
-    return base_factors | {
+    sso_factors: set[FactorBase[typing.Any]] = {
         build_sso_factor(
             connection,
             organization_slug=organization.slug,
@@ -320,3 +319,8 @@ async def get_org_factors(
         )
         for connection in connections
     }
+
+    if organization.sso_enforced:
+        return sso_factors
+
+    return base_factors | sso_factors

--- a/server/tests/auth/test_factors.py
+++ b/server/tests/auth/test_factors.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import pytest
 
 from polar.auth.factors import get_org_factors
@@ -63,3 +65,51 @@ class TestGetOrgFactors:
         )
 
         assert {factor.identifier for factor in factors} == {str(enabled.id)}
+
+    async def test_offers_base_factors_when_not_enforced(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        connection = await create_sso_connection(
+            save_fixture, organization, enabled=True
+        )
+        base_factor = MagicMock()
+
+        factors = await get_org_factors(
+            slug=organization.slug,
+            base_factors={base_factor},
+            session=session,
+            state_service=OAuth2StateService(session),
+        )
+
+        assert base_factor in factors
+        assert any(
+            factor.identifier == str(connection.id)
+            for factor in factors
+            if factor is not base_factor
+        )
+
+    async def test_excludes_base_factors_when_enforced(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        connection = await create_sso_connection(
+            save_fixture, organization, enabled=True
+        )
+        organization.sso_enforced = True
+        await save_fixture(organization)
+        base_factor = MagicMock()
+
+        factors = await get_org_factors(
+            slug=organization.slug,
+            base_factors={base_factor},
+            session=session,
+            state_service=OAuth2StateService(session),
+        )
+
+        assert base_factor not in factors
+        assert {factor.identifier for factor in factors} == {str(connection.id)}


### PR DESCRIPTION
## Summary

Two tweaks to the org SSO login page (`/auth/sso/{slug}`):

- **Enforced orgs only offer SSO.** When an org has `sso_enforced`, the login page no longer shows base factors (email, GitHub, Google) — they'd yield a global session that's denied the org anyway. Only the org's SSO connections are offered.
- **Consistent header & footer.** The page previously showed a bare "Sign in". It now shows the same welcome header and Terms of Service / Privacy Policy footer as the main login page, via shared `AuthHeader` / `AuthTermsFooter` components extracted from it (markup unchanged, so the main login page renders exactly as before).

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

