### PR TITLE
feat(subscription): pause and resume subscriptions

### DIFF
--- a/clients/apps/app/app/(authenticated)/subscriptions/[id]/index.tsx
+++ b/clients/apps/app/app/(authenticated)/subscriptions/[id]/index.tsx
@@ -25,6 +25,7 @@ const statusColors = {
   past_due: 'red',
   trialing: 'blue',
   unpaid: 'yellow',
+  paused: 'yellow',
 } as const
 
 export default function Index() {

--- a/clients/apps/app/components/Subscriptions/SubscriptionRow.tsx
+++ b/clients/apps/app/components/Subscriptions/SubscriptionRow.tsx
@@ -20,6 +20,7 @@ const subscriptionStatusColors: Record<
   incomplete: 'yellow',
   incomplete_expired: 'red',
   unpaid: 'yellow',
+  paused: 'yellow',
 }
 
 export interface SubscriptionRowProps {

--- a/clients/apps/web/src/components/Customer/CustomerContextView.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerContextView.tsx
@@ -155,6 +155,7 @@ const STATUS_DISPLAY_NAMES: Record<schemas['SubscriptionStatus'], string> = {
   active: 'Active',
   trialing: 'Trialing',
   past_due: 'Past Due',
+  paused: 'Paused',
   unpaid: 'Unpaid',
   canceled: 'Canceled',
   incomplete: 'Incomplete',
@@ -165,10 +166,11 @@ const STATUS_ORDER: Record<schemas['SubscriptionStatus'], number> = {
   active: 0,
   trialing: 1,
   past_due: 2,
-  unpaid: 3,
-  incomplete: 4,
-  canceled: 5,
-  incomplete_expired: 6,
+  paused: 3,
+  unpaid: 4,
+  incomplete: 5,
+  canceled: 6,
+  incomplete_expired: 7,
 }
 
 const INTERVAL_LABELS: Record<schemas['RecurringInterval'], string> = {

--- a/clients/apps/web/src/components/Settings/OrganizationCustomerEmailSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationCustomerEmailSettings.tsx
@@ -76,6 +76,16 @@ const customerEmails: {
     title: 'Subscription past due',
     description: 'Sent when a subscription payment fails and becomes overdue',
   },
+  {
+    key: 'subscription_paused',
+    title: 'Subscription paused',
+    description: 'Sent when a customer pauses their subscription',
+  },
+  {
+    key: 'subscription_resumed',
+    title: 'Subscription resumed',
+    description: 'Sent when a paused subscription resumes and billing restarts',
+  },
 ]
 
 const OrganizationCustomerEmailSettings: React.FC<

--- a/clients/apps/web/src/components/Subscriptions/utils.tsx
+++ b/clients/apps/web/src/components/Subscriptions/utils.tsx
@@ -11,6 +11,7 @@ export const subscriptionStatusDisplayNames: {
   trialing: 'Trialing',
   active: 'Active',
   past_due: 'Past due',
+  paused: 'Paused',
   canceled: 'Canceled',
   unpaid: 'Unpaid',
 }

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -31676,6 +31676,100 @@ export interface components {
       resumes_at?: string | null
     }
     /**
+     * SubscriptionPausedEvent
+     * @description An event created by Polar when a subscription is paused.
+     */
+    SubscriptionPausedEvent: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the object.
+       */
+      id: string
+      /**
+       * Timestamp
+       * Format: date-time
+       * @description The timestamp of the event.
+       */
+      timestamp: string
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description The ID of the organization owning the event.
+       * @example 1dbfc517-0bbf-4301-9ba8-555ca42b9737
+       */
+      organization_id: string
+      /**
+       * Customer Id
+       * @description ID of the customer in your Polar organization associated with the event.
+       */
+      customer_id: string | null
+      /** @description The customer associated with the event. */
+      customer: components['schemas']['Customer'] | null
+      /**
+       * External Customer Id
+       * @description ID of the customer in your system associated with the event.
+       */
+      external_customer_id: string | null
+      /**
+       * Member Id
+       * @description ID of the member within the customer's organization who performed the action inside B2B.
+       */
+      member_id?: string | null
+      /**
+       * External Member Id
+       * @description ID of the member in your system within the customer's organization who performed the action inside B2B.
+       */
+      external_member_id?: string | null
+      /**
+       * Child Count
+       * @description Number of direct child events linked to this event.
+       * @default 0
+       */
+      child_count: number
+      /**
+       * Parent Id
+       * @description The ID of the parent event.
+       */
+      parent_id?: string | null
+      /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
+      /**
+       * Source
+       * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
+       * @constant
+       */
+      source: 'system'
+      /**
+       * @description The name of the event. (enum property replaced by openapi-typescript)
+       * @enum {string}
+       */
+      name: 'subscription.paused'
+      metadata: components['schemas']['SubscriptionPausedMetadata']
+    }
+    /** SubscriptionPausedMetadata */
+    SubscriptionPausedMetadata: {
+      /** Subscription Id */
+      subscription_id: string
+      /** Product Id */
+      product_id?: string
+      /** Amount */
+      amount?: number
+      /** Currency */
+      currency?: string
+      /** Recurring Interval */
+      recurring_interval?: string
+      /** Recurring Interval Count */
+      recurring_interval_count?: number
+      /** Paused At */
+      paused_at: string
+      /** Resumes At */
+      resumes_at?: string
+    }
+    /**
      * SubscriptionProductUpdatedEvent
      * @description An event created by Polar when a subscription changes the product.
      */
@@ -31866,6 +31960,96 @@ export interface components {
        * @constant
        */
       resume: true
+    }
+    /**
+     * SubscriptionResumedEvent
+     * @description An event created by Polar when a paused subscription is resumed.
+     */
+    SubscriptionResumedEvent: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the object.
+       */
+      id: string
+      /**
+       * Timestamp
+       * Format: date-time
+       * @description The timestamp of the event.
+       */
+      timestamp: string
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description The ID of the organization owning the event.
+       * @example 1dbfc517-0bbf-4301-9ba8-555ca42b9737
+       */
+      organization_id: string
+      /**
+       * Customer Id
+       * @description ID of the customer in your Polar organization associated with the event.
+       */
+      customer_id: string | null
+      /** @description The customer associated with the event. */
+      customer: components['schemas']['Customer'] | null
+      /**
+       * External Customer Id
+       * @description ID of the customer in your system associated with the event.
+       */
+      external_customer_id: string | null
+      /**
+       * Member Id
+       * @description ID of the member within the customer's organization who performed the action inside B2B.
+       */
+      member_id?: string | null
+      /**
+       * External Member Id
+       * @description ID of the member in your system within the customer's organization who performed the action inside B2B.
+       */
+      external_member_id?: string | null
+      /**
+       * Child Count
+       * @description Number of direct child events linked to this event.
+       * @default 0
+       */
+      child_count: number
+      /**
+       * Parent Id
+       * @description The ID of the parent event.
+       */
+      parent_id?: string | null
+      /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
+      /**
+       * Source
+       * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
+       * @constant
+       */
+      source: 'system'
+      /**
+       * @description The name of the event. (enum property replaced by openapi-typescript)
+       * @enum {string}
+       */
+      name: 'subscription.resumed'
+      metadata: components['schemas']['SubscriptionResumedMetadata']
+    }
+    /** SubscriptionResumedMetadata */
+    SubscriptionResumedMetadata: {
+      /** Subscription Id */
+      subscription_id: string
+      /** Product Id */
+      product_id?: string
+      /** Amount */
+      amount?: number
+      /** Currency */
+      currency?: string
+      /** Recurring Interval */
+      recurring_interval?: string
+      /** Recurring Interval Count */
+      recurring_interval_count?: number
     }
     /** SubscriptionRevoke */
     SubscriptionRevoke: {
@@ -32683,6 +32867,8 @@ export interface components {
       | components['schemas']['SubscriptionRevokedEvent']
       | components['schemas']['SubscriptionPastDueEvent']
       | components['schemas']['SubscriptionReactivatedEvent']
+      | components['schemas']['SubscriptionPausedEvent']
+      | components['schemas']['SubscriptionResumedEvent']
       | components['schemas']['SubscriptionUncanceledEvent']
       | components['schemas']['SubscriptionProductUpdatedEvent']
       | components['schemas']['SubscriptionSeatsUpdatedEvent']
@@ -62088,6 +62274,9 @@ export const subscriptionCycledEventNameValues: ReadonlyArray<
 export const subscriptionPastDueEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SubscriptionPastDueEvent']['name']
 > = ['subscription.past_due']
+export const subscriptionPausedEventNameValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['SubscriptionPausedEvent']['name']
+> = ['subscription.paused']
 export const subscriptionProductUpdatedEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SubscriptionProductUpdatedEvent']['name']
 > = ['subscription.product_updated']
@@ -62097,6 +62286,9 @@ export const subscriptionProrationBehaviorValues: ReadonlyArray<
 export const subscriptionReactivatedEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SubscriptionReactivatedEvent']['name']
 > = ['subscription.reactivated']
+export const subscriptionResumedEventNameValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['SubscriptionResumedEvent']['name']
+> = ['subscription.resumed']
 export const subscriptionRevokedEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SubscriptionRevokedEvent']['name']
 > = ['subscription.revoked']

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -6275,6 +6275,55 @@ export interface webhooks {
     patch?: never
     trace?: never
   }
+  'subscription.paused': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * subscription.paused
+     * @description Sent when a subscription is paused and the customer temporarily loses access.
+     *
+     *     No order is created while paused. The subscription resumes either on its
+     *     scheduled resume date or when resumed manually, starting a new billing period.
+     *
+     *     **Discord & Slack support:** Full
+     */
+    post: operations['_endpointsubscription_paused_post']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  'subscription.resumed': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * subscription.resumed
+     * @description Sent when a paused subscription resumes, restoring the customer's access.
+     *
+     *     Resuming starts a new billing period and charges the customer immediately.
+     *
+     *     **Discord & Slack support:** Full
+     */
+    post: operations['_endpointsubscription_resumed_post']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   'refund.created': {
     parameters: {
       query?: never
@@ -16662,6 +16711,21 @@ export interface components {
        */
       past_due_at?: string | null
       /**
+       * Pause At Period End
+       * @description Whether the subscription will be paused at the end of the current period.
+       */
+      pause_at_period_end: boolean
+      /**
+       * Paused At
+       * @description The timestamp when the subscription was paused.
+       */
+      paused_at?: string | null
+      /**
+       * Resumes At
+       * @description The timestamp when a paused subscription is scheduled to automatically resume, if set.
+       */
+      resumes_at?: string | null
+      /**
        * Customer Id
        * Format: uuid4
        * @description The ID of the subscribed customer.
@@ -17035,6 +17099,8 @@ export interface components {
       update_seats: boolean
       /** Update Plan */
       update_plan: boolean
+      /** Pause */
+      pause?: boolean
     }
     /** CustomerPortalUsageSettings */
     CustomerPortalUsageSettings: {
@@ -18103,6 +18169,21 @@ export interface components {
        */
       past_due_at?: string | null
       /**
+       * Pause At Period End
+       * @description Whether the subscription will be paused at the end of the current period.
+       */
+      pause_at_period_end: boolean
+      /**
+       * Paused At
+       * @description The timestamp when the subscription was paused.
+       */
+      paused_at?: string | null
+      /**
+       * Resumes At
+       * @description The timestamp when a paused subscription is scheduled to automatically resume, if set.
+       */
+      resumes_at?: string | null
+      /**
        * Customer Id
        * Format: uuid4
        * @description The ID of the subscribed customer.
@@ -18249,6 +18330,22 @@ export interface components {
        */
       name: string
     }
+    /** CustomerSubscriptionPause */
+    CustomerSubscriptionPause: {
+      /**
+       * Pause At Period End
+       * @description Pause an active subscription at the end of the current period.
+       *
+       *     Or cancel a scheduled pause on a subscription set to be paused at
+       *     period end.
+       */
+      pause_at_period_end: boolean
+      /**
+       * Resumes At
+       * @description Date at which the paused subscription should automatically resume. If not set, it stays paused until resumed. Must be after the current period end.
+       */
+      resumes_at?: string | null
+    }
     /** CustomerSubscriptionProduct */
     CustomerSubscriptionProduct: {
       /**
@@ -18337,6 +18434,15 @@ export interface components {
       medias: components['schemas']['ProductMediaFileRead'][]
       organization: components['schemas']['CustomerOrganization']
     }
+    /** CustomerSubscriptionResume */
+    CustomerSubscriptionResume: {
+      /**
+       * Resume
+       * @description Resume a paused subscription immediately, starting a new billing period and charging the customer.
+       * @constant
+       */
+      resume: true
+    }
     /**
      * CustomerSubscriptionSortProperty
      * @enum {string}
@@ -18356,6 +18462,8 @@ export interface components {
       | components['schemas']['CustomerSubscriptionUpdateProduct']
       | components['schemas']['CustomerSubscriptionUpdateSeats']
       | components['schemas']['CustomerSubscriptionCancel']
+      | components['schemas']['CustomerSubscriptionPause']
+      | components['schemas']['CustomerSubscriptionResume']
       | components['schemas']['CustomerSubscriptionUpdateClear']
     /** CustomerSubscriptionUpdateClear */
     CustomerSubscriptionUpdateClear: {
@@ -24364,6 +24472,21 @@ export interface components {
        */
       past_due_at?: string | null
       /**
+       * Pause At Period End
+       * @description Whether the subscription will be paused at the end of the current period.
+       */
+      pause_at_period_end: boolean
+      /**
+       * Paused At
+       * @description The timestamp when the subscription was paused.
+       */
+      paused_at?: string | null
+      /**
+       * Resumes At
+       * @description The timestamp when a paused subscription is scheduled to automatically resume, if set.
+       */
+      resumes_at?: string | null
+      /**
        * Customer Id
        * Format: uuid4
        * @description The ID of the subscribed customer.
@@ -25492,6 +25615,10 @@ export interface components {
       subscription_cycled_after_trial: boolean
       /** Subscription Past Due */
       subscription_past_due: boolean
+      /** Subscription Paused */
+      subscription_paused: boolean
+      /** Subscription Resumed */
+      subscription_resumed: boolean
       /** Subscription Renewal Reminder */
       subscription_renewal_reminder: boolean
       /** Subscription Revoked */
@@ -30664,6 +30791,21 @@ export interface components {
        */
       past_due_at?: string | null
       /**
+       * Pause At Period End
+       * @description Whether the subscription will be paused at the end of the current period.
+       */
+      pause_at_period_end: boolean
+      /**
+       * Paused At
+       * @description The timestamp when the subscription was paused.
+       */
+      paused_at?: string | null
+      /**
+       * Resumes At
+       * @description The timestamp when a paused subscription is scheduled to automatically resume, if set.
+       */
+      resumes_at?: string | null
+      /**
        * Customer Id
        * Format: uuid4
        * @description The ID of the subscribed customer.
@@ -31514,6 +31656,25 @@ export interface components {
       /** Recurring Interval Count */
       recurring_interval_count?: number
     }
+    /** SubscriptionPause */
+    SubscriptionPause: {
+      /**
+       * Pause At Period End
+       * @description Pause an active subscription at the end of the current period.
+       *
+       *     Or cancel a scheduled pause on a subscription set to be paused at
+       *     period end.
+       */
+      pause_at_period_end: boolean
+      /**
+       * Resumes At
+       * @description Date at which the paused subscription should automatically resume.
+       *
+       *     If not set, the subscription stays paused until it is resumed manually.
+       *     Must be after the current period end.
+       */
+      resumes_at?: string | null
+    }
     /**
      * SubscriptionProductUpdatedEvent
      * @description An event created by Polar when a subscription changes the product.
@@ -31696,6 +31857,15 @@ export interface components {
       recurring_interval?: string
       /** Recurring Interval Count */
       recurring_interval_count?: number
+    }
+    /** SubscriptionResume */
+    SubscriptionResume: {
+      /**
+       * Resume
+       * @description Resume a paused subscription immediately, starting a new billing period and charging the customer.
+       * @constant
+       */
+      resume: true
     }
     /** SubscriptionRevoke */
     SubscriptionRevoke: {
@@ -31952,6 +32122,7 @@ export interface components {
       | 'past_due'
       | 'canceled'
       | 'unpaid'
+      | 'paused'
     /**
      * SubscriptionUncanceledEvent
      * @description An event created by Polar when a subscription cancellation is reversed.
@@ -32048,6 +32219,8 @@ export interface components {
       | components['schemas']['SubscriptionUpdateBillingPeriod']
       | components['schemas']['SubscriptionCancel']
       | components['schemas']['SubscriptionRevoke']
+      | components['schemas']['SubscriptionPause']
+      | components['schemas']['SubscriptionResume']
       | components['schemas']['SubscriptionUpdateClear']
     /** SubscriptionUpdateBase */
     SubscriptionUpdateBase: {
@@ -34321,6 +34494,8 @@ export interface components {
       | 'subscription.uncanceled'
       | 'subscription.revoked'
       | 'subscription.past_due'
+      | 'subscription.paused'
+      | 'subscription.resumed'
       | 'refund.created'
       | 'refund.updated'
       | 'product.created'
@@ -34687,6 +34862,51 @@ export interface components {
        * @constant
        */
       type: 'subscription.past_due'
+      /**
+       * Timestamp
+       * Format: date-time
+       */
+      timestamp: string
+      data: components['schemas']['Subscription']
+    }
+    /**
+     * WebhookSubscriptionPausedPayload
+     * @description Sent when a subscription is paused and the customer temporarily loses access.
+     *
+     *     No order is created while paused. The subscription resumes either on its
+     *     scheduled resume date or when resumed manually, starting a new billing period.
+     *
+     *     **Discord & Slack support:** Full
+     */
+    WebhookSubscriptionPausedPayload: {
+      /**
+       * Type
+       * @example subscription.paused
+       * @constant
+       */
+      type: 'subscription.paused'
+      /**
+       * Timestamp
+       * Format: date-time
+       */
+      timestamp: string
+      data: components['schemas']['Subscription']
+    }
+    /**
+     * WebhookSubscriptionResumedPayload
+     * @description Sent when a paused subscription resumes, restoring the customer's access.
+     *
+     *     Resuming starts a new billing period and charges the customer immediately.
+     *
+     *     **Discord & Slack support:** Full
+     */
+    WebhookSubscriptionResumedPayload: {
+      /**
+       * Type
+       * @example subscription.resumed
+       * @constant
+       */
+      type: 'subscription.resumed'
       /**
        * Timestamp
        * Format: date-time
@@ -53549,6 +53769,72 @@ export interface operations {
       }
     }
   }
+  _endpointsubscription_paused_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['WebhookSubscriptionPausedPayload']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  _endpointsubscription_resumed_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['WebhookSubscriptionResumedPayload']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
   _endpointrefund_created_post: {
     parameters: {
       query?: never
@@ -61849,6 +62135,7 @@ export const subscriptionStatusValues: ReadonlyArray<
   'past_due',
   'canceled',
   'unpaid',
+  'paused',
 ]
 export const subscriptionUncanceledEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SubscriptionUncanceledEvent']['name']
@@ -62299,6 +62586,8 @@ export const webhookEventTypeValues: ReadonlyArray<
   'subscription.uncanceled',
   'subscription.revoked',
   'subscription.past_due',
+  'subscription.paused',
+  'subscription.resumed',
   'refund.created',
   'refund.updated',
   'product.created',

--- a/server/emails/src/emails/index.ts
+++ b/server/emails/src/emails/index.ts
@@ -27,7 +27,9 @@ import { SubscriptionCycled } from './subscription_cycled'
 import { SubscriptionCycledAfterTrial } from './subscription_cycled_after_trial'
 import { SubscriptionFinalInvoice } from './subscription_final_invoice'
 import { SubscriptionPastDue } from './subscription_past_due'
+import { SubscriptionPaused } from './subscription_paused'
 import { SubscriptionRenewalReminder } from './subscription_renewal_reminder'
+import { SubscriptionResumed } from './subscription_resumed'
 import { SubscriptionRevoked } from './subscription_revoked'
 import { SubscriptionTrialConversionReminder } from './subscription_trial_conversion_reminder'
 import { SubscriptionUncanceled } from './subscription_uncanceled'
@@ -55,6 +57,8 @@ const TEMPLATES: Record<string, React.FC<never>> = {
   subscription_cycled_after_trial: SubscriptionCycledAfterTrial,
   subscription_final_invoice: SubscriptionFinalInvoice,
   subscription_past_due: SubscriptionPastDue,
+  subscription_paused: SubscriptionPaused,
+  subscription_resumed: SubscriptionResumed,
   subscription_renewal_reminder: SubscriptionRenewalReminder,
   subscription_revoked: SubscriptionRevoked,
   subscription_trial_conversion_reminder: SubscriptionTrialConversionReminder,

--- a/server/emails/src/emails/subscription_paused.tsx
+++ b/server/emails/src/emails/subscription_paused.tsx
@@ -1,0 +1,67 @@
+import {
+  Button,
+  FooterCustomer,
+  Intro,
+  Text,
+  WrapperOrganization,
+} from '../components/foundation'
+import { organization, product } from '../preview'
+import type { schemas } from '../types'
+
+export function SubscriptionPaused({
+  email,
+  organization,
+  product,
+  subscription,
+  url,
+}: schemas['SubscriptionPausedProps']) {
+  const formatDate = (value: string) =>
+    new Date(value).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
+  const accessUntil = formatDate(subscription.current_period_end!)
+  const resumeDate = subscription.resumes_at
+    ? formatDate(subscription.resumes_at)
+    : null
+
+  return (
+    <WrapperOrganization
+      organization={organization}
+      preview={`Your ${product.name} subscription will pause`}
+    >
+      <Intro headline="Your subscription is set to pause">
+        Your{' '}
+        <Text as="span" weight="medium">
+          {product.name}
+        </Text>{' '}
+        subscription will pause at the end of your current period. You keep full
+        access until {accessUntil}, and you won&rsquo;t be charged while
+        it&rsquo;s paused.
+      </Intro>
+      <Text>
+        {resumeDate
+          ? `Your subscription will automatically resume on ${resumeDate}.`
+          : 'Your subscription will stay paused until you resume it.'}
+      </Text>
+      <Button href={url}>Manage subscription</Button>
+      <FooterCustomer organization={organization} email={email} />
+    </WrapperOrganization>
+  )
+}
+
+SubscriptionPaused.PreviewProps = {
+  email: 'john@example.com',
+  organization,
+  product,
+  subscription: {
+    current_period_end: new Date(
+      Date.now() + 10 * 24 * 60 * 60 * 1000,
+    ).toISOString(),
+    resumes_at: new Date(Date.now() + 40 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  url: 'https://polar.sh/acme-inc/portal/subscriptions/12345',
+}
+
+export default SubscriptionPaused

--- a/server/emails/src/emails/subscription_resumed.tsx
+++ b/server/emails/src/emails/subscription_resumed.tsx
@@ -1,0 +1,43 @@
+import {
+  Button,
+  FooterCustomer,
+  Intro,
+  Text,
+  WrapperOrganization,
+} from '../components/foundation'
+import { organization, product } from '../preview'
+import type { schemas } from '../types'
+
+export function SubscriptionResumed({
+  email,
+  organization,
+  product,
+  url,
+}: schemas['SubscriptionResumedProps']) {
+  return (
+    <WrapperOrganization
+      organization={organization}
+      preview={`Your ${product.name} subscription has resumed`}
+    >
+      <Intro headline="Your subscription has resumed">
+        Your{' '}
+        <Text as="span" weight="medium">
+          {product.name}
+        </Text>{' '}
+        subscription is active again and your access has been restored. Regular
+        billing has resumed.
+      </Intro>
+      <Button href={url}>Manage subscription</Button>
+      <FooterCustomer organization={organization} email={email} />
+    </WrapperOrganization>
+  )
+}
+
+SubscriptionResumed.PreviewProps = {
+  email: 'john@example.com',
+  organization,
+  product,
+  url: 'https://polar.sh/acme-inc/portal/subscriptions/12345',
+}
+
+export default SubscriptionResumed

--- a/server/emails/src/types/openapi.ts
+++ b/server/emails/src/types/openapi.ts
@@ -1476,6 +1476,12 @@ export interface components {
       subscription_id: string | null
       /** Checkout Id */
       checkout_id: string | null
+      /**
+       * Next Payment Attempt At
+       * @description When the next automatic payment retry is scheduled. `null` if the order is not in dunning or all retries have been exhausted.
+       * @default null
+       */
+      next_payment_attempt_at: string | null
       /** Description */
       description: string
       /** Items */
@@ -1619,6 +1625,11 @@ export interface components {
        * @description When the business details were submitted for review.
        */
       details_submitted_at: string | null
+      /**
+       * Sso Enforced
+       * @description Whether members must access this organization through its SSO connection.
+       */
+      sso_enforced: boolean
       /**
        * Default Presentment Currency
        * @description Default presentment currency. Used as fallback in checkout and customer portal, if the customer's local currency is not available.
@@ -1927,25 +1938,6 @@ export interface components {
       /** Url */
       url: string
     }
-    /** OrganizationAccountUnlinkEmail */
-    OrganizationAccountUnlinkEmail: {
-      /**
-       * Template
-       * @default organization_account_unlink
-       * @constant
-       */
-      template: 'organization_account_unlink'
-      props: components['schemas']['OrganizationAccountUnlinkProps']
-    }
-    /** OrganizationAccountUnlinkProps */
-    OrganizationAccountUnlinkProps: {
-      /** Email */
-      email: string
-      /** Organization Kept Name */
-      organization_kept_name: string
-      /** Organizations Unlinked */
-      organizations_unlinked: string[]
-    }
     /** OrganizationCapabilities */
     OrganizationCapabilities: {
       /**
@@ -1993,6 +1985,10 @@ export interface components {
       subscription_cycled_after_trial: boolean
       /** Subscription Past Due */
       subscription_past_due: boolean
+      /** Subscription Paused */
+      subscription_paused: boolean
+      /** Subscription Resumed */
+      subscription_resumed: boolean
       /** Subscription Renewal Reminder */
       subscription_renewal_reminder: boolean
       /** Subscription Revoked */
@@ -2072,6 +2068,24 @@ export interface components {
        * @default false
        */
       preview_access_enabled: boolean
+      /**
+       * Disputes Enabled
+       * @description If this organization has the disputes dashboard enabled
+       * @default false
+       */
+      disputes_enabled: boolean
+      /**
+       * Sso Enabled
+       * @description If this organization has single sign-on configuration enabled
+       * @default false
+       */
+      sso_enabled: boolean
+      /**
+       * Compass Enabled
+       * @description If this organization has the split product navigation (Billing / Compass / Customers) enabled in the dashboard
+       * @default false
+       */
+      compass_enabled: boolean
     }
     /** OrganizationInviteEmail */
     OrganizationInviteEmail: {
@@ -2337,14 +2351,19 @@ export interface components {
       /** @description The visibility of the product. */
       visibility: components['schemas']['ProductVisibility']
       /** @description The recurring interval of the product. If `None`, the product is a one-time purchase. */
-      recurring_interval:
-        | components['schemas']['SubscriptionRecurringInterval']
-        | null
+      recurring_interval: components['schemas']['RecurringInterval'] | null
       /**
        * Recurring Interval Count
        * @description Number of interval units of the subscription. If this is set to 1 the charge will happen every interval (e.g. every month), if set to 2 it will be every other month, and so on. None for one-time products.
        */
       recurring_interval_count: number | null
+      /** @description The meter cycle of the product, independent of the billing interval. If `None`, metered concerns follow the billing interval. */
+      meter_interval: components['schemas']['RecurringInterval'] | null
+      /**
+       * Meter Interval Count
+       * @description Number of meter interval units. None when no meter cycle is set.
+       */
+      meter_interval_count: number | null
       /**
        * Is Recurring
        * @description Whether the product is a subscription.
@@ -2372,6 +2391,11 @@ export interface components {
      * @enum {string}
      */
     ProductVisibility: 'draft' | 'private' | 'public'
+    /**
+     * RecurringInterval
+     * @enum {string}
+     */
+    RecurringInterval: 'day' | 'week' | 'month' | 'year'
     /** SeatInvitationEmail */
     SeatInvitationEmail: {
       /**
@@ -2512,7 +2536,7 @@ export interface components {
        * @description The interval at which the subscription recurs.
        * @example month
        */
-      recurring_interval: components['schemas']['SubscriptionRecurringInterval']
+      recurring_interval: components['schemas']['RecurringInterval']
       /**
        * Recurring Interval Count
        * @description Number of interval units of the subscription. If this is set to 1 the charge will happen every interval (e.g. every month), if set to 2 it will be every other month, and so on.
@@ -2535,6 +2559,16 @@ export interface components {
        * @description The end timestamp of the current billing period.
        */
       current_period_end: string
+      /**
+       * Current Meter Period Start
+       * @description The start timestamp of the current meter period, if the product has a meter cycle set. Metered credits are granted and overage is settled on this cadence.
+       */
+      current_meter_period_start: string | null
+      /**
+       * Current Meter Period End
+       * @description The end timestamp of the current meter period, if the product has a meter cycle set. This is when credits next renew.
+       */
+      current_meter_period_end: string | null
       /**
        * Trial Start
        * @description The start timestamp of the trial period, if any.
@@ -2570,6 +2604,29 @@ export interface components {
        * @description The timestamp when the subscription ended.
        */
       ended_at: string | null
+      /**
+       * Past Due At
+       * @description The timestamp when the subscription entered `past_due` status.
+       * @default null
+       */
+      past_due_at: string | null
+      /**
+       * Pause At Period End
+       * @description Whether the subscription will be paused at the end of the current period.
+       */
+      pause_at_period_end: boolean
+      /**
+       * Paused At
+       * @description The timestamp when the subscription was paused.
+       * @default null
+       */
+      paused_at: string | null
+      /**
+       * Resumes At
+       * @description The timestamp when a paused subscription is scheduled to automatically resume, if set.
+       * @default null
+       */
+      resumes_at: string | null
       /**
        * Customer Id
        * Format: uuid4
@@ -2647,6 +2704,26 @@ export interface components {
        */
       payment_url: string | null
     }
+    /** SubscriptionPausedEmail */
+    SubscriptionPausedEmail: {
+      /**
+       * Template
+       * @default subscription_paused
+       * @constant
+       */
+      template: 'subscription_paused'
+      props: components['schemas']['SubscriptionPausedProps']
+    }
+    /** SubscriptionPausedProps */
+    SubscriptionPausedProps: {
+      /** Email */
+      email: string
+      organization: components['schemas']['Organization']
+      product: components['schemas']['ProductEmail']
+      subscription: components['schemas']['SubscriptionEmail']
+      /** Url */
+      url: string
+    }
     /**
      * SubscriptionProrationBehavior
      * @enum {string}
@@ -2656,11 +2733,6 @@ export interface components {
       | 'prorate'
       | 'next_period'
       | 'reset'
-    /**
-     * SubscriptionRecurringInterval
-     * @enum {string}
-     */
-    SubscriptionRecurringInterval: 'day' | 'week' | 'month' | 'year'
     /** SubscriptionRenewalReminderEmail */
     SubscriptionRenewalReminderEmail: {
       /**
@@ -2682,6 +2754,26 @@ export interface components {
       url: string
       /** Renewal Date */
       renewal_date: string
+    }
+    /** SubscriptionResumedEmail */
+    SubscriptionResumedEmail: {
+      /**
+       * Template
+       * @default subscription_resumed
+       * @constant
+       */
+      template: 'subscription_resumed'
+      props: components['schemas']['SubscriptionResumedProps']
+    }
+    /** SubscriptionResumedProps */
+    SubscriptionResumedProps: {
+      /** Email */
+      email: string
+      organization: components['schemas']['Organization']
+      product: components['schemas']['ProductEmail']
+      subscription: components['schemas']['SubscriptionEmail']
+      /** Url */
+      url: string
     }
     /** SubscriptionRevokedEmail */
     SubscriptionRevokedEmail: {
@@ -2715,6 +2807,7 @@ export interface components {
       | 'past_due'
       | 'canceled'
       | 'unpaid'
+      | 'paused'
     /** SubscriptionTrialConversionReminderEmail */
     SubscriptionTrialConversionReminderEmail: {
       /**

--- a/server/polar/customer_portal/schemas/subscription.py
+++ b/server/polar/customer_portal/schemas/subscription.py
@@ -1,7 +1,7 @@
 import inspect
-from typing import Annotated
+from typing import Annotated, Literal
 
-from pydantic import UUID4, AliasChoices, AliasPath, Field
+from pydantic import UUID4, AliasChoices, AliasPath, Field, FutureDatetime
 from pydantic.json_schema import SkipJsonSchema
 
 from polar.enums import SubscriptionProrationBehavior
@@ -127,6 +127,36 @@ class CustomerSubscriptionCancel(Schema):
     )
 
 
+class CustomerSubscriptionPause(Schema):
+    pause_at_period_end: bool = Field(
+        description=inspect.cleandoc(
+            """
+        Pause an active subscription at the end of the current period.
+
+        Or cancel a scheduled pause on a subscription set to be paused at
+        period end.
+        """
+        ),
+    )
+    resumes_at: FutureDatetime | None = Field(
+        None,
+        description=(
+            "Date at which the paused subscription should automatically resume. "
+            "If not set, it stays paused until resumed. Must be after the current "
+            "period end."
+        ),
+    )
+
+
+class CustomerSubscriptionResume(Schema):
+    resume: Literal[True] = Field(
+        description=(
+            "Resume a paused subscription immediately, "
+            "starting a new billing period and charging the customer."
+        )
+    )
+
+
 class CustomerSubscriptionUpdateClear(Schema):
     pending_update: None = Field(description="Clear the pending subscription update.")
 
@@ -135,6 +165,8 @@ CustomerSubscriptionUpdate = Annotated[
     CustomerSubscriptionUpdateProduct
     | CustomerSubscriptionUpdateSeats
     | CustomerSubscriptionCancel
+    | CustomerSubscriptionPause
+    | CustomerSubscriptionResume
     | CustomerSubscriptionUpdateClear,
     SetSchemaReference("CustomerSubscriptionUpdate"),
 ]

--- a/server/polar/customer_portal/service/subscription.py
+++ b/server/polar/customer_portal/service/subscription.py
@@ -24,6 +24,8 @@ from polar.subscription.service import SubscriptionUpdateContext
 from polar.subscription.service import subscription as subscription_service
 
 from ..schemas.subscription import (
+    CustomerSubscriptionPause,
+    CustomerSubscriptionResume,
     CustomerSubscriptionUpdate,
     CustomerSubscriptionUpdateClear,
     CustomerSubscriptionUpdateProduct,
@@ -43,6 +45,11 @@ class UpdateSubscriptionPlanNotAllowed(CustomerSubscriptionError):
 class UpdateSubscriptionSeatsNotAllowed(CustomerSubscriptionError):
     def __init__(self) -> None:
         super().__init__("Updating subscription seats is not allowed.", 403)
+
+
+class PauseSubscriptionNotAllowed(CustomerSubscriptionError):
+    def __init__(self) -> None:
+        super().__init__("Pausing a subscription is not allowed.", 403)
 
 
 class CustomerSubscriptionSortProperty(StrEnum):
@@ -183,6 +190,30 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
                 return await subscription_service.clear_pending_update(
                     session, ctx, subscription
                 )
+
+        if isinstance(updates, CustomerSubscriptionPause):
+            if not organization.customer_portal_subscription_pause:
+                raise PauseSubscriptionNotAllowed()
+
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                if updates.pause_at_period_end:
+                    return await subscription_service.pause(
+                        session, ctx, subscription, resumes_at=updates.resumes_at
+                    )
+                return await subscription_service.cancel_scheduled_pause(
+                    session, ctx, subscription
+                )
+
+        if isinstance(updates, CustomerSubscriptionResume):
+            if not organization.customer_portal_subscription_pause:
+                raise PauseSubscriptionNotAllowed()
+
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                return await subscription_service.resume(session, ctx, subscription)
 
         cancel = updates.cancel_at_period_end is True
         uncancel = updates.cancel_at_period_end is False

--- a/server/polar/email/schemas.py
+++ b/server/polar/email/schemas.py
@@ -46,6 +46,8 @@ class EmailTemplate(StrEnum):
     subscription_cycled_after_trial = "subscription_cycled_after_trial"
     subscription_final_invoice = "subscription_final_invoice"
     subscription_past_due = "subscription_past_due"
+    subscription_paused = "subscription_paused"
+    subscription_resumed = "subscription_resumed"
     subscription_revoked = "subscription_revoked"
     subscription_uncanceled = "subscription_uncanceled"
     subscription_renewal_reminder = "subscription_renewal_reminder"
@@ -372,6 +374,26 @@ class SubscriptionUncanceledEmail(BaseModel):
     props: SubscriptionUncanceledProps
 
 
+class SubscriptionPausedProps(SubscriptionPropsBase): ...
+
+
+class SubscriptionPausedEmail(BaseModel):
+    template: Literal[EmailTemplate.subscription_paused] = (
+        EmailTemplate.subscription_paused
+    )
+    props: SubscriptionPausedProps
+
+
+class SubscriptionResumedProps(SubscriptionPropsBase): ...
+
+
+class SubscriptionResumedEmail(BaseModel):
+    template: Literal[EmailTemplate.subscription_resumed] = (
+        EmailTemplate.subscription_resumed
+    )
+    props: SubscriptionResumedProps
+
+
 class SubscriptionUpdatedProps(SubscriptionPropsBase):
     order: OrderEmail | None
 
@@ -538,6 +560,8 @@ Email = Annotated[
     | SubscriptionCycledAfterTrialEmail
     | SubscriptionFinalInvoiceEmail
     | SubscriptionPastDueEmail
+    | SubscriptionPausedEmail
+    | SubscriptionResumedEmail
     | SubscriptionRenewalReminderEmail
     | SubscriptionTrialConversionReminderEmail
     | SubscriptionRevokedEmail

--- a/server/polar/event/schemas.py
+++ b/server/polar/event/schemas.py
@@ -35,8 +35,10 @@ from polar.event.system import (
     SubscriptionCreatedMetadata,
     SubscriptionCycledMetadata,
     SubscriptionPastDueMetadata,
+    SubscriptionPausedMetadata,
     SubscriptionProductUpdatedMetadata,
     SubscriptionReactivatedMetadata,
+    SubscriptionResumedMetadata,
     SubscriptionRevokedMetadata,
     SubscriptionSeatsUpdatedMetadata,
     SubscriptionUncanceledMetadata,
@@ -414,6 +416,28 @@ class SubscriptionReactivatedEvent(SystemEventBase):
     )
 
 
+class SubscriptionPausedEvent(SystemEventBase):
+    """An event created by Polar when a subscription is paused."""
+
+    name: Literal[SystemEventEnum.subscription_paused] = Field(
+        description=_NAME_DESCRIPTION
+    )
+    metadata: SubscriptionPausedMetadata = Field(
+        validation_alias=AliasChoices("user_metadata", "metadata")
+    )
+
+
+class SubscriptionResumedEvent(SystemEventBase):
+    """An event created by Polar when a paused subscription is resumed."""
+
+    name: Literal[SystemEventEnum.subscription_resumed] = Field(
+        description=_NAME_DESCRIPTION
+    )
+    metadata: SubscriptionResumedMetadata = Field(
+        validation_alias=AliasChoices("user_metadata", "metadata")
+    )
+
+
 class SubscriptionProductUpdatedEvent(SystemEventBase):
     """An event created by Polar when a subscription changes the product."""
 
@@ -605,6 +629,8 @@ SystemEvent = Annotated[
     | SubscriptionRevokedEvent
     | SubscriptionPastDueEvent
     | SubscriptionReactivatedEvent
+    | SubscriptionPausedEvent
+    | SubscriptionResumedEvent
     | SubscriptionUncanceledEvent
     | SubscriptionProductUpdatedEvent
     | SubscriptionSeatsUpdatedEvent

--- a/server/polar/event/system.py
+++ b/server/polar/event/system.py
@@ -26,6 +26,8 @@ class SystemEvent(StrEnum):
     subscription_revoked = "subscription.revoked"
     subscription_past_due = "subscription.past_due"
     subscription_reactivated = "subscription.reactivated"
+    subscription_paused = "subscription.paused"
+    subscription_resumed = "subscription.resumed"
     subscription_uncanceled = "subscription.uncanceled"
     subscription_product_updated = "subscription.product_updated"
     subscription_seats_updated = "subscription.seats_updated"
@@ -58,6 +60,8 @@ SYSTEM_EVENT_LABELS: dict[str, str] = {
     "subscription.revoked": "Subscription Revoked",
     "subscription.past_due": "Subscription Past Due",
     "subscription.reactivated": "Subscription Reactivated",
+    "subscription.paused": "Subscription Paused",
+    "subscription.resumed": "Subscription Resumed",
     "subscription.uncanceled": "Subscription Uncanceled",
     "subscription.product_updated": "Subscription Product Updated",
     "order.paid": "Order Paid",
@@ -313,6 +317,40 @@ class SubscriptionReactivatedEvent(Event):
         source: Mapped[Literal[EventSource.system]]
         name: Mapped[Literal[SystemEvent.subscription_reactivated]]
         user_metadata: Mapped[SubscriptionReactivatedMetadata]  # type: ignore[assignment]
+
+
+class SubscriptionPausedMetadata(TypedDict):
+    subscription_id: str
+    product_id: NotRequired[str]
+    amount: NotRequired[int]
+    currency: NotRequired[str]
+    recurring_interval: NotRequired[str]
+    recurring_interval_count: NotRequired[int]
+    paused_at: str
+    resumes_at: NotRequired[str]
+
+
+class SubscriptionPausedEvent(Event):
+    if TYPE_CHECKING:
+        source: Mapped[Literal[EventSource.system]]
+        name: Mapped[Literal[SystemEvent.subscription_paused]]
+        user_metadata: Mapped[SubscriptionPausedMetadata]  # type: ignore[assignment]
+
+
+class SubscriptionResumedMetadata(TypedDict):
+    subscription_id: str
+    product_id: NotRequired[str]
+    amount: NotRequired[int]
+    currency: NotRequired[str]
+    recurring_interval: NotRequired[str]
+    recurring_interval_count: NotRequired[int]
+
+
+class SubscriptionResumedEvent(Event):
+    if TYPE_CHECKING:
+        source: Mapped[Literal[EventSource.system]]
+        name: Mapped[Literal[SystemEvent.subscription_resumed]]
+        user_metadata: Mapped[SubscriptionResumedMetadata]  # type: ignore[assignment]
 
 
 class SubscriptionUncanceledMetadata(TypedDict):
@@ -699,6 +737,24 @@ def build_system_event(
     customer: Customer,
     organization: Organization,
     metadata: SubscriptionReactivatedMetadata,
+) -> Event: ...
+
+
+@overload
+def build_system_event(
+    name: Literal[SystemEvent.subscription_paused],
+    customer: Customer,
+    organization: Organization,
+    metadata: SubscriptionPausedMetadata,
+) -> Event: ...
+
+
+@overload
+def build_system_event(
+    name: Literal[SystemEvent.subscription_resumed],
+    customer: Customer,
+    organization: Organization,
+    metadata: SubscriptionResumedMetadata,
 ) -> Event: ...
 
 

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -115,6 +115,8 @@ class OrganizationCustomerEmailSettings(TypedDict):
     subscription_cycled: bool
     subscription_cycled_after_trial: bool
     subscription_past_due: bool
+    subscription_paused: bool
+    subscription_resumed: bool
     subscription_renewal_reminder: bool
     subscription_revoked: bool
     subscription_trial_conversion_reminder: bool
@@ -129,6 +131,8 @@ _default_customer_email_settings: OrganizationCustomerEmailSettings = {
     "subscription_cycled": True,
     "subscription_cycled_after_trial": True,
     "subscription_past_due": True,
+    "subscription_paused": True,
+    "subscription_resumed": True,
     "subscription_renewal_reminder": True,
     "subscription_revoked": True,
     "subscription_trial_conversion_reminder": True,

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -148,6 +148,7 @@ class CustomerPortalUsageSettings(TypedDict):
 class CustomerPortalSubscriptionSettings(TypedDict):
     update_seats: bool
     update_plan: bool
+    pause: NotRequired[bool]
 
 
 class CustomerPortalCustomerSettings(TypedDict):
@@ -811,6 +812,10 @@ class Organization(RateLimitGroupMixin, RecordModel):
         return self.customer_portal_settings.get("subscription", {}).get(
             "update_plan", True
         )
+
+    @property
+    def customer_portal_subscription_pause(self) -> bool:
+        return self.customer_portal_settings.get("subscription", {}).get("pause", False)
 
     @property
     def checkout_require_3ds(self) -> bool:

--- a/server/polar/models/subscription.py
+++ b/server/polar/models/subscription.py
@@ -66,6 +66,7 @@ class SubscriptionStatus(StrEnum):
     past_due = "past_due"
     canceled = "canceled"
     unpaid = "unpaid"
+    paused = "paused"
 
     @classmethod
     def incomplete_statuses(cls) -> set[Self]:
@@ -392,6 +393,15 @@ class Subscription(CustomFieldDataMixin, MetadataMixin, RecordModel):
         )
 
     @hybrid_property
+    def paused(self) -> bool:
+        return self.status == SubscriptionStatus.paused
+
+    @paused.inplace.expression
+    @classmethod
+    def _paused_expression(cls) -> ColumnElement[bool]:
+        return cls.status == SubscriptionStatus.paused
+
+    @hybrid_property
     def canceled(self) -> bool:
         return self.canceled_at is not None
 
@@ -452,6 +462,11 @@ class Subscription(CustomFieldDataMixin, MetadataMixin, RecordModel):
         return cast(cls.past_due_at + total_interval, TIMESTAMP(timezone=True))
 
     def can_cancel(self, immediately: bool = False) -> bool:
+        # A paused subscription isn't billable, but can still be revoked
+        # immediately instead of having to be resumed first.
+        if immediately and self.status == SubscriptionStatus.paused:
+            return self.ended_at is None
+
         if not SubscriptionStatus.is_billable(self.status):
             return False
 
@@ -470,6 +485,22 @@ class Subscription(CustomFieldDataMixin, MetadataMixin, RecordModel):
             self.cancel_at_period_end
             and self.status in SubscriptionStatus.billable_statuses()
         )
+
+    def can_pause(self) -> bool:
+        return (
+            self.status == SubscriptionStatus.active
+            and not self.cancel_at_period_end
+            and not self.pause_at_period_end
+            and self.ends_at is None
+        )
+
+    def can_cancel_scheduled_pause(self) -> bool:
+        return bool(self.pause_at_period_end) and (
+            self.status == SubscriptionStatus.active
+        )
+
+    def can_resume(self) -> bool:
+        return self.status == SubscriptionStatus.paused
 
     def update_amount_and_currency(
         self, prices: Sequence["SubscriptionProductPrice"], discount: "Discount | None"

--- a/server/polar/models/webhook_endpoint.py
+++ b/server/polar/models/webhook_endpoint.py
@@ -37,6 +37,8 @@ class WebhookEventType(StrEnum):
     subscription_uncanceled = "subscription.uncanceled"
     subscription_revoked = "subscription.revoked"
     subscription_past_due = "subscription.past_due"
+    subscription_paused = "subscription.paused"
+    subscription_resumed = "subscription.resumed"
     refund_created = "refund.created"
     refund_updated = "refund.updated"
     product_created = "product.created"

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -36,6 +36,7 @@ from polar.models.organization import (
     OrganizationCustomerPortalSettings,
     OrganizationStatus,
     OrganizationSubscriptionSettings,
+    _default_customer_email_settings,
 )
 from polar.models.organization_review import OrganizationReview
 from polar.models.support_case import ReviewAppealSupportCase
@@ -320,6 +321,20 @@ class OrganizationSocialLink(Schema):
         return data
 
 
+def _merge_customer_email_settings_defaults(value: Any) -> Any:
+    """Complete stored settings with defaults so reads tolerate keys added after
+    an organization's settings were last written (lazy materialization)."""
+    if isinstance(value, dict):
+        return {**_default_customer_email_settings, **value}
+    return value
+
+
+CustomerEmailSettings = Annotated[
+    OrganizationCustomerEmailSettings,
+    BeforeValidator(_merge_customer_email_settings_defaults),
+]
+
+
 class OrganizationBase(IDSchema, TimestampedSchema):
     name: str = Field(
         description="Organization name shown in checkout, customer portal, emails etc.",
@@ -407,7 +422,7 @@ class OrganizationPublicBase(OrganizationBase):
 
     feature_settings: SkipJsonSchema[OrganizationFeatureSettings | None]
     subscription_settings: SkipJsonSchema[OrganizationSubscriptionSettings]
-    customer_email_settings: SkipJsonSchema[OrganizationCustomerEmailSettings]
+    customer_email_settings: SkipJsonSchema[CustomerEmailSettings]
 
 
 class Organization(OrganizationBase):
@@ -442,7 +457,7 @@ class Organization(OrganizationBase):
     subscription_settings: OrganizationSubscriptionSettings = Field(
         description="Settings related to subscriptions management",
     )
-    customer_email_settings: OrganizationCustomerEmailSettings = Field(
+    customer_email_settings: CustomerEmailSettings = Field(
         description="Settings related to customer emails",
     )
     customer_portal_settings: OrganizationCustomerPortalSettings = Field(

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -316,11 +316,30 @@ class SubscriptionRepository(
             .where(
                 Subscription.status == SubscriptionStatus.active,
                 Subscription.cancel_at_period_end.is_(False),
+                Subscription.pause_at_period_end.is_(False),
                 Subscription.current_period_end.isnot(None),
                 Subscription.current_period_end > now,
                 Subscription.current_period_end <= reminder_window_end,
                 long_cycle_condition,
                 ~dedup_subquery,
+            )
+            .options(*options)
+        )
+        return await self.get_all(statement)
+
+    async def get_subscriptions_to_resume(
+        self,
+        now: datetime,
+        *,
+        options: Options = (),
+    ) -> Sequence[Subscription]:
+        """Find paused subscriptions whose scheduled resume time has passed."""
+        statement = (
+            self.get_base_statement()
+            .where(
+                Subscription.status == SubscriptionStatus.paused,
+                Subscription.resumes_at.isnot(None),
+                Subscription.resumes_at <= now,
             )
             .options(*options)
         )

--- a/server/polar/subscription/schemas.py
+++ b/server/polar/subscription/schemas.py
@@ -133,8 +133,7 @@ class SubscriptionBase(IDSchema, TimestampedSchema):
     )
     pause_at_period_end: bool = Field(
         description=(
-            "Whether the subscription will be paused "
-            "at the end of the current period."
+            "Whether the subscription will be paused at the end of the current period."
         )
     )
     paused_at: datetime | None = Field(

--- a/server/polar/subscription/schemas.py
+++ b/server/polar/subscription/schemas.py
@@ -131,6 +131,23 @@ class SubscriptionBase(IDSchema, TimestampedSchema):
         None,
         description=("The timestamp when the subscription entered `past_due` status."),
     )
+    pause_at_period_end: bool = Field(
+        description=(
+            "Whether the subscription will be paused "
+            "at the end of the current period."
+        )
+    )
+    paused_at: datetime | None = Field(
+        None,
+        description="The timestamp when the subscription was paused.",
+    )
+    resumes_at: datetime | None = Field(
+        None,
+        description=(
+            "The timestamp when a paused subscription is scheduled to "
+            "automatically resume, if set."
+        ),
+    )
 
     customer_id: UUID4 = Field(description="The ID of the subscribed customer.")
     product_id: UUID4 = Field(description="The ID of the subscribed product.")
@@ -435,6 +452,43 @@ class SubscriptionRevoke(SubscriptionCancelBase):
     )
 
 
+class SubscriptionPause(Schema):
+    model_config = ConfigDict(extra="forbid")
+
+    pause_at_period_end: bool = Field(
+        description=inspect.cleandoc(
+            """
+        Pause an active subscription at the end of the current period.
+
+        Or cancel a scheduled pause on a subscription set to be paused at
+        period end.
+        """
+        ),
+    )
+    resumes_at: FutureDatetime | None = Field(
+        None,
+        description=inspect.cleandoc(
+            """
+        Date at which the paused subscription should automatically resume.
+
+        If not set, the subscription stays paused until it is resumed manually.
+        Must be after the current period end.
+        """
+        ),
+    )
+
+
+class SubscriptionResume(Schema):
+    model_config = ConfigDict(extra="forbid")
+
+    resume: Literal[True] = Field(
+        description=(
+            "Resume a paused subscription immediately, "
+            "starting a new billing period and charging the customer."
+        )
+    )
+
+
 class SubscriptionUpdateClear(Schema):
     model_config = ConfigDict(extra="forbid")
 
@@ -449,6 +503,8 @@ SubscriptionUpdate = Annotated[
     | SubscriptionUpdateBillingPeriod
     | SubscriptionCancel
     | SubscriptionRevoke
+    | SubscriptionPause
+    | SubscriptionResume
     | SubscriptionUpdateClear,
     SetSchemaReference("SubscriptionUpdate"),
 ]

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -40,8 +40,8 @@ from polar.event.system import (
     SubscriptionCanceledMetadata,
     SubscriptionCreatedMetadata,
     SubscriptionCycledMetadata,
-    SubscriptionPausedMetadata,
     SubscriptionPastDueMetadata,
+    SubscriptionPausedMetadata,
     SubscriptionReactivatedMetadata,
     SubscriptionResumedMetadata,
     SubscriptionRevokedMetadata,
@@ -1930,6 +1930,12 @@ class SubscriptionService:
         subscription.pause_at_period_end = True
         subscription.resumes_at = resumes_at
         session.add(subscription)
+
+        # Notify the customer at request time, while the subscription is still
+        # active until the end of the current period.
+        # The actual`paused` transition happens later in `cycle()`.
+        await self.send_paused_email(session, subscription)
+
         return subscription
 
     async def cancel_scheduled_pause(
@@ -2463,6 +2469,8 @@ class SubscriptionService:
             ),
         )
 
+        await self.send_resumed_email(session, subscription)
+
     async def _on_subscription_past_due(
         self, session: AsyncSession, subscription: Subscription
     ) -> None:
@@ -2811,6 +2819,26 @@ class SubscriptionService:
             template_name="subscription_past_due",
         )
 
+    async def send_paused_email(
+        self, session: AsyncSession, subscription: Subscription
+    ) -> None:
+        return await self._send_customer_email(
+            session,
+            subscription,
+            subject_template="Your {product.name} subscription is paused",
+            template_name="subscription_paused",
+        )
+
+    async def send_resumed_email(
+        self, session: AsyncSession, subscription: Subscription
+    ) -> None:
+        return await self._send_customer_email(
+            session,
+            subscription,
+            subject_template="Your {product.name} subscription has resumed",
+            template_name="subscription_resumed",
+        )
+
     async def send_subscription_updated_email(
         self,
         session: AsyncSession,
@@ -2882,6 +2910,8 @@ class SubscriptionService:
         template_name: Literal[
             "subscription_cancellation",
             "subscription_past_due",
+            "subscription_paused",
+            "subscription_resumed",
             "subscription_renewal_reminder",
             "subscription_revoked",
             "subscription_trial_conversion_reminder",
@@ -2907,7 +2937,10 @@ class SubscriptionService:
         )
         assert organization is not None
 
-        if not organization.customer_email_settings[template_name]:
+        # Read-default to enabled: the key is absent from the stored settings of
+        # organizations created before this template existed, and is materialized
+        # only when an admin next edits their notification settings.
+        if not organization.customer_email_settings.get(template_name, True):
             return
 
         customer = subscription.customer

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -40,8 +40,10 @@ from polar.event.system import (
     SubscriptionCanceledMetadata,
     SubscriptionCreatedMetadata,
     SubscriptionCycledMetadata,
+    SubscriptionPausedMetadata,
     SubscriptionPastDueMetadata,
     SubscriptionReactivatedMetadata,
+    SubscriptionResumedMetadata,
     SubscriptionRevokedMetadata,
     SubscriptionUncanceledMetadata,
     SubscriptionUpdatedMetadataFields,
@@ -2303,11 +2305,22 @@ class SubscriptionService:
     ) -> None:
         await self._on_subscription_updated(session, subscription)
 
-        became_activated = subscription.active and not SubscriptionStatus.is_active(
-            previous_status
+        became_resumed = (
+            subscription.active and previous_status == SubscriptionStatus.paused
+        )
+        # A resume re-activates the subscription but is not a first activation:
+        # exclude it so the "new subscription" notification isn't sent again.
+        became_activated = (
+            subscription.active
+            and not SubscriptionStatus.is_active(previous_status)
+            and not became_resumed
         )
         became_reactivated = (
             became_activated and previous_status == SubscriptionStatus.past_due
+        )
+        became_paused = (
+            subscription.status == SubscriptionStatus.paused
+            and previous_status != SubscriptionStatus.paused
         )
         became_past_due = (
             subscription.status == SubscriptionStatus.past_due
@@ -2323,6 +2336,12 @@ class SubscriptionService:
             await self._on_subscription_activated(
                 session, subscription, became_reactivated
             )
+
+        if became_paused:
+            await self._on_subscription_paused(session, subscription)
+
+        if became_resumed:
+            await self._on_subscription_resumed(session, subscription)
 
         if became_uncanceled:
             await self._on_subscription_uncanceled(session, subscription)
@@ -2389,6 +2408,60 @@ class SubscriptionService:
                     ),
                 ),
             )
+
+    async def _on_subscription_paused(
+        self, session: AsyncSession, subscription: Subscription
+    ) -> None:
+        await self._send_webhook(
+            session, subscription, WebhookEventType.subscription_paused
+        )
+
+        assert subscription.paused_at is not None
+        metadata = SubscriptionPausedMetadata(
+            subscription_id=str(subscription.id),
+            product_id=str(subscription.product_id),
+            amount=subscription.amount,
+            currency=subscription.currency,
+            recurring_interval=subscription.recurring_interval.value,
+            recurring_interval_count=subscription.recurring_interval_count,
+            paused_at=subscription.paused_at.isoformat(),
+        )
+        if subscription.resumes_at is not None:
+            metadata["resumes_at"] = subscription.resumes_at.isoformat()
+
+        await event_service.create_event(
+            session,
+            build_system_event(
+                SystemEvent.subscription_paused,
+                customer=subscription.customer,
+                organization=subscription.organization,
+                metadata=metadata,
+            ),
+        )
+
+    async def _on_subscription_resumed(
+        self, session: AsyncSession, subscription: Subscription
+    ) -> None:
+        await self._send_webhook(
+            session, subscription, WebhookEventType.subscription_resumed
+        )
+
+        await event_service.create_event(
+            session,
+            build_system_event(
+                SystemEvent.subscription_resumed,
+                customer=subscription.customer,
+                organization=subscription.organization,
+                metadata=SubscriptionResumedMetadata(
+                    subscription_id=str(subscription.id),
+                    product_id=str(subscription.product_id),
+                    amount=subscription.amount,
+                    currency=subscription.currency,
+                    recurring_interval=subscription.recurring_interval.value,
+                    recurring_interval_count=subscription.recurring_interval_count,
+                ),
+            ),
+        )
 
     async def _on_subscription_past_due(
         self, session: AsyncSession, subscription: Subscription
@@ -2566,6 +2639,8 @@ class SubscriptionService:
             WebhookEventType.subscription_uncanceled,
             WebhookEventType.subscription_revoked,
             WebhookEventType.subscription_past_due,
+            WebhookEventType.subscription_paused,
+            WebhookEventType.subscription_resumed,
         ],
     ) -> None:
         repository = SubscriptionRepository.from_session(session)

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -798,6 +798,21 @@ class SubscriptionService:
             return subscription
 
         revoke = subscription.cancel_at_period_end
+
+        # Subscription is due to pause: it enters the paused state at the end of
+        # its current period instead of renewing. Benefits are revoked and no
+        # order is created; a scheduled or manual resume starts a new period. A
+        # scheduled cancellation takes precedence over a scheduled pause.
+        if not revoke and subscription.pause_at_period_end:
+            subscription.status = SubscriptionStatus.paused
+            subscription.paused_at = utc_now()
+            subscription.pause_at_period_end = False
+            await self.enqueue_benefits_grants(session, subscription)
+            repository = SubscriptionRepository.from_session(session)
+            return await repository.update(
+                subscription, update_dict={"scheduler_locked_at": None}
+            )
+
         previous_status = subscription.status
         previous_canceled = subscription.canceled
 

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -115,6 +115,8 @@ from .schemas import (
     SubscriptionChargePreviewProration,
     SubscriptionCreate,
     SubscriptionCreateCustomer,
+    SubscriptionPause,
+    SubscriptionResume,
     SubscriptionRevoke,
     SubscriptionUpdate,
     SubscriptionUpdateBase,
@@ -174,6 +176,27 @@ class SubscriptionLocked(SubscriptionError):
     def __init__(self, subscription: Subscription) -> None:
         self.subscription = subscription
         message = "This subscription is pending an update."
+        super().__init__(message, 409)
+
+
+class CannotPauseSubscription(SubscriptionError):
+    def __init__(self, subscription: Subscription) -> None:
+        self.subscription = subscription
+        message = "This subscription cannot be paused."
+        super().__init__(message, 409)
+
+
+class NoScheduledPause(SubscriptionError):
+    def __init__(self, subscription: Subscription) -> None:
+        self.subscription = subscription
+        message = "This subscription is not scheduled to be paused."
+        super().__init__(message, 409)
+
+
+class NotPausedSubscription(SubscriptionError):
+    def __init__(self, subscription: Subscription) -> None:
+        self.subscription = subscription
+        message = "This subscription is not paused."
         super().__init__(message, 409)
 
 
@@ -1105,6 +1128,19 @@ class SubscriptionService:
                 immediately=True,
             )
 
+        if isinstance(update, SubscriptionPause):
+            if update.pause_at_period_end:
+                subscription = await self.pause(
+                    session, ctx, subscription, resumes_at=update.resumes_at
+                )
+            else:
+                subscription = await self.cancel_scheduled_pause(
+                    session, ctx, subscription
+                )
+
+        if isinstance(update, SubscriptionResume):
+            subscription = await self.resume(session, ctx, subscription)
+
         if isinstance(update, SubscriptionUpdateClear):
             subscription = await self.clear_pending_update(session, ctx, subscription)
 
@@ -1850,6 +1886,91 @@ class SubscriptionService:
             customer_reason=customer_reason,
             customer_comment=customer_comment,
         )
+
+    async def pause(
+        self,
+        session: AsyncSession,
+        ctx: SubscriptionUpdateContext,
+        subscription: Subscription,
+        *,
+        resumes_at: datetime | None = None,
+    ) -> Subscription:
+        if not subscription.can_pause():
+            raise CannotPauseSubscription(subscription)
+
+        if resumes_at is not None and resumes_at <= subscription.current_period_end:
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "resumes_at"),
+                        "msg": "resumes_at must be after the current period end.",
+                        "input": resumes_at,
+                    }
+                ]
+            )
+
+        subscription.pause_at_period_end = True
+        subscription.resumes_at = resumes_at
+        session.add(subscription)
+        return subscription
+
+    async def cancel_scheduled_pause(
+        self,
+        session: AsyncSession,
+        ctx: SubscriptionUpdateContext,
+        subscription: Subscription,
+    ) -> Subscription:
+        if not subscription.can_cancel_scheduled_pause():
+            raise NoScheduledPause(subscription)
+
+        subscription.pause_at_period_end = False
+        subscription.resumes_at = None
+        session.add(subscription)
+        return subscription
+
+    async def resume(
+        self,
+        session: AsyncSession,
+        ctx: SubscriptionUpdateContext,
+        subscription: Subscription,
+    ) -> Subscription:
+        if not subscription.can_resume():
+            raise NotPausedSubscription(subscription)
+
+        now = utc_now()
+        subscription.status = SubscriptionStatus.active
+        subscription.paused_at = None
+        subscription.resumes_at = None
+
+        # Start a fresh billing period from now and charge immediately.
+        subscription.current_period_start = now
+        subscription.anchor_day = now.day
+        subscription.current_period_end = (
+            subscription.recurring_interval.get_next_period(
+                now, subscription.anchor_day, subscription.recurring_interval_count
+            )
+        )
+        subscription.initialize_meter_period(now)
+
+        await self.enqueue_benefits_grants(session, subscription)
+        await self._create_cycle_billing_entries(session, subscription)
+
+        repository = SubscriptionRepository.from_session(session)
+        subscription = await repository.update(subscription)
+
+        enqueue_job(
+            "order.create_subscription_order",
+            subscription.id,
+            OrderBillingReasonInternal.subscription_cycle,
+        )
+
+        log.info(
+            "subscription.resumed",
+            id=subscription.id,
+            current_period_end=subscription.current_period_end,
+        )
+        return subscription
 
     async def cancel_customer(
         self, session: AsyncSession, customer_id: uuid.UUID

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -857,49 +857,7 @@ class SubscriptionService:
                 ):
                     subscription.discount = None
 
-            event = event = await event_service.create_event(
-                session,
-                build_system_event(
-                    SystemEvent.subscription_cycled,
-                    customer=subscription.customer,
-                    organization=subscription.organization,
-                    metadata=SubscriptionCycledMetadata(
-                        subscription_id=str(subscription.id),
-                        product_id=str(subscription.product_id),
-                        amount=subscription.amount,
-                        currency=subscription.currency,
-                        recurring_interval=subscription.recurring_interval.value,
-                        recurring_interval_count=subscription.recurring_interval_count,
-                    ),
-                ),
-            )
-            # Add a billing entry for a new period
-            billing_entry_repository = BillingEntryRepository.from_session(session)
-            for subscription_product_price in subscription.subscription_product_prices:
-                product_price = subscription_product_price.product_price
-                if is_static_price(product_price):
-                    discount_amount = 0
-                    if subscription.discount:
-                        discount_amount = subscription.discount.get_discount_amount(
-                            subscription_product_price.amount, subscription.currency
-                        )
-
-                    await billing_entry_repository.create(
-                        BillingEntry(
-                            start_timestamp=subscription.current_period_start,
-                            end_timestamp=subscription.current_period_end,
-                            type=BillingEntryType.cycle,
-                            direction=BillingEntryDirection.debit,
-                            amount=subscription_product_price.amount,
-                            currency=subscription.currency,
-                            customer=subscription.customer,
-                            product_price=product_price,
-                            discount=subscription.discount,
-                            discount_amount=discount_amount,
-                            subscription=subscription,
-                            event=event,
-                        ),
-                    )
+            await self._create_cycle_billing_entries(session, subscription)
 
         if previous_status == SubscriptionStatus.trialing:
             subscription.status = SubscriptionStatus.active
@@ -930,6 +888,53 @@ class SubscriptionService:
         )
 
         return subscription
+
+    async def _create_cycle_billing_entries(
+        self, session: AsyncSession, subscription: Subscription
+    ) -> None:
+        event = event = await event_service.create_event(
+            session,
+            build_system_event(
+                SystemEvent.subscription_cycled,
+                customer=subscription.customer,
+                organization=subscription.organization,
+                metadata=SubscriptionCycledMetadata(
+                    subscription_id=str(subscription.id),
+                    product_id=str(subscription.product_id),
+                    amount=subscription.amount,
+                    currency=subscription.currency,
+                    recurring_interval=subscription.recurring_interval.value,
+                    recurring_interval_count=subscription.recurring_interval_count,
+                ),
+            ),
+        )
+        # Add a billing entry for a new period
+        billing_entry_repository = BillingEntryRepository.from_session(session)
+        for subscription_product_price in subscription.subscription_product_prices:
+            product_price = subscription_product_price.product_price
+            if is_static_price(product_price):
+                discount_amount = 0
+                if subscription.discount:
+                    discount_amount = subscription.discount.get_discount_amount(
+                        subscription_product_price.amount, subscription.currency
+                    )
+
+                await billing_entry_repository.create(
+                    BillingEntry(
+                        start_timestamp=subscription.current_period_start,
+                        end_timestamp=subscription.current_period_end,
+                        type=BillingEntryType.cycle,
+                        direction=BillingEntryDirection.debit,
+                        amount=subscription_product_price.amount,
+                        currency=subscription.currency,
+                        customer=subscription.customer,
+                        product_price=product_price,
+                        discount=subscription.discount,
+                        discount_amount=discount_amount,
+                        subscription=subscription,
+                        event=event,
+                    ),
+                )
 
     async def reset_meters(
         self, session: AsyncSession, subscription: Subscription

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -892,7 +892,7 @@ class SubscriptionService:
     async def _create_cycle_billing_entries(
         self, session: AsyncSession, subscription: Subscription
     ) -> None:
-        event = event = await event_service.create_event(
+        event = await event_service.create_event(
             session,
             build_system_event(
                 SystemEvent.subscription_cycled,

--- a/server/polar/subscription/tasks.py
+++ b/server/polar/subscription/tasks.py
@@ -150,6 +150,47 @@ async def subscription_cancel_customer(customer_id: uuid.UUID) -> None:
 
 
 @actor(
+    actor_name="subscription.scan_paused_resumptions",
+    cron_trigger=CronTrigger.from_crontab("15 * * * *"),
+    priority=TaskPriority.LOW,
+)
+async def scan_paused_resumptions() -> None:
+    """Scan for paused subscriptions due to resume and fan out."""
+    now = utc_now()
+    async with AsyncSessionMaker() as session:
+        repository = SubscriptionRepository.from_session(session)
+        subscriptions = await repository.get_subscriptions_to_resume(now)
+
+    for sub in subscriptions:
+        enqueue_job("subscription.resume", sub.id)
+
+
+@actor(actor_name="subscription.resume", priority=TaskPriority.MEDIUM)
+async def subscription_resume(subscription_id: uuid.UUID) -> None:
+    async with AsyncSessionMaker() as session:
+        repository = SubscriptionRepository.from_session(session)
+        subscription = await repository.get_by_id(
+            subscription_id,
+            options=repository.get_eager_options(),
+            for_update=True,
+        )
+        if subscription is None:
+            raise SubscriptionDoesNotExist(subscription_id)
+
+        if not subscription.can_resume():
+            log.info(
+                "Subscription is no longer paused, skipping resume",
+                subscription_id=subscription_id,
+            )
+            return
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.resume(session, ctx, subscription)
+
+
+@actor(
     actor_name="subscription.scan_renewal_reminders",
     cron_trigger=CronTrigger.from_crontab("30 * * * *"),
     priority=TaskPriority.LOW,

--- a/server/polar/webhook/service.py
+++ b/server/polar/webhook/service.py
@@ -684,6 +684,24 @@ class WebhookService:
         self,
         session: AsyncSession,
         target: Organization,
+        event: Literal[WebhookEventType.subscription_paused],
+        data: Subscription,
+    ) -> list[WebhookEvent]: ...
+
+    @overload
+    async def send(
+        self,
+        session: AsyncSession,
+        target: Organization,
+        event: Literal[WebhookEventType.subscription_resumed],
+        data: Subscription,
+    ) -> list[WebhookEvent]: ...
+
+    @overload
+    async def send(
+        self,
+        session: AsyncSession,
+        target: Organization,
         event: Literal[WebhookEventType.refund_created],
         data: Refund,
     ) -> list[WebhookEvent]: ...

--- a/server/polar/webhook/webhooks.py
+++ b/server/polar/webhook/webhooks.py
@@ -682,8 +682,91 @@ class WebhookSubscriptionUpdatedPayloadBase(BaseWebhookPayload):
         | Literal[WebhookEventType.subscription_uncanceled]
         | Literal[WebhookEventType.subscription_revoked]
         | Literal[WebhookEventType.subscription_past_due]
+        | Literal[WebhookEventType.subscription_paused]
+        | Literal[WebhookEventType.subscription_resumed]
     )
     data: SubscriptionSchema
+
+    def _get_paused_discord_payload(self, target: User | Organization) -> str:
+        fields = self._get_discord_fields(target)
+        if self.data.resumes_at:
+            fields.append(
+                {
+                    "name": "Resumes At",
+                    "value": format_date(self.data.resumes_at, locale="en_US"),
+                }
+            )
+        payload: DiscordPayload = {
+            "content": "Subscription has been paused.",
+            "embeds": [
+                get_branded_discord_embed(
+                    {
+                        "title": "Paused Subscription",
+                        "description": "Subscription has been paused.",
+                        "fields": fields,
+                    }
+                )
+            ],
+        }
+
+        return json.dumps(payload)
+
+    def _get_paused_slack_payload(self, target: User | Organization) -> str:
+        fields = self._get_slack_fields(target)
+        payload: SlackPayload = get_branded_slack_payload(
+            {
+                "text": "Subscription has been paused.",
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "Subscription has been paused.",
+                        },
+                        "fields": fields,
+                    }
+                ],
+            }
+        )
+
+        return json.dumps(payload)
+
+    def _get_resumed_discord_payload(self, target: User | Organization) -> str:
+        fields = self._get_discord_fields(target)
+        payload: DiscordPayload = {
+            "content": "Subscription has resumed.",
+            "embeds": [
+                get_branded_discord_embed(
+                    {
+                        "title": "Resumed Subscription",
+                        "description": "Subscription has resumed.",
+                        "fields": fields,
+                    }
+                )
+            ],
+        }
+
+        return json.dumps(payload)
+
+    def _get_resumed_slack_payload(self, target: User | Organization) -> str:
+        fields = self._get_slack_fields(target)
+        payload: SlackPayload = get_branded_slack_payload(
+            {
+                "text": "Subscription has resumed.",
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "Subscription has resumed.",
+                        },
+                        "fields": fields,
+                    }
+                ],
+            }
+        )
+
+        return json.dumps(payload)
 
     def _get_active_discord_payload(self, target: User | Organization) -> str:
         fields = self._get_discord_fields(target)
@@ -1085,6 +1168,57 @@ class WebhookSubscriptionPastDuePayload(WebhookSubscriptionUpdatedPayloadBase):
         return self._get_past_due_slack_payload(target)
 
 
+class WebhookSubscriptionPausedPayload(WebhookSubscriptionUpdatedPayloadBase):
+    """
+    Sent when a subscription is paused and the customer temporarily loses access.
+
+    No order is created while paused. The subscription resumes either on its
+    scheduled resume date or when resumed manually, starting a new billing period.
+
+    **Discord & Slack support:** Full
+    """
+
+    type: Literal[WebhookEventType.subscription_paused]
+    data: SubscriptionSchema
+
+    def get_discord_payload(self, target: User | Organization) -> str:
+        if isinstance(target, User):
+            raise UnsupportedTarget(target, self.__class__, WebhookFormat.discord)
+
+        return self._get_paused_discord_payload(target)
+
+    def get_slack_payload(self, target: User | Organization) -> str:
+        if isinstance(target, User):
+            raise UnsupportedTarget(target, self.__class__, WebhookFormat.slack)
+
+        return self._get_paused_slack_payload(target)
+
+
+class WebhookSubscriptionResumedPayload(WebhookSubscriptionUpdatedPayloadBase):
+    """
+    Sent when a paused subscription resumes, restoring the customer's access.
+
+    Resuming starts a new billing period and charges the customer immediately.
+
+    **Discord & Slack support:** Full
+    """
+
+    type: Literal[WebhookEventType.subscription_resumed]
+    data: SubscriptionSchema
+
+    def get_discord_payload(self, target: User | Organization) -> str:
+        if isinstance(target, User):
+            raise UnsupportedTarget(target, self.__class__, WebhookFormat.discord)
+
+        return self._get_resumed_discord_payload(target)
+
+    def get_slack_payload(self, target: User | Organization) -> str:
+        if isinstance(target, User):
+            raise UnsupportedTarget(target, self.__class__, WebhookFormat.slack)
+
+        return self._get_resumed_slack_payload(target)
+
+
 class WebhookRefundBase(BaseWebhookPayload):
     """
     Base Refund
@@ -1340,6 +1474,8 @@ WebhookPayload = Annotated[
     | WebhookSubscriptionUncanceledPayload
     | WebhookSubscriptionRevokedPayload
     | WebhookSubscriptionPastDuePayload
+    | WebhookSubscriptionPausedPayload
+    | WebhookSubscriptionResumedPayload
     | WebhookRefundCreatedPayload
     | WebhookRefundUpdatedPayload
     | WebhookProductCreatedPayload

--- a/server/scripts/seeds_load.py
+++ b/server/scripts/seeds_load.py
@@ -1590,6 +1590,8 @@ async def create_seed_data(
                 "subscription_trial_conversion_reminder": False,
                 "subscription_uncanceled": False,
                 "subscription_updated": False,
+                "subscription_paused": False,
+                "subscription_resumed": False,
             },
             "products": [],
         },

--- a/server/tests/customer_portal/service/test_subscription.py
+++ b/server/tests/customer_portal/service/test_subscription.py
@@ -5,11 +5,14 @@ import pytest
 
 from polar.auth.models import AuthSubject
 from polar.customer_portal.schemas.subscription import (
+    CustomerSubscriptionPause,
+    CustomerSubscriptionResume,
     CustomerSubscriptionUpdateClear,
     CustomerSubscriptionUpdateProduct,
     CustomerSubscriptionUpdateSeats,
 )
 from polar.customer_portal.service.subscription import (
+    PauseSubscriptionNotAllowed,
     UpdateSubscriptionPlanNotAllowed,
     UpdateSubscriptionSeatsNotAllowed,
 )
@@ -450,3 +453,73 @@ class TestClearPendingUpdate:
         assert errors[0]["type"] == "value_error"
         assert errors[0]["loc"] == ("body", "pending_update")
         assert "no pending update" in errors[0]["msg"]
+
+
+@pytest.mark.asyncio
+class TestUpdatePause:
+    async def test_pause_not_allowed(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        with pytest.raises(PauseSubscriptionNotAllowed):
+            await customer_subscription_service.update(
+                session,
+                subscription,
+                updates=CustomerSubscriptionPause(pause_at_period_end=True),
+            )
+
+    async def test_pause_allowed(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        organization.customer_portal_settings = {
+            **organization.customer_portal_settings,
+            "subscription": {
+                **organization.customer_portal_settings["subscription"],
+                "pause": True,
+            },
+        }
+        await save_fixture(organization)
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        updated = await customer_subscription_service.update(
+            session,
+            subscription,
+            updates=CustomerSubscriptionPause(pause_at_period_end=True),
+        )
+
+        assert updated.pause_at_period_end is True
+
+    async def test_resume_not_allowed(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+
+        with pytest.raises(PauseSubscriptionNotAllowed):
+            await customer_subscription_service.update(
+                session,
+                subscription,
+                updates=CustomerSubscriptionResume(resume=True),
+            )

--- a/server/tests/subscription/test_endpoints.py
+++ b/server/tests/subscription/test_endpoints.py
@@ -1404,3 +1404,155 @@ class TestGetChargePreview:
         )
 
         assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestSubscriptionUpdatePause:
+    async def test_anonymous(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        response = await client.patch(
+            f"/v1/subscriptions/{subscription.id}",
+            json={"pause_at_period_end": True},
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_valid(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        current_period_end = utc_now() + timedelta(days=30)
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            current_period_end=current_period_end,
+        )
+        resumes_at = current_period_end + timedelta(days=30)
+
+        response = await client.patch(
+            f"/v1/subscriptions/{subscription.id}",
+            json={
+                "pause_at_period_end": True,
+                "resumes_at": resumes_at.isoformat(),
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == SubscriptionStatus.active
+        assert data["pause_at_period_end"] is True
+        assert data["resumes_at"] is not None
+
+    @pytest.mark.auth
+    async def test_cancel_scheduled_pause(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        subscription.pause_at_period_end = True
+        subscription.resumes_at = utc_now() + timedelta(days=30)
+        await save_fixture(subscription)
+
+        response = await client.patch(
+            f"/v1/subscriptions/{subscription.id}",
+            json={"pause_at_period_end": False},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pause_at_period_end"] is False
+        assert data["resumes_at"] is None
+
+    @pytest.mark.auth
+    async def test_not_pausable(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            started_at=utc_now(),
+            status=SubscriptionStatus.past_due,
+        )
+
+        response = await client.patch(
+            f"/v1/subscriptions/{subscription.id}",
+            json={"pause_at_period_end": True},
+        )
+
+        assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+class TestSubscriptionUpdateResume:
+    @pytest.mark.auth
+    async def test_valid(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            started_at=utc_now(),
+            status=SubscriptionStatus.paused,
+        )
+        subscription.paused_at = utc_now() - timedelta(days=10)
+        await save_fixture(subscription)
+
+        response = await client.patch(
+            f"/v1/subscriptions/{subscription.id}",
+            json={"resume": True},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == SubscriptionStatus.active
+
+    @pytest.mark.auth
+    async def test_not_paused(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        response = await client.patch(
+            f"/v1/subscriptions/{subscription.id}",
+            json={"resume": True},
+        )
+
+        assert response.status_code == 409

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -86,10 +86,13 @@ from polar.subscription.service import (
     AboveMaximumSeats,
     AlreadyCanceledSubscription,
     BelowMinimumSeats,
+    CannotPauseSubscription,
     InactiveSubscription,
     MissingCheckoutCustomer,
+    NoScheduledPause,
     NotARecurringProduct,
     NotASeatBasedSubscription,
+    NotPausedSubscription,
     SeatsAlreadyAssigned,
     SubscriptionUpdateContext,
 )
@@ -118,7 +121,9 @@ from tests.fixtures.random_objects import (
     set_product_benefits,
 )
 
-Hooks = namedtuple("Hooks", "updated activated canceled uncanceled revoked")
+Hooks = namedtuple(
+    "Hooks", "updated activated canceled uncanceled revoked paused resumed"
+)
 HookNames = frozenset(Hooks._fields)
 
 
@@ -190,12 +195,16 @@ def subscription_hooks(mocker: MockerFixture) -> Hooks:
         subscription_service, "_on_subscription_uncanceled"
     )
     revoked = mocker.patch.object(subscription_service, "_on_subscription_revoked")
+    paused = mocker.patch.object(subscription_service, "_on_subscription_paused")
+    resumed = mocker.patch.object(subscription_service, "_on_subscription_resumed")
     return Hooks(
         updated=updated,
         activated=activated,
         canceled=canceled,
         uncanceled=uncanceled,
         revoked=revoked,
+        paused=paused,
+        resumed=resumed,
     )
 
 
@@ -2300,6 +2309,288 @@ class TestUncancel:
         assert updated_subscription.cancel_at_period_end is False
         assert updated_subscription.ends_at is None
         assert updated_subscription.canceled_at is None
+
+
+@pytest.mark.asyncio
+class TestPause:
+    async def test_not_active(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.past_due,
+        )
+
+        with pytest.raises(CannotPauseSubscription):
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.pause(session, ctx, subscription)
+
+    async def test_scheduled_to_cancel(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            cancel_at_period_end=True,
+        )
+
+        with pytest.raises(CannotPauseSubscription):
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.pause(session, ctx, subscription)
+
+    async def test_resumes_at_before_period_end(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        mocker.patch.object(subscription_service, "send_paused_email")
+        current_period_end = utc_now() + timedelta(days=30)
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            current_period_end=current_period_end,
+        )
+
+        with pytest.raises(PolarRequestValidationError):
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.pause(
+                    session,
+                    ctx,
+                    subscription,
+                    resumes_at=current_period_end - timedelta(days=1),
+                )
+
+    async def test_valid(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        enqueue_benefits_grants_mock: MagicMock,
+        subscription_hooks: Hooks,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        send_paused_email_mock = mocker.patch.object(
+            subscription_service, "send_paused_email"
+        )
+        current_period_end = utc_now() + timedelta(days=30)
+        resumes_at = current_period_end + timedelta(days=30)
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            current_period_end=current_period_end,
+        )
+        reset_hooks(subscription_hooks)
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.pause(
+                session, ctx, subscription, resumes_at=resumes_at
+            )
+
+        # Still active until the end of the current period, only scheduled to pause.
+        assert updated.status == SubscriptionStatus.active
+        assert updated.pause_at_period_end is True
+        assert updated.resumes_at == resumes_at
+        assert updated.paused_at is None
+        # Benefits stay granted; the customer is notified at request time.
+        enqueue_benefits_grants_mock.assert_not_called()
+        send_paused_email_mock.assert_called_once()
+        assert_hooks_called_once(subscription_hooks, {"updated"})
+
+    async def test_valid_indefinite(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        mocker.patch.object(subscription_service, "send_paused_email")
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.pause(session, ctx, subscription)
+
+        assert updated.pause_at_period_end is True
+        assert updated.resumes_at is None
+
+    async def test_cycle_pauses_at_period_end(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        enqueue_job_mock: MagicMock,
+        enqueue_benefits_grants_mock: MagicMock,
+        subscription_hooks: Hooks,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            scheduler_locked_at=utc_now(),
+        )
+        subscription.pause_at_period_end = True
+        subscription.resumes_at = utc_now() + timedelta(days=60)
+        await save_fixture(subscription)
+        reset_hooks(subscription_hooks)
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.cycle(session, ctx, subscription)
+
+        assert updated.status == SubscriptionStatus.paused
+        assert updated.paused_at is not None
+        assert updated.pause_at_period_end is False
+        assert updated.scheduler_locked_at is None
+        # Benefits revoked, no order created for the paused period.
+        enqueue_benefits_grants_mock.assert_called_once_with(session, updated)
+        order_calls = [
+            call
+            for call in enqueue_job_mock.call_args_list
+            if call.args and call.args[0] == "order.create_subscription_order"
+        ]
+        assert order_calls == []
+        assert_hooks_called_once(subscription_hooks, {"updated", "paused"})
+
+
+@pytest.mark.asyncio
+class TestCancelScheduledPause:
+    async def test_not_scheduled(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        with pytest.raises(NoScheduledPause):
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.cancel_scheduled_pause(
+                    session, ctx, subscription
+                )
+
+    async def test_valid(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        subscription_hooks: Hooks,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        subscription.pause_at_period_end = True
+        subscription.resumes_at = utc_now() + timedelta(days=30)
+        await save_fixture(subscription)
+        reset_hooks(subscription_hooks)
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.cancel_scheduled_pause(
+                session, ctx, subscription
+            )
+
+        assert updated.status == SubscriptionStatus.active
+        assert updated.pause_at_period_end is False
+        assert updated.resumes_at is None
+        assert_hooks_called_once(subscription_hooks, {"updated"})
+
+
+@pytest.mark.asyncio
+class TestResume:
+    async def test_not_paused(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        with pytest.raises(NotPausedSubscription):
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.resume(session, ctx, subscription)
+
+    async def test_valid(
+        self,
+        frozen_time: datetime,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        enqueue_job_mock: MagicMock,
+        enqueue_benefits_grants_mock: MagicMock,
+        subscription_hooks: Hooks,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+        subscription.paused_at = frozen_time - timedelta(days=10)
+        subscription.resumes_at = frozen_time
+        await save_fixture(subscription)
+        reset_hooks(subscription_hooks)
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.resume(session, ctx, subscription)
+
+        # A fresh billing period starts now and the customer is charged.
+        assert updated.status == SubscriptionStatus.active
+        assert updated.paused_at is None
+        assert updated.resumes_at is None
+        assert updated.current_period_start == frozen_time
+        assert updated.current_period_end is not None
+        assert updated.current_period_end > frozen_time
+        enqueue_benefits_grants_mock.assert_called_once_with(session, updated)
+        enqueue_job_mock.assert_any_call(
+            "order.create_subscription_order", subscription.id, ANY
+        )
+        assert_hooks_called_once(subscription_hooks, {"updated", "resumed"})
 
 
 async def create_event_billing_entry(

--- a/server/tests/subscription/test_tasks.py
+++ b/server/tests/subscription/test_tasks.py
@@ -1,8 +1,10 @@
 import uuid
+from datetime import timedelta
 
 import pytest
 from pytest_mock import MockerFixture
 
+from polar.kit.utils import utc_now
 from polar.models import Customer, Organization, Product, Subscription
 from polar.models.organization import OrganizationStatus
 from polar.models.subscription import SubscriptionStatus
@@ -11,8 +13,10 @@ from polar.subscription.service import SubscriptionService
 from polar.subscription.tasks import (  # type: ignore[attr-defined]
     SubscriptionDoesNotExist,
     SubscriptionTierDoesNotExist,
+    scan_paused_resumptions,
     subscription_cancel_for_organization,
     subscription_enqueue_benefits_grants,
+    subscription_resume,
     subscription_service,
     subscription_update_product_benefits_grants,
 )
@@ -146,3 +150,100 @@ class TestSubscriptionEnqueueBenefitsGrants:
         await subscription_enqueue_benefits_grants(subscription.id)
 
         enqueue_benefits_grants_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+class TestScanPausedResumptions:
+    async def test_enqueues_only_due_subscriptions(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        now = utc_now()
+        due = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+        due.resumes_at = now - timedelta(hours=1)
+        await save_fixture(due)
+
+        not_yet_due = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+        not_yet_due.resumes_at = now + timedelta(days=1)
+        await save_fixture(not_yet_due)
+
+        # Paused indefinitely (no resumes_at) — never auto-resumed.
+        await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+
+        enqueue_job_mock = mocker.patch("polar.subscription.tasks.enqueue_job")
+        session.expunge_all()
+
+        await scan_paused_resumptions()
+
+        enqueue_job_mock.assert_called_once_with("subscription.resume", due.id)
+
+
+@pytest.mark.asyncio
+class TestSubscriptionResume:
+    async def test_not_existing_subscription(self, session: AsyncSession) -> None:
+        session.expunge_all()
+
+        with pytest.raises(SubscriptionDoesNotExist):
+            await subscription_resume(uuid.uuid4())
+
+    async def test_paused_subscription_is_resumed(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+        resume_mock = mocker.patch.object(
+            subscription_service, "resume", spec=SubscriptionService.resume
+        )
+        session.expunge_all()
+
+        await subscription_resume(subscription.id)
+
+        resume_mock.assert_called_once()
+
+    async def test_not_paused_subscription_is_skipped(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        resume_mock = mocker.patch.object(
+            subscription_service, "resume", spec=SubscriptionService.resume
+        )
+        session.expunge_all()
+
+        await subscription_resume(subscription.id)
+
+        resume_mock.assert_not_called()


### PR DESCRIPTION
## Summary

**Related Issue**: https://github.com/polarsource/feedback/issues/120


Implements native pause/resume for subscriptions, so merchants and customers can pause instead of churning.

**Model** — Adds a paused subscription status and drives pausing off the pause columns (`pause_at_period_end`, `paused_at`, `resumes_at`, shipped separately). paused is kept out of the active/billable/revoked status sets, so benefits, the billing scheduler and dunning exclude paused subscriptions automatically.

**Behaviour (skip-cycle, at period end)** — Pausing schedules `pause_at_period_end` while the subscription stays active until the end of the current paid period. At the next cycle it transitions to paused: benefits are revoked and no order is created. Resuming (automatically on resumes_at, or manually/early) starts a fresh billing period from now, re-grants benefits and charges immediately. A scheduled pause can be cancelled before it takes effect, and a scheduled cancellation takes precedence over a scheduled pause.

**API & scope** — Merchant PATCH `/v1/subscriptions/{id}` gains `pause_at_period_end` (schedule, or false to cancel the schedule) and resume. The customer portal exposes the same operations, gated by a new opt-in customer_portal_subscription_pause organization setting.

**Notifications** — New subscription.paused / subscription.resumed webhooks (plus system events and Discord/Slack payloads). A pause email is sent at request time (it states access continues until the current period end and that no charge is made) and a resume email on resume; both are toggleable in customer notification settings.

| Pause email | Resume email | Notification settings |
|:---:|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/98bb5f8c-fa10-4cbc-ab47-0472345fa60f" width="320" /> | <img src="https://github.com/user-attachments/assets/b5ddf095-7ece-4beb-ad62-ab8176be67ce" width="320" /> | <img src="https://github.com/user-attachments/assets/b09377d9-10f7-4bd9-ac79-fd02aaad9b45" width="320" /> |


**Auto-resume** — An hourly `subscription.scan_paused_resumptions` cron resumes subscriptions whose `resumes_at` has passed; early/manual resume goes through the API.

**Tests** — Service, endpoint, task and customer-portal coverage.

Follow-ups in separate PRs: the frontend UI (merchant dropdown/modal, customer-portal button, status badges), and preserving license keys across revoke→re-grant.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

