### PR TITLE
feat(merchant-migration): run precheck as a background job

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -22201,6 +22201,7 @@ export interface components {
        */
       organization_id: string
       source_platform: components['schemas']['MerchantMigrationSourcePlatform']
+      precheck_report?: components['schemas']['PrecheckReport'] | null
     }
     /** MerchantMigrationNotFound */
     MerchantMigrationNotFound: {
@@ -47949,13 +47950,13 @@ export interface operations {
     }
     requestBody?: never
     responses: {
-      /** @description Successful Response */
-      200: {
+      /** @description Pre-check scheduled. */
+      202: {
         headers: {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['PrecheckReport']
+          'application/json': components['schemas']['MerchantMigration']
         }
       }
       /** @description The source is not connected or isn't supported. */

--- a/server/migrations/versions/2026-07-02-1200_add_precheck_report_to_merchant_.py
+++ b/server/migrations/versions/2026-07-02-1200_add_precheck_report_to_merchant_.py
@@ -1,0 +1,34 @@
+"""add precheck_report to merchant_migrations
+
+Revision ID: b7f3a9c21d84
+Revises: fef393bb1f53
+Create Date: 2026-07-02 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "b7f3a9c21d84"
+down_revision = "fef393bb1f53"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "merchant_migrations",
+        sa.Column(
+            "precheck_report",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("merchant_migrations", "precheck_report")

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -15,7 +15,6 @@ from polar.routing import APIRouter
 
 from .auth import MerchantMigrationRead, MerchantMigrationWrite
 from .schemas import MerchantMigration as MerchantMigrationSchema
-from .schemas import PrecheckReport
 from .service import (
     MerchantMigrationNotFound,
     SourceNotConnected,
@@ -90,9 +89,11 @@ async def get(
 
 @router.post(
     "/{id}/precheck",
-    response_model=PrecheckReport,
+    response_model=MerchantMigrationSchema,
+    status_code=202,
     summary="Run Merchant Migration Pre-check",
     responses={
+        202: {"description": "Pre-check scheduled."},
         400: {
             "description": "The source is not connected or isn't supported.",
             "model": SourceNotConnected.schema() | UnsupportedMigrationSource.schema(),
@@ -111,5 +112,5 @@ async def precheck(
     id: UUID4,
     auth_subject: MerchantMigrationWrite,
     session: AsyncSession = Depends(get_db_session),
-) -> PrecheckReport:
-    return await merchant_migration_service.run_precheck(session, auth_subject, id)
+) -> MerchantMigration:
+    return await merchant_migration_service.enqueue_precheck(session, auth_subject, id)

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -26,3 +26,5 @@ class PrecheckReport(Schema):
 class MerchantMigration(IDSchema, TimestampedSchema):
     organization_id: UUID4
     source_platform: MerchantMigrationSourcePlatform
+    # Null until the precheck task has run at least once.
+    precheck_report: PrecheckReport | None = None

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -17,11 +17,11 @@ from polar.models.merchant_migration import (
 )
 from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncReadSession
+from polar.worker import enqueue_job
 
 from .adapters import SourceAdapter, StripeAdapter
 from .precheck import precheck_engine
 from .repository import MerchantMigrationRepository
-from .schemas import PrecheckReport
 from .stripe_oauth import (
     StripeAppNotConfigured,
     StripeOAuthError,
@@ -101,14 +101,15 @@ class MerchantMigrationService:
         )
         return await repository.get_one_or_none(statement)
 
-    async def run_precheck(
+    async def enqueue_precheck(
         self,
         session: AsyncSession,
         auth_subject: AuthSubject[User | Organization],
         migration_id: UUID,
-    ) -> PrecheckReport:
-        """Read the connected source, normalize it, and report whether it can be
-        imported. Advances the migration from source setup to the precheck step.
+    ) -> MerchantMigration:
+        """Validate the request and schedule the precheck. Reading the source can
+        be slow on large accounts, so the extraction and evaluation run in a
+        background task; the report lands on ``migration.precheck_report``.
         """
         repository = MerchantMigrationRepository.from_session(session)
         statement = repository.get_readable_statement(auth_subject).where(
@@ -123,6 +124,18 @@ class MerchantMigrationService:
             migration.organization_id,
             OrganizationPermission.organization_manage,
         )
+        self._validate_source(migration)
+
+        enqueue_job("merchant_migration.precheck", migration_id=migration.id)
+        return migration
+
+    async def execute_precheck(self, session: AsyncSession, migration_id: UUID) -> None:
+        """Background body: read the connected source, run the precheck, store the
+        report, and advance the migration to the precheck step."""
+        repository = MerchantMigrationRepository.from_session(session)
+        migration = await repository.get_by_id(migration_id)
+        if migration is None:
+            raise MerchantMigrationNotFound()
 
         organization = await OrganizationRepository.from_session(session).get_by_id(
             migration.organization_id
@@ -134,15 +147,23 @@ class MerchantMigrationService:
         report = await precheck_engine.run(adapter.extract(), organization)
 
         await repository.update(
-            migration, update_dict={"step": MerchantMigrationStep.pre_check}
+            migration,
+            update_dict={
+                "precheck_report": report.model_dump(mode="json"),
+                "step": MerchantMigrationStep.pre_check,
+            },
         )
-        return report
+
+    def _validate_source(self, migration: MerchantMigration) -> None:
+        if migration.source_platform != MerchantMigrationSourcePlatform.stripe:
+            raise UnsupportedMigrationSource(migration.source_platform)
+        if not migration.source_credentials.get("refresh_token_encrypted"):
+            raise SourceNotConnected()
 
     async def _build_adapter(
         self, session: AsyncSession, migration: MerchantMigration
     ) -> SourceAdapter:
-        if migration.source_platform != MerchantMigrationSourcePlatform.stripe:
-            raise UnsupportedMigrationSource(migration.source_platform)
+        self._validate_source(migration)
         access_token = await self._refresh_stripe_access_token(session, migration)
         return StripeAdapter(access_token)
 

--- a/server/polar/merchant_migration/tasks.py
+++ b/server/polar/merchant_migration/tasks.py
@@ -1,0 +1,11 @@
+from uuid import UUID
+
+from polar.worker import AsyncSessionMaker, TaskPriority, actor
+
+from .service import merchant_migration as merchant_migration_service
+
+
+@actor(actor_name="merchant_migration.precheck", priority=TaskPriority.LOW)
+async def merchant_migration_precheck(migration_id: UUID) -> None:
+    async with AsyncSessionMaker() as session:
+        await merchant_migration_service.execute_precheck(session, migration_id)

--- a/server/polar/models/merchant_migration.py
+++ b/server/polar/models/merchant_migration.py
@@ -63,6 +63,11 @@ class MerchantMigration(RecordModel):
     pan_transfer_steps: Mapped[list[dict[str, Any]]] = mapped_column(
         JSONB, nullable=False, default=list
     )
+    # The latest PrecheckReport (a serialized schemas.PrecheckReport), computed by
+    # the precheck background task. Null until the first run completes.
+    precheck_report: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, nullable=True, default=None
+    )
 
     @declared_attr
     def organization(cls) -> Mapped["Organization"]:

--- a/server/polar/tasks.py
+++ b/server/polar/tasks.py
@@ -19,6 +19,7 @@ from polar.integrations.chargeback_stop import tasks as chargeback_stop
 from polar.integrations.polar import tasks as polar_self
 from polar.integrations.stripe import tasks as stripe
 from polar.integrations.tinybird import tasks as tinybird
+from polar.merchant_migration import tasks as merchant_migration
 from polar.meter import tasks as meter
 from polar.notifications import tasks as notifications
 from polar.oauth2 import tasks as oauth2
@@ -57,6 +58,7 @@ __all__ = [
     "eventstream",
     "external_event",
     "feedback",
+    "merchant_migration",
     "meter",
     "notifications",
     "oauth2",

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -1,4 +1,3 @@
-from collections.abc import AsyncIterator
 from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
 
@@ -217,7 +216,7 @@ class TestPrecheck:
         assert response.status_code == 401
 
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
-    async def test_runs_and_returns_report(
+    async def test_schedules_precheck(
         self,
         client: AsyncClient,
         session: AsyncSession,
@@ -230,15 +229,7 @@ class TestPrecheck:
             "polar.merchant_migration.service.stripe_oauth.exchange_code",
             return_value=build_stripe_oauth_token(),
         )
-        mocker.patch(
-            "polar.merchant_migration.service.stripe_oauth.refresh",
-            return_value=build_stripe_oauth_token("rt_new"),
-        )
-        adapter = mocker.MagicMock()
-        adapter.extract.return_value = _empty_extract()
-        mocker.patch(
-            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
-        )
+        enqueue_job = mocker.patch("polar.merchant_migration.service.enqueue_job")
 
         authorize = await client.get(
             "/v1/merchant-migrations/stripe/authorize",
@@ -257,15 +248,13 @@ class TestPrecheck:
         assert migration is not None
 
         response = await client.post(f"/v1/merchant-migrations/{migration.id}/precheck")
-        assert response.status_code == 200
+        assert response.status_code == 202
         json_body = response.json()
-        assert json_body["can_start"] is True
-        assert json_body["issues"] == []
-
-
-async def _empty_extract() -> AsyncIterator[object]:
-    return
-    yield
+        assert json_body["id"] == str(migration.id)
+        assert json_body["precheck_report"] is None
+        enqueue_job.assert_called_once_with(
+            "merchant_migration.precheck", migration_id=migration.id
+        )
 
 
 async def _create_migration(

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -154,9 +154,9 @@ async def _create_connected_migration(
 
 
 @pytest.mark.asyncio
-class TestRunPrecheck:
+class TestEnqueuePrecheck:
     @pytest.mark.auth
-    async def test_extracts_rotates_token_and_advances_step(
+    async def test_validates_and_enqueues(
         self,
         mocker: MockerFixture,
         session: AsyncSession,
@@ -164,6 +164,64 @@ class TestRunPrecheck:
         auth_subject: AuthSubject[User],
         organization: Organization,
         user_organization: UserOrganization,
+    ) -> None:
+        migration = await _create_connected_migration(save_fixture, organization)
+        enqueue_job = mocker.patch("polar.merchant_migration.service.enqueue_job")
+
+        result = await service.enqueue_precheck(session, auth_subject, migration.id)
+
+        assert result.id == migration.id
+        enqueue_job.assert_called_once_with(
+            "merchant_migration.precheck", migration_id=migration.id
+        )
+
+    @pytest.mark.auth
+    async def test_source_not_connected(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = MerchantMigration(
+            organization_id=organization.id,
+            source_platform=MerchantMigrationSourcePlatform.stripe,
+            step=MerchantMigrationStep.source_setup,
+        )
+        await save_fixture(migration)
+
+        with pytest.raises(SourceNotConnected):
+            await service.enqueue_precheck(session, auth_subject, migration.id)
+
+    @pytest.mark.auth
+    async def test_unsupported_source(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = MerchantMigration(
+            organization_id=organization.id,
+            source_platform=MerchantMigrationSourcePlatform.paddle,
+            step=MerchantMigrationStep.source_setup,
+        )
+        await save_fixture(migration)
+
+        with pytest.raises(UnsupportedMigrationSource):
+            await service.enqueue_precheck(session, auth_subject, migration.id)
+
+
+@pytest.mark.asyncio
+class TestExecutePrecheck:
+    async def test_extracts_rotates_token_and_stores_report(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
     ) -> None:
         migration = await _create_connected_migration(save_fixture, organization)
         old_ciphertext = migration.source_credentials["refresh_token_encrypted"]
@@ -195,9 +253,8 @@ class TestRunPrecheck:
             "polar.merchant_migration.service.StripeAdapter", return_value=adapter
         )
 
-        report = await service.run_precheck(session, auth_subject, migration.id)
+        await service.execute_precheck(session, migration.id)
 
-        assert report.can_start is True
         refresh.assert_awaited_once_with("rt_old")
         stripe_adapter.assert_called_once_with("rk_test")
 
@@ -205,43 +262,7 @@ class TestRunPrecheck:
         updated = await repository.get_by_id(migration.id)
         assert updated is not None
         assert updated.step == MerchantMigrationStep.pre_check
+        assert updated.precheck_report is not None
+        assert updated.precheck_report["can_start"] is True
         # the rotated refresh token is re-persisted as fresh ciphertext
         assert updated.source_credentials["refresh_token_encrypted"] != old_ciphertext
-
-    @pytest.mark.auth
-    async def test_source_not_connected(
-        self,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        auth_subject: AuthSubject[User],
-        organization: Organization,
-        user_organization: UserOrganization,
-    ) -> None:
-        migration = MerchantMigration(
-            organization_id=organization.id,
-            source_platform=MerchantMigrationSourcePlatform.stripe,
-            step=MerchantMigrationStep.source_setup,
-        )
-        await save_fixture(migration)
-
-        with pytest.raises(SourceNotConnected):
-            await service.run_precheck(session, auth_subject, migration.id)
-
-    @pytest.mark.auth
-    async def test_unsupported_source(
-        self,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        auth_subject: AuthSubject[User],
-        organization: Organization,
-        user_organization: UserOrganization,
-    ) -> None:
-        migration = MerchantMigration(
-            organization_id=organization.id,
-            source_platform=MerchantMigrationSourcePlatform.paddle,
-            step=MerchantMigrationStep.source_setup,
-        )
-        await save_fixture(migration)
-
-        with pytest.raises(UnsupportedMigrationSource):
-            await service.run_precheck(session, auth_subject, migration.id)


### PR DESCRIPTION
Turns the synchronous pre-check into an async background job.

- `POST /{id}/precheck` now validates + enqueues, returning **202** with the migration (`precheck_report: null`).
- A Dramatiq worker (`merchant_migration.precheck`) extracts the source, runs the engine, and stores the result on a new `precheck_report` JSONB column, advancing the migration to the `pre_check` step.
- `GET /{id}` surfaces the stored report once ready.


## Checklist
- [x] Tests pass (`tests/merchant_migration/`, 34 passed)
- [x] Lint + mypy clean
- [x] Migration re-parented onto current `main` head

🤖 Generated with [Claude Code](https://claude.com/claude-code)