### PR TITLE
fix(dashboard): invoice download getting stuck and overview widgets reappearing

### DIFF
--- a/clients/apps/web/src/components/DashboardOverview/OverviewSection.tsx
+++ b/clients/apps/web/src/components/DashboardOverview/OverviewSection.tsx
@@ -31,13 +31,11 @@ export function OverviewSection({ organization }: OverviewSectionProps) {
   const { isShown, show, hide } = useMetricSelectorModal()
 
   const initialMetrics = React.useMemo<(keyof schemas['Metrics'])[]>(() => {
-    const stored = organization.feature_settings?.overview_metrics
-    if (stored?.length === 5) {
-      return stored.filter((slug) =>
-        ALL_METRICS.some((m) => m.slug === slug),
-      ) as (keyof schemas['Metrics'])[]
-    }
-    return DEFAULT_OVERVIEW_METRICS
+    const stored = organization.feature_settings?.overview_metrics ?? []
+    const valid = stored.filter((slug) =>
+      ALL_METRICS.some((m) => m.slug === slug),
+    ) as (keyof schemas['Metrics'])[]
+    return valid.length > 0 ? valid : DEFAULT_OVERVIEW_METRICS
   }, [organization.feature_settings?.overview_metrics])
 
   const [activeMetrics, setActiveMetrics] =

--- a/clients/apps/web/src/components/Orders/DownloadInvoice.tsx
+++ b/clients/apps/web/src/components/Orders/DownloadInvoice.tsx
@@ -175,7 +175,11 @@ const DownloadInvoice = ({
         // billing field changed, so skip the wait for an unchanged re-submit.
         const expectGeneration = !order.is_invoice_generated || isDirty
         const generation = expectGeneration
-          ? waitForInvoice(eventEmitter, order.id, INVOICE_GENERATION_TIMEOUT_MS)
+          ? waitForInvoice(
+              eventEmitter,
+              order.id,
+              INVOICE_GENERATION_TIMEOUT_MS,
+            )
           : null
 
         const { error: generateError } = await api.POST(invoiceURL, {

--- a/clients/apps/web/src/components/Orders/DownloadInvoice.tsx
+++ b/clients/apps/web/src/components/Orders/DownloadInvoice.tsx
@@ -54,8 +54,9 @@ const waitForInvoice = (
   eventEmitter: EventEmitter,
   orderId: string,
   timeoutMs: number,
-) =>
-  new Promise<boolean>((resolve) => {
+): { promise: Promise<boolean>; cancel: () => void } => {
+  let cleanup = () => {}
+  const promise = new Promise<boolean>((resolve) => {
     const listener = ({ order_id }: { order_id: string }) => {
       if (order_id !== orderId) return
       cleanup()
@@ -65,12 +66,14 @@ const waitForInvoice = (
       cleanup()
       resolve(false)
     }, timeoutMs)
-    const cleanup = () => {
+    cleanup = () => {
       clearTimeout(timer)
       eventEmitter.off(INVOICE_GENERATED_EVENT, listener)
     }
     eventEmitter.on(INVOICE_GENERATED_EVENT, listener)
   })
+  return { promise, cancel: () => cleanup() }
+}
 
 const DownloadInvoice = ({
   order,
@@ -166,10 +169,20 @@ const DownloadInvoice = ({
           return
         }
 
+        // Subscribe to the generation event before triggering it, so a fast
+        // backend can't emit before we're listening. The backend only
+        // regenerates (and emits) when the invoice doesn't exist yet or a
+        // billing field changed, so skip the wait for an unchanged re-submit.
+        const expectGeneration = !order.is_invoice_generated || isDirty
+        const generation = expectGeneration
+          ? waitForInvoice(eventEmitter, order.id, INVOICE_GENERATION_TIMEOUT_MS)
+          : null
+
         const { error: generateError } = await api.POST(invoiceURL, {
           params: { path: { id: order.id } },
         })
         if (generateError) {
+          generation?.cancel()
           if (isValidationError(generateError.detail)) {
             setValidationErrors(generateError.detail, setError)
           } else {
@@ -178,16 +191,8 @@ const DownloadInvoice = ({
           return
         }
 
-        // The backend only regenerates (and emits an event) when the invoice
-        // doesn't exist yet or a billing field changed; an unchanged re-submit
-        // is a no-op with no event, so only wait when we expect one.
-        const expectGeneration = !order.is_invoice_generated || isDirty
-        if (expectGeneration) {
-          const arrived = await waitForInvoice(
-            eventEmitter,
-            order.id,
-            INVOICE_GENERATION_TIMEOUT_MS,
-          )
+        if (generation) {
+          const arrived = await generation.promise
           if (!arrived) {
             setError('root', {
               message:

--- a/clients/apps/web/src/components/Orders/DownloadInvoice.tsx
+++ b/clients/apps/web/src/components/Orders/DownloadInvoice.tsx
@@ -31,14 +31,46 @@ import {
   FormLabel,
   FormMessage,
 } from '@polar-sh/ui/components/ui/form'
-import EventEmitter from 'eventemitter3'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import type EventEmitter from 'eventemitter3'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { twMerge } from 'tailwind-merge'
 import { useCustomerPortalContext } from '../CustomerPortal/CustomerPortalProvider'
 
 type Variant = NonNullable<Parameters<typeof buttonVariants>[0]>['variant']
 type Size = NonNullable<Parameters<typeof buttonVariants>[0]>['size']
+
+const INVOICE_GENERATED_EVENT = 'order.invoice_generated'
+const INVOICE_GENERATION_TIMEOUT_MS = 30_000
+
+const openInNewTab = (url: string) => {
+  const newWindow = window.open(url, '_blank')
+  if (!newWindow) {
+    window.location.href = url
+  }
+}
+
+const waitForInvoice = (
+  eventEmitter: EventEmitter,
+  orderId: string,
+  timeoutMs: number,
+) =>
+  new Promise<boolean>((resolve) => {
+    const listener = ({ order_id }: { order_id: string }) => {
+      if (order_id !== orderId) return
+      cleanup()
+      resolve(true)
+    }
+    const timer = setTimeout(() => {
+      cleanup()
+      resolve(false)
+    }, timeoutMs)
+    const cleanup = () => {
+      clearTimeout(timer)
+      eventEmitter.off(INVOICE_GENERATED_EVENT, listener)
+    }
+    eventEmitter.on(INVOICE_GENERATED_EVENT, listener)
+  })
 
 const DownloadInvoice = ({
   order,
@@ -66,6 +98,7 @@ const DownloadInvoice = ({
   dropdown?: boolean
 }) => {
   const [loading, setLoading] = useState(false)
+  const inFlightRef = useRef(false)
   const { isShown, hide, show } = useModal()
   const form = useForm<schemas['OrderUpdate'] | schemas['CustomerOrderUpdate']>(
     {
@@ -82,85 +115,131 @@ const DownloadInvoice = ({
     handleSubmit,
     watch,
     setError,
-    formState: { errors },
+    clearErrors,
+    formState: { errors, isDirty },
   } = form
-  // eslint-disable-next-line react-hooks/incompatible-library
   const country = watch('billing_address.country')
 
-  const downloadInvoice = useCallback(async () => {
-    setLoading(true)
+  const fetchInvoiceUrl = useCallback(async (): Promise<string | null> => {
     const response = await api.GET(invoiceURL, {
       params: { path: { id: order.id } },
     })
-    if (response.error) {
-      setLoading(false)
-      return
-    }
-    const newWindow = window.open(response.data.url, '_blank')
-
-    if (!newWindow) {
-      window.location.href = response.data.url
-    }
-
-    setLoading(false)
-    hide()
-  }, [order, api, hide, invoiceURL])
+    return response.data?.url ?? null
+  }, [api, order.id, invoiceURL])
 
   const onDownload = useCallback(async () => {
     if (!order.is_invoice_generated) {
       show()
       return
     }
-
-    await downloadInvoice()
-  }, [order, show, downloadInvoice])
+    if (inFlightRef.current) return
+    inFlightRef.current = true
+    setLoading(true)
+    try {
+      const url = await fetchInvoiceUrl()
+      if (url) {
+        openInNewTab(url)
+      }
+    } finally {
+      setLoading(false)
+      inFlightRef.current = false
+    }
+  }, [order.is_invoice_generated, show, fetchInvoiceUrl])
 
   const onModalSubmit = useCallback(
     async (data: schemas['OrderUpdate']) => {
+      if (inFlightRef.current) return
+      inFlightRef.current = true
       setLoading(true)
-      const { error } = await api.PATCH(orderURL, {
-        params: { path: { id: order.id } },
-        body: data,
-      })
-
-      if (error) {
-        if (isValidationError(error.detail)) {
-          setValidationErrors(error.detail, setError)
-        } else {
-          setError('root', { message: error.detail })
+      clearErrors('root')
+      try {
+        const { error } = await api.PATCH(orderURL, {
+          params: { path: { id: order.id } },
+          body: data,
+        })
+        if (error) {
+          if (isValidationError(error.detail)) {
+            setValidationErrors(error.detail, setError)
+          } else {
+            setError('root', { message: error.detail })
+          }
+          return
         }
-        setLoading(false)
-        return
-      }
 
-      const { error: generateError } = await api.POST(invoiceURL, {
-        params: { path: { id: order.id } },
-      })
-      if (generateError) {
-        if (isValidationError(generateError.detail)) {
-          setValidationErrors(generateError.detail, setError)
-        } else {
-          setError('root', { message: generateError.detail })
+        const { error: generateError } = await api.POST(invoiceURL, {
+          params: { path: { id: order.id } },
+        })
+        if (generateError) {
+          if (isValidationError(generateError.detail)) {
+            setValidationErrors(generateError.detail, setError)
+          } else {
+            setError('root', { message: generateError.detail })
+          }
+          return
         }
+
+        // The backend only regenerates (and emits an event) when the invoice
+        // doesn't exist yet or a billing field changed; an unchanged re-submit
+        // is a no-op with no event, so only wait when we expect one.
+        const expectGeneration = !order.is_invoice_generated || isDirty
+        if (expectGeneration) {
+          const arrived = await waitForInvoice(
+            eventEmitter,
+            order.id,
+            INVOICE_GENERATION_TIMEOUT_MS,
+          )
+          if (!arrived) {
+            setError('root', {
+              message:
+                'Invoice generation is taking longer than expected. Please try again.',
+            })
+            return
+          }
+        }
+
+        const url = await fetchInvoiceUrl()
+        if (url) {
+          openInNewTab(url)
+          hide()
+        } else {
+          setError('root', {
+            message: 'Failed to download the invoice. Please try again.',
+          })
+        }
+      } finally {
         setLoading(false)
-        return
+        inFlightRef.current = false
       }
     },
-    [order, api, setError, orderURL, invoiceURL],
+    [
+      order.id,
+      order.is_invoice_generated,
+      isDirty,
+      api,
+      setError,
+      clearErrors,
+      orderURL,
+      invoiceURL,
+      eventEmitter,
+      fetchInvoiceUrl,
+      hide,
+    ],
   )
 
+  // Keep the parent's order in sync whenever an invoice finishes generating,
+  // even if it completes after our submit-scoped wait timed out or was
+  // triggered elsewhere. Refetch only — the download stays user-initiated.
   useEffect(() => {
     const callback = ({ order_id }: { order_id: string }) => {
       if (order_id === order.id) {
         onInvoiceGenerated()
-        downloadInvoice()
       }
     }
-    eventEmitter.on('order.invoice_generated', callback)
+    eventEmitter.on(INVOICE_GENERATED_EVENT, callback)
     return () => {
-      eventEmitter.off('order.invoice_generated', callback)
+      eventEmitter.off(INVOICE_GENERATED_EVENT, callback)
     }
-  }, [eventEmitter, order.id, onInvoiceGenerated, downloadInvoice])
+  }, [eventEmitter, order.id, onInvoiceGenerated])
 
   const action = useMemo(
     () =>


### PR DESCRIPTION
## Summary

Fixes two small but persistent dashboard bugs.

- **Invoice download** would get stuck on the loading spinner: the invoice was marked as generated but the download never opened, forcing a page refresh and a re-generate before it worked.
- **Overview customization** didn't stick: removing widgets from the overview and refreshing brought them all back.

## What

- Rework the invoice generate → wait-for-event → download flow so the button never hangs: wait for the generation event only when the backend will actually regenerate (invoice missing or a billing field changed), otherwise download the existing document directly. On timeout, reset loading and show a retry message instead of spinning forever, and download via a user gesture. A refetch-only event listener keeps state fresh when generation finishes late or is triggered elsewhere.
- Restore any non-empty saved overview metric selection instead of only a selection of exactly five items, so removed widgets stay removed after a refresh (falling back to defaults only when nothing valid is stored).

## Why

Both were user-facing paper cuts: the stuck invoice download required a manual refresh to recover, and the overview reset silently discarded any customization that wasn't exactly the default count.

## Checklist

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (web lint + type check on the changed files)
- [x] No unrelated changes or drive-by fixes are included

> Note: bundles two related dashboard bug fixes (invoice download + overview widgets), so the single-concern box is intentionally left unchecked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)