### PR TITLE
dx: reduce dictatorship of François

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 * @polarsource/engineering
 
 # Backend
-server/** @frankie567 @polarsource/engineering
+server/** @polarsource/engineering
 server/polar/metrics/** @Yopi @pieterbeulque
 server/tests/metrics/** @Yopi @pieterbeulque
 server/polar/organization_review/** @psincraian
@@ -10,6 +10,16 @@ server/tests/organization_review/** @psincraian
 server/polar/customer_seat/** @psincraian
 server/tests/customer_seat/** @psincraian
 server/tests/e2e/** @psincraian
+
+# API
+server/polar/**/endpoints.py @frankie567
+server/polar/**/schemas.py @frankie567
+server/polar/customer_portal/endpoints/** @frankie567
+server/polar/customer_portal/schemas/** @frankie567
+
+# Authentication
+server/polar/auth/** @frankie567
+server/polar/oauth2/** @frankie567
 
 # Infrastructure
 terraform/** @Yopi
@@ -22,6 +32,9 @@ clients/packages/orbit/** @emilwidlund @sebastianekstrom
 
 # Docs
 /docs/ @pieterbeulque
+
+# ADR
+handbook/engineering/decisions/** @frankie567
 
 # Other
 **/legal @victoriabolin @birkjernstrom


### PR DESCRIPTION

Reduce my code ownership to some specific areas:

- REST API (endpoints and schemas)
- Authentication and OAuth2 server
- ADRs (Architecture Decision Records)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

