### PR TITLE
fix slow query in scripts.unset_subscription_license_key_expiration

### DIFF
--- a/server/scripts/unset_subscription_license_key_expiration.py
+++ b/server/scripts/unset_subscription_license_key_expiration.py
@@ -1,14 +1,14 @@
-import typer
-from sqlalchemy import String, select, update
+import asyncio
 
+import typer
+from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
+from sqlalchemy import Uuid, select, update
+
+from polar.kit.db.postgres import create_async_sessionmaker
 from polar.models import BenefitGrant, LicenseKey, Subscription
 from polar.models.subscription import SubscriptionStatus
-from scripts.helper import (
-    configure_script_logging,
-    limit_bindparam,
-    run_batched_update,
-    typer_async,
-)
+from polar.postgres import create_async_engine
+from scripts.helper import configure_script_logging, typer_async
 
 cli = typer.Typer()
 
@@ -18,7 +18,7 @@ configure_script_logging()
 @cli.command()
 @typer_async
 async def unset_subscription_license_key_expiration(
-    batch_size: int = typer.Option(5000, help="Number of rows to process per batch"),
+    batch_size: int = typer.Option(5000, help="Number of rows to update per batch"),
     sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
 ) -> None:
     """Unset `expires_at` on license keys granted through an active subscription.
@@ -30,33 +30,66 @@ async def unset_subscription_license_key_expiration(
     "Active" here means billable — active, trialing, or past due (still in the
     grace period) — matching `SubscriptionStatus.billable_statuses()`.
     """
-    subscription_license_key_ids = (
-        select(LicenseKey.id)
-        .join(
-            BenefitGrant,
-            LicenseKey.id.cast(String)
-            == BenefitGrant.properties["license_key_id"].as_string(),
-        )
-        .join(Subscription, Subscription.id == BenefitGrant.subscription_id)
-        .where(
-            LicenseKey.expires_at.is_not(None),
-            LicenseKey.deleted_at.is_(None),
-            BenefitGrant.is_deleted.is_(False),
-            Subscription.status.in_(SubscriptionStatus.billable_statuses()),
-        )
-        .order_by(LicenseKey.id)
-        .limit(limit_bindparam())
-    )
+    engine = create_async_engine("script")
+    sessionmaker = create_async_sessionmaker(engine)
 
-    await run_batched_update(
-        (
-            update(LicenseKey)
-            .values(expires_at=None)
-            .where(LicenseKey.id.in_(subscription_license_key_ids))
-        ),
-        batch_size=batch_size,
-        sleep_seconds=sleep_seconds,
-    )
+    try:
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(LicenseKey.id)
+                .join(
+                    BenefitGrant,
+                    BenefitGrant.properties["license_key_id"].as_string().cast(Uuid)
+                    == LicenseKey.id,
+                )
+                .join(Subscription, Subscription.id == BenefitGrant.subscription_id)
+                .where(
+                    LicenseKey.expires_at.is_not(None),
+                    LicenseKey.deleted_at.is_(None),
+                    BenefitGrant.is_deleted.is_(False),
+                    Subscription.status.in_(SubscriptionStatus.billable_statuses()),
+                )
+            )
+            license_key_ids = result.scalars().all()
+
+        total = len(license_key_ids)
+
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            TimeElapsedColumn(),
+            transient=False,
+        ) as progress:
+            task = progress.add_task(
+                f"[cyan]0/{total} license keys updated", total=total
+            )
+
+            for start in range(0, total, batch_size):
+                chunk = license_key_ids[start : start + batch_size]
+                async with sessionmaker() as session:
+                    await session.execute(
+                        update(LicenseKey)
+                        .where(LicenseKey.id.in_(chunk))
+                        .values(expires_at=None)
+                    )
+                    await session.commit()
+
+                updated = min(start + batch_size, total)
+                progress.update(
+                    task,
+                    completed=updated,
+                    description=f"[cyan]{updated}/{total} license keys updated",
+                )
+
+                if sleep_seconds > 0 and updated < total:
+                    await asyncio.sleep(sleep_seconds)
+
+            progress.update(
+                task,
+                description=f"[green]✓ Complete: {total} license keys updated",
+            )
+    finally:
+        await engine.dispose()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This script timed out in production, so gotta fix it

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes slow query in the license key expiry script by switching to async, chunked updates and a direct `Uuid` join. This runs faster and reduces DB load/timeouts.

- **Bug Fixes**
  - Use a direct join on `BenefitGrant.properties['license_key_id']::uuid = LicenseKey.id` (avoid string cast and subquery IN).
  - Pre-fetch matching `LicenseKey.id`s, then update in chunks (`batch_size`) with optional sleeps to throttle.
  - Replace helper-based updates with `create_async_engine`/`create_async_sessionmaker`; commit per batch and dispose the engine.
  - Add progress output with `rich` to track updated keys.

<sup>Written for commit 591f2fa182a5185c7460595025c7756b1d62b5a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

