### PR TITLE
feat(merchant-migration): persist canonical records to the ledger

### DIFF
--- a/server/polar/merchant_migration/canonical.py
+++ b/server/polar/merchant_migration/canonical.py
@@ -137,49 +137,51 @@ def deserialize(
     """Rebuild a canonical record from a stored ``canonical`` dict, the inverse
     of ``serialize``. Lets consumers work off the staged ledger instead of
     re-reading the source."""
-    if type == MerchantMigrationRecordType.product:
-        return CanonicalProduct(
-            source_id=data["source_id"],
-            product_source_id=data["product_source_id"],
-            name=data["name"],
-            recurring_interval=data["recurring_interval"],
-            recurring_interval_count=data["recurring_interval_count"],
-            prices=[
-                CanonicalPrice(
-                    source_id=price["source_id"],
-                    currency=price["currency"],
-                    amount=price["amount"],
-                    pricing_scheme=CanonicalPricingScheme(price["pricing_scheme"]),
-                )
-                for price in data["prices"]
-            ],
-        )
-    if type == MerchantMigrationRecordType.customer:
-        return CanonicalCustomer(
-            source_id=data["source_id"],
-            email=data["email"],
-            name=data["name"],
-            country=data["country"],
-        )
-    if type == MerchantMigrationRecordType.subscription:
-        payment_method = data["payment_method"]
-        return CanonicalSubscription(
-            source_id=data["source_id"],
-            customer_source_id=data["customer_source_id"],
-            price_source_id=data["price_source_id"],
-            status=CanonicalSubscriptionStatus(data["status"]),
-            collection_method=CanonicalCollectionMethod(data["collection_method"]),
-            current_period_start=_parse_datetime(data["current_period_start"]),
-            current_period_end=_parse_datetime(data["current_period_end"]),
-            trialing=data["trialing"],
-            paused_collection=data["paused_collection"],
-            line_item_count=data["line_item_count"],
-            quantity=data["quantity"],
-            payment_method=CanonicalPaymentMethod(
-                source_id=payment_method["source_id"],
-                type=CanonicalPaymentMethodType(payment_method["type"]),
+    match type:
+        case MerchantMigrationRecordType.product:
+            return CanonicalProduct(
+                source_id=data["source_id"],
+                product_source_id=data["product_source_id"],
+                name=data["name"],
+                recurring_interval=data["recurring_interval"],
+                recurring_interval_count=data["recurring_interval_count"],
+                prices=[
+                    CanonicalPrice(
+                        source_id=price["source_id"],
+                        currency=price["currency"],
+                        amount=price["amount"],
+                        pricing_scheme=CanonicalPricingScheme(price["pricing_scheme"]),
+                    )
+                    for price in data["prices"]
+                ],
             )
-            if payment_method is not None
-            else None,
-        )
-    raise ValueError(f"Cannot deserialize record of type {type}")
+        case MerchantMigrationRecordType.customer:
+            return CanonicalCustomer(
+                source_id=data["source_id"],
+                email=data["email"],
+                name=data["name"],
+                country=data["country"],
+            )
+        case MerchantMigrationRecordType.subscription:
+            payment_method = data["payment_method"]
+            return CanonicalSubscription(
+                source_id=data["source_id"],
+                customer_source_id=data["customer_source_id"],
+                price_source_id=data["price_source_id"],
+                status=CanonicalSubscriptionStatus(data["status"]),
+                collection_method=CanonicalCollectionMethod(data["collection_method"]),
+                current_period_start=_parse_datetime(data["current_period_start"]),
+                current_period_end=_parse_datetime(data["current_period_end"]),
+                trialing=data["trialing"],
+                paused_collection=data["paused_collection"],
+                line_item_count=data["line_item_count"],
+                quantity=data["quantity"],
+                payment_method=CanonicalPaymentMethod(
+                    source_id=payment_method["source_id"],
+                    type=CanonicalPaymentMethodType(payment_method["type"]),
+                )
+                if payment_method is not None
+                else None,
+            )
+        case _:
+            raise ValueError(f"Cannot deserialize record of type {type}")

--- a/server/polar/merchant_migration/canonical.py
+++ b/server/polar/merchant_migration/canonical.py
@@ -4,6 +4,9 @@ engine and importer don't need to know which billing provider data came from."""
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
+from typing import Any
+
+from fastapi.encoders import jsonable_encoder
 
 from polar.models.merchant_migration_record import MerchantMigrationRecordType
 
@@ -116,3 +119,67 @@ class CanonicalAccount:
 
 
 CanonicalRecord = CanonicalProduct | CanonicalCustomer | CanonicalSubscription
+
+
+def serialize(record: CanonicalRecord) -> dict[str, Any]:
+    """JSON-safe dict for the ``canonical`` column; the DB serializer can't
+    encode the ``CanonicalSubscription`` datetimes on its own."""
+    return jsonable_encoder(record)
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    return datetime.fromisoformat(value) if value else None
+
+
+def deserialize(
+    type: MerchantMigrationRecordType, data: dict[str, Any]
+) -> CanonicalRecord:
+    """Rebuild a canonical record from a stored ``canonical`` dict, the inverse
+    of ``serialize``. Lets consumers work off the staged ledger instead of
+    re-reading the source."""
+    if type == MerchantMigrationRecordType.product:
+        return CanonicalProduct(
+            source_id=data["source_id"],
+            product_source_id=data["product_source_id"],
+            name=data["name"],
+            recurring_interval=data["recurring_interval"],
+            recurring_interval_count=data["recurring_interval_count"],
+            prices=[
+                CanonicalPrice(
+                    source_id=price["source_id"],
+                    currency=price["currency"],
+                    amount=price["amount"],
+                    pricing_scheme=CanonicalPricingScheme(price["pricing_scheme"]),
+                )
+                for price in data["prices"]
+            ],
+        )
+    if type == MerchantMigrationRecordType.customer:
+        return CanonicalCustomer(
+            source_id=data["source_id"],
+            email=data["email"],
+            name=data["name"],
+            country=data["country"],
+        )
+    if type == MerchantMigrationRecordType.subscription:
+        payment_method = data["payment_method"]
+        return CanonicalSubscription(
+            source_id=data["source_id"],
+            customer_source_id=data["customer_source_id"],
+            price_source_id=data["price_source_id"],
+            status=CanonicalSubscriptionStatus(data["status"]),
+            collection_method=CanonicalCollectionMethod(data["collection_method"]),
+            current_period_start=_parse_datetime(data["current_period_start"]),
+            current_period_end=_parse_datetime(data["current_period_end"]),
+            trialing=data["trialing"],
+            paused_collection=data["paused_collection"],
+            line_item_count=data["line_item_count"],
+            quantity=data["quantity"],
+            payment_method=CanonicalPaymentMethod(
+                source_id=payment_method["source_id"],
+                type=CanonicalPaymentMethodType(payment_method["type"]),
+            )
+            if payment_method is not None
+            else None,
+        )
+    raise ValueError(f"Cannot deserialize record of type {type}")

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from uuid import UUID
 
 from sqlalchemy import Select
@@ -9,7 +10,13 @@ from polar.kit.repository import (
     RepositorySoftDeletionIDMixin,
     RepositorySoftDeletionMixin,
 )
-from polar.models import MerchantMigration
+from polar.models import MerchantMigration, MerchantMigrationRecord
+from polar.models.merchant_migration_record import (
+    MerchantMigrationRecordStatus,
+    MerchantMigrationRecordType,
+)
+
+from .canonical import CanonicalRecord, serialize
 
 
 class MerchantMigrationRepository(
@@ -34,3 +41,70 @@ class MerchantMigrationRepository(
                 MerchantMigration.organization_id == auth_subject.subject.id
             )
         return statement
+
+
+class MerchantMigrationRecordRepository(
+    RepositorySoftDeletionIDMixin[MerchantMigrationRecord, UUID],
+    RepositorySoftDeletionMixin[MerchantMigrationRecord],
+    RepositoryBase[MerchantMigrationRecord],
+):
+    model = MerchantMigrationRecord
+
+    async def get_by_source(
+        self,
+        *,
+        organization_id: UUID,
+        type: MerchantMigrationRecordType,
+        source_id: str,
+    ) -> MerchantMigrationRecord | None:
+        statement = self.get_base_statement().where(
+            MerchantMigrationRecord.organization_id == organization_id,
+            MerchantMigrationRecord.type == type,
+            MerchantMigrationRecord.source_id == source_id,
+        )
+        return await self.get_one_or_none(statement)
+
+    async def list_by_migration(
+        self, migration_id: UUID
+    ) -> Sequence[MerchantMigrationRecord]:
+        statement = self.get_base_statement().where(
+            MerchantMigrationRecord.merchant_migration_id == migration_id
+        )
+        return await self.get_all(statement)
+
+    async def upsert(
+        self,
+        merchant_migration: MerchantMigration,
+        organization: Organization,
+        record: CanonicalRecord,
+    ) -> MerchantMigrationRecord:
+        """Idempotently stage a record, keyed per org by (type, source_id). A
+        re-run refreshes a still-pending row; imported/skipped/failed rows are
+        left as-is so a prior run's results aren't re-imported."""
+        existing = await self.get_by_source(
+            organization_id=organization.id,
+            type=record.type,
+            source_id=record.source_id,
+        )
+        canonical = serialize(record)
+        if existing is not None:
+            if existing.status == MerchantMigrationRecordStatus.pending:
+                return await self.update(
+                    existing,
+                    update_dict={
+                        "canonical": canonical,
+                        "merchant_migration_id": merchant_migration.id,
+                    },
+                    flush=True,
+                )
+            return existing
+        return await self.create(
+            MerchantMigrationRecord(
+                merchant_migration=merchant_migration,
+                organization=organization,
+                type=record.type,
+                source_id=record.source_id,
+                canonical=canonical,
+            ),
+            flush=True,
+        )

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -1,4 +1,4 @@
-from collections.abc import Sequence
+from collections.abc import AsyncIterator, Sequence
 from dataclasses import dataclass
 from typing import Any, Literal, TypedDict
 from uuid import UUID
@@ -23,8 +23,12 @@ from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncReadSession
 
 from .adapters import SourceAdapter, StripeAdapter
+from .canonical import CanonicalRecord, deserialize
 from .precheck import classify_records, precheck_engine
-from .repository import MerchantMigrationRepository
+from .repository import (
+    MerchantMigrationRecordRepository,
+    MerchantMigrationRepository,
+)
 from .schemas import (
     MerchantMigrationCreate,
     MerchantMigrationRecordItem,
@@ -197,8 +201,13 @@ class MerchantMigrationService:
 
         adapter = await self._build_adapter(session, migration)
         source_account = await adapter.get_source_account()
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
         report = await precheck_engine.run(
-            adapter.extract(), organization, source_account
+            self._stage_records(
+                record_repository, migration, organization, adapter.extract()
+            ),
+            organization,
+            source_account,
         )
 
         await repository.update(
@@ -216,8 +225,9 @@ class MerchantMigrationService:
         status: PrecheckRecordStatus | None,
         pagination: PaginationParams,
     ) -> tuple[Sequence[MerchantMigrationRecordItem], int]:
-        """Read the connected source on demand and return the records of one
-        entity type, classified importable/skipped and paginated in memory."""
+        """Return the records of one entity type from the staged ledger,
+        classified importable/skipped and paginated in memory. Reads what
+        ``run_precheck`` persisted, so it never re-reads the source."""
         repository = MerchantMigrationRepository.from_session(session)
         statement = repository.get_readable_statement(auth_subject).where(
             MerchantMigration.id == migration_id
@@ -232,14 +242,28 @@ class MerchantMigrationService:
             OrganizationPermission.organization_manage,
         )
 
-        adapter = await self._build_adapter(session, migration)
-        records = [record async for record in adapter.extract()]
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        staged = await record_repository.list_by_migration(migration.id)
+        records = [deserialize(record.type, record.canonical) for record in staged]
         items = classify_records(records, entity)
         if status is not None:
             items = [item for item in items if item.status == status]
 
         start = (pagination.page - 1) * pagination.limit
         return items[start : start + pagination.limit], len(items)
+
+    async def _stage_records(
+        self,
+        record_repository: MerchantMigrationRecordRepository,
+        migration: MerchantMigration,
+        organization: Organization,
+        records: AsyncIterator[CanonicalRecord],
+    ) -> AsyncIterator[CanonicalRecord]:
+        """Stage each record as it streams past, so we persist the catalog in
+        the same single pass the precheck reads (extraction stays incremental)."""
+        async for record in records:
+            await record_repository.upsert(migration, organization, record)
+            yield record
 
     async def _build_adapter(
         self, session: AsyncSession, migration: MerchantMigration

--- a/server/tests/merchant_migration/test_canonical.py
+++ b/server/tests/merchant_migration/test_canonical.py
@@ -1,0 +1,94 @@
+from datetime import UTC, datetime
+
+from polar.merchant_migration.canonical import (
+    CanonicalCollectionMethod,
+    CanonicalCustomer,
+    CanonicalPaymentMethod,
+    CanonicalPaymentMethodType,
+    CanonicalPrice,
+    CanonicalPricingScheme,
+    CanonicalProduct,
+    CanonicalSubscription,
+    CanonicalSubscriptionStatus,
+    serialize,
+)
+
+
+class TestSerialize:
+    def test_product_flattens_nested_prices_and_enums(self) -> None:
+        product = CanonicalProduct(
+            source_id="prod_1:month:1",
+            product_source_id="prod_1",
+            name="Pro",
+            recurring_interval="month",
+            recurring_interval_count=1,
+            prices=[
+                CanonicalPrice(
+                    source_id="price_1",
+                    currency="usd",
+                    amount=1000,
+                    pricing_scheme=CanonicalPricingScheme.fixed,
+                )
+            ],
+        )
+
+        result = serialize(product)
+
+        assert result == {
+            "source_id": "prod_1:month:1",
+            "product_source_id": "prod_1",
+            "name": "Pro",
+            "recurring_interval": "month",
+            "recurring_interval_count": 1,
+            "prices": [
+                {
+                    "source_id": "price_1",
+                    "currency": "usd",
+                    "amount": 1000,
+                    "pricing_scheme": "fixed",
+                }
+            ],
+        }
+        # the pricing_scheme is a plain string, not a StrEnum instance
+        assert type(result["prices"][0]["pricing_scheme"]) is str
+        # `type` is a class attribute, not a field, so it isn't serialized
+        assert "type" not in result
+
+    def test_subscription_datetimes_become_iso_strings(self) -> None:
+        subscription = CanonicalSubscription(
+            source_id="sub_1",
+            customer_source_id="cus_1",
+            price_source_id="price_1",
+            status=CanonicalSubscriptionStatus.active,
+            collection_method=CanonicalCollectionMethod.charge_automatically,
+            current_period_start=datetime(2026, 1, 1, tzinfo=UTC),
+            current_period_end=datetime(2026, 2, 1, tzinfo=UTC),
+            trialing=False,
+            paused_collection=False,
+            line_item_count=1,
+            quantity=1,
+            payment_method=CanonicalPaymentMethod(
+                source_id="pm_1", type=CanonicalPaymentMethodType.card
+            ),
+        )
+
+        result = serialize(subscription)
+
+        assert result["current_period_start"] == "2026-01-01T00:00:00+00:00"
+        assert result["current_period_end"] == "2026-02-01T00:00:00+00:00"
+        assert result["status"] == "active"
+        assert result["payment_method"] == {"source_id": "pm_1", "type": "card"}
+
+    def test_optional_fields_stay_none(self) -> None:
+        customer = CanonicalCustomer(
+            source_id="cus_1", email="a@example.com", name=None, country=None
+        )
+
+        result = serialize(customer)
+
+        assert result == {
+            "source_id": "cus_1",
+            "email": "a@example.com",
+            "name": None,
+            "country": None,
+        }

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -475,6 +475,11 @@ class TestRecords:
             params={"state": state, "code": "ac_test"},
         )
 
+        precheck = await client.post(
+            f"/v1/merchant-migrations/{migration.id}/precheck"
+        )
+        assert precheck.status_code == 200
+
         response = await client.get(
             f"/v1/merchant-migrations/{migration.id}/records",
             params={"entity": "products"},

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -475,9 +475,7 @@ class TestRecords:
             params={"state": state, "code": "ac_test"},
         )
 
-        precheck = await client.post(
-            f"/v1/merchant-migrations/{migration.id}/precheck"
-        )
+        precheck = await client.post(f"/v1/merchant-migrations/{migration.id}/precheck")
         assert precheck.status_code == 200
 
         response = await client.get(

--- a/server/tests/merchant_migration/test_repository.py
+++ b/server/tests/merchant_migration/test_repository.py
@@ -1,0 +1,185 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from polar.merchant_migration.canonical import (
+    CanonicalCollectionMethod,
+    CanonicalCustomer,
+    CanonicalPaymentMethod,
+    CanonicalPaymentMethodType,
+    CanonicalSubscription,
+    CanonicalSubscriptionStatus,
+)
+from polar.merchant_migration.repository import MerchantMigrationRecordRepository
+from polar.models import MerchantMigration, Organization
+from polar.models.merchant_migration import (
+    MerchantMigrationSourcePlatform,
+    MerchantMigrationStep,
+)
+from polar.models.merchant_migration_record import (
+    MerchantMigrationRecordStatus,
+    MerchantMigrationRecordType,
+)
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+
+
+async def _create_migration(
+    save_fixture: SaveFixture, organization: Organization
+) -> MerchantMigration:
+    migration = MerchantMigration(
+        organization_id=organization.id,
+        source_platform=MerchantMigrationSourcePlatform.stripe,
+        step=MerchantMigrationStep.source_setup,
+    )
+    await save_fixture(migration)
+    return migration
+
+
+@pytest.mark.asyncio
+class TestUpsert:
+    async def test_creates_pending_record_with_canonical(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        migration = await _create_migration(save_fixture, organization)
+        repository = MerchantMigrationRecordRepository.from_session(session)
+
+        record = await repository.upsert(
+            migration,
+            organization,
+            CanonicalCustomer(
+                source_id="cus_1", email="a@example.com", name="A", country="US"
+            ),
+        )
+
+        assert record.organization_id == organization.id
+        assert record.merchant_migration_id == migration.id
+        assert record.type == MerchantMigrationRecordType.customer
+        assert record.source_id == "cus_1"
+        assert record.status == MerchantMigrationRecordStatus.pending
+        assert record.canonical["email"] == "a@example.com"
+        assert record.canonical["country"] == "US"
+
+    async def test_stores_subscription_datetimes_through_jsonb(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        migration = await _create_migration(save_fixture, organization)
+        repository = MerchantMigrationRecordRepository.from_session(session)
+
+        record = await repository.upsert(
+            migration,
+            organization,
+            CanonicalSubscription(
+                source_id="sub_1",
+                customer_source_id="cus_1",
+                price_source_id="price_1",
+                status=CanonicalSubscriptionStatus.active,
+                collection_method=CanonicalCollectionMethod.charge_automatically,
+                current_period_start=datetime(2026, 1, 1, tzinfo=UTC),
+                current_period_end=datetime(2026, 2, 1, tzinfo=UTC),
+                trialing=False,
+                paused_collection=False,
+                line_item_count=1,
+                quantity=1,
+                payment_method=CanonicalPaymentMethod(
+                    source_id="pm_1", type=CanonicalPaymentMethodType.card
+                ),
+            ),
+        )
+        await session.flush()
+        session.expunge(record)
+
+        reloaded = await repository.get_by_source(
+            organization_id=organization.id,
+            type=MerchantMigrationRecordType.subscription,
+            source_id="sub_1",
+        )
+        assert reloaded is not None
+        # datetimes round-trip through JSONB as ISO strings
+        assert reloaded.canonical["current_period_start"] == "2026-01-01T00:00:00+00:00"
+        assert reloaded.canonical["payment_method"]["type"] == "card"
+
+    async def test_is_idempotent_per_source(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        migration = await _create_migration(save_fixture, organization)
+        repository = MerchantMigrationRecordRepository.from_session(session)
+        customer = CanonicalCustomer(
+            source_id="cus_1", email="a@example.com", name="A", country="US"
+        )
+
+        first = await repository.upsert(migration, organization, customer)
+        second = await repository.upsert(
+            migration,
+            organization,
+            CanonicalCustomer(
+                source_id="cus_1", email="new@example.com", name="A", country="US"
+            ),
+        )
+
+        assert first.id == second.id
+        # a still-pending record gets its snapshot refreshed
+        assert second.canonical["email"] == "new@example.com"
+
+        all_records = await repository.get_all(repository.get_base_statement())
+        assert len(all_records) == 1
+
+    async def test_leaves_already_imported_record_untouched(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        migration = await _create_migration(save_fixture, organization)
+        repository = MerchantMigrationRecordRepository.from_session(session)
+        customer = CanonicalCustomer(
+            source_id="cus_1", email="a@example.com", name="A", country="US"
+        )
+        record = await repository.upsert(migration, organization, customer)
+        await repository.update(
+            record,
+            update_dict={"status": MerchantMigrationRecordStatus.imported},
+        )
+
+        result = await repository.upsert(
+            migration,
+            organization,
+            CanonicalCustomer(
+                source_id="cus_1", email="new@example.com", name="A", country="US"
+            ),
+        )
+
+        assert result.status == MerchantMigrationRecordStatus.imported
+        # the imported snapshot is preserved, not overwritten by a re-run
+        assert result.canonical["email"] == "a@example.com"
+
+    async def test_repoints_pending_record_to_the_current_migration(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        first_migration = await _create_migration(save_fixture, organization)
+        second_migration = await _create_migration(save_fixture, organization)
+        repository = MerchantMigrationRecordRepository.from_session(session)
+        customer = CanonicalCustomer(
+            source_id="cus_1", email="a@example.com", name="A", country="US"
+        )
+
+        await repository.upsert(first_migration, organization, customer)
+        reused = await repository.upsert(second_migration, organization, customer)
+
+        # a second migration reusing a still-pending record takes ownership,
+        # rather than leaving it linked to the abandoned first migration
+        assert reused.merchant_migration_id == second_migration.id
+        all_records = await repository.get_all(repository.get_base_statement())
+        assert len(all_records) == 1

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -15,7 +15,10 @@ from polar.merchant_migration.canonical import (
     CanonicalProduct,
     CanonicalRecord,
 )
-from polar.merchant_migration.repository import MerchantMigrationRepository
+from polar.merchant_migration.repository import (
+    MerchantMigrationRecordRepository,
+    MerchantMigrationRepository,
+)
 from polar.merchant_migration.schemas import (
     MerchantMigrationCreate,
     PrecheckEntity,
@@ -262,6 +265,16 @@ class TestRunPrecheck:
         # the rotated refresh token is re-persisted as fresh ciphertext
         assert updated.source_credentials["refresh_token_encrypted"] != old_ciphertext
 
+        # the extracted canonical records are staged in the ledger
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        records = await record_repository.get_all(
+            record_repository.get_base_statement()
+        )
+        assert len(records) == 1
+        assert records[0].source_id == "prod_1:month:1"
+        assert records[0].merchant_migration_id == migration.id
+        assert records[0].canonical["name"] == "Pro"
+
     @pytest.mark.auth
     async def test_source_not_connected(
         self,
@@ -358,6 +371,7 @@ class TestListRecords:
             return_value=_FakeAdapter(_catalog()),
         )
 
+        await service.run_precheck(session, auth_subject, migration.id)
         items, count = await service.list_records(
             session,
             auth_subject,
@@ -390,6 +404,7 @@ class TestListRecords:
             return_value=_FakeAdapter(_catalog()),
         )
 
+        await service.run_precheck(session, auth_subject, migration.id)
         items, count = await service.list_records(
             session,
             auth_subject,


### PR DESCRIPTION
## Summary

Persist normalized canonical records to the `merchant_migration_records` during precheck, so we don't check again and again.

## What

- Add `serialize()` for canonical dataclasses, producing a JSON-safe dict via `jsonable_encoder` (datetimes to ISO strings, enums to values) for the `canonical` JSONB column.
- Add `MerchantMigrationRecordRepository` with an idempotent `upsert`, keyed per organization by `(type, source_id)`.
- `run_precheck` now stages each record as it streams to the precheck engine, in the same single incremental pass.


## How

Re-running a migration refreshes a `pending` snapshot and re-points it at the current migration, while leaving `imported`/`skipped`/`failed` records untouched, so a prior run's results are never re-imported.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

