### PR TITLE
tf/s3: Explicitly state that encryption is enabled

### DIFF
--- a/terraform/modules/athena_spans/main.tf
+++ b/terraform/modules/athena_spans/main.tf
@@ -21,6 +21,16 @@ resource "aws_s3_bucket" "athena_results" {
   bucket = "${local.full_name_prefix}-athena-results"
 }
 
+resource "aws_s3_bucket_server_side_encryption_configuration" "athena_results" {
+  bucket = aws_s3_bucket.athena_results.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
 resource "aws_s3_bucket_lifecycle_configuration" "athena_results" {
   bucket = aws_s3_bucket.athena_results.id
 

--- a/terraform/modules/s3_buckets/main.tf
+++ b/terraform/modules/s3_buckets/main.tf
@@ -59,16 +59,56 @@ resource "aws_s3_bucket" "customer_invoices" {
   bucket = "${local.name_prefix}-customer-invoices"
 }
 
+resource "aws_s3_bucket_server_side_encryption_configuration" "customer_invoices" {
+  bucket = aws_s3_bucket.customer_invoices.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
 resource "aws_s3_bucket" "customer_receipts" {
   bucket = "${local.name_prefix}-customer-receipts"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "customer_receipts" {
+  bucket = aws_s3_bucket.customer_receipts.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
 }
 
 resource "aws_s3_bucket" "payout_invoices" {
   bucket = "${local.name_prefix}-payout-invoices"
 }
 
+resource "aws_s3_bucket_server_side_encryption_configuration" "payout_invoices" {
+  bucket = aws_s3_bucket.payout_invoices.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
 resource "aws_s3_bucket" "files" {
   bucket = "${local.full_name_prefix}-files"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "files" {
+  bucket = aws_s3_bucket.files.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
 }
 
 resource "aws_s3_bucket_cors_configuration" "files" {
@@ -84,6 +124,16 @@ resource "aws_s3_bucket_cors_configuration" "files" {
 
 resource "aws_s3_bucket" "public_assets" {
   bucket = "${local.name_prefix}-public-assets"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "public_assets" {
+  bucket = aws_s3_bucket.public_assets.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "public_assets" {
@@ -113,6 +163,16 @@ resource "aws_s3_bucket_policy" "public_assets" {
 
 resource "aws_s3_bucket" "public_files" {
   bucket = local.public_files_bucket
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "public_files" {
+  bucket = aws_s3_bucket.public_files.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "public_files" {
@@ -153,4 +213,14 @@ resource "aws_s3_bucket_cors_configuration" "public_files" {
 
 resource "aws_s3_bucket" "logs" {
   bucket = "${local.full_name_prefix}-logs"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "logs" {
+  bucket = aws_s3_bucket.logs.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
 }

--- a/terraform/organization/production.tf
+++ b/terraform/organization/production.tf
@@ -178,6 +178,16 @@ resource "aws_s3_bucket" "production_lambda_artifacts" {
   bucket = "polar-lambda-artifacts"
 }
 
+resource "aws_s3_bucket_server_side_encryption_configuration" "production_lambda_artifacts" {
+  bucket = aws_s3_bucket.production_lambda_artifacts.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
 resource "aws_s3_bucket_versioning" "production_lambda_artifacts" {
   bucket = aws_s3_bucket.production_lambda_artifacts.id
   versioning_configuration {
@@ -363,6 +373,18 @@ resource "aws_s3_bucket" "production_backups" {
   provider = aws.us_east_2
 
   bucket = "polar-sh-backups"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "production_backups" {
+  provider = aws.us_east_2
+
+  bucket = aws_s3_bucket.production_backups.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "production_backups" {


### PR DESCRIPTION
This should already be enabled by default, but the Terraform does not state it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly enable default server-side encryption (SSE-S3 AES256) on all managed S3 buckets across modules and production using `aws_s3_bucket_server_side_encryption_configuration`. This makes encryption explicit in Terraform and ensures new objects are encrypted by default.

- **Migration**
  - No manual steps. `terraform apply` will update buckets in place.
  - Existing objects are unchanged; new objects will use AES256.

<sup>Written for commit 25369965c4190f19b716a003f5b7cddcd70f4b26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

