### PR TITLE
Filter dispute CTA based on status

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/DisputesBanner.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/DisputesBanner.tsx
@@ -11,6 +11,8 @@ const OPEN_DISPUTE_STATUSES: schemas['DisputeStatus'][] = [
   'early_warning',
 ]
 
+const ACTION_REQUIRED_STATUS: schemas['DisputeStatus'] = 'needs_response'
+
 interface DisputesBannerProps {
   organization: schemas['Organization']
 }
@@ -46,7 +48,9 @@ export const DisputesBanner = ({ organization }: DisputesBannerProps) => {
         {
           text: single ? 'Review dispute' : 'Review disputes',
           onClick: () => {
-            router.push(`/dashboard/${organization.slug}/sales/disputes`)
+            router.push(
+              `/dashboard/${organization.slug}/sales/disputes?status=${ACTION_REQUIRED_STATUS}`,
+            )
           },
         },
       ]}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the Disputes banner CTA to open the disputes page filtered to action-required cases. Adds `status=needs_response` to the route so users land on disputes that need a response.

<sup>Written for commit dbe43bf146d5e38662a7c625461e16ead4d389be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

