### PR TITLE
feat: merchant migration dashboard UI + Stripe connect

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/ConnectGuide.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/ConnectGuide.tsx
@@ -1,0 +1,54 @@
+import { Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { Check } from 'lucide-react'
+import { MigrationSteps } from './MigrationSteps'
+
+const READ_SCOPES = [
+  'Products and prices',
+  'Customers and payment methods',
+  'Subscriptions',
+  'Discounts and coupons',
+]
+
+export function ConnectGuide() {
+  return (
+    <Box flexDirection="column" rowGap="xl">
+      <Box flexDirection="column" rowGap="l">
+        <Text variant="label">How it works</Text>
+        <MigrationSteps />
+      </Box>
+
+      <Box
+        borderTopWidth={1}
+        borderStyle="solid"
+        borderColor="border-primary"
+      />
+
+      <Box flexDirection="column" rowGap="m">
+        <Text variant="label">What we access</Text>
+        <Box as="ul" flexDirection="column" rowGap="s">
+          {READ_SCOPES.map((scope) => (
+            <Box
+              as="li"
+              key={scope}
+              display="flex"
+              alignItems="center"
+              columnGap="s"
+            >
+              <Check size={14} strokeWidth={2.5} />
+              <Text variant="caption" color="muted">
+                {scope}
+              </Text>
+            </Box>
+          ))}
+        </Box>
+        <Text variant="caption" color="muted">
+          Read-only access to your Stripe data, plus one write permission used
+          only at the final cutover step, to stop billing the migrated
+          subscriptions on Stripe. Card numbers never touch Polar; cards are
+          copied Stripe-to-Stripe.
+        </Text>
+      </Box>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/ConnectGuide.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/ConnectGuide.tsx
@@ -35,7 +35,7 @@ export function ConnectGuide() {
               alignItems="center"
               columnGap="s"
             >
-              <Check size={14} strokeWidth={2.5} />
+              <Check size={14} strokeWidth={2.5} aria-hidden="true" />
               <Text variant="caption" color="muted">
                 {scope}
               </Text>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/CreateMigrationModal.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/CreateMigrationModal.tsx
@@ -18,18 +18,22 @@ export function CreateMigrationModal({
   const createMigration = useCreateMerchantMigration(organizationId)
 
   const create = async () => {
-    const result = await createMigration.mutateAsync({
-      organization_id: organizationId,
-      source_platform: 'stripe',
-    })
-    if (result.data) {
-      onCreated(result.data)
-    } else {
-      toast({
-        title: 'Could not start migration',
-        description: 'Something went wrong. Please try again.',
+    try {
+      const result = await createMigration.mutateAsync({
+        organization_id: organizationId,
+        source_platform: 'stripe',
       })
+      if (result.data) {
+        onCreated(result.data)
+        return
+      }
+    } catch {
+      // fall through to the error toast below
     }
+    toast({
+      title: 'Could not start migration',
+      description: 'Something went wrong. Please try again.',
+    })
   }
 
   return (

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/CreateMigrationModal.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/CreateMigrationModal.tsx
@@ -1,3 +1,4 @@
+import { toast } from '@/components/Toast/use-toast'
 import { useCreateMerchantMigration } from '@/hooks/queries/merchantMigrations'
 import { schemas } from '@polar-sh/client'
 import { Button, InlineModalHeader, Text } from '@polar-sh/orbit'
@@ -23,6 +24,11 @@ export function CreateMigrationModal({
     })
     if (result.data) {
       onCreated(result.data)
+    } else {
+      toast({
+        title: 'Could not start migration',
+        description: 'Something went wrong. Please try again.',
+      })
     }
   }
 

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/CreateMigrationModal.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/CreateMigrationModal.tsx
@@ -1,0 +1,67 @@
+import { useCreateMerchantMigration } from '@/hooks/queries/merchantMigrations'
+import { schemas } from '@polar-sh/client'
+import { Button, InlineModalHeader, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { ConnectGuide } from './ConnectGuide'
+import { StripeMark } from './StripeMark'
+
+export function CreateMigrationModal({
+  organizationId,
+  onCreated,
+  onClose,
+}: {
+  organizationId: string
+  onCreated: (migration: schemas['MerchantMigration']) => void
+  onClose: () => void
+}) {
+  const createMigration = useCreateMerchantMigration(organizationId)
+
+  const create = async () => {
+    const result = await createMigration.mutateAsync({
+      organization_id: organizationId,
+      source_platform: 'stripe',
+    })
+    if (result.data) {
+      onCreated(result.data)
+    }
+  }
+
+  return (
+    <>
+      <InlineModalHeader hide={onClose}>
+        <Text variant="body">New migration</Text>
+      </InlineModalHeader>
+
+      <Box
+        flexDirection="column"
+        rowGap="xl"
+        paddingHorizontal="2xl"
+        paddingBottom="2xl"
+      >
+        <Box alignItems="center" columnGap="m">
+          <StripeMark size={48} />
+          <Box flexDirection="column" rowGap="xs">
+            <Text variant="heading-xs" as="h2">
+              Stripe
+            </Text>
+            <Text variant="caption" color="muted">
+              The only source available for now.
+            </Text>
+          </Box>
+        </Box>
+
+        <Text color="muted">
+          We&apos;ll create a migration for your Stripe account. Next
+          you&apos;ll connect Stripe so we can read your catalog, customers, and
+          subscriptions. Nothing in Stripe changes until you approve each step.
+        </Text>
+
+        <ConnectGuide />
+
+        <Button onClick={create} loading={createMigration.isPending} fullWidth>
+          Create migration
+        </Button>
+      </Box>
+    </>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/MigrationCard.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/MigrationCard.tsx
@@ -1,0 +1,85 @@
+import { schemas } from '@polar-sh/client'
+import { Status, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
+import Link from 'next/link'
+import { StripeMark } from './StripeMark'
+import { MIGRATION_STEPS, currentStepKey, stepPosition } from './steps'
+
+function summary(migration: schemas['MerchantMigration']): string {
+  if (!migration.source_connected) {
+    return 'Connect Stripe to begin'
+  }
+  const index = stepPosition(currentStepKey(migration))
+  const def = MIGRATION_STEPS[index]
+  if (!def) {
+    return 'Completed'
+  }
+  return `Step ${index + 1} of ${MIGRATION_STEPS.length} · ${def.title}`
+}
+
+export function MigrationCard({
+  migration,
+  href,
+}: {
+  migration: schemas['MerchantMigration']
+  href: string
+}) {
+  const connected = migration.source_connected
+
+  return (
+    <Link href={href}>
+      <Box
+        flexDirection="column"
+        rowGap="l"
+        height="100%"
+        padding="xl"
+        borderRadius="l"
+        backgroundColor="background-card"
+        borderWidth={1}
+        borderStyle="solid"
+        borderColor="border-primary"
+        boxShadow={{ base: 'none', hover: 's' }}
+        transform={{ hover: 'translateY(-2px)' }}
+        transitionProperty="common"
+        transitionDuration="fast"
+        ease="decelerate"
+        cursor={{ hover: 'pointer' }}
+      >
+        <Box alignItems="center" justifyContent="between">
+          <StripeMark size={40} />
+          <Status
+            status={connected ? 'Connected' : 'Not connected'}
+            color={connected ? 'green' : 'gray'}
+            size="small"
+          />
+        </Box>
+
+        <Box flexDirection="column" rowGap="xs">
+          <Text variant="body">Stripe</Text>
+          {connected && migration.source?.stripe_user_id ? (
+            <Text variant="caption" color="muted" monospace>
+              {migration.source.stripe_user_id as string}
+            </Text>
+          ) : (
+            <Text variant="caption" color="muted">
+              Started <FormattedDateTime datetime={migration.created_at} />
+            </Text>
+          )}
+        </Box>
+
+        <Box
+          marginTop="auto"
+          paddingTop="m"
+          borderTopWidth={1}
+          borderStyle="solid"
+          borderColor="border-secondary"
+        >
+          <Text variant="caption" color="muted">
+            {summary(migration)}
+          </Text>
+        </Box>
+      </Box>
+    </Link>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/MigrationSteps.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/MigrationSteps.tsx
@@ -1,0 +1,37 @@
+import { Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { MIGRATION_STEPS } from './steps'
+
+export function MigrationSteps() {
+  return (
+    <Box as="ol" flexDirection="column" rowGap="m">
+      {MIGRATION_STEPS.map(({ step, title }, index) => (
+        <Box
+          as="li"
+          key={step}
+          display="flex"
+          alignItems="center"
+          columnGap="m"
+        >
+          <Box
+            width={24}
+            height={24}
+            flexShrink={0}
+            borderRadius="full"
+            alignItems="center"
+            justifyContent="center"
+            backgroundColor="background-secondary"
+            borderWidth={1}
+            borderStyle="solid"
+            borderColor="border-primary"
+          >
+            <Text variant="caption" color="muted">
+              {index + 1}
+            </Text>
+          </Box>
+          <Text variant="body">{title}</Text>
+        </Box>
+      ))}
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/MigrationTimeline.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/MigrationTimeline.tsx
@@ -103,7 +103,7 @@ function StepNode({ state, index }: { state: StepState; index: number }) {
         backgroundColor="background-success"
         color="text-success"
       >
-        <Check size={13} strokeWidth={2.5} />
+        <Check size={13} strokeWidth={2.5} aria-hidden="true" />
       </Box>
     )
   }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/MigrationTimeline.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/MigrationTimeline.tsx
@@ -1,0 +1,131 @@
+import { schemas } from '@polar-sh/client'
+import { Button, Status, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { Check } from 'lucide-react'
+import {
+  MIGRATION_STEPS,
+  OWNER_LABELS,
+  currentStepKey,
+  stepPosition,
+} from './steps'
+
+type StepState = 'done' | 'current' | 'upcoming'
+
+export function MigrationTimeline({
+  migration,
+  onConnect,
+}: {
+  migration: schemas['MerchantMigration']
+  onConnect: () => void
+}) {
+  const connected = migration.source_connected
+  const currentIndex = stepPosition(currentStepKey(migration))
+
+  return (
+    <Box as="ol" flexDirection="column">
+      {MIGRATION_STEPS.map((def, index) => {
+        const position = stepPosition(def.step)
+        const state: StepState =
+          position < currentIndex
+            ? 'done'
+            : position === currentIndex
+              ? 'current'
+              : 'upcoming'
+        const last = index === MIGRATION_STEPS.length - 1
+        const ownerLabel = OWNER_LABELS[def.owner]
+        const showConnect =
+          state === 'current' && def.step === 'source_setup' && !connected
+
+        return (
+          <Box as="li" key={def.step} display="flex" columnGap="m">
+            <Box flexDirection="column" alignItems="center" flexShrink={0}>
+              <StepNode state={state} index={index} />
+              {!last && (
+                <Box
+                  flex={1}
+                  minHeight={20}
+                  borderLeftWidth={2}
+                  borderStyle="solid"
+                  borderColor="border-primary"
+                />
+              )}
+            </Box>
+
+            <Box
+              flexDirection="column"
+              rowGap="xs"
+              flex={1}
+              paddingBottom={last ? 'none' : 'xl'}
+            >
+              <Box alignItems="center" columnGap="s">
+                <Text
+                  variant="body"
+                  color={state === 'upcoming' ? 'muted' : 'default'}
+                >
+                  {def.title}
+                </Text>
+                {ownerLabel && (
+                  <Status
+                    status={ownerLabel}
+                    color={def.owner === 'stripe' ? 'purple' : 'blue'}
+                    size="small"
+                  />
+                )}
+              </Box>
+              <Text variant="caption" color="muted">
+                {def.description}
+              </Text>
+              {showConnect && (
+                <Box paddingTop="s">
+                  <Button size="sm" onClick={onConnect}>
+                    Connect Stripe
+                  </Button>
+                </Box>
+              )}
+            </Box>
+          </Box>
+        )
+      })}
+    </Box>
+  )
+}
+
+function StepNode({ state, index }: { state: StepState; index: number }) {
+  if (state === 'done') {
+    return (
+      <Box
+        width={24}
+        height={24}
+        flexShrink={0}
+        borderRadius="full"
+        alignItems="center"
+        justifyContent="center"
+        backgroundColor="background-success"
+        color="text-success"
+      >
+        <Check size={13} strokeWidth={2.5} />
+      </Box>
+    )
+  }
+
+  return (
+    <Box
+      width={24}
+      height={24}
+      flexShrink={0}
+      borderRadius="full"
+      alignItems="center"
+      justifyContent="center"
+      borderWidth={1}
+      borderStyle="solid"
+      borderColor="border-primary"
+      backgroundColor={
+        state === 'current' ? 'background-accent' : 'background-secondary'
+      }
+    >
+      <Text variant="caption" color={state === 'current' ? 'accent' : 'muted'}>
+        {index + 1}
+      </Text>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/MigrationsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/MigrationsPage.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import { DashboardBody } from '@/components/Layout/DashboardLayout'
+import { useModal } from '@/components/Modal/useModal'
+import { useMerchantMigrations } from '@/hooks/queries/merchantMigrations'
+import { schemas } from '@polar-sh/client'
+import { Button, Grid, InlineModal, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import AddOutlined from '@mui/icons-material/AddOutlined'
+import { useRouter } from 'next/navigation'
+import { useCallback } from 'react'
+import { CreateMigrationModal } from './CreateMigrationModal'
+import { MigrationCard } from './MigrationCard'
+
+const GRID_COLUMNS = {
+  base: '1fr',
+  md: 'repeat(2, minmax(0, 1fr))',
+  xl: 'repeat(3, minmax(0, 1fr))',
+}
+
+interface Props {
+  organization: schemas['Organization']
+}
+
+export default function MigrationsPage({ organization }: Props) {
+  const router = useRouter()
+  const { data, isLoading } = useMerchantMigrations(organization.id)
+  const { isShown, show, hide } = useModal()
+
+  const migrations = data?.items ?? []
+  const basePath = `/dashboard/${organization.slug}/settings/migrations`
+
+  const onCreated = useCallback(
+    (migration: schemas['MerchantMigration']) => {
+      hide()
+      router.push(`${basePath}/${migration.id}`)
+    },
+    [hide, router, basePath],
+  )
+
+  return (
+    <DashboardBody title="Migrations">
+      <Box flexDirection="column" rowGap="2xl">
+        <Box
+          flexDirection={{ base: 'column', sm: 'row' }}
+          alignItems={{ sm: 'center' }}
+          justifyContent="between"
+          rowGap="m"
+          columnGap="l"
+        >
+          <Text color="muted" wrap="pretty">
+            Migrate your billing from Stripe to Polar. Each migration connects
+            one Stripe account and runs in guided steps.
+          </Text>
+          <Button onClick={show}>
+            <Box alignItems="center" columnGap="s">
+              <AddOutlined fontSize="inherit" />
+              New migration
+            </Box>
+          </Button>
+        </Box>
+
+        {isLoading ? (
+          <SkeletonGrid />
+        ) : migrations.length === 0 ? (
+          <EmptyState onStart={show} />
+        ) : (
+          <Grid templateColumns={GRID_COLUMNS} gap="l">
+            {migrations.map((migration) => (
+              <MigrationCard
+                key={migration.id}
+                migration={migration}
+                href={`${basePath}/${migration.id}`}
+              />
+            ))}
+          </Grid>
+        )}
+      </Box>
+
+      <InlineModal
+        isShown={isShown}
+        hide={hide}
+        modalContent={
+          <CreateMigrationModal
+            organizationId={organization.id}
+            onCreated={onCreated}
+            onClose={hide}
+          />
+        }
+      />
+    </DashboardBody>
+  )
+}
+
+function EmptyState({ onStart }: { onStart: () => void }) {
+  return (
+    <Box
+      flexDirection="column"
+      alignItems="center"
+      justifyContent="center"
+      rowGap="l"
+      paddingVertical="5xl"
+      borderRadius="l"
+      backgroundColor="background-card"
+      borderWidth={1}
+      borderStyle="solid"
+      borderColor="border-primary"
+    >
+      <Text variant="heading-xs" as="h2">
+        No migrations yet
+      </Text>
+      <Text color="muted">
+        Start a migration to bring your Stripe billing to Polar.
+      </Text>
+      <Button variant="secondary" onClick={onStart}>
+        <Box alignItems="center" columnGap="s">
+          <AddOutlined fontSize="inherit" />
+          New migration
+        </Box>
+      </Button>
+    </Box>
+  )
+}
+
+function SkeletonGrid() {
+  return (
+    <Grid templateColumns={GRID_COLUMNS} gap="l">
+      {[0, 1, 2].map((i) => (
+        <Box
+          key={i}
+          flexDirection="column"
+          rowGap="l"
+          padding="xl"
+          borderRadius="l"
+          backgroundColor="background-card"
+          borderWidth={1}
+          borderStyle="solid"
+          borderColor="border-primary"
+        >
+          <Box
+            width={40}
+            height={40}
+            borderRadius="m"
+            backgroundColor="background-secondary"
+          />
+          <Text variant="body" loading placeholderText="Stripe" />
+          <Text variant="caption" loading placeholderText="Started recently" />
+        </Box>
+      ))}
+    </Grid>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/MigrationsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/MigrationsPage.tsx
@@ -4,7 +4,7 @@ import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import { useModal } from '@/components/Modal/useModal'
 import { useMerchantMigrations } from '@/hooks/queries/merchantMigrations'
 import { schemas } from '@polar-sh/client'
-import { Button, Grid, InlineModal, Text } from '@polar-sh/orbit'
+import { Alert, Button, Grid, InlineModal, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import AddOutlined from '@mui/icons-material/AddOutlined'
 import { useRouter } from 'next/navigation'
@@ -24,7 +24,7 @@ interface Props {
 
 export default function MigrationsPage({ organization }: Props) {
   const router = useRouter()
-  const { data, isLoading } = useMerchantMigrations(organization.id)
+  const { data, isLoading, isError } = useMerchantMigrations(organization.id)
   const { isShown, show, hide } = useModal()
 
   const migrations = data?.items ?? []
@@ -62,6 +62,12 @@ export default function MigrationsPage({ organization }: Props) {
 
         {isLoading ? (
           <SkeletonGrid />
+        ) : isError ? (
+          <Alert
+            variant="danger"
+            title="We couldn't load your migrations"
+            description="Something went wrong. Please refresh the page and try again."
+          />
         ) : migrations.length === 0 ? (
           <EmptyState onStart={show} />
         ) : (

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/StripeMark.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/StripeMark.tsx
@@ -1,0 +1,32 @@
+const STRIPE_INDIGO = '#635BFF'
+
+const STRIPE_S =
+  'M13.976 9.15c-2.172-.806-3.356-1.426-3.356-2.409 0-.831.683-1.305 ' +
+  '1.901-1.305 2.227 0 4.515.858 6.09 1.631l.89-5.494C18.252.975 15.697 0 ' +
+  '12.165 0 9.667 0 7.589.654 6.104 1.872 4.56 3.147 3.757 4.992 3.757 ' +
+  '7.219c0 4.039 2.467 5.76 6.476 7.219 2.585.92 3.445 1.574 3.445 2.583 0 ' +
+  '.98-.84 1.545-2.354 1.545-1.875 0-4.965-.921-6.99-2.109l-.9 5.555C5.175 ' +
+  '22.99 8.385 24 11.714 24c2.641 0 4.843-.624 6.328-1.813 1.664-1.305 ' +
+  '2.525-3.236 2.525-5.732 0-4.128-2.524-5.851-6.594-7.305h.003z'
+
+export function StripeMark({ size = 44 }: { size?: number }) {
+  const inset = (size - size * 0.55) / 2
+  const scale = (size * 0.55) / 24
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${size} ${size}`}
+      fill="none"
+      role="img"
+      aria-label="Stripe"
+    >
+      <rect width={size} height={size} rx={size * 0.25} fill={STRIPE_INDIGO} />
+      <path
+        d={STRIPE_S}
+        fill="#ffffff"
+        transform={`translate(${inset} ${inset}) scale(${scale})`}
+      />
+    </svg>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/[id]/MigrationDetailPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/[id]/MigrationDetailPage.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import { DashboardBody } from '@/components/Layout/DashboardLayout'
+import { useMerchantMigration } from '@/hooks/queries/merchantMigrations'
+import { getPublicServerURL } from '@/utils/api'
+import { schemas } from '@polar-sh/client'
+import { Alert, Spinner, Status, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { ChevronLeft } from 'lucide-react'
+import Link from 'next/link'
+import { useCallback } from 'react'
+import { MigrationTimeline } from '../MigrationTimeline'
+import { StripeMark } from '../StripeMark'
+
+interface Props {
+  organization: schemas['Organization']
+  migrationId: string
+  error?: string
+}
+
+export default function MigrationDetailPage({
+  organization,
+  migrationId,
+  error,
+}: Props) {
+  const { data: migration, isLoading } = useMerchantMigration(migrationId)
+
+  const basePath = `/dashboard/${organization.slug}/settings/migrations`
+  const connected = migration?.source_connected ?? false
+
+  const connect = useCallback(() => {
+    const returnTo = `${basePath}/${migrationId}`
+    window.location.href = getPublicServerURL(
+      `/v1/merchant-migrations/stripe/authorize?migration_id=${migrationId}` +
+        `&return_to=${encodeURIComponent(returnTo)}`,
+    )
+  }, [basePath, migrationId])
+
+  return (
+    <DashboardBody title="Migration">
+      <Box flexDirection="column" rowGap="2xl">
+        <Link href={basePath}>
+          <Box
+            alignItems="center"
+            columnGap="xs"
+            color={{ base: 'text-secondary', hover: 'text-primary' }}
+            cursor={{ hover: 'pointer' }}
+          >
+            <ChevronLeft size={16} />
+            <Text variant="caption" color="inherit">
+              All migrations
+            </Text>
+          </Box>
+        </Link>
+
+        {error && (
+          <Alert
+            variant="danger"
+            title="We couldn't connect your Stripe account"
+            description="The authorization didn't complete. Please try connecting again."
+          />
+        )}
+
+        {isLoading ? (
+          <Box padding="3xl" alignItems="center" justifyContent="center">
+            <Spinner />
+          </Box>
+        ) : !migration ? (
+          <Text color="muted">This migration no longer exists.</Text>
+        ) : (
+          <Box as="section" flexDirection="column" rowGap="xl">
+            <AccountHeader migration={migration} />
+
+            <Divider />
+
+            <MigrationTimeline migration={migration} onConnect={connect} />
+
+            {connected && (
+              <Text variant="caption" color="muted">
+                Import and cutover steps are being rolled out. We&apos;ll move
+                each one forward and keep this page up to date.
+              </Text>
+            )}
+          </Box>
+        )}
+      </Box>
+    </DashboardBody>
+  )
+}
+
+function AccountHeader({
+  migration,
+}: {
+  migration: schemas['MerchantMigration']
+}) {
+  const connected = migration.source_connected
+  const stripeUserId = migration.source?.stripe_user_id as string | undefined
+  const livemode = migration.source?.livemode as boolean | undefined
+  return (
+    <Box alignItems="center" justifyContent="between" columnGap="m">
+      <Box alignItems="center" columnGap="m">
+        <StripeMark size={44} />
+        <Box flexDirection="column" rowGap="xs">
+          <Text variant="heading-xs" as="h2">
+            Stripe
+          </Text>
+          {connected && stripeUserId ? (
+            <Text variant="caption" color="muted" monospace>
+              {stripeUserId}
+            </Text>
+          ) : (
+            <Text variant="caption" color="muted">
+              Not connected yet
+            </Text>
+          )}
+        </Box>
+      </Box>
+      <Box alignItems="center" columnGap="s">
+        {connected && (
+          <Status
+            status={livemode ? 'Live' : 'Test'}
+            color={livemode ? 'green' : 'yellow'}
+            size="small"
+          />
+        )}
+        <Status
+          status={connected ? 'Connected' : 'Not connected'}
+          color={connected ? 'green' : 'gray'}
+          size="small"
+        />
+      </Box>
+    </Box>
+  )
+}
+
+function Divider() {
+  return (
+    <Box borderTopWidth={1} borderStyle="solid" borderColor="border-primary" />
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/[id]/MigrationDetailPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/[id]/MigrationDetailPage.tsx
@@ -23,7 +23,11 @@ export default function MigrationDetailPage({
   migrationId,
   error,
 }: Props) {
-  const { data: migration, isLoading } = useMerchantMigration(migrationId)
+  const {
+    data: migration,
+    isLoading,
+    isError,
+  } = useMerchantMigration(migrationId)
 
   const basePath = `/dashboard/${organization.slug}/settings/migrations`
   const connected = migration?.source_connected ?? false
@@ -31,7 +35,8 @@ export default function MigrationDetailPage({
   const connect = useCallback(() => {
     const returnTo = `${basePath}/${migrationId}`
     window.location.href = getPublicServerURL(
-      `/v1/merchant-migrations/stripe/authorize?migration_id=${migrationId}` +
+      `/v1/merchant-migrations/stripe/authorize` +
+        `?migration_id=${encodeURIComponent(migrationId)}` +
         `&return_to=${encodeURIComponent(returnTo)}`,
     )
   }, [basePath, migrationId])
@@ -65,6 +70,12 @@ export default function MigrationDetailPage({
           <Box padding="3xl" alignItems="center" justifyContent="center">
             <Spinner />
           </Box>
+        ) : isError ? (
+          <Alert
+            variant="danger"
+            title="We couldn't load this migration"
+            description="Something went wrong. Please refresh the page and try again."
+          />
         ) : !migration ? (
           <Text color="muted">This migration no longer exists.</Text>
         ) : (

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/[id]/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/[id]/page.tsx
@@ -1,0 +1,40 @@
+import { getServerSideAPI } from '@/utils/client/serverside'
+import { getOrganizationBySlugOrNotFound } from '@/utils/organization'
+import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import MigrationDetailPage from './MigrationDetailPage'
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Migration',
+  }
+}
+
+export default async function Page(props: {
+  params: Promise<{ organization: string; id: string }>
+  searchParams: Promise<{ error?: string | string[] }>
+}) {
+  const params = await props.params
+  const searchParams = await props.searchParams
+  const api = await getServerSideAPI()
+  const organization = await getOrganizationBySlugOrNotFound(
+    api,
+    params.organization,
+  )
+
+  if (!organization.feature_settings?.merchant_migration_enabled) {
+    notFound()
+  }
+
+  const error = Array.isArray(searchParams.error)
+    ? searchParams.error[0]
+    : searchParams.error
+
+  return (
+    <MigrationDetailPage
+      organization={organization}
+      migrationId={params.id}
+      error={error}
+    />
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/page.tsx
@@ -1,0 +1,28 @@
+import { getServerSideAPI } from '@/utils/client/serverside'
+import { getOrganizationBySlugOrNotFound } from '@/utils/organization'
+import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import MigrationsPage from './MigrationsPage'
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Migrations',
+  }
+}
+
+export default async function Page(props: {
+  params: Promise<{ organization: string }>
+}) {
+  const params = await props.params
+  const api = await getServerSideAPI()
+  const organization = await getOrganizationBySlugOrNotFound(
+    api,
+    params.organization,
+  )
+
+  if (!organization.feature_settings?.merchant_migration_enabled) {
+    notFound()
+  }
+
+  return <MigrationsPage organization={organization} />
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/steps.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/steps.ts
@@ -1,0 +1,75 @@
+import { schemas } from '@polar-sh/client'
+
+type Step = schemas['MerchantMigrationStep']
+
+// Who moves a step forward. `you` (the merchant) is implicit and never badged;
+// `polar` and `stripe` are surfaced so the merchant knows they're waiting on
+// someone else.
+export type StepOwner = 'you' | 'polar' | 'stripe'
+
+export interface MigrationStepDef {
+  step: Step
+  title: string
+  description: string
+  owner: StepOwner
+}
+
+export const MIGRATION_STEPS: MigrationStepDef[] = [
+  {
+    step: 'source_setup',
+    owner: 'you',
+    title: 'Connect your Stripe account',
+    description:
+      'Authorize Polar to read your Stripe products, customers and subscriptions.',
+  },
+  {
+    step: 'pre_check',
+    owner: 'polar',
+    title: 'Pre-check your catalog',
+    description:
+      'Polar verifies your products, prices and customers can be imported.',
+  },
+  {
+    step: 'create_catalog',
+    owner: 'polar',
+    title: 'Switch new checkouts to Polar',
+    description:
+      'We import your catalog so new customers check out on Polar, not Stripe.',
+  },
+  {
+    step: 'copy_cards',
+    owner: 'stripe',
+    title: 'Move saved cards',
+    description:
+      "Stripe copies your customers' saved cards onto Polar's account.",
+  },
+  {
+    step: 'activate_subscriptions',
+    owner: 'polar',
+    title: 'Migrate existing subscriptions',
+    description:
+      'Polar takes over billing for active subscriptions and stops them on Stripe.',
+  },
+]
+
+export const OWNER_LABELS: Record<StepOwner, string | null> = {
+  you: null,
+  polar: 'Polar',
+  stripe: 'Stripe',
+}
+
+// Position within the visible steps. Terminal states (`cleanup`/`completed`)
+// aren't listed as their own rows, so they resolve past the last step.
+export function stepPosition(step: Step): number {
+  const index = MIGRATION_STEPS.findIndex((s) => s.step === step)
+  return index === -1 ? MIGRATION_STEPS.length : index
+}
+
+// Connecting completes `source_setup`, but the backend doesn't advance the step
+// yet, so surface the next reachable step as current once connected.
+export function currentStepKey(migration: schemas['MerchantMigration']): Step {
+  if (!migration.source_connected) {
+    return 'source_setup'
+  }
+  return migration.step === 'source_setup' ? 'pre_check' : migration.step
+}

--- a/clients/apps/web/src/components/Dashboard/navigation.tsx
+++ b/clients/apps/web/src/components/Dashboard/navigation.tsx
@@ -385,6 +385,11 @@ const organizationRoutesList = (
         link: `/dashboard/${org?.slug}/settings/sso`,
         if: !!org?.feature_settings?.sso_enabled,
       },
+      {
+        title: 'Migrations',
+        link: `/dashboard/${org?.slug}/settings/migrations`,
+        if: !!org?.feature_settings?.merchant_migration_enabled,
+      },
     ],
   },
 ]

--- a/clients/apps/web/src/hooks/queries/merchantMigrations.ts
+++ b/clients/apps/web/src/hooks/queries/merchantMigrations.ts
@@ -2,6 +2,7 @@ import { getQueryClient } from '@/utils/api/query'
 import { api } from '@/utils/client'
 import { schemas, unwrap } from '@polar-sh/client'
 import { useMutation, useQuery } from '@tanstack/react-query'
+import { defaultRetry } from './retry'
 
 export const useMerchantMigrations = (organizationId: string) =>
   useQuery({
@@ -12,6 +13,7 @@ export const useMerchantMigrations = (organizationId: string) =>
           params: { query: { organization_id: organizationId } },
         }),
       ),
+    retry: defaultRetry,
     enabled: !!organizationId,
   })
 
@@ -24,6 +26,7 @@ export const useMerchantMigration = (id: string) =>
           params: { path: { id } },
         }),
       ),
+    retry: defaultRetry,
     enabled: !!id,
   })
 

--- a/clients/apps/web/src/hooks/queries/merchantMigrations.ts
+++ b/clients/apps/web/src/hooks/queries/merchantMigrations.ts
@@ -1,0 +1,42 @@
+import { getQueryClient } from '@/utils/api/query'
+import { api } from '@/utils/client'
+import { schemas, unwrap } from '@polar-sh/client'
+import { useMutation, useQuery } from '@tanstack/react-query'
+
+export const useMerchantMigrations = (organizationId: string) =>
+  useQuery({
+    queryKey: ['merchantMigrations', { organizationId }],
+    queryFn: () =>
+      unwrap(
+        api.GET('/v1/merchant-migrations/', {
+          params: { query: { organization_id: organizationId } },
+        }),
+      ),
+    enabled: !!organizationId,
+  })
+
+export const useMerchantMigration = (id: string) =>
+  useQuery({
+    queryKey: ['merchantMigration', { id }],
+    queryFn: () =>
+      unwrap(
+        api.GET('/v1/merchant-migrations/{id}', {
+          params: { path: { id } },
+        }),
+      ),
+    enabled: !!id,
+  })
+
+export const useCreateMerchantMigration = (organizationId: string) =>
+  useMutation({
+    mutationFn: (body: schemas['MerchantMigrationCreate']) =>
+      api.POST('/v1/merchant-migrations/', { body }),
+    onSuccess: (result) => {
+      if (result.error) {
+        return
+      }
+      getQueryClient().invalidateQueries({
+        queryKey: ['merchantMigrations', { organizationId }],
+      })
+    },
+  })


### PR DESCRIPTION
## Summary

Adds the org dashboard for **merchant migrations**. Only basic listing + creating for now.

The idea is to allow multiple migrations, to allow testing it first.

<img width="1200" height="941" alt="image" src="https://github.com/user-attachments/assets/1395a26f-ebd5-4c95-b6fb-c58719b6982c" />

<img width="1312" height="1196" alt="image" src="https://github.com/user-attachments/assets/7bbfee3d-1785-4ec4-baaf-3a6dbe48d3da" />



## What

- **Migrations list** (`settings/migrations`) — cards per migration, empty state, and a "New migration" modal that creates a Stripe migration and routes to its detail page.
- **Migration detail** (`settings/migrations/[id]`) — account header (connected Stripe account id + live/test badge), a guided step timeline, and the "Connect Stripe" CTA that starts the migration-scoped Stripe App OAuth.
- **Nav item** — "Migrations" under settings, shown only when the flag is on. Both pages `notFound()` when the flag is off.
- **Query hooks** — `useMerchantMigrations`, `useMerchantMigration`, `useCreateMerchantMigration`.

## How

- Server components read `feature_settings.merchant_migration_enabled` and 404 when disabled; the client renders through the generated API client.
- Create sends `source_platform: "stripe", and the detail page reads metadata (`stripe_user_id`, `livemode`) to show additional information.
- UI using Orbit `<Box />` design system.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass for the changed files (`pnpm lint`; migration files typecheck clean)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

