### PR TITLE
pgbouncer: Add statement_timeout to ignore parameters

### DIFF
--- a/infra/pgbouncer/entrypoint.sh
+++ b/infra/pgbouncer/entrypoint.sh
@@ -30,7 +30,7 @@ reserve_pool_size = ${RESERVE_POOL_SIZE:-0}
 reserve_pool_timeout = ${RESERVE_POOL_TIMEOUT:-5}
 max_prepared_statements = ${MAX_PREPARED_STATEMENTS:-200}
 server_tls_sslmode = ${SERVER_TLS_SSLMODE:-prefer}
-ignore_startup_parameters = ${IGNORE_STARTUP_PARAMETERS:-extra_float_digits}
+ignore_startup_parameters = ${IGNORE_STARTUP_PARAMETERS:-extra_float_digits,statement_timeout}
 EOF
 
 exec pgbouncer /etc/pgbouncer/pgbouncer.ini


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make PgBouncer ignore the `statement_timeout` startup parameter by default to avoid pool fragmentation and unexpected disconnects when clients set timeouts. The default now sets `ignore_startup_parameters=extra_float_digits,statement_timeout` in `infra/pgbouncer/entrypoint.sh`.

<sup>Written for commit 8daa0feb9f25f686f08b7deb464dc9e772411937. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

