### PR TITLE
feat(terraform): add Cloudflare IP ranges module with Render proxy CIDR

### DIFF
--- a/terraform/modules/cloudflare_ips/main.tf
+++ b/terraform/modules/cloudflare_ips/main.tf
@@ -1,0 +1,52 @@
+# Cloudflare IP Ranges Module
+#
+# Fetches Cloudflare's published IP ranges (IPv4 and IPv6) and outputs them
+# as a comma-separated string suitable for use with forwarded_allow_ips
+# configuration.
+
+# Fetch Cloudflare IPv4 ranges
+# https://www.cloudflare.com/ips-v4
+# Returns a plain text file with one IP range per line
+data "http" "cloudflare_ips_v4" {
+  url                = "https://www.cloudflare.com/ips-v4"
+  request_timeout_ms = 30000
+
+  lifecycle {
+    postcondition {
+      condition     = self.response_body != "" && self.status_code == 200
+      error_message = "Cloudflare IPv4 ranges endpoint failed. Check https://www.cloudflare.com/ips-v4"
+    }
+  }
+}
+
+# Fetch Cloudflare IPv6 ranges
+# https://www.cloudflare.com/ips-v6
+# Returns a plain text file with one IP range per line
+data "http" "cloudflare_ips_v6" {
+  url                = "https://www.cloudflare.com/ips-v6"
+  request_timeout_ms = 30000
+
+  lifecycle {
+    postcondition {
+      condition     = self.response_body != "" && self.status_code == 200
+      error_message = "Cloudflare IPv6 ranges endpoint failed. Check https://www.cloudflare.com/ips-v6"
+    }
+  }
+}
+
+locals {
+  # Parse IPv4 ranges: split by newlines, trim whitespace, filter empty lines
+  ipv4_ranges = [
+    for ip in split("\n", data.http.cloudflare_ips_v4.response_body) :
+    trimspace(ip) if trimspace(ip) != ""
+  ]
+
+  # Parse IPv6 ranges: split by newlines, trim whitespace, filter empty lines
+  ipv6_ranges = [
+    for ip in split("\n", data.http.cloudflare_ips_v6.response_body) :
+    trimspace(ip) if trimspace(ip) != ""
+  ]
+
+  # Combine all ranges into a single comma-separated string
+  all_ranges = join(",", concat(local.ipv4_ranges, local.ipv6_ranges))
+}

--- a/terraform/modules/cloudflare_ips/outputs.tf
+++ b/terraform/modules/cloudflare_ips/outputs.tf
@@ -1,0 +1,19 @@
+output "ipv4_ranges" {
+  description = "List of Cloudflare IPv4 CIDR ranges."
+  value       = local.ipv4_ranges
+}
+
+output "ipv6_ranges" {
+  description = "List of Cloudflare IPv6 CIDR ranges."
+  value       = local.ipv6_ranges
+}
+
+output "all_ranges" {
+  description = "All Cloudflare IP ranges (IPv4 and IPv6) as a comma-separated string."
+  value       = local.all_ranges
+}
+
+output "all_ranges_list" {
+  description = "All Cloudflare IP ranges (IPv4 and IPv6) as a list."
+  value       = concat(local.ipv4_ranges, local.ipv6_ranges)
+}

--- a/terraform/modules/cloudflare_ips/terraform.tf
+++ b/terraform/modules/cloudflare_ips/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 3.0"
+    }
+  }
+}

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -29,6 +29,10 @@ locals {
   # Redis connection info
   redis_host = render_redis.redis.id
   redis_port = "6379"
+
+  # Forwarded allow IPs: Cloudflare ranges + Render proxy
+  render_proxy_cidr   = "10.0.0.0/8"
+  forwarded_allow_ips = "${module.cloudflare_ips.all_ranges},${local.render_proxy_cidr}"
 }
 
 # =============================================================================
@@ -153,7 +157,7 @@ module "production" {
     custom_domains         = [{ name = "api.polar.sh" }, { name = "api-alt.polar.sh" }, { name = "buy.polar.sh" }, { name = "backoffice.polar.sh" }]
     plan                   = "pro_plus"
     web_concurrency        = "6"
-    forwarded_allow_ips    = module.cloudflare_ips.all_ranges
+    forwarded_allow_ips    = local.forwarded_allow_ips
   }
 
   postgres_config = {

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -112,6 +112,14 @@ resource "render_redis" "redis" {
 }
 
 # =============================================================================
+# Cloudflare IP Ranges
+# =============================================================================
+
+module "cloudflare_ips" {
+  source = "../modules/cloudflare_ips"
+}
+
+# =============================================================================
 # Production
 # =============================================================================
 
@@ -145,6 +153,7 @@ module "production" {
     custom_domains         = [{ name = "api.polar.sh" }, { name = "api-alt.polar.sh" }, { name = "buy.polar.sh" }, { name = "backoffice.polar.sh" }]
     plan                   = "pro_plus"
     web_concurrency        = "6"
+    forwarded_allow_ips    = module.cloudflare_ips.all_ranges
   }
 
   postgres_config = {

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -71,6 +71,14 @@ locals {
 }
 
 # =============================================================================
+# Cloudflare IP Ranges
+# =============================================================================
+
+module "cloudflare_ips" {
+  source = "../modules/cloudflare_ips"
+}
+
+# =============================================================================
 # Sandbox
 # =============================================================================
 
@@ -123,7 +131,7 @@ module "sandbox" {
     cors_origins           = "[\"https://sandbox.polar.sh\", \"https://github.com\", \"https://docs.polar.sh\"]"
     custom_domains         = [{ name = "sandbox-api.polar.sh" }]
     web_concurrency        = "2"
-    forwarded_allow_ips    = "*"
+    forwarded_allow_ips    = module.cloudflare_ips.all_ranges
     database_pool_size     = "10"
     postgres_database      = "polar_sandbox"
     postgres_read_database = "polar_sandbox"

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -68,6 +68,10 @@ locals {
   # Production Redis connection info - for the drain worker
   production_redis_host = data.render_redis.redis.id
   production_redis_port = "6379"
+
+  # Forwarded allow IPs: Cloudflare ranges + Render proxy
+  render_proxy_cidr   = "10.0.0.0/8"
+  forwarded_allow_ips = "${module.cloudflare_ips.all_ranges},${local.render_proxy_cidr}"
 }
 
 # =============================================================================
@@ -131,7 +135,7 @@ module "sandbox" {
     cors_origins           = "[\"https://sandbox.polar.sh\", \"https://github.com\", \"https://docs.polar.sh\"]"
     custom_domains         = [{ name = "sandbox-api.polar.sh" }]
     web_concurrency        = "2"
-    forwarded_allow_ips    = module.cloudflare_ips.all_ranges
+    forwarded_allow_ips    = local.forwarded_allow_ips
     database_pool_size     = "10"
     postgres_database      = "polar_sandbox"
     postgres_read_database = "polar_sandbox"

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -74,6 +74,14 @@ resource "render_redis" "redis" {
 }
 
 # =============================================================================
+# Cloudflare IP Ranges
+# =============================================================================
+
+module "cloudflare_ips" {
+  source = "../modules/cloudflare_ips"
+}
+
+# =============================================================================
 # Test
 # =============================================================================
 locals {
@@ -135,7 +143,7 @@ module "test" {
     cors_origins           = "[\"https://test.polar.sh\", \"https://github.com\", \"https://docs.polar.sh\"]"
     custom_domains         = [{ name = "test-api.polar.sh" }]
     web_concurrency        = "2"
-    forwarded_allow_ips    = "*"
+    forwarded_allow_ips    = module.cloudflare_ips.all_ranges
     database_pool_size     = "10"
     postgres_database      = local.db_name
     postgres_read_database = local.db_name

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -102,6 +102,10 @@ locals {
   # Redis connection info
   redis_host = local.test_enabled ? render_redis.redis[0].id : ""
   redis_port = "6379"
+
+  # Forwarded allow IPs: Cloudflare ranges + Render proxy
+  render_proxy_cidr   = "10.0.0.0/8"
+  forwarded_allow_ips = "${module.cloudflare_ips.all_ranges},${local.render_proxy_cidr}"
 }
 
 module "test" {
@@ -143,7 +147,7 @@ module "test" {
     cors_origins           = "[\"https://test.polar.sh\", \"https://github.com\", \"https://docs.polar.sh\"]"
     custom_domains         = [{ name = "test-api.polar.sh" }]
     web_concurrency        = "2"
-    forwarded_allow_ips    = module.cloudflare_ips.all_ranges
+    forwarded_allow_ips    = local.forwarded_allow_ips
     database_pool_size     = "10"
     postgres_database      = local.db_name
     postgres_read_database = local.db_name


### PR DESCRIPTION
## Summary

**Related Issue**: N/A

This PR reapplies commit aef390d613b2649cccdfc680eb9cc2b0b00c3940 and adds the Render proxy IP range (10.0.0.0/8).

## What

### New Module: cloudflare_ips
Created `terraform/modules/cloudflare_ips/` with:
- Fetches IPv4 ranges from https://www.cloudflare.com/ips-v4
- Fetches IPv6 ranges from https://www.cloudflare.com/ips-v6
- Sets request_timeout_ms = 30000 (30s) to prevent hanging
- Uses postcondition blocks to validate HTTP 200 responses with non-empty bodies
- Outputs all_ranges as a comma-separated string

### Environment Integration
Integrated into all three environments:
- `terraform/production/render.tf`
- `terraform/sandbox/render.tf`
- `terraform/test/render.tf`

Each environment now:
- Calls the cloudflare_ips module
- Defines a local variable `render_proxy_cidr = "10.0.0.0/8"`
- Combines them: `forwarded_allow_ips = "${module.cloudflare_ips.all_ranges},${local.render_proxy_cidr}"`
- Uses the combined value in api_service_config

## Why

Previously, forwarded_allow_ips was set to "*" (allow all IPs) in all environments. This change:
1. Restricts traffic to only Cloudflare's published IP ranges + Render proxy
2. Prevents direct access to the origin from non-Cloudflare IPs
3. Improves security by explicitly defining allowed IP ranges
4. Automatically stays up-to-date with Cloudflare's IP range changes

## How

The module uses Terraform's http data source to fetch Cloudflare's published IP ranges, with proper validation:
- request_timeout_ms = 30000 prevents indefinite hangs
- postcondition checks ensure HTTP 200 + non-empty response
- If Cloudflare endpoints fail, Terraform plan fails explicitly

## Checklist

- [x] This PR addresses a single concern (security improvement for forwarded_allow_ips)
- [x] The diff is reasonably sized and easy to review
- [x] No unrelated changes or drive-by fixes are included
- [ ] New functionality is covered by tests (N/A - infrastructure change)
- [ ] Linting and type checking pass (to be verified)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

