### PR TITLE
pdf: Fix mojibake in email/customer render

### DIFF
--- a/server/polar/invoice/generator.py
+++ b/server/polar/invoice/generator.py
@@ -435,11 +435,15 @@ class InvoiceGenerator(FPDF):
         # causing subsequent ASCII cells to render with the CJK font's
         # cmap. Re-resolve `current_font` from the canonical font_family +
         # font_style after delegating, so it always matches the logical
-        # font selection.
+        # font selection. When correcting such a drift, also clear
+        # `current_font_is_set_on_page` so fpdf re-emits the font-selection
+        # operator on the next cell; otherwise the corrected font never
+        # reaches the page and the text still renders with the stale cmap.
         super().set_font(family, style, size)
         fontkey = self.font_family + self.font_style
-        if fontkey in self.fonts:
+        if fontkey in self.fonts and self.current_font is not self.fonts[fontkey]:
             self.current_font = self.fonts[fontkey]
+            self.current_font_is_set_on_page = False
 
     def _shape_text(self, text: str) -> str:
         lines = text.split("\n")
@@ -543,6 +547,7 @@ class InvoiceGenerator(FPDF):
             new_y=YPos.NEXT,
         )
         if self.data.seller_additional_info:
+            self.set_font(style="")
             self.multi_cell(
                 80,
                 self.cell_height(),
@@ -574,6 +579,7 @@ class InvoiceGenerator(FPDF):
                 new_y=YPos.NEXT,
             )
         if self.data.customer_additional_info:
+            self.set_font(style="")
             self.multi_cell(
                 80,
                 self.cell_height(),


### PR DESCRIPTION
We need to reset the font correctly when we write out the customer email after CJK or other font rendering. Otherwise it renders as mojibake and is unintelligible


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

