### PR TITLE
Dedicated schemas for each support type

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/disputes/[id]/respond/DisputeRespondView.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/disputes/[id]/respond/DisputeRespondView.tsx
@@ -76,10 +76,11 @@ export const DisputeRespondView = ({ organization, dispute }: Props) => {
     }
     const result = await reply.mutateAsync({
       caseId,
+      type: 'dispute',
       body: explanation.trim(),
       file_ids: evidence.fileIds,
-      dispute_win_reason: reason || null,
-      dispute_win_reason_other: reason === 'other' ? otherReason.trim() : null,
+      win_reason: reason || null,
+      win_reason_other: reason === 'other' ? otherReason.trim() : null,
     })
     if (result.error) {
       toast({

--- a/clients/apps/web/src/components/Disputes/DisputeConversation.tsx
+++ b/clients/apps/web/src/components/Disputes/DisputeConversation.tsx
@@ -95,7 +95,12 @@ export const DisputeConversation = ({
         allowAttachments: true,
         placeholder: 'Write a reply…',
         onSend: (text, fileIds) =>
-          reply.mutateAsync({ caseId, body: text, file_ids: fileIds }),
+          reply.mutateAsync({
+            caseId,
+            type: 'dispute',
+            body: text,
+            file_ids: fileIds,
+          }),
       }}
     />
   )

--- a/clients/apps/web/src/components/Organization/HumanReviewCase/index.tsx
+++ b/clients/apps/web/src/components/Organization/HumanReviewCase/index.tsx
@@ -142,7 +142,12 @@ const HumanReviewCase = ({ organization }: Props) => {
           : 'Tell us why your organization should be approved…',
         onSend: (text, fileIds) =>
           caseId
-            ? reply.mutateAsync({ caseId, body: text, file_ids: fileIds })
+            ? reply.mutateAsync({
+                caseId,
+                type: 'review_appeal',
+                body: text,
+                file_ids: fileIds,
+              })
             : requestReview.mutateAsync({ reason: text }),
       }}
     />

--- a/clients/apps/web/src/hooks/queries/org.ts
+++ b/clients/apps/web/src/hooks/queries/org.ts
@@ -433,25 +433,11 @@ export const useReplyToSupportCase = () =>
   useMutation({
     mutationFn: ({
       caseId,
-      body,
-      file_ids,
-      dispute_win_reason,
-      dispute_win_reason_other,
-    }: {
-      caseId: string
-      body?: string
-      file_ids?: string[]
-      dispute_win_reason?: schemas['DisputeWinReason'] | null
-      dispute_win_reason_other?: string | null
-    }) =>
+      ...payload
+    }: { caseId: string } & schemas['SupportCaseMessageCreate']) =>
       api.POST('/v1/support-cases/{id}/messages', {
         params: { path: { id: caseId } },
-        body: {
-          body: body || null,
-          file_ids,
-          dispute_win_reason,
-          dispute_win_reason_other,
-        },
+        body: { ...payload, body: payload.body || null },
       }),
     onSuccess: async (result, { caseId }) => {
       if (result.error) return

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -19958,6 +19958,28 @@ export interface components {
       | 'lost'
       | 'won'
     /**
+     * DisputeSupportCaseMessageCreate
+     * @description A reply on a dispute case.
+     */
+    DisputeSupportCaseMessageCreate: {
+      /** Body */
+      body?: string | null
+      /** File Ids */
+      file_ids?: string[]
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'dispute'
+      /** @description The merchant's stated grounds for contesting, set on the counter submission. */
+      win_reason?: components['schemas']['DisputeWinReason'] | null
+      /**
+       * Win Reason Other
+       * @description Free-text detail when `win_reason` is `other`.
+       */
+      win_reason_other?: string | null
+    }
+    /**
      * DisputeWinReason
      * @description Why the merchant believes they should win the chargeback.
      *
@@ -29763,6 +29785,21 @@ export interface components {
       /** Detail */
       detail: string
     }
+    /**
+     * ReviewAppealSupportCaseMessageCreate
+     * @description A reply on a review-appeal case.
+     */
+    ReviewAppealSupportCaseMessageCreate: {
+      /** Body */
+      body?: string | null
+      /** File Ids */
+      file_ids?: string[]
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'review_appeal'
+    }
     /** RevokeTokenResponse */
     RevokeTokenResponse: Record<string, never>
     /** S3DownloadURL */
@@ -32414,23 +32451,9 @@ export interface components {
       | 'merchant'
       | 'customer'
       | 'system'
-    /**
-     * SupportCaseMessageCreate
-     * @description A reply: free text, attachments (already uploaded files), or both.
-     */
-    SupportCaseMessageCreate: {
-      /** Body */
-      body?: string | null
-      /** File Ids */
-      file_ids?: string[]
-      /** @description For a dispute case, the merchant's stated grounds for contesting. Set on the counter submission; ignored for other case types. */
-      dispute_win_reason?: components['schemas']['DisputeWinReason'] | null
-      /**
-       * Dispute Win Reason Other
-       * @description Free-text detail when `dispute_win_reason` is `other`.
-       */
-      dispute_win_reason_other?: string | null
-    }
+    SupportCaseMessageCreate:
+      | components['schemas']['ReviewAppealSupportCaseMessageCreate']
+      | components['schemas']['DisputeSupportCaseMessageCreate']
     /**
      * SupportCaseMessageType
      * @description Known message types. Stored as a plain string column (not a DB enum):
@@ -59622,6 +59645,9 @@ export const disputeStatusValues: ReadonlyArray<
   'lost',
   'won',
 ]
+export const disputeSupportCaseMessageCreateTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['DisputeSupportCaseMessageCreate']['type']
+> = ['dispute']
 export const disputeWinReasonValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['DisputeWinReason']
 > = [
@@ -61546,6 +61572,9 @@ export const refundSortPropertyValues: ReadonlyArray<
 export const refundStatusValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['RefundStatus']
 > = ['pending', 'succeeded', 'failed', 'canceled']
+export const reviewAppealSupportCaseMessageCreateTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['ReviewAppealSupportCaseMessageCreate']['type']
+> = ['review_appeal']
 export const sSOFactorTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SSOFactor']['type']
 > = ['sso']

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -62,6 +62,7 @@ from polar.models.organization_review import OrganizationReview
 from polar.models.support_case import (
     ReviewAppealSupportCase,
     SupportCaseMessageAuthorKind,
+    SupportCaseType,
 )
 from polar.models.transaction import TransactionType
 from polar.models.user import IdentityVerificationStatus
@@ -101,6 +102,7 @@ from polar.startup_program.service import (
 from polar.support_case.repository import (
     SupportCaseMessageRepository,
 )
+from polar.support_case.schemas import ReviewAppealSupportCaseMessageCreate
 from polar.transaction.service.transaction import transaction as transaction_service
 from polar.worker import enqueue_job
 
@@ -1737,6 +1739,8 @@ async def appeal_case_approve_dialog(
                 "An internal note is required to approve — it overrides the AI's "
                 "denial."
             )
+        elif len(internal_note) > 5000:
+            error_message = "The internal note must be at most 5000 characters."
         elif not await message_repository.is_open(case.id):
             error_message = "This appeal case is already closed."
         else:
@@ -1752,9 +1756,11 @@ async def appeal_case_approve_dialog(
                 await appeal_case_service.add_reply(
                     session,
                     case,
+                    ReviewAppealSupportCaseMessageCreate(
+                        type=SupportCaseType.review_appeal, body=internal_note
+                    ),
                     author_kind=SupportCaseMessageAuthorKind.platform,
                     author_user=user_session.user,
-                    body=internal_note,
                     internal=True,
                 )
                 await organization_service.backoffice_approve(
@@ -1806,6 +1812,7 @@ async def appeal_case_approve_dialog(
                     "Staff-only — recorded for future reviews.",
                     rows="3",
                     required=True,
+                    maxlength="5000",
                 ):
                     pass
             with tag.div(classes="form-control"):

--- a/server/polar/dispute/dispute_case.py
+++ b/server/polar/dispute/dispute_case.py
@@ -5,7 +5,6 @@ from polar.exceptions import PolarError
 from polar.models import Dispute, File, Organization, User
 from polar.models.support_case import (
     DisputeSupportCase,
-    DisputeWinReason,
     SupportCaseAudience,
     SupportCaseMessage,
     SupportCaseMessageAuthorKind,
@@ -17,6 +16,7 @@ from polar.support_case.repository import (
     DisputeSupportCaseRepository,
     SupportCaseMessageRepository,
 )
+from polar.support_case.schemas import DisputeSupportCaseMessageCreate
 from polar.support_case.service import support_case as support_case_service
 from polar.worker import enqueue_job
 
@@ -135,28 +135,26 @@ class DisputeCaseService:
         self,
         session: AsyncSession,
         case: DisputeSupportCase,
+        reply: DisputeSupportCaseMessageCreate,
         *,
         author_kind: SupportCaseMessageAuthorKind,
         author_user: User | None = None,
-        body: str | None = None,
         files: Sequence[File] = (),
         internal: bool = False,
-        win_reason: DisputeWinReason | None = None,
-        win_reason_other: str | None = None,
     ) -> SupportCaseMessage:
         """Post a reply to the dispute thread, optionally carrying files.
 
         This is the merchant ↔ support conversation channel: the merchant's
         evidence and any back-and-forth live here as ``chat`` messages, which
-        support reviews and submits to the processor. ``win_reason`` records the
-        merchant's stated grounds for contesting, set on their counter;
-        ``win_reason_other`` carries their free-text detail for ``other``.
+        support reviews and submits to the processor. ``reply.win_reason``
+        records the merchant's stated grounds for contesting, set on their
+        counter.
         """
         await self._assert_open(session, case)
 
-        if win_reason is not None:
-            case.win_reason = win_reason
-            case.win_reason_other = win_reason_other
+        if reply.win_reason is not None:
+            case.win_reason = reply.win_reason
+            case.win_reason_other = reply.win_reason_other
 
         is_first_merchant_reply = (
             author_kind == SupportCaseMessageAuthorKind.merchant
@@ -169,7 +167,7 @@ class DisputeCaseService:
             case,
             author_kind=author_kind,
             author_user=author_user,
-            body=body,
+            body=reply.body,
             audience=audience,
         )
         for file in files:

--- a/server/polar/organization_review/appeal_case.py
+++ b/server/polar/organization_review/appeal_case.py
@@ -18,6 +18,7 @@ from polar.support_case.repository import (
     ReviewAppealSupportCaseRepository,
     SupportCaseMessageRepository,
 )
+from polar.support_case.schemas import ReviewAppealSupportCaseMessageCreate
 from polar.support_case.service import support_case as support_case_service
 from polar.worker import enqueue_job
 
@@ -116,10 +117,10 @@ class AppealCaseService:
         self,
         session: AsyncSession,
         case: ReviewAppealSupportCase,
+        reply: ReviewAppealSupportCaseMessageCreate,
         *,
         author_kind: SupportCaseMessageAuthorKind,
         author_user: User | None = None,
-        body: str | None = None,
         files: Sequence[File] = (),
         internal: bool = False,
     ) -> SupportCaseMessage:
@@ -131,7 +132,7 @@ class AppealCaseService:
             case,
             author_kind=author_kind,
             author_user=author_user,
-            body=body,
+            body=reply.body,
             audience=audience,
         )
         for file in files:

--- a/server/polar/support_case/endpoints.py
+++ b/server/polar/support_case/endpoints.py
@@ -2,7 +2,11 @@ from fastapi import Depends
 from fastapi.responses import RedirectResponse
 
 from polar.dispute.dispute_case import dispute_case as dispute_case_service
-from polar.exceptions import PolarError, ResourceNotFound
+from polar.exceptions import (
+    PolarError,
+    PolarRequestValidationError,
+    ResourceNotFound,
+)
 from polar.file.service import file as file_service
 from polar.models import File
 from polar.models.file import FileServiceTypes
@@ -27,6 +31,8 @@ from polar.routing import APIRouter
 
 from . import auth
 from .schemas import (
+    DisputeSupportCaseMessageCreate,
+    ReviewAppealSupportCaseMessageCreate,
     SupportCaseAttachmentID,
     SupportCaseID,
     SupportCaseMessageCreate,
@@ -42,6 +48,21 @@ router = APIRouter(prefix="/support-cases", tags=["support-cases", APITag.privat
 class CaseRepliesNotSupportedError(PolarError):
     def __init__(self, case: SupportCase) -> None:
         super().__init__(f"Replies to {case.type} cases are not supported yet.", 409)
+
+
+def _reply_type_mismatch(
+    message: ReviewAppealSupportCaseMessageCreate | DisputeSupportCaseMessageCreate,
+) -> PolarRequestValidationError:
+    return PolarRequestValidationError(
+        [
+            {
+                "type": "value_error",
+                "loc": ("body", "type"),
+                "msg": "Reply type does not match the support case type.",
+                "input": message.type,
+            }
+        ]
+    )
 
 
 @router.get(
@@ -121,24 +142,26 @@ async def reply_to_support_case(
         files.append(file)
 
     if isinstance(case, ReviewAppealSupportCase):
+        if not isinstance(message, ReviewAppealSupportCaseMessageCreate):
+            raise _reply_type_mismatch(message)
         return await appeal_case_service.add_reply(
             session,
             case,
+            message,
             author_kind=SupportCaseMessageAuthorKind.merchant,
             author_user=auth_subject.subject,
-            body=message.body,
             files=files,
         )
     if isinstance(case, DisputeSupportCase):
+        if not isinstance(message, DisputeSupportCaseMessageCreate):
+            raise _reply_type_mismatch(message)
         return await dispute_case_service.add_reply(
             session,
             case,
+            message,
             author_kind=SupportCaseMessageAuthorKind.merchant,
             author_user=auth_subject.subject,
-            body=message.body,
             files=files,
-            win_reason=message.dispute_win_reason,
-            win_reason_other=message.dispute_win_reason_other,
         )
     raise CaseRepliesNotSupportedError(case)
 

--- a/server/polar/support_case/schemas.py
+++ b/server/polar/support_case/schemas.py
@@ -1,10 +1,15 @@
-from typing import Annotated, Self
+from typing import Annotated, Literal, Self
 
 from fastapi import Path
-from pydantic import UUID4, Field, model_validator
+from pydantic import UUID4, Discriminator, Field, model_validator
 
 from polar.exceptions import ResourceNotFound
-from polar.kit.schemas import IDSchema, Schema, TimestampedSchema
+from polar.kit.schemas import (
+    IDSchema,
+    Schema,
+    SetSchemaReference,
+    TimestampedSchema,
+)
 from polar.models.support_case import (
     DisputeWinReason,
     SupportCaseMessageAuthorKind,
@@ -51,24 +56,11 @@ class SupportCaseThread(Schema):
     is_open: bool
 
 
-class SupportCaseMessageCreate(Schema):
+class SupportCaseMessageCreateBase(Schema):
     """A reply: free text, attachments (already uploaded files), or both."""
 
     body: str | None = Field(default=None, min_length=1, max_length=5000)
     file_ids: list[UUID4] = Field(default_factory=list, max_length=10)
-    dispute_win_reason: DisputeWinReason | None = Field(
-        default=None,
-        description=(
-            "For a dispute case, the merchant's stated grounds for contesting. "
-            "Set on the counter submission; ignored for other case types."
-        ),
-    )
-    dispute_win_reason_other: str | None = Field(
-        default=None,
-        min_length=1,
-        max_length=500,
-        description="Free-text detail when `dispute_win_reason` is `other`.",
-    )
 
     @model_validator(mode="after")
     def _require_content(self) -> Self:
@@ -76,24 +68,50 @@ class SupportCaseMessageCreate(Schema):
             raise ValueError("A reply needs a body, an attachment, or both.")
         return self
 
+
+class ReviewAppealSupportCaseMessageCreate(SupportCaseMessageCreateBase):
+    """A reply on a review-appeal case."""
+
+    type: Literal[SupportCaseType.review_appeal]
+
+
+class DisputeSupportCaseMessageCreate(SupportCaseMessageCreateBase):
+    """A reply on a dispute case."""
+
+    type: Literal[SupportCaseType.dispute]
+    win_reason: DisputeWinReason | None = Field(
+        default=None,
+        description=(
+            "The merchant's stated grounds for contesting, "
+            "set on the counter submission."
+        ),
+    )
+    win_reason_other: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=500,
+        description="Free-text detail when `win_reason` is `other`.",
+    )
+
     @model_validator(mode="after")
     def _validate_win_reason(self) -> Self:
         if (
-            self.dispute_win_reason_other is not None
-            and self.dispute_win_reason != DisputeWinReason.other
+            self.win_reason_other is not None
+            and self.win_reason != DisputeWinReason.other
         ):
             raise ValueError(
-                "dispute_win_reason_other is only allowed when "
-                "dispute_win_reason is `other`."
+                "win_reason_other is only allowed when win_reason is `other`."
             )
-        if (
-            self.dispute_win_reason == DisputeWinReason.other
-            and not self.dispute_win_reason_other
-        ):
-            raise ValueError(
-                "dispute_win_reason `other` requires dispute_win_reason_other."
-            )
+        if self.win_reason == DisputeWinReason.other and not self.win_reason_other:
+            raise ValueError("win_reason `other` requires win_reason_other.")
         return self
+
+
+SupportCaseMessageCreate = Annotated[
+    ReviewAppealSupportCaseMessageCreate | DisputeSupportCaseMessageCreate,
+    Discriminator("type"),
+    SetSchemaReference("SupportCaseMessageCreate"),
+]
 
 
 class HumanReviewRequest(Schema):

--- a/server/tests/organization_review/test_appeal_case.py
+++ b/server/tests/organization_review/test_appeal_case.py
@@ -31,6 +31,7 @@ from polar.support_case.repository import (
     SupportCaseMessageRepository,
     SupportCaseParticipantRepository,
 )
+from polar.support_case.schemas import ReviewAppealSupportCaseMessageCreate
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_organization_review
 
@@ -40,6 +41,12 @@ _post_appeal_greeting = post_appeal_greeting.__wrapped__  # type: ignore[attr-de
 @contextlib.asynccontextmanager
 async def _session_maker(session: AsyncSession) -> AsyncIterator[AsyncSession]:
     yield session
+
+
+def _reply(body: str) -> ReviewAppealSupportCaseMessageCreate:
+    return ReviewAppealSupportCaseMessageCreate(
+        type=SupportCaseType.review_appeal, body=body
+    )
 
 
 @pytest_asyncio.fixture
@@ -160,9 +167,9 @@ class TestReplyAndLock:
         await appeal_case_service.add_reply(
             session,
             case,
+            _reply("some more info"),
             author_kind=SupportCaseMessageAuthorKind.merchant,
             author_user=user,
-            body="some more info",
         )
 
         await appeal_case_service.record_decision(
@@ -176,9 +183,9 @@ class TestReplyAndLock:
             await appeal_case_service.add_reply(
                 session,
                 case,
+                _reply("please reconsider again"),
                 author_kind=SupportCaseMessageAuthorKind.merchant,
                 author_user=user,
-                body="please reconsider again",
             )
 
 
@@ -207,9 +214,9 @@ class TestReplyNotifiesMerchant:
         message = await appeal_case_service.add_reply(
             session,
             case,
+            _reply("staff reply"),
             author_kind=SupportCaseMessageAuthorKind.platform,
             author_user=user,
-            body="staff reply",
         )
         enqueue.assert_called_once_with(
             "support_case.notify_organization_of_new_message", message_id=message.id
@@ -239,9 +246,9 @@ class TestReplyNotifiesMerchant:
         await appeal_case_service.add_reply(
             session,
             case,
+            _reply("internal staff note"),
             author_kind=SupportCaseMessageAuthorKind.platform,
             author_user=user,
-            body="internal staff note",
             internal=True,
         )
         enqueue.assert_not_called()

--- a/server/tests/support_case/test_endpoints.py
+++ b/server/tests/support_case/test_endpoints.py
@@ -118,7 +118,8 @@ class TestReplyToSupportCase:
     ) -> None:
         case = await create_appeal_case(save_fixture, organization)
         response = await client.post(
-            f"/v1/support-cases/{case.id}/messages", json={"body": "hello"}
+            f"/v1/support-cases/{case.id}/messages",
+            json={"type": "review_appeal", "body": "hello"},
         )
         assert response.status_code == 401
 
@@ -133,7 +134,7 @@ class TestReplyToSupportCase:
         case = await create_appeal_case(save_fixture, organization)
         response = await client.post(
             f"/v1/support-cases/{case.id}/messages",
-            json={"body": "here is more detail"},
+            json={"type": "review_appeal", "body": "here is more detail"},
         )
         assert response.status_code == 201
         assert response.json()["body"] == "here is more detail"
@@ -153,7 +154,11 @@ class TestReplyToSupportCase:
 
         response = await client.post(
             f"/v1/support-cases/{case.id}/messages",
-            json={"body": "see attached", "file_ids": [str(file.id)]},
+            json={
+                "type": "review_appeal",
+                "body": "see attached",
+                "file_ids": [str(file.id)],
+            },
         )
         assert response.status_code == 201
 
@@ -180,7 +185,7 @@ class TestReplyToSupportCase:
 
         response = await client.post(
             f"/v1/support-cases/{case.id}/messages",
-            json={"file_ids": [str(file.id)]},
+            json={"type": "review_appeal", "file_ids": [str(file.id)]},
         )
         assert response.status_code == 404
 
@@ -203,9 +208,25 @@ class TestReplyToSupportCase:
         await session.flush()
 
         response = await client.post(
-            f"/v1/support-cases/{case.id}/messages", json={"body": "reopen?"}
+            f"/v1/support-cases/{case.id}/messages",
+            json={"type": "review_appeal", "body": "reopen?"},
         )
         assert response.status_code == 409
+
+    @pytest.mark.auth
+    async def test_reply_type_must_match_case_type(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        case = await create_appeal_case(save_fixture, organization)
+        response = await client.post(
+            f"/v1/support-cases/{case.id}/messages",
+            json={"type": "dispute", "body": "wrong reply type"},
+        )
+        assert response.status_code == 422
 
     @pytest.mark.auth
     async def test_dispute_case_accepts_reply(
@@ -219,7 +240,8 @@ class TestReplyToSupportCase:
     ) -> None:
         case = await create_dispute_case(save_fixture, organization, customer, product)
         response = await client.post(
-            f"/v1/support-cases/{case.id}/messages", json={"body": "my evidence"}
+            f"/v1/support-cases/{case.id}/messages",
+            json={"type": "dispute", "body": "my evidence"},
         )
         assert response.status_code == 201
         assert response.json()["body"] == "my evidence"
@@ -241,8 +263,9 @@ class TestReplyToSupportCase:
         response = await client.post(
             f"/v1/support-cases/{case.id}/messages",
             json={
+                "type": "dispute",
                 "body": "my evidence",
-                "dispute_win_reason": "cardholder_withdrew",
+                "win_reason": "cardholder_withdrew",
             },
         )
         assert response.status_code == 201
@@ -270,9 +293,10 @@ class TestReplyToSupportCase:
         response = await client.post(
             f"/v1/support-cases/{case.id}/messages",
             json={
+                "type": "dispute",
                 "body": "my evidence",
-                "dispute_win_reason": "other",
-                "dispute_win_reason_other": "The subscription was reactivated",
+                "win_reason": "other",
+                "win_reason_other": "The subscription was reactivated",
             },
         )
         assert response.status_code == 201
@@ -302,8 +326,9 @@ class TestReplyToSupportCase:
         response = await client.post(
             f"/v1/support-cases/{case.id}/messages",
             json={
+                "type": "dispute",
                 "body": "my evidence",
-                "dispute_win_reason_other": "would be silently lost",
+                "win_reason_other": "would be silently lost",
             },
         )
         assert response.status_code == 422
@@ -321,7 +346,7 @@ class TestReplyToSupportCase:
         case = await create_dispute_case(save_fixture, organization, customer, product)
         response = await client.post(
             f"/v1/support-cases/{case.id}/messages",
-            json={"body": "my evidence", "dispute_win_reason": "other"},
+            json={"type": "dispute", "body": "my evidence", "win_reason": "other"},
         )
         assert response.status_code == 422
 
@@ -340,7 +365,8 @@ class TestReplyToSupportCase:
         enqueue = mocker.patch("polar.dispute.dispute_case.enqueue_job")
 
         await client.post(
-            f"/v1/support-cases/{case.id}/messages", json={"body": "my evidence"}
+            f"/v1/support-cases/{case.id}/messages",
+            json={"type": "dispute", "body": "my evidence"},
         )
         enqueue.assert_any_call(
             "dispute.post_dispute_greeting",
@@ -351,7 +377,7 @@ class TestReplyToSupportCase:
         enqueue.reset_mock()
         await client.post(
             f"/v1/support-cases/{case.id}/messages",
-            json={"body": "one more thing"},
+            json={"type": "dispute", "body": "one more thing"},
         )
         greeting_calls = [
             call
@@ -377,7 +403,7 @@ class TestDownloadSupportCaseAttachment:
         await session.flush()
         await client.post(
             f"/v1/support-cases/{case.id}/messages",
-            json={"file_ids": [str(file.id)]},
+            json={"type": "review_appeal", "file_ids": [str(file.id)]},
         )
 
         thread = await client.get(f"/v1/support-cases/{case.id}")


### PR DESCRIPTION
## Summary

This PR will add dedicated reply schemas for each support case

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

