### PR TITLE
feat(oauth2): revoke org-scoped OAuth2 tokens when an org enforces SSO

### DIFF
--- a/clients/apps/web/src/components/Settings/SSO/SSOSettings.tsx
+++ b/clients/apps/web/src/components/Settings/SSO/SSOSettings.tsx
@@ -14,12 +14,18 @@ import { schemas } from '@polar-sh/client'
 import { Button, InlineModal, ListGroup, Status, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import CopyToClipboardInput from '@polar-sh/ui/components/atoms/CopyToClipboardInput'
+import { ConfirmModal } from '../../Modal/ConfirmModal'
 import { useModal } from '../../Modal/useModal'
 import EditSSOConnectionModal from './EditSSOConnectionModal'
 import NewSSOConnectionModal from './NewSSOConnectionModal'
 
 const SSOSettings = ({ org }: { org: schemas['Organization'] }) => {
   const { isShown, show, hide } = useModal()
+  const {
+    isShown: enforceModalShown,
+    show: showEnforceModal,
+    hide: hideEnforceModal,
+  } = useModal()
   const { currentUser } = useAuth()
   const connections = useSSOConnections(org.id)
   const updateOrganization = useUpdateOrganization()
@@ -32,19 +38,10 @@ const SSOSettings = ({ org }: { org: schemas['Organization'] }) => {
   // `organization_scoped` here means "signed in via this org's SSO".
   const canEnforce = currentUser?.organization_scoped ?? false
 
-  const toggleEnforced = async () => {
-    const enabling = !org.sso_enforced
-    if (
-      enabling &&
-      !window.confirm(
-        'Enforce SSO for this organization? Third-party apps that members authorized for this organization will be disconnected and must re-authorize through SSO.',
-      )
-    ) {
-      return
-    }
+  const applyEnforced = async (sso_enforced: boolean) => {
     const { error } = await updateOrganization.mutateAsync({
       id: org.id,
-      body: { sso_enforced: !org.sso_enforced },
+      body: { sso_enforced },
     })
     if (error) {
       toast({
@@ -108,7 +105,9 @@ const SSOSettings = ({ org }: { org: schemas['Organization'] }) => {
           </Box>
           <Button
             variant="secondary"
-            onClick={toggleEnforced}
+            onClick={() =>
+              org.sso_enforced ? applyEnforced(false) : showEnforceModal()
+            }
             loading={updateOrganization.isPending}
             disabled={
               !org.sso_enforced && (!canEnforce || !hasEnabledConnection)
@@ -118,6 +117,15 @@ const SSOSettings = ({ org }: { org: schemas['Organization'] }) => {
           </Button>
         </Box>
       </Box>
+      <ConfirmModal
+        isShown={enforceModalShown}
+        hide={hideEnforceModal}
+        onConfirm={() => applyEnforced(true)}
+        title="Enforce SSO"
+        description="Members will have to sign in through SSO to access this organization. Third-party apps they authorized for this organization will be disconnected and must be re-authorized through SSO."
+        destructive
+        destructiveText="Enforce"
+      />
       <InlineModal
         isShown={isShown}
         hide={hide}
@@ -137,6 +145,11 @@ const SSOConnectionRow = ({
   connection: schemas['OrganizationSSOConnection']
 }) => {
   const { isShown, show, hide } = useModal()
+  const {
+    isShown: deleteModalShown,
+    show: showDeleteModal,
+    hide: hideDeleteModal,
+  } = useModal()
   const updateConnection = useUpdateSSOConnection(org.id, connection.id)
   const deleteConnection = useDeleteSSOConnection(org.id)
 
@@ -153,13 +166,6 @@ const SSOConnectionRow = ({
   }
 
   const onDelete = async () => {
-    if (
-      !window.confirm(
-        'Delete this SSO connection? Members will no longer be able to sign in with it.',
-      )
-    ) {
-      return
-    }
     const { error } = await deleteConnection.mutateAsync(connection.id)
     if (error) {
       toast({
@@ -198,13 +204,21 @@ const SSOConnectionRow = ({
           </Button>
           <Button
             variant="ghost"
-            onClick={onDelete}
+            onClick={showDeleteModal}
             loading={deleteConnection.isPending}
           >
             Delete
           </Button>
         </Box>
       </Box>
+      <ConfirmModal
+        isShown={deleteModalShown}
+        hide={hideDeleteModal}
+        onConfirm={onDelete}
+        title="Delete SSO connection"
+        description="Members will no longer be able to sign in with this connection."
+        destructive
+      />
       <InlineModal
         isShown={isShown}
         hide={hide}

--- a/clients/apps/web/src/components/Settings/SSO/SSOSettings.tsx
+++ b/clients/apps/web/src/components/Settings/SSO/SSOSettings.tsx
@@ -33,6 +33,15 @@ const SSOSettings = ({ org }: { org: schemas['Organization'] }) => {
   const canEnforce = currentUser?.organization_scoped ?? false
 
   const toggleEnforced = async () => {
+    const enabling = !org.sso_enforced
+    if (
+      enabling &&
+      !window.confirm(
+        'Enforce SSO for this organization? Third-party apps that members authorized for this organization will be disconnected and must re-authorize through SSO.',
+      )
+    ) {
+      return
+    }
     const { error } = await updateOrganization.mutateAsync({
       id: org.id,
       body: { sso_enforced: !org.sso_enforced },

--- a/server/polar/oauth2/repository.py
+++ b/server/polar/oauth2/repository.py
@@ -1,14 +1,32 @@
 import time
 from collections.abc import Sequence
+from uuid import UUID
 
 from sqlalchemy import delete, or_
 
 from polar.kit.repository import RepositoryBase
-from polar.models import OAuth2Token
+from polar.models import OAuth2Token, OAuth2TokenOrganization
 
 
 class OAuth2TokenRepository(RepositoryBase[OAuth2Token]):
     model = OAuth2Token
+
+    async def get_scoped_to_organization(
+        self, organization_id: UUID
+    ) -> Sequence[OAuth2Token]:
+        """Live (non-revoked) tokens explicitly down-scoped to an organization."""
+        statement = (
+            self.get_base_statement()
+            .join(
+                OAuth2TokenOrganization,
+                OAuth2TokenOrganization.oauth2_token_id == OAuth2Token.id,
+            )
+            .where(
+                OAuth2TokenOrganization.organization_id == organization_id,
+                OAuth2Token.access_token_revoked_at == 0,
+            )
+        )
+        return await self.get_all(statement)
 
     async def delete_expired(self, *, exclude_client_ids: Sequence[str] = ()) -> None:
         now = int(time.time())

--- a/server/polar/oauth2/repository.py
+++ b/server/polar/oauth2/repository.py
@@ -2,7 +2,7 @@ import time
 from collections.abc import Sequence
 from uuid import UUID
 
-from sqlalchemy import delete, or_
+from sqlalchemy import delete, or_, select, update
 
 from polar.kit.repository import RepositoryBase
 from polar.models import OAuth2Token, OAuth2TokenOrganization
@@ -11,22 +11,26 @@ from polar.models import OAuth2Token, OAuth2TokenOrganization
 class OAuth2TokenRepository(RepositoryBase[OAuth2Token]):
     model = OAuth2Token
 
-    async def get_scoped_to_organization(
-        self, organization_id: UUID
-    ) -> Sequence[OAuth2Token]:
-        """Live (non-revoked) tokens explicitly down-scoped to an organization."""
-        statement = (
-            self.get_base_statement()
-            .join(
-                OAuth2TokenOrganization,
-                OAuth2TokenOrganization.oauth2_token_id == OAuth2Token.id,
-            )
-            .where(
-                OAuth2TokenOrganization.organization_id == organization_id,
-                OAuth2Token.access_token_revoked_at == 0,
-            )
+    async def revoke_scoped_to_organization(self, organization_id: UUID) -> None:
+        """Revoke tokens explicitly down-scoped to an organization."""
+        now = int(time.time())
+        scoped_token_ids = (
+            select(OAuth2TokenOrganization.oauth2_token_id)
+            .where(OAuth2TokenOrganization.organization_id == organization_id)
+            .scalar_subquery()
         )
-        return await self.get_all(statement)
+        statement = (
+            update(OAuth2Token)
+            .where(
+                OAuth2Token.id.in_(scoped_token_ids),
+                or_(
+                    OAuth2Token.access_token_revoked_at == 0,
+                    OAuth2Token.refresh_token_revoked_at == 0,
+                ),
+            )
+            .values(access_token_revoked_at=now, refresh_token_revoked_at=now)
+        )
+        await self.session.execute(statement)
 
     async def delete_expired(self, *, exclude_client_ids: Sequence[str] = ()) -> None:
         now = int(time.time())

--- a/server/polar/oauth2/service/oauth2_token.py
+++ b/server/polar/oauth2/service/oauth2_token.py
@@ -1,5 +1,6 @@
 import time
 from typing import cast
+from uuid import UUID
 
 import structlog
 from sqlalchemy import select
@@ -73,6 +74,29 @@ class OAuth2TokenService(ResourceServiceReader[OAuth2Token]):
         if APP_CLIENT_ID is not None:
             exclude_client_ids.append(APP_CLIENT_ID)
         await repository.delete_expired(exclude_client_ids=exclude_client_ids)
+
+    async def revoke_for_sso_enforcement(
+        self, session: AsyncSession, organization_id: UUID
+    ) -> int:
+        """Revoke tokens scoped to an organization once it enforces SSO.
+
+        Such tokens were scoped before enforcement (so through a non-SSO session);
+        revoking forces the app to re-consent through SSO. Unrestricted tokens are
+        handled at request time and are left untouched here.
+        """
+        repository = OAuth2TokenRepository.from_session(session)
+        tokens = await repository.get_scoped_to_organization(organization_id)
+        now = int(time.time())
+        for token in tokens:
+            token.access_token_revoked_at = now  # pyright: ignore
+            token.refresh_token_revoked_at = now  # pyright: ignore
+            session.add(token)
+        log.info(
+            "Revoke OAuth2 tokens scoped to SSO-enforced organization",
+            organization_id=str(organization_id),
+            count=len(tokens),
+        )
+        return len(tokens)
 
     async def revoke_leaked(
         self,

--- a/server/polar/oauth2/service/oauth2_token.py
+++ b/server/polar/oauth2/service/oauth2_token.py
@@ -77,7 +77,7 @@ class OAuth2TokenService(ResourceServiceReader[OAuth2Token]):
 
     async def revoke_for_sso_enforcement(
         self, session: AsyncSession, organization_id: UUID
-    ) -> int:
+    ) -> None:
         """Revoke tokens scoped to an organization once it enforces SSO.
 
         Such tokens were scoped before enforcement (so through a non-SSO session);
@@ -85,18 +85,7 @@ class OAuth2TokenService(ResourceServiceReader[OAuth2Token]):
         handled at request time and are left untouched here.
         """
         repository = OAuth2TokenRepository.from_session(session)
-        tokens = await repository.get_scoped_to_organization(organization_id)
-        now = int(time.time())
-        for token in tokens:
-            token.access_token_revoked_at = now  # pyright: ignore
-            token.refresh_token_revoked_at = now  # pyright: ignore
-            session.add(token)
-        log.info(
-            "Revoke OAuth2 tokens scoped to SSO-enforced organization",
-            organization_id=str(organization_id),
-            count=len(tokens),
-        )
-        return len(tokens)
+        await repository.revoke_scoped_to_organization(organization_id)
 
     async def revoke_leaked(
         self,

--- a/server/polar/oauth2/tasks.py
+++ b/server/polar/oauth2/tasks.py
@@ -1,5 +1,3 @@
-from uuid import UUID
-
 from polar.worker import AsyncSessionMaker, CronTrigger, TaskPriority, actor
 
 from .service.oauth2_token import oauth2_token as oauth2_token_service
@@ -14,12 +12,3 @@ from .service.oauth2_token import oauth2_token as oauth2_token_service
 async def oauth2_token_delete_expired() -> None:
     async with AsyncSessionMaker() as session:
         await oauth2_token_service.delete_expired(session)
-
-
-@actor(
-    actor_name="oauth2_token.revoke_for_sso_enforcement",
-    priority=TaskPriority.LOW,
-)
-async def oauth2_token_revoke_for_sso_enforcement(organization_id: UUID) -> None:
-    async with AsyncSessionMaker() as session:
-        await oauth2_token_service.revoke_for_sso_enforcement(session, organization_id)

--- a/server/polar/oauth2/tasks.py
+++ b/server/polar/oauth2/tasks.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from polar.worker import AsyncSessionMaker, CronTrigger, TaskPriority, actor
 
 from .service.oauth2_token import oauth2_token as oauth2_token_service
@@ -12,3 +14,12 @@ from .service.oauth2_token import oauth2_token as oauth2_token_service
 async def oauth2_token_delete_expired() -> None:
     async with AsyncSessionMaker() as session:
         await oauth2_token_service.delete_expired(session)
+
+
+@actor(
+    actor_name="oauth2_token.revoke_for_sso_enforcement",
+    priority=TaskPriority.LOW,
+)
+async def oauth2_token_revoke_for_sso_enforcement(organization_id: UUID) -> None:
+    async with AsyncSessionMaker() as session:
+        await oauth2_token_service.revoke_for_sso_enforcement(session, organization_id)

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -548,6 +548,10 @@ class OrganizationService:
                 session, organization, update_schema.default_presentment_currency
             )
 
+        sso_newly_enforced = (
+            update_schema.sso_enforced is True and not organization.sso_enforced
+        )
+
         update_dict = update_schema.model_dump(
             by_alias=True,
             exclude_unset=True,
@@ -565,6 +569,12 @@ class OrganizationService:
             )
 
         organization = await repository.update(organization, update_dict=update_dict)
+
+        if sso_newly_enforced:
+            enqueue_job(
+                "oauth2_token.revoke_for_sso_enforcement",
+                organization_id=organization.id,
+            )
 
         await self._after_update(session, organization)
         return organization

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -57,6 +57,9 @@ from polar.models.transaction import TransactionType
 from polar.models.user import IdentityVerificationStatus
 from polar.models.user_organization import OrganizationRole
 from polar.models.webhook_endpoint import WebhookEventType
+from polar.oauth2.service.oauth2_token import (
+    oauth2_token as oauth2_token_service,
+)
 from polar.organization_access_token.repository import (
     OrganizationAccessTokenRepository,
 )
@@ -571,9 +574,8 @@ class OrganizationService:
         organization = await repository.update(organization, update_dict=update_dict)
 
         if sso_newly_enforced:
-            enqueue_job(
-                "oauth2_token.revoke_for_sso_enforcement",
-                organization_id=organization.id,
+            await oauth2_token_service.revoke_for_sso_enforcement(
+                session, organization.id
             )
 
         await self._after_update(session, organization)

--- a/server/tests/oauth2/service/test_oauth2_token.py
+++ b/server/tests/oauth2/service/test_oauth2_token.py
@@ -414,11 +414,9 @@ class TestRevokeForSSOEnforcement:
             organizations=[organization],
         )
 
-        count = await oauth2_token_service.revoke_for_sso_enforcement(
-            session, organization.id
-        )
+        await oauth2_token_service.revoke_for_sso_enforcement(session, organization.id)
 
-        assert count == 1
+        await session.refresh(token)
         assert token.access_token_revoked_at
         assert token.refresh_token_revoked_at
 
@@ -442,11 +440,9 @@ class TestRevokeForSSOEnforcement:
             organizations=[organization, organization_second],
         )
 
-        count = await oauth2_token_service.revoke_for_sso_enforcement(
-            session, organization.id
-        )
+        await oauth2_token_service.revoke_for_sso_enforcement(session, organization.id)
 
-        assert count == 1
+        await session.refresh(token)
         assert token.access_token_revoked_at
 
     async def test_ignores_token_scoped_to_other_org(
@@ -461,18 +457,16 @@ class TestRevokeForSSOEnforcement:
         token = await create_oauth2_token(
             save_fixture,
             client=oauth2_client,
-            access_token="polar_at_u_sso3",
-            refresh_token="polar_rt_u_sso3",
+            access_token="polar_at_u_sso4",
+            refresh_token="polar_rt_u_sso4",
             scopes=["openid"],
             user=user,
             organizations=[organization_second],
         )
 
-        count = await oauth2_token_service.revoke_for_sso_enforcement(
-            session, organization.id
-        )
+        await oauth2_token_service.revoke_for_sso_enforcement(session, organization.id)
 
-        assert count == 0
+        await session.refresh(token)
         assert not token.access_token_revoked_at
 
     async def test_ignores_unrestricted_token(
@@ -487,20 +481,18 @@ class TestRevokeForSSOEnforcement:
         token = await create_oauth2_token(
             save_fixture,
             client=oauth2_client,
-            access_token="polar_at_u_sso4",
-            refresh_token="polar_rt_u_sso4",
+            access_token="polar_at_u_sso5",
+            refresh_token="polar_rt_u_sso5",
             scopes=["openid"],
             user=user,
         )
 
-        count = await oauth2_token_service.revoke_for_sso_enforcement(
-            session, organization.id
-        )
+        await oauth2_token_service.revoke_for_sso_enforcement(session, organization.id)
 
-        assert count == 0
+        await session.refresh(token)
         assert not token.access_token_revoked_at
 
-    async def test_ignores_already_revoked_token(
+    async def test_leaves_fully_revoked_token_untouched(
         self,
         save_fixture: SaveFixture,
         session: AsyncSession,
@@ -508,19 +500,20 @@ class TestRevokeForSSOEnforcement:
         user: User,
         organization: Organization,
     ) -> None:
-        await create_oauth2_token(
+        token = await create_oauth2_token(
             save_fixture,
             client=oauth2_client,
-            access_token="polar_at_u_sso5",
-            refresh_token="polar_rt_u_sso5",
+            access_token="polar_at_u_sso6",
+            refresh_token="polar_rt_u_sso6",
             scopes=["openid"],
             user=user,
             organizations=[organization],
-            access_token_revoked_at=int(time.time()),
+            access_token_revoked_at=1,
+            refresh_token_revoked_at=1,
         )
 
-        count = await oauth2_token_service.revoke_for_sso_enforcement(
-            session, organization.id
-        )
+        await oauth2_token_service.revoke_for_sso_enforcement(session, organization.id)
 
-        assert count == 0
+        await session.refresh(token)
+        assert token.access_token_revoked_at == 1
+        assert token.refresh_token_revoked_at == 1

--- a/server/tests/oauth2/service/test_oauth2_token.py
+++ b/server/tests/oauth2/service/test_oauth2_token.py
@@ -392,3 +392,135 @@ class TestDeleteExpired:
 
         preserved = await session.get(OAuth2Token, expired.id)
         assert preserved is not None
+
+
+@pytest.mark.asyncio
+class TestRevokeForSSOEnforcement:
+    async def test_revokes_token_scoped_to_org(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        oauth2_client: OAuth2Client,
+        user: User,
+        organization: Organization,
+    ) -> None:
+        token = await create_oauth2_token(
+            save_fixture,
+            client=oauth2_client,
+            access_token="polar_at_u_sso1",
+            refresh_token="polar_rt_u_sso1",
+            scopes=["openid"],
+            user=user,
+            organizations=[organization],
+        )
+
+        count = await oauth2_token_service.revoke_for_sso_enforcement(
+            session, organization.id
+        )
+
+        assert count == 1
+        assert token.access_token_revoked_at
+        assert token.refresh_token_revoked_at
+
+    async def test_revokes_token_scoped_to_multiple_orgs(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        oauth2_client: OAuth2Client,
+        user: User,
+        organization: Organization,
+        organization_second: Organization,
+    ) -> None:
+        # Revoked even though it also covers a non-enforced org.
+        token = await create_oauth2_token(
+            save_fixture,
+            client=oauth2_client,
+            access_token="polar_at_u_sso2",
+            refresh_token="polar_rt_u_sso2",
+            scopes=["openid"],
+            user=user,
+            organizations=[organization, organization_second],
+        )
+
+        count = await oauth2_token_service.revoke_for_sso_enforcement(
+            session, organization.id
+        )
+
+        assert count == 1
+        assert token.access_token_revoked_at
+
+    async def test_ignores_token_scoped_to_other_org(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        oauth2_client: OAuth2Client,
+        user: User,
+        organization: Organization,
+        organization_second: Organization,
+    ) -> None:
+        token = await create_oauth2_token(
+            save_fixture,
+            client=oauth2_client,
+            access_token="polar_at_u_sso3",
+            refresh_token="polar_rt_u_sso3",
+            scopes=["openid"],
+            user=user,
+            organizations=[organization_second],
+        )
+
+        count = await oauth2_token_service.revoke_for_sso_enforcement(
+            session, organization.id
+        )
+
+        assert count == 0
+        assert not token.access_token_revoked_at
+
+    async def test_ignores_unrestricted_token(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        oauth2_client: OAuth2Client,
+        user: User,
+        organization: Organization,
+    ) -> None:
+        # No org rows == unrestricted; handled at request time, not revoked here.
+        token = await create_oauth2_token(
+            save_fixture,
+            client=oauth2_client,
+            access_token="polar_at_u_sso4",
+            refresh_token="polar_rt_u_sso4",
+            scopes=["openid"],
+            user=user,
+        )
+
+        count = await oauth2_token_service.revoke_for_sso_enforcement(
+            session, organization.id
+        )
+
+        assert count == 0
+        assert not token.access_token_revoked_at
+
+    async def test_ignores_already_revoked_token(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        oauth2_client: OAuth2Client,
+        user: User,
+        organization: Organization,
+    ) -> None:
+        await create_oauth2_token(
+            save_fixture,
+            client=oauth2_client,
+            access_token="polar_at_u_sso5",
+            refresh_token="polar_rt_u_sso5",
+            scopes=["openid"],
+            user=user,
+            organizations=[organization],
+            access_token_revoked_at=int(time.time()),
+        )
+
+        count = await oauth2_token_service.revoke_for_sso_enforcement(
+            session, organization.id
+        )
+
+        assert count == 0

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -43,6 +43,7 @@ from polar.models.organization_access_token import OrganizationAccessToken
 from polar.models.organization_review import OrganizationReview
 from polar.models.user import IdentityVerificationStatus
 from polar.models.user_organization import OrganizationRole
+from polar.oauth2.service.oauth2_token import oauth2_token as oauth2_token_service
 from polar.organization.repository import OrganizationRepository
 from polar.organization.schemas import (
     LegacyOrganizationStatus,
@@ -60,7 +61,6 @@ from polar.organization.schemas import (
     OrganizationSocialPlatforms,
     OrganizationUpdate,
 )
-from polar.oauth2.service.oauth2_token import oauth2_token as oauth2_token_service
 from polar.organization.service import (
     CannotCreateOrganizationError,
     OrganizationError,

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -5070,3 +5070,45 @@ class TestCancelExpiredOrganizationsSubscriptions:
 
         assert organization.id not in {org.id for org in result}
         enqueue_job_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestUpdateSSOEnforcement:
+    @pytest.mark.auth
+    async def test_enabling_enqueues_token_revocation(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+        organization.sso_enforced = False
+        session.add(organization)
+        await session.flush()
+
+        await organization_service.update(
+            session, organization, OrganizationUpdate(sso_enforced=True)
+        )
+
+        enqueue_job_mock.assert_called_once_with(
+            "oauth2_token.revoke_for_sso_enforcement",
+            organization_id=organization.id,
+        )
+
+    @pytest.mark.auth
+    async def test_already_enforced_does_not_enqueue(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+        organization.sso_enforced = True
+        session.add(organization)
+        await session.flush()
+
+        await organization_service.update(
+            session, organization, OrganizationUpdate(sso_enforced=True)
+        )
+
+        enqueue_job_mock.assert_not_called()

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -60,6 +60,7 @@ from polar.organization.schemas import (
     OrganizationSocialPlatforms,
     OrganizationUpdate,
 )
+from polar.oauth2.service.oauth2_token import oauth2_token as oauth2_token_service
 from polar.organization.service import (
     CannotCreateOrganizationError,
     OrganizationError,
@@ -5075,13 +5076,15 @@ class TestCancelExpiredOrganizationsSubscriptions:
 @pytest.mark.asyncio
 class TestUpdateSSOEnforcement:
     @pytest.mark.auth
-    async def test_enabling_enqueues_token_revocation(
+    async def test_enabling_revokes_tokens(
         self,
         mocker: MockerFixture,
         session: AsyncSession,
         organization: Organization,
     ) -> None:
-        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+        revoke_mock = mocker.patch.object(
+            oauth2_token_service, "revoke_for_sso_enforcement"
+        )
         organization.sso_enforced = False
         session.add(organization)
         await session.flush()
@@ -5090,19 +5093,18 @@ class TestUpdateSSOEnforcement:
             session, organization, OrganizationUpdate(sso_enforced=True)
         )
 
-        enqueue_job_mock.assert_called_once_with(
-            "oauth2_token.revoke_for_sso_enforcement",
-            organization_id=organization.id,
-        )
+        revoke_mock.assert_awaited_once_with(session, organization.id)
 
     @pytest.mark.auth
-    async def test_already_enforced_does_not_enqueue(
+    async def test_already_enforced_does_not_revoke(
         self,
         mocker: MockerFixture,
         session: AsyncSession,
         organization: Organization,
     ) -> None:
-        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+        revoke_mock = mocker.patch.object(
+            oauth2_token_service, "revoke_for_sso_enforcement"
+        )
         organization.sso_enforced = True
         session.add(organization)
         await session.flush()
@@ -5111,4 +5113,4 @@ class TestUpdateSSOEnforcement:
             session, organization, OrganizationUpdate(sso_enforced=True)
         )
 
-        enqueue_job_mock.assert_not_called()
+        revoke_mock.assert_not_awaited()


### PR DESCRIPTION
## Summary

When an org flips `sso_enforced` on, revoke every OAuth2 token explicitly down-scoped to that org (a row in `oauth2_token_organizations`).

<img width="1913" height="945" alt="Screenshot 2026-07-03 at 14 27 24" src="https://github.com/user-attachments/assets/f7798439-c4f3-41fa-9da8-6c93889f13c1" />


## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

