### PR TITLE
2fa: Require code to be able to disable 2fa or regenerate backup codes

### DIFF
--- a/clients/apps/web/src/components/Settings/BackupCodesRegenerateModal.tsx
+++ b/clients/apps/web/src/components/Settings/BackupCodesRegenerateModal.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { ConfirmModal } from '@/components/Modal/ConfirmModal'
+import TwoFactorCodeModal from './TwoFactorCodeModal'
 
 interface BackupCodesRegenerateModalProps {
   isShown: boolean
   hide: () => void
-  onRegenerate: () => Promise<{ codes: string[] } | null>
+  onRegenerate: (code: string) => Promise<{ error?: { detail?: unknown } }>
 }
 
 export default function BackupCodesRegenerateModal({
@@ -13,20 +13,15 @@ export default function BackupCodesRegenerateModal({
   hide,
   onRegenerate,
 }: BackupCodesRegenerateModalProps) {
-  const handleConfirm = async () => {
-    await onRegenerate()
-    hide()
-  }
-
   return (
-    <ConfirmModal
+    <TwoFactorCodeModal
       isShown={isShown}
       hide={hide}
       title="Regenerate backup codes?"
       description="Your current backup codes will stop working immediately and be replaced with new backup codes."
       destructive
-      destructiveText="Regenerate"
-      onConfirm={handleConfirm}
+      confirmLabel="Regenerate"
+      onConfirm={onRegenerate}
     />
   )
 }

--- a/clients/apps/web/src/components/Settings/TOTPSetupModal.tsx
+++ b/clients/apps/web/src/components/Settings/TOTPSetupModal.tsx
@@ -17,10 +17,14 @@ import { toast } from '../Toast/use-toast'
 export interface TOTPSetupModalProps {
   isShown: boolean
   hide: () => void
-  onEnabled: () => void
+  onEnabled: (backupCodes: string[]) => void
 }
 
-const TOTPSetupContent = ({ onEnabled }: { onEnabled: () => void }) => {
+const TOTPSetupContent = ({
+  onEnabled,
+}: {
+  onEnabled: (backupCodes: string[]) => void
+}) => {
   const [code, setCode] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [invalidCodeError, setInvalidCodeError] = useState<boolean>(false)
@@ -150,14 +154,14 @@ const TOTPSetupContent = ({ onEnabled }: { onEnabled: () => void }) => {
       return
     }
     setError(null)
-    const { error } = await totpEnable.mutateAsync(code)
+    const { data, error } = await totpEnable.mutateAsync(code)
     if (error) {
       setError('Invalid code. Please try again.')
       setInvalidCodeError(true)
       return
     }
     toast({ title: 'Two-factor authentication enabled' })
-    onEnabled()
+    onEnabled(data?.codes ?? [])
   }
 
   const handleCodeChange = (value: string) => {

--- a/clients/apps/web/src/components/Settings/TwoFactorCodeModal.tsx
+++ b/clients/apps/web/src/components/Settings/TwoFactorCodeModal.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { extractApiErrorMessage } from '@/utils/api/errors'
+import { Button, Input, Modal, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { useState } from 'react'
+
+export interface TwoFactorCodeModalProps {
+  isShown: boolean
+  hide: () => void
+  title: string
+  description: string
+  confirmLabel: string
+  destructive?: boolean
+  onConfirm: (code: string) => Promise<{ error?: { detail?: unknown } }>
+}
+
+const TwoFactorCodeContent = ({
+  hide,
+  description,
+  confirmLabel,
+  destructive,
+  onConfirm,
+}: Omit<TwoFactorCodeModalProps, 'isShown' | 'title'>) => {
+  const [code, setCode] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!code) return
+    setError(null)
+    setSubmitting(true)
+    const result = await onConfirm(code.trim().toUpperCase())
+    setSubmitting(false)
+    if (result.error) {
+      setError(extractApiErrorMessage(result.error))
+      return
+    }
+    hide()
+  }
+
+  return (
+    <Box
+      as="form"
+      flexDirection="column"
+      gap="l"
+      padding="2xl"
+      onSubmit={handleSubmit}
+    >
+      <Text color="muted">{description}</Text>
+      <Text color="muted">
+        Enter the 6-digit code from your authenticator app, or one of your
+        backup codes.
+      </Text>
+      <Input
+        value={code}
+        onChange={(e) => setCode(e.target.value)}
+        placeholder="Authenticator code or backup code"
+        autoComplete="one-time-code"
+        autoFocus
+      />
+      {error && <Text color="danger">{error}</Text>}
+      <Box justifyContent="end" gap="m">
+        <Button type="button" variant="ghost" onClick={hide}>
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          variant={destructive ? 'destructive' : 'default'}
+          loading={submitting}
+          disabled={!code}
+        >
+          {confirmLabel}
+        </Button>
+      </Box>
+    </Box>
+  )
+}
+
+const TwoFactorCodeModal = ({
+  isShown,
+  title,
+  ...props
+}: TwoFactorCodeModalProps) => {
+  return (
+    <Modal
+      title={title}
+      isShown={isShown}
+      hide={props.hide}
+      className="md:min-w-100 lg:max-w-135"
+      modalContent={<TwoFactorCodeContent key={String(isShown)} {...props} />}
+    />
+  )
+}
+
+export default TwoFactorCodeModal

--- a/clients/apps/web/src/components/Settings/TwoFactorCodeModal.tsx
+++ b/clients/apps/web/src/components/Settings/TwoFactorCodeModal.tsx
@@ -3,6 +3,11 @@
 import { extractApiErrorMessage } from '@/utils/api/errors'
 import { Button, Input, Modal, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
+import {
+  InputOTP,
+  InputOTPGroup,
+  InputOTPSlot,
+} from '@polar-sh/ui/components/atoms/InputOTP'
 import { useState } from 'react'
 
 export interface TwoFactorCodeModalProps {
@@ -23,12 +28,15 @@ const TwoFactorCodeContent = ({
   onConfirm,
 }: Omit<TwoFactorCodeModalProps, 'isShown' | 'title'>) => {
   const [code, setCode] = useState('')
+  const [useBackupCode, setUseBackupCode] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [submitting, setSubmitting] = useState(false)
 
+  const canSubmit = useBackupCode ? code.length > 0 : code.length === 6
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (!code) return
+    if (!canSubmit || submitting) return
     setError(null)
     setSubmitting(true)
     const result = await onConfirm(code.trim().toUpperCase())
@@ -40,6 +48,12 @@ const TwoFactorCodeContent = ({
     hide()
   }
 
+  const toggleBackupCode = () => {
+    setUseBackupCode(!useBackupCode)
+    setCode('')
+    setError(null)
+  }
+
   return (
     <Box
       as="form"
@@ -49,18 +63,62 @@ const TwoFactorCodeContent = ({
       onSubmit={handleSubmit}
     >
       <Text color="muted">{description}</Text>
-      <Text color="muted">
-        Enter the 6-digit code from your authenticator app, or one of your
-        backup codes.
-      </Text>
-      <Input
-        value={code}
-        onChange={(e) => setCode(e.target.value)}
-        placeholder="Authenticator code or backup code"
-        autoComplete="one-time-code"
-        autoFocus
-      />
-      {error && <Text color="danger">{error}</Text>}
+      {useBackupCode ? (
+        <Input
+          value={code}
+          onChange={(e) => {
+            setCode(e.target.value)
+            if (error) setError(null)
+          }}
+          placeholder="Backup code"
+          autoComplete="one-time-code"
+          autoFocus
+        />
+      ) : (
+        <Box flexDirection="column" gap="m">
+          <Text color="muted" align="center">
+            Enter the 6-digit code from your authenticator app.
+          </Text>
+          <Box justifyContent="center">
+            <InputOTP
+              maxLength={6}
+              minLength={6}
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              autoFocus
+              value={code}
+              onChange={(value) => {
+                setCode(value)
+                if (error) setError(null)
+              }}
+            >
+              <InputOTPGroup>
+                {Array.from({ length: 6 }).map((_, index) => (
+                  <InputOTPSlot
+                    key={index}
+                    index={index}
+                    className="dark:border-polar-600 h-12 w-12 border-gray-300 text-xl"
+                  />
+                ))}
+              </InputOTPGroup>
+            </InputOTP>
+          </Box>
+        </Box>
+      )}
+      <button
+        type="button"
+        className="dark:text-polar-500 dark:hover:text-polar-400 mx-auto cursor-pointer appearance-none text-center text-xs text-gray-500 hover:text-gray-700"
+        onClick={toggleBackupCode}
+      >
+        {useBackupCode
+          ? 'Use an authenticator code instead'
+          : 'Use a backup code instead'}
+      </button>
+      {error && (
+        <Text color="danger" align="center">
+          {error}
+        </Text>
+      )}
       <Box justifyContent="end" gap="m">
         <Button type="button" variant="ghost" onClick={hide}>
           Cancel
@@ -69,7 +127,7 @@ const TwoFactorCodeContent = ({
           type="submit"
           variant={destructive ? 'destructive' : 'default'}
           loading={submitting}
-          disabled={!code}
+          disabled={!canSubmit}
         >
           {confirmLabel}
         </Button>

--- a/clients/apps/web/src/components/Settings/TwoFactorSettings.tsx
+++ b/clients/apps/web/src/components/Settings/TwoFactorSettings.tsx
@@ -6,15 +6,14 @@ import {
   useTOTPStatus,
   useTOTPDelete,
 } from '@/hooks'
-import { extractApiErrorMessage } from '@/utils/api/errors'
 import { Button } from '@polar-sh/orbit'
 import { ListGroup } from '@polar-sh/orbit'
-import { ConfirmModal } from '@/components/Modal/ConfirmModal'
 import { useModal } from '@/components/Modal/useModal'
 import { useState } from 'react'
 import TOTPSetupModal from './TOTPSetupModal'
 import BackupCodesModal from './BackupCodesModal'
 import BackupCodesRegenerateModal from './BackupCodesRegenerateModal'
+import TwoFactorCodeModal from './TwoFactorCodeModal'
 import { toast } from '../Toast/use-toast'
 import { KeyRoundIcon, ShieldCheckIcon } from 'lucide-react'
 
@@ -75,21 +74,31 @@ const TwoFactorSettings = () => {
     hide: hideBackupCodesRegenerateModal,
   } = useModal()
 
+  const {
+    isShown: isBackupCodesGenerateModalShown,
+    show: showBackupCodesGenerateModal,
+    hide: hideBackupCodesGenerateModal,
+  } = useModal()
+
   const [newBackupCodes, setNewBackupCodes] = useState<string[] | null>(null)
 
-  const handleDeleteTOTP = async () => {
-    const { error } = await totpDelete.mutateAsync()
-    if (error) {
-      toast({
-        title: 'Error',
-        description: extractApiErrorMessage(error),
-        variant: 'error',
-      })
-      return
+  const handleDeleteTOTP = async (code: string) => {
+    const result = await totpDelete.mutateAsync(code)
+    if (!result.error) {
+      await totpStatus.refetch()
+      toast({ title: 'Two-factor authentication disabled' })
     }
-    await totpStatus.refetch()
-    hideDeleteConfirmModal()
-    toast({ title: 'Two-factor authentication disabled' })
+    return result
+  }
+
+  const handleBackupCodesEnroll = async (code?: string) => {
+    const result = await backupCodesEnroll.mutateAsync(code)
+    if (result.data?.codes) {
+      setNewBackupCodes(result.data.codes)
+      await backupCodesStatus.refetch()
+      showBackupCodesModal()
+    }
+    return result
   }
 
   return (
@@ -142,23 +151,7 @@ const TwoFactorSettings = () => {
                   </Button>
                 ) : (
                   <Button
-                    onClick={async () => {
-                      const { data, error } =
-                        await backupCodesEnroll.mutateAsync()
-                      if (error) {
-                        toast({
-                          title: 'Error',
-                          description: extractApiErrorMessage(error),
-                          variant: 'error',
-                        })
-                        return
-                      }
-                      if (data?.codes) {
-                        setNewBackupCodes(data.codes)
-                        await backupCodesStatus.refetch()
-                        showBackupCodesModal()
-                      }
-                    }}
+                    onClick={showBackupCodesGenerateModal}
                     loading={backupCodesEnroll.isPending}
                   >
                     Generate
@@ -173,57 +166,38 @@ const TwoFactorSettings = () => {
       <TOTPSetupModal
         isShown={isTOTPModalShown}
         hide={hideTOTPModal}
-        onEnabled={async () => {
+        onEnabled={async (backupCodes) => {
           hideTOTPModal()
           await totpStatus.refetch()
-          const { data, error } = await backupCodesEnroll.mutateAsync()
-          if (error) {
-            toast({
-              title: 'Error',
-              description: extractApiErrorMessage(error),
-              variant: 'error',
-            })
-            return
-          }
-          if (data?.codes) {
-            setNewBackupCodes(data.codes)
-            await backupCodesStatus.refetch()
-            showBackupCodesModal()
-          }
+          setNewBackupCodes(backupCodes)
+          await backupCodesStatus.refetch()
+          showBackupCodesModal()
         }}
       />
 
-      <ConfirmModal
+      <TwoFactorCodeModal
         isShown={isDeleteConfirmShown}
         hide={hideDeleteConfirmModal}
         title="Disable Authenticator App?"
         description="You'll no longer be asked for a code when you sign in, and your backup codes will stop working. You can turn it back on anytime."
         destructive
-        destructiveText="Disable"
+        confirmLabel="Disable"
         onConfirm={handleDeleteTOTP}
+      />
+
+      <TwoFactorCodeModal
+        isShown={isBackupCodesGenerateModalShown}
+        hide={hideBackupCodesGenerateModal}
+        title="Generate Backup Codes"
+        description="Backup codes let you sign in if you lose access to your authenticator app."
+        confirmLabel="Generate"
+        onConfirm={handleBackupCodesEnroll}
       />
 
       <BackupCodesRegenerateModal
         isShown={isBackupCodesRegenerateModalShown}
         hide={hideBackupCodesRegenerateModal}
-        onRegenerate={async () => {
-          const { data, error } = await backupCodesEnroll.mutateAsync()
-          if (error) {
-            toast({
-              title: 'Error',
-              description: extractApiErrorMessage(error),
-              variant: 'error',
-            })
-            return null
-          }
-          if (data?.codes) {
-            setNewBackupCodes(data.codes)
-            await backupCodesStatus.refetch()
-            showBackupCodesModal()
-            return data
-          }
-          return null
-        }}
+        onRegenerate={handleBackupCodesEnroll}
       />
 
       <BackupCodesModal

--- a/clients/apps/web/src/hooks/auth.ts
+++ b/clients/apps/web/src/hooks/auth.ts
@@ -114,7 +114,8 @@ export const useTOTPEnable = () =>
 
 export const useTOTPDelete = () =>
   useMutation({
-    mutationFn: () => api.DELETE('/v1/auth/totp'),
+    mutationFn: (code: string) =>
+      api.DELETE('/v1/auth/totp', { body: { code } }),
   })
 
 export const useBackupCodesStatus = () =>
@@ -131,5 +132,6 @@ export const useBackupCodesStatus = () =>
 
 export const useBackupCodesEnroll = () =>
   useMutation({
-    mutationFn: () => api.POST('/v1/auth/backup-codes', {}),
+    mutationFn: (code?: string) =>
+      api.POST('/v1/auth/backup-codes', { body: { code } }),
   })

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -7545,6 +7545,11 @@ export interface components {
       | 'notifications:write'
       | 'notification_recipients:read'
       | 'notification_recipients:write'
+    /** BackupCodesEnroll */
+    BackupCodesEnroll: {
+      /** Code */
+      code?: string | null
+    }
     /** BackupCodesEnrollment */
     BackupCodesEnrollment: {
       /** Codes */
@@ -28000,6 +28005,17 @@ export interface components {
       | 'disputed'
       | 'charge_disputed'
       | 'cancelled'
+    /** PolarAuthError */
+    PolarAuthError: {
+      /**
+       * Error
+       * @example PolarAuthError
+       * @constant
+       */
+      error: 'PolarAuthError'
+      /** Detail */
+      detail: string
+    }
     /** PolarSelfPaymentMethodInUse */
     PolarSelfPaymentMethodInUse: {
       /**
@@ -32528,6 +32544,11 @@ export interface components {
       | components['schemas']['BalanceRefundReversalEvent']
       | components['schemas']['BalanceDisputeEvent']
       | components['schemas']['BalanceDisputeReversalEvent']
+    /** TOTPDelete */
+    TOTPDelete: {
+      /** Code */
+      code?: string | null
+    }
     /** TOTPEnable */
     TOTPEnable: {
       /** Code */
@@ -38779,7 +38800,11 @@ export interface operations {
       path?: never
       cookie?: never
     }
-    requestBody?: never
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['TOTPDelete'] | null
+      }
+    }
     responses: {
       /** @description Successful Response */
       204: {
@@ -38787,6 +38812,31 @@ export interface operations {
           [name: string]: unknown
         }
         content?: never
+      }
+      /** @description Invalid or missing verification code */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PolarAuthError']
+        }
+      }
+      /** @description TOTP factor not enrolled */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
       }
     }
   }
@@ -38804,12 +38854,30 @@ export interface operations {
     }
     responses: {
       /** @description Successful Response */
-      202: {
+      200: {
         headers: {
           [name: string]: unknown
         }
         content: {
-          'application/json': unknown
+          'application/json': components['schemas']['BackupCodesEnrollment']
+        }
+      }
+      /** @description TOTP factor not enrolled or invalid code */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PolarAuthError']
+        }
+      }
+      /** @description TOTP factor already enabled */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PolarAuthError']
         }
       }
       /** @description Validation Error */
@@ -38890,7 +38958,11 @@ export interface operations {
       path?: never
       cookie?: never
     }
-    requestBody?: never
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['BackupCodesEnroll'] | null
+      }
+    }
     responses: {
       /** @description Successful Response */
       201: {
@@ -38899,6 +38971,24 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['BackupCodesEnrollment']
+        }
+      }
+      /** @description Invalid or missing verification code */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PolarAuthError']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
         }
       }
     }

--- a/server/polar/auth/endpoints.py
+++ b/server/polar/auth/endpoints.py
@@ -11,12 +11,14 @@ from reauth.authentication_session import (
 from reauth.factors.backup_codes import (
     AlreadyUsedBackupCodeException,
     InvalidBackupCodeException,
+    NotEnrolledBackupCodesException,
 )
 from reauth.factors.email_otp import ExpiredOTPException, InvalidOTPException
 from reauth.factors.totp import (
     AlreadyEnabledTOTPException,
     AlreadyEnrolledTOTPException,
     InvalidTOTPCodeException,
+    NotEnabledTOTPException,
     NotEnrolledTOTPException,
 )
 
@@ -56,12 +58,14 @@ from .oauth2.router import get_oauth_link_router, get_oauth_login_router
 from .schemas import AuthenticationSession as AuthenticationSessionSchema
 from .schemas import (
     AuthenticationSessionStart,
+    BackupCodesEnroll,
     BackupCodesEnrollment,
     BackupCodesStatus,
     BackupCodesVerify,
     EmailOTPRequest,
     EmailOTPVerify,
     LoginMethod,
+    TOTPDelete,
     TOTPEnable,
     TOTPEnrollment,
     TOTPStatus,
@@ -238,6 +242,34 @@ async def email_otp_verify(
     return await authentication_session_service.to_schema(authentication_session)
 
 
+async def _verify_second_factor(
+    identity_id: UUID,
+    code: str | None,
+    totp_factor: TOTPFactor,
+    backup_codes_factor: BackupCodesFactor,
+) -> None:
+    if code is None:
+        raise PolarAuthError("Verification code required", 403)
+    if len(code) == totp_factor.code_length and code.isdigit():
+        try:
+            await totp_factor.verify(identity_id, code)
+        except (
+            NotEnrolledTOTPException,
+            NotEnabledTOTPException,
+            InvalidTOTPCodeException,
+        ) as e:
+            raise PolarAuthError("Invalid verification code", 403) from e
+    else:
+        try:
+            await backup_codes_factor.verify(identity_id, code)
+        except (
+            NotEnrolledBackupCodesException,
+            InvalidBackupCodeException,
+            AlreadyUsedBackupCodeException,
+        ) as e:
+            raise PolarAuthError("Invalid verification code", 403) from e
+
+
 @router.get("/totp", responses={404: {"description": "TOTP factor not enrolled"}})
 async def totp_status(
     auth_subject: AuthorizeWebUserRead,
@@ -271,12 +303,25 @@ async def totp_enroll(
     )
 
 
-@router.post("/totp/enable", status_code=202)
+@router.post(
+    "/totp/enable",
+    responses={
+        403: {
+            "description": "TOTP factor not enrolled or invalid code",
+            "model": PolarAuthError.schema(),
+        },
+        409: {
+            "description": "TOTP factor already enabled",
+            "model": PolarAuthError.schema(),
+        },
+    },
+)
 async def totp_enable(
     enable: TOTPEnable,
     auth_subject: AuthorizeWebUserWrite,
     totp_factor: TOTPFactor = Depends(get_totp_factor),
-) -> None:
+    backup_codes_factor: BackupCodesFactor = Depends(get_backup_codes_factor),
+) -> BackupCodesEnrollment:
     user = auth_subject.subject
     try:
         await totp_factor.enable(user.id, enable.code)
@@ -286,12 +331,25 @@ async def totp_enable(
         raise PolarAuthError("TOTP factor already enabled", 409) from e
     except InvalidTOTPCodeException as e:
         raise PolarAuthError("Invalid TOTP code", 403) from e
-    return None
+
+    codes, _ = await backup_codes_factor.enroll(user.id)
+    return BackupCodesEnrollment(codes=codes)
 
 
-@router.delete("/totp", status_code=204)
+@router.delete(
+    "/totp",
+    status_code=204,
+    responses={
+        403: {
+            "description": "Invalid or missing verification code",
+            "model": PolarAuthError.schema(),
+        },
+        404: {"description": "TOTP factor not enrolled"},
+    },
+)
 async def totp_delete(
     auth_subject: AuthorizeWebUserWrite,
+    totp_delete: TOTPDelete | None = None,
     totp_factor: TOTPFactor = Depends(get_totp_factor),
     backup_codes_factor: BackupCodesFactor = Depends(get_backup_codes_factor),
 ) -> None:
@@ -299,6 +357,9 @@ async def totp_delete(
     enrollment = await totp_factor.get_by_identity_id(user.id)
     if enrollment is None:
         raise ResourceNotFound()
+    if enrollment.enabled:
+        code = totp_delete.code if totp_delete is not None else None
+        await _verify_second_factor(user.id, code, totp_factor, backup_codes_factor)
     await totp_factor.delete(enrollment)
 
     # Disable backup codes as well since they are meant to be used as a backup for TOTP
@@ -354,12 +415,27 @@ async def backup_codes_status(
     )
 
 
-@router.post("/backup-codes", status_code=201)
+@router.post(
+    "/backup-codes",
+    status_code=201,
+    responses={
+        403: {
+            "description": "Invalid or missing verification code",
+            "model": PolarAuthError.schema(),
+        }
+    },
+)
 async def backup_codes_enroll(
     auth_subject: AuthorizeWebUserWrite,
+    backup_codes_enroll: BackupCodesEnroll | None = None,
+    totp_factor: TOTPFactor = Depends(get_totp_factor),
     backup_codes_factor: BackupCodesFactor = Depends(get_backup_codes_factor),
 ) -> BackupCodesEnrollment:
     user = auth_subject.subject
+    totp_enrollment = await totp_factor.get_enrollment(user.id)
+    if totp_enrollment is not None:
+        code = backup_codes_enroll.code if backup_codes_enroll is not None else None
+        await _verify_second_factor(user.id, code, totp_factor, backup_codes_factor)
     codes, _ = await backup_codes_factor.enroll(user.id)
     return BackupCodesEnrollment(codes=codes)
 

--- a/server/polar/auth/schemas.py
+++ b/server/polar/auth/schemas.py
@@ -94,6 +94,14 @@ class TOTPVerify(Schema):
     code: str
 
 
+class TOTPDelete(Schema):
+    code: str | None = None
+
+
+class BackupCodesEnroll(Schema):
+    code: str | None = None
+
+
 class BackupCodesEnrollment(Schema):
     codes: list[str]
 

--- a/server/tests/auth/test_endpoints.py
+++ b/server/tests/auth/test_endpoints.py
@@ -1,0 +1,340 @@
+import time
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from reauth.crypto import get_token_hash
+from sqlalchemy import select
+
+from polar.config import settings
+from polar.models import BackupCodesEnrollment, TOTPEnrollment, User
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+
+TOTP_SECRET = "GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"
+BACKUP_CODES = ["ABCDEFGH23", "JKLMNPQR45", "STUVWXYZ67"]
+
+
+async def create_totp_enrollment(
+    save_fixture: SaveFixture, user: User, *, enabled: bool = True
+) -> TOTPEnrollment:
+    enrollment = TOTPEnrollment(
+        enabled=enabled,
+        secret=TOTP_SECRET,
+        algorithm="sha256",
+        code_length=6,
+        time_step=30,
+        last_verified_time_step=None,
+        identity_id=user.id,
+    )
+    await save_fixture(enrollment)
+    return enrollment
+
+
+def generate_totp_code(enrollment: TOTPEnrollment) -> str:
+    return enrollment.to_dataclass()._impl.generate(int(time.time())).decode()
+
+
+def invalid_totp_code(valid_code: str) -> str:
+    return "000000" if valid_code != "000000" else "111111"
+
+
+async def create_backup_codes_enrollment(
+    save_fixture: SaveFixture,
+    user: User,
+    codes: list[str] = BACKUP_CODES,
+    used_codes: list[str] = [],
+) -> BackupCodesEnrollment:
+    enrollment = BackupCodesEnrollment(
+        codes_hashes=[get_token_hash(code, secret=settings.SECRET) for code in codes],
+        used_codes_hashes=[
+            get_token_hash(code, secret=settings.SECRET) for code in used_codes
+        ],
+        identity_id=user.id,
+    )
+    await save_fixture(enrollment)
+    return enrollment
+
+
+async def get_totp_enrollment(
+    session: AsyncSession, user_id: uuid.UUID
+) -> TOTPEnrollment | None:
+    result = await session.execute(
+        select(TOTPEnrollment).where(TOTPEnrollment.identity_id == user_id)
+    )
+    return result.scalar_one_or_none()
+
+
+async def get_backup_codes_enrollment(
+    session: AsyncSession, user_id: uuid.UUID
+) -> BackupCodesEnrollment | None:
+    result = await session.execute(
+        select(BackupCodesEnrollment).where(
+            BackupCodesEnrollment.identity_id == user_id
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+@pytest.mark.asyncio
+class TestTOTPDelete:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.delete("/v1/auth/totp")
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_not_enrolled(self, client: AsyncClient) -> None:
+        response = await client.delete("/v1/auth/totp")
+        assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_enabled_without_code(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        await create_totp_enrollment(save_fixture, user)
+
+        response = await client.delete("/v1/auth/totp")
+
+        assert response.status_code == 403
+        assert await get_totp_enrollment(session, user.id) is not None
+
+    @pytest.mark.auth
+    async def test_enabled_invalid_totp_code(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        enrollment = await create_totp_enrollment(save_fixture, user)
+        code = invalid_totp_code(generate_totp_code(enrollment))
+
+        response = await client.request("DELETE", "/v1/auth/totp", json={"code": code})
+
+        assert response.status_code == 403
+        assert await get_totp_enrollment(session, user.id) is not None
+
+    @pytest.mark.auth
+    async def test_enabled_valid_totp_code(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        enrollment = await create_totp_enrollment(save_fixture, user)
+        await create_backup_codes_enrollment(save_fixture, user)
+        code = generate_totp_code(enrollment)
+
+        response = await client.request("DELETE", "/v1/auth/totp", json={"code": code})
+
+        assert response.status_code == 204
+        assert await get_totp_enrollment(session, user.id) is None
+        assert await get_backup_codes_enrollment(session, user.id) is None
+
+    @pytest.mark.auth
+    async def test_enabled_valid_backup_code(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        await create_totp_enrollment(save_fixture, user)
+        await create_backup_codes_enrollment(save_fixture, user)
+
+        response = await client.request(
+            "DELETE", "/v1/auth/totp", json={"code": BACKUP_CODES[0]}
+        )
+
+        assert response.status_code == 204
+        assert await get_totp_enrollment(session, user.id) is None
+        assert await get_backup_codes_enrollment(session, user.id) is None
+
+    @pytest.mark.auth
+    async def test_enabled_used_backup_code(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        await create_totp_enrollment(save_fixture, user)
+        await create_backup_codes_enrollment(
+            save_fixture, user, used_codes=[BACKUP_CODES[0]]
+        )
+
+        response = await client.request(
+            "DELETE", "/v1/auth/totp", json={"code": BACKUP_CODES[0]}
+        )
+
+        assert response.status_code == 403
+        assert await get_totp_enrollment(session, user.id) is not None
+
+    @pytest.mark.auth
+    async def test_disabled_without_code(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        await create_totp_enrollment(save_fixture, user, enabled=False)
+
+        response = await client.delete("/v1/auth/totp")
+
+        assert response.status_code == 204
+        assert await get_totp_enrollment(session, user.id) is None
+
+
+@pytest.mark.asyncio
+class TestBackupCodesEnroll:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.post("/v1/auth/backup-codes")
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_no_totp_enrollment(self, client: AsyncClient) -> None:
+        response = await client.post("/v1/auth/backup-codes")
+
+        assert response.status_code == 201
+        assert len(response.json()["codes"]) == 10
+
+    @pytest.mark.auth
+    async def test_disabled_totp_enrollment(
+        self, client: AsyncClient, save_fixture: SaveFixture, user: User
+    ) -> None:
+        await create_totp_enrollment(save_fixture, user, enabled=False)
+
+        response = await client.post("/v1/auth/backup-codes")
+
+        assert response.status_code == 201
+        assert len(response.json()["codes"]) == 10
+
+    @pytest.mark.auth
+    async def test_enabled_totp_without_code(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        await create_totp_enrollment(save_fixture, user)
+        existing = await create_backup_codes_enrollment(save_fixture, user)
+        existing_hashes = list(existing.codes_hashes)
+
+        response = await client.post("/v1/auth/backup-codes")
+
+        assert response.status_code == 403
+        enrollment = await get_backup_codes_enrollment(session, user.id)
+        assert enrollment is not None
+        assert enrollment.codes_hashes == existing_hashes
+
+    @pytest.mark.auth
+    async def test_enabled_totp_invalid_code(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        user: User,
+    ) -> None:
+        enrollment = await create_totp_enrollment(save_fixture, user)
+        code = invalid_totp_code(generate_totp_code(enrollment))
+
+        response = await client.post("/v1/auth/backup-codes", json={"code": code})
+
+        assert response.status_code == 403
+
+    @pytest.mark.auth
+    async def test_enabled_totp_valid_totp_code(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        enrollment = await create_totp_enrollment(save_fixture, user)
+        existing = await create_backup_codes_enrollment(save_fixture, user)
+        existing_hashes = list(existing.codes_hashes)
+        code = generate_totp_code(enrollment)
+
+        response = await client.post("/v1/auth/backup-codes", json={"code": code})
+
+        assert response.status_code == 201
+        assert len(response.json()["codes"]) == 10
+        new_enrollment = await get_backup_codes_enrollment(session, user.id)
+        assert new_enrollment is not None
+        for code_hash in existing_hashes:
+            assert code_hash not in new_enrollment.codes_hashes
+
+    @pytest.mark.auth
+    async def test_enabled_totp_valid_backup_code(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        user: User,
+    ) -> None:
+        await create_totp_enrollment(save_fixture, user)
+        await create_backup_codes_enrollment(save_fixture, user)
+
+        response = await client.post(
+            "/v1/auth/backup-codes", json={"code": BACKUP_CODES[0]}
+        )
+
+        assert response.status_code == 201
+        assert len(response.json()["codes"]) == 10
+
+
+@pytest.mark.asyncio
+class TestTOTPEnable:
+    @pytest.mark.auth
+    async def test_valid_code(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        enrollment = await create_totp_enrollment(save_fixture, user, enabled=False)
+        code = generate_totp_code(enrollment)
+
+        response = await client.post("/v1/auth/totp/enable", json={"code": code})
+
+        assert response.status_code == 200
+        assert len(response.json()["codes"]) == 10
+        assert await get_backup_codes_enrollment(session, user.id) is not None
+
+    @pytest.mark.auth
+    async def test_invalid_code(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        enrollment = await create_totp_enrollment(save_fixture, user, enabled=False)
+        code = invalid_totp_code(generate_totp_code(enrollment))
+
+        response = await client.post("/v1/auth/totp/enable", json={"code": code})
+
+        assert response.status_code == 403
+        assert await get_backup_codes_enrollment(session, user.id) is None
+
+    @pytest.mark.auth
+    async def test_enable_code_replay_rejected_on_backup_codes_enroll(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        user: User,
+    ) -> None:
+        enrollment = await create_totp_enrollment(save_fixture, user, enabled=False)
+        code = generate_totp_code(enrollment)
+
+        enable_response = await client.post("/v1/auth/totp/enable", json={"code": code})
+        assert enable_response.status_code == 200
+
+        response = await client.post("/v1/auth/backup-codes", json={"code": code})
+        assert response.status_code == 403


### PR DESCRIPTION
Otherwise an attacker who is logged in might delete the already configured 2fa or regenerate the backup codes, loosening up the benefits of the system

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a 2FA code to disable/delete TOTP and to generate/regenerate backup codes, with a consistent OTP input in Settings. Enabling TOTP now returns backup codes immediately so users can save them.

- **New Features**
  - Require a valid TOTP or backup code to disable TOTP, and to generate/regenerate backup codes when TOTP is enabled.
  - Add a reusable TwoFactorCode modal with OTP slots and a backup code toggle, used for disable and backup code actions.
  - TOTP enable returns newly generated backup codes; UI surfaces them.

- **Migration**
  - API changes:
    - DELETE /v1/auth/totp now accepts { code } in the JSON body and returns 204; returns 403 on invalid/missing code and 404 if not enrolled.
    - POST /v1/auth/backup-codes accepts optional { code }; when TOTP is enabled a code is required; returns 201 on success or 403 on invalid/missing code.
    - POST /v1/auth/totp/enable returns 200 with { codes } (backup codes) instead of 202; may return 403 (invalid code) or 409 (already enabled).
  - Update client usage:
    - `useTOTPDelete(code)` and `useBackupCodesEnroll(code?)` now take a code.
    - Handle new 403/409 responses and the backup codes payload from TOTP enable.

<sup>Written for commit 086a9b5e57748af2347b2f1f56d48761c17ef167. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

