### PR TITLE
feat(merchant-migration): block India and Connect-platform sources in precheck

### DIFF
--- a/server/polar/merchant_migration/adapters/base.py
+++ b/server/polar/merchant_migration/adapters/base.py
@@ -1,7 +1,7 @@
 from collections.abc import AsyncIterator
 from typing import Protocol
 
-from ..canonical import CanonicalRecord
+from ..canonical import CanonicalAccount, CanonicalRecord
 
 
 class SourceAdapter(Protocol):
@@ -12,3 +12,5 @@ class SourceAdapter(Protocol):
     """
 
     def extract(self) -> AsyncIterator[CanonicalRecord]: ...
+
+    async def get_source_account(self) -> CanonicalAccount: ...

--- a/server/polar/merchant_migration/adapters/stripe.py
+++ b/server/polar/merchant_migration/adapters/stripe.py
@@ -55,11 +55,17 @@ class StripeAdapter:
         except stripe_lib.StripeError:
             pass
         try:
-            connected = await self._client.v1.accounts.list_async(params={"limit": 1})
-            is_connect_platform = len(connected.data) > 0
+            # Only Connect platforms may list connected accounts; a non-platform
+            # gets a permission error. So the call *succeeding* — not the number
+            # of accounts returned — is what identifies a platform (a platform
+            # with zero connected accounts still succeeds here).
+            await self._client.v1.accounts.list_async(params={"limit": 1})
+            is_connect_platform = True
         except stripe_lib.StripeError:
             pass
-        return CanonicalAccount(country=country, is_connect_platform=is_connect_platform)
+        return CanonicalAccount(
+            country=country, is_connect_platform=is_connect_platform
+        )
 
     async def _extract_products(self) -> AsyncIterator[CanonicalProduct]:
         # Buffer + group prices per (product, interval); catalogs are small,

--- a/server/polar/merchant_migration/adapters/stripe.py
+++ b/server/polar/merchant_migration/adapters/stripe.py
@@ -8,6 +8,7 @@ from typing import Any
 import stripe as stripe_lib
 
 from ..canonical import (
+    CanonicalAccount,
     CanonicalCollectionMethod,
     CanonicalCustomer,
     CanonicalPaymentMethod,
@@ -42,6 +43,23 @@ class StripeAdapter:
             yield customer
         async for subscription in self._extract_subscriptions():
             yield subscription
+
+    async def get_source_account(self) -> CanonicalAccount:
+        # Best-effort: the restricted OAuth key may lack account/Connect read
+        # scope, in which case we can't determine these and don't block.
+        country: str | None = None
+        is_connect_platform = False
+        try:
+            account = await self._client.v1.accounts.retrieve_current_async()
+            country = account.country
+        except stripe_lib.StripeError:
+            pass
+        try:
+            connected = await self._client.v1.accounts.list_async(params={"limit": 1})
+            is_connect_platform = len(connected.data) > 0
+        except stripe_lib.StripeError:
+            pass
+        return CanonicalAccount(country=country, is_connect_platform=is_connect_platform)
 
     async def _extract_products(self) -> AsyncIterator[CanonicalProduct]:
         # Buffer + group prices per (product, interval); catalogs are small,

--- a/server/polar/merchant_migration/canonical.py
+++ b/server/polar/merchant_migration/canonical.py
@@ -107,4 +107,12 @@ class CanonicalSubscription:
     type = MerchantMigrationRecordType.subscription
 
 
+@dataclass
+class CanonicalAccount:
+    """Source-account-level facts the precheck needs but that aren't per-record."""
+
+    country: str | None
+    is_connect_platform: bool
+
+
 CanonicalRecord = CanonicalProduct | CanonicalCustomer | CanonicalSubscription

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -18,6 +18,7 @@ from polar.models import Organization
 from polar.models.organization import OrganizationStatus
 
 from .canonical import (
+    CanonicalAccount,
     CanonicalCollectionMethod,
     CanonicalCustomer,
     CanonicalPrice,
@@ -52,8 +53,10 @@ class PrecheckEngine:
         self,
         records: AsyncIterable[CanonicalRecord],
         organization: Organization,
+        source_account: CanonicalAccount,
     ) -> PrecheckReport:
         issues: list[PrecheckIssue] = list(self._check_organization(organization))
+        issues.extend(self._check_account(source_account))
 
         products_by_name: dict[str, set[str]] = {}
         email_counts: Counter[str] = Counter()
@@ -94,6 +97,28 @@ class PrecheckEngine:
                 message=(
                     "The organization must be in a renewal-enabled status "
                     "(Review or Active) before migrating."
+                ),
+                source_id=None,
+            )
+
+    def _check_account(self, account: CanonicalAccount) -> Iterable[PrecheckIssue]:
+        if account.country == "IN":
+            yield PrecheckIssue(
+                level=PrecheckIssueLevel.blocker,
+                code="india_account",
+                message=(
+                    "India (RBI) accounts can't move card data across the border, "
+                    "so the card copy can't run."
+                ),
+                source_id=None,
+            )
+        if account.is_connect_platform:
+            yield PrecheckIssue(
+                level=PrecheckIssueLevel.blocker,
+                code="connect_platform_account",
+                message=(
+                    "The source is a Connect platform; only platform-account data "
+                    "is copyable, so it can't be migrated automatically."
                 ),
                 source_id=None,
             )

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -131,7 +131,10 @@ class MerchantMigrationService:
             raise MerchantMigrationNotFound()
 
         adapter = await self._build_adapter(session, migration)
-        report = await precheck_engine.run(adapter.extract(), organization)
+        source_account = await adapter.get_source_account()
+        report = await precheck_engine.run(
+            adapter.extract(), organization, source_account
+        )
 
         await repository.update(
             migration, update_dict={"step": MerchantMigrationStep.pre_check}

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -8,6 +8,7 @@ from pytest_mock import MockerFixture
 
 from polar.auth.scope import Scope
 from polar.config import settings
+from polar.merchant_migration.canonical import CanonicalAccount
 from polar.merchant_migration.repository import MerchantMigrationRepository
 from polar.merchant_migration.stripe_oauth import StripeOAuthError
 from polar.models import MerchantMigration, Organization, UserOrganization
@@ -236,6 +237,9 @@ class TestPrecheck:
         )
         adapter = mocker.MagicMock()
         adapter.extract.return_value = _empty_extract()
+        adapter.get_source_account = mocker.AsyncMock(
+            return_value=CanonicalAccount(country="US", is_connect_platform=False)
+        )
         mocker.patch(
             "polar.merchant_migration.service.StripeAdapter", return_value=adapter
         )

--- a/server/tests/merchant_migration/test_precheck.py
+++ b/server/tests/merchant_migration/test_precheck.py
@@ -3,6 +3,7 @@ from collections.abc import AsyncIterator
 import pytest
 
 from polar.merchant_migration.canonical import (
+    CanonicalAccount,
     CanonicalCollectionMethod,
     CanonicalCustomer,
     CanonicalPaymentMethod,
@@ -31,6 +32,12 @@ def build_organization(
     status: OrganizationStatus = OrganizationStatus.ACTIVE,
 ) -> Organization:
     return Organization(status=status)
+
+
+def build_account(
+    *, country: str | None = "US", is_connect_platform: bool = False
+) -> CanonicalAccount:
+    return CanonicalAccount(country=country, is_connect_platform=is_connect_platform)
 
 
 def build_customer(
@@ -118,10 +125,12 @@ async def run(
     records: list[CanonicalRecord],
     *,
     organization: Organization | None = None,
+    account: CanonicalAccount | None = None,
 ) -> PrecheckReport:
     return await precheck_engine.run(
         aiter_records(records),
         organization or build_organization(),
+        account or build_account(),
     )
 
 
@@ -155,6 +164,16 @@ class TestPrecheckEngine:
         assert "organization_not_renewal_enabled" in codes(
             report, PrecheckIssueLevel.blocker
         )
+
+    async def test_india_account_blocks(self) -> None:
+        report = await run([build_product()], account=build_account(country="IN"))
+        assert "india_account" in codes(report, PrecheckIssueLevel.blocker)
+
+    async def test_connect_platform_account_blocks(self) -> None:
+        report = await run(
+            [build_product()], account=build_account(is_connect_platform=True)
+        )
+        assert "connect_platform_account" in codes(report, PrecheckIssueLevel.blocker)
 
     async def test_non_fixed_pricing_warns_and_can_start(self) -> None:
         report = await run(

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -7,6 +7,7 @@ from polar.auth.models import AuthSubject
 from polar.config import settings
 from polar.kit import jwt
 from polar.merchant_migration.canonical import (
+    CanonicalAccount,
     CanonicalPrice,
     CanonicalPricingScheme,
     CanonicalProduct,
@@ -40,6 +41,9 @@ class _FakeAdapter:
     async def extract(self) -> AsyncIterator[CanonicalRecord]:
         for record in self._records:
             yield record
+
+    async def get_source_account(self) -> CanonicalAccount:
+        return CanonicalAccount(country="US", is_connect_platform=False)
 
 
 @pytest.mark.asyncio

--- a/server/tests/merchant_migration/test_stripe_adapter.py
+++ b/server/tests/merchant_migration/test_stripe_adapter.py
@@ -1,0 +1,62 @@
+from typing import Any
+
+import pytest
+import stripe as stripe_lib
+from pytest_mock import MockerFixture
+
+from polar.merchant_migration.adapters.stripe import StripeAdapter
+
+
+def _adapter(mocker: MockerFixture) -> tuple[StripeAdapter, Any]:
+    adapter = StripeAdapter("rk_test")
+    client: Any = mocker.MagicMock()
+    adapter._client = client
+    return adapter, client
+
+
+@pytest.mark.asyncio
+class TestGetSourceAccount:
+    async def test_platform_with_zero_connected_accounts_is_flagged(
+        self, mocker: MockerFixture
+    ) -> None:
+        adapter, client = _adapter(mocker)
+        client.v1.accounts.retrieve_current_async = mocker.AsyncMock(
+            return_value=mocker.MagicMock(country="US")
+        )
+        # A platform with no connected accounts still lists successfully.
+        client.v1.accounts.list_async = mocker.AsyncMock(
+            return_value=mocker.MagicMock(data=[])
+        )
+
+        account = await adapter.get_source_account()
+
+        assert account.is_connect_platform is True
+
+    async def test_non_platform_is_not_flagged(self, mocker: MockerFixture) -> None:
+        adapter, client = _adapter(mocker)
+        client.v1.accounts.retrieve_current_async = mocker.AsyncMock(
+            return_value=mocker.MagicMock(country="US")
+        )
+        # Non-platforms get a permission error when listing connected accounts.
+        client.v1.accounts.list_async = mocker.AsyncMock(
+            side_effect=stripe_lib.PermissionError("not a platform")
+        )
+
+        account = await adapter.get_source_account()
+
+        assert account.is_connect_platform is False
+        assert account.country == "US"
+
+    async def test_scope_gap_is_tolerated(self, mocker: MockerFixture) -> None:
+        adapter, client = _adapter(mocker)
+        client.v1.accounts.retrieve_current_async = mocker.AsyncMock(
+            side_effect=stripe_lib.PermissionError("missing scope")
+        )
+        client.v1.accounts.list_async = mocker.AsyncMock(
+            side_effect=stripe_lib.PermissionError("missing scope")
+        )
+
+        account = await adapter.get_source_account()
+
+        assert account.country is None
+        assert account.is_connect_platform is False


### PR DESCRIPTION
Adds a source-account-level check to the migration pre-check.

- New `CanonicalAccount` + `SourceAdapter.get_source_account` (best-effort; tolerates restricted-key scope gaps).
- Two blockers: **India (RBI)** accounts (card data can't cross the border) and **Connect platforms** (only platform-account data is copyable).


## Checklist
- [x] Tests pass (`tests/merchant_migration/`, 35 passed)
- [x] Lint + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

