### PR TITLE
files: Prevent too many parts and too big bodies

### DIFF
--- a/server/polar/app.py
+++ b/server/polar/app.py
@@ -40,6 +40,7 @@ from polar.middlewares import (
     CacheControlMiddleware,
     FlushEnqueuedWorkerJobsMiddleware,
     LogCorrelationIdMiddleware,
+    MaxBodySizeMiddleware,
     OperationalErrorMiddleware,
     PathRewriteMiddleware,
     SandboxResponseHeaderMiddleware,
@@ -222,6 +223,7 @@ def create_app() -> FastAPI:
         app.add_middleware(rate_limit.get_middleware, redis=rate_limit_redis)
     app.add_middleware(PathRewriteMiddleware, pattern=r"^/api/v1", replacement="/v1")
     app.add_middleware(LogCorrelationIdMiddleware)
+    app.add_middleware(MaxBodySizeMiddleware, limit=settings.API_MAX_REQUEST_BODY_SIZE)
     if not settings.is_testing():
         app.add_middleware(HttpMetricsMiddleware)
 

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -422,6 +422,7 @@ class Settings(BaseSettings):
 
     # Application behaviours
     API_PAGINATION_MAX_LIMIT: int = 100
+    API_MAX_REQUEST_BODY_SIZE: int = 10 * 1024 * 1024
 
     ACCOUNT_PAYOUT_DELAY: timedelta = timedelta(seconds=1)
     ACCOUNT_DEFAULT_PAYOUT_INTERVAL: timedelta = timedelta(hours=24)

--- a/server/polar/integrations/aws/s3/schemas.py
+++ b/server/polar/integrations/aws/s3/schemas.py
@@ -3,7 +3,7 @@ import hashlib
 from datetime import datetime
 from typing import Any, Self
 
-from pydantic import UUID4, computed_field
+from pydantic import UUID4, Field, computed_field
 
 from polar.kit.schemas import IDSchema, Schema
 from polar.kit.utils import human_readable_size
@@ -29,7 +29,7 @@ class S3FileCreatePart(Schema):
 
 
 class S3FileCreateMultipart(Schema):
-    parts: list[S3FileCreatePart]
+    parts: list[S3FileCreatePart] = Field(max_length=10_000)
 
 
 class S3FileCreate(Schema):

--- a/server/polar/middlewares.py
+++ b/server/polar/middlewares.py
@@ -1,5 +1,6 @@
 import contextlib
 import functools
+import json
 import re
 
 import dramatiq
@@ -164,6 +165,62 @@ class CacheControlMiddleware:
             await send(message)
 
         await self.app(scope, receive, send_wrapper)
+
+
+class MaxBodySizeMiddleware:
+    def __init__(self, app: ASGIApp, limit: int) -> None:
+        self.app = app
+        self.limit = limit
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        content_length = headers.get("content-length")
+        if content_length is None:
+            if scope["method"] in ("POST", "PUT", "PATCH"):
+                await self._send_error(
+                    send,
+                    status=411,
+                    error="LengthRequired",
+                    detail="A Content-Length header is required.",
+                )
+                return
+        else:
+            try:
+                if int(content_length) > self.limit:
+                    await self._send_error(
+                        send,
+                        status=413,
+                        error="RequestBodyTooLarge",
+                        detail=(
+                            "Request body exceeded the maximum allowed size "
+                            f"of {self.limit} bytes."
+                        ),
+                    )
+                    return
+            except ValueError:
+                pass
+
+        await self.app(scope, receive, send)
+
+    async def _send_error(
+        self, send: Send, *, status: int, error: str, detail: str
+    ) -> None:
+        body = json.dumps({"error": error, "detail": detail}).encode("utf-8")
+        await send(
+            {
+                "type": "http.response.start",
+                "status": status,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(body)).encode("latin-1")),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body})
 
 
 class OperationalErrorMiddleware:

--- a/server/tests/file/test_endpoints.py
+++ b/server/tests/file/test_endpoints.py
@@ -35,6 +35,22 @@ class TestEndpoints:
 
         assert response.status_code == 422
 
+    @pytest.mark.auth
+    async def test_create_with_too_many_parts(
+        self, client: AsyncClient, organization: Organization, logo_png: TestFile
+    ) -> None:
+        payload = logo_png.build_create(organization.id).model_dump(mode="json")
+        part = payload["upload"]["parts"][0]
+        payload["upload"]["parts"] = [{**part, "number": i + 1} for i in range(10_001)]
+
+        response = await client.post("/v1/files/", json=payload)
+
+        assert response.status_code == 422
+        errors = response.json()["detail"]
+        assert any(
+            error["type"] == "too_long" and "parts" in error["loc"] for error in errors
+        )
+
     async def test_create_downloadable_with_web_scope(
         self, session: AsyncSession, organization: Organization, logo_png: TestFile
     ) -> None:

--- a/server/tests/test_middlewares.py
+++ b/server/tests/test_middlewares.py
@@ -1,0 +1,113 @@
+import asyncio
+import json
+from typing import Any, cast
+
+from starlette.types import Message, Receive, Scope, Send
+
+from polar.middlewares import MaxBodySizeMiddleware
+
+
+def _http_scope(headers: list[tuple[bytes, bytes]], method: str = "POST") -> Scope:
+    return cast(
+        Scope,
+        {
+            "type": "http",
+            "method": method,
+            "path": "/v1/files/",
+            "headers": headers,
+        },
+    )
+
+
+def _run(
+    limit: int,
+    headers: list[tuple[bytes, bytes]],
+    body_chunks: list[bytes],
+    method: str = "POST",
+) -> tuple[list[Message], bool]:
+    app_called = False
+
+    async def reading_app(scope: Scope, receive: Receive, send: Send) -> None:
+        nonlocal app_called
+        app_called = True
+        more_body = True
+        while more_body:
+            message = await receive()
+            more_body = message.get("more_body", False)
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    middleware = MaxBodySizeMiddleware(reading_app, limit=limit)
+
+    messages = [
+        {
+            "type": "http.request",
+            "body": chunk,
+            "more_body": i < len(body_chunks) - 1,
+        }
+        for i, chunk in enumerate(body_chunks)
+    ]
+    messages_iter = iter(messages)
+
+    async def receive() -> Message:
+        return cast(Message, next(messages_iter))
+
+    sent: list[Message] = []
+
+    async def send(message: Message) -> None:
+        sent.append(message)
+
+    asyncio.run(middleware(_http_scope(headers, method), receive, cast(Send, send)))
+    return sent, app_called
+
+
+def _response_status(sent: list[Message]) -> int:
+    return next(m["status"] for m in sent if m["type"] == "http.response.start")
+
+
+def _response_json(sent: list[Message]) -> dict[str, Any]:
+    body = b"".join(
+        m.get("body", b"") for m in sent if m["type"] == "http.response.body"
+    )
+    return json.loads(body)
+
+
+class TestMaxBodySizeMiddleware:
+    def test_under_limit(self) -> None:
+        sent, app_called = _run(
+            limit=10,
+            headers=[(b"content-length", b"4")],
+            body_chunks=[b"1234"],
+        )
+        assert app_called is True
+        assert _response_status(sent) == 200
+
+    def test_content_length_over_limit(self) -> None:
+        sent, app_called = _run(
+            limit=10,
+            headers=[(b"content-length", b"11")],
+            body_chunks=[b"12345678901"],
+        )
+        assert app_called is False
+        assert _response_status(sent) == 413
+        assert _response_json(sent)["error"] == "RequestBodyTooLarge"
+
+    def test_missing_content_length_post(self) -> None:
+        sent, app_called = _run(
+            limit=10,
+            headers=[],
+            body_chunks=[b"1234"],
+        )
+        assert app_called is False
+        assert _response_status(sent) == 411
+        assert _response_json(sent)["error"] == "LengthRequired"
+
+    def test_missing_content_length_get(self) -> None:
+        sent, app_called = _run(
+            limit=10,
+            headers=[],
+            body_chunks=[b""],
+            method="GET",
+        )
+        assert app_called is True
+        assert _response_status(sent) == 200


### PR DESCRIPTION
By uploading a large number of parts, we parse that into Python objects which are held in memory. S3 limits the number of parts to 10k, which prevents this issue.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

