### PR TITLE
Merge dispute attachments

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
@@ -23,6 +23,7 @@ from polar.models.support_case import (
     SupportCaseMessageType,
     SupportCaseType,
 )
+from polar.support_case.pdf import is_mergeable
 
 from .... import formatters
 from ....components import button, card, dispute_status_badge
@@ -123,6 +124,106 @@ _EVENT_NODES: dict[SupportCaseMessageType, tuple[str, str]] = {
 }
 
 Thread = tuple[SupportCase, bool, Sequence[SupportCaseMessage]]
+
+MERGED_PDFS_REGION_ID = "merged-pdfs"
+MERGE_POLL_MAX_ATTEMPTS = 60
+
+
+def render_attachment_pill(request: Request, attachment: SupportCaseAttachment) -> None:
+    file = attachment.file
+    url = str(
+        request.url_for(
+            "support_cases:attachment_download", attachment_id=attachment.id
+        )
+    )
+    with tag.a(
+        href=url,
+        target="_blank",
+        classes="flex items-center gap-3 max-w-md rounded-lg border "
+        "border-base-300 bg-base-100 px-3 py-2 hover:bg-base-200",
+    ):
+        if file.mime_type.startswith("image/"):
+            with tag.img(
+                src=url,
+                alt=file.name,
+                loading="lazy",
+                classes="h-12 w-12 flex-none rounded-md object-cover bg-base-200",
+            ):
+                pass
+        else:
+            with tag.div(
+                classes="flex h-12 w-12 flex-none items-center "
+                "justify-center rounded-md bg-base-200 "
+                "text-base-content/40"
+            ):
+                with tag.span(classes="icon-paperclip"):
+                    pass
+        with tag.div(classes="min-w-0"):
+            with tag.div(classes="text-sm font-medium truncate"):
+                text(file.name)
+            with tag.div(classes="text-xs text-base-content/50"):
+                text(_format_size(file.size))
+
+
+def render_merged_pdfs_region(
+    request: Request,
+    case_id: UUID,
+    merged_files: Sequence[SupportCaseAttachment],
+    *,
+    expected: int | None = None,
+    merging: int | None = None,
+    attempts: int = 0,
+) -> None:
+    """The "Merged PDFs" block below the evidence list.
+
+    While fewer files than ``expected`` exist, the region polls itself until
+    the new PDF appears, giving up after ``MERGE_POLL_MAX_ATTEMPTS``."""
+    pending = expected is not None and len(merged_files) < expected
+    timed_out = pending and attempts >= MERGE_POLL_MAX_ATTEMPTS
+    with tag.div(id=MERGED_PDFS_REGION_ID, classes="flex flex-col gap-2"):
+        if pending and not timed_out:
+            partial_url = str(
+                request.url_for(
+                    "support_cases:attachments_merged_partial", case_id=case_id
+                )
+            )
+            attr(
+                "hx-get",
+                f"{partial_url}?expected={expected}"
+                f"&merging={merging or 0}&attempts={attempts + 1}",
+            )
+            attr("hx-trigger", "every 2s")
+            attr("hx-swap", "outerHTML")
+        if merged_files or pending:
+            with tag.div(
+                classes="text-xs uppercase tracking-wide text-base-content/40 mt-2"
+            ):
+                text(f"Merged PDFs ({len(merged_files)})")
+        for attachment in merged_files:
+            with tag.div(classes="flex"):
+                render_attachment_pill(request, attachment)
+        if timed_out:
+            with tag.div(classes="text-sm text-error"):
+                text(
+                    "The merge did not complete. Reload the page to check "
+                    "for the file, or try again."
+                )
+        elif pending:
+            with tag.div(
+                classes="flex items-center gap-2 text-sm text-base-content/60"
+            ):
+                with tag.span(classes="loading loading-spinner loading-xs"):
+                    pass
+                text(f"Merging {merging} files…" if merging else "Merging files…")
+
+
+def _format_size(size: int) -> str:
+    value = float(size)
+    for unit in ("B", "KB", "MB", "GB"):
+        if value < 1024:
+            return f"{value:.0f} {unit}" if unit == "B" else f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} TB"
 
 
 class SupportCaseSection:
@@ -371,10 +472,8 @@ class SupportCaseSection:
             text(label)
 
     def _merchant_attachments(self) -> list[SupportCaseAttachment]:
-        """Attachments carried by merchant-authored messages.
-
-        The case can also hold platform/internal attachments; those must not
-        appear under a "merchant submitted" heading."""
+        """Attachments carried by merchant-authored messages — internal
+        case-level files must not appear under a "merchant submitted" heading."""
         if self.thread is None:
             return []
         _case, _is_open, messages = self.thread
@@ -390,20 +489,65 @@ class SupportCaseSection:
         ]
 
     def _render_evidence_files(self, request: Request) -> None:
-        """The merchant's evidence — the counter submission and any files sent
-        later in the chat — consolidated so support always has the full set."""
-        attachments = self._merchant_attachments()
-        if not attachments:
+        """All merchant evidence consolidated, with checkboxes feeding the
+        "Merge into PDF" action for mergeable files."""
+        if self.thread is None:
             return
-        with tag.div(
-            classes="flex flex-col gap-2 px-4 pb-4 border-t border-base-300 pt-4"
+        attachments = self._merchant_attachments()
+        merged_files = [a for a in self.attachments if a.message_id is None]
+        if not attachments and not merged_files:
+            return
+        case = self.thread[0]
+        merge_url = str(
+            request.url_for("support_cases:attachments_merge", case_id=case.id)
+        )
+        with tag.form(
+            method="post",
+            action=merge_url,
+            hx_post=merge_url,
+            hx_target=f"#{MERGED_PDFS_REGION_ID}",
+            hx_swap="outerHTML",
+            _="on htmx:afterRequest[detail.elt is me and detail.successful] "
+            "from me reset() me "
+            "then add @disabled to first <button[type='submit']/> in me",
+            classes="flex flex-col gap-2 px-4 pb-4 border-t border-base-300 pt-4",
         ):
             with tag.div(
                 classes="text-xs uppercase tracking-wide text-base-content/40"
             ):
                 text(f"Merchant submitted files ({len(attachments)})")
+            mergeable_count = 0
             for attachment in attachments:
-                self._render_attachment(request, attachment)
+                with tag.div(classes="flex items-center gap-3"):
+                    if is_mergeable(attachment.file.mime_type):
+                        mergeable_count += 1
+                        with tag.input(
+                            type="checkbox",
+                            name="attachment_ids",
+                            value=str(attachment.id),
+                            classes="checkbox checkbox-sm flex-none",
+                        ):
+                            pass
+                    else:
+                        with tag.div(classes="w-5 flex-none"):
+                            pass
+                    render_attachment_pill(request, attachment)
+            if mergeable_count > 0:
+                with tag.div(classes="mt-2"):
+                    with button(
+                        size="sm",
+                        outline=True,
+                        type="submit",
+                        disabled=True,
+                        _="on change from closest <form/> "
+                        "if <input[name='attachment_ids']:checked/> "
+                        "in closest <form/> is empty "
+                        "add @disabled else remove @disabled",
+                    ):
+                        with tag.span(classes="icon-file-text"):
+                            pass
+                        text("Merge into PDF")
+            render_merged_pdfs_region(request, case.id, merged_files)
 
     @contextlib.contextmanager
     def _fact(self, label: str) -> Generator[None]:
@@ -559,53 +703,7 @@ class SupportCaseSection:
                         text(message.body)
             for attachment in attachments:
                 with tag.div(classes=f"flex {justify}"):
-                    self._render_attachment(request, attachment)
-
-    def _render_attachment(
-        self, request: Request, attachment: SupportCaseAttachment
-    ) -> None:
-        file = attachment.file
-        url = str(
-            request.url_for(
-                "support_cases:attachment_download", attachment_id=attachment.id
-            )
-        )
-        with tag.a(
-            href=url,
-            target="_blank",
-            classes="flex items-center gap-3 max-w-md rounded-lg border "
-            "border-base-300 bg-base-100 px-3 py-2 hover:bg-base-200",
-        ):
-            if file.mime_type.startswith("image/"):
-                with tag.img(
-                    src=url,
-                    alt=file.name,
-                    loading="lazy",
-                    classes="h-12 w-12 flex-none rounded-md object-cover bg-base-200",
-                ):
-                    pass
-            else:
-                with tag.div(
-                    classes="flex h-12 w-12 flex-none items-center "
-                    "justify-center rounded-md bg-base-200 "
-                    "text-base-content/40"
-                ):
-                    with tag.span(classes="icon-paperclip"):
-                        pass
-            with tag.div(classes="min-w-0"):
-                with tag.div(classes="text-sm font-medium truncate"):
-                    text(file.name)
-                with tag.div(classes="text-xs text-base-content/50"):
-                    text(self._format_size(file.size))
-
-    @staticmethod
-    def _format_size(size: int) -> str:
-        value = float(size)
-        for unit in ("B", "KB", "MB", "GB"):
-            if value < 1024:
-                return f"{value:.0f} {unit}" if unit == "B" else f"{value:.1f} {unit}"
-            value /= 1024
-        return f"{value:.1f} TB"
+                    render_attachment_pill(request, attachment)
 
     def _bubble(self, message: SupportCaseMessage, internal: bool) -> str:
         if internal:

--- a/server/polar/backoffice/support_cases/endpoints.py
+++ b/server/polar/backoffice/support_cases/endpoints.py
@@ -23,6 +23,7 @@ from polar.models.support_case import (
 )
 from polar.models.user_session import UserSession
 from polar.postgres import AsyncSession, get_db_read_session, get_db_session
+from polar.support_case.pdf import is_mergeable
 from polar.support_case.repository import (
     SupportCaseAttachmentRepository,
     SupportCaseMessageRepository,
@@ -35,8 +36,12 @@ from ..components import datatable, dispute_status_badge, support_tier_badge
 from ..components._tab_nav import Tab, tab_nav
 from ..dependencies import get_admin
 from ..layout import layout
-from ..organizations_v2.views.sections.support_case_section import SupportCaseSection
+from ..organizations_v2.views.sections.support_case_section import (
+    SupportCaseSection,
+    render_merged_pdfs_region,
+)
 from ..responses import HXRedirectResponse
+from ..toast import add_toast
 from .queries import TYPE_LABELS, Row, cases_statement
 from .urls import case_detail_url, is_safe_return_to
 
@@ -320,6 +325,98 @@ async def download_attachment(
         raise HTTPException(status_code=404, detail="Attachment not found")
     url, _ = file_service.generate_download_url(attachment.file)
     return RedirectResponse(url)
+
+
+@router.post(
+    "/{case_id}/attachments/merge",
+    name="support_cases:attachments_merge",
+    response_model=None,
+)
+async def merge_case_attachments(
+    request: Request,
+    case_id: UUID4,
+    session: AsyncSession = Depends(get_db_read_session),
+    user_session: UserSession = Depends(get_admin),
+) -> None:
+    """Enqueue the merge and respond with the region in its pending,
+    self-polling state."""
+    del user_session
+    form_data = await request.form()
+    attachments = await SupportCaseAttachmentRepository.from_session(
+        session
+    ).list_by_case(case_id)
+    merged_files = [a for a in attachments if a.message_id is None]
+
+    try:
+        selected_ids = {
+            uuid.UUID(str(raw)) for raw in form_data.getlist("attachment_ids")
+        }
+    except ValueError:
+        await add_toast(request, "Invalid attachment id.", "error")
+        return render_merged_pdfs_region(request, case_id, merged_files)
+    if not selected_ids:
+        await add_toast(request, "Select at least one attachment.", "error")
+        return render_merged_pdfs_region(request, case_id, merged_files)
+
+    selected = [a for a in attachments if a.id in selected_ids]
+    if len(selected) != len(selected_ids):
+        await add_toast(
+            request,
+            "Attachment not found — reload the page and try again.",
+            "error",
+        )
+        return render_merged_pdfs_region(request, case_id, merged_files)
+    unmergeable = [a.file.name for a in selected if not is_mergeable(a.file.mime_type)]
+    if unmergeable:
+        await add_toast(
+            request,
+            f"Cannot merge into PDF: {', '.join(unmergeable)}",
+            "error",
+        )
+        return render_merged_pdfs_region(request, case_id, merged_files)
+
+    enqueue_job(
+        "support_case.merge_attachments",
+        case_id=case_id,
+        attachment_ids=[attachment.id for attachment in selected],
+    )
+    render_merged_pdfs_region(
+        request,
+        case_id,
+        merged_files,
+        expected=len(merged_files) + 1,
+        merging=len(selected),
+    )
+
+
+@router.get(
+    "/{case_id}/attachments/merged",
+    name="support_cases:attachments_merged_partial",
+    response_model=None,
+)
+async def merged_attachments_partial(
+    request: Request,
+    case_id: UUID4,
+    expected: Annotated[int, Query(ge=0)] = 0,
+    merging: Annotated[int, Query(ge=0)] = 0,
+    attempts: Annotated[int, Query(ge=0)] = 0,
+    session: AsyncSession = Depends(get_db_read_session),
+    user_session: UserSession = Depends(get_admin),
+) -> None:
+    """The "Merged PDFs" region, polled while a merge is running."""
+    del user_session
+    attachments = await SupportCaseAttachmentRepository.from_session(
+        session
+    ).list_by_case(case_id)
+    merged_files = [a for a in attachments if a.message_id is None]
+    render_merged_pdfs_region(
+        request,
+        case_id,
+        merged_files,
+        expected=expected or None,
+        merging=merging or None,
+        attempts=attempts,
+    )
 
 
 @router.get("/{case_id}", name="support_cases:detail")

--- a/server/polar/file/endpoints.py
+++ b/server/polar/file/endpoints.py
@@ -12,6 +12,7 @@ from polar.exceptions import NotPermitted, ResourceNotFound
 from polar.kit.pagination import ListResource, PaginationParamsQuery
 from polar.kit.schemas import MultipleQueryFilter
 from polar.models import File
+from polar.models.file import FileServiceTypes
 from polar.openapi import APITag
 from polar.organization.resolver import get_payload_organization
 from polar.organization.schemas import OrganizationID
@@ -38,6 +39,16 @@ router = APIRouter(prefix="/files", tags=["files", APITag.public])
 
 FileID = Annotated[UUID4, Path(description="The file ID.")]
 FileNotFound = {"description": "File not found.", "model": ResourceNotFound.schema()}
+
+
+def _assert_mutable(file: File) -> None:
+    """Files attached to a support case are part of the case record — they are
+    created through this API but can't be modified or deleted through it."""
+    if file.service == FileServiceTypes.support_case_attachment:
+        raise NotPermitted(
+            "Support case attachments cannot be modified or deleted "
+            "through the files API."
+        )
 
 
 @router.get("/", summary="List Files", response_model=ListResource[FileRead])
@@ -153,6 +164,7 @@ async def update(
     if file is None:
         raise ResourceNotFound()
 
+    _assert_mutable(file)
     await assert_resource_permission(
         session, auth_subject, file, OrganizationPermission.products_manage
     )
@@ -182,6 +194,7 @@ async def delete(
     if file is None:
         raise ResourceNotFound()
 
+    _assert_mutable(file)
     await assert_resource_permission(
         session, auth_subject, file, OrganizationPermission.products_manage
     )

--- a/server/polar/file/service.py
+++ b/server/polar/file/service.py
@@ -9,7 +9,7 @@ from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
 from polar.kit.pagination import PaginationParams
 from polar.models import Organization, ProductMedia, User
-from polar.models.file import File, ProductMediaFile
+from polar.models.file import File, FileServiceTypes, ProductMediaFile
 from polar.postgres import AsyncReadSession, AsyncSession, sql
 
 from .repository import FileRepository
@@ -41,7 +41,8 @@ class FileService:
         )
 
         statement = repository.get_statement_by_org_ids(org_ids).where(
-            File.is_uploaded.is_(True)
+            File.is_uploaded.is_(True),
+            File.service != FileServiceTypes.support_case_attachment,
         )
 
         if organization_id is not None:

--- a/server/polar/support_case/pdf.py
+++ b/server/polar/support_case/pdf.py
@@ -1,0 +1,82 @@
+from collections.abc import Sequence
+from io import BytesIO
+
+from fpdf import FPDF
+from pypdf import PdfReader, PdfWriter
+
+_TEXT_MIME_TYPES = frozenset({"text/plain", "text/csv"})
+
+
+def is_mergeable(mime_type: str) -> bool:
+    """Types ``merge_attachments`` can combine: PDFs, images and plain text."""
+    return (
+        mime_type == "application/pdf"
+        or mime_type.startswith("image/")
+        or mime_type in _TEXT_MIME_TYPES
+    )
+
+
+def merge_attachments(files: Sequence[tuple[str, str, bytes]]) -> bytes:
+    """Combine ``(name, mime_type, content)`` attachments into a single PDF.
+
+    Unreadable files become note pages instead of failing the merge — mime
+    types are client-declared and may not match the content.
+    """
+    writer = PdfWriter()
+    for name, mime_type, content in files:
+        if mime_type == "application/pdf":
+            # pypdf raises non-PyPdfError exceptions on some malformed inputs.
+            try:
+                writer.append(PdfReader(BytesIO(content)))
+            except Exception:
+                note = (
+                    f"Could not include {name}: the PDF is unreadable "
+                    "(corrupt or password-protected)."
+                )
+                writer.append(PdfReader(BytesIO(_note_page(note))))
+        else:
+            try:
+                page = _content_page(name, mime_type, content)
+            except Exception:
+                note = (
+                    f"Could not include {name}: the file could not be "
+                    f"rendered as {mime_type}."
+                )
+                page = _note_page(note)
+            writer.append(PdfReader(BytesIO(page)))
+    output = BytesIO()
+    writer.write(output)
+    return output.getvalue()
+
+
+def _content_page(name: str, mime_type: str, content: bytes) -> bytes:
+    pdf = FPDF()
+    pdf.set_auto_page_break(auto=True, margin=15)
+    pdf.add_page()
+    pdf.set_font("Helvetica", style="B", size=10)
+    pdf.cell(0, 6, _latin1(name))
+    pdf.ln(10)
+    if mime_type.startswith("image/"):
+        pdf.image(
+            BytesIO(content),
+            w=pdf.epw,
+            h=pdf.page_break_trigger - pdf.y,
+            keep_aspect_ratio=True,
+        )
+    else:
+        pdf.set_font("Courier", size=9)
+        pdf.multi_cell(0, 4, _latin1(content.decode("utf-8", errors="replace")))
+    return bytes(pdf.output())
+
+
+def _note_page(note: str) -> bytes:
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Helvetica", style="I", size=10)
+    pdf.multi_cell(0, 6, _latin1(note))
+    return bytes(pdf.output())
+
+
+def _latin1(value: str) -> str:
+    """Fit text to fpdf2's built-in fonts, which only cover latin-1."""
+    return value.encode("latin-1", "replace").decode("latin-1")

--- a/server/polar/support_case/tasks.py
+++ b/server/polar/support_case/tasks.py
@@ -1,4 +1,6 @@
-from uuid import UUID
+from uuid import UUID, uuid4
+
+from sqlalchemy.orm import joinedload
 
 from polar.config import settings
 from polar.email.schemas import (
@@ -6,21 +8,46 @@ from polar.email.schemas import (
     SupportCaseOrganizationNewMessageProps,
 )
 from polar.email.sender import enqueue_email_template
-from polar.models import Organization
+from polar.exceptions import PolarTaskError
+from polar.file.s3 import S3_SERVICES
+from polar.kit.utils import utc_now
+from polar.models import File, Organization
+from polar.models.file import FileServiceTypes
 from polar.models.support_case import (
     DisputeSupportCase,
     SupportCase,
     SupportCaseMessageAuthorKind,
     SupportCaseType,
 )
+from polar.support_case.pdf import is_mergeable, merge_attachments
 from polar.support_case.repository import (
+    SupportCaseAttachmentRepository,
     SupportCaseMessageRepository,
     SupportCaseRepository,
 )
+from polar.support_case.service import support_case as support_case_service
 from polar.user_organization.service import (
     user_organization as user_organization_service,
 )
-from polar.worker import AsyncSessionMaker, actor
+from polar.worker import AsyncSessionMaker, TaskPriority, actor
+
+
+class SupportCaseTaskError(PolarTaskError): ...
+
+
+class SupportCaseDoesNotExist(SupportCaseTaskError):
+    def __init__(self, case_id: UUID) -> None:
+        self.case_id = case_id
+        message = f"The support case with id {case_id} does not exist."
+        super().__init__(message)
+
+
+class SupportCaseAttachmentsNotFound(SupportCaseTaskError):
+    def __init__(self, case_id: UUID) -> None:
+        self.case_id = case_id
+        message = f"No attachments were provided to merge on case {case_id}."
+        super().__init__(message)
+
 
 # Recipient-facing label per case type, so the email copy stays generic.
 _CASE_LABELS: dict[SupportCaseType, str] = {
@@ -93,3 +120,73 @@ async def notify_organization_of_new_message(message_id: UUID) -> None:
                 reply_to_name=None,
                 reply_to_email_addr=None,
             )
+
+
+@actor(actor_name="support_case.merge_attachments", priority=TaskPriority.LOW)
+async def merge_case_attachments(case_id: UUID, attachment_ids: list[UUID]) -> None:
+    """Merge the selected case attachments into one PDF stored back on the
+    case as an internal, case-level attachment (no message)."""
+    async with AsyncSessionMaker() as session:
+        case = await SupportCaseRepository.from_session(session).get_by_id(
+            case_id, options=(joinedload(SupportCase.organization),)
+        )
+        if case is None:
+            raise SupportCaseDoesNotExist(case_id)
+
+        wanted = {UUID(str(raw)) for raw in attachment_ids}
+        attachments = await SupportCaseAttachmentRepository.from_session(
+            session
+        ).list_by_case(case.id)
+        selected = [a for a in attachments if a.id in wanted]
+        mergeable = [a for a in selected if is_mergeable(a.file.mime_type)]
+
+        # Files the selection can't contribute — an unmergeable type, or one
+        # deleted between enqueue and now — are documented as note pages rather
+        # than dropped, so the merge still runs as long as anything was selected.
+        payloads = []
+        for attachment in mergeable:
+            s3_service = S3_SERVICES[attachment.file.service]
+            content = s3_service.get_object_or_raise(attachment.file.path)[
+                "Body"
+            ].read()
+            payloads.append((attachment.file.name, attachment.file.mime_type, content))
+        skipped = [a for a in selected if not is_mergeable(a.file.mime_type)]
+        if skipped:
+            note = "\n".join(
+                f"Skipped {a.file.name}: file type {a.file.mime_type} "
+                "cannot be merged into a PDF."
+                for a in skipped
+            )
+            payloads.append(("Skipped files", "text/plain", note.encode()))
+        missing = wanted - {a.id for a in selected}
+        if missing:
+            note = "\n".join(
+                f"Attachment {attachment_id} was deleted before the merge "
+                "ran and could not be included."
+                for attachment_id in sorted(missing)
+            )
+            payloads.append(("Missing attachments", "text/plain", note.encode()))
+        if not payloads:
+            raise SupportCaseAttachmentsNotFound(case_id)
+        merged = merge_attachments(payloads)
+
+        filename = f"merged-attachments-{utc_now().strftime('%Y%m%d-%H%M%S')}.pdf"
+        path = (
+            f"{FileServiceTypes.support_case_attachment.value}/"
+            f"{case.organization_id}/{uuid4()}/{filename}"
+        )
+        s3_service = S3_SERVICES[FileServiceTypes.support_case_attachment]
+        s3_service.upload(merged, path, "application/pdf")
+
+        file = File(
+            organization=case.organization,
+            name=filename,
+            path=path,
+            mime_type="application/pdf",
+            size=len(merged),
+            service=FileServiceTypes.support_case_attachment,
+            is_uploaded=True,
+            is_enabled=True,
+        )
+        session.add(file)
+        await support_case_service.add_attachment(session, case, file=file)

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -67,6 +67,7 @@ dependencies = [
   "tzdata>=2026.2",
   "reauth==0.2.0",
   "langcodes>=3.5.1",
+  "pypdf>=6.14.2",
 ]
 
 [dependency-groups]

--- a/server/tests/file/test_endpoints.py
+++ b/server/tests/file/test_endpoints.py
@@ -6,9 +6,13 @@ from httpx import AsyncClient, ReadError
 from polar.file.repository import FileRepository
 from polar.file.s3 import S3_SERVICES
 from polar.integrations.aws.s3.exceptions import S3FileError
-from polar.models import Organization
+from polar.models import Organization, UserOrganization
+from polar.models.file import FileServiceTypes
 from polar.postgres import AsyncSession
+from tests.fixtures.auth import AuthSubjectFixture
+from tests.fixtures.database import SaveFixture
 from tests.fixtures.file import TestFile
+from tests.fixtures.random_objects import create_support_case_attachment_file
 
 
 @pytest.mark.asyncio
@@ -124,3 +128,89 @@ class TestEndpoints:
         record = await repository.get_by_id(created.id, include_deleted=True)
         assert record
         assert record.is_uploaded is True
+
+
+@pytest.mark.asyncio
+class TestList:
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="user"),
+        AuthSubjectFixture(subject="organization"),
+    )
+    async def test_excludes_support_case_attachments(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await create_support_case_attachment_file(save_fixture, organization)
+        visible = await create_support_case_attachment_file(
+            save_fixture,
+            organization,
+            name="media.jpg",
+            service=FileServiceTypes.product_media,
+        )
+
+        response = await client.get(
+            "/v1/files/", params={"organization_id": str(organization.id)}
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+        assert [item["id"] for item in json["items"]] == [str(visible.id)]
+
+
+@pytest.mark.asyncio
+class TestUpdate:
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="user"),
+        AuthSubjectFixture(subject="organization"),
+    )
+    async def test_support_case_attachment_not_permitted(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        file = await create_support_case_attachment_file(save_fixture, organization)
+
+        response = await client.patch(
+            f"/v1/files/{file.id}", json={"name": "renamed.pdf"}
+        )
+
+        assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+class TestDelete:
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="user"),
+        AuthSubjectFixture(subject="organization"),
+    )
+    async def test_support_case_attachment_not_permitted(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        file = await create_support_case_attachment_file(save_fixture, organization)
+
+        response = await client.delete(f"/v1/files/{file.id}")
+
+        assert response.status_code == 403
+
+    @pytest.mark.auth(AuthSubjectFixture(subject="organization"))
+    async def test_other_services_remain_deletable(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        organization: Organization,
+        logo_png: TestFile,
+    ) -> None:
+        created = await logo_png.create(session, organization)
+
+        response = await client.delete(f"/v1/files/{created.id}")
+
+        assert response.status_code == 204

--- a/server/tests/support_case/test_pdf.py
+++ b/server/tests/support_case/test_pdf.py
@@ -1,0 +1,86 @@
+import re
+from io import BytesIO
+
+from fpdf import FPDF
+from PIL import Image
+
+from polar.support_case.pdf import is_mergeable, merge_attachments
+
+
+def _png_bytes(width: int = 32, height: int = 32) -> bytes:
+    buffer = BytesIO()
+    Image.new("RGB", (width, height), "red").save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _pdf_bytes(pages: int = 1) -> bytes:
+    pdf = FPDF()
+    for number in range(pages):
+        pdf.add_page()
+        pdf.set_font("Helvetica", size=10)
+        pdf.cell(0, 6, f"page {number + 1}")
+    return bytes(pdf.output())
+
+
+def _page_count(pdf: bytes) -> int:
+    return pdf.count(b"/Type /Page") - pdf.count(b"/Type /Pages")
+
+
+class TestIsMergeable:
+    def test_mime_types(self) -> None:
+        assert is_mergeable("application/pdf") is True
+        assert is_mergeable("image/png") is True
+        assert is_mergeable("image/jpeg") is True
+        assert is_mergeable("text/csv") is True
+        assert is_mergeable("text/plain") is True
+        assert is_mergeable("video/mp4") is False
+        assert is_mergeable("application/msword") is False
+
+
+class TestMergeAttachments:
+    def test_combines_pdf_image_and_text(self) -> None:
+        output = merge_attachments(
+            [
+                ("receipt.pdf", "application/pdf", _pdf_bytes(pages=2)),
+                ("evidence.png", "image/png", _png_bytes()),
+                ("orders.csv", "text/csv", b"id,amount\n1,100\n"),
+            ]
+        )
+        assert output.startswith(b"%PDF")
+        assert _page_count(output) == 4
+
+    def test_unreadable_files_become_note_pages(self) -> None:
+        data = _pdf_bytes()
+        kids = re.search(rb"/Kids \[(\d+ 0 R)\]", data)
+        assert kids is not None
+        corrupt_tree = (
+            data[: kids.start(1)]
+            + b"(bad)".ljust(len(kids.group(1)), b" ")
+            + data[kids.end(1) :]
+        )
+
+        output = merge_attachments(
+            [
+                ("broken.pdf", "application/pdf", b"%PDF-1.4 not really a pdf"),
+                ("evil.pdf", "application/pdf", corrupt_tree),
+                ("garbage.png", "image/png", b"not an image at all"),
+                ("truncated.png", "image/png", _png_bytes()[:20]),
+            ]
+        )
+
+        assert output.startswith(b"%PDF")
+        assert _page_count(output) == 4
+
+    def test_tall_image_stays_on_one_page(self) -> None:
+        output = merge_attachments(
+            [("tall.png", "image/png", _png_bytes(width=100, height=2000))]
+        )
+        assert output.startswith(b"%PDF")
+        assert _page_count(output) == 1
+
+    def test_non_latin_text_does_not_crash(self) -> None:
+        output = merge_attachments(
+            [("nöte.txt", "text/plain", "receipt — 100€ 領収書".encode())]
+        )
+        assert output.startswith(b"%PDF")
+        assert _page_count(output) == 1

--- a/server/tests/support_case/test_tasks.py
+++ b/server/tests/support_case/test_tasks.py
@@ -1,9 +1,15 @@
-"""Tests for support_case.tasks — merchant reply email fan-out."""
+"""Tests for support_case.tasks — merchant reply email fan-out and the
+attachment PDF merge."""
 
 import contextlib
 from collections.abc import AsyncIterator, Sequence
+from io import BytesIO
+from unittest.mock import MagicMock
+from uuid import uuid4
 
 import pytest
+from fpdf import FPDF
+from pypdf import PdfReader
 from pytest_mock import MockerFixture
 
 from polar.models import (
@@ -12,6 +18,7 @@ from polar.models import (
     Product,
     UserOrganization,
 )
+from polar.models.file import FileServiceTypes
 from polar.models.support_case import (
     SupportCase,
     SupportCaseAudience,
@@ -20,15 +27,23 @@ from polar.models.support_case import (
     SupportCaseMessageType,
 )
 from polar.postgres import AsyncSession
-from polar.support_case.tasks import notify_organization_of_new_message
+from polar.support_case.repository import SupportCaseAttachmentRepository
+from polar.support_case.service import support_case as support_case_service
+from polar.support_case.tasks import (
+    SupportCaseAttachmentsNotFound,
+    merge_case_attachments,
+    notify_organization_of_new_message,
+)
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_appeal_case,
     create_dispute_case,
+    create_support_case_attachment_file,
 )
 
 # Unwrap to bypass the actor decorator (which needs the Dramatiq broker).
 _notify = notify_organization_of_new_message.__wrapped__  # type: ignore[attr-defined]
+_merge = merge_case_attachments.__wrapped__  # type: ignore[attr-defined]
 
 
 @contextlib.asynccontextmanager
@@ -147,3 +162,149 @@ class TestNotifyOrganization:
         await _notify(message.id)
 
         enqueue.assert_not_called()
+
+
+def _pdf_bytes() -> bytes:
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Helvetica", size=10)
+    pdf.cell(0, 6, "evidence")
+    return bytes(pdf.output())
+
+
+@pytest.mark.asyncio
+class TestMergeCaseAttachments:
+    async def test_stores_merged_pdf_as_case_level_attachment(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        case = await create_dispute_case(save_fixture, organization, customer, product)
+        first = await create_support_case_attachment_file(
+            save_fixture, organization, name="a.pdf"
+        )
+        second = await create_support_case_attachment_file(
+            save_fixture, organization, name="b.pdf"
+        )
+        one = await support_case_service.add_attachment(session, case, file=first)
+        two = await support_case_service.add_attachment(session, case, file=second)
+        await session.flush()
+
+        s3 = MagicMock()
+        s3.get_object_or_raise.side_effect = lambda path: {
+            "Body": BytesIO(_pdf_bytes())
+        }
+        mocker.patch(
+            "polar.support_case.tasks.S3_SERVICES",
+            {FileServiceTypes.support_case_attachment: s3},
+        )
+        mocker.patch(
+            "polar.support_case.tasks.AsyncSessionMaker",
+            return_value=_session_maker(session),
+        )
+
+        await _merge(case.id, [one.id, two.id])
+
+        attachments = await SupportCaseAttachmentRepository.from_session(
+            session
+        ).list_by_case(case.id)
+        merged = [
+            attachment
+            for attachment in attachments
+            if attachment.file.name.startswith("merged-attachments-")
+        ]
+        assert len(merged) == 1
+        assert merged[0].message_id is None
+        assert merged[0].file.mime_type == "application/pdf"
+        assert merged[0].file.is_uploaded is True
+
+        s3.upload.assert_called_once()
+        content = s3.upload.call_args.args[0]
+        assert content.startswith(b"%PDF")
+
+    async def test_raises_when_nothing_selected(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        case = await create_dispute_case(save_fixture, organization, customer, product)
+        mocker.patch(
+            "polar.support_case.tasks.AsyncSessionMaker",
+            return_value=_session_maker(session),
+        )
+
+        with pytest.raises(SupportCaseAttachmentsNotFound):
+            await _merge(case.id, [])
+
+    async def test_stores_notes_only_pdf_when_all_attachments_gone(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        case = await create_dispute_case(save_fixture, organization, customer, product)
+        s3 = MagicMock()
+        mocker.patch(
+            "polar.support_case.tasks.S3_SERVICES",
+            {FileServiceTypes.support_case_attachment: s3},
+        )
+        mocker.patch(
+            "polar.support_case.tasks.AsyncSessionMaker",
+            return_value=_session_maker(session),
+        )
+
+        await _merge(case.id, [uuid4()])
+
+        s3.upload.assert_called_once()
+        content = s3.upload.call_args.args[0]
+        pages = PdfReader(BytesIO(content)).pages
+        assert len(pages) == 1
+        assert "was deleted before the merge" in pages[0].extract_text()
+
+    async def test_notes_attachments_deleted_before_merge(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        case = await create_dispute_case(save_fixture, organization, customer, product)
+        file = await create_support_case_attachment_file(
+            save_fixture, organization, name="a.pdf"
+        )
+        attachment = await support_case_service.add_attachment(session, case, file=file)
+        await session.flush()
+
+        s3 = MagicMock()
+        s3.get_object_or_raise.side_effect = lambda path: {
+            "Body": BytesIO(_pdf_bytes())
+        }
+        mocker.patch(
+            "polar.support_case.tasks.S3_SERVICES",
+            {FileServiceTypes.support_case_attachment: s3},
+        )
+        mocker.patch(
+            "polar.support_case.tasks.AsyncSessionMaker",
+            return_value=_session_maker(session),
+        )
+
+        await _merge(case.id, [attachment.id, uuid4()])
+
+        s3.upload.assert_called_once()
+        content = s3.upload.call_args.args[0]
+        pages = PdfReader(BytesIO(content)).pages
+        assert len(pages) == 2
+        assert "was deleted before the merge" in pages[1].extract_text()

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -2445,6 +2445,7 @@ dependencies = [
     { name = "pydantic-extra-types" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
+    { name = "pypdf" },
     { name = "python-bidi" },
     { name = "python-dateutil" },
     { name = "python-multipart" },
@@ -2541,6 +2542,7 @@ requires-dist = [
     { name = "pydantic-extra-types", specifier = ">=2.9.0" },
     { name = "pydantic-settings", specifier = ">=2.14.1" },
     { name = "pyjwt", specifier = ">=2.13.0" },
+    { name = "pypdf", specifier = ">=6.14.2" },
     { name = "python-bidi", specifier = ">=0.6.10" },
     { name = "python-dateutil", specifier = ">=2.9.0.post0" },
     { name = "python-multipart", specifier = ">=0.0.32" },
@@ -2935,6 +2937,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[[package]]
+name = "pypdf"
+version = "6.14.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/72/7dfd5ff1c9c37de97a731701f51af091325f123d9d4270361c9c69e4431f/pypdf-6.14.2.tar.gz", hash = "sha256:7873f502fe4385e79539b21d872392dc0c4e3714327c15881cbc7fbfd1f95b25", size = 6491182, upload-time = "2026-06-23T14:18:30.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/e6/136aa8993a2ae7214e0b0ef2edaa0d2e08d1d4e4982635b08a835ff31ec8/pypdf-6.14.2-py3-none-any.whl", hash = "sha256:3f07891af76dc002657e04993ab9b4de81de29f9013b9761d0b7968bff12e946", size = 349514, upload-time = "2026-06-23T14:18:28.867Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR will add the ability to merge dispute attachments in Backoffice (often used when managing the dispute in Stripe).

## Demo

https://github.com/user-attachments/assets/383ff4b5-e269-4d2b-b383-2c3fc7531858



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Backoffice action to merge selected support‑case attachments into a single PDF via a low‑priority worker. Adds a “Merged PDFs” panel that auto‑polls and times out; reviewers can download one file combining PDFs, images, and plain text.

- **New Features**
  - Backoffice: checkboxes only on mergeable files; submit enables with ≥1 selected; form resets on success; toasts on invalid IDs, empty or unmergeable selection, or missing attachments. “Merged PDFs” shows progress, polls every 2s (up to 60), then shows an error on timeout.
  - Endpoints: POST `/{case_id}/attachments/merge` enqueues the job and returns the pending region with expected/merging counts; GET `/{case_id}/attachments/merged` returns the HTMX partial and tracks poll attempts.
  - Worker task `support_case.merge_attachments` merges PDFs, images, and `text/plain`/CSV; unreadable files render as a note page; non‑mergeable selections are listed under a “Skipped files” note; missing/deleted selections are noted; the result is stored as a case‑level attachment (no message).
  - Files API: hide support‑case attachments from `/v1/files` and block update/delete to keep case records immutable.

- **Dependencies**
  - Added `pypdf` for PDF read/write; still uses `fpdf` to render image/text pages.

<sup>Written for commit 37f4179ea6c6ced8c93f4b20cd03c492c333b5c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



