### PR TITLE
aws: Set up security account + Guard Duty

### DIFF
--- a/terraform/modules/malware_protection/main.tf
+++ b/terraform/modules/malware_protection/main.tf
@@ -1,0 +1,154 @@
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.55"
+    }
+  }
+}
+
+variable "environment" {
+  description = "Environment to run in"
+  type        = string
+
+  validation {
+    condition     = contains(["production", "sandbox", "test"], var.environment)
+    error_message = "Must be either \"production\", \"sandbox\" or \"test\"."
+  }
+}
+
+variable "buckets" {
+  description = "S3 bucket names to protect, keyed by a short identifier"
+  type        = map(string)
+}
+
+variable "permissions_boundary_arn" {
+  description = "Permission boundary applied to the malware protection role"
+  type        = string
+  default     = null
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+locals {
+  bucket_arns        = [for name in values(var.buckets) : "arn:aws:s3:::${name}"]
+  bucket_object_arns = [for name in values(var.buckets) : "arn:aws:s3:::${name}/*"]
+
+  guardduty_managed_rule_arn = "arn:aws:events:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rule/DO-NOT-DELETE-AmazonGuardDutyMalwareProtectionS3*"
+}
+
+resource "aws_iam_role" "malware_protection" {
+  name                 = "polar-${var.environment}-malware-protection"
+  permissions_boundary = var.permissions_boundary_arn
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "malware-protection-plan.guardduty.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+          ArnLike = {
+            "aws:SourceArn" = "arn:aws:guardduty:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:malware-protection-plan/*"
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "malware_protection" {
+  name = "malware-protection"
+  role = aws_iam_role.malware_protection.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ManageGuardDutyManagedRules"
+        Effect = "Allow"
+        Action = [
+          "events:PutRule",
+          "events:DeleteRule",
+          "events:PutTargets",
+          "events:RemoveTargets",
+        ]
+        Resource = local.guardduty_managed_rule_arn
+        Condition = {
+          StringLike = {
+            "events:ManagedBy" = "malware-protection-plan.guardduty.amazonaws.com"
+          }
+        }
+      },
+      {
+        Sid    = "DescribeGuardDutyManagedRules"
+        Effect = "Allow"
+        Action = [
+          "events:DescribeRule",
+          "events:ListTargetsByRule",
+        ]
+        Resource = local.guardduty_managed_rule_arn
+      },
+      {
+        Sid    = "ManageBucketEventBridgeNotifications"
+        Effect = "Allow"
+        Action = [
+          "s3:GetBucketNotification",
+          "s3:PutBucketNotification",
+        ]
+        Resource = local.bucket_arns
+      },
+      {
+        Sid    = "ReadObjects"
+        Effect = "Allow"
+        Action = [
+          "s3:ListBucket",
+          "s3:GetObject",
+          "s3:GetObjectVersion",
+        ]
+        Resource = concat(local.bucket_arns, local.bucket_object_arns)
+      },
+      {
+        Sid    = "TagObjectsWithScanStatus"
+        Effect = "Allow"
+        Action = [
+          "s3:GetObjectTagging",
+          "s3:GetObjectVersionTagging",
+          "s3:PutObjectTagging",
+          "s3:PutObjectVersionTagging",
+        ]
+        Resource = local.bucket_object_arns
+      },
+    ]
+  })
+}
+
+resource "aws_guardduty_malware_protection_plan" "bucket" {
+  for_each = var.buckets
+
+  role = aws_iam_role.malware_protection.arn
+
+  protected_resource {
+    s3_bucket {
+      bucket_name = each.value
+    }
+  }
+
+  actions {
+    tagging {
+      status = "ENABLED"
+    }
+  }
+
+  depends_on = [aws_iam_role_policy.malware_protection]
+}

--- a/terraform/modules/malware_protection/outputs.tf
+++ b/terraform/modules/malware_protection/outputs.tf
@@ -1,0 +1,10 @@
+output "role_arn" {
+  value = aws_iam_role.malware_protection.arn
+}
+
+output "malware_protection_plan_ids" {
+  value = {
+    for key, plan in aws_guardduty_malware_protection_plan.bucket :
+    key => plan.id
+  }
+}

--- a/terraform/modules/s3_buckets/main.tf
+++ b/terraform/modules/s3_buckets/main.tf
@@ -31,8 +31,14 @@ variable "public_files_bucket_name" {
   default     = null
 }
 
+variable "malware_protection_enabled" {
+  description = "Enable tag-based access control for GuardDuty Malware Protection scan results on the files and public files buckets"
+  type        = bool
+  default     = false
+}
+
 variable "malware_protection_role_arn" {
-  description = "GuardDuty Malware Protection role allowed to manage the scan status tag; enables tag-based access control on the files and public files buckets"
+  description = "GuardDuty Malware Protection role allowed to manage the scan status tag"
   type        = string
   default     = null
 }
@@ -42,10 +48,10 @@ locals {
   full_name_prefix    = "polar-${var.environment}"
   public_files_bucket = coalesce(var.public_files_bucket_name, "${local.name_prefix}-public-files")
 
-  malware_scan_protected_buckets = var.malware_protection_role_arn == null ? {} : {
+  malware_scan_protected_buckets = var.malware_protection_enabled ? {
     files        = aws_s3_bucket.files.arn
     public_files = aws_s3_bucket.public_files.arn
-  }
+  } : {}
 
   malware_scan_tbac_statements = {
     for key, bucket_arn in local.malware_scan_protected_buckets :
@@ -174,7 +180,7 @@ resource "aws_s3_bucket_cors_configuration" "files" {
 }
 
 resource "aws_s3_bucket_policy" "files" {
-  count = var.malware_protection_role_arn == null ? 0 : 1
+  count = var.malware_protection_enabled ? 1 : 0
 
   bucket = aws_s3_bucket.files.id
   policy = jsonencode({

--- a/terraform/modules/s3_buckets/main.tf
+++ b/terraform/modules/s3_buckets/main.tf
@@ -31,10 +31,61 @@ variable "public_files_bucket_name" {
   default     = null
 }
 
+variable "malware_protection_role_arn" {
+  description = "GuardDuty Malware Protection role allowed to manage the scan status tag; enables tag-based access control on the files and public files buckets"
+  type        = string
+  default     = null
+}
+
 locals {
   name_prefix         = (var.environment == "production" ? "polar" : "polar-${var.environment}")
   full_name_prefix    = "polar-${var.environment}"
   public_files_bucket = coalesce(var.public_files_bucket_name, "${local.name_prefix}-public-files")
+
+  malware_scan_protected_buckets = var.malware_protection_role_arn == null ? {} : {
+    files        = aws_s3_bucket.files.arn
+    public_files = aws_s3_bucket.public_files.arn
+  }
+
+  malware_scan_tbac_statements = {
+    for key, bucket_arn in local.malware_scan_protected_buckets :
+    key => [
+      {
+        Sid       = "DenyReadThreatsFound"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:GetObject"
+        Resource  = "${bucket_arn}/*"
+        Condition = {
+          StringEquals = {
+            "s3:ExistingObjectTag/GuardDutyMalwareScanStatus" = "THREATS_FOUND"
+          }
+          ArnNotLike = {
+            "aws:PrincipalArn" = var.malware_protection_role_arn
+          }
+        }
+      },
+      {
+        Sid       = "DenyScanStatusTagTampering"
+        Effect    = "Deny"
+        Principal = "*"
+        Action = [
+          "s3:PutObject",
+          "s3:PutObjectTagging",
+          "s3:DeleteObjectTagging",
+        ]
+        Resource = "${bucket_arn}/*"
+        Condition = {
+          "ForAnyValue:StringEquals" = {
+            "s3:RequestObjectTagKeys" = "GuardDutyMalwareScanStatus"
+          }
+          ArnNotLike = {
+            "aws:PrincipalArn" = var.malware_protection_role_arn
+          }
+        }
+      },
+    ]
+  }
 }
 
 
@@ -122,6 +173,16 @@ resource "aws_s3_bucket_cors_configuration" "files" {
   }
 }
 
+resource "aws_s3_bucket_policy" "files" {
+  count = var.malware_protection_role_arn == null ? 0 : 1
+
+  bucket = aws_s3_bucket.files.id
+  policy = jsonencode({
+    Version   = "2012-10-17"
+    Statement = local.malware_scan_tbac_statements["files"]
+  })
+}
+
 resource "aws_s3_bucket" "public_assets" {
   bucket = "${local.name_prefix}-public-assets"
 }
@@ -187,15 +248,18 @@ resource "aws_s3_bucket_policy" "public_files" {
   bucket = aws_s3_bucket.public_files.id
   policy = jsonencode({
     Version = "2012-10-17"
-    Statement = [
-      {
-        Sid       = "PublicReadGetObject"
-        Effect    = "Allow"
-        Principal = "*"
-        Action    = "s3:GetObject"
-        Resource  = "${aws_s3_bucket.public_files.arn}/*"
-      }
-    ]
+    Statement = concat(
+      [
+        {
+          Sid       = "PublicReadGetObject"
+          Effect    = "Allow"
+          Principal = "*"
+          Action    = "s3:GetObject"
+          Resource  = "${aws_s3_bucket.public_files.arn}/*"
+        }
+      ],
+      lookup(local.malware_scan_tbac_statements, "public_files", []),
+    )
   })
   depends_on = [aws_s3_bucket_public_access_block.public_files]
 }

--- a/terraform/modules/s3_buckets/outputs.tf
+++ b/terraform/modules/s3_buckets/outputs.tf
@@ -10,6 +10,14 @@ output "public_assets_bucket_regional_domain_name" {
   value = aws_s3_bucket.public_assets.bucket_regional_domain_name
 }
 
+output "files_bucket_id" {
+  value = aws_s3_bucket.files.id
+}
+
+output "files_bucket_arn" {
+  value = aws_s3_bucket.files.arn
+}
+
 output "public_files_bucket_id" {
   value = aws_s3_bucket.public_files.id
 }

--- a/terraform/organization/README.md
+++ b/terraform/organization/README.md
@@ -15,7 +15,8 @@ AWS Organization
 │   └── Test
 │       └── test
 └── Security
-    └── identity
+    ├── identity
+    └── security
 ```
 
 The management account owns the AWS Organization control plane. It should stay limited to
@@ -27,6 +28,9 @@ Application workloads live under the `Workloads` OU:
 - `Production` contains the public production environment.
 - `Sandbox` contains the sandbox production-class environment.
 - `Test` contains the staging/test environment.
+
+The `Security` OU holds the `identity` account (IAM Identity Center delegated administrator) and
+the `security` account (GuardDuty delegated administrator, managed from `terraform/security`).
 
 ## Guardrails
 

--- a/terraform/organization/guardduty.tf
+++ b/terraform/organization/guardduty.tf
@@ -1,0 +1,86 @@
+resource "aws_guardduty_detector" "management" {
+  enable = true
+}
+
+resource "aws_guardduty_detector" "management_us_east_2" {
+  provider = aws.us_east_2
+
+  enable = true
+}
+
+resource "aws_guardduty_detector_feature" "management_s3_data_events" {
+  detector_id = aws_guardduty_detector.management.id
+  name        = "S3_DATA_EVENTS"
+  status      = "ENABLED"
+}
+
+resource "aws_guardduty_detector_feature" "management_us_east_2_s3_data_events" {
+  provider = aws.us_east_2
+
+  detector_id = aws_guardduty_detector.management_us_east_2.id
+  name        = "S3_DATA_EVENTS"
+  status      = "ENABLED"
+}
+
+resource "aws_cloudwatch_event_rule" "malware_scan_threats_found" {
+  provider = aws.us_east_2
+
+  name        = "guardduty-malware-scan-threats-found"
+  description = "GuardDuty Malware Protection scan results where threats were found in an uploaded S3 object."
+  event_pattern = jsonencode({
+    source      = ["aws.guardduty"]
+    detail-type = ["GuardDuty Malware Protection Object Scan Result"]
+    detail = {
+      scanStatus = ["COMPLETED"]
+      scanResultDetails = {
+        scanResultStatus = ["THREATS_FOUND"]
+      }
+    }
+  })
+}
+
+resource "aws_sns_topic" "malware_scan_threats_found" {
+  provider = aws.us_east_2
+
+  name = "guardduty-malware-scan-threats-found"
+}
+
+resource "aws_sns_topic_policy" "malware_scan_threats_found" {
+  provider = aws.us_east_2
+
+  arn = aws_sns_topic.malware_scan_threats_found.arn
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowEventBridgePublish"
+        Effect = "Allow"
+        Principal = {
+          Service = "events.amazonaws.com"
+        }
+        Action   = "sns:Publish"
+        Resource = aws_sns_topic.malware_scan_threats_found.arn
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn" = aws_cloudwatch_event_rule.malware_scan_threats_found.arn
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_sns_topic_subscription" "malware_scan_threats_found_email" {
+  provider = aws.us_east_2
+
+  topic_arn = aws_sns_topic.malware_scan_threats_found.arn
+  protocol  = "email"
+  endpoint  = var.guardduty_alert_email
+}
+
+resource "aws_cloudwatch_event_target" "malware_scan_threats_found" {
+  provider = aws.us_east_2
+
+  rule = aws_cloudwatch_event_rule.malware_scan_threats_found.name
+  arn  = aws_sns_topic.malware_scan_threats_found.arn
+}

--- a/terraform/organization/main.tf
+++ b/terraform/organization/main.tf
@@ -8,9 +8,14 @@ provider "aws" {
 }
 
 resource "aws_organizations_organization" "current" {
-  feature_set                   = "ALL"
-  aws_service_access_principals = ["account.amazonaws.com", "sso.amazonaws.com"]
-  enabled_policy_types          = ["SERVICE_CONTROL_POLICY"]
+  feature_set = "ALL"
+  aws_service_access_principals = [
+    "account.amazonaws.com",
+    "guardduty.amazonaws.com",
+    "malware-protection.guardduty.amazonaws.com",
+    "sso.amazonaws.com",
+  ]
+  enabled_policy_types = ["SERVICE_CONTROL_POLICY"]
 
   lifecycle {
     prevent_destroy = true

--- a/terraform/organization/outputs.tf
+++ b/terraform/organization/outputs.tf
@@ -39,6 +39,13 @@ output "identity_account" {
   }
 }
 
+output "security_account" {
+  value = {
+    id   = aws_organizations_account.security.id
+    name = aws_organizations_account.security.name
+  }
+}
+
 output "terraform_cloud_run_roles" {
   value = {
     production = module.terraform_cloud_run_role_production.role_arn

--- a/terraform/organization/production.tf
+++ b/terraform/organization/production.tf
@@ -170,8 +170,23 @@ module "production_s3_buckets" {
     aws = aws.us_east_2
   }
 
-  environment     = "production"
-  allowed_origins = ["https://polar.sh"]
+  environment                 = "production"
+  allowed_origins             = ["https://polar.sh"]
+  malware_protection_role_arn = module.production_malware_protection.role_arn
+}
+
+module "production_malware_protection" {
+  source = "../modules/malware_protection"
+  providers = {
+    aws = aws.us_east_2
+  }
+
+  environment = "production"
+  buckets = {
+    files        = module.production_s3_buckets.files_bucket_id
+    public_files = module.production_s3_buckets.public_files_bucket_id
+  }
+  permissions_boundary_arn = module.permission_boundary_management.policy_arn
 }
 
 resource "aws_s3_bucket" "production_lambda_artifacts" {

--- a/terraform/organization/production.tf
+++ b/terraform/organization/production.tf
@@ -172,6 +172,7 @@ module "production_s3_buckets" {
 
   environment                 = "production"
   allowed_origins             = ["https://polar.sh"]
+  malware_protection_enabled  = true
   malware_protection_role_arn = module.production_malware_protection.role_arn
 }
 

--- a/terraform/organization/sandbox.tf
+++ b/terraform/organization/sandbox.tf
@@ -7,6 +7,7 @@ module "sandbox_s3_buckets" {
   environment                 = "sandbox"
   allowed_origins             = ["https://sandbox.polar.sh"]
   public_files_bucket_name    = "polar-public-sandbox-files"
+  malware_protection_enabled  = true
   malware_protection_role_arn = module.sandbox_malware_protection.role_arn
 }
 

--- a/terraform/organization/sandbox.tf
+++ b/terraform/organization/sandbox.tf
@@ -4,9 +4,24 @@ module "sandbox_s3_buckets" {
     aws = aws.us_east_2
   }
 
-  environment              = "sandbox"
-  allowed_origins          = ["https://sandbox.polar.sh"]
-  public_files_bucket_name = "polar-public-sandbox-files"
+  environment                 = "sandbox"
+  allowed_origins             = ["https://sandbox.polar.sh"]
+  public_files_bucket_name    = "polar-public-sandbox-files"
+  malware_protection_role_arn = module.sandbox_malware_protection.role_arn
+}
+
+module "sandbox_malware_protection" {
+  source = "../modules/malware_protection"
+  providers = {
+    aws = aws.us_east_2
+  }
+
+  environment = "sandbox"
+  buckets = {
+    files        = module.sandbox_s3_buckets.files_bucket_id
+    public_files = module.sandbox_s3_buckets.public_files_bucket_id
+  }
+  permissions_boundary_arn = module.permission_boundary_management.policy_arn
 }
 
 module "sandbox_application_access" {

--- a/terraform/organization/security_account.tf
+++ b/terraform/organization/security_account.tf
@@ -1,0 +1,14 @@
+resource "aws_organizations_account" "security" {
+  name              = "security"
+  email             = var.security_account_email
+  parent_id         = aws_organizations_organizational_unit.security.id
+  close_on_deletion = false
+
+  tags = {
+    purpose = "security"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/terraform/organization/service_control_policies.tf
+++ b/terraform/organization/service_control_policies.tf
@@ -127,6 +127,38 @@ locals {
       }
     }
 
+    region_restriction = {
+      name        = "RestrictRegions"
+      description = "Deny use of AWS regions other than us-east-1 and us-east-2 in workload accounts."
+      target_ids  = [aws_organizations_organizational_unit.workloads.id]
+      content = {
+        Version = "2012-10-17"
+        Statement = [
+          {
+            Sid    = "DenyRegionsOutsideAllowedList"
+            Effect = "Deny"
+            NotAction = [
+              "budgets:*",
+              "ce:*",
+              "cloudfront:*",
+              "health:*",
+              "iam:*",
+              "organizations:*",
+              "route53:*",
+              "sts:*",
+              "support:*",
+            ]
+            Resource = "*"
+            Condition = {
+              StringNotEquals = {
+                "aws:RequestedRegion" = ["us-east-1", "us-east-2"]
+              }
+            }
+          },
+        ]
+      }
+    }
+
     require_permissions_boundary = {
       name        = "RequirePermissionsBoundary"
       description = "Require the Polar permission boundary on IAM roles and users created in workload accounts, and protect it from removal."

--- a/terraform/organization/test.tf
+++ b/terraform/organization/test.tf
@@ -6,6 +6,7 @@ module "test_s3_buckets" {
 
   environment                 = "test"
   allowed_origins             = ["https://test.polar.sh"]
+  malware_protection_enabled  = true
   malware_protection_role_arn = module.test_malware_protection.role_arn
 }
 

--- a/terraform/organization/test.tf
+++ b/terraform/organization/test.tf
@@ -4,8 +4,23 @@ module "test_s3_buckets" {
     aws = aws.us_east_2
   }
 
-  environment     = "test"
-  allowed_origins = ["https://test.polar.sh"]
+  environment                 = "test"
+  allowed_origins             = ["https://test.polar.sh"]
+  malware_protection_role_arn = module.test_malware_protection.role_arn
+}
+
+module "test_malware_protection" {
+  source = "../modules/malware_protection"
+  providers = {
+    aws = aws.us_east_2
+  }
+
+  environment = "test"
+  buckets = {
+    files        = module.test_s3_buckets.files_bucket_id
+    public_files = module.test_s3_buckets.public_files_bucket_id
+  }
+  permissions_boundary_arn = module.permission_boundary_management.policy_arn
 }
 
 module "test_application_access" {

--- a/terraform/organization/variables.tf
+++ b/terraform/organization/variables.tf
@@ -31,3 +31,17 @@ variable "identity_account_email" {
   sensitive   = true
   nullable    = false
 }
+
+variable "security_account_email" {
+  description = "Email address for the security AWS account."
+  type        = string
+  sensitive   = true
+  nullable    = false
+}
+
+variable "guardduty_alert_email" {
+  description = "Email address subscribed to GuardDuty malware scan alerts."
+  type        = string
+  sensitive   = true
+  nullable    = false
+}

--- a/terraform/security/alerting.tf
+++ b/terraform/security/alerting.tf
@@ -1,0 +1,107 @@
+locals {
+  guardduty_findings_event_pattern = jsonencode({
+    source      = ["aws.guardduty"]
+    detail-type = ["GuardDuty Finding"]
+    detail = {
+      severity = [{ numeric = [">=", var.guardduty_finding_severity_threshold] }]
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_rule" "guardduty_findings_us_east_1" {
+  name          = "guardduty-findings"
+  description   = "GuardDuty findings at or above the alerting severity threshold, across all member accounts."
+  event_pattern = local.guardduty_findings_event_pattern
+}
+
+resource "aws_cloudwatch_event_rule" "guardduty_findings_us_east_2" {
+  provider = aws.us_east_2
+
+  name          = "guardduty-findings"
+  description   = "GuardDuty findings at or above the alerting severity threshold, across all member accounts."
+  event_pattern = local.guardduty_findings_event_pattern
+}
+
+resource "aws_sns_topic" "guardduty_findings_us_east_1" {
+  name = "guardduty-findings"
+}
+
+resource "aws_sns_topic" "guardduty_findings_us_east_2" {
+  provider = aws.us_east_2
+
+  name = "guardduty-findings"
+}
+
+resource "aws_sns_topic_policy" "guardduty_findings_us_east_1" {
+  arn = aws_sns_topic.guardduty_findings_us_east_1.arn
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowEventBridgePublish"
+        Effect = "Allow"
+        Principal = {
+          Service = "events.amazonaws.com"
+        }
+        Action   = "sns:Publish"
+        Resource = aws_sns_topic.guardduty_findings_us_east_1.arn
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn" = aws_cloudwatch_event_rule.guardduty_findings_us_east_1.arn
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_sns_topic_policy" "guardduty_findings_us_east_2" {
+  provider = aws.us_east_2
+
+  arn = aws_sns_topic.guardduty_findings_us_east_2.arn
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowEventBridgePublish"
+        Effect = "Allow"
+        Principal = {
+          Service = "events.amazonaws.com"
+        }
+        Action   = "sns:Publish"
+        Resource = aws_sns_topic.guardduty_findings_us_east_2.arn
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn" = aws_cloudwatch_event_rule.guardduty_findings_us_east_2.arn
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_sns_topic_subscription" "guardduty_findings_email_us_east_1" {
+  topic_arn = aws_sns_topic.guardduty_findings_us_east_1.arn
+  protocol  = "email"
+  endpoint  = var.guardduty_alert_email
+}
+
+resource "aws_sns_topic_subscription" "guardduty_findings_email_us_east_2" {
+  provider = aws.us_east_2
+
+  topic_arn = aws_sns_topic.guardduty_findings_us_east_2.arn
+  protocol  = "email"
+  endpoint  = var.guardduty_alert_email
+}
+
+resource "aws_cloudwatch_event_target" "guardduty_findings_us_east_1" {
+  rule = aws_cloudwatch_event_rule.guardduty_findings_us_east_1.name
+  arn  = aws_sns_topic.guardduty_findings_us_east_1.arn
+}
+
+resource "aws_cloudwatch_event_target" "guardduty_findings_us_east_2" {
+  provider = aws.us_east_2
+
+  rule = aws_cloudwatch_event_rule.guardduty_findings_us_east_2.name
+  arn  = aws_sns_topic.guardduty_findings_us_east_2.arn
+}

--- a/terraform/security/guardduty.tf
+++ b/terraform/security/guardduty.tf
@@ -1,0 +1,39 @@
+resource "aws_guardduty_detector" "us_east_1" {
+  enable = true
+}
+
+resource "aws_guardduty_detector" "us_east_2" {
+  provider = aws.us_east_2
+
+  enable = true
+}
+
+resource "aws_guardduty_organization_configuration" "us_east_1" {
+  detector_id                      = aws_guardduty_detector.us_east_1.id
+  auto_enable_organization_members = "ALL"
+}
+
+resource "aws_guardduty_organization_configuration" "us_east_2" {
+  provider = aws.us_east_2
+
+  detector_id                      = aws_guardduty_detector.us_east_2.id
+  auto_enable_organization_members = "ALL"
+}
+
+resource "aws_guardduty_organization_configuration_feature" "us_east_1_s3_data_events" {
+  detector_id = aws_guardduty_detector.us_east_1.id
+  name        = "S3_DATA_EVENTS"
+  auto_enable = "ALL"
+
+  depends_on = [aws_guardduty_organization_configuration.us_east_1]
+}
+
+resource "aws_guardduty_organization_configuration_feature" "us_east_2_s3_data_events" {
+  provider = aws.us_east_2
+
+  detector_id = aws_guardduty_detector.us_east_2.id
+  name        = "S3_DATA_EVENTS"
+  auto_enable = "ALL"
+
+  depends_on = [aws_guardduty_organization_configuration.us_east_2]
+}

--- a/terraform/security/main.tf
+++ b/terraform/security/main.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+provider "aws" {
+  alias  = "us_east_2"
+  region = "us-east-2"
+}

--- a/terraform/security/terraform.tf
+++ b/terraform/security/terraform.tf
@@ -1,0 +1,17 @@
+terraform {
+  cloud {
+    organization = "polar-sh"
+    workspaces {
+      name = "security"
+    }
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.92"
+    }
+  }
+
+  required_version = ">= 1.2"
+}

--- a/terraform/security/variables.tf
+++ b/terraform/security/variables.tf
@@ -1,0 +1,12 @@
+variable "guardduty_alert_email" {
+  description = "Email address subscribed to GuardDuty finding alerts."
+  type        = string
+  sensitive   = true
+  nullable    = false
+}
+
+variable "guardduty_finding_severity_threshold" {
+  description = "Minimum GuardDuty finding severity that triggers an alert (4 = Medium, 7 = High)."
+  type        = number
+  default     = 4
+}


### PR DESCRIPTION
This sets up a new AWS account to contain security things, as well as Guard Duty and virus scanning on uploaded files

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

