### PR TITLE
docker: Run Tailscale as non-root user

### DIFF
--- a/infra/tailscale/Dockerfile
+++ b/infra/tailscale/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get -qq update \
     apt-transport-https \
     ca-certificates \
     dnsmasq \
+    libcap2-bin \
     wget \
     dnsutils \
   > /dev/null \
@@ -18,10 +19,18 @@ RUN apt-get -qq update \
     /tmp/* \
     /var/tmp/*
 
-RUN echo "+search +short" > /root/.digrc
+RUN groupadd --system tailscale \
+  && useradd --system --gid tailscale --home-dir /render --shell /usr/sbin/nologin tailscale
+
+RUN echo "+search +short" > /render/.digrc
 COPY --chmod=755 run-tailscale.sh /render/
 
 COPY --chmod=755 install-tailscale.sh /tmp/
 RUN /tmp/install-tailscale.sh && rm -r /tmp/*
+
+RUN setcap 'cap_net_bind_service=+ep' /usr/sbin/dnsmasq \
+  && chown -R tailscale:tailscale /render /var/run/tailscale /var/cache/tailscale /var/lib/tailscale
+
+USER tailscale
 
 CMD ./run-tailscale.sh


### PR DESCRIPTION
To reduce the risks, even though this is a standalone container, we can create and run Tailscale as its own user

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

