### PR TITLE
orbit: fix alert color

### DIFF
--- a/clients/packages/orbit/src/components/Alert.tsx
+++ b/clients/packages/orbit/src/components/Alert.tsx
@@ -13,7 +13,6 @@ import { ButtonGroup, type ButtonGroupActions } from './ButtonGroup'
 import { Grid } from './Grid'
 import { GridItem } from './GridItem'
 import { Text, type TextColor } from './Text'
-import type { BackgroundColorToken } from '../tokens/semantics.stylex'
 
 export type AlertVariant = 'info' | 'warning' | 'danger' | 'success'
 
@@ -23,28 +22,23 @@ const variantStyles: Record<
   AlertVariant,
   {
     icon: LucideIcon
-    backgroundColor: BackgroundColorToken
     accentColor: TextColor
   }
 > = {
   info: {
     icon: Info,
-    backgroundColor: 'background-card',
     accentColor: 'default',
   },
   warning: {
     icon: TriangleAlert,
-    backgroundColor: 'background-warning',
     accentColor: 'warning',
   },
   danger: {
     icon: CircleAlert,
-    backgroundColor: 'background-danger',
     accentColor: 'danger',
   },
   success: {
     icon: CircleCheck,
-    backgroundColor: 'background-success',
     accentColor: 'success',
   },
 }
@@ -108,11 +102,7 @@ export const Alert = ({
   onDismiss,
   actions,
 }: AlertProps) => {
-  const {
-    icon: VariantIcon,
-    backgroundColor,
-    accentColor,
-  } = variantStyles[variant]
+  const { icon: VariantIcon, accentColor } = variantStyles[variant]
   const Icon = loading ? LoaderCircle : VariantIcon
 
   return (
@@ -121,7 +111,7 @@ export const Alert = ({
       columnGap="m"
       rowGap="xs"
       alignItems="center"
-      backgroundColor={backgroundColor}
+      backgroundColor="background-card"
       borderRadius="s"
       paddingVertical="l"
       paddingHorizontal="xl"
@@ -159,9 +149,7 @@ export const Alert = ({
       )}
       {description && (
         <GridItem colStart={2}>
-          <Text color={accentColor === 'default' ? 'muted' : accentColor}>
-            {description}
-          </Text>
+          <Text color="muted">{description}</Text>
         </GridItem>
       )}
       {actions && (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardizes `Alert` colors in `orbit` for better readability and consistency. All variants now use the card background and muted description text while keeping variant accent for icon/title.

- **Bug Fixes**
  - Set backgroundColor to "background-card" for all variants.
  - Always render description with color="muted"; removed per-variant background logic and unused types.

<sup>Written for commit 8e8ccddd941045ea0b274064ae10dc30f5b07e37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

