### PR TITLE
feat(dev): dev switch and dev stop commands

### DIFF
--- a/dev/cli/README.md
+++ b/dev/cli/README.md
@@ -29,11 +29,15 @@ dev reset --force       # Reset without confirmation
 ### Running Services
 
 ```bash
+dev start               # Start all services (api, worker, web, stripe) in tmux
+dev stop                # Stop all services (kills the tmux session)
 dev api                 # Start backend API (port 8000)
 dev api --port 8080     # Start on custom port
 dev web                 # Start frontend (port 3000)
 dev web --port 3001     # Start on custom port
 dev worker              # Start background job worker
+dev switch my-branch    # Stop web, checkout branch, wipe .next, relaunch web
+dev switch -i my-branch # ...and reinstall JS deps (skips package prebuilds)
 ```
 
 ### Database

--- a/dev/cli/README.md
+++ b/dev/cli/README.md
@@ -37,6 +37,7 @@ dev web                 # Start frontend (port 3000)
 dev web --port 3001     # Start on custom port
 dev worker              # Start background job worker
 dev switch my-branch    # Stop web, checkout branch, wipe .next, relaunch web
+dev switch -b my-branch # ...creating the branch (git checkout -b)
 dev switch -i my-branch # ...and reinstall JS deps (skips package prebuilds)
 ```
 

--- a/dev/cli/cli.py
+++ b/dev/cli/cli.py
@@ -211,6 +211,7 @@ def up(
     next_steps.add_row()
     next_steps.add_row("[dim]Start all services", "")
     next_steps.add_row("dev start", "API, worker, web, and Stripe in a tmux session")
+    next_steps.add_row("dev stop", "Stop all services")
     next_steps.add_row()
     next_steps.add_row("[dim]Start specific services", "")
     next_steps.add_row("dev api", "API server")
@@ -253,6 +254,8 @@ def help() -> None:
     recipes.add_row("dev api", "Start API server")
     recipes.add_row("dev worker", "Start background worker")
     recipes.add_row("dev web", "Start frontend dev server")
+    recipes.add_row("dev switch", "Switch branch with a clean web restart")
+    recipes.add_row("dev stop", "Stop all services")
 
     console.print("\n  [bold]Common commands[/bold]")
     console.print(Padding(recipes, (0, 2)))

--- a/dev/cli/commands/start.py
+++ b/dev/cli/commands/start.py
@@ -103,6 +103,10 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
             ["tmux", "send-keys", "-t", f"{svc}.2", f"{dev_bin} web", "C-m"],
             ["tmux", "send-keys", "-t", f"{svc}.3", f"{dev_bin} stripe --listen", "C-m"],
 
+            # Tag the web pane so `dev switch` can find it reliably (its cwd is
+            # not a stable marker — the stripe pane also lives in the web dir)
+            ["tmux", "set-option", "-p", "-t", f"{svc}.2", "@polar_role", "web"],
+
             # Create second window for general use
             ["tmux", "new-window", "-t", SESSION, "-n", "dev", "-c", root_dir],
 

--- a/dev/cli/commands/stop.py
+++ b/dev/cli/commands/stop.py
@@ -1,0 +1,28 @@
+"""Stop the running dev services (the tmux session started by `dev start`)."""
+
+import typer
+
+from shared import console, run_command
+
+SESSION = "polar"
+
+
+def register(app: typer.Typer, prompt_setup: callable) -> None:
+    @app.command()
+    def stop() -> None:
+        """Stop all dev services by killing the `dev start` tmux session."""
+        has_session = run_command(
+            ["tmux", "has-session", "-t", SESSION], capture=True
+        )
+        if not has_session or has_session.returncode != 0:
+            console.print(f"[dim]No '{SESSION}' session running[/dim]")
+            return
+
+        result = run_command(["tmux", "kill-session", "-t", SESSION], capture=True)
+        if result and result.returncode == 0:
+            console.print(f"[green]✓[/green] Stopped '{SESSION}' session")
+        else:
+            console.print(f"[red]✗[/red] Failed to stop '{SESSION}' session")
+            if result:
+                console.print(f"[dim]{result.stderr}[/dim]")
+            raise typer.Exit(1)

--- a/dev/cli/commands/switch.py
+++ b/dev/cli/commands/switch.py
@@ -1,0 +1,131 @@
+"""Switch git branch with a clean web dev-server restart."""
+
+import os
+import shutil
+import time
+from typing import Annotated
+
+import typer
+
+from shared import (
+    CLIENTS_DIR,
+    DEFAULT_WEB_PORT,
+    ROOT_DIR,
+    console,
+    is_port_in_use,
+    run_command,
+)
+
+WEB_DIR = CLIENTS_DIR / "apps" / "web"
+
+
+def _find_web_pane() -> str | None:
+    """Return the tmux pane id tagged as the web pane by `dev start`.
+
+    Matching on the working directory is unreliable: the stripe pane is also
+    created in the web dir, and any pane's path follows its foreground process.
+    """
+    result = run_command(
+        ["tmux", "list-panes", "-a", "-F", "#{pane_id} #{@polar_role}"],
+        capture=True,
+    )
+    if not result or result.returncode != 0:
+        return None
+
+    for line in result.stdout.strip().splitlines():
+        pane_id, _, role = line.partition(" ")
+        if role == "web":
+            return pane_id
+    return None
+
+
+def _wait_port_free(port: int, timeout: float = 10.0) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not is_port_in_use(port):
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def _kill_port(port: int) -> None:
+    result = run_command(
+        ["lsof", "-nP", f"-tiTCP:{port}", "-sTCP:LISTEN"], capture=True
+    )
+    if result and result.returncode == 0 and result.stdout.strip():
+        run_command(["kill", "-9", *result.stdout.split()])
+
+
+def register(app: typer.Typer, prompt_setup: callable) -> None:
+    @app.command()
+    def switch(
+        branch: Annotated[str, typer.Argument(help="Branch to switch to")],
+        install: Annotated[
+            bool,
+            typer.Option(
+                "--install",
+                "-i",
+                help="Reinstall JS deps, skipping package prebuilds "
+                "(fast, but reuses existing dist — stale if a package changed)",
+            ),
+        ] = False,
+    ) -> None:
+        """
+        Switch branch with a clean web restart.
+
+        Stops the web dev server first so file watchers don't storm on the
+        branch write-burst, checks out the branch, wipes the Turbopack cache,
+        then relaunches web in its tmux pane.
+        """
+        dev_bin = str(ROOT_DIR / "dev" / "cli" / "dev")
+        web_pane = _find_web_pane()
+        if web_pane is None:
+            console.print(
+                "[red]No web pane found.[/red] Start the stack with "
+                "[cyan]dev start[/cyan] so the web pane gets tagged."
+            )
+            raise typer.Exit(1)
+
+        # From the web pane itself, relaunch in place (exec) — web is already
+        # stopped (you had to interrupt it to type this). From any other pane,
+        # drive the web pane remotely via send-keys.
+        exec_here = os.environ.get("TMUX_PANE") == web_pane
+
+        def relaunch() -> None:
+            console.print("[blue]Relaunching web[/blue]")
+            if exec_here:
+                os.execvp(dev_bin, [dev_bin, "web"])
+            run_command(["tmux", "send-keys", "-t", web_pane, f"{dev_bin} web", "C-m"])
+            run_command(["tmux", "select-window", "-t", web_pane])
+            run_command(["tmux", "select-pane", "-t", web_pane])
+
+        if not exec_here:
+            console.print(f"[blue]Stopping web[/blue] [dim](pane {web_pane})[/dim]")
+            run_command(["tmux", "send-keys", "-t", web_pane, "C-c"])
+
+        if not _wait_port_free(DEFAULT_WEB_PORT):
+            console.print(
+                f"[yellow]Port {DEFAULT_WEB_PORT} still held, killing listeners[/yellow]"
+            )
+            _kill_port(DEFAULT_WEB_PORT)
+            _wait_port_free(DEFAULT_WEB_PORT, timeout=3.0)
+
+        console.print(f"[blue]Switching to[/blue] [bold]{branch}[/bold]")
+        result = run_command(["git", "checkout", branch], cwd=ROOT_DIR)
+        if not result or result.returncode != 0:
+            console.print("[red]Checkout failed[/red]")
+            relaunch()
+            raise typer.Exit(1)
+
+        if install:
+            console.print(
+                "[blue]Installing JS deps[/blue] [dim](--ignore-scripts)[/dim]"
+            )
+            run_command(
+                ["pnpm", "install", "--ignore-scripts"], cwd=CLIENTS_DIR
+            )
+
+        console.print("[blue]Wiping Turbopack cache[/blue] [dim](.next)[/dim]")
+        shutil.rmtree(WEB_DIR / ".next", ignore_errors=True)
+
+        relaunch()

--- a/dev/cli/commands/switch.py
+++ b/dev/cli/commands/switch.py
@@ -60,6 +60,10 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
     @app.command()
     def switch(
         branch: Annotated[str, typer.Argument(help="Branch to switch to")],
+        create: Annotated[
+            bool,
+            typer.Option("--create", "-b", help="Create the branch (git checkout -b)"),
+        ] = False,
         install: Annotated[
             bool,
             typer.Option(
@@ -110,8 +114,11 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
             _kill_port(DEFAULT_WEB_PORT)
             _wait_port_free(DEFAULT_WEB_PORT, timeout=3.0)
 
-        console.print(f"[blue]Switching to[/blue] [bold]{branch}[/bold]")
-        result = run_command(["git", "checkout", branch], cwd=ROOT_DIR)
+        checkout = ["git", "checkout", *(["-b"] if create else []), branch]
+        console.print(
+            f"[blue]{'Creating' if create else 'Switching to'}[/blue] [bold]{branch}[/bold]"
+        )
+        result = run_command(checkout, cwd=ROOT_DIR)
         if not result or result.returncode != 0:
             console.print("[red]Checkout failed[/red]")
             relaunch()


### PR DESCRIPTION
## Summary

Two dev CLI commands, born from debugging a web dev-server memory leak that only triggered when switching branches with the stack running:

- `dev switch <branch>` — stop web, checkout, wipe the Turbopack `.next` cache, relaunch web in its pane. Avoids the file-watcher storm on the branch write-burst. `-i` also reinstalls JS deps, skipping package
  prebuilds.
- `dev stop` — kill the `polar` tmux session (instead of `tmux kill-server`).

`dev start` now tags the web pane so `dev switch` targets it reliably.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

