### PR TITLE
tf: Prevent overwriting tf var for scale product

### DIFF
--- a/terraform/global/production.tf
+++ b/terraform/global/production.tf
@@ -404,6 +404,10 @@ resource "tfe_variable" "polar_scale_product_id_production" {
   category        = "terraform"
   description     = "Polar Scale-tier product ID for production"
   variable_set_id = tfe_variable_set.production.id
+
+  lifecycle {
+    ignore_changes = [value]
+  }
 }
 
 resource "tfe_variable" "customer_portal_url_overrides_production" {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents Terraform from overwriting the production Polar Scale product ID by ignoring changes to the variable’s value. Adds lifecycle ignore_changes = [value] to `tfe_variable.polar_scale_product_id_production` so manual updates in TFE persist.

<sup>Written for commit 0530cc9ebddfe04fbdd9cbf076b1196fefbf80a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

