### PR TITLE
Add list endpoint for support cases

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/DisputesBanner.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/DisputesBanner.tsx
@@ -1,15 +1,9 @@
 'use client'
 
-import { useDisputes } from '@/hooks/queries/disputes'
+import { useSupportCases } from '@/hooks/queries/supportCases'
 import { schemas } from '@polar-sh/client'
 import { Alert } from '@polar-sh/orbit'
 import { useRouter } from 'next/navigation'
-
-const OPEN_DISPUTE_STATUSES: schemas['DisputeStatus'][] = [
-  'needs_response',
-  'under_review',
-  'early_warning',
-]
 
 const ACTION_REQUIRED_STATUS: schemas['DisputeStatus'] = 'needs_response'
 
@@ -21,9 +15,9 @@ export const DisputesBanner = ({ organization }: DisputesBannerProps) => {
   const router = useRouter()
   const disputesEnabled = !!organization.feature_settings?.disputes_enabled
 
-  const { data } = useDisputes(
+  const { data } = useSupportCases(
     organization.id,
-    { status: OPEN_DISPUTE_STATUSES, limit: 1 },
+    { type: 'dispute', dispute_status: ACTION_REQUIRED_STATUS, limit: 1 },
     disputesEnabled,
   )
 
@@ -37,12 +31,14 @@ export const DisputesBanner = ({ organization }: DisputesBannerProps) => {
   return (
     <Alert
       title={
-        single ? 'You have an open dispute' : `You have ${count} open disputes`
+        single
+          ? 'You have a dispute that needs a response'
+          : `You have ${count} disputes that need a response`
       }
       description={
         single
-          ? 'A customer has disputed a payment. Respond with evidence before the deadline to contest it.'
-          : 'Customers have disputed payments. Respond with evidence before the deadline to contest them.'
+          ? 'A customer disputed a payment. Submit evidence before the deadline to contest it.'
+          : 'Customers disputed payments. Submit evidence before the deadline to contest them.'
       }
       actions={[
         {

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/disputes/DisputesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/disputes/DisputesPage.tsx
@@ -2,7 +2,7 @@
 
 import { DisputeStatusSelect } from '@/components/Disputes/DisputeStatusSelect'
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
-import { useDisputes } from '@/hooks/queries/disputes'
+import { useSupportCases } from '@/hooks/queries/supportCases'
 import {
   DataTablePaginationState,
   DataTableSortingState,
@@ -82,14 +82,17 @@ const DisputesPage = ({
     router.push(buildUrl(pagination, sorting, value))
   }
 
-  const disputesHook = useDisputes(organization.id, {
+  const { data: supportCases, isLoading } = useSupportCases(organization.id, {
     ...getAPIParams(pagination, sorting),
-    status: status === 'any' ? undefined : [status],
+    type: 'dispute',
+    dispute_status: status === 'any' ? undefined : [status],
   })
 
-  const disputes = disputesHook.data?.items || []
-  const rowCount = disputesHook.data?.pagination.total_count ?? 0
-  const pageCount = disputesHook.data?.pagination.max_page ?? 1
+  const disputes = (supportCases?.items ?? []).flatMap((item) =>
+    item.type === 'dispute' ? [item.dispute] : [],
+  )
+  const rowCount = supportCases?.pagination.total_count ?? 0
+  const pageCount = supportCases?.pagination.max_page ?? 1
 
   const columns: DataTableColumnDef<schemas['Dispute']>[] = [
     {
@@ -127,7 +130,7 @@ const DisputesPage = ({
     },
     {
       accessorKey: 'amount',
-      enableSorting: true,
+      enableSorting: false,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Amount" />
       ),
@@ -182,7 +185,7 @@ const DisputesPage = ({
           onPaginationChange={setPagination}
           sorting={sorting}
           onSortingChange={setSorting}
-          isLoading={disputesHook.isLoading}
+          isLoading={isLoading}
           getRowId={(row) => row.id}
           onRowClick={(row) =>
             router.push(

--- a/clients/apps/web/src/hooks/queries/supportCases.ts
+++ b/clients/apps/web/src/hooks/queries/supportCases.ts
@@ -1,0 +1,28 @@
+import { api } from '@/utils/client'
+import { operations, unwrap } from '@polar-sh/client'
+import { useQuery } from '@tanstack/react-query'
+import { defaultRetry } from './retry'
+
+export const useSupportCases = (
+  organizationId: string,
+  parameters?: Omit<
+    NonNullable<
+      operations['support-cases:list_support_cases']['parameters']['query']
+    >,
+    'organization_id'
+  >,
+  enabled: boolean = true,
+) =>
+  useQuery({
+    queryKey: ['supportCases', { organizationId, parameters }],
+    queryFn: () =>
+      unwrap(
+        api.GET('/v1/support-cases/', {
+          params: {
+            query: { organization_id: organizationId, ...(parameters || {}) },
+          },
+        }),
+      ),
+    retry: defaultRetry,
+    enabled,
+  })

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -2646,6 +2646,28 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/support-cases/': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * List Support Cases
+     * @description List the organization's support cases.
+     *
+     *     **Scopes**: `organizations:read` `organizations:write`
+     */
+    get: operations['support-cases:list_support_cases']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/support-cases/{id}': {
     parameters: {
       query?: never
@@ -19957,6 +19979,33 @@ export interface components {
       | 'under_review'
       | 'lost'
       | 'won'
+    /** DisputeSupportCaseListItem */
+    DisputeSupportCaseListItem: {
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the object.
+       */
+      id: string
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'dispute'
+      /** @description The dispute this case handles. */
+      dispute: components['schemas']['Dispute']
+    }
     /**
      * DisputeSupportCaseMessageCreate
      * @description A reply on a dispute case.
@@ -21800,6 +21849,12 @@ export interface components {
     ListResource_Subscription_: {
       /** Items */
       items: components['schemas']['Subscription'][]
+      pagination: components['schemas']['Pagination']
+    }
+    /** ListResource[SupportCaseListItem] */
+    ListResource_SupportCaseListItem_: {
+      /** Items */
+      items: components['schemas']['SupportCaseListItem'][]
       pagination: components['schemas']['Pagination']
     }
     /** ListResource[TaxJurisdiction] */
@@ -29791,6 +29846,31 @@ export interface components {
       /** Detail */
       detail: string
     }
+    /** ReviewAppealSupportCaseListItem */
+    ReviewAppealSupportCaseListItem: {
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the object.
+       */
+      id: string
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'review_appeal'
+    }
     /**
      * ReviewAppealSupportCaseMessageCreate
      * @description A reply on a review-appeal case.
@@ -32424,6 +32504,9 @@ export interface components {
       /** Size Readable */
       readonly size_readable: string
     }
+    SupportCaseListItem:
+      | components['schemas']['DisputeSupportCaseListItem']
+      | components['schemas']['ReviewAppealSupportCaseListItem']
     /** SupportCaseMessage */
     SupportCaseMessage: {
       /**
@@ -32481,6 +32564,11 @@ export interface components {
       | 'dispute_lost'
       | 'dispute_prevented'
       | 'merchant_accepted'
+    /**
+     * SupportCaseSortProperty
+     * @enum {string}
+     */
+    SupportCaseSortProperty: 'created_at' | '-created_at'
     /** SupportCaseThread */
     SupportCaseThread: {
       case: components['schemas']['SupportCase']
@@ -40801,6 +40889,54 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['DisputeNotOpenError']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'support-cases:list_support_cases': {
+    parameters: {
+      query?: {
+        /** @description Filter by organization ID. */
+        organization_id?: string | string[] | null
+        /** @description Filter by support case type. */
+        type?:
+          | components['schemas']['SupportCaseType']
+          | components['schemas']['SupportCaseType'][]
+          | null
+        /** @description Filter dispute cases by the linked dispute's status. */
+        dispute_status?:
+          | components['schemas']['DisputeStatus']
+          | components['schemas']['DisputeStatus'][]
+          | null
+        /** @description Page number, defaults to 1. */
+        page?: number
+        /** @description Size of a page, defaults to 10. Maximum is 100. */
+        limit?: number
+        /** @description Sorting criterion. Several criteria can be used simultaneously and will be applied in order. Add a minus sign `-` before the criteria name to sort by descending order. */
+        sorting?: components['schemas']['SupportCaseSortProperty'][] | null
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ListResource_SupportCaseListItem_']
         }
       }
       /** @description Validation Error */
@@ -59643,6 +59779,9 @@ export const disputeStatusValues: ReadonlyArray<
   'lost',
   'won',
 ]
+export const disputeSupportCaseListItemTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['DisputeSupportCaseListItem']['type']
+> = ['dispute']
 export const disputeSupportCaseMessageCreateTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['DisputeSupportCaseMessageCreate']['type']
 > = ['dispute']
@@ -61570,6 +61709,9 @@ export const refundSortPropertyValues: ReadonlyArray<
 export const refundStatusValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['RefundStatus']
 > = ['pending', 'succeeded', 'failed', 'canceled']
+export const reviewAppealSupportCaseListItemTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['ReviewAppealSupportCaseListItem']['type']
+> = ['review_appeal']
 export const reviewAppealSupportCaseMessageCreateTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['ReviewAppealSupportCaseMessageCreate']['type']
 > = ['review_appeal']
@@ -61885,6 +62027,9 @@ export const supportCaseMessageTypeValues: ReadonlyArray<
   'dispute_prevented',
   'merchant_accepted',
 ]
+export const supportCaseSortPropertyValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['SupportCaseSortProperty']
+> = ['created_at', '-created_at']
 export const supportCaseTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SupportCaseType']
 > = ['review_appeal', 'dispute']

--- a/server/polar/support_case/endpoints.py
+++ b/server/polar/support_case/endpoints.py
@@ -1,4 +1,4 @@
-from fastapi import Depends
+from fastapi import Depends, Query
 from fastapi.responses import RedirectResponse
 
 from polar.dispute.dispute_case import dispute_case as dispute_case_service
@@ -8,7 +8,10 @@ from polar.exceptions import (
     ResourceNotFound,
 )
 from polar.file.service import file as file_service
+from polar.kit.pagination import ListResource, PaginationParamsQuery
+from polar.kit.schemas import MultipleQueryFilter
 from polar.models import File
+from polar.models.dispute import DisputeStatus
 from polar.models.file import FileServiceTypes
 from polar.models.support_case import (
     DisputeSupportCase,
@@ -17,8 +20,10 @@ from polar.models.support_case import (
     SupportCaseAudience,
     SupportCaseMessage,
     SupportCaseMessageAuthorKind,
+    SupportCaseType,
 )
 from polar.openapi import APITag
+from polar.organization.schemas import OrganizationID
 from polar.organization_review.appeal_case import CaseClosedError
 from polar.organization_review.appeal_case import appeal_case as appeal_case_service
 from polar.postgres import (
@@ -29,12 +34,14 @@ from polar.postgres import (
 )
 from polar.routing import APIRouter
 
-from . import auth
+from . import auth, sorting
 from .schemas import (
     DisputeSupportCaseMessageCreate,
     ReviewAppealSupportCaseMessageCreate,
     SupportCaseAttachmentID,
     SupportCaseID,
+    SupportCaseListItem,
+    SupportCaseListItemAdapter,
     SupportCaseMessageCreate,
     SupportCaseNotFound,
     SupportCaseThread,
@@ -62,6 +69,45 @@ def _reply_type_mismatch(
                 "input": message.type,
             }
         ]
+    )
+
+
+@router.get(
+    "/",
+    summary="List Support Cases",
+    response_model=ListResource[SupportCaseListItem],
+)
+async def list_support_cases(
+    auth_subject: auth.SupportCasesRead,
+    pagination: PaginationParamsQuery,
+    sorting: sorting.ListSorting,
+    organization_id: MultipleQueryFilter[OrganizationID] | None = Query(
+        None, title="OrganizationID Filter", description="Filter by organization ID."
+    ),
+    type: MultipleQueryFilter[SupportCaseType] | None = Query(
+        None, title="Type Filter", description="Filter by support case type."
+    ),
+    dispute_status: MultipleQueryFilter[DisputeStatus] | None = Query(
+        None,
+        title="DisputeStatus Filter",
+        description="Filter dispute cases by the linked dispute's status.",
+    ),
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> ListResource[SupportCaseListItem]:
+    """List the organization's support cases."""
+    results, count = await support_case_service.list(
+        session,
+        auth_subject,
+        organization_id=organization_id,
+        type=type,
+        dispute_status=dispute_status,
+        pagination=pagination,
+        sorting=sorting,
+    )
+    return ListResource.from_paginated_results(
+        [SupportCaseListItemAdapter.validate_python(result) for result in results],
+        count,
+        pagination,
     )
 
 

--- a/server/polar/support_case/repository.py
+++ b/server/polar/support_case/repository.py
@@ -9,6 +9,10 @@ from sqlalchemy.orm import joinedload
 from polar.auth.models import AuthSubject, Organization, User, is_organization, is_user
 from polar.auth.permission import OrganizationPermission
 from polar.authz.repository import select_accessible_org_ids
+from polar.kit.repository import (
+    RepositorySortingMixin,
+    SortingClause,
+)
 from polar.kit.repository.base import (
     RepositoryBase,
     RepositorySoftDeletionIDMixin,
@@ -27,6 +31,8 @@ from polar.models.support_case import (
     SupportCaseParticipantKind,
 )
 
+from .sorting import SupportCaseSortProperty
+
 # Message types whose latest occurrence determines the open/closed state.
 _LIFECYCLE_TYPES = (
     SupportCaseMessageType.opened,
@@ -35,11 +41,17 @@ _LIFECYCLE_TYPES = (
 
 
 class SupportCaseRepository(
+    RepositorySortingMixin[SupportCase, SupportCaseSortProperty],
     RepositorySoftDeletionIDMixin[SupportCase, UUID],
     RepositorySoftDeletionMixin[SupportCase],
     RepositoryBase[SupportCase],
 ):
     model = SupportCase
+
+    def get_sorting_clause(self, property: SupportCaseSortProperty) -> SortingClause:
+        match property:
+            case SupportCaseSortProperty.created_at:
+                return SupportCase.created_at
 
     def get_readable_statement(
         self, auth_subject: AuthSubject[User | Organization]

--- a/server/polar/support_case/schemas.py
+++ b/server/polar/support_case/schemas.py
@@ -1,10 +1,12 @@
 from typing import Annotated, Literal, Self
 
 from fastapi import Path
-from pydantic import UUID4, Discriminator, Field, model_validator
+from pydantic import UUID4, Discriminator, Field, TypeAdapter, model_validator
 
+from polar.dispute.schemas import Dispute
 from polar.exceptions import ResourceNotFound
 from polar.kit.schemas import (
+    ClassName,
     IDSchema,
     Schema,
     SetSchemaReference,
@@ -34,6 +36,30 @@ class SupportCaseMessage(IDSchema, TimestampedSchema):
 
 class SupportCase(IDSchema, TimestampedSchema):
     type: SupportCaseType
+
+
+class SupportCaseListItemBase(IDSchema, TimestampedSchema): ...
+
+
+class DisputeSupportCaseListItem(SupportCaseListItemBase):
+    type: Literal[SupportCaseType.dispute]
+    dispute: Dispute = Field(description="The dispute this case handles.")
+
+
+class ReviewAppealSupportCaseListItem(SupportCaseListItemBase):
+    type: Literal[SupportCaseType.review_appeal]
+
+
+SupportCaseListItem = Annotated[
+    DisputeSupportCaseListItem | ReviewAppealSupportCaseListItem,
+    Discriminator("type"),
+    SetSchemaReference("SupportCaseListItem"),
+    ClassName("SupportCaseListItem"),
+]
+
+SupportCaseListItemAdapter: TypeAdapter[SupportCaseListItem] = TypeAdapter[
+    SupportCaseListItem
+](SupportCaseListItem)
 
 
 class SupportCaseAttachmentFile(Schema):

--- a/server/polar/support_case/service.py
+++ b/server/polar/support_case/service.py
@@ -2,9 +2,16 @@ from collections.abc import Sequence
 from datetime import UTC, datetime
 from uuid import UUID
 
+from sqlalchemy import select
+from sqlalchemy.orm import joinedload
+
 from polar.auth.models import AuthSubject, Organization, User
-from polar.models import Customer, File
+from polar.kit.pagination import PaginationParams
+from polar.kit.sorting import Sorting
+from polar.models import Customer, Dispute, File, Order
+from polar.models.dispute import DisputeStatus
 from polar.models.support_case import (
+    DisputeSupportCase,
     SupportCase,
     SupportCaseAttachment,
     SupportCaseAudience,
@@ -13,6 +20,7 @@ from polar.models.support_case import (
     SupportCaseMessageType,
     SupportCaseParticipant,
     SupportCaseParticipantKind,
+    SupportCaseType,
 )
 from polar.postgres import AsyncReadSession, AsyncSession
 
@@ -22,6 +30,7 @@ from .repository import (
     SupportCaseParticipantRepository,
     SupportCaseRepository,
 )
+from .sorting import SupportCaseSortProperty
 
 
 class SupportCaseService:
@@ -59,6 +68,43 @@ class SupportCaseService:
             SupportCase.id == case_id
         )
         return await repository.get_one_or_none(statement)
+
+    async def list(
+        self,
+        session: AsyncReadSession,
+        auth_subject: AuthSubject[User | Organization],
+        *,
+        organization_id: Sequence[UUID] | None = None,
+        type: Sequence[SupportCaseType] | None = None,
+        dispute_status: Sequence[DisputeStatus] | None = None,
+        pagination: PaginationParams,
+        sorting: list[Sorting[SupportCaseSortProperty]],
+    ) -> tuple[Sequence[SupportCase], int]:
+        """Cases the subject may read, filtered by type and (for dispute cases)
+        the linked dispute's status. Dispute cases embed their dispute."""
+        repository = SupportCaseRepository.from_session(session)
+        statement = repository.get_readable_statement(auth_subject)
+        if organization_id is not None:
+            statement = statement.where(
+                SupportCase.organization_id.in_(organization_id)
+            )
+        if type is not None:
+            statement = statement.where(SupportCase.type.in_(type))
+        if dispute_status is not None:
+            statement = statement.where(
+                DisputeSupportCase.dispute_id.in_(
+                    select(Dispute.id).where(Dispute.status.in_(dispute_status))
+                )
+            )
+        statement = statement.options(
+            joinedload(DisputeSupportCase.dispute)
+            .joinedload(Dispute.order)
+            .joinedload(Order.customer)
+        )
+        statement = repository.apply_sorting(statement, sorting)
+        return await repository.paginate(
+            statement, limit=pagination.limit, page=pagination.page
+        )
 
     async def get_thread(
         self,

--- a/server/polar/support_case/sorting.py
+++ b/server/polar/support_case/sorting.py
@@ -1,0 +1,16 @@
+from enum import StrEnum
+from typing import Annotated
+
+from fastapi import Depends
+
+from polar.kit.sorting import Sorting, SortingGetter
+
+
+class SupportCaseSortProperty(StrEnum):
+    created_at = "created_at"
+
+
+ListSorting = Annotated[
+    list[Sorting[SupportCaseSortProperty]],
+    Depends(SortingGetter(SupportCaseSortProperty, ["-created_at"])),
+]

--- a/server/tests/support_case/test_endpoints.py
+++ b/server/tests/support_case/test_endpoints.py
@@ -450,3 +450,96 @@ class TestDownloadSupportCaseAttachment:
             "00000000-0000-4000-8000-000000000000/download"
         )
         assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestListSupportCases:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/support-cases/")
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_lists_dispute_cases_with_embedded_dispute(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+        user_organization: UserOrganization,
+    ) -> None:
+        case = await create_dispute_case(save_fixture, organization, customer, product)
+
+        response = await client.get("/v1/support-cases/", params={"type": "dispute"})
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pagination"]["total_count"] == 1
+        item = data["items"][0]
+        assert item["id"] == str(case.id)
+        assert item["type"] == "dispute"
+        assert item["dispute"]["id"] == str(case.dispute_id)
+        assert item["dispute"]["status"] == "needs_response"
+        assert item["dispute"]["customer"]["email"] == customer.email
+
+    @pytest.mark.auth
+    async def test_filters_by_dispute_status(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+        user_organization: UserOrganization,
+    ) -> None:
+        await create_dispute_case(save_fixture, organization, customer, product)
+
+        matching = await client.get(
+            "/v1/support-cases/",
+            params={"type": "dispute", "dispute_status": "needs_response"},
+        )
+        assert matching.json()["pagination"]["total_count"] == 1
+
+        other = await client.get(
+            "/v1/support-cases/",
+            params={"type": "dispute", "dispute_status": "won"},
+        )
+        assert other.json()["pagination"]["total_count"] == 0
+
+    @pytest.mark.auth
+    async def test_type_filter_excludes_appeals(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+        user_organization: UserOrganization,
+    ) -> None:
+        await create_appeal_case(save_fixture, organization)
+        await create_dispute_case(save_fixture, organization, customer, product)
+
+        response = await client.get("/v1/support-cases/", params={"type": "dispute"})
+
+        data = response.json()
+        assert data["pagination"]["total_count"] == 1
+        assert data["items"][0]["type"] == "dispute"
+
+    @pytest.mark.auth
+    async def test_member_without_manage_sees_nothing(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+        user_organization: UserOrganization,
+    ) -> None:
+        user_organization.role = OrganizationRole.member
+        await save_fixture(user_organization)
+        await create_dispute_case(save_fixture, organization, customer, product)
+
+        response = await client.get("/v1/support-cases/", params={"type": "dispute"})
+
+        assert response.status_code == 200
+        assert response.json()["pagination"]["total_count"] == 0


### PR DESCRIPTION
## Summary

This PR will create a new support case list endpoint, with filtering through query params. It also refactors the types so that we can easily add more support cases in the future (e.g appeals).

This new endpoint is used in the dashboard to display disputes.

<img width="1840" height="1133" alt="Screenshot 2026-07-06 at 16 22 16" src="https://github.com/user-attachments/assets/f3dff32e-a7f8-4042-ada5-2e8c7f80d860" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

