### PR TITLE
fix(transaction): count payout reversals as available balance

### DIFF
--- a/server/polar/transaction/service/transaction.py
+++ b/server/polar/transaction/service/transaction.py
@@ -181,7 +181,12 @@ class TransactionService(BaseTransactionService):
                     func.coalesce(
                         func.sum(Transaction.amount).filter(
                             or_(
-                                Transaction.type == TransactionType.payout,
+                                Transaction.type.in_(
+                                    (
+                                        TransactionType.payout,
+                                        TransactionType.payout_reversal,
+                                    )
+                                ),
                                 Transaction.platform_fee_type.in_(
                                     PlatformFeeType.payout_fee_types()
                                 ),
@@ -198,7 +203,12 @@ class TransactionService(BaseTransactionService):
                     func.coalesce(
                         func.sum(Transaction.account_amount).filter(
                             or_(
-                                Transaction.type == TransactionType.payout,
+                                Transaction.type.in_(
+                                    (
+                                        TransactionType.payout,
+                                        TransactionType.payout_reversal,
+                                    )
+                                ),
                                 Transaction.platform_fee_type.in_(
                                     PlatformFeeType.payout_fee_types()
                                 ),

--- a/server/tests/payout/test_service_ledger.py
+++ b/server/tests/payout/test_service_ledger.py
@@ -75,8 +75,72 @@ class TestHeldPayoutLedger:
         # The full reserved amount (gross plus fees) is returned to the ledger:
         # the total balance is restored to its original value.
         assert summary_after.balance.amount == available_before
-        # The fees become available immediately (they carry a payout fee type).
-        # The gross is returned via a payout_reversal row, which re-ages into
-        # the available balance like any other balance row — this matches how
-        # canceling a regular pending payout already behaves.
-        assert summary_after.available_balance.amount == payout.fees_amount
+        # The gross was reserved from funds that had already cleared the payout
+        # delay, so canceling must make it available again immediately — the
+        # payout_reversal row must not re-age it behind the held balance.
+        assert summary_after.available_balance.amount == available_before
+
+    async def test_cancel_pending_returns_gross_and_fees(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        locker: Locker,
+        organization: Organization,
+        account: Account,
+        user: User,
+    ) -> None:
+        # Canceling a payout must not re-hold the released gross behind the
+        # full payout delay.
+        await create_payout_account(save_fixture, organization, user)
+
+        payment_transaction = await create_payment_transaction(save_fixture)
+        await create_balance_transaction(
+            save_fixture, account=account, payment_transaction=payment_transaction
+        )
+
+        summary_before = await transaction_service.get_summary(session, account)
+        available_before = summary_before.available_balance.amount
+        assert available_before == 10000
+
+        payout = await payout_service.create(session, locker, organization)
+        assert payout.status == PayoutStatus.pending
+        assert payout.fees_amount > 0
+
+        summary_pending = await transaction_service.get_summary(session, account)
+        assert summary_pending.available_balance.amount == 0
+
+        canceled = await payout_service.cancel(session, payout)
+        assert canceled.status == PayoutStatus.canceled
+
+        summary_after = await transaction_service.get_summary(session, account)
+        assert summary_after.balance.amount == available_before
+        assert summary_after.available_balance.amount == available_before
+
+    async def test_released_funds_are_immediately_repayable(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        locker: Locker,
+        organization: Organization,
+        account: Account,
+        user: User,
+    ) -> None:
+        # After canceling a payout, the released funds must be available
+        # for a *new* payout right away.
+        await create_payout_account(save_fixture, organization, user)
+
+        payment_transaction = await create_payment_transaction(save_fixture)
+        await create_balance_transaction(
+            save_fixture, account=account, payment_transaction=payment_transaction
+        )
+
+        first_payout = await payout_service.create(session, locker, organization)
+        canceled = await payout_service.cancel(session, first_payout)
+        assert canceled.status == PayoutStatus.canceled
+
+        second_payout = await payout_service.create(session, locker, organization)
+        assert second_payout.status == PayoutStatus.pending
+        assert second_payout.amount + second_payout.fees_amount == 10000
+
+        summary_after = await transaction_service.get_summary(session, account)
+        assert summary_after.available_balance.amount == 0


### PR DESCRIPTION
## Summary

**Related Issue**: #12103

Canceling a pending or held payout returned the reserved gross via a payout_reversal row dated now, which then re-aged behind the full payout_transaction_delay instead of becoming available again — so the funds fell under held balance and couldn't back a new payout, even though they'd already cleared the delay before being reserved. The available-balance filter exempts payout-side rows from aging (the payout debit and its fees always count immediately) but was missing the mirror branch for the payout_reversal credit, so the debit landed instantly while its reversal didn't. 

Fix adds payout_reversal alongside payout in the filter, restoring the symmetry. This gap dates to the delay filter (#11494) never being reconciled with the reversal row from the cancel path; #12097 documented the re-aging as matching pending-cancel but that behavior was itself the same unclosed gap. 
Return-of-funds is unchanged (total balance was always restored); only the availability classification is corrected, for both cancel paths. Tests exercise the real transaction/fee services: held and pending cancel now leave the full gross+fees available, plus a test that a second payout can be created from the released funds (previously raised InsufficientBalance).

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

