### PR TITLE
Add 'Inactive' option to customers list filter

### DIFF
--- a/clients/apps/web/src/components/Customer/CustomerListSidebar.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerListSidebar.tsx
@@ -55,7 +55,9 @@ export const CustomerListSidebar: React.FC<CustomerListSidebarProps> = ({
   const [query, setQuery] = useQueryState('query', parseAsString)
   const [activeFilter, setActiveFilter] = useQueryState(
     'filter',
-    parseAsStringLiteral(['all', 'active'] as const).withDefault('all'),
+    parseAsStringLiteral(['all', 'active', 'inactive'] as const).withDefault(
+      'all',
+    ),
   )
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useCustomers(
@@ -63,7 +65,7 @@ export const CustomerListSidebar: React.FC<CustomerListSidebarProps> = ({
     {
       query: query ?? undefined,
       sorting: [sorting],
-      active: activeFilter === 'all' ? undefined : true,
+      active: activeFilter === 'all' ? undefined : activeFilter === 'active',
     },
   )
 
@@ -152,6 +154,15 @@ export const CustomerListSidebar: React.FC<CustomerListSidebarProps> = ({
                     )}
                   />
                   <span>Active</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => setActiveFilter('inactive')}>
+                  <CheckOutlined
+                    className={twMerge(
+                      'h-4 w-4',
+                      activeFilter !== 'inactive' && 'invisible',
+                    )}
+                  />
+                  <span>Inactive</span>
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>


### PR DESCRIPTION
## Summary

Adds an "Inactive" option to the customers overview filter, alongside the existing "All" and "Active" options.

Requested via customer feedback: https://backoffice.polar.sh/feedbacks/8ca56023-f237-4bfd-bb4f-984ee216e68e

## What

- Extends the `filter` query-state literal in `CustomerListSidebar` from `['all', 'active']` to `['all', 'active', 'inactive']`
- Adds an "Inactive" item to the filter dropdown menu
- Maps the filter to the customers list query: `all` → `active: undefined`, `active` → `active: true`, `inactive` → `active: false`

## Why

The customers sidebar could only show all customers or active ones. There was no way to list inactive customers (those without any trialing, active, or past_due subscription), even though the `/v1/customers/` API already supports it.

## How

Frontend-only change: the backend `active` filter already accepts `false` (`CustomerRepository.get_active_clause` negates the billable-subscription exists clause), so the new option just passes `active: false` to the existing `useCustomers` hook.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (frontend: `eslint` + `tsc --noEmit` on `apps/web`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013sNFAiK7nmwBzr2Huv2Akw

---
_Generated by [Claude Code](https://claude.ai/code/session_013sNFAiK7nmwBzr2Huv2Akw)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

