### PR TITLE
tf/pgbouncer: Roll back usage in test

### DIFF
--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -117,18 +117,14 @@ module "test" {
   registry_credential_id = render_registry_credential.ghcr.id
 
   postgres_config = {
-    host               = module.pgbouncer[0].host
-    port               = module.pgbouncer[0].port
-    user               = local.db_user
-    password           = local.db_password
-    host_fallback      = local.db_internal_host
-    port_fallback      = local.db_port
-    read_host          = module.pgbouncer_read[0].host
-    read_port          = module.pgbouncer_read[0].port
-    read_user          = local.db_user
-    read_password      = local.db_password
-    read_host_fallback = local.read_replica.id
-    read_port_fallback = local.db_port
+    host          = local.db_internal_host
+    port          = local.db_port
+    user          = local.db_user
+    password      = local.db_password
+    read_host     = local.read_replica.id
+    read_port     = local.db_port
+    read_user     = local.db_user
+    read_password = local.db_password
   }
 
   redis_config = {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reverts the test environment to connect directly to Postgres and removes `pgbouncer` usage. Updates `postgres_config` to use the internal host/port and the read replica for reads.

- **Refactors**
  - Replaced `module.pgbouncer[...]` and `module.pgbouncer_read[...]` with `local.db_internal_host`, `local.db_port`, and `local.read_replica.id`.
  - Removed fallback fields (`host_fallback`, `port_fallback`, `read_host_fallback`, `read_port_fallback`).

<sup>Written for commit cadb05176dd955918cc8f1000447f71e2d7052d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

