### PR TITLE
Normalize whitespace in ConfirmModal confirmation text

### DIFF
--- a/clients/apps/web/src/components/Modal/ConfirmModal.tsx
+++ b/clients/apps/web/src/components/Modal/ConfirmModal.tsx
@@ -11,6 +11,12 @@ import { MouseEvent, useCallback } from 'react'
 import { useForm } from 'react-hook-form'
 import { Modal, type ModalProps } from '@polar-sh/orbit'
 
+// Collapses runs of any Unicode whitespace (including non-breaking spaces,
+// common in labels pasted from design tools) into a single regular space, so
+// the confirmation text stays typeable on a regular keyboard.
+const normalizeWhitespace = (value: string) =>
+  value.replace(/\s+/gu, ' ').trim()
+
 export interface ConfirmModalProps extends Omit<
   ModalProps,
   'title' | 'modalContent'
@@ -44,7 +50,8 @@ export const ConfirmModal = ({
   const { control, handleSubmit, reset, watch } = form
   // eslint-disable-next-line react-hooks/incompatible-library
   const prompt = watch('prompt')
-  const trimmedConfirmPrompt = confirmPrompt?.trim()
+  const normalizedConfirmPrompt =
+    confirmPrompt !== undefined ? normalizeWhitespace(confirmPrompt) : undefined
 
   const handleConfirm = useCallback(() => {
     onConfirm()
@@ -91,14 +98,16 @@ export const ConfirmModal = ({
               {confirmPrompt && (
                 <>
                   <p className="dark:text-polar-400 max-w-full text-sm text-gray-500">
-                    Please enter &quot;{trimmedConfirmPrompt}&quot; to confirm:
+                    Please enter &quot;{normalizedConfirmPrompt}&quot; to
+                    confirm:
                   </p>
                   <FormField
                     control={control}
                     name="prompt"
                     rules={{
                       validate: (value) =>
-                        (value ?? '').trim() === trimmedConfirmPrompt ||
+                        normalizeWhitespace(value ?? '') ===
+                          normalizedConfirmPrompt ||
                         'Please enter the exact text to confirm',
                     }}
                     render={({ field }) => {
@@ -109,7 +118,7 @@ export const ConfirmModal = ({
                               <Input
                                 type="input"
                                 required
-                                placeholder={trimmedConfirmPrompt}
+                                placeholder={normalizedConfirmPrompt}
                                 autoComplete="off"
                                 {...field}
                               />
@@ -127,8 +136,9 @@ export const ConfirmModal = ({
                   type="submit"
                   variant={destructive ? 'destructive' : 'default'}
                   disabled={
-                    trimmedConfirmPrompt
-                      ? (prompt ?? '').trim() !== trimmedConfirmPrompt
+                    normalizedConfirmPrompt
+                      ? normalizeWhitespace(prompt ?? '') !==
+                        normalizedConfirmPrompt
                       : false
                   }
                 >


### PR DESCRIPTION
## Summary

Improves the ConfirmModal component to handle Unicode whitespace characters (including non-breaking spaces commonly pasted from design tools) by normalizing them to regular spaces.

## What

- Added `normalizeWhitespace()` utility function that collapses runs of any Unicode whitespace into a single regular space and trims the result
- Updated confirmation text handling to use `normalizeWhitespace()` instead of simple `.trim()`
- Applied normalization consistently across:
  - The confirmation prompt display text
  - The input field validation logic
  - The input field placeholder
  - The submit button disabled state

## Why

When design specifications or labels are pasted from design tools, they often contain non-breaking spaces and other Unicode whitespace characters. This makes the confirmation text difficult or impossible to type on a regular keyboard, creating a poor user experience. Normalizing these characters ensures the confirmation text is always typeable while maintaining the intended meaning.

## How

The `normalizeWhitespace()` function uses a Unicode-aware regex (`/\s+/gu`) to match any whitespace character (including non-breaking spaces) and replaces runs of them with a single regular space, then trims the result. This normalized value is then used throughout the component for consistency between what's displayed and what's validated.

## Checklist

- [x] This PR addresses a single concern (one bug fix)
- [x] The diff is reasonably sized and easy to review
- [x] No new tests needed (existing component tests cover this behavior)
- [x] No unrelated changes included

https://claude.ai/code/session_013msKZVwGJB2D1jt86WW8HP

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

