### PR TITLE
feat(subscription): add paused status

### DIFF
--- a/clients/apps/app/app/(authenticated)/subscriptions/[id]/index.tsx
+++ b/clients/apps/app/app/(authenticated)/subscriptions/[id]/index.tsx
@@ -25,6 +25,7 @@ const statusColors = {
   past_due: 'red',
   trialing: 'blue',
   unpaid: 'yellow',
+  paused: 'yellow',
 } as const
 
 export default function Index() {

--- a/clients/apps/app/components/Subscriptions/SubscriptionRow.tsx
+++ b/clients/apps/app/components/Subscriptions/SubscriptionRow.tsx
@@ -20,6 +20,7 @@ const subscriptionStatusColors: Record<
   incomplete: 'yellow',
   incomplete_expired: 'red',
   unpaid: 'yellow',
+  paused: 'yellow',
 }
 
 export interface SubscriptionRowProps {

--- a/clients/apps/web/src/components/Customer/CustomerContextView.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerContextView.tsx
@@ -155,6 +155,7 @@ const STATUS_DISPLAY_NAMES: Record<schemas['SubscriptionStatus'], string> = {
   active: 'Active',
   trialing: 'Trialing',
   past_due: 'Past Due',
+  paused: 'Paused',
   unpaid: 'Unpaid',
   canceled: 'Canceled',
   incomplete: 'Incomplete',
@@ -165,10 +166,11 @@ const STATUS_ORDER: Record<schemas['SubscriptionStatus'], number> = {
   active: 0,
   trialing: 1,
   past_due: 2,
-  unpaid: 3,
-  incomplete: 4,
-  canceled: 5,
-  incomplete_expired: 6,
+  paused: 3,
+  unpaid: 4,
+  incomplete: 5,
+  canceled: 6,
+  incomplete_expired: 7,
 }
 
 const INTERVAL_LABELS: Record<schemas['RecurringInterval'], string> = {

--- a/clients/apps/web/src/components/Subscriptions/utils.tsx
+++ b/clients/apps/web/src/components/Subscriptions/utils.tsx
@@ -11,6 +11,7 @@ export const subscriptionStatusDisplayNames: {
   trialing: 'Trialing',
   active: 'Active',
   past_due: 'Past due',
+  paused: 'Paused',
   canceled: 'Canceled',
   unpaid: 'Unpaid',
 }

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -32249,6 +32249,7 @@ export interface components {
       | 'past_due'
       | 'canceled'
       | 'unpaid'
+      | 'paused'
     /**
      * SubscriptionUncanceledEvent
      * @description An event created by Polar when a subscription cancellation is reversed.
@@ -63535,6 +63536,7 @@ export const subscriptionStatusValues: ReadonlyArray<
   'past_due',
   'canceled',
   'unpaid',
+  'paused',
 ]
 export const subscriptionUncanceledEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SubscriptionUncanceledEvent']['name']

--- a/server/polar/models/subscription.py
+++ b/server/polar/models/subscription.py
@@ -66,6 +66,7 @@ class SubscriptionStatus(StrEnum):
     past_due = "past_due"
     canceled = "canceled"
     unpaid = "unpaid"
+    paused = "paused"
 
     @classmethod
     def incomplete_statuses(cls) -> set[Self]:
@@ -388,6 +389,15 @@ class Subscription(CustomFieldDataMixin, MetadataMixin, RecordModel):
         )
 
     @hybrid_property
+    def paused(self) -> bool:
+        return self.status == SubscriptionStatus.paused
+
+    @paused.inplace.expression
+    @classmethod
+    def _paused_expression(cls) -> ColumnElement[bool]:
+        return cls.status == SubscriptionStatus.paused
+
+    @hybrid_property
     def canceled(self) -> bool:
         return self.canceled_at is not None
 
@@ -448,6 +458,11 @@ class Subscription(CustomFieldDataMixin, MetadataMixin, RecordModel):
         return cast(cls.past_due_at + total_interval, TIMESTAMP(timezone=True))
 
     def can_cancel(self, immediately: bool = False) -> bool:
+        # A paused subscription isn't billable, but can still be revoked
+        # immediately instead of having to be resumed first.
+        if immediately and self.status == SubscriptionStatus.paused:
+            return self.ended_at is None
+
         if not SubscriptionStatus.is_billable(self.status):
             return False
 
@@ -466,6 +481,22 @@ class Subscription(CustomFieldDataMixin, MetadataMixin, RecordModel):
             self.cancel_at_period_end
             and self.status in SubscriptionStatus.billable_statuses()
         )
+
+    def can_pause(self) -> bool:
+        return (
+            self.status == SubscriptionStatus.active
+            and not self.cancel_at_period_end
+            and not self.pause_at_period_end
+            and self.ends_at is None
+        )
+
+    def can_cancel_scheduled_pause(self) -> bool:
+        return bool(self.pause_at_period_end) and (
+            self.status == SubscriptionStatus.active
+        )
+
+    def can_resume(self) -> bool:
+        return self.status == SubscriptionStatus.paused
 
     def update_amount_and_currency(
         self, prices: Sequence["SubscriptionProductPrice"], discount: "Discount | None"

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -416,9 +416,10 @@ class SubscriptionRepository(
                             (Subscription.cancel_at_period_end.is_(True), 5),
                         ),
                     ),
-                    (Subscription.status == SubscriptionStatus.past_due, 6),
-                    (Subscription.status == SubscriptionStatus.canceled, 7),
-                    (Subscription.status == SubscriptionStatus.unpaid, 8),
+                    (Subscription.status == SubscriptionStatus.paused, 6),
+                    (Subscription.status == SubscriptionStatus.past_due, 7),
+                    (Subscription.status == SubscriptionStatus.canceled, 8),
+                    (Subscription.status == SubscriptionStatus.unpaid, 9),
                 )
             case SubscriptionSortProperty.started_at:
                 return Subscription.started_at


### PR DESCRIPTION
- **feat(subscription): add paused status and guards**
- **fix(app): handle paused status in subscription color maps**
- **chore(client): regenerate client + handle paused status in web maps**


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

