### PR TITLE
docs: add architecture decision records (ADRs)

### DIFF
--- a/.agents/skills/adr-check/SKILL.md
+++ b/.agents/skills/adr-check/SKILL.md
@@ -36,6 +36,9 @@ git diff --name-only                # unstaged
 git diff --name-only --staged       # staged
 ```
 
+This assumes the branch targets `main` (the default). If the PR targets another branch, diff
+against that base instead.
+
 Then read the actual hunks for the changed files (`git diff main...HEAD -- <file>`).
 
 ### 2. Load the ADRs (dynamically, never hardcode the list)

--- a/.agents/skills/adr-check/SKILL.md
+++ b/.agents/skills/adr-check/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: adr-check
+description: Check a code change against the repo's Accepted Architecture Decision Records (ADRs) in handbook/engineering/decisions/ and report violations with citations. Use before opening a PR, when reviewing a diff, or when the user asks to check ADR compliance, whether changes follow the architecture decisions, or to verify a change against the ADRs.
+license: MIT
+metadata:
+  author: polar
+  version: "1.0.0"
+---
+
+# ADR Compliance Checker (Polar)
+
+The handle is the **diff**. The evidence is a short report of **which Accepted ADRs
+the change touches and where it breaks them**. This is the ADR analogue of
+[`verifier-web`](../verifier-web/SKILL.md): that skill replays UI changes, this one
+reviews a change against the recorded architecture decisions.
+
+ADRs live in `handbook/engineering/decisions/`. Treat every ADR whose Status is
+**Accepted** as binding.
+
+## When to use
+
+- Before opening a PR, or while reviewing one.
+- When the user asks to "check the ADRs", "does this follow our decisions", or
+  "verify against the architecture decisions".
+- As one dimension of a broader review, alongside `/polar-code-review`.
+
+## How to run
+
+### 1. Get the change
+
+Prefer the branch diff; fall back to the working tree.
+
+```bash
+git diff --name-only main...HEAD    # committed on this branch
+git diff --name-only                # unstaged
+git diff --name-only --staged       # staged
+```
+
+Then read the actual hunks for the changed files (`git diff main...HEAD -- <file>`).
+
+### 2. Load the ADRs (dynamically, never hardcode the list)
+
+```bash
+ls handbook/engineering/decisions/[0-9]*.mdx
+```
+
+Read each one. For every ADR with **Status: Accepted**, extract its **Decision**
+(the rule) and its **Area** (Backend, Frontend, Infra, or Cross-cutting). Apply an
+ADR only to files in its Area: a frontend ADR does not apply to `server/`, and vice
+versa. Reading the ADRs each run keeps the check current as ADRs are added or
+superseded.
+
+### 3. Check each relevant ADR against the diff
+
+Read the ADR's Decision and Consequences, then look for the violation signature in
+the changed hunks. For the ADRs that exist today:
+
+- **ADR-0002 (status-coded `PolarError`)**: a `PolarError` subclass or a `raise`
+  with no explicit `status_code` (it defaults to 500); a business or logic error
+  raised as `PolarRequestValidationError` (422); an endpoint that declares an error
+  but omits it from `responses=`; a content-less `422: {"description": ...}`
+  override. Area: Backend.
+- **ADR-0003 (one transaction per request or task)**: any `session.commit()` in
+  application code (services, endpoints, tasks). Grep the diff for `.commit(`.
+  Area: Backend.
+- **ADR-0004 (Orbit `Box` + tokens)**: new UI using a raw `<div>` plus Tailwind for
+  layout, spacing, or color; `dark:` variants; raw hex or px values; or `className`
+  / `style` on `<Box />` or `<Text />`. Most of this is caught by ESLint
+  (`no-classname-box`, `no-view`, `no-hardcoded-colors`, and friends); the value you
+  add is flagging new component files that avoid `Box` entirely. Area: Frontend.
+- **ADR-0005 (`AuthSubject` + scopes)**: a new endpoint with no `auth_subject`
+  dependency that is not meant to be public; a hand-rolled `AuthSubject`; an endpoint
+  that bypasses its module's `Authenticator`. Area: Backend.
+- **ADR-0006 (migration + backfill safety)**: a migration under
+  `server/migrations/versions/` with an unbatched `UPDATE`; adding a NOT NULL column
+  in one step instead of add-nullable, then batched backfill, then enforce; a
+  migration PR that also touches non-migration application code. Area: Backend.
+
+ADR-0001 is the meta record and has no code rule. For any ADR not in this list,
+derive its violation signature from its own Decision and Consequences the same way.
+
+### 4. Report
+
+Keep it short and scannable:
+
+- **Violations**, most severe first. For each: the ADR id and title, the
+  `file:line`, one line on what breaks the rule, and the fix.
+- **Uncovered decisions**: if the change makes a significant, cross-cutting, or
+  hard-to-reverse decision that no ADR covers, say so and offer to draft one from
+  `handbook/engineering/decisions/template.mdx`.
+- If nothing conflicts and nothing new is ADR-worthy, say so in one line, and list
+  which ADRs you checked and which were not applicable to this diff.
+
+This skill reviews and reports. It does not edit code; fixes are a follow-up.

--- a/.agents/skills/adr-check/SKILL.md
+++ b/.agents/skills/adr-check/SKILL.md
@@ -52,32 +52,12 @@ superseded.
 
 ### 3. Check each relevant ADR against the diff
 
-Read the ADR's Decision and Consequences, then look for the violation signature in
-the changed hunks. For the ADRs that exist today:
-
-- **ADR-0002 (status-coded `PolarError`)**: a `PolarError` subclass or a `raise`
-  with no explicit `status_code` (it defaults to 500); a business or logic error
-  raised as `PolarRequestValidationError` (422); an endpoint that declares an error
-  but omits it from `responses=`; a content-less `422: {"description": ...}`
-  override. Area: Backend.
-- **ADR-0003 (one transaction per request or task)**: any `session.commit()` in
-  application code (services, endpoints, tasks). Grep the diff for `.commit(`.
-  Area: Backend.
-- **ADR-0004 (Orbit `Box` + tokens)**: new UI using a raw `<div>` plus Tailwind for
-  layout, spacing, or color; `dark:` variants; raw hex or px values; or `className`
-  / `style` on `<Box />` or `<Text />`. Most of this is caught by ESLint
-  (`no-classname-box`, `no-view`, `no-hardcoded-colors`, and friends); the value you
-  add is flagging new component files that avoid `Box` entirely. Area: Frontend.
-- **ADR-0005 (`AuthSubject` + scopes)**: a new endpoint with no `auth_subject`
-  dependency that is not meant to be public; a hand-rolled `AuthSubject`; an endpoint
-  that bypasses its module's `Authenticator`. Area: Backend.
-- **ADR-0006 (migration + backfill safety)**: a migration under
-  `server/migrations/versions/` with an unbatched `UPDATE`; adding a NOT NULL column
-  in one step instead of add-nullable, then batched backfill, then enforce; a
-  migration PR that also touches non-migration application code. Area: Backend.
-
-ADR-0001 is the meta record and has no code rule. For any ADR not in this list,
-derive its violation signature from its own Decision and Consequences the same way.
+For each Accepted ADR whose Area matches a changed file, read its Decision and
+Consequences and derive the violation signature from them: the Decision states the
+rule, and the Consequences often spell out the "must" and the failure it prevents.
+Then look for that signature in the changed hunks (grep for the concrete identifiers
+the ADR names, and read the surrounding code). Don't rely on a signature list kept
+here: it would drift from the ADRs. The ADR text is the source of truth.
 
 ### 4. Report
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,17 @@ Detailed, review-enforced patterns live next to the code — read the relevant f
 **i18n:** add new translatable strings only to `clients/packages/i18n/src/locales/en.ts` — a CI
 job auto-translates the rest. Don't edit other locale files. (More in `clients/AGENTS.md`.)
 
+## Architecture Decisions (ADRs)
+
+Significant, cross-cutting, or hard-to-reverse decisions are recorded as short ADRs in
+`handbook/engineering/decisions/` (see the [index](handbook/engineering/decisions/index.mdx)).
+Treat **Accepted** ADRs as binding:
+
+- Before changing a load-bearing pattern, check for a relevant ADR (grep that directory).
+- If code contradicts an Accepted ADR, flag it and cite the id (e.g. "violates ADR-0002").
+- If a change makes a significant decision no ADR covers, propose a new one from
+  `handbook/engineering/decisions/template.mdx` rather than losing the rationale in the diff.
+
 ## Custom Commands
 
 - `/polar-code-review` — comprehensive review with 3 parallel agents (security, conventions, simplification).

--- a/handbook/docs.json
+++ b/handbook/docs.json
@@ -93,6 +93,19 @@
               "engineering/design-documents/merchant-migrations"
             ]
           },
+          {
+            "group": "Architecture Decisions",
+            "pages": [
+              "engineering/decisions/index",
+              "engineering/decisions/template",
+              "engineering/decisions/0001-record-architecture-decisions",
+              "engineering/decisions/0002-status-coded-polar-errors",
+              "engineering/decisions/0003-request-scoped-unit-of-work",
+              "engineering/decisions/0004-orbit-box-design-system",
+              "engineering/decisions/0005-auth-subject-and-scopes",
+              "engineering/decisions/0006-migration-and-backfill-safety"
+            ]
+          },
           "engineering/tech-notes",
           {
             "group": "On-Call Procedures",

--- a/handbook/engineering/decisions/0001-record-architecture-decisions.mdx
+++ b/handbook/engineering/decisions/0001-record-architecture-decisions.mdx
@@ -1,0 +1,51 @@
+---
+title: "ADR-0001: Record architecture decisions"
+description: "We keep short, immutable ADRs for significant, cross-cutting decisions."
+---
+
+<Info>
+**Status**: Accepted
+
+**Area**: Cross-cutting
+
+**Date**: 2026-07-02
+</Info>
+
+## Context
+
+We write [design documents](/engineering/design-documents/index),
+and those are useful to show a feature will work.
+We have some rules in `AGENTS.md` files and lint scripts.
+But most of the conventions in the code are not written.
+New engineers and agents don't have all the context,
+and the rules may be missed.
+
+Design docs don't fill this gap: they're large, forward-looking, and go stale once a feature
+ships. We need a home for short, durable *decision* records.
+
+## Decision
+
+We record conventions or hard-to-reverse decisions as **ADRs** under
+`handbook/engineering/decisions/`, one sequentially numbered file each, from the
+[template](/engineering/decisions/template). One numbered sequence covers the whole
+monorepo, and the **Area** field scopes each ADR (Backend, Frontend, Infra, or Cross-cutting).
+
+## Consequences
+
+- One place to learn *why* the codebase is shaped the way it is, reviewed and published like
+  design docs.
+- Agents and reviewers treat ADRs as binding, cite them when flagging violations,
+  and propose new ones for uncovered decisions.
+- Design docs are unchanged; an ADR may summarize and link to one.
+
+## Alternatives considered
+
+- **Keep everything in `AGENTS.md` or lint only**: captures the *rule* but not the *why* or
+  the alternatives, and mixes binding decisions with tips and setup.
+- **Only write design docs**: those should be used for feature design, being heavy and providing details.
+- **Per-package ADR logs**: fragment cross-tier decisions and duplicate numbering.
+
+## References
+
+- [ADR index and lifecycle](/engineering/decisions/index)
+- [Design documents](/engineering/design-documents/index)

--- a/handbook/engineering/decisions/0001-record-architecture-decisions.mdx
+++ b/handbook/engineering/decisions/0001-record-architecture-decisions.mdx
@@ -14,7 +14,7 @@ description: "We keep short, immutable ADRs for significant, cross-cutting decis
 ## Context
 
 We write [design documents](/engineering/design-documents/index),
-and those are useful to show a feature will work.
+and those are useful to show how a feature will work.
 We have some rules in `AGENTS.md` files and lint scripts.
 But most of the conventions in the code are not written.
 New engineers and agents don't have all the context,

--- a/handbook/engineering/decisions/0002-status-coded-polar-errors.mdx
+++ b/handbook/engineering/decisions/0002-status-coded-polar-errors.mdx
@@ -9,8 +9,6 @@ description: "Logical errors carry an explicit HTTP status; 422 is reserved for 
 **Area**: Backend
 
 **Date**: 2026-07-02
-
-**Deciders**: Engineering
 </Info>
 
 ## Context

--- a/handbook/engineering/decisions/0002-status-coded-polar-errors.mdx
+++ b/handbook/engineering/decisions/0002-status-coded-polar-errors.mdx
@@ -1,0 +1,48 @@
+---
+title: "ADR-0002: Business errors are status-coded PolarError subclasses"
+description: "Logical errors carry an explicit HTTP status; 422 is reserved for payload validation."
+---
+
+<Info>
+**Status**: Accepted
+
+**Area**: Backend
+
+**Date**: 2026-07-02
+
+**Deciders**: Engineering
+</Info>
+
+## Context
+
+`PolarError`'s default status code is 500, and Sentry reports every 500 as a hard crash. So a
+normal business conflict (say, "you already have an active subscription") raised without an
+explicit status pages on-call as if the service fell over, burying real incidents. Separately,
+422 means one specific thing to clients: the request payload was malformed.
+
+## Decision
+
+For logical and conflict errors, raise `PolarError` subclasses with an explicit `status_code`
+(404, 409, 410, 403, and so on) and declare them on the endpoint's `responses=` so the
+generated client gets the error schema. Reserve 422 for request-payload validation: never
+re-raise a business error as a validation error.
+
+## Consequences
+
+- Clients get correct HTTP status codes, and expected conflicts stay out of the crash reporter.
+- The generated TypeScript client gets typed error shapes via `PolarError.schema()`.
+- Don't add a content-less `422: {"description": ...}` override: it clobbers FastAPI's default
+  `HTTPValidationError` and breaks the generated client.
+
+## Alternatives considered
+
+- **Let business errors fall through as bare 500s**: right response body, but pages on-call and
+  pollutes Sentry.
+- **Raise 422 for logical failures**: misleads clients into thinking they sent bad JSON.
+
+## References
+
+- `server/polar/exceptions.py` (base + subclasses), `server/polar/exception_handlers.py`
+  (handlers, 422 separation).
+- Real usage: `server/polar/checkout/service.py`, `server/polar/checkout/endpoints.py`.
+- `server/AGENTS.md`, "Errors to status-coded `PolarError`".

--- a/handbook/engineering/decisions/0003-request-scoped-unit-of-work.mdx
+++ b/handbook/engineering/decisions/0003-request-scoped-unit-of-work.mdx
@@ -9,8 +9,6 @@ description: "The session commits once at the boundary; application code never c
 **Area**: Backend
 
 **Date**: 2026-07-02
-
-**Deciders**: Engineering
 </Info>
 
 ## Context

--- a/handbook/engineering/decisions/0003-request-scoped-unit-of-work.mdx
+++ b/handbook/engineering/decisions/0003-request-scoped-unit-of-work.mdx
@@ -1,0 +1,48 @@
+---
+title: "ADR-0003: One request or task is one transaction"
+description: "The session commits once at the boundary; application code never calls session.commit()."
+---
+
+<Info>
+**Status**: Accepted
+
+**Area**: Backend
+
+**Date**: 2026-07-02
+
+**Deciders**: Engineering
+</Info>
+
+## Context
+
+One request or task should be one database transaction: all its writes commit together at the
+end, or none do. If a handler calls `session.commit()` midway, its writes are already saved, so
+a later failure leaves the database half-applied and the automatic rollback can no longer undo
+it.
+
+## Decision
+
+Application code never calls `session.commit()`. The single commit happens at the edge of the
+request (in middleware) or task (in the worker's session context): commit on success, rollback
+on exception. Call `session.flush()` when you need database-generated values (like IDs) before
+that final commit. Read handlers take `AsyncReadSession` (routed to the read replica); anything
+that writes takes `AsyncSession`.
+
+## Consequences
+
+- Each request or task is all-or-nothing.
+- Sessions use `expire_on_commit=False`, so ORM objects stay usable after the final commit.
+  Endpoints return the ORM model directly, and FastAPI serializes it after the handler returns.
+- Background tasks follow the same rule: open a session, let it commit at the end.
+
+## Alternatives considered
+
+- **Commit as you go inside services**: a later failure leaves partial writes behind, and one
+  logical operation gets split across many transactions.
+
+## References
+
+- `server/polar/postgres.py` (request middleware, `get_db_session`),
+  `server/polar/worker/_sqlalchemy.py` (task session).
+- `server/polar/kit/db/postgres.py` (`AsyncReadSession` / `AsyncSession`).
+- `server/AGENTS.md`, "CRITICAL: Never call `session.commit()`".

--- a/handbook/engineering/decisions/0004-orbit-box-design-system.mdx
+++ b/handbook/engineering/decisions/0004-orbit-box-design-system.mdx
@@ -9,8 +9,6 @@ description: "New UI uses the typed Box and Text primitives consuming design tok
 **Area**: Frontend
 
 **Date**: 2026-07-02
-
-**Deciders**: Engineering
 </Info>
 
 ## Context

--- a/handbook/engineering/decisions/0004-orbit-box-design-system.mdx
+++ b/handbook/engineering/decisions/0004-orbit-box-design-system.mdx
@@ -1,0 +1,47 @@
+---
+title: "ADR-0004: Frontend UI is authored with Orbit Box and design tokens"
+description: "New UI uses the typed Box and Text primitives consuming design tokens; raw div plus Tailwind is deprecated."
+---
+
+<Info>
+**Status**: Accepted
+
+**Area**: Frontend
+
+**Date**: 2026-07-02
+
+**Deciders**: Engineering
+</Info>
+
+## Context
+
+Raw `<div>` plus Tailwind lets anyone (human or agent) invent off-scale spacing and colors,
+forget `dark:` variants, and none of it is type-checked. As AI-authored UI grew, that freedom
+became a consistency and correctness problem.
+
+## Decision
+
+Author UI with `<Box />` and `<Text />` from `@polar-sh/orbit`, passing design tokens as typed
+props. Raw `<div>` plus Tailwind for layout, spacing, color, border, radius, shadow, flex,
+grid, and position is deprecated. Tokens are two-tiered (primitive values feed semantic names);
+`<Box />` takes token names, never raw values. Tailwind remains only for third-party override
+classNames and temporary glue while migrating legacy files.
+
+## Consequences
+
+- Token props resolve light and dark automatically, so no per-element `dark:` duplication, and
+  off-token values become unwriteable. The type system makes the wrong thing hard to write.
+- Custom ESLint rules enforce it: `no-classname-box`, `no-style-box`, `no-classname-text` on
+  web, and `no-view`, `no-text`, `no-hardcoded-colors`, `no-hardcoded-spacing` on the Expo app.
+- Editing a legacy Tailwind file? Migrate it to `<Box />` rather than extend the Tailwind.
+
+## Alternatives considered
+
+- **Tailwind utilities plus `dark:` variants**: per-element dark-mode duplication, arbitrary
+  off-token values, no type safety.
+
+## References
+
+- `clients/packages/orbit/` (`src/components/Box.tsx`, `src/tokens/`).
+- Enforcement: `clients/apps/web/eslint-rules/`, `clients/apps/app/eslint-rules/`.
+- `clients/AGENTS.md`, "UI Authoring Rule".

--- a/handbook/engineering/decisions/0004-orbit-box-design-system.mdx
+++ b/handbook/engineering/decisions/0004-orbit-box-design-system.mdx
@@ -21,8 +21,8 @@ became a consistency and correctness problem.
 
 ## Decision
 
-Author UI with `<Box />` and `<Text />` from `@polar-sh/orbit`, passing design tokens as typed
-props. Raw `<div>` plus Tailwind for layout, spacing, color, border, radius, shadow, flex,
+Author UI with `<Box />` (imported from `@polar-sh/orbit/Box`) and `<Text />` (from
+`@polar-sh/orbit`), passing design tokens as typed props. Raw `<div>` plus Tailwind for layout, spacing, color, border, radius, shadow, flex,
 grid, and position is deprecated. Tokens are two-tiered (primitive values feed semantic names);
 `<Box />` takes token names, never raw values. Tailwind remains only for third-party override
 classNames and temporary glue while migrating legacy files.

--- a/handbook/engineering/decisions/0005-auth-subject-and-scopes.mdx
+++ b/handbook/engineering/decisions/0005-auth-subject-and-scopes.mdx
@@ -1,0 +1,58 @@
+---
+title: "ADR-0005: Authorization is AuthSubject plus scopes, with per-module authenticators"
+description: "Every request resolves to a typed AuthSubject; endpoints opt into protection via an authenticator; roles add a second per-org layer."
+---
+
+<Info>
+**Status**: Accepted
+
+**Area**: Backend
+
+**Date**: 2026-07-02
+
+**Deciders**: Engineering
+</Info>
+
+## Context
+
+Callers come in several kinds: user tokens and sessions, organization access tokens,
+customer sessions, and anonymous visitors. We want one consistent way to protect endpoints
+across all of them, with no ambient trust and no "forgot to check the token type" bug.
+
+## Decision
+
+Two independent layers.
+
+**1. Who is calling, and with what scopes.** Every request resolves to a typed
+`AuthSubject[T]`: a User, Organization, Customer, or Anonymous. An endpoint protects itself
+by depending on a per-module `Authenticator` (defined in that module's `auth.py`), which fixes
+the `allowed_subjects` it accepts and the `required_scopes` it needs. Rules of thumb:
+
+- No `auth_subject` dependency means the endpoint is public.
+- Dashboard routes use the ready-made `WebUser` / `WebUserOrAnonymous` dependencies, which
+  also require a web session.
+
+**2. What that caller may do inside an org.** Per-org role permissions
+(`OrganizationPermission` / `ROLE_PERMISSIONS`) decide authorization within a single
+organization. This layer is separate from scopes and is combined with layer 1 at policy time.
+
+## Consequences
+
+- A handler typed `AuthSubject[User]` cannot be reached by the wrong subject: a disallowed
+  subject fails closed to Anonymous before the scope check runs.
+- Required scopes surface in the OpenAPI schema.
+- Roles stay per-org and decoupled from token scopes, since tokens are org-agnostic. The role
+  layer is already live in production (webhook, order, and metrics services); further rollout
+  is tracked in the RBAC design doc.
+- In tests, get an `AuthSubject` via the `@pytest.mark.auth` marker, never hand-rolled.
+
+## Alternatives considered
+
+- **Encode per-org roles into token scopes**: either coarsens scopes to a cross-org union
+  (making the check redundant) or churns tokens on every role change. Rejected in the RBAC
+  design doc.
+
+## References
+
+- `server/polar/auth/` (`models.py`, `dependencies.py`, `scope.py`, `permission.py`); per-module `auth.py`.
+- [RBAC design document](/engineering/design-documents/rbac).

--- a/handbook/engineering/decisions/0005-auth-subject-and-scopes.mdx
+++ b/handbook/engineering/decisions/0005-auth-subject-and-scopes.mdx
@@ -24,7 +24,7 @@ across all of them, with no ambient trust and no "forgot to check the token type
 Two independent layers.
 
 **1. Who is calling, and with what scopes.** Every request resolves to a typed
-`AuthSubject[T]`: a User, Organization, Customer, or Anonymous. An endpoint protects itself
+`AuthSubject[T]`: a User, Organization, Customer, Member, or Anonymous. An endpoint protects itself
 by depending on a per-module `Authenticator` (defined in that module's `auth.py`), which fixes
 the `allowed_subjects` it accepts and the `required_scopes` it needs. Rules of thumb:
 

--- a/handbook/engineering/decisions/0005-auth-subject-and-scopes.mdx
+++ b/handbook/engineering/decisions/0005-auth-subject-and-scopes.mdx
@@ -9,8 +9,6 @@ description: "Every request resolves to a typed AuthSubject; endpoints opt into 
 **Area**: Backend
 
 **Date**: 2026-07-02
-
-**Deciders**: Engineering
 </Info>
 
 ## Context

--- a/handbook/engineering/decisions/0006-migration-and-backfill-safety.mdx
+++ b/handbook/engineering/decisions/0006-migration-and-backfill-safety.mdx
@@ -9,8 +9,6 @@ description: "Migrations run under a lock timeout, backfills run as separate bat
 **Area**: Backend
 
 **Date**: 2026-07-02
-
-**Deciders**: Engineering
 </Info>
 
 ## Context

--- a/handbook/engineering/decisions/0006-migration-and-backfill-safety.mdx
+++ b/handbook/engineering/decisions/0006-migration-and-backfill-safety.mdx
@@ -28,7 +28,10 @@ Two things make migrations risky during a deploy:
   `SET LOCAL lock_timeout = '5s'` from the template.
 - Add a NOT NULL column across separate PRs: add it nullable, backfill with a batched script
   (`run_batched_update`), then enforce NOT NULL.
-- Never run an unbatched, table-rewriting `UPDATE` inside a migration.
+- The enforce migration still includes an inline `UPDATE ... WHERE col IS NULL` so fresh and
+  local databases (where the script never ran) work naturally. In production, run the batched
+  backfill first and confirm it before deploying, so that `UPDATE` matches almost no rows and
+  never rewrites the table under lock.
 - Keep migration PRs isolated from application code.
 
 ## Consequences
@@ -38,13 +41,16 @@ Two things make migrations risky during a deploy:
 - Code never ships ahead of the schema it needs.
 - CI enforces this: a "Migration Isolation Check" gates which files travel together, and
   `alembic check` catches model-versus-migration drift.
-- The no-unbatched-`UPDATE` rule relies on convention, review, and the lock-timeout safety net,
-  not a static lint.
+- The inline `UPDATE` is safe only because the batched backfill runs first in production; that
+  ordering is convention and review, backed by the lock-timeout net, not a static lint.
 
 ## Alternatives considered
 
-- **One-shot NOT NULL with an inline `UPDATE`, or shipping a migration with its dependent code**:
-  rewrites the table under lock during deploy and breaks the API-before-workers ordering.
+- **Add NOT NULL in one step and let the migration's `UPDATE` backfill every row**: rewrites the
+  table under lock during deploy. The inline `UPDATE` stays only as a fallback for fresh and local
+  databases; the batched script does the real backfill first.
+- **Ship a migration in the same PR as the code that depends on it**: breaks the
+  API-before-workers ordering.
 
 ## References
 

--- a/handbook/engineering/decisions/0006-migration-and-backfill-safety.mdx
+++ b/handbook/engineering/decisions/0006-migration-and-backfill-safety.mdx
@@ -33,10 +33,13 @@ Two things make migrations risky during a deploy:
   `SET NOT NULL` then doubles as a check that the backfill completed.
 - Keep migration PRs isolated from application code.
 
-The local-only guard is a plain inline check. `settings` comes from `polar.config`, which
-`migrations/env.py` already imports:
+The local-only guard is a plain inline check. Import `settings` in the migration (from
+`polar.config`, the same module `migrations/env.py` already imports); `is_development()` is
+true only when `POLAR_ENV=development`, which is local:
 
 ```python
+from polar.config import settings
+
 def upgrade() -> None:
     # Local dev only: deployed environments run the batched backfill first.
     if settings.is_development():

--- a/handbook/engineering/decisions/0006-migration-and-backfill-safety.mdx
+++ b/handbook/engineering/decisions/0006-migration-and-backfill-safety.mdx
@@ -26,10 +26,11 @@ Two things make migrations risky during a deploy:
   `SET LOCAL lock_timeout = '5s'` from the template.
 - Add a NOT NULL column across separate PRs: add it nullable, backfill with a batched script
   (`run_batched_update`), then enforce NOT NULL.
-- The enforce migration still includes an inline `UPDATE ... WHERE col IS NULL` so fresh and
-  local databases (where the script never ran) work naturally. In production, run the batched
-  backfill first and confirm it before deploying, so that `UPDATE` matches almost no rows and
-  never rewrites the table under lock.
+- The enforce migration's inline `UPDATE ... WHERE col IS NULL` is guarded by
+  `settings.is_development()`, so it runs only against a local database. Deployed environments
+  (testing, sandbox, production) run the batched backfill script first, verified before deploy,
+  so they skip the inline `UPDATE` and never rewrite a hot table under lock. The following
+  `SET NOT NULL` then doubles as a check that the backfill completed.
 - Keep migration PRs isolated from application code.
 
 ## Consequences
@@ -39,14 +40,15 @@ Two things make migrations risky during a deploy:
 - Code never ships ahead of the schema it needs.
 - CI enforces this: a "Migration Isolation Check" gates which files travel together, and
   `alembic check` catches model-versus-migration drift.
-- The inline `UPDATE` is safe only because the batched backfill runs first in production; that
-  ordering is convention and review, backed by the lock-timeout net, not a static lint.
+- `settings.is_development()` is the single decision for what counts as local. A deployed
+  enforce migration cannot rewrite the table; if the backfill was skipped, `SET NOT NULL` fails
+  the deploy instead.
 
 ## Alternatives considered
 
 - **Add NOT NULL in one step and let the migration's `UPDATE` backfill every row**: rewrites the
-  table under lock during deploy. The inline `UPDATE` stays only as a fallback for fresh and local
-  databases; the batched script does the real backfill first.
+  table under lock during deploy. The inline `UPDATE` runs in local development only; the batched
+  script does the real backfill everywhere else.
 - **Ship a migration in the same PR as the code that depends on it**: breaks the
   API-before-workers ordering.
 

--- a/handbook/engineering/decisions/0006-migration-and-backfill-safety.mdx
+++ b/handbook/engineering/decisions/0006-migration-and-backfill-safety.mdx
@@ -33,6 +33,17 @@ Two things make migrations risky during a deploy:
   `SET NOT NULL` then doubles as a check that the backfill completed.
 - Keep migration PRs isolated from application code.
 
+The local-only guard is a plain inline check. `settings` comes from `polar.config`, which
+`migrations/env.py` already imports:
+
+```python
+def upgrade() -> None:
+    # Local dev only: deployed environments run the batched backfill first.
+    if settings.is_development():
+        op.execute("UPDATE organizations SET sso_enforced = false WHERE sso_enforced IS NULL")
+    op.alter_column("organizations", "sso_enforced", nullable=False)
+```
+
 ## Consequences
 
 - A lock-holding migration fails fast at the 5s timeout instead of taking the database down.

--- a/handbook/engineering/decisions/0006-migration-and-backfill-safety.mdx
+++ b/handbook/engineering/decisions/0006-migration-and-backfill-safety.mdx
@@ -1,0 +1,53 @@
+---
+title: "ADR-0006: Migrations and backfills are deploy-safe by construction"
+description: "Migrations run under a lock timeout, backfills run as separate batched scripts, and migration PRs stay isolated from code."
+---
+
+<Info>
+**Status**: Accepted
+
+**Area**: Backend
+
+**Date**: 2026-07-02
+
+**Deciders**: Engineering
+</Info>
+
+## Context
+
+Two things make migrations risky during a deploy:
+
+- **Locks.** A blocking `ALTER` or an unbatched `UPDATE` on a hot table takes an `ACCESS EXCLUSIVE`
+  lock, which can stall live API traffic until it finishes.
+- **Deploy order.** The API deploys before the workers. If a migration ships in the same PR as the
+  code that needs it, that code can go live before its schema exists.
+
+## Decision
+
+- Generate migrations with `alembic revision --autogenerate`. Every migration inherits
+  `SET LOCAL lock_timeout = '5s'` from the template.
+- Add a NOT NULL column across separate PRs: add it nullable, backfill with a batched script
+  (`run_batched_update`), then enforce NOT NULL.
+- Never run an unbatched, table-rewriting `UPDATE` inside a migration.
+- Keep migration PRs isolated from application code.
+
+## Consequences
+
+- A lock-holding migration fails fast at the 5s timeout instead of taking the database down.
+- Large backfills run outside the deploy path, in controlled batches.
+- Code never ships ahead of the schema it needs.
+- CI enforces this: a "Migration Isolation Check" gates which files travel together, and
+  `alembic check` catches model-versus-migration drift.
+- The no-unbatched-`UPDATE` rule relies on convention, review, and the lock-timeout safety net,
+  not a static lint.
+
+## Alternatives considered
+
+- **One-shot NOT NULL with an inline `UPDATE`, or shipping a migration with its dependent code**:
+  rewrites the table under lock during deploy and breaks the API-before-workers ordering.
+
+## References
+
+- `server/migrations/script.py.mako`, `server/migrations/env.py`, `server/migrations/README.md`.
+- `server/scripts/helper.py` (`run_batched_update`) and the `server/scripts/backfill_*.py`
+  scripts. CI: `.github/workflows/test_server.yaml` (`migration-check`).

--- a/handbook/engineering/decisions/index.mdx
+++ b/handbook/engineering/decisions/index.mdx
@@ -76,7 +76,7 @@ Agents working in this repo should treat **Accepted** ADRs as binding convention
   decision that no ADR covers, propose one (draft it from the template) rather than letting
   the rationale vanish into the diff.
 
-The per-area `AGENTS.md` files link here so this contract reaches agents wherever they work.
+The root `AGENTS.md` links here so this contract reaches agents working anywhere in the repo.
 To check a diff against these ADRs, run the `adr-check` skill.
 
 ## All decisions

--- a/handbook/engineering/decisions/index.mdx
+++ b/handbook/engineering/decisions/index.mdx
@@ -1,0 +1,88 @@
+---
+title: "Architecture Decision Records"
+description: "Short, immutable records of the significant, cross-cutting decisions behind Polar."
+---
+
+An **Architecture Decision Record (ADR)** captures one significant decision: what we
+chose, why, and what it costs us.
+
+They are deliberately short. If you just joined and read the ADR log top to bottom, you
+should understand the load-bearing choices in the codebase in under an hour.
+
+## ADR vs. design document
+
+We already write [design documents](/engineering/design-documents/index): big,
+forward-looking RFCs that explore a *solution*. ADRs are the
+opposite shape:
+
+| | Design document | ADR |
+|---|---|---|
+| Answers | "What are we going to build?" | "Why is it this way?" |
+| Size | Pages | One page |
+| Lifespan | Goes stale after ship | Immutable; superseded, not edited |
+| Trigger | A feature or system worth designing | A decision worth remembering |
+
+A design doc can make several decisions; distil each into an ADR that links back. Reach for
+an ADR when the *decision* outlives the *document*.
+
+## When to write one
+
+Write an ADR when a decision is **significant and hard to reverse or re-litigate**:
+
+- It's cross-cutting (touches many modules, or both backend and frontend).
+- It's surprising: a newcomer would reasonably do the opposite.
+- It's a convention we enforce in review or lint, but whose *why* lives only in someone's head.
+- We picked one option over a real alternative and the trade-off matters.
+
+Don't write one for reversible, local, or obvious choices; a comment or a PR is enough.
+
+## Structure in a monorepo
+
+One **global, sequentially numbered** sequence for the whole repo (`NNNN-title.mdx`), not a
+separate log per package. Our most important decisions (the OpenAPI to generated-client
+seam, API versioning, auth) span tiers, and a single log keeps them findable.
+
+Capture the monorepo dimension with the **Area** field in each ADR's header
+(`Backend` / `Frontend` / `Infra` / `Cross-cutting`) instead of by splitting directories.
+It tells you (and an agent) which ADRs apply to the code you're touching.
+
+## Lifecycle
+
+An ADR's **Status** is one of:
+
+- **Accepted**: the decision stands; treat it as binding. An ADR in the repo is Accepted;
+  while it is still under discussion it lives in an open PR, not here.
+- **Superseded by [ADR-XXXX](...)**: replaced. We never delete or rewrite the decision; we
+  add a new ADR and point the old one at it.
+
+## Writing a new ADR
+
+1. Copy [`template.mdx`](/engineering/decisions/template) to `NNNN-title.mdx` with the next
+   free number.
+2. Fill in Context / Decision / Consequences. Keep it to a page.
+3. Add it to the **All decisions** list below and to the `Architecture Decisions` group in
+   `handbook/docs.json`.
+4. Open a PR. Review happens there, like design docs.
+
+## For AI agents and reviewers
+
+Agents working in this repo should treat **Accepted** ADRs as binding conventions:
+
+- **Read them for the *why*.** Before changing a load-bearing pattern, check for a
+  relevant ADR (grep `handbook/engineering/decisions/`).
+- **Flag violations.** If code contradicts an Accepted ADR, call it out and cite the ADR id
+  (e.g. "violates ADR-0004: raw Tailwind used for layout instead of Orbit Box").
+- **Suggest new ADRs.** If a PR makes a significant, cross-cutting, or hard-to-reverse
+  decision that no ADR covers, propose one (draft it from the template) rather than letting
+  the rationale vanish into the diff.
+
+The per-area `AGENTS.md` files link here so this contract reaches agents wherever they work.
+
+## All decisions
+
+- [ADR-0001: Record architecture decisions](/engineering/decisions/0001-record-architecture-decisions) · Cross-cutting · Accepted
+- [ADR-0002: Business errors are status-coded PolarError subclasses](/engineering/decisions/0002-status-coded-polar-errors) · Backend · Accepted
+- [ADR-0003: One request or task is one transaction](/engineering/decisions/0003-request-scoped-unit-of-work) · Backend · Accepted
+- [ADR-0004: Frontend UI is authored with Orbit Box and design tokens](/engineering/decisions/0004-orbit-box-design-system) · Frontend · Accepted
+- [ADR-0005: Authorization is AuthSubject plus scopes](/engineering/decisions/0005-auth-subject-and-scopes) · Backend · Accepted
+- [ADR-0006: Migrations and backfills are deploy-safe by construction](/engineering/decisions/0006-migration-and-backfill-safety) · Backend · Accepted

--- a/handbook/engineering/decisions/index.mdx
+++ b/handbook/engineering/decisions/index.mdx
@@ -77,6 +77,7 @@ Agents working in this repo should treat **Accepted** ADRs as binding convention
   the rationale vanish into the diff.
 
 The per-area `AGENTS.md` files link here so this contract reaches agents wherever they work.
+To check a diff against these ADRs, run the `adr-check` skill.
 
 ## All decisions
 

--- a/handbook/engineering/decisions/template.mdx
+++ b/handbook/engineering/decisions/template.mdx
@@ -9,8 +9,6 @@ description: "One-line summary of the decision."
 **Area**: Backend {/* Backend | Frontend | Infra | Cross-cutting */}
 
 **Date**: YYYY-MM-DD
-
-**Deciders**: [your name]
 </Info>
 
 ## Context

--- a/handbook/engineering/decisions/template.mdx
+++ b/handbook/engineering/decisions/template.mdx
@@ -1,0 +1,37 @@
+---
+title: "ADR-NNNN: <short decision title>"
+description: "One-line summary of the decision."
+---
+
+<Info>
+**Status**: Accepted {/* Accepted | Superseded by [ADR-XXXX](...) */}
+
+**Area**: Backend {/* Backend | Frontend | Infra | Cross-cutting */}
+
+**Date**: YYYY-MM-DD
+
+**Deciders**: [your name]
+</Info>
+
+## Context
+
+Why this decision came up and the forces at play. What is true today, and what breaks or
+stays ambiguous if we don't decide. Keep it to 2 to 4 sentences.
+
+## Decision
+
+What we do, in the imperative. One or two sentences. This is the line people will quote.
+
+## Consequences
+
+- What gets easier or safer because of this.
+- What you must now do as a result (the new rule to follow).
+- The trade-off we knowingly accept.
+
+## Alternatives considered
+
+- **[Option]**: why we didn't pick it. One line each. _(Omit the section if there was no real alternative.)_
+
+## References
+
+- Related design doc, PRs, code paths, or lint rule that enforces this.

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -323,8 +323,6 @@ class TestListResources:
 ## Conventions (enforced in review)
 
 Cross-cutting patterns the team enforces in code review. New backend code is expected to follow them.
-The *why* behind the load-bearing ones is recorded as ADRs in `handbook/engineering/decisions/`;
-treat Accepted ADRs as binding and cite them when flagging violations.
 
 ### Imports
 Keep `import` statements at module top, never inside functions or methods. Import models from

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -323,6 +323,8 @@ class TestListResources:
 ## Conventions (enforced in review)
 
 Cross-cutting patterns the team enforces in code review. New backend code is expected to follow them.
+The *why* behind the load-bearing ones is recorded as ADRs in `handbook/engineering/decisions/`;
+treat Accepted ADRs as binding and cite them when flagging violations.
 
 ### Imports
 Keep `import` statements at module top, never inside functions or methods. Import models from


### PR DESCRIPTION
## Summary

Adds an Architecture Decision Record (ADR) system to the handbook, records the first six decisions, and adds a skill to check changes against them.

## What

- New `handbook/engineering/decisions/`: an index, a short template, and six ADRs — the meta ADR that establishes the practice, plus business errors as status-coded `PolarError`, one transaction per request/task, the Orbit design system, the authorization model, and migration/backfill safety.
- Handbook nav (`docs.json`) updated; the root `AGENTS.md` points at the log so agents treat Accepted ADRs as binding.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

> Docs and tooling change (Markdown / MDX / `docs.json` / a skill file), so backend lint and type-check do not apply. Validated instead: `docs.json` is valid JSON, MDX is build-safe (no bare JSX tags), all cross-links resolve, and ADR titles match their filenames.
