### PR TITLE
feat(oauth2): enforce SSO for unrestricted OAuth2 tokens at request time

### DIFF
--- a/server/polar/authz/repository.py
+++ b/server/polar/authz/repository.py
@@ -5,7 +5,7 @@ from sqlalchemy import Select, select
 
 from polar.auth.models import AuthSubject, User, is_organization, is_user
 from polar.auth.permission import OrganizationPermission, roles_with_permission
-from polar.models import Organization, UserOrganization, UserSession
+from polar.models import OAuth2Token, Organization, UserOrganization, UserSession
 from polar.postgres import AsyncReadSession
 
 
@@ -56,10 +56,11 @@ def select_accessible_org_ids(
     (optionally narrowed by ``permission``) intersected with that scope.
 
     A subject scoped to specific organizations (``organization_ids``) is
-    narrowed to them. An unscoped **user session** additionally cannot reach
-    organizations that enforce SSO (``sso_enforced``) — those are only
-    accessible through an SSO-scoped session. Token credentials (PAT / OAuth)
-    are exempt from SSO enforcement.
+    narrowed to them. Without such a scope, a **user session** or an
+    **unrestricted OAuth2 token** cannot reach organizations that enforce SSO
+    (``sso_enforced``) — those are only accessible through an SSO-scoped session
+    or a token explicitly scoped to them (which can only be issued via SSO).
+    Personal access tokens remain exempt from SSO enforcement.
     """
     # Composes the raw helper, then applies the session down-scope right below.
     stmt = select_user_org_ids(auth_subject.subject.id, permission=permission)  # noqa: org-scope
@@ -67,7 +68,7 @@ def select_accessible_org_ids(
         stmt = stmt.where(
             UserOrganization.organization_id.in_(auth_subject.organization_ids)
         )
-    elif isinstance(auth_subject.session, UserSession):
+    elif isinstance(auth_subject.session, (UserSession, OAuth2Token)):
         stmt = stmt.where(Organization.sso_enforced.is_not(True))
     return stmt
 

--- a/server/tests/authz/test_service.py
+++ b/server/tests/authz/test_service.py
@@ -5,7 +5,7 @@ import pytest
 
 from polar.auth.models import AuthSubject
 from polar.authz.service import get_accessible_org_ids, get_accessible_organization
-from polar.models import Organization, PersonalAccessToken, User
+from polar.models import OAuth2Token, Organization, PersonalAccessToken, User
 from polar.models.organization import OrganizationStatus
 from polar.models.user_organization import UserOrganization
 from polar.postgres import AsyncSession
@@ -179,7 +179,7 @@ class TestGetAccessibleOrgIdsSSOEnforced:
         assert result == {organization.id}
 
     @pytest.mark.auth
-    async def test_token_credential_exempt(
+    async def test_personal_access_token_exempt(
         self,
         session: AsyncSession,
         auth_subject: AuthSubject[User],
@@ -188,8 +188,42 @@ class TestGetAccessibleOrgIdsSSOEnforced:
     ) -> None:
         organization.sso_enforced = True
         await session.flush()
-        # PAT / OAuth credentials are not user sessions and stay exempt.
+        # A PAT is the user's own credential and stays exempt from SSO enforcement.
         auth_subject.session = MagicMock(spec=PersonalAccessToken)
+
+        result = await get_accessible_org_ids(session, auth_subject)
+        assert result == {organization.id}
+
+    @pytest.mark.auth
+    async def test_unrestricted_oauth2_token_denied_enforced_org(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        organization.sso_enforced = True
+        await session.flush()
+        # An unrestricted OAuth2 token (no down-scope) can't reach enforced orgs.
+        auth_subject.session = MagicMock(spec=OAuth2Token)
+        auth_subject.organization_ids = None
+
+        result = await get_accessible_org_ids(session, auth_subject)
+        assert result == set()
+
+    @pytest.mark.auth
+    async def test_scoped_oauth2_token_allowed_enforced_org(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        organization.sso_enforced = True
+        await session.flush()
+        # A token explicitly scoped to the org (only issuable via SSO) is allowed.
+        auth_subject.session = MagicMock(spec=OAuth2Token)
+        auth_subject.organization_ids = frozenset({organization.id})
 
         result = await get_accessible_org_ids(session, auth_subject)
         assert result == {organization.id}


### PR DESCRIPTION
## Summary

Request-time counterpart to #12928 (which gated token org scope at *issuance*).

## What
`select_accessible_org_ids` now treats an **unrestricted** OAuth2 token (no org down-scope) like an unscoped web session: it cannot reach organizations that enforce SSO. Scoped tokens (`organization_ids` set) are unchanged — they take the down-scope branch — and PATs stay exempt (they aren't `OAuth2Token`).

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

