### PR TITLE
Fix dispute alert type

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/DisputesBanner.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/DisputesBanner.tsx
@@ -34,7 +34,6 @@ export const DisputesBanner = ({ organization }: DisputesBannerProps) => {
   const single = count === 1
   return (
     <Alert
-      variant="warning"
       title={
         single ? 'You have an open dispute' : `You have ${count} open disputes`
       }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Corrects the Disputes banner alert type by removing the warning variant so it uses the default style. This matches design and avoids unnecessary warning emphasis for open disputes.

<sup>Written for commit 94c2175eff1040151c3a704c918eea3a7d7cd102. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

