### PR TITLE
fix: make push notification recipient registration race-safe

### DIFF
--- a/server/polar/notification_recipient/repository.py
+++ b/server/polar/notification_recipient/repository.py
@@ -1,6 +1,8 @@
 from collections.abc import Sequence
 from uuid import UUID
 
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
 from polar.kit.repository import (
     RepositoryBase,
     RepositorySoftDeletionIDMixin,
@@ -58,10 +60,52 @@ class NotificationRecipientRepository(
 
         return await self.get_all(statement.options(*options))
 
-    async def get_by_expo_token(
-        self, expo_push_token: str
+    async def get_by_user_and_expo_token(
+        self, user_id: UUID, expo_push_token: str
     ) -> NotificationRecipient | None:
         statement = self.get_base_statement().where(
-            NotificationRecipient.expo_push_token == expo_push_token
+            NotificationRecipient.user_id == user_id,
+            NotificationRecipient.expo_push_token == expo_push_token,
         )
         return await self.get_one_or_none(statement)
+
+    async def list_by_expo_token_excluding_user(
+        self, expo_push_token: str, user_id: UUID
+    ) -> Sequence[NotificationRecipient]:
+        statement = self.get_base_statement().where(
+            NotificationRecipient.expo_push_token == expo_push_token,
+            NotificationRecipient.user_id != user_id,
+        )
+        return await self.get_all(statement)
+
+    async def create_race_safe(
+        self, object: NotificationRecipient
+    ) -> NotificationRecipient:
+        # Atomic insert that closes the TOCTOU race between the existence check
+        # and the INSERT when the same device registers concurrently. On
+        # conflict with the live (user_id, expo_push_token) row, keep the
+        # existing registration and return it instead of raising IntegrityError.
+        statement = (
+            pg_insert(NotificationRecipient)
+            .values(
+                user_id=object.user_id,
+                platform=object.platform,
+                expo_push_token=object.expo_push_token,
+            )
+            .on_conflict_do_nothing(
+                index_elements=["user_id", "expo_push_token", "deleted_at"]
+            )
+            .returning(NotificationRecipient)
+        )
+        result = await self.session.execute(statement)
+        inserted = result.scalars().first()
+        if inserted is not None:
+            return inserted
+
+        existing = await self.get_by_user_and_expo_token(
+            object.user_id, object.expo_push_token
+        )
+        assert existing is not None, (
+            "notification_recipients row missing after on_conflict_do_nothing conflict"
+        )
+        return existing

--- a/server/polar/notification_recipient/service.py
+++ b/server/polar/notification_recipient/service.py
@@ -33,25 +33,23 @@ class NotificationRecipientService:
         auth_subject: AuthSubject[User],
     ) -> NotificationRecipient:
         repository = NotificationRecipientRepository.from_session(session)
+        user_id = auth_subject.subject.id
+        expo_push_token = notification_recipient_create.expo_push_token
 
-        existing = await repository.get_by_expo_token(
-            notification_recipient_create.expo_push_token
+        # Same device previously registered under other accounts: remove those
+        # registrations so the old users stop receiving this device's pushes.
+        others = await repository.list_by_expo_token_excluding_user(
+            expo_push_token, user_id
         )
+        for recipient in others:
+            await repository.soft_delete(recipient)
 
-        if existing:
-            if existing.user_id == auth_subject.subject.id:
-                return existing
-            # Token registered by another user (same device, different account)
-            # Remove the old registration so we can create a new one
-            await repository.soft_delete(existing, flush=True)
-
-        return await repository.create(
+        return await repository.create_race_safe(
             NotificationRecipient(
-                user_id=auth_subject.subject.id,
+                user_id=user_id,
                 platform=notification_recipient_create.platform,
-                expo_push_token=notification_recipient_create.expo_push_token,
-            ),
-            flush=True,
+                expo_push_token=expo_push_token,
+            )
         )
 
     async def delete(

--- a/server/tests/notification_recipient/test_service.py
+++ b/server/tests/notification_recipient/test_service.py
@@ -1,0 +1,76 @@
+import pytest
+
+from polar.auth.models import AuthSubject
+from polar.models.notification_recipient import NotificationRecipient
+from polar.models.user import User
+from polar.notification_recipient.repository import NotificationRecipientRepository
+from polar.notification_recipient.schemas import (
+    NotificationRecipientCreate,
+    NotificationRecipientPlatform,
+)
+from polar.notification_recipient.service import (
+    notification_recipient as notification_recipient_service,
+)
+from polar.postgres import AsyncSession
+from tests.fixtures.auth import AuthSubjectFixture
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_notification_recipient
+
+
+@pytest.mark.asyncio
+class TestCreate:
+    async def test_conflicting_row_returns_existing(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        # Simulates the concurrent-registration race: a live row already exists
+        # for this (user, token) when create_race_safe runs its INSERT. It must
+        # resolve to the existing row instead of raising IntegrityError.
+        existing = await create_notification_recipient(
+            save_fixture,
+            user=user,
+            expo_push_token="token",
+            platform=NotificationRecipientPlatform.ios,
+        )
+
+        repository = NotificationRecipientRepository.from_session(session)
+        result = await repository.create_race_safe(
+            NotificationRecipient(
+                user_id=user.id,
+                platform=NotificationRecipientPlatform.ios,
+                expo_push_token="token",
+            )
+        )
+
+        assert result.id == existing.id
+
+    @pytest.mark.auth(AuthSubjectFixture(subject="user_second"))
+    async def test_reassign_from_other_user_soft_deletes_previous(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user: User,
+        user_second: User,
+    ) -> None:
+        previous = await create_notification_recipient(
+            save_fixture,
+            user=user,
+            expo_push_token="shared",
+            platform=NotificationRecipientPlatform.ios,
+        )
+
+        result = await notification_recipient_service.create(
+            session,
+            NotificationRecipientCreate(
+                platform=NotificationRecipientPlatform.ios,
+                expo_push_token="shared",
+            ),
+            auth_subject,
+        )
+
+        assert result.user_id == user_second.id
+        assert result.id != previous.id
+        assert previous.deleted_at is not None


### PR DESCRIPTION
## Summary

Registering a device for push notifications (`POST /v1/notifications/recipients`) was not safe under concurrency. When the same device fired two registrations near-simultaneously, both passed the "does this token exist?" check, both inserted, and the second violated the `(user_id, expo_push_token, deleted_at)` unique index — surfacing an unhandled `IntegrityError` as a 500. Sentry: SERVER-4TW.

## What

- `create_race_safe` in the recipient repository does an atomic `INSERT ... ON CONFLICT DO NOTHING RETURNING`, falling back to a user-scoped refetch of the existing row on conflict.
- Service `create` now soft-deletes any other users' live registrations for the token, then calls the race-safe insert.
- Replaced the single-row `get_by_expo_token` (which could raise `MultipleResultsFound` once a token is live for two users) with `get_by_user_and_expo_token` + `list_by_expo_token_excluding_user`.

## Why

The check-then-insert had a time-of-check-to-time-of-use race. Two overlapping requests were confirmed in tracing (one succeeded, one 500'd milliseconds apart). Device registration should be idempotent.

## How

Push the uniqueness decision into the database via `ON CONFLICT`, so concurrent inserts resolve to a single live row instead of raising. On conflict, refetch and return the winning row.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

