### PR TITLE
feat(slack): read encrypted SlackApp secrets with plaintext fallback

### DIFF
--- a/server/polar/benefit/strategies/slack_shared_channel/service.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/service.py
@@ -83,9 +83,9 @@ class BenefitSlackSharedChannelService(
             properties = self._get_properties(benefit)
             team_invitees = properties.get("team_invitees") or []
             if team_invitees:
-                integration = await self._get_installed_integration(benefit)
+                _, bot_token = await self._get_installed_integration(benefit)
                 await self._safe_invite_team(
-                    bot_token=cast(str, await integration.get_bot_token()),
+                    bot_token=bot_token,
                     channel=existing_channel_id,
                     users=team_invitees,
                     bound_logger=bound_logger,
@@ -119,10 +119,9 @@ class BenefitSlackSharedChannelService(
         bound_logger: Any,
     ) -> BenefitGrantSlackSharedChannelProperties:
         properties = self._get_properties(benefit)
-        integration = await self._get_installed_integration(benefit)
+        _, bot_token = await self._get_installed_integration(benefit)
 
         context = self._build_context(customer)
-        bot_token = cast(str, await integration.get_bot_token())
 
         existing_channel_id = grant_properties.get("channel_id")
         if existing_channel_id:
@@ -316,7 +315,7 @@ class BenefitSlackSharedChannelService(
                     }
                 ]
             )
-        if integration.bot_token is None:
+        if await integration.get_bot_token() is None:
             raise BenefitPropertiesValidationError(
                 [
                     {
@@ -329,13 +328,16 @@ class BenefitSlackSharedChannelService(
             )
         return cast(BenefitSlackSharedChannelProperties, properties)
 
-    async def _get_installed_integration(self, benefit: Benefit) -> SlackApp:
+    async def _get_installed_integration(
+        self, benefit: Benefit
+    ) -> tuple[SlackApp, str]:
         integration = await self._get_integration(benefit)
-        if integration is None or integration.bot_token is None:
+        bot_token = await integration.get_bot_token() if integration else None
+        if integration is None or bot_token is None:
             raise BenefitActionRequiredError(
                 "The Slack integration is not installed for this benefit."
             )
-        return integration
+        return integration, bot_token
 
     async def _get_integration(self, benefit: Benefit) -> SlackApp | None:
         integration_id = benefit.properties.get("slack_integration_id")

--- a/server/polar/benefit/strategies/slack_shared_channel/service.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/service.py
@@ -85,7 +85,7 @@ class BenefitSlackSharedChannelService(
             if team_invitees:
                 integration = await self._get_installed_integration(benefit)
                 await self._safe_invite_team(
-                    bot_token=cast(str, integration.bot_token),
+                    bot_token=cast(str, await integration.get_bot_token()),
                     channel=existing_channel_id,
                     users=team_invitees,
                     bound_logger=bound_logger,
@@ -122,7 +122,7 @@ class BenefitSlackSharedChannelService(
         integration = await self._get_installed_integration(benefit)
 
         context = self._build_context(customer)
-        bot_token = cast(str, integration.bot_token)
+        bot_token = cast(str, await integration.get_bot_token())
 
         existing_channel_id = grant_properties.get("channel_id")
         if existing_channel_id:
@@ -241,13 +241,14 @@ class BenefitSlackSharedChannelService(
             return self._revoked_properties(grant_properties, keep_channel=True)
 
         integration = await self._get_integration(benefit)
-        if integration is None or integration.bot_token is None:
+        bot_token = await integration.get_bot_token() if integration else None
+        if bot_token is None:
             bound_logger.info("Slack integration uninstalled; skipping archive")
             return self._revoked_properties(grant_properties, keep_channel=True)
 
         try:
             result = await self._client.conversations_archive(
-                bot_token=integration.bot_token, channel=channel_id
+                bot_token=bot_token, channel=channel_id
             )
         except httpx.HTTPError as e:
             bound_logger.warning("Slack archive failed", error=str(e))

--- a/server/polar/integrations/slack/endpoints.py
+++ b/server/polar/integrations/slack/endpoints.py
@@ -281,11 +281,12 @@ async def events(
 
     repository = SlackAppRepository.from_session(session)
     integration = await repository.get_by_app_id(api_app_id)
-    if integration is None or integration.signing_secret is None:
+    signing_secret = await integration.get_signing_secret() if integration else None
+    if signing_secret is None:
         raise Unauthorized()
 
     if not verify_slack_signature(
-        signing_secret=integration.signing_secret,
+        signing_secret=signing_secret,
         request_body=body,
         signature_header=x_slack_signature,
         timestamp_header=x_slack_request_timestamp,

--- a/server/polar/integrations/slack/endpoints.py
+++ b/server/polar/integrations/slack/endpoints.py
@@ -122,7 +122,7 @@ async def list_workspace_users(
     session: AsyncReadSession = Depends(get_db_read_session),
 ) -> SlackWorkspaceUsersResponse:
     integration = await _get_writable_integration(session, auth_subject, integration_id)
-    if integration.bot_token is None:
+    if await integration.get_bot_token() is None:
         raise ResourceNotFound()
     users = await slack_app_service.list_workspace_users(integration)
     return SlackWorkspaceUsersResponse(users=[SlackWorkspaceUser(**u) for u in users])

--- a/server/polar/integrations/slack/service.py
+++ b/server/polar/integrations/slack/service.py
@@ -79,25 +79,24 @@ class SlackAppService:
         if existing is not None and existing.organization_id != organization_id:
             raise SlackIntegrationAppIdAlreadyLinked()
 
+        existing_client_secret = (
+            await existing.get_client_secret() if existing else None
+        )
+        existing_signing_secret = (
+            await existing.get_signing_secret() if existing else None
+        )
+
         # First time pasting credentials for this app requires both secrets.
         has_existing_credentials = (
-            existing is not None
-            and existing.client_secret is not None
-            and existing.signing_secret is not None
+            existing_client_secret is not None and existing_signing_secret is not None
         )
         if update.client_secret is None and not has_existing_credentials:
             raise SlackIntegrationInvalidCredentials("missing_client_secret")
         if update.signing_secret is None and not has_existing_credentials:
             raise SlackIntegrationInvalidCredentials("missing_signing_secret")
 
-        client_secret = (
-            update.client_secret or (existing.client_secret if existing else None) or ""
-        )
-        signing_secret = (
-            update.signing_secret
-            or (existing.signing_secret if existing else None)
-            or ""
-        )
+        client_secret = update.client_secret or existing_client_secret or ""
+        signing_secret = update.signing_secret or existing_signing_secret or ""
 
         # Only round-trip to Slack when the credentials actually changed,
         # since the validation call costs a request and shouldn't run on
@@ -105,7 +104,7 @@ class SlackAppService:
         if (
             existing is None
             or update.client_id != existing.client_id
-            or client_secret != existing.client_secret
+            or client_secret != existing_client_secret
         ):
             await self._validate_credentials(
                 client_id=update.client_id,
@@ -210,15 +209,14 @@ class SlackAppService:
         self,
         integration: SlackApp,
     ) -> list[dict[str, Any]]:
-        if integration.bot_token is None:
+        bot_token = await integration.get_bot_token()
+        if bot_token is None:
             return []
 
         users: list[dict[str, Any]] = []
         cursor: str | None = None
         while True:
-            result = await self._client.users_list(
-                bot_token=integration.bot_token, cursor=cursor
-            )
+            result = await self._client.users_list(bot_token=bot_token, cursor=cursor)
             if not result.get("ok"):
                 break
             for member in result.get("members") or []:
@@ -253,16 +251,17 @@ class SlackAppService:
     ) -> SlackApp:
         repository = SlackAppRepository.from_session(session)
         integration = await repository.get_by_id(integration_id)
+        client_secret = await integration.get_client_secret() if integration else None
         if (
             integration is None
             or integration.client_id is None
-            or integration.client_secret is None
+            or client_secret is None
         ):
             raise SlackIntegrationNotConfigured()
 
         result = await self._client.oauth_v2_access(
             client_id=integration.client_id,
-            client_secret=integration.client_secret,
+            client_secret=client_secret,
             code=code,
             redirect_uri=redirect_uri,
         )

--- a/server/polar/models/slack_app.py
+++ b/server/polar/models/slack_app.py
@@ -92,6 +92,21 @@ class SlackApp(RecordModel):
     def organization(cls) -> Mapped["Organization"]:
         return relationship(Organization, lazy="raise")
 
+    async def get_client_secret(self) -> str | None:
+        if self.client_secret_encrypted is not None:
+            return await self.client_secret_encrypted.decrypt(id=str(self.id))
+        return self.client_secret
+
+    async def get_signing_secret(self) -> str | None:
+        if self.signing_secret_encrypted is not None:
+            return await self.signing_secret_encrypted.decrypt(id=str(self.id))
+        return self.signing_secret
+
+    async def get_bot_token(self) -> str | None:
+        if self.bot_token_encrypted is not None:
+            return await self.bot_token_encrypted.decrypt(id=str(self.id))
+        return self.bot_token
+
     @classmethod
     async def encrypt_client_secret(
         cls, id: UUID, client_secret: str | None

--- a/server/tests/benefit/strategies/test_slack_shared_channel.py
+++ b/server/tests/benefit/strategies/test_slack_shared_channel.py
@@ -52,7 +52,9 @@ async def _create_integration(
     benefit: Benefit,
     *,
     bot_token: str | None = "xoxb-test-token",
+    encrypted_only: bool = False,
 ) -> SlackApp:
+    installed = bot_token is not None
     integration = SlackApp(
         organization_id=benefit.organization_id,
         display_name="Test",
@@ -60,13 +62,18 @@ async def _create_integration(
         client_id="100.200",
         client_secret="cs-test",
         signing_secret="ss-test",
-        team_id="T1" if bot_token else None,
-        team_name="Test team" if bot_token else None,
-        bot_user_id="U1" if bot_token else None,
-        bot_token=bot_token,
-        authed_user_id="U2" if bot_token else None,
-        scopes=["channels:manage"] if bot_token else None,
+        team_id="T1" if installed else None,
+        team_name="Test team" if installed else None,
+        bot_user_id="U1" if installed else None,
+        bot_token=None if encrypted_only else bot_token,
+        authed_user_id="U2" if installed else None,
+        scopes=["channels:manage"] if installed else None,
     )
+    if encrypted_only and bot_token is not None:
+        integration.id = SlackApp.generate_id()
+        integration.bot_token_encrypted = await SlackApp.encrypt_bot_token(
+            integration.id, bot_token
+        )
     await save_fixture(integration)
     benefit.properties = {
         **benefit.properties,
@@ -1181,6 +1188,37 @@ class TestSlackSharedChannelGrant:
             properties={**_BASE_PROPERTIES, "team_invitees": ["U01", "U02"]},
         )
         await _create_integration(save_fixture, benefit)
+        client = _mock_client(mocker)
+        strategy = _strategy(session, redis, client)
+
+        await strategy.grant(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example"},
+        )
+
+        client.conversations_invite.assert_awaited_once_with(
+            bot_token="xoxb-test-token", channel="C123", users=["U01", "U02"]
+        )
+
+    async def test_grant_uses_encrypted_only_bot_token(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties={**_BASE_PROPERTIES, "team_invitees": ["U01", "U02"]},
+        )
+        await _create_integration(
+            save_fixture, benefit, bot_token="xoxb-test-token", encrypted_only=True
+        )
         client = _mock_client(mocker)
         strategy = _strategy(session, redis, client)
 

--- a/server/tests/models/test_slack_app.py
+++ b/server/tests/models/test_slack_app.py
@@ -67,6 +67,63 @@ class TestEncryptClassmethods:
 
 
 @pytest.mark.asyncio
+class TestGetSecrets:
+    async def test_prefers_encrypted(self, organization: Organization) -> None:
+        integration = _build(organization)
+        integration.id = SlackApp.generate_id()
+        integration.client_secret_encrypted = await SlackApp.encrypt_client_secret(
+            integration.id, "cs-encrypted"
+        )
+        integration.signing_secret_encrypted = await SlackApp.encrypt_signing_secret(
+            integration.id, "ss-encrypted"
+        )
+        integration.bot_token_encrypted = await SlackApp.encrypt_bot_token(
+            integration.id, "xoxb-encrypted"
+        )
+        integration.client_secret = "cs-plain"
+        integration.signing_secret = "ss-plain"
+        integration.bot_token = "xoxb-plain"
+
+        assert await integration.get_client_secret() == "cs-encrypted"
+        assert await integration.get_signing_secret() == "ss-encrypted"
+        assert await integration.get_bot_token() == "xoxb-encrypted"
+
+    async def test_falls_back_to_plain(self, organization: Organization) -> None:
+        integration = _build(organization)
+        integration.id = SlackApp.generate_id()
+        integration.client_secret = "cs-plain"
+        integration.signing_secret = "ss-plain"
+        integration.bot_token = "xoxb-plain"
+
+        assert await integration.get_client_secret() == "cs-plain"
+        assert await integration.get_signing_secret() == "ss-plain"
+        assert await integration.get_bot_token() == "xoxb-plain"
+
+    async def test_none_without_encrypted(self, organization: Organization) -> None:
+        integration = _build(organization)
+        integration.id = SlackApp.generate_id()
+
+        assert await integration.get_client_secret() is None
+        assert await integration.get_signing_secret() is None
+        assert await integration.get_bot_token() is None
+
+    async def test_resolves_each_secret_independently(
+        self, organization: Organization
+    ) -> None:
+        integration = _build(organization)
+        integration.id = SlackApp.generate_id()
+        integration.client_secret_encrypted = await SlackApp.encrypt_client_secret(
+            integration.id, "cs-encrypted"
+        )
+        integration.signing_secret = "ss-plain"
+        integration.bot_token = None
+
+        assert await integration.get_client_secret() == "cs-encrypted"
+        assert await integration.get_signing_secret() == "ss-plain"
+        assert await integration.get_bot_token() is None
+
+
+@pytest.mark.asyncio
 class TestPersistence:
     async def test_round_trip_through_database(
         self,


### PR DESCRIPTION
## Summary

read encrypted slack secrets by default, fallback to old columns

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

