### PR TITLE
feat(impersonation): scope the session to the impersonated org

### DIFF
--- a/server/polar/backoffice/impersonation/endpoints.py
+++ b/server/polar/backoffice/impersonation/endpoints.py
@@ -53,8 +53,6 @@ async def start_impersonation(
             status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
         )
 
-    # Resolve the organization to impersonate into (the requested one, or the
-    # user's first) before minting the session, so we can scope the session to it.
     org_repository = OrganizationRepository.from_session(session)
     user_orgs = await org_repository.get_all_by_user(target_user.id)
     target_org = next(
@@ -68,7 +66,7 @@ async def start_impersonation(
         )
 
     # Scope the session to the organization so it can reach the org even when SSO
-    # is enforced (the break-glass path) and stays limited to it.
+    # is enforced (and eventually break the glass if something is missconfigured).
     token, impersonation_session = await auth_service._create_user_session(
         session=session,
         user=target_user,

--- a/server/polar/backoffice/impersonation/endpoints.py
+++ b/server/polar/backoffice/impersonation/endpoints.py
@@ -53,24 +53,8 @@ async def start_impersonation(
             status_code=status.HTTP_404_NOT_FOUND, detail="User not found"
         )
 
-    # Create a read-only impersonation session for the target user
-    token, impersonation_session = await auth_service._create_user_session(
-        session=session,
-        user=target_user,
-        user_agent=request.headers.get("User-Agent", ""),
-        scopes=list(READ_ONLY_SCOPES),
-        expire_in=timedelta(minutes=60),
-    )
-
-    admin_token = request.cookies.get(settings.IMPERSONATION_COOKIE_KEY)
-    if admin_token:
-        token_hash = get_token_hash(admin_token, secret=settings.SECRET)
-        if token_hash != admin_session.token:
-            admin_token = None
-    if not admin_token:
-        admin_token = request.cookies.get(settings.USER_SESSION_COOKIE_KEY)
-
-    # Create response object
+    # Resolve the organization to impersonate into (the requested one, or the
+    # user's first) before minting the session, so we can scope the session to it.
     org_repository = OrganizationRepository.from_session(session)
     user_orgs = await org_repository.get_all_by_user(target_user.id)
     target_org = next(
@@ -82,6 +66,26 @@ async def start_impersonation(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="User has no organizations to impersonate into",
         )
+
+    # Scope the session to the organization so it can reach the org even when SSO
+    # is enforced (the break-glass path) and stays limited to it.
+    token, impersonation_session = await auth_service._create_user_session(
+        session=session,
+        user=target_user,
+        user_agent=request.headers.get("User-Agent", ""),
+        scopes=list(READ_ONLY_SCOPES),
+        expire_in=timedelta(minutes=60),
+        organization_ids=frozenset({target_org.id}),
+    )
+
+    admin_token = request.cookies.get(settings.IMPERSONATION_COOKIE_KEY)
+    if admin_token:
+        token_hash = get_token_hash(admin_token, secret=settings.SECRET)
+        if token_hash != admin_session.token:
+            admin_token = None
+    if not admin_token:
+        admin_token = request.cookies.get(settings.USER_SESSION_COOKIE_KEY)
+
     response = HXRedirectResponse(
         request, f"{settings.FRONTEND_BASE_URL}/dashboard/{target_org.slug}", 307
     )

--- a/server/polar/backoffice/impersonation/endpoints.py
+++ b/server/polar/backoffice/impersonation/endpoints.py
@@ -148,14 +148,19 @@ async def end_impersonation(
         )
 
     # Get the current impersonated session to delete it
-    impersonated_user_id = None
+    impersonated_org_id = None
     current_token = request.cookies.get(settings.USER_SESSION_COOKIE_KEY)
     if current_token:
         current_session = await auth_service._get_user_session_by_token(
             session, current_token
         )
         if current_session:
-            impersonated_user_id = current_session.user_id
+            # Impersonation sessions are scoped to a single organization; use it
+            # to send the admin back to that organization in the backoffice.
+            if current_session.organization_scopes:
+                impersonated_org_id = current_session.organization_scopes[
+                    0
+                ].organization_id
             await session.delete(current_session)
 
     # Validate the admin session is still valid
@@ -166,9 +171,9 @@ async def end_impersonation(
             detail="Admin session expired or invalid",
         )
 
-    if impersonated_user_id:
+    if impersonated_org_id:
         response = RedirectResponse(
-            settings.generate_backoffice_url(f"/users/{impersonated_user_id}")
+            settings.generate_backoffice_url(f"/organizations/{impersonated_org_id}")
         )
     else:
         response = RedirectResponse(settings.generate_backoffice_url("/"))

--- a/server/polar/backoffice/impersonation/endpoints.py
+++ b/server/polar/backoffice/impersonation/endpoints.py
@@ -66,7 +66,7 @@ async def start_impersonation(
         )
 
     # Scope the session to the organization so it can reach the org even when SSO
-    # is enforced (and eventually break the glass if something is missconfigured).
+    # is enforced (and can eventually break the glass if something is misconfigured).
     token, impersonation_session = await auth_service._create_user_session(
         session=session,
         user=target_user,

--- a/server/tests/backoffice/impersonation/test_endpoints.py
+++ b/server/tests/backoffice/impersonation/test_endpoints.py
@@ -1,0 +1,55 @@
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+from starlette.requests import Request
+
+from polar.backoffice.impersonation.endpoints import start_impersonation
+from polar.models import Organization, User, UserOrganization, UserSession
+from polar.postgres import AsyncSession
+
+
+def _request() -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/start",
+            "headers": [(b"user-agent", b"test"), (b"host", b"127.0.0.1")],
+            "query_string": b"",
+            "scheme": "http",
+            "server": ("127.0.0.1", 8000),
+        }
+    )
+
+
+@pytest.mark.asyncio
+class TestStartImpersonation:
+    async def test_scopes_session_to_organization(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+        user_organization: UserOrganization,
+    ) -> None:
+        # The impersonation session must be scoped to the organization so it can
+        # reach the org even when SSO is enforced (and eventually break the glass
+        # if something is missconfigured).
+        await start_impersonation(
+            request=_request(),
+            admin_session=MagicMock(),
+            user_id=str(user.id),
+            organization_id=str(organization.id),
+            session=session,
+        )
+
+        result = await session.execute(
+            select(UserSession)
+            .where(UserSession.user_id == user.id)
+            .options(selectinload(UserSession.organization_scopes))
+        )
+        user_session = result.unique().scalars().one()
+        assert {
+            scope.organization_id for scope in user_session.organization_scopes
+        } == {organization.id}


### PR DESCRIPTION
## Summary

So an admin impersonation can reach an organization even when it enforces SSO. 
The session is scoped to the target org (and stays limited to it).

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

