### PR TITLE
feat(merchant-migration): backend API for migrations + Stripe connect

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -22278,7 +22278,7 @@ export interface components {
        * Source
        * @description Non-secret metadata about the connected source. The shape varies by provider (e.g. Stripe exposes `stripe_user_id`, `livemode`).
        */
-      source?: {
+      source: {
         [key: string]: unknown
       } | null
     }

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -4878,6 +4878,30 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/merchant-migrations/': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * List Merchant Migrations
+     * @description **Scopes**: `organizations:read` `organizations:write`
+     */
+    get: operations['merchant-migrations:list']
+    put?: never
+    /**
+     * Create Merchant Migration
+     * @description **Scopes**: `organizations:write`
+     */
+    post: operations['merchant-migrations:create']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/merchant-migrations/{id}': {
     parameters: {
       query?: never
@@ -21694,6 +21718,12 @@ export interface components {
       items: components['schemas']['Member'][]
       pagination: components['schemas']['Pagination']
     }
+    /** ListResource[MerchantMigration] */
+    ListResource_MerchantMigration_: {
+      /** Items */
+      items: components['schemas']['MerchantMigration'][]
+      pagination: components['schemas']['Pagination']
+    }
     /** ListResource[Meter] */
     ListResource_Meter_: {
       /** Items */
@@ -22235,6 +22265,32 @@ export interface components {
        * Format: uuid4
        */
       organization_id: string
+      /** @description The provider the billing is being migrated from. */
+      source_platform: components['schemas']['MerchantMigrationSourcePlatform']
+      /** @description The current step of the migration. */
+      step: components['schemas']['MerchantMigrationStep']
+      /**
+       * Source Connected
+       * @description Whether the source provider has been connected.
+       */
+      source_connected: boolean
+      /**
+       * Source
+       * @description Non-secret metadata about the connected source. The shape varies by provider (e.g. Stripe exposes `stripe_user_id`, `livemode`).
+       */
+      source?: {
+        [key: string]: unknown
+      } | null
+    }
+    /** MerchantMigrationCreate */
+    MerchantMigrationCreate: {
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description The organization the migration belongs to.
+       */
+      organization_id: string
+      /** @description The provider to migrate the billing from. */
       source_platform: components['schemas']['MerchantMigrationSourcePlatform']
     }
     /** MerchantMigrationNotFound */
@@ -22253,6 +22309,18 @@ export interface components {
      * @enum {string}
      */
     MerchantMigrationSourcePlatform: 'stripe' | 'lemon_squeezy' | 'paddle'
+    /**
+     * MerchantMigrationStep
+     * @enum {string}
+     */
+    MerchantMigrationStep:
+      | 'source_setup'
+      | 'pre_check'
+      | 'create_catalog'
+      | 'copy_cards'
+      | 'activate_subscriptions'
+      | 'cleanup'
+      | 'completed'
     MetadataOutputType: {
       [key: string]: string | number | boolean
     }
@@ -25687,6 +25755,12 @@ export interface components {
        * @default false
        */
       compass_enabled: boolean
+      /**
+       * Merchant Migration Enabled
+       * @description If this organization can migrate its billing from another provider (e.g. Stripe) to Polar.
+       * @default false
+       */
+      merchant_migration_enabled: boolean
     }
     /**
      * OrganizationFeatureSettingsUpdate
@@ -47941,6 +48015,74 @@ export interface operations {
       }
     }
   }
+  'merchant-migrations:list': {
+    parameters: {
+      query: {
+        organization_id: string
+        /** @description Page number, defaults to 1. */
+        page?: number
+        /** @description Size of a page, defaults to 10. Maximum is 100. */
+        limit?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ListResource_MerchantMigration_']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'merchant-migrations:create': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['MerchantMigrationCreate']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigration']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
   'merchant-migrations:get': {
     parameters: {
       query?: never
@@ -59770,6 +59912,17 @@ export const memberSortPropertyValues: ReadonlyArray<
 export const merchantMigrationSourcePlatformValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['MerchantMigrationSourcePlatform']
 > = ['stripe', 'lemon_squeezy', 'paddle']
+export const merchantMigrationStepValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['MerchantMigrationStep']
+> = [
+  'source_setup',
+  'pre_check',
+  'create_catalog',
+  'copy_cards',
+  'activate_subscriptions',
+  'cleanup',
+  'completed',
+]
 export const meterCreditEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['MeterCreditEvent']['name']
 > = ['meter.credited']

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -7,6 +7,7 @@ from pydantic import UUID4
 from polar.exceptions import NotPermitted, ResourceNotFound
 from polar.kit.db.postgres import AsyncSession
 from polar.kit.http import ReturnTo, add_query_parameters, get_safe_return_url
+from polar.kit.pagination import ListResource, PaginationParamsQuery
 from polar.models import MerchantMigration
 from polar.openapi import APITag
 from polar.organization.schemas import OrganizationID
@@ -15,7 +16,7 @@ from polar.routing import APIRouter
 
 from .auth import MerchantMigrationRead, MerchantMigrationWrite
 from .schemas import MerchantMigration as MerchantMigrationSchema
-from .schemas import PrecheckReport
+from .schemas import MerchantMigrationCreate, PrecheckReport
 from .service import (
     MerchantMigrationNotFound,
     SourceNotConnected,
@@ -31,9 +32,49 @@ router = APIRouter(
 STRIPE_CALLBACK_ROUTE_NAME = "merchant_migrations.stripe.callback"
 
 
+@router.get(
+    "/",
+    response_model=ListResource[MerchantMigrationSchema],
+    summary="List Merchant Migrations",
+)
+async def list(
+    auth_subject: MerchantMigrationRead,
+    pagination: PaginationParamsQuery,
+    organization_id: Annotated[OrganizationID, Query()],
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> ListResource[MerchantMigrationSchema]:
+    results, count = await merchant_migration_service.list(
+        session,
+        auth_subject,
+        organization_id=organization_id,
+        pagination=pagination,
+    )
+    return ListResource.from_paginated_results(
+        [MerchantMigrationSchema.model_validate(result) for result in results],
+        count,
+        pagination,
+    )
+
+
+@router.post(
+    "/",
+    response_model=MerchantMigrationSchema,
+    status_code=201,
+    summary="Create Merchant Migration",
+)
+async def create(
+    migration_create: MerchantMigrationCreate,
+    auth_subject: MerchantMigrationWrite,
+    session: AsyncSession = Depends(get_db_session),
+) -> MerchantMigration:
+    return await merchant_migration_service.create(
+        session, auth_subject, migration_create
+    )
+
+
 @router.get("/stripe/authorize", include_in_schema=False)
 async def stripe_authorize(
-    organization_id: Annotated[OrganizationID, Query()],
+    migration_id: Annotated[UUID4, Query()],
     return_to: ReturnTo,
     auth_subject: MerchantMigrationWrite,
     request: Request,
@@ -43,7 +84,7 @@ async def stripe_authorize(
     authorize_url = await merchant_migration_service.create_stripe_authorization_url(
         session,
         auth_subject,
-        organization_id=organization_id,
+        migration_id=migration_id,
         redirect_uri=redirect_uri,
         return_to=return_to,
     )

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -10,10 +10,6 @@ from polar.kit.repository import (
     RepositorySoftDeletionMixin,
 )
 from polar.models import MerchantMigration
-from polar.models.merchant_migration import (
-    MerchantMigrationSourcePlatform,
-    MerchantMigrationStep,
-)
 
 
 class MerchantMigrationRepository(
@@ -38,20 +34,3 @@ class MerchantMigrationRepository(
                 MerchantMigration.organization_id == auth_subject.subject.id
             )
         return statement
-
-    async def get_ongoing_by_source(
-        self,
-        organization_id: UUID,
-        source_platform: MerchantMigrationSourcePlatform,
-    ) -> MerchantMigration | None:
-        statement = (
-            self.get_base_statement()
-            .where(
-                MerchantMigration.organization_id == organization_id,
-                MerchantMigration.source_platform == source_platform,
-                MerchantMigration.step != MerchantMigrationStep.completed,
-            )
-            .order_by(MerchantMigration.created_at.desc())
-            .limit(1)
-        )
-        return await self.get_one_or_none(statement)

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -1,9 +1,22 @@
 from enum import StrEnum
+from typing import Any
 
-from pydantic import UUID4
+from pydantic import UUID4, Field
 
 from polar.kit.schemas import IDSchema, Schema, TimestampedSchema
-from polar.models.merchant_migration import MerchantMigrationSourcePlatform
+from polar.models.merchant_migration import (
+    MerchantMigrationSourcePlatform,
+    MerchantMigrationStep,
+)
+
+
+class MerchantMigrationCreate(Schema):
+    organization_id: UUID4 = Field(
+        description="The organization the migration belongs to."
+    )
+    source_platform: MerchantMigrationSourcePlatform = Field(
+        description="The provider to migrate the billing from.",
+    )
 
 
 class PrecheckIssueLevel(StrEnum):
@@ -25,4 +38,19 @@ class PrecheckReport(Schema):
 
 class MerchantMigration(IDSchema, TimestampedSchema):
     organization_id: UUID4
-    source_platform: MerchantMigrationSourcePlatform
+    source_platform: MerchantMigrationSourcePlatform = Field(
+        description="The provider the billing is being migrated from."
+    )
+    step: MerchantMigrationStep = Field(
+        description="The current step of the migration."
+    )
+    source_connected: bool = Field(
+        description="Whether the source provider has been connected."
+    )
+    source: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Non-secret metadata about the connected source. The shape varies by "
+            "provider (e.g. Stripe exposes `stripe_user_id`, `livemode`)."
+        ),
+    )

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -48,6 +48,11 @@ class MerchantMigration(IDSchema, TimestampedSchema):
         description="Whether the source provider has been connected."
     )
     source: dict[str, Any] | None = Field(
+        description=(
+            "Non-secret metadata about the connected source. The shape varies by "
+            "provider (e.g. Stripe exposes `stripe_user_id`, `livemode`)."
+        ),
+    )
         default=None,
         description=(
             "Non-secret metadata about the connected source. The shape varies by "

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -53,9 +53,3 @@ class MerchantMigration(IDSchema, TimestampedSchema):
             "provider (e.g. Stripe exposes `stripe_user_id`, `livemode`)."
         ),
     )
-        default=None,
-        description=(
-            "Non-secret metadata about the connected source. The shape varies by "
-            "provider (e.g. Stripe exposes `stripe_user_id`, `livemode`)."
-        ),
-    )

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -1,15 +1,19 @@
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Literal, TypedDict
 from uuid import UUID
+
+import structlog
 
 from polar.auth.models import AuthSubject, Organization, User
 from polar.auth.permission import OrganizationPermission
 from polar.authz.service import assert_organization_permission
 from polar.config import settings
-from polar.exceptions import PolarError
+from polar.exceptions import PolarError, ResourceNotFound
 from polar.kit import jwt
 from polar.kit.db.postgres import AsyncSession
 from polar.kit.encryption import EncryptedString
+from polar.kit.pagination import PaginationParams
 from polar.models import MerchantMigration
 from polar.models.merchant_migration import (
     MerchantMigrationSourcePlatform,
@@ -21,13 +25,15 @@ from polar.postgres import AsyncReadSession
 from .adapters import SourceAdapter, StripeAdapter
 from .precheck import precheck_engine
 from .repository import MerchantMigrationRepository
-from .schemas import PrecheckReport
+from .schemas import MerchantMigrationCreate, PrecheckReport
 from .stripe_oauth import (
     StripeAppNotConfigured,
     StripeOAuthError,
     StripeOAuthToken,
     stripe_oauth,
 )
+
+log = structlog.get_logger()
 
 OAUTH_STATE_JWT_TYPE: Literal["stripe_app_oauth"] = "stripe_app_oauth"
 # The state must survive the whole interactive consent on Stripe, so give it more
@@ -79,6 +85,18 @@ class UnsupportedMigrationSource(MerchantMigrationError):
         )
 
 
+class MerchantMigrationNotEnabled(MerchantMigrationError):
+    def __init__(self) -> None:
+        super().__init__(
+            "Merchant migration is not enabled for this organization.", 403
+        )
+
+
+class NotAStripeMigration(MerchantMigrationError):
+    def __init__(self) -> None:
+        super().__init__("This migration does not use Stripe as its source.", 400)
+
+
 @dataclass
 class StripeConnectResult:
     """Where the callback should send the merchant back, and an error message to
@@ -100,6 +118,47 @@ class MerchantMigrationService:
             MerchantMigration.id == migration_id
         )
         return await repository.get_one_or_none(statement)
+
+    async def list(
+        self,
+        session: AsyncReadSession,
+        auth_subject: AuthSubject[User | Organization],
+        *,
+        organization_id: UUID,
+        pagination: PaginationParams,
+    ) -> tuple[Sequence[MerchantMigration], int]:
+        repository = MerchantMigrationRepository.from_session(session)
+        statement = (
+            repository.get_readable_statement(auth_subject)
+            .where(MerchantMigration.organization_id == organization_id)
+            .order_by(MerchantMigration.created_at.desc())
+        )
+        return await repository.paginate(
+            statement, limit=pagination.limit, page=pagination.page
+        )
+
+    async def create(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        create_schema: MerchantMigrationCreate,
+    ) -> MerchantMigration:
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            create_schema.organization_id,
+            OrganizationPermission.organization_manage,
+        )
+        await self._assert_feature_enabled(session, create_schema.organization_id)
+        repository = MerchantMigrationRepository.from_session(session)
+        return await repository.create(
+            MerchantMigration(
+                organization_id=create_schema.organization_id,
+                source_platform=create_schema.source_platform,
+                step=MerchantMigrationStep.source_setup,
+            ),
+            flush=True,
+        )
 
     async def run_precheck(
         self,
@@ -171,25 +230,36 @@ class MerchantMigrationService:
         )
         return token.access_token
 
+    async def _assert_feature_enabled(
+        self, session: AsyncReadSession, organization_id: UUID
+    ) -> None:
+        organization_repository = OrganizationRepository.from_session(session)
+        organization = await organization_repository.get_by_id(organization_id)
+        if organization is None or not organization.is_merchant_migration_enabled:
+            raise MerchantMigrationNotEnabled()
+
     async def create_stripe_authorization_url(
         self,
         session: AsyncSession,
         auth_subject: AuthSubject[User | Organization],
         *,
-        organization_id: UUID,
+        migration_id: UUID,
         redirect_uri: str,
         return_to: str,
     ) -> str:
+        migration = await self.get(session, auth_subject, migration_id)
+        if migration is None:
+            raise ResourceNotFound()
         await assert_organization_permission(
             session,
             auth_subject,
-            organization_id,
+            migration.organization_id,
             OrganizationPermission.organization_manage,
         )
+        if migration.source_platform != MerchantMigrationSourcePlatform.stripe:
+            raise NotAStripeMigration()
         if not stripe_oauth.is_configured():
             raise StripeAppNotConfigured()
-
-        migration = await self._get_or_create_stripe_migration(session, organization_id)
 
         state = jwt.encode(
             data={
@@ -236,7 +306,12 @@ class MerchantMigrationService:
             await self._store_stripe_credentials(
                 session, auth_subject, UUID(state_data["migration_id"]), code
             )
-        except (StripeOAuthError, MerchantMigrationError):
+        except (StripeOAuthError, MerchantMigrationError) as e:
+            log.error(
+                "merchant_migration.stripe_authorization_failed",
+                migration_id=state_data.get("migration_id"),
+                error=str(e),
+            )
             return StripeConnectResult(
                 return_to=return_to, error="Failed to connect Stripe account."
             )
@@ -272,24 +347,6 @@ class MerchantMigrationService:
         credentials = await self._build_stripe_credentials(migration, token)
         await repository.update(
             migration, update_dict={"source_credentials": dict(credentials)}
-        )
-
-    async def _get_or_create_stripe_migration(
-        self, session: AsyncSession, organization_id: UUID
-    ) -> MerchantMigration:
-        repository = MerchantMigrationRepository.from_session(session)
-        migration = await repository.get_ongoing_by_source(
-            organization_id, MerchantMigrationSourcePlatform.stripe
-        )
-        if migration is not None:
-            return migration
-        return await repository.create(
-            MerchantMigration(
-                organization_id=organization_id,
-                source_platform=MerchantMigrationSourcePlatform.stripe,
-                step=MerchantMigrationStep.source_setup,
-            ),
-            flush=True,
         )
 
     async def _build_stripe_credentials(

--- a/server/polar/models/merchant_migration.py
+++ b/server/polar/models/merchant_migration.py
@@ -67,3 +67,22 @@ class MerchantMigration(RecordModel):
     @declared_attr
     def organization(cls) -> Mapped["Organization"]:
         return relationship("Organization", lazy="raise")
+
+    @property
+    def source_connected(self) -> bool:
+        """Whether the source provider has been connected (credentials stored)."""
+        return bool(self.source_credentials)
+
+    @property
+    def source(self) -> dict[str, Any] | None:
+        """Non-secret metadata about the connected source, exposed to the API.
+
+        Whitelist the specific public fields rather than dumping the credentials
+        blob, so secrets can't leak by accident. The fields vary by provider.
+        """
+        if not self.source_credentials:
+            return None
+        return {
+            "stripe_user_id": self.source_credentials.get("stripe_user_id"),
+            "livemode": self.source_credentials.get("livemode"),
+        }

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -635,6 +635,10 @@ class Organization(RateLimitGroupMixin, RecordModel):
     def is_sso_enabled(self) -> bool:
         return self.feature_settings.get("sso_enabled", False)
 
+    @property
+    def is_merchant_migration_enabled(self) -> bool:
+        return self.feature_settings.get("merchant_migration_enabled", False)
+
     sso_enforced: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     #

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -187,6 +187,13 @@ class OrganizationFeatureSettings(Schema):
             "(Billing / Compass / Customers) enabled in the dashboard"
         ),
     )
+    merchant_migration_enabled: bool = Field(
+        False,
+        description=(
+            "If this organization can migrate its billing from another "
+            "provider (e.g. Stripe) to Polar."
+        ),
+    )
 
 
 class OrganizationFeatureSettingsUpdate(Schema):

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -8,6 +8,7 @@ from pytest_mock import MockerFixture
 
 from polar.auth.scope import Scope
 from polar.config import settings
+from polar.kit import jwt
 from polar.merchant_migration.canonical import CanonicalAccount
 from polar.merchant_migration.repository import MerchantMigrationRepository
 from polar.merchant_migration.stripe_oauth import StripeOAuthError
@@ -27,39 +28,134 @@ def _configure_app(mocker: MockerFixture) -> None:
     mocker.patch.object(settings, "STRIPE_APP_CLIENT_LINK_ID", "chnlink_test")
 
 
+async def _enable_feature(
+    save_fixture: SaveFixture, organization: Organization
+) -> None:
+    organization.feature_settings = {
+        **organization.feature_settings,
+        "merchant_migration_enabled": True,
+    }
+    await save_fixture(organization)
+
+
+def _state_migration_id(location: str) -> str:
+    state = parse_qs(urlparse(location).query)["state"][0]
+    return jwt.decode(token=state, secret=settings.SECRET, type="stripe_app_oauth")[
+        "migration_id"
+    ]
+
+
 @pytest.mark.asyncio
-class TestStripeAuthorize:
-    async def test_anonymous(self, client: AsyncClient) -> None:
-        response = await client.get(
-            "/v1/merchant-migrations/stripe/authorize",
-            params={"organization_id": str(uuid4()), "return_to": "/dashboard"},
+class TestCreate:
+    async def test_anonymous(
+        self, client: AsyncClient, organization: Organization
+    ) -> None:
+        response = await client.post(
+            "/v1/merchant-migrations/",
+            json={"organization_id": str(organization.id), "source_platform": "stripe"},
         )
         assert response.status_code == 401
 
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
     async def test_not_member_returns_403(
-        self, client: AsyncClient, organization: Organization, mocker: MockerFixture
+        self, client: AsyncClient, organization: Organization
     ) -> None:
-        _configure_app(mocker)
-        response = await client.get(
-            "/v1/merchant-migrations/stripe/authorize",
-            params={"organization_id": str(organization.id), "return_to": "/dashboard"},
+        response = await client.post(
+            "/v1/merchant-migrations/",
+            json={"organization_id": str(organization.id), "source_platform": "stripe"},
         )
         assert response.status_code == 403
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_feature_disabled_returns_403(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.post(
+            "/v1/merchant-migrations/",
+            json={"organization_id": str(organization.id), "source_platform": "stripe"},
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_creates_multiple_migrations(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await _enable_feature(save_fixture, organization)
+
+        first = await client.post(
+            "/v1/merchant-migrations/",
+            json={"organization_id": str(organization.id), "source_platform": "stripe"},
+        )
+        assert first.status_code == 201
+        body = first.json()
+        assert body["source_platform"] == "stripe"
+        assert body["step"] == "source_setup"
+        assert body["source_connected"] is False
+        assert "source_credentials" not in body
+
+        second = await client.post(
+            "/v1/merchant-migrations/",
+            json={"organization_id": str(organization.id), "source_platform": "stripe"},
+        )
+        assert second.status_code == 201
+        assert second.json()["id"] != body["id"]
+
+        repository = MerchantMigrationRepository.from_session(session)
+        migrations = await repository.get_all(
+            repository.get_base_statement().where(
+                MerchantMigration.organization_id == organization.id
+            )
+        )
+        assert len(migrations) == 2
+
+
+@pytest.mark.asyncio
+class TestStripeAuthorize:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get(
+            "/v1/merchant-migrations/stripe/authorize",
+            params={"migration_id": str(uuid4()), "return_to": "/dashboard"},
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_not_member_returns_404(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        mocker: MockerFixture,
+    ) -> None:
+        _configure_app(mocker)
+        migration = await _create_migration(save_fixture, organization)
+        response = await client.get(
+            "/v1/merchant-migrations/stripe/authorize",
+            params={"migration_id": str(migration.id), "return_to": "/dashboard"},
+        )
+        assert response.status_code == 404
 
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
     async def test_redirects_to_stripe(
         self,
         client: AsyncClient,
-        session: AsyncSession,
+        save_fixture: SaveFixture,
         organization: Organization,
         user_organization: UserOrganization,
         mocker: MockerFixture,
     ) -> None:
         _configure_app(mocker)
+        migration = await _create_migration(save_fixture, organization)
         response = await client.get(
             "/v1/merchant-migrations/stripe/authorize",
-            params={"organization_id": str(organization.id), "return_to": "/dashboard"},
+            params={"migration_id": str(migration.id), "return_to": "/dashboard"},
         )
         assert response.status_code == 303
         location = response.headers["location"]
@@ -67,12 +163,7 @@ class TestStripeAuthorize:
             "https://marketplace.stripe.com/oauth/v2/chnlink_test/authorize"
         )
         assert "ca_test" in location
-
-        repository = MerchantMigrationRepository.from_session(session)
-        migration = await repository.get_ongoing_by_source(
-            organization.id, MerchantMigrationSourcePlatform.stripe
-        )
-        assert migration is not None
+        assert _state_migration_id(location) == str(migration.id)
 
 
 @pytest.mark.asyncio
@@ -82,11 +173,13 @@ class TestStripeCallback:
         self,
         client: AsyncClient,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         organization: Organization,
         user_organization: UserOrganization,
         mocker: MockerFixture,
     ) -> None:
         _configure_app(mocker)
+        migration = await _create_migration(save_fixture, organization)
         mocker.patch(
             "polar.merchant_migration.service.stripe_oauth.exchange_code",
             return_value=build_stripe_oauth_token(),
@@ -94,7 +187,7 @@ class TestStripeCallback:
 
         authorize = await client.get(
             "/v1/merchant-migrations/stripe/authorize",
-            params={"organization_id": str(organization.id), "return_to": "/dashboard"},
+            params={"migration_id": str(migration.id), "return_to": "/dashboard"},
         )
         state = parse_qs(urlparse(authorize.headers["location"]).query)["state"][0]
 
@@ -106,26 +199,26 @@ class TestStripeCallback:
         assert response.headers["location"].endswith("/dashboard")
 
         repository = MerchantMigrationRepository.from_session(session)
-        migration = await repository.get_ongoing_by_source(
-            organization.id, MerchantMigrationSourcePlatform.stripe
-        )
-        assert migration is not None
-        assert migration.source_credentials["stripe_user_id"] == "acct_test"
+        stored = await repository.get_by_id(migration.id)
+        assert stored is not None
+        assert stored.source_credentials["stripe_user_id"] == "acct_test"
         # the refresh token is stored as ciphertext, never in clear text
-        assert migration.source_credentials["refresh_token_encrypted"].startswith("v1.")
+        assert stored.source_credentials["refresh_token_encrypted"].startswith("v1.")
 
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
     async def test_missing_code_redirects_with_error(
         self,
         client: AsyncClient,
+        save_fixture: SaveFixture,
         organization: Organization,
         user_organization: UserOrganization,
         mocker: MockerFixture,
     ) -> None:
         _configure_app(mocker)
+        migration = await _create_migration(save_fixture, organization)
         authorize = await client.get(
             "/v1/merchant-migrations/stripe/authorize",
-            params={"organization_id": str(organization.id), "return_to": "/dashboard"},
+            params={"migration_id": str(migration.id), "return_to": "/dashboard"},
         )
         state = parse_qs(urlparse(authorize.headers["location"]).query)["state"][0]
 
@@ -140,18 +233,20 @@ class TestStripeCallback:
     async def test_exchange_failure_redirects_with_error(
         self,
         client: AsyncClient,
+        save_fixture: SaveFixture,
         organization: Organization,
         user_organization: UserOrganization,
         mocker: MockerFixture,
     ) -> None:
         _configure_app(mocker)
+        migration = await _create_migration(save_fixture, organization)
         mocker.patch(
             "polar.merchant_migration.service.stripe_oauth.exchange_code",
             side_effect=StripeOAuthError("stripe down", 502),
         )
         authorize = await client.get(
             "/v1/merchant-migrations/stripe/authorize",
-            params={"organization_id": str(organization.id), "return_to": "/dashboard"},
+            params={"migration_id": str(migration.id), "return_to": "/dashboard"},
         )
         state = parse_qs(urlparse(authorize.headers["location"]).query)["state"][0]
 
@@ -209,6 +304,43 @@ class TestGet:
 
 
 @pytest.mark.asyncio
+class TestList:
+    async def test_anonymous(
+        self, client: AsyncClient, organization: Organization
+    ) -> None:
+        response = await client.get(
+            "/v1/merchant-migrations/",
+            params={"organization_id": str(organization.id)},
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_read}))
+    async def test_returns_only_org_migrations(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        organization_second: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _create_migration(save_fixture, organization)
+        await _create_migration(save_fixture, organization_second)
+
+        response = await client.get(
+            "/v1/merchant-migrations/",
+            params={"organization_id": str(organization.id)},
+        )
+        assert response.status_code == 200
+        json_body = response.json()
+        assert json_body["pagination"]["total_count"] == 1
+        item = json_body["items"][0]
+        assert item["id"] == str(migration.id)
+        assert item["step"] == "source_setup"
+        assert item["source_connected"] is False
+        assert "source_credentials" not in item
+
+
+@pytest.mark.asyncio
 class TestPrecheck:
     async def test_anonymous(
         self, client: AsyncClient, save_fixture: SaveFixture, organization: Organization
@@ -222,11 +354,13 @@ class TestPrecheck:
         self,
         client: AsyncClient,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         organization: Organization,
         user_organization: UserOrganization,
         mocker: MockerFixture,
     ) -> None:
         _configure_app(mocker)
+        migration = await _create_migration(save_fixture, organization)
         mocker.patch(
             "polar.merchant_migration.service.stripe_oauth.exchange_code",
             return_value=build_stripe_oauth_token(),
@@ -246,19 +380,13 @@ class TestPrecheck:
 
         authorize = await client.get(
             "/v1/merchant-migrations/stripe/authorize",
-            params={"organization_id": str(organization.id), "return_to": "/dashboard"},
+            params={"migration_id": str(migration.id), "return_to": "/dashboard"},
         )
         state = parse_qs(urlparse(authorize.headers["location"]).query)["state"][0]
         await client.get(
             "/v1/merchant-migrations/stripe/callback",
             params={"state": state, "code": "ac_test"},
         )
-
-        repository = MerchantMigrationRepository.from_session(session)
-        migration = await repository.get_ongoing_by_source(
-            organization.id, MerchantMigrationSourcePlatform.stripe
-        )
-        assert migration is not None
 
         response = await client.post(f"/v1/merchant-migrations/{migration.id}/precheck")
         assert response.status_code == 200

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -1,4 +1,5 @@
 from collections.abc import AsyncIterator
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from pytest_mock import MockerFixture
@@ -14,6 +15,7 @@ from polar.merchant_migration.canonical import (
     CanonicalRecord,
 )
 from polar.merchant_migration.repository import MerchantMigrationRepository
+from polar.merchant_migration.schemas import MerchantMigrationCreate
 from polar.merchant_migration.service import (
     SourceNotConnected,
     UnsupportedMigrationSource,
@@ -46,50 +48,93 @@ class _FakeAdapter:
         return CanonicalAccount(country="US", is_connect_platform=False)
 
 
+async def _enable_feature(
+    save_fixture: SaveFixture, organization: Organization
+) -> None:
+    organization.feature_settings = {
+        **organization.feature_settings,
+        "merchant_migration_enabled": True,
+    }
+    await save_fixture(organization)
+
+
+@pytest.mark.asyncio
+class TestCreate:
+    @pytest.mark.auth
+    async def test_creates_independent_migrations(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await _enable_feature(save_fixture, organization)
+
+        first = await service.create(
+            session,
+            auth_subject,
+            MerchantMigrationCreate(
+                organization_id=organization.id,
+                source_platform=MerchantMigrationSourcePlatform.stripe,
+            ),
+        )
+        second = await service.create(
+            session,
+            auth_subject,
+            MerchantMigrationCreate(
+                organization_id=organization.id,
+                source_platform=MerchantMigrationSourcePlatform.stripe,
+            ),
+        )
+
+        assert first.id != second.id
+        assert first.step == MerchantMigrationStep.source_setup
+        assert first.source_platform == MerchantMigrationSourcePlatform.stripe
+
+        repository = MerchantMigrationRepository.from_session(session)
+        migrations = await repository.get_all(
+            repository.get_base_statement().where(
+                MerchantMigration.organization_id == organization.id
+            )
+        )
+        assert len(migrations) == 2
+
+
 @pytest.mark.asyncio
 class TestCreateStripeAuthorizationUrl:
     @pytest.mark.auth
-    async def test_creates_migration_and_reuses_ongoing(
+    async def test_targets_the_given_migration(
         self,
         mocker: MockerFixture,
         session: AsyncSession,
+        save_fixture: SaveFixture,
         auth_subject: AuthSubject[User],
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
         mocker.patch.object(settings, "STRIPE_APP_CLIENT_ID", "ca_test")
         mocker.patch.object(settings, "STRIPE_APP_CLIENT_LINK_ID", "chnlink_test")
+        migration = MerchantMigration(
+            organization_id=organization.id,
+            source_platform=MerchantMigrationSourcePlatform.stripe,
+            step=MerchantMigrationStep.source_setup,
+        )
+        await save_fixture(migration)
 
         url = await service.create_stripe_authorization_url(
             session,
             auth_subject,
-            organization_id=organization.id,
+            migration_id=migration.id,
             redirect_uri="http://test/callback",
             return_to="http://test/return",
         )
         assert "chnlink_test" in url
         assert "ca_test" in url
-        assert "state=" in url
 
-        repository = MerchantMigrationRepository.from_session(session)
-        migration = await repository.get_ongoing_by_source(
-            organization.id, MerchantMigrationSourcePlatform.stripe
-        )
-        assert migration is not None
-        assert migration.step == MerchantMigrationStep.source_setup
-
-        await service.create_stripe_authorization_url(
-            session,
-            auth_subject,
-            organization_id=organization.id,
-            redirect_uri="http://test/callback",
-            return_to="http://test/return",
-        )
-        statement = repository.get_base_statement().where(
-            MerchantMigration.organization_id == organization.id
-        )
-        migrations = await repository.get_all(statement)
-        assert len(migrations) == 1
+        token = parse_qs(urlparse(url).query)["state"][0]
+        state = jwt.decode(token=token, secret=settings.SECRET, type="stripe_app_oauth")
+        assert state["migration_id"] == str(migration.id)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This one addscreate and list migrations and connect a Stripe account.

## What

- Create a migration (gated on the `merchant_migration_enabled` org feature flag) and list an organization's migrations. `source_platform` is required on create.
- Per-migration Stripe App OAuth connect (authorize + callback).
- The flag gates whether a migration can be *created*; once one exists, listing and connecting it are not re-gated.


## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included
