### PR TITLE
oauth2: Simplify localhost URL detection

### DIFF
--- a/server/polar/oauth2/schemas.py
+++ b/server/polar/oauth2/schemas.py
@@ -1,5 +1,4 @@
 import ipaddress
-import re
 from typing import Annotated, Any, Literal
 
 from fastapi.openapi.constants import REF_TEMPLATE
@@ -25,14 +24,12 @@ from polar.kit.schemas import Schema, TimestampedSchema
 
 from .sub_type import SubType
 
-_LOCALHOST_HOST_PATTERN = re.compile(r"([^\.]+\.)?localhost(\d+)?", flags=re.IGNORECASE)
-
 
 def _is_localhost(host: str) -> bool:
     try:
         return ipaddress.IPv4Address(host).is_private
     except ValueError:
-        return _LOCALHOST_HOST_PATTERN.match(host) is not None
+        return host == "localhost" or host.endswith(".localhost")
 
 
 def _is_https_or_localhost(value: HttpUrl) -> HttpUrl:

--- a/server/tests/oauth2/endpoints/test_oauth2.py
+++ b/server/tests/oauth2/endpoints/test_oauth2.py
@@ -148,7 +148,17 @@ async def create_oauth2_grant(
 
 @pytest.mark.asyncio
 class TestOAuth2Register:
-    @pytest.mark.parametrize("redirect_uri", ["http://example.com", "foobar"])
+    @pytest.mark.parametrize(
+        "redirect_uri",
+        [
+            "http://example.com",
+            "foobar",
+            f"http://{'a' * 54773}slocalhost/callback",
+            "http://localhost.evil/callback",
+            "http://localhostevil/callback",
+            "http://localhost./callback",
+        ],
+    )
     @pytest.mark.auth
     async def test_invalid_redirect_uri(
         self, redirect_uri: str, client: AsyncClient
@@ -169,6 +179,7 @@ class TestOAuth2Register:
         [
             "https://example.com",
             "http://localhost:8000/callback",
+            "http://foo.localhost:8000/callback",
             "http://127.0.0.1:8000/callback",
         ],
     )


### PR DESCRIPTION
Instead of relying on a regex that might expand too much (ReDoS) we simplify it to look at equals or endswith .localhost


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

