### PR TITLE
feat(merchant-migration): add pre-check phase

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -4898,6 +4898,26 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/merchant-migrations/{id}/precheck': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Run Merchant Migration Pre-check
+     * @description **Scopes**: `organizations:write`
+     */
+    post: operations['merchant-migrations:precheck']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/email-update/request': {
     parameters: {
       query?: never
@@ -22182,6 +22202,17 @@ export interface components {
       organization_id: string
       source_platform: components['schemas']['MerchantMigrationSourcePlatform']
     }
+    /** MerchantMigrationNotFound */
+    MerchantMigrationNotFound: {
+      /**
+       * Error
+       * @example MerchantMigrationNotFound
+       * @constant
+       */
+      error: 'MerchantMigrationNotFound'
+      /** Detail */
+      detail: string
+    }
     /**
      * MerchantMigrationSourcePlatform
      * @enum {string}
@@ -27976,6 +28007,28 @@ export interface components {
        */
       role?: string | null
     }
+    /** PrecheckIssue */
+    PrecheckIssue: {
+      level: components['schemas']['PrecheckIssueLevel']
+      /** Code */
+      code: string
+      /** Message */
+      message: string
+      /** Source Id */
+      source_id: string | null
+    }
+    /**
+     * PrecheckIssueLevel
+     * @enum {string}
+     */
+    PrecheckIssueLevel: 'blocker' | 'warning'
+    /** PrecheckReport */
+    PrecheckReport: {
+      /** Can Start */
+      can_start: boolean
+      /** Issues */
+      issues: components['schemas']['PrecheckIssue'][]
+    }
     /**
      * PresentmentCurrency
      * @enum {string}
@@ -30276,6 +30329,17 @@ export interface components {
        * @description Active, non-bot users in the connected Slack workspace.
        */
       users: components['schemas']['SlackWorkspaceUser'][]
+    }
+    /** SourceNotConnected */
+    SourceNotConnected: {
+      /**
+       * Error
+       * @example SourceNotConnected
+       * @constant
+       */
+      error: 'SourceNotConnected'
+      /** Detail */
+      detail: string
     }
     /**
      * StatisticsPeriod
@@ -32955,6 +33019,17 @@ export interface components {
       func: 'unique'
       /** Property */
       property: string
+    }
+    /** UnsupportedMigrationSource */
+    UnsupportedMigrationSource: {
+      /**
+       * Error
+       * @example UnsupportedMigrationSource
+       * @constant
+       */
+      error: 'UnsupportedMigrationSource'
+      /** Detail */
+      detail: string
     }
     /**
      * UserDeletionBlockedReason
@@ -47863,6 +47938,66 @@ export interface operations {
       }
     }
   }
+  'merchant-migrations:precheck': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PrecheckReport']
+        }
+      }
+      /** @description The source is not connected or isn't supported. */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json':
+            | components['schemas']['SourceNotConnected']
+            | components['schemas']['UnsupportedMigrationSource']
+        }
+      }
+      /** @description Not allowed to manage this organization. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['NotPermitted']
+        }
+      }
+      /** @description Merchant migration not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
   'email-update:request_email_update': {
     parameters: {
       query?: never
@@ -61160,6 +61295,9 @@ export const pledgeStateValues: ReadonlyArray<
   'charge_disputed',
   'cancelled',
 ]
+export const precheckIssueLevelValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['PrecheckIssueLevel']
+> = ['blocker', 'warning']
 export const presentmentCurrencyValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['PresentmentCurrency']
 > = [

--- a/server/polar/merchant_migration/adapters/__init__.py
+++ b/server/polar/merchant_migration/adapters/__init__.py
@@ -1,0 +1,4 @@
+from .base import SourceAdapter
+from .stripe import StripeAdapter
+
+__all__ = ["SourceAdapter", "StripeAdapter"]

--- a/server/polar/merchant_migration/adapters/base.py
+++ b/server/polar/merchant_migration/adapters/base.py
@@ -1,0 +1,14 @@
+from collections.abc import AsyncIterator
+from typing import Protocol
+
+from ..canonical import CanonicalRecord
+
+
+class SourceAdapter(Protocol):
+    """Reads one billing provider into provider-agnostic CanonicalRecords.
+
+    ``extract`` is an async iterator because source data can be huge and must be
+    streamed, not materialized.
+    """
+
+    def extract(self) -> AsyncIterator[CanonicalRecord]: ...

--- a/server/polar/merchant_migration/adapters/stripe.py
+++ b/server/polar/merchant_migration/adapters/stripe.py
@@ -1,0 +1,211 @@
+"""Reads a merchant's Stripe account with its own restricted-key client
+(never Polar's platform key) and normalizes it into CanonicalRecords."""
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any
+
+import stripe as stripe_lib
+
+from ..canonical import (
+    CanonicalCollectionMethod,
+    CanonicalCustomer,
+    CanonicalPaymentMethod,
+    CanonicalPaymentMethodType,
+    CanonicalPrice,
+    CanonicalPricingScheme,
+    CanonicalProduct,
+    CanonicalRecord,
+    CanonicalSubscription,
+    CanonicalSubscriptionStatus,
+)
+
+# Period data moved onto the subscription item in this version; read it per item.
+STRIPE_API_VERSION = "2026-01-28.clover"
+PAGE_SIZE = 100
+
+SKIPPED_SUBSCRIPTION_STATUSES = frozenset(
+    {"canceled", "incomplete", "incomplete_expired"}
+)
+
+
+class StripeAdapter:
+    def __init__(self, access_token: str) -> None:
+        self._client = stripe_lib.StripeClient(
+            access_token, stripe_version=STRIPE_API_VERSION
+        )
+
+    async def extract(self) -> AsyncIterator[CanonicalRecord]:
+        async for product in self._extract_products():
+            yield product
+        async for customer in self._extract_customers():
+            yield customer
+        async for subscription in self._extract_subscriptions():
+            yield subscription
+
+    async def _extract_products(self) -> AsyncIterator[CanonicalProduct]:
+        # Buffer + group prices per (product, interval); catalogs are small,
+        # unlike customers, so holding them in memory is fine.
+        grouped: dict[str, CanonicalProduct] = {}
+        prices = await self._client.v1.prices.list_async(
+            params={
+                "active": True,
+                "limit": PAGE_SIZE,
+                "expand": ["data.product"],
+            }
+        )
+        async for price in prices.auto_paging_iter():
+            product = price.product
+            # A deleted product deserializes as a Product with no `active`/`name`;
+            # `not active` skips deleted and archived alike.
+            if not isinstance(product, stripe_lib.Product) or not product.get("active"):
+                continue
+            recurring = price.recurring
+            interval = recurring.interval if recurring else None
+            interval_count = recurring.interval_count if recurring else 1
+            key = f"{product.id}:{interval}:{interval_count}"
+            canonical = grouped.get(key)
+            if canonical is None:
+                canonical = CanonicalProduct(
+                    source_id=key,
+                    product_source_id=product.id,
+                    name=product.name or "",
+                    recurring_interval=interval,
+                    recurring_interval_count=interval_count,
+                    prices=[],
+                )
+                grouped[key] = canonical
+            canonical.prices.append(self._map_price(price))
+        for canonical in grouped.values():
+            yield canonical
+
+    async def _extract_customers(self) -> AsyncIterator[CanonicalCustomer]:
+        customers = await self._client.v1.customers.list_async(
+            params={"limit": PAGE_SIZE}
+        )
+        async for customer in customers.auto_paging_iter():
+            yield self._map_customer(customer)
+
+    async def _extract_subscriptions(self) -> AsyncIterator[CanonicalSubscription]:
+        subscriptions = await self._client.v1.subscriptions.list_async(
+            params={
+                "status": "all",
+                "limit": PAGE_SIZE,
+                "expand": [
+                    "data.default_payment_method",
+                    "data.customer.invoice_settings.default_payment_method",
+                    "data.customer.default_source",
+                ],
+            }
+        )
+        async for subscription in subscriptions.auto_paging_iter():
+            if subscription.status in SKIPPED_SUBSCRIPTION_STATUSES:
+                continue
+            if not subscription["items"]["data"]:
+                continue
+            yield self._map_subscription(subscription)
+
+    def _map_price(self, price: stripe_lib.Price) -> CanonicalPrice:
+        return CanonicalPrice(
+            source_id=price.id,
+            currency=price.currency,
+            amount=price.unit_amount,
+            pricing_scheme=self._map_pricing_scheme(price),
+        )
+
+    def _map_pricing_scheme(self, price: stripe_lib.Price) -> CanonicalPricingScheme:
+        if price.billing_scheme == "tiered":
+            return CanonicalPricingScheme.tiered
+        recurring = price.recurring
+        if recurring is not None and recurring.usage_type == "metered":
+            return CanonicalPricingScheme.metered
+        return CanonicalPricingScheme.fixed
+
+    def _map_subscription(
+        self, subscription: stripe_lib.Subscription
+    ) -> CanonicalSubscription:
+        items = subscription["items"]["data"]
+        first_item = items[0]
+        return CanonicalSubscription(
+            source_id=subscription.id,
+            customer_source_id=self._id_of(subscription.customer),
+            price_source_id=self._id_of(first_item["price"]),
+            status=self._map_status(subscription.status),
+            collection_method=self._map_collection_method(
+                subscription.collection_method
+            ),
+            current_period_start=self._to_datetime(
+                first_item.get("current_period_start")
+            ),
+            current_period_end=self._to_datetime(first_item.get("current_period_end")),
+            trialing=subscription.status == "trialing",
+            paused_collection=subscription.pause_collection is not None,
+            line_item_count=len(items),
+            quantity=first_item.get("quantity") or 1,
+            payment_method=self._resolve_payment_method(subscription),
+        )
+
+    def _map_customer(self, customer: stripe_lib.Customer) -> CanonicalCustomer:
+        address = customer.address
+        return CanonicalCustomer(
+            source_id=customer.id,
+            email=customer.email or "",
+            name=customer.name,
+            country=address.country if address is not None else None,
+        )
+
+    def _resolve_payment_method(
+        self, subscription: stripe_lib.Subscription
+    ) -> CanonicalPaymentMethod | None:
+        # Fall back to the customer's default like Stripe does when the sub has
+        # no explicit method, so a re-entry-only method isn't silently missed.
+        payment_method = self._map_payment_method(subscription.default_payment_method)
+        if payment_method is not None:
+            return payment_method
+        customer = subscription.customer
+        if not isinstance(customer, stripe_lib.Customer):
+            return None
+        invoice_settings = customer.invoice_settings
+        if invoice_settings is not None:
+            payment_method = self._map_payment_method(
+                invoice_settings.default_payment_method
+            )
+            if payment_method is not None:
+                return payment_method
+        default_source = customer.default_source
+        if default_source is not None and not isinstance(default_source, str):
+            # Legacy `source`/`card` object (not a PaymentMethod): doesn't PAN-copy.
+            return CanonicalPaymentMethod(
+                source_id=default_source["id"], type=CanonicalPaymentMethodType.other
+            )
+        return None
+
+    def _map_status(self, status: str) -> CanonicalSubscriptionStatus:
+        try:
+            return CanonicalSubscriptionStatus(status)
+        except ValueError:
+            return CanonicalSubscriptionStatus.other
+
+    def _map_collection_method(self, method: str | None) -> CanonicalCollectionMethod:
+        if method == "send_invoice":
+            return CanonicalCollectionMethod.send_invoice
+        return CanonicalCollectionMethod.charge_automatically
+
+    def _map_payment_method(self, payment_method: Any) -> CanonicalPaymentMethod | None:
+        if not isinstance(payment_method, stripe_lib.PaymentMethod):
+            return None
+        try:
+            type = CanonicalPaymentMethodType(payment_method.type)
+        except ValueError:
+            type = CanonicalPaymentMethodType.other
+        return CanonicalPaymentMethod(source_id=payment_method.id, type=type)
+
+    def _id_of(self, value: Any) -> str:
+        if isinstance(value, str):
+            return value
+        return value["id"]
+
+    def _to_datetime(self, timestamp: int | None) -> datetime | None:
+        if timestamp is None:
+            return None
+        return datetime.fromtimestamp(timestamp, tz=UTC)

--- a/server/polar/merchant_migration/canonical.py
+++ b/server/polar/merchant_migration/canonical.py
@@ -1,0 +1,110 @@
+"""Provider-agnostic records the adapters normalize into, so the precheck
+engine and importer don't need to know which billing provider data came from."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+from polar.models.merchant_migration_record import MerchantMigrationRecordType
+
+
+class CanonicalPricingScheme(StrEnum):
+    fixed = "fixed"
+    tiered = "tiered"
+    metered = "metered"
+
+
+class CanonicalSubscriptionStatus(StrEnum):
+    active = "active"
+    trialing = "trialing"
+    past_due = "past_due"
+    unpaid = "unpaid"
+    paused = "paused"
+    canceled = "canceled"
+    other = "other"
+
+
+class CanonicalCollectionMethod(StrEnum):
+    charge_automatically = "charge_automatically"
+    send_invoice = "send_invoice"
+
+
+class CanonicalPaymentMethodType(StrEnum):
+    card = "card"
+    us_bank_account = "us_bank_account"
+    sepa_debit = "sepa_debit"
+    bacs_debit = "bacs_debit"
+    link = "link"
+    other = "other"
+
+    @property
+    def requires_reentry(self) -> bool:
+        return self in {
+            CanonicalPaymentMethodType.bacs_debit,
+            CanonicalPaymentMethodType.link,
+            CanonicalPaymentMethodType.other,
+        }
+
+
+@dataclass
+class CanonicalPaymentMethod:
+    source_id: str
+    type: CanonicalPaymentMethodType
+
+
+@dataclass
+class CanonicalPrice:
+    source_id: str
+    currency: str
+    # None when the source has no representable integer amount (e.g. a sub-cent
+    # decimal price); such prices can't be imported.
+    amount: int | None
+    pricing_scheme: CanonicalPricingScheme
+
+
+@dataclass
+class CanonicalProduct:
+    # In Polar the recurring interval lives on the product and a product holds
+    # several prices (one per currency), so a source product is grouped per
+    # interval: one CanonicalProduct = one Polar product = (source product,
+    # interval), carrying its currency prices.
+    source_id: str
+    product_source_id: str
+    name: str
+    recurring_interval: str | None
+    recurring_interval_count: int
+    prices: list[CanonicalPrice]
+
+    type = MerchantMigrationRecordType.product
+
+
+@dataclass
+class CanonicalCustomer:
+    source_id: str
+    email: str
+    name: str | None
+    country: str | None
+
+    type = MerchantMigrationRecordType.customer
+
+
+@dataclass
+class CanonicalSubscription:
+    source_id: str
+    customer_source_id: str
+    price_source_id: str
+    status: CanonicalSubscriptionStatus
+    collection_method: CanonicalCollectionMethod
+    # End may be None: the importer derives it from current_period_start + interval.
+    current_period_start: datetime | None
+    current_period_end: datetime | None
+    trialing: bool
+    paused_collection: bool
+    line_item_count: int
+    quantity: int
+    payment_method: CanonicalPaymentMethod | None
+
+    type = MerchantMigrationRecordType.subscription
+
+
+CanonicalRecord = CanonicalProduct | CanonicalCustomer | CanonicalSubscription

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -4,7 +4,7 @@ from fastapi import Depends, Query, Request
 from fastapi.responses import RedirectResponse
 from pydantic import UUID4
 
-from polar.exceptions import ResourceNotFound
+from polar.exceptions import NotPermitted, ResourceNotFound
 from polar.kit.db.postgres import AsyncSession
 from polar.kit.http import ReturnTo, add_query_parameters, get_safe_return_url
 from polar.models import MerchantMigration
@@ -15,6 +15,12 @@ from polar.routing import APIRouter
 
 from .auth import MerchantMigrationRead, MerchantMigrationWrite
 from .schemas import MerchantMigration as MerchantMigrationSchema
+from .schemas import PrecheckReport
+from .service import (
+    MerchantMigrationNotFound,
+    SourceNotConnected,
+    UnsupportedMigrationSource,
+)
 from .service import merchant_migration as merchant_migration_service
 
 router = APIRouter(
@@ -80,3 +86,30 @@ async def get(
     if migration is None:
         raise ResourceNotFound()
     return migration
+
+
+@router.post(
+    "/{id}/precheck",
+    response_model=PrecheckReport,
+    summary="Run Merchant Migration Pre-check",
+    responses={
+        400: {
+            "description": "The source is not connected or isn't supported.",
+            "model": SourceNotConnected.schema() | UnsupportedMigrationSource.schema(),
+        },
+        403: {
+            "description": "Not allowed to manage this organization.",
+            "model": NotPermitted.schema(),
+        },
+        404: {
+            "description": "Merchant migration not found.",
+            "model": MerchantMigrationNotFound.schema(),
+        },
+    },
+)
+async def precheck(
+    id: UUID4,
+    auth_subject: MerchantMigrationWrite,
+    session: AsyncSession = Depends(get_db_session),
+) -> PrecheckReport:
+    return await merchant_migration_service.run_precheck(session, auth_subject, id)

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -1,0 +1,301 @@
+"""Streams CanonicalRecords into a PrecheckReport of blockers and warnings
+(design Appendices A and D).
+
+Consumes the records once and keeps only the aggregates the cross-record checks
+need, so it never holds the whole source catalog in memory.
+"""
+
+from collections import Counter
+from collections.abc import AsyncIterable, Iterable
+
+from polar.enums import SubscriptionRecurringInterval
+from polar.kit.currency import (
+    PresentmentCurrency,
+    get_maximum_currency_amount,
+    get_minimum_currency_amount,
+)
+from polar.models import Organization
+from polar.models.organization import OrganizationStatus
+
+from .canonical import (
+    CanonicalCollectionMethod,
+    CanonicalCustomer,
+    CanonicalPrice,
+    CanonicalPricingScheme,
+    CanonicalProduct,
+    CanonicalRecord,
+    CanonicalSubscription,
+    CanonicalSubscriptionStatus,
+)
+from .schemas import PrecheckIssue, PrecheckIssueLevel, PrecheckReport
+
+RENEWAL_ENABLED_STATUSES = {OrganizationStatus.REVIEW, OrganizationStatus.ACTIVE}
+SUPPORTED_INTERVALS = {interval.value for interval in SubscriptionRecurringInterval}
+MAX_INTERVAL_COUNT = 999
+NON_IMPORTABLE_STATUSES = {
+    CanonicalSubscriptionStatus.past_due,
+    CanonicalSubscriptionStatus.unpaid,
+    CanonicalSubscriptionStatus.paused,
+}
+
+
+def _is_supported_currency(currency: str) -> bool:
+    try:
+        PresentmentCurrency(currency.lower())
+        return True
+    except ValueError:
+        return False
+
+
+class PrecheckEngine:
+    async def run(
+        self,
+        records: AsyncIterable[CanonicalRecord],
+        organization: Organization,
+    ) -> PrecheckReport:
+        issues: list[PrecheckIssue] = list(self._check_organization(organization))
+
+        products_by_name: dict[str, set[str]] = {}
+        email_counts: Counter[str] = Counter()
+        customers_without_country = 0
+
+        async for record in records:
+            if isinstance(record, CanonicalProduct):
+                products_by_name.setdefault(record.name, set()).add(
+                    record.product_source_id
+                )
+                issues.extend(self._check_product(record))
+            elif isinstance(record, CanonicalCustomer):
+                if record.email:
+                    email_counts[record.email.lower()] += 1
+                if not record.country:
+                    customers_without_country += 1
+            elif isinstance(record, CanonicalSubscription):
+                issues.extend(self._check_subscription(record))
+
+        issues.extend(self._check_duplicate_names(products_by_name))
+        issues.extend(self._check_duplicate_emails(email_counts))
+        issues.extend(self._check_missing_country(customers_without_country))
+
+        return PrecheckReport(
+            issues=issues,
+            can_start=not any(
+                issue.level == PrecheckIssueLevel.blocker for issue in issues
+            ),
+        )
+
+    def _check_organization(
+        self, organization: Organization
+    ) -> Iterable[PrecheckIssue]:
+        if organization.status not in RENEWAL_ENABLED_STATUSES:
+            yield PrecheckIssue(
+                level=PrecheckIssueLevel.blocker,
+                code="organization_not_renewal_enabled",
+                message=(
+                    "The organization must be in a renewal-enabled status "
+                    "(Review or Active) before migrating."
+                ),
+                source_id=None,
+            )
+
+    def _check_product(self, product: CanonicalProduct) -> Iterable[PrecheckIssue]:
+        # A product Polar can't represent is skipped along with its subscriptions,
+        # rather than blocking the whole migration.
+        if product.recurring_interval is None:
+            yield PrecheckIssue(
+                level=PrecheckIssueLevel.warning,
+                code="one_time_product",
+                message=(
+                    f"Product '{product.name}' is one-time; it and its "
+                    "subscriptions won't be imported."
+                ),
+                source_id=product.source_id,
+            )
+        elif (
+            product.recurring_interval not in SUPPORTED_INTERVALS
+            or not 1 <= product.recurring_interval_count <= MAX_INTERVAL_COUNT
+        ):
+            yield PrecheckIssue(
+                level=PrecheckIssueLevel.warning,
+                code="unsupported_recurring_interval",
+                message=(
+                    f"Product '{product.name}' recurs every "
+                    f"{product.recurring_interval_count} {product.recurring_interval}, "
+                    "which Polar can't represent; it and its subscriptions won't "
+                    "be imported."
+                ),
+                source_id=product.source_id,
+            )
+        for price in product.prices:
+            yield from self._check_price(product, price)
+
+    def _check_price(
+        self, product: CanonicalProduct, price: CanonicalPrice
+    ) -> Iterable[PrecheckIssue]:
+        if price.pricing_scheme != CanonicalPricingScheme.fixed:
+            yield PrecheckIssue(
+                level=PrecheckIssueLevel.warning,
+                code="unsupported_pricing_scheme",
+                message=(
+                    f"Product '{product.name}' has a {price.pricing_scheme.value} "
+                    "price (only fixed is supported); that price won't be imported."
+                ),
+                source_id=price.source_id,
+            )
+        elif price.amount is None:
+            yield PrecheckIssue(
+                level=PrecheckIssueLevel.warning,
+                code="unsupported_price_amount",
+                message=(
+                    f"Product '{product.name}' has a price with no representable "
+                    "amount (e.g. sub-cent); that price won't be imported."
+                ),
+                source_id=price.source_id,
+            )
+        if not _is_supported_currency(price.currency):
+            yield PrecheckIssue(
+                level=PrecheckIssueLevel.warning,
+                code="unsupported_currency",
+                message=(
+                    f"Product '{product.name}' has a price in {price.currency}, "
+                    "which Polar doesn't support; that price won't be imported."
+                ),
+                source_id=price.source_id,
+            )
+        elif (
+            price.amount is not None
+            and price.amount != 0
+            and not (
+                get_minimum_currency_amount(price.currency)
+                <= price.amount
+                <= get_maximum_currency_amount(price.currency)
+            )
+        ):
+            yield PrecheckIssue(
+                level=PrecheckIssueLevel.warning,
+                code="price_out_of_bounds",
+                message=(
+                    f"Product '{product.name}' has a price outside the allowed "
+                    f"range for {price.currency}; that price won't be imported."
+                ),
+                source_id=price.source_id,
+            )
+
+    def _check_duplicate_names(
+        self, products_by_name: dict[str, set[str]]
+    ) -> Iterable[PrecheckIssue]:
+        for name, product_source_ids in products_by_name.items():
+            if len(product_source_ids) > 1:
+                yield PrecheckIssue(
+                    level=PrecheckIssueLevel.warning,
+                    code="duplicate_product_name",
+                    message=(
+                        f"Multiple products share the name '{name}'; the duplicates "
+                        "won't be imported."
+                    ),
+                    source_id=None,
+                )
+
+    def _check_duplicate_emails(
+        self, email_counts: Counter[str]
+    ) -> Iterable[PrecheckIssue]:
+        for email, count in email_counts.items():
+            if count > 1:
+                yield PrecheckIssue(
+                    level=PrecheckIssueLevel.warning,
+                    code="duplicate_customer_email",
+                    message=(
+                        f"{count} source customers share the email '{email}'; the "
+                        "duplicates and their subscriptions won't be imported."
+                    ),
+                    source_id=None,
+                )
+
+    def _check_missing_country(self, count: int) -> Iterable[PrecheckIssue]:
+        if count > 0:
+            yield PrecheckIssue(
+                level=PrecheckIssueLevel.warning,
+                code="customer_missing_country",
+                message=(
+                    f"{count} customers have no billing country; the payment "
+                    "card's country will be used as a default."
+                ),
+                source_id=None,
+            )
+
+    def _check_subscription(
+        self, subscription: CanonicalSubscription
+    ) -> Iterable[PrecheckIssue]:
+        source_id = subscription.source_id
+        if subscription.line_item_count > 1:
+            yield PrecheckIssue(
+                level=PrecheckIssueLevel.warning,
+                code="multiple_line_items",
+                message=(
+                    "Subscription has multiple line items, which can't be "
+                    "represented; it won't be imported."
+                ),
+                source_id=source_id,
+            )
+        if subscription.quantity > 1:
+            yield PrecheckIssue(
+                level=PrecheckIssueLevel.warning,
+                code="unsupported_quantity",
+                message=(
+                    f"Subscription has quantity {subscription.quantity}; Polar "
+                    "doesn't support per-subscription quantity, so it won't be "
+                    "imported."
+                ),
+                source_id=source_id,
+            )
+        if subscription.collection_method == CanonicalCollectionMethod.send_invoice:
+            yield PrecheckIssue(
+                level=PrecheckIssueLevel.warning,
+                code="send_invoice_collection",
+                message=(
+                    "Invoice-collected subscriptions can't be handled; it won't "
+                    "be imported."
+                ),
+                source_id=source_id,
+            )
+        if subscription.status in NON_IMPORTABLE_STATUSES:
+            yield PrecheckIssue(
+                level=PrecheckIssueLevel.warning,
+                code="subscription_not_importable",
+                message=(
+                    f"Subscription is {subscription.status.value}; it won't be "
+                    "imported and stays on the current provider."
+                ),
+                source_id=source_id,
+            )
+        if subscription.paused_collection:
+            yield PrecheckIssue(
+                level=PrecheckIssueLevel.warning,
+                code="subscription_paused_collection",
+                message=(
+                    "Subscription has paused collection; it won't be imported and "
+                    "stays on the current provider."
+                ),
+                source_id=source_id,
+            )
+        if subscription.trialing:
+            yield PrecheckIssue(
+                level=PrecheckIssueLevel.warning,
+                code="subscription_trialing",
+                message="Subscription is on trial.",
+                source_id=source_id,
+            )
+        payment_method = subscription.payment_method
+        if payment_method is not None and payment_method.type.requires_reentry:
+            yield PrecheckIssue(
+                level=PrecheckIssueLevel.warning,
+                code="payment_method_requires_reentry",
+                message=(
+                    f"Payment method ({payment_method.type.value}) can't be "
+                    "copied; the customer must re-enter their billing details."
+                ),
+                source_id=source_id,
+            )
+
+
+precheck_engine = PrecheckEngine()

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -1,7 +1,26 @@
+from enum import StrEnum
+
 from pydantic import UUID4
 
-from polar.kit.schemas import IDSchema, TimestampedSchema
+from polar.kit.schemas import IDSchema, Schema, TimestampedSchema
 from polar.models.merchant_migration import MerchantMigrationSourcePlatform
+
+
+class PrecheckIssueLevel(StrEnum):
+    blocker = "blocker"
+    warning = "warning"
+
+
+class PrecheckIssue(Schema):
+    level: PrecheckIssueLevel
+    code: str
+    message: str
+    source_id: str | None
+
+
+class PrecheckReport(Schema):
+    can_start: bool
+    issues: list[PrecheckIssue]
 
 
 class MerchantMigration(IDSchema, TimestampedSchema):

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -15,9 +15,13 @@ from polar.models.merchant_migration import (
     MerchantMigrationSourcePlatform,
     MerchantMigrationStep,
 )
+from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncReadSession
 
+from .adapters import SourceAdapter, StripeAdapter
+from .precheck import precheck_engine
 from .repository import MerchantMigrationRepository
+from .schemas import PrecheckReport
 from .stripe_oauth import (
     StripeAppNotConfigured,
     StripeOAuthError,
@@ -58,6 +62,23 @@ class InvalidStripeOAuthState(MerchantMigrationError):
         super().__init__(message, 400)
 
 
+class MerchantMigrationNotFound(MerchantMigrationError):
+    def __init__(self) -> None:
+        super().__init__("Merchant migration not found.", 404)
+
+
+class SourceNotConnected(MerchantMigrationError):
+    def __init__(self) -> None:
+        super().__init__("The migration source is not connected yet.", 400)
+
+
+class UnsupportedMigrationSource(MerchantMigrationError):
+    def __init__(self, source_platform: MerchantMigrationSourcePlatform) -> None:
+        super().__init__(
+            f"Migrations from {source_platform.value} are not supported yet.", 400
+        )
+
+
 @dataclass
 class StripeConnectResult:
     """Where the callback should send the merchant back, and an error message to
@@ -79,6 +100,73 @@ class MerchantMigrationService:
             MerchantMigration.id == migration_id
         )
         return await repository.get_one_or_none(statement)
+
+    async def run_precheck(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        migration_id: UUID,
+    ) -> PrecheckReport:
+        """Read the connected source, normalize it, and report whether it can be
+        imported. Advances the migration from source setup to the precheck step.
+        """
+        repository = MerchantMigrationRepository.from_session(session)
+        statement = repository.get_readable_statement(auth_subject).where(
+            MerchantMigration.id == migration_id
+        )
+        migration = await repository.get_one_or_none(statement)
+        if migration is None:
+            raise MerchantMigrationNotFound()
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            migration.organization_id,
+            OrganizationPermission.organization_manage,
+        )
+
+        organization = await OrganizationRepository.from_session(session).get_by_id(
+            migration.organization_id
+        )
+        if organization is None:
+            raise MerchantMigrationNotFound()
+
+        adapter = await self._build_adapter(session, migration)
+        report = await precheck_engine.run(adapter.extract(), organization)
+
+        await repository.update(
+            migration, update_dict={"step": MerchantMigrationStep.pre_check}
+        )
+        return report
+
+    async def _build_adapter(
+        self, session: AsyncSession, migration: MerchantMigration
+    ) -> SourceAdapter:
+        if migration.source_platform != MerchantMigrationSourcePlatform.stripe:
+            raise UnsupportedMigrationSource(migration.source_platform)
+        access_token = await self._refresh_stripe_access_token(session, migration)
+        return StripeAdapter(access_token)
+
+    async def _refresh_stripe_access_token(
+        self, session: AsyncSession, migration: MerchantMigration
+    ) -> str:
+        """Mint a short-lived access token from the stored refresh token, and
+        persist the rotated refresh token Stripe returns."""
+        credentials = migration.source_credentials
+        encrypted = credentials.get("refresh_token_encrypted")
+        if not encrypted:
+            raise SourceNotConnected()
+
+        refresh_token = await EncryptedString(
+            encrypted, SOURCE_CREDENTIALS_ENCRYPTION_CONTEXT
+        ).decrypt(id=str(migration.id))
+        token = await stripe_oauth.refresh(refresh_token)
+
+        new_credentials = await self._build_stripe_credentials(migration, token)
+        repository = MerchantMigrationRepository.from_session(session)
+        await repository.update(
+            migration, update_dict={"source_credentials": dict(new_credentials)}
+        )
+        return token.access_token
 
     async def create_stripe_authorization_url(
         self,

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -1,3 +1,4 @@
+from collections.abc import AsyncIterator
 from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
 
@@ -204,6 +205,67 @@ class TestGet:
         assert json_body["id"] == str(migration.id)
         assert json_body["source_platform"] == "stripe"
         assert "source_credentials" not in json_body
+
+
+@pytest.mark.asyncio
+class TestPrecheck:
+    async def test_anonymous(
+        self, client: AsyncClient, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        migration = await _create_migration(save_fixture, organization)
+        response = await client.post(f"/v1/merchant-migrations/{migration.id}/precheck")
+        assert response.status_code == 401
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_runs_and_returns_report(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        _configure_app(mocker)
+        mocker.patch(
+            "polar.merchant_migration.service.stripe_oauth.exchange_code",
+            return_value=build_stripe_oauth_token(),
+        )
+        mocker.patch(
+            "polar.merchant_migration.service.stripe_oauth.refresh",
+            return_value=build_stripe_oauth_token("rt_new"),
+        )
+        adapter = mocker.MagicMock()
+        adapter.extract.return_value = _empty_extract()
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
+        )
+
+        authorize = await client.get(
+            "/v1/merchant-migrations/stripe/authorize",
+            params={"organization_id": str(organization.id), "return_to": "/dashboard"},
+        )
+        state = parse_qs(urlparse(authorize.headers["location"]).query)["state"][0]
+        await client.get(
+            "/v1/merchant-migrations/stripe/callback",
+            params={"state": state, "code": "ac_test"},
+        )
+
+        repository = MerchantMigrationRepository.from_session(session)
+        migration = await repository.get_ongoing_by_source(
+            organization.id, MerchantMigrationSourcePlatform.stripe
+        )
+        assert migration is not None
+
+        response = await client.post(f"/v1/merchant-migrations/{migration.id}/precheck")
+        assert response.status_code == 200
+        json_body = response.json()
+        assert json_body["can_start"] is True
+        assert json_body["issues"] == []
+
+
+async def _empty_extract() -> AsyncIterator[object]:
+    return
+    yield
 
 
 async def _create_migration(

--- a/server/tests/merchant_migration/test_precheck.py
+++ b/server/tests/merchant_migration/test_precheck.py
@@ -1,0 +1,286 @@
+from collections.abc import AsyncIterator
+
+import pytest
+
+from polar.merchant_migration.canonical import (
+    CanonicalCollectionMethod,
+    CanonicalCustomer,
+    CanonicalPaymentMethod,
+    CanonicalPaymentMethodType,
+    CanonicalPrice,
+    CanonicalPricingScheme,
+    CanonicalProduct,
+    CanonicalRecord,
+    CanonicalSubscription,
+    CanonicalSubscriptionStatus,
+)
+from polar.merchant_migration.precheck import precheck_engine
+from polar.merchant_migration.schemas import PrecheckIssueLevel, PrecheckReport
+from polar.models import Organization
+from polar.models.organization import OrganizationStatus
+
+
+async def aiter_records(
+    records: list[CanonicalRecord],
+) -> AsyncIterator[CanonicalRecord]:
+    for record in records:
+        yield record
+
+
+def build_organization(
+    status: OrganizationStatus = OrganizationStatus.ACTIVE,
+) -> Organization:
+    return Organization(status=status)
+
+
+def build_customer(
+    *,
+    source_id: str = "cus_1",
+    email: str = "a@example.com",
+    country: str | None = "US",
+) -> CanonicalCustomer:
+    return CanonicalCustomer(
+        source_id=source_id,
+        email=email,
+        name="A",
+        country=country,
+    )
+
+
+def build_price(
+    *,
+    source_id: str = "price_1",
+    currency: str = "usd",
+    amount: int | None = 1000,
+    pricing_scheme: CanonicalPricingScheme = CanonicalPricingScheme.fixed,
+) -> CanonicalPrice:
+    return CanonicalPrice(
+        source_id=source_id,
+        currency=currency,
+        amount=amount,
+        pricing_scheme=pricing_scheme,
+    )
+
+
+def build_product(
+    *,
+    source_id: str = "prod_1:month:1",
+    product_source_id: str = "prod_1",
+    name: str = "Pro",
+    recurring_interval: str | None = "month",
+    recurring_interval_count: int = 1,
+    prices: list[CanonicalPrice] | None = None,
+) -> CanonicalProduct:
+    return CanonicalProduct(
+        source_id=source_id,
+        product_source_id=product_source_id,
+        name=name,
+        recurring_interval=recurring_interval,
+        recurring_interval_count=recurring_interval_count,
+        prices=prices if prices is not None else [build_price()],
+    )
+
+
+def build_subscription(
+    *,
+    source_id: str = "sub_1",
+    status: CanonicalSubscriptionStatus = CanonicalSubscriptionStatus.active,
+    collection_method: CanonicalCollectionMethod = (
+        CanonicalCollectionMethod.charge_automatically
+    ),
+    trialing: bool = False,
+    paused_collection: bool = False,
+    line_item_count: int = 1,
+    quantity: int = 1,
+    payment_method: CanonicalPaymentMethod | None = None,
+) -> CanonicalSubscription:
+    return CanonicalSubscription(
+        source_id=source_id,
+        customer_source_id="cus_1",
+        price_source_id="price_1",
+        status=status,
+        collection_method=collection_method,
+        current_period_start=None,
+        current_period_end=None,
+        trialing=trialing,
+        paused_collection=paused_collection,
+        line_item_count=line_item_count,
+        quantity=quantity,
+        payment_method=payment_method,
+    )
+
+
+def codes(report: PrecheckReport, level: PrecheckIssueLevel) -> set[str]:
+    return {issue.code for issue in report.issues if issue.level == level}
+
+
+async def run(
+    records: list[CanonicalRecord],
+    *,
+    organization: Organization | None = None,
+) -> PrecheckReport:
+    return await precheck_engine.run(
+        aiter_records(records),
+        organization or build_organization(),
+    )
+
+
+@pytest.mark.asyncio
+class TestPrecheckEngine:
+    async def test_clean_catalog_can_start(self) -> None:
+        report = await run([build_product(), build_customer(), build_subscription()])
+        assert report.can_start is True
+        assert report.issues == []
+
+    async def test_consumes_stream_without_losing_record_types(self) -> None:
+        # Regression: a one-shot stream must not be exhausted before customers.
+        report = await run(
+            [
+                build_product(
+                    prices=[build_price(pricing_scheme=CanonicalPricingScheme.tiered)]
+                ),
+                build_customer(source_id="cus_1", email="dup@example.com"),
+                build_customer(source_id="cus_2", email="dup@example.com"),
+            ]
+        )
+        warnings = codes(report, PrecheckIssueLevel.warning)
+        assert "unsupported_pricing_scheme" in warnings
+        assert "duplicate_customer_email" in warnings
+
+    async def test_organization_not_renewal_enabled_blocks(self) -> None:
+        report = await run(
+            [build_product()],
+            organization=build_organization(OrganizationStatus.CREATED),
+        )
+        assert "organization_not_renewal_enabled" in codes(
+            report, PrecheckIssueLevel.blocker
+        )
+
+    async def test_non_fixed_pricing_warns_and_can_start(self) -> None:
+        report = await run(
+            [
+                build_product(
+                    prices=[build_price(pricing_scheme=CanonicalPricingScheme.tiered)]
+                )
+            ]
+        )
+        assert "unsupported_pricing_scheme" in codes(report, PrecheckIssueLevel.warning)
+        assert report.can_start is True
+
+    async def test_one_time_product_warns(self) -> None:
+        report = await run([build_product(recurring_interval=None)])
+        assert "one_time_product" in codes(report, PrecheckIssueLevel.warning)
+
+    async def test_unsupported_interval_count_warns(self) -> None:
+        report = await run([build_product(recurring_interval_count=1000)])
+        assert "unsupported_recurring_interval" in codes(
+            report, PrecheckIssueLevel.warning
+        )
+
+    async def test_unsupported_currency_warns(self) -> None:
+        report = await run([build_product(prices=[build_price(currency="xyz")])])
+        assert "unsupported_currency" in codes(report, PrecheckIssueLevel.warning)
+
+    async def test_price_below_minimum_warns(self) -> None:
+        report = await run([build_product(prices=[build_price(amount=1)])])
+        assert "price_out_of_bounds" in codes(report, PrecheckIssueLevel.warning)
+
+    async def test_free_price_is_allowed(self) -> None:
+        report = await run([build_product(prices=[build_price(amount=0)])])
+        assert "price_out_of_bounds" not in codes(report, PrecheckIssueLevel.warning)
+
+    async def test_price_without_amount_warns(self) -> None:
+        report = await run([build_product(prices=[build_price(amount=None)])])
+        assert "unsupported_price_amount" in codes(report, PrecheckIssueLevel.warning)
+
+    async def test_duplicate_product_names_warn(self) -> None:
+        report = await run(
+            [
+                build_product(source_id="prod_1:month:1", product_source_id="prod_1"),
+                build_product(source_id="prod_2:month:1", product_source_id="prod_2"),
+            ]
+        )
+        assert "duplicate_product_name" in codes(report, PrecheckIssueLevel.warning)
+        assert report.can_start is True
+
+    async def test_same_product_different_intervals_is_not_a_duplicate(self) -> None:
+        report = await run(
+            [
+                build_product(
+                    source_id="prod_1:month:1",
+                    product_source_id="prod_1",
+                    recurring_interval="month",
+                ),
+                build_product(
+                    source_id="prod_1:year:1",
+                    product_source_id="prod_1",
+                    recurring_interval="year",
+                ),
+            ]
+        )
+        assert "duplicate_product_name" not in codes(report, PrecheckIssueLevel.warning)
+
+    async def test_duplicate_emails_warn(self) -> None:
+        report = await run(
+            [
+                build_customer(source_id="cus_1", email="a@example.com"),
+                build_customer(source_id="cus_2", email="A@Example.com"),
+            ]
+        )
+        assert "duplicate_customer_email" in codes(report, PrecheckIssueLevel.warning)
+
+    async def test_missing_country_warns(self) -> None:
+        report = await run(
+            [
+                build_customer(source_id="cus_1", country=None),
+                build_customer(source_id="cus_2", country="US"),
+            ]
+        )
+        assert "customer_missing_country" in codes(report, PrecheckIssueLevel.warning)
+
+    async def test_subscription_warnings_do_not_block(self) -> None:
+        report = await run(
+            [
+                build_subscription(source_id="sub_multi", line_item_count=2),
+                build_subscription(source_id="sub_qty", quantity=5),
+                build_subscription(
+                    source_id="sub_invoice",
+                    collection_method=CanonicalCollectionMethod.send_invoice,
+                ),
+                build_subscription(
+                    source_id="sub_past_due",
+                    status=CanonicalSubscriptionStatus.past_due,
+                ),
+                build_subscription(source_id="sub_paused", paused_collection=True),
+                build_subscription(source_id="sub_trial", trialing=True),
+                build_subscription(
+                    source_id="sub_link",
+                    payment_method=CanonicalPaymentMethod(
+                        source_id="pm_1", type=CanonicalPaymentMethodType.link
+                    ),
+                ),
+            ]
+        )
+        warnings = codes(report, PrecheckIssueLevel.warning)
+        assert "multiple_line_items" in warnings
+        assert "unsupported_quantity" in warnings
+        assert "send_invoice_collection" in warnings
+        assert "subscription_not_importable" in warnings
+        assert "subscription_paused_collection" in warnings
+        assert "subscription_trialing" in warnings
+        assert "payment_method_requires_reentry" in warnings
+        assert report.can_start is True
+
+    async def test_copyable_payment_method_does_not_warn(self) -> None:
+        report = await run(
+            [
+                build_subscription(
+                    payment_method=CanonicalPaymentMethod(
+                        source_id="pm_1", type=CanonicalPaymentMethodType.card
+                    )
+                )
+            ]
+        )
+        assert "payment_method_requires_reentry" not in codes(
+            report, PrecheckIssueLevel.warning
+        )

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -1,10 +1,22 @@
+from collections.abc import AsyncIterator
+
 import pytest
 from pytest_mock import MockerFixture
 
 from polar.auth.models import AuthSubject
 from polar.config import settings
 from polar.kit import jwt
+from polar.merchant_migration.canonical import (
+    CanonicalPrice,
+    CanonicalPricingScheme,
+    CanonicalProduct,
+    CanonicalRecord,
+)
 from polar.merchant_migration.repository import MerchantMigrationRepository
+from polar.merchant_migration.service import (
+    SourceNotConnected,
+    UnsupportedMigrationSource,
+)
 from polar.merchant_migration.service import merchant_migration as service
 from polar.models import (
     MerchantMigration,
@@ -19,6 +31,15 @@ from polar.models.merchant_migration import (
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
 from tests.merchant_migration._helpers import build_stripe_oauth_token
+
+
+class _FakeAdapter:
+    def __init__(self, records: list[CanonicalRecord]) -> None:
+        self._records = records
+
+    async def extract(self) -> AsyncIterator[CanonicalRecord]:
+        for record in self._records:
+            yield record
 
 
 @pytest.mark.asyncio
@@ -113,3 +134,114 @@ class TestCompleteStripeAuthorization:
         # the refresh token is stored as ciphertext, never in clear text
         assert credentials["refresh_token_encrypted"] != "rt_secret"
         assert credentials["refresh_token_encrypted"].startswith("v1.")
+
+
+async def _create_connected_migration(
+    save_fixture: SaveFixture, organization: Organization
+) -> MerchantMigration:
+    migration = MerchantMigration(
+        organization_id=organization.id,
+        source_platform=MerchantMigrationSourcePlatform.stripe,
+        step=MerchantMigrationStep.source_setup,
+    )
+    await save_fixture(migration)
+    credentials = await service._build_stripe_credentials(
+        migration, build_stripe_oauth_token("rt_old")
+    )
+    migration.source_credentials = dict(credentials)
+    await save_fixture(migration)
+    return migration
+
+
+@pytest.mark.asyncio
+class TestRunPrecheck:
+    @pytest.mark.auth
+    async def test_extracts_rotates_token_and_advances_step(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _create_connected_migration(save_fixture, organization)
+        old_ciphertext = migration.source_credentials["refresh_token_encrypted"]
+
+        refresh = mocker.patch(
+            "polar.merchant_migration.service.stripe_oauth.refresh",
+            return_value=build_stripe_oauth_token("rt_new"),
+        )
+        adapter = _FakeAdapter(
+            [
+                CanonicalProduct(
+                    source_id="prod_1:month:1",
+                    product_source_id="prod_1",
+                    name="Pro",
+                    recurring_interval="month",
+                    recurring_interval_count=1,
+                    prices=[
+                        CanonicalPrice(
+                            source_id="price_1",
+                            currency="usd",
+                            amount=1000,
+                            pricing_scheme=CanonicalPricingScheme.fixed,
+                        )
+                    ],
+                )
+            ]
+        )
+        stripe_adapter = mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
+        )
+
+        report = await service.run_precheck(session, auth_subject, migration.id)
+
+        assert report.can_start is True
+        refresh.assert_awaited_once_with("rt_old")
+        stripe_adapter.assert_called_once_with("rk_test")
+
+        repository = MerchantMigrationRepository.from_session(session)
+        updated = await repository.get_by_id(migration.id)
+        assert updated is not None
+        assert updated.step == MerchantMigrationStep.pre_check
+        # the rotated refresh token is re-persisted as fresh ciphertext
+        assert updated.source_credentials["refresh_token_encrypted"] != old_ciphertext
+
+    @pytest.mark.auth
+    async def test_source_not_connected(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = MerchantMigration(
+            organization_id=organization.id,
+            source_platform=MerchantMigrationSourcePlatform.stripe,
+            step=MerchantMigrationStep.source_setup,
+        )
+        await save_fixture(migration)
+
+        with pytest.raises(SourceNotConnected):
+            await service.run_precheck(session, auth_subject, migration.id)
+
+    @pytest.mark.auth
+    async def test_unsupported_source(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = MerchantMigration(
+            organization_id=organization.id,
+            source_platform=MerchantMigrationSourcePlatform.paddle,
+            step=MerchantMigrationStep.source_setup,
+        )
+        await save_fixture(migration)
+
+        with pytest.raises(UnsupportedMigrationSource):
+            await service.run_precheck(session, auth_subject, migration.id)


### PR DESCRIPTION
## Summary

Adds the pre-check step of merchant migrations: before importing anything, read the merchant's connected billing source (Stripe), normalize it, and report whether its catalog + subscriptions can be imported into Polar. Nothing is written for now.

Three pieces to review:

1. adapters/stripe.py - reads customers / products+prices / subscriptions via a restricted-key Stripe client and maps them to CanonicalRecords (canonical.py). So the engine never sees Stripe types.
2. precheck.py - PrecheckEngine.run reads the adapter output and aggregates (email counts, product-name map). Each check yields a PrecheckIssue.
3. service.py / endpoints.py - a thin wiring only

There are two categories for checks:
- warning: the migration can proceed but the record is skipped. Most of the errors will be warnings. 
- blocker: the migration cannot be performed. For now, we only check the org status, but later on we will check stripe account country (we cannot import India PAN) or from Connect accounts.


## Checklist

- [x] This PR addresses a single concern (one feature)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)