### PR TITLE
Add disputes banner on home

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/DashboardPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/DashboardPage.tsx
@@ -7,6 +7,7 @@ import { AccountWidget } from '@/components/Widgets/AccountWidget'
 import { OrdersWidget } from '@/components/Widgets/OrdersWidget'
 import RevenueWidget from '@/components/Widgets/RevenueWidget'
 import { schemas } from '@polar-sh/client'
+import { DisputesBanner } from './DisputesBanner'
 import { OrganizationStatusBanner } from './OrganizationStatusBanner'
 
 const cellClassName =
@@ -21,6 +22,7 @@ export default function OverviewPage({ organization }: OverviewPageProps) {
     <DashboardBody className="gap-y-8 pb-16 md:gap-y-16" title={null}>
       <PlanUpsell organization={organization} />
       <OrganizationStatusBanner organization={organization} />
+      <DisputesBanner organization={organization} />
       <OverviewSection organization={organization} />
 
       <div className="dark:border-polar-700 overflow-hidden rounded-xl border border-gray-200">

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/DisputesBanner.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/DisputesBanner.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useDisputes } from '@/hooks/queries/disputes'
+import { schemas } from '@polar-sh/client'
+import { Alert } from '@polar-sh/orbit'
+import { useRouter } from 'next/navigation'
+
+const OPEN_DISPUTE_STATUSES: schemas['DisputeStatus'][] = [
+  'needs_response',
+  'under_review',
+  'early_warning',
+]
+
+interface DisputesBannerProps {
+  organization: schemas['Organization']
+}
+
+export const DisputesBanner = ({ organization }: DisputesBannerProps) => {
+  const router = useRouter()
+  const disputesEnabled = !!organization.feature_settings?.disputes_enabled
+
+  const { data } = useDisputes(
+    organization.id,
+    { status: OPEN_DISPUTE_STATUSES, limit: 1 },
+    disputesEnabled,
+  )
+
+  const count = data?.pagination.total_count ?? 0
+
+  if (!disputesEnabled || count === 0) {
+    return null
+  }
+
+  const single = count === 1
+  return (
+    <Alert
+      variant="warning"
+      title={
+        single ? 'You have an open dispute' : `You have ${count} open disputes`
+      }
+      description={
+        single
+          ? 'A customer has disputed a payment. Respond with evidence before the deadline to contest it.'
+          : 'Customers have disputed payments. Respond with evidence before the deadline to contest them.'
+      }
+      actions={[
+        {
+          text: single ? 'Review dispute' : 'Review disputes',
+          onClick: () => {
+            router.push(`/dashboard/${organization.slug}/sales/disputes`)
+          },
+        },
+      ]}
+    />
+  )
+}

--- a/clients/apps/web/src/hooks/queries/disputes.ts
+++ b/clients/apps/web/src/hooks/queries/disputes.ts
@@ -31,6 +31,7 @@ export const useDisputes = (
     NonNullable<operations['disputes:list']['parameters']['query']>,
     'organization_id'
   >,
+  enabled: boolean = true,
 ) =>
   useQuery({
     queryKey: ['disputes', { organizationId, parameters }],
@@ -43,4 +44,5 @@ export const useDisputes = (
         }),
       ),
     retry: defaultRetry,
+    enabled,
   })


### PR DESCRIPTION
## Summary

Show a banner on home if the merchant has any non won/lost disputes (and the feature flag).

<img width="1840" height="1133" alt="Screenshot 2026-07-06 at 12 25 03" src="https://github.com/user-attachments/assets/16e93151-b882-49c4-88b6-36af8d6af7d1" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

