### PR TITLE
stripe: Use get_safe_return_url for redirect urls

### DIFF
--- a/server/polar/integrations/stripe/endpoints.py
+++ b/server/polar/integrations/stripe/endpoints.py
@@ -5,6 +5,7 @@ from starlette.responses import RedirectResponse
 
 from polar.config import settings
 from polar.external_event.service import external_event as external_event_service
+from polar.kit.http import get_safe_return_url
 from polar.models.external_event import ExternalEventSource
 from polar.postgres import AsyncSession, get_db_session
 from polar.routing import APIRouter
@@ -60,7 +61,7 @@ async def stripe_connect_refresh(
 ) -> RedirectResponse:
     if return_path is None:
         raise HTTPException(404)
-    return RedirectResponse(settings.generate_frontend_url(return_path))
+    return RedirectResponse(get_safe_return_url(return_path))
 
 
 class WebhookEventGetter:

--- a/server/polar/integrations/stripe/service.py
+++ b/server/polar/integrations/stripe/service.py
@@ -1,11 +1,13 @@
 from collections.abc import AsyncGenerator, AsyncIterator
 from typing import TYPE_CHECKING, Literal, Unpack, cast, overload
+from urllib.parse import urlencode
 
 import stripe as stripe_lib
 import structlog
 
 from polar.config import settings
 from polar.exceptions import PolarError
+from polar.kit.http import get_safe_return_url
 from polar.logfire import instrument_httpx
 from polar.logging import Logger
 
@@ -134,9 +136,9 @@ class StripeService:
         self, stripe_id: str, return_path: str
     ) -> stripe_lib.AccountLink:
         refresh_url = settings.generate_external_url(
-            f"/v1/integrations/stripe/refresh?return_path={return_path}"
+            f"/v1/integrations/stripe/refresh?{urlencode({'return_path': return_path})}"
         )
-        return_url = settings.generate_frontend_url(return_path)
+        return_url = get_safe_return_url(return_path)
         return await stripe_lib.AccountLink.create_async(
             account=stripe_id,
             refresh_url=refresh_url,

--- a/server/tests/integrations/stripe/test_endpoints.py
+++ b/server/tests/integrations/stripe/test_endpoints.py
@@ -1,0 +1,44 @@
+import pytest
+from httpx import AsyncClient
+
+from polar.config import settings
+
+
+@pytest.mark.asyncio
+class TestStripeConnectRefresh:
+    async def test_missing_return_path(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/integrations/stripe/refresh")
+
+        assert response.status_code == 404
+
+    async def test_valid_return_path(self, client: AsyncClient) -> None:
+        return_path = "/dashboard/acme/finance/account"
+        response = await client.get(
+            "/v1/integrations/stripe/refresh", params={"return_path": return_path}
+        )
+
+        assert response.status_code == 307
+        assert response.headers["location"] == settings.generate_frontend_url(
+            return_path
+        )
+
+    @pytest.mark.parametrize(
+        "return_path",
+        [
+            "@evil.com",
+            "https://evil.com/phish",
+            "//evil.com",
+            "evil.com",
+        ],
+    )
+    async def test_unsafe_return_path(
+        self, client: AsyncClient, return_path: str
+    ) -> None:
+        response = await client.get(
+            "/v1/integrations/stripe/refresh", params={"return_path": return_path}
+        )
+
+        assert response.status_code == 307
+        assert response.headers["location"] == settings.generate_frontend_url(
+            settings.FRONTEND_DEFAULT_RETURN_PATH
+        )


### PR DESCRIPTION
Otherwise they might be vulnerable to redirect attacks


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secure Stripe Connect redirects by sanitizing return URLs and encoding query params to block open-redirects. This prevents users from being sent to untrusted domains.

- **Bug Fixes**
  - Use get_safe_return_url for return redirects in the refresh endpoint and Stripe account link creation.
  - Encode return_path with urlencode in refresh_url to avoid injection.
  - Add tests: valid paths redirect as expected; unsafe paths fall back to the default; missing return_path returns 404.

<sup>Written for commit 478262a734e2124857d4409185e4ba98202d38ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

