### PR TITLE
postgres: Add support for fallback hosts and configure pgbouncer in test

### DIFF
--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -12,6 +12,7 @@ from pydantic import AfterValidator, DirectoryPath, Field, PostgresDsn
 from pydantic_ai.models import Model, infer_model, parse_model_id
 from pydantic_ai.providers.gateway import gateway_provider
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from sqlalchemy import URL
 
 from polar.enums import EmailSender, TaxProcessor
 from polar.kit.address import Address, CountryAlpha2
@@ -166,6 +167,8 @@ class Settings(BaseSettings):
     POSTGRES_PWD: str = "polar"
     POSTGRES_HOST: str = "127.0.0.1"
     POSTGRES_PORT: int = 5432
+    POSTGRES_HOST_FALLBACK: str | None = None
+    POSTGRES_PORT_FALLBACK: int | None = None
     POSTGRES_DATABASE: str = "polar"
     POSTGRES_SSL: bool = False
     DATABASE_POOL_SIZE: int = 5
@@ -178,6 +181,8 @@ class Settings(BaseSettings):
     POSTGRES_READ_PWD: str | None = None
     POSTGRES_READ_HOST: str | None = None
     POSTGRES_READ_PORT: int | None = None
+    POSTGRES_READ_HOST_FALLBACK: str | None = None
+    POSTGRES_READ_PORT_FALLBACK: int | None = None
     POSTGRES_READ_DATABASE: str | None = None
 
     # Redis
@@ -553,16 +558,54 @@ class Settings(BaseSettings):
     def redis_url(self) -> str:
         return f"redis://{self.REDIS_HOST}:{self.REDIS_PORT}/{self.REDIS_DB}"
 
-    def get_postgres_dsn(self, driver: Literal["asyncpg", "psycopg2"]) -> str:
-        return str(
-            PostgresDsn.build(
-                scheme=f"postgresql+{driver}",
-                username=self.POSTGRES_USER,
-                password=self.POSTGRES_PWD,
-                host=self.POSTGRES_HOST,
-                port=self.POSTGRES_PORT,
-                path=self.POSTGRES_DATABASE,
+    def _build_postgres_dsn(
+        self,
+        driver: Literal["asyncpg", "psycopg2"],
+        *,
+        username: str | None,
+        password: str | None,
+        host: str | None,
+        port: int | None,
+        database: str | None,
+        fallback_host: str | None,
+        fallback_port: int | None,
+    ) -> str:
+        if fallback_host is None:
+            return str(
+                PostgresDsn.build(
+                    scheme=f"postgresql+{driver}",
+                    username=username,
+                    password=password,
+                    host=host,
+                    port=port,
+                    path=database,
+                )
             )
+        return str(
+            URL.create(
+                f"postgresql+{driver}",
+                username=username,
+                password=password,
+                database=database,
+                query={
+                    "host": [
+                        f"{host}:{port}",
+                        f"{fallback_host}:{fallback_port or port}",
+                    ]
+                },
+            )
+        )
+
+    def get_postgres_dsn(self, driver: Literal["asyncpg", "psycopg2"]) -> str:
+        return self._build_postgres_dsn(
+            driver,
+            username=self.POSTGRES_USER,
+            password=self.POSTGRES_PWD,
+            host=self.POSTGRES_HOST,
+            port=self.POSTGRES_PORT,
+            database=self.POSTGRES_DATABASE,
+            fallback_host=self.POSTGRES_HOST_FALLBACK,
+            fallback_port=self.POSTGRES_PORT_FALLBACK,
         )
 
     def is_read_replica_configured(self) -> bool:
@@ -582,15 +625,15 @@ class Settings(BaseSettings):
         if not self.is_read_replica_configured():
             return None
 
-        return str(
-            PostgresDsn.build(
-                scheme=f"postgresql+{driver}",
-                username=self.POSTGRES_READ_USER,
-                password=self.POSTGRES_READ_PWD,
-                host=self.POSTGRES_READ_HOST,
-                port=self.POSTGRES_READ_PORT,
-                path=self.POSTGRES_READ_DATABASE,
-            )
+        return self._build_postgres_dsn(
+            driver,
+            username=self.POSTGRES_READ_USER,
+            password=self.POSTGRES_READ_PWD,
+            host=self.POSTGRES_READ_HOST,
+            port=self.POSTGRES_READ_PORT,
+            database=self.POSTGRES_READ_DATABASE,
+            fallback_host=self.POSTGRES_READ_HOST_FALLBACK,
+            fallback_port=self.POSTGRES_READ_PORT_FALLBACK,
         )
 
     def is_environment(self, environments: set[Environment]) -> bool:

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -175,6 +175,7 @@ class Settings(BaseSettings):
     DATABASE_SYNC_POOL_SIZE: int = 1  # Specific pool size for sync connection: since we only use it in OAuth2 router, don't waste resources.
     DATABASE_POOL_RECYCLE_SECONDS: int = 600  # 10 minutes
     DATABASE_COMMAND_TIMEOUT_SECONDS: float = 30.0
+    DATABASE_CONNECT_TIMEOUT_SECONDS: float = 10.0
     DATABASE_STREAM_YIELD_PER: int = 100
 
     POSTGRES_READ_USER: str | None = None

--- a/server/polar/kit/db/postgres.py
+++ b/server/polar/kit/db/postgres.py
@@ -52,6 +52,7 @@ def create_async_engine(
     pool_size: int | None = None,
     pool_recycle: int | None = None,
     command_timeout: float | None = None,
+    connect_timeout: float | None = None,
     debug: bool = False,
     ssl: str | None = None,
 ) -> AsyncEngine:
@@ -60,6 +61,8 @@ def create_async_engine(
         connect_args["server_settings"] = {"application_name": application_name}
     if command_timeout is not None:
         connect_args["command_timeout"] = command_timeout
+    if connect_timeout is not None:
+        connect_args["timeout"] = connect_timeout
     if ssl is not None:
         connect_args["ssl"] = ssl
 
@@ -83,6 +86,7 @@ def create_sync_engine(
     pool_size: int | None = None,
     pool_recycle: int | None = None,
     command_timeout: float | None = None,
+    connect_timeout: float | None = None,
     debug: bool = False,
     sslmode: str | None = None,
 ) -> Engine:
@@ -91,6 +95,8 @@ def create_sync_engine(
         connect_args["application_name"] = application_name
     if command_timeout is not None:
         connect_args["options"] = f"-c statement_timeout={int(command_timeout * 1000)}"
+    if connect_timeout is not None:
+        connect_args["connect_timeout"] = int(connect_timeout)
     if sslmode is not None:
         connect_args["sslmode"] = sslmode
     return _create_engine(

--- a/server/polar/postgres.py
+++ b/server/polar/postgres.py
@@ -31,6 +31,7 @@ def create_async_engine(
         pool_size=settings.DATABASE_POOL_SIZE,
         pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
         command_timeout=settings.DATABASE_COMMAND_TIMEOUT_SECONDS,
+        connect_timeout=settings.DATABASE_CONNECT_TIMEOUT_SECONDS,
         ssl="require" if settings.POSTGRES_SSL else None,
     )
 
@@ -44,6 +45,7 @@ def create_async_read_engine(process_name: ProcessName) -> AsyncEngine:
         pool_size=settings.DATABASE_POOL_SIZE,
         pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
         command_timeout=settings.DATABASE_COMMAND_TIMEOUT_SECONDS,
+        connect_timeout=settings.DATABASE_CONNECT_TIMEOUT_SECONDS,
         ssl="require" if settings.POSTGRES_SSL else None,
     )
 
@@ -57,6 +59,7 @@ def create_sync_engine(process_name: ProcessName) -> Engine:
         pool_size=settings.DATABASE_SYNC_POOL_SIZE,
         pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
         command_timeout=settings.DATABASE_COMMAND_TIMEOUT_SECONDS,
+        connect_timeout=settings.DATABASE_CONNECT_TIMEOUT_SECONDS,
         sslmode="require" if settings.POSTGRES_SSL else None,
     )
 

--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -271,18 +271,28 @@ resource "render_env_group" "memory_profile" {
 resource "render_env_group" "database" {
   environment_id = var.render_environment_id
   name           = "database-${var.environment}"
-  env_vars = {
-    POLAR_POSTGRES_DATABASE      = { value = var.api_service_config.postgres_database }
-    POLAR_POSTGRES_HOST          = { value = var.postgres_config.host }
-    POLAR_POSTGRES_PORT          = { value = var.postgres_config.port }
-    POLAR_POSTGRES_USER          = { value = var.postgres_config.user }
-    POLAR_POSTGRES_PWD           = { value = var.postgres_config.password }
-    POLAR_POSTGRES_READ_DATABASE = { value = var.api_service_config.postgres_read_database }
-    POLAR_POSTGRES_READ_HOST     = { value = var.postgres_config.read_host }
-    POLAR_POSTGRES_READ_PORT     = { value = var.postgres_config.read_port }
-    POLAR_POSTGRES_READ_USER     = { value = var.postgres_config.read_user }
-    POLAR_POSTGRES_READ_PWD      = { value = var.postgres_config.read_password }
-  }
+  env_vars = merge(
+    {
+      POLAR_POSTGRES_DATABASE      = { value = var.api_service_config.postgres_database }
+      POLAR_POSTGRES_HOST          = { value = var.postgres_config.host }
+      POLAR_POSTGRES_PORT          = { value = var.postgres_config.port }
+      POLAR_POSTGRES_USER          = { value = var.postgres_config.user }
+      POLAR_POSTGRES_PWD           = { value = var.postgres_config.password }
+      POLAR_POSTGRES_READ_DATABASE = { value = var.api_service_config.postgres_read_database }
+      POLAR_POSTGRES_READ_HOST     = { value = var.postgres_config.read_host }
+      POLAR_POSTGRES_READ_PORT     = { value = var.postgres_config.read_port }
+      POLAR_POSTGRES_READ_USER     = { value = var.postgres_config.read_user }
+      POLAR_POSTGRES_READ_PWD      = { value = var.postgres_config.read_password }
+    },
+    var.postgres_config.host_fallback == null ? {} : {
+      POLAR_POSTGRES_HOST_FALLBACK = { value = var.postgres_config.host_fallback }
+      POLAR_POSTGRES_PORT_FALLBACK = { value = coalesce(var.postgres_config.port_fallback, var.postgres_config.port) }
+    },
+    var.postgres_config.read_host_fallback == null ? {} : {
+      POLAR_POSTGRES_READ_HOST_FALLBACK = { value = var.postgres_config.read_host_fallback }
+      POLAR_POSTGRES_READ_PORT_FALLBACK = { value = coalesce(var.postgres_config.read_port_fallback, var.postgres_config.read_port) }
+    },
+  )
 }
 
 resource "render_env_group" "redis" {

--- a/terraform/modules/render_service/variables.tf
+++ b/terraform/modules/render_service/variables.tf
@@ -58,14 +58,18 @@ variable "workers" {
 variable "postgres_config" {
   description = "PostgreSQL connection configuration"
   type = object({
-    host          = string
-    port          = string
-    user          = string
-    password      = string
-    read_host     = string
-    read_port     = string
-    read_user     = string
-    read_password = string
+    host               = string
+    port               = string
+    user               = string
+    password           = string
+    host_fallback      = optional(string)
+    port_fallback      = optional(string)
+    read_host          = string
+    read_port          = string
+    read_user          = string
+    read_password      = string
+    read_host_fallback = optional(string)
+    read_port_fallback = optional(string)
   })
   sensitive = true
 }

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -113,14 +113,18 @@ module "test" {
   registry_credential_id = render_registry_credential.ghcr.id
 
   postgres_config = {
-    host          = local.db_internal_host
-    port          = local.db_port
-    user          = local.db_user
-    password      = local.db_password
-    read_host     = local.read_replica.id
-    read_port     = local.db_port
-    read_user     = local.db_user
-    read_password = local.db_password
+    host               = module.pgbouncer[0].host
+    port               = module.pgbouncer[0].port
+    user               = local.db_user
+    password           = local.db_password
+    host_fallback      = local.db_internal_host
+    port_fallback      = local.db_port
+    read_host          = module.pgbouncer_read[0].host
+    read_port          = module.pgbouncer_read[0].port
+    read_user          = local.db_user
+    read_password      = local.db_password
+    read_host_fallback = local.read_replica.id
+    read_port_fallback = local.db_port
   }
 
   redis_config = {


### PR DESCRIPTION
This adds support for fallback hosts for postgres as well as a connect timeout (to trigger the fallback in the event that we can't connect to the primary). Additionally this configures us to use pgbouncer in the test env as a primary host (and the regular connection as fallback).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

