### PR TITLE
docs: make adr-check report terse

### DIFF
--- a/.agents/skills/adr-check/SKILL.md
+++ b/.agents/skills/adr-check/SKILL.md
@@ -64,14 +64,12 @@ here: it would drift from the ADRs. The ADR text is the source of truth.
 
 ### 4. Report
 
-Keep it short and scannable:
+Be terse. Do not narrate which ADRs you checked, list applicable/not-applicable
+ADRs, or explain your process.
 
-- **Violations**, most severe first. For each: the ADR id and title, the
-  `file:line`, one line on what breaks the rule, and the fix.
-- **Uncovered decisions**: if the change makes a significant, cross-cutting, or
-  hard-to-reverse decision that no ADR covers, say so and offer to draft one from
-  `handbook/engineering/decisions/template.mdx`.
-- If nothing conflicts and nothing new is ADR-worthy, say so in one line, and list
-  which ADRs you checked and which were not applicable to this diff.
+- **No violations**: reply with exactly `No violations` and nothing else.
+- **Violations found**: list them most severe first. For each, reference the ADR
+  (id and title) and the violation: the `file:line`, one line on what breaks the
+  rule, and the fix.
 
 This skill reviews and reports. It does not edit code; fixes are a follow-up.


### PR DESCRIPTION
## Summary

Make the `/adr-check` skill's report output terse instead of verbose.

## What

- No violations → reply with exactly `No violations`, nothing else.
- Violations → list them most severe first, each referencing the ADR (id + title) and the violation (`file:line`, what breaks the rule, the fix).
- Drop the process narration (which ADRs were checked, applicable/not-applicable recap) and the standalone uncovered-decisions section.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

