### PR TITLE
cache: Set cache control on API responses

### DIFF
--- a/server/polar/app.py
+++ b/server/polar/app.py
@@ -37,6 +37,7 @@ from polar.logfire import (
 from polar.logging import Logger
 from polar.logging import configure as configure_logging
 from polar.middlewares import (
+    CacheControlMiddleware,
     FlushEnqueuedWorkerJobsMiddleware,
     LogCorrelationIdMiddleware,
     OperationalErrorMiddleware,
@@ -211,6 +212,7 @@ def create_app() -> FastAPI:
     if settings.is_sandbox():
         app.add_middleware(SandboxResponseHeaderMiddleware)
     app.add_middleware(APIVersionMiddleware, current=CURRENT_API_VERSION)
+    app.add_middleware(CacheControlMiddleware)
     if not settings.is_testing():
         rate_limit_redis = create_redis("rate-limit")
         app.state.rate_limit_redis = rate_limit_redis

--- a/server/polar/middlewares.py
+++ b/server/polar/middlewares.py
@@ -146,6 +146,26 @@ class SandboxResponseHeaderMiddleware:
         await self.app(scope, receive, send_wrapper)
 
 
+class CacheControlMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def send_wrapper(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                message.setdefault("headers", [])
+                headers = MutableHeaders(scope=message)
+                if "cache-control" not in headers:
+                    headers["Cache-Control"] = "private, no-store"
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)
+
+
 class OperationalErrorMiddleware:
     def __init__(self, app: ASGIApp) -> None:
         self.app = app

--- a/server/tests/test_cache_control.py
+++ b/server/tests/test_cache_control.py
@@ -1,0 +1,15 @@
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+class TestCacheControlMiddleware:
+    async def test_success_response(self, client: AsyncClient) -> None:
+        response = await client.get("/openapi.json")
+        assert response.status_code == 200
+        assert response.headers["cache-control"] == "private, no-store"
+
+    async def test_error_response(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/customers/")
+        assert response.status_code == 401
+        assert response.headers["cache-control"] == "private, no-store"


### PR DESCRIPTION
This will explicitly tell the API user to not cache sensitive API responses


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

