### PR TITLE
receipt/invoice: Fix italic font error

### DIFF
--- a/server/polar/invoice/generator.py
+++ b/server/polar/invoice/generator.py
@@ -397,6 +397,11 @@ class InvoiceGenerator(FPDF):
             self.add_font(family, fname=bold, style="B")
             self.loaded_font_families.add(family)
 
+        # fpdf markdown preloads styles "I"/"BI"; no italic Inter ships, so alias upright
+        regular, bold = self.font_files[self.font_name]
+        self.add_font(self.font_name, fname=regular, style="I")
+        self.add_font(self.font_name, fname=bold, style="BI")
+
         # Fallback order: Hebrew, Arabic, then CJK with the customer's script
         # first so shared Han chars get the right regional glyph form.
         # customer locale/country first, and then all other scripts.

--- a/server/polar/invoice/generator.py
+++ b/server/polar/invoice/generator.py
@@ -1,3 +1,4 @@
+import re
 import textwrap
 from datetime import date, datetime
 from pathlib import Path
@@ -39,6 +40,10 @@ def format_percent(rate: float) -> str:
 
 def format_date(date: date | datetime) -> str:
     return _format_date(date, format="long", locale="en_US")
+
+
+def escape_markdown(text: str) -> str:
+    return re.sub(r"(\*\*|__|--|~~)", r"\\\1", text)
 
 
 class InvoiceItem(BaseModel):
@@ -220,7 +225,9 @@ class Invoice(BaseModel):
             seller_address=settings.INVOICES_ADDRESS,
             seller_additional_info=get_polar_additional_info(order.billing_address),
             customer_name=order.billing_name,
-            customer_additional_info=order.tax_id[0] if order.tax_id else None,
+            customer_additional_info=escape_markdown(order.tax_id[0])
+            if order.tax_id
+            else None,
             customer_address=order.billing_address,
             customer_locale=order.customer.locale,
             subtotal_amount=order.subtotal_amount,

--- a/server/polar/receipt/generator.py
+++ b/server/polar/receipt/generator.py
@@ -12,6 +12,7 @@ from polar.invoice.generator import (
     InvoiceHeadingItem,
     InvoiceItem,
     InvoiceTotalsItem,
+    escape_markdown,
     format_date,
 )
 from polar.invoice.seller import get_polar_additional_info
@@ -111,9 +112,9 @@ class Receipt(Invoice):
 
         additional_info_parts: list[str] = []
         if order.tax_id:
-            additional_info_parts.append(order.tax_id[0])
+            additional_info_parts.append(escape_markdown(order.tax_id[0]))
         if order.customer.email and order.customer.email != customer_name:
-            additional_info_parts.append(order.customer.email)
+            additional_info_parts.append(escape_markdown(order.customer.email))
         customer_additional_info = (
             "\n".join(additional_info_parts) if additional_info_parts else None
         )

--- a/server/tests/invoice/test_generator.py
+++ b/server/tests/invoice/test_generator.py
@@ -6,7 +6,12 @@ from typing import Any
 
 import pytest
 
-from polar.invoice.generator import Invoice, InvoiceGenerator, InvoiceItem
+from polar.invoice.generator import (
+    Invoice,
+    InvoiceGenerator,
+    InvoiceItem,
+    escape_markdown,
+)
 from polar.kit.address import Address, CountryAlpha2
 from polar.tax.calculation import TaxabilityReason
 
@@ -135,6 +140,13 @@ Thank you for your business!
                 ],
             },
             "multiple_tax_breakdown",
+        ),
+        (
+            {
+                "customer_additional_info": "john__doe__1@example.com",
+                "notes": "Thank you! __Terms__ apply, **conditions** too.",
+            },
+            "markdown_markers",
         ),
         (
             {
@@ -459,3 +471,17 @@ def test_generator_renders_amounts_in_primary_font_after_cjk(
         f"{cjk_tf_ops}. This means current_font drifted after the "
         f"description cell and amounts rendered in the CJK font."
     )
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("john__doe__1@example.com", "john\\__doe\\__1@example.com"),
+        ("**bold**", "\\**bold\\**"),
+        ("--underline--", "\\--underline\\--"),
+        ("~~strike~~", "\\~~strike\\~~"),
+        ("plain@example.com", "plain@example.com"),
+    ],
+)
+def test_escape_markdown(text: str, expected: str) -> None:
+    assert escape_markdown(text) == expected

--- a/server/tests/receipt/test_generator.py
+++ b/server/tests/receipt/test_generator.py
@@ -80,6 +80,18 @@ class TestReceiptGenerator:
         assert len(output) > 100
         assert bytes(output).startswith(b"%PDF-")
 
+    def test_renders_with_markdown_markers_in_customer_info(self) -> None:
+        receipt = _build_receipt().model_copy(
+            update={"customer_additional_info": "john__doe__1@example.com"}
+        )
+        generator = ReceiptGenerator(
+            receipt, heading_title="Receipt", add_sandbox_warning=False
+        )
+        generator.generate()
+        output = generator.output()
+
+        assert bytes(output).startswith(b"%PDF-")
+
     def test_renders_with_refunds(self) -> None:
         now = utc_now()
         receipt = _build_receipt(


### PR DESCRIPTION
Fixes [SERVER-4TX](https://polar-sh.sentry.io/issues/7597571133/?referrer=activity_notification&notification_uuid=36d3e347-1394-4ce2-92f7-20e2062af1b6)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes PDF generation crashes by registering italic font fallbacks and escaping markdown markers in customer details. Prevents underscores and other markers in emails/tax IDs from triggering markdown so invoices and receipts render reliably.

- **Bug Fixes**
  - Escape `**`, `__`, `--`, `~~` in customer additional info via `escape_markdown` (invoice and receipt).
  - Register `I` and `BI` font styles by aliasing to regular/bold to avoid missing-italic errors when markdown triggers italics.
  - Added tests for escaping and successful PDF rendering with markdown-like input.

<sup>Written for commit cdb42329aef6c07a1d801a7fe08c0e3506c39aa0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

