### PR TITLE
email: Handle someone trying to use existing email

### DIFF
--- a/server/emails/src/emails/email_update_already_registered.tsx
+++ b/server/emails/src/emails/email_update_already_registered.tsx
@@ -1,0 +1,30 @@
+import { Footer, Intro, Text, WrapperPolar } from '../components/foundation'
+import type { schemas } from '../types'
+
+export function EmailUpdateAlreadyRegistered({
+  email,
+}: schemas['EmailUpdateAlreadyRegisteredProps']) {
+  return (
+    <WrapperPolar preview="Someone tried to use your email address on Polar">
+      <Intro>
+        Someone attempted to set the email address of their Polar account to{' '}
+        <Text as="span" weight="bold">
+          {email}
+        </Text>
+        . Since this email address is already associated with an account, no
+        changes were made.
+      </Intro>
+      <Text variant="caption">
+        If this was you, sign in to your existing Polar account instead. If you
+        don&apos;t recognize this activity, you can safely ignore this email.
+      </Text>
+      <Footer email={email} />
+    </WrapperPolar>
+  )
+}
+
+EmailUpdateAlreadyRegistered.PreviewProps = {
+  email: 'john@example.com',
+}
+
+export default EmailUpdateAlreadyRegistered

--- a/server/emails/src/emails/index.ts
+++ b/server/emails/src/emails/index.ts
@@ -3,6 +3,7 @@ import { CustomerEmailChangedNotification } from './customer_email_changed_notif
 import { CustomerEmailUpdateVerification } from './customer_email_update_verification'
 import { CustomerSessionCode } from './customer_session_code'
 import { EmailUpdate } from './email_update'
+import { EmailUpdateAlreadyRegistered } from './email_update_already_registered'
 import { LoginCode } from './login_code'
 import { NotificationCreditsGranted } from './notification_credits_granted'
 import { NotificationNewSale } from './notification_new_sale'
@@ -41,6 +42,7 @@ const TEMPLATES: Record<string, React.FC<never>> = {
   customer_email_update_verification: CustomerEmailUpdateVerification,
   customer_session_code: CustomerSessionCode,
   email_update: EmailUpdate,
+  email_update_already_registered: EmailUpdateAlreadyRegistered,
   oauth2_leaked_client: OAuth2LeakedClient,
   oauth2_leaked_token: OAuth2LeakedToken,
   order_confirmation: OrderConfirmation,

--- a/server/emails/src/types/openapi.ts
+++ b/server/emails/src/types/openapi.ts
@@ -1063,6 +1063,21 @@ export interface components {
       /** Domain */
       domain: string
     }
+    /** EmailUpdateAlreadyRegisteredEmail */
+    EmailUpdateAlreadyRegisteredEmail: {
+      /**
+       * Template
+       * @default email_update_already_registered
+       * @constant
+       */
+      template: 'email_update_already_registered'
+      props: components['schemas']['EmailUpdateAlreadyRegisteredProps']
+    }
+    /** EmailUpdateAlreadyRegisteredProps */
+    EmailUpdateAlreadyRegisteredProps: {
+      /** Email */
+      email: string
+    }
     /** EmailUpdateEmail */
     EmailUpdateEmail: {
       /**
@@ -1476,6 +1491,12 @@ export interface components {
       subscription_id: string | null
       /** Checkout Id */
       checkout_id: string | null
+      /**
+       * Next Payment Attempt At
+       * @description When the next automatic payment retry is scheduled. `null` if the order is not in dunning or all retries have been exhausted.
+       * @default null
+       */
+      next_payment_attempt_at: string | null
       /** Description */
       description: string
       /** Items */
@@ -1619,6 +1640,11 @@ export interface components {
        * @description When the business details were submitted for review.
        */
       details_submitted_at: string | null
+      /**
+       * Sso Enforced
+       * @description Whether members must access this organization through its SSO connection.
+       */
+      sso_enforced: boolean
       /**
        * Default Presentment Currency
        * @description Default presentment currency. Used as fallback in checkout and customer portal, if the customer's local currency is not available.
@@ -1927,25 +1953,6 @@ export interface components {
       /** Url */
       url: string
     }
-    /** OrganizationAccountUnlinkEmail */
-    OrganizationAccountUnlinkEmail: {
-      /**
-       * Template
-       * @default organization_account_unlink
-       * @constant
-       */
-      template: 'organization_account_unlink'
-      props: components['schemas']['OrganizationAccountUnlinkProps']
-    }
-    /** OrganizationAccountUnlinkProps */
-    OrganizationAccountUnlinkProps: {
-      /** Email */
-      email: string
-      /** Organization Kept Name */
-      organization_kept_name: string
-      /** Organizations Unlinked */
-      organizations_unlinked: string[]
-    }
     /** OrganizationCapabilities */
     OrganizationCapabilities: {
       /**
@@ -2072,6 +2079,30 @@ export interface components {
        * @default false
        */
       preview_access_enabled: boolean
+      /**
+       * Disputes Enabled
+       * @description If this organization has the disputes dashboard enabled
+       * @default false
+       */
+      disputes_enabled: boolean
+      /**
+       * Sso Enabled
+       * @description If this organization has single sign-on configuration enabled
+       * @default false
+       */
+      sso_enabled: boolean
+      /**
+       * Compass Enabled
+       * @description If this organization has the split product navigation (Billing / Compass / Customers) enabled in the dashboard
+       * @default false
+       */
+      compass_enabled: boolean
+      /**
+       * Merchant Migration Enabled
+       * @description If this organization can migrate its billing from another provider (e.g. Stripe) to Polar.
+       * @default false
+       */
+      merchant_migration_enabled: boolean
     }
     /** OrganizationInviteEmail */
     OrganizationInviteEmail: {
@@ -2337,14 +2368,19 @@ export interface components {
       /** @description The visibility of the product. */
       visibility: components['schemas']['ProductVisibility']
       /** @description The recurring interval of the product. If `None`, the product is a one-time purchase. */
-      recurring_interval:
-        | components['schemas']['SubscriptionRecurringInterval']
-        | null
+      recurring_interval: components['schemas']['RecurringInterval'] | null
       /**
        * Recurring Interval Count
        * @description Number of interval units of the subscription. If this is set to 1 the charge will happen every interval (e.g. every month), if set to 2 it will be every other month, and so on. None for one-time products.
        */
       recurring_interval_count: number | null
+      /** @description The meter cycle of the product, independent of the billing interval. If `None`, metered concerns follow the billing interval. */
+      meter_interval: components['schemas']['RecurringInterval'] | null
+      /**
+       * Meter Interval Count
+       * @description Number of meter interval units. None when no meter cycle is set.
+       */
+      meter_interval_count: number | null
       /**
        * Is Recurring
        * @description Whether the product is a subscription.
@@ -2372,6 +2408,11 @@ export interface components {
      * @enum {string}
      */
     ProductVisibility: 'draft' | 'private' | 'public'
+    /**
+     * RecurringInterval
+     * @enum {string}
+     */
+    RecurringInterval: 'day' | 'week' | 'month' | 'year'
     /** SeatInvitationEmail */
     SeatInvitationEmail: {
       /**
@@ -2512,7 +2553,7 @@ export interface components {
        * @description The interval at which the subscription recurs.
        * @example month
        */
-      recurring_interval: components['schemas']['SubscriptionRecurringInterval']
+      recurring_interval: components['schemas']['RecurringInterval']
       /**
        * Recurring Interval Count
        * @description Number of interval units of the subscription. If this is set to 1 the charge will happen every interval (e.g. every month), if set to 2 it will be every other month, and so on.
@@ -2535,6 +2576,16 @@ export interface components {
        * @description The end timestamp of the current billing period.
        */
       current_period_end: string
+      /**
+       * Current Meter Period Start
+       * @description The start timestamp of the current meter period, if the product has a meter cycle set. Metered credits are granted and overage is settled on this cadence.
+       */
+      current_meter_period_start: string | null
+      /**
+       * Current Meter Period End
+       * @description The end timestamp of the current meter period, if the product has a meter cycle set. This is when credits next renew.
+       */
+      current_meter_period_end: string | null
       /**
        * Trial Start
        * @description The start timestamp of the trial period, if any.
@@ -2570,6 +2621,12 @@ export interface components {
        * @description The timestamp when the subscription ended.
        */
       ended_at: string | null
+      /**
+       * Past Due At
+       * @description The timestamp when the subscription entered `past_due` status.
+       * @default null
+       */
+      past_due_at: string | null
       /**
        * Customer Id
        * Format: uuid4
@@ -2656,11 +2713,6 @@ export interface components {
       | 'prorate'
       | 'next_period'
       | 'reset'
-    /**
-     * SubscriptionRecurringInterval
-     * @enum {string}
-     */
-    SubscriptionRecurringInterval: 'day' | 'week' | 'month' | 'year'
     /** SubscriptionRenewalReminderEmail */
     SubscriptionRenewalReminderEmail: {
       /**

--- a/server/polar/email/schemas.py
+++ b/server/polar/email/schemas.py
@@ -31,6 +31,7 @@ class EmailTemplate(StrEnum):
     customer_email_update_verification = "customer_email_update_verification"
     customer_session_code = "customer_session_code"
     email_update = "email_update"
+    email_update_already_registered = "email_update_already_registered"
     oauth2_leaked_client = "oauth2_leaked_client"
     oauth2_leaked_token = "oauth2_leaked_token"
     order_confirmation = "order_confirmation"
@@ -124,6 +125,16 @@ class EmailUpdateProps(EmailProps):
 class EmailUpdateEmail(BaseModel):
     template: Literal[EmailTemplate.email_update] = EmailTemplate.email_update
     props: EmailUpdateProps
+
+
+class EmailUpdateAlreadyRegisteredProps(EmailProps): ...
+
+
+class EmailUpdateAlreadyRegisteredEmail(BaseModel):
+    template: Literal[EmailTemplate.email_update_already_registered] = (
+        EmailTemplate.email_update_already_registered
+    )
+    props: EmailUpdateAlreadyRegisteredProps
 
 
 class CustomerEmailUpdateVerificationProps(EmailProps):
@@ -523,6 +534,7 @@ Email = Annotated[
     | CustomerEmailUpdateVerificationEmail
     | CustomerSessionCodeEmail
     | EmailUpdateEmail
+    | EmailUpdateAlreadyRegisteredEmail
     | OAuth2LeakedClientEmail
     | OAuth2LeakedTokenEmail
     | OrderConfirmationEmail

--- a/server/polar/email_update/endpoints.py
+++ b/server/polar/email_update/endpoints.py
@@ -23,11 +23,14 @@ async def request_email_update(
     auth_subject: AuthorizeWebUserWrite,
     session: AsyncSession = Depends(get_db_session),
 ) -> None:
-    email_update_record, token = await email_update_service.request_email_update(
+    result = await email_update_service.request_email_update(
         email_update_request.email,
         session,
         auth_subject,
     )
+    if result is None:
+        return
+    email_update_record, token = result
 
     await email_update_service.send_email(
         email_update_record,

--- a/server/polar/email_update/service.py
+++ b/server/polar/email_update/service.py
@@ -6,9 +6,14 @@ from sqlalchemy.orm import joinedload
 
 from polar.auth.models import AuthSubject
 from polar.config import settings
-from polar.email.schemas import EmailUpdateEmail, EmailUpdateProps
+from polar.email.schemas import (
+    EmailUpdateAlreadyRegisteredEmail,
+    EmailUpdateAlreadyRegisteredProps,
+    EmailUpdateEmail,
+    EmailUpdateProps,
+)
 from polar.email.sender import enqueue_email_template
-from polar.exceptions import PolarError, PolarRequestValidationError
+from polar.exceptions import PolarError
 from polar.kit.crypto import generate_token_hash_pair, get_token_hash
 from polar.kit.extensions.sqlalchemy import sql
 from polar.kit.services import ResourceServiceReader
@@ -31,28 +36,34 @@ class InvalidEmailUpdate(EmailUpdateError):
         )
 
 
+class EmailAlreadyInUse(EmailUpdateError):
+    def __init__(self) -> None:
+        super().__init__(
+            "This email address is already in use by another account.",
+            status_code=409,
+        )
+
+
 class EmailUpdateService(ResourceServiceReader[EmailVerification]):
     async def request_email_update(
         self,
         email: str,
         session: AsyncSession,
         auth_subject: AuthSubject[User],
-    ) -> tuple[EmailVerification, str]:
+    ) -> tuple[EmailVerification, str] | None:
         user = auth_subject.subject
 
         user_repository = UserRepository.from_session(session)
         existing_user = await user_repository.get_by_email(email)
         if existing_user is not None and existing_user.id != user.id:
-            raise PolarRequestValidationError(
-                [
-                    {
-                        "type": "value_error",
-                        "loc": ("body", "email"),
-                        "msg": "Another user is already using this email.",
-                        "input": email,
-                    }
-                ]
+            enqueue_email_template(
+                EmailUpdateAlreadyRegisteredEmail(
+                    props=EmailUpdateAlreadyRegisteredProps(email=email)
+                ),
+                to_email_addr=email,
+                subject="Someone tried to use your email address on Polar",
             )
+            return None
 
         token, token_hash = generate_token_hash_pair(
             secret=settings.SECRET, prefix=TOKEN_PREFIX
@@ -99,6 +110,11 @@ class EmailUpdateService(ResourceServiceReader[EmailVerification]):
 
         if email_update_record is None or email_update_record.user_id != user.id:
             raise InvalidEmailUpdate()
+
+        user_repository = UserRepository.from_session(session)
+        existing_user = await user_repository.get_by_email(email_update_record.email)
+        if existing_user is not None and existing_user.id != user.id:
+            raise EmailAlreadyInUse()
 
         user = email_update_record.user
         user.email = email_update_record.email

--- a/server/tests/email_update/test_endpoints.py
+++ b/server/tests/email_update/test_endpoints.py
@@ -1,0 +1,38 @@
+from unittest.mock import MagicMock
+
+import pytest
+from httpx import AsyncClient
+from pytest_mock import MockerFixture
+
+from polar.models import User
+
+
+@pytest.fixture(autouse=True)
+def mock_enqueue_email(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("polar.email_update.service.enqueue_email_template")
+
+
+@pytest.mark.asyncio
+class TestRequestEmailUpdate:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.post(
+            "/v1/email-update/request", json={"email": "new@example.com"}
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_identical_response_for_fresh_and_taken_email(
+        self,
+        client: AsyncClient,
+        user_second: User,
+    ) -> None:
+        fresh_response = await client.post(
+            "/v1/email-update/request", json={"email": "fresh@example.com"}
+        )
+        taken_response = await client.post(
+            "/v1/email-update/request", json={"email": user_second.email}
+        )
+
+        assert fresh_response.status_code == taken_response.status_code == 200
+        assert fresh_response.json() == taken_response.json()

--- a/server/tests/email_update/test_service.py
+++ b/server/tests/email_update/test_service.py
@@ -1,0 +1,190 @@
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+from sqlalchemy import select
+
+from polar.auth.models import AuthSubject
+from polar.config import settings
+from polar.email.schemas import EmailUpdateAlreadyRegisteredEmail
+from polar.email_update.service import (
+    TOKEN_PREFIX,
+    EmailAlreadyInUse,
+    InvalidEmailUpdate,
+)
+from polar.email_update.service import email_update as email_update_service
+from polar.kit.crypto import generate_token_hash_pair, get_token_hash
+from polar.kit.utils import utc_now
+from polar.models import EmailVerification, User
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+
+
+@pytest.fixture(autouse=True)
+def mock_enqueue_email(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("polar.email_update.service.enqueue_email_template")
+
+
+async def _create_verification(
+    save_fixture: SaveFixture,
+    user: User,
+    email: str = "new@example.com",
+) -> tuple[EmailVerification, str]:
+    token, token_hash = generate_token_hash_pair(
+        secret=settings.SECRET, prefix=TOKEN_PREFIX
+    )
+    record = EmailVerification(email=email, token_hash=token_hash, user=user)
+    await save_fixture(record)
+    return record, token
+
+
+@pytest.mark.asyncio
+class TestRequestEmailUpdate:
+    @pytest.mark.auth
+    async def test_fresh_email(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        mock_enqueue_email: MagicMock,
+    ) -> None:
+        result = await email_update_service.request_email_update(
+            "fresh@example.com", session, auth_subject
+        )
+
+        assert result is not None
+        record, token = result
+        assert record.email == "fresh@example.com"
+        assert record.user_id == auth_subject.subject.id
+        assert token.startswith(TOKEN_PREFIX)
+        assert record.token_hash == get_token_hash(token, secret=settings.SECRET)
+        mock_enqueue_email.assert_not_called()
+
+    @pytest.mark.auth
+    async def test_email_taken_by_other_user(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user_second: User,
+        mock_enqueue_email: MagicMock,
+    ) -> None:
+        result = await email_update_service.request_email_update(
+            user_second.email, session, auth_subject
+        )
+
+        assert result is None
+        statement = select(EmailVerification).where(
+            EmailVerification.user_id == auth_subject.subject.id
+        )
+        records = (await session.execute(statement)).scalars().all()
+        assert len(records) == 0
+        mock_enqueue_email.assert_called_once()
+        email, kwargs = (
+            mock_enqueue_email.call_args.args[0],
+            mock_enqueue_email.call_args.kwargs,
+        )
+        assert isinstance(email, EmailUpdateAlreadyRegisteredEmail)
+        assert kwargs["to_email_addr"] == user_second.email
+
+    @pytest.mark.auth
+    async def test_email_taken_case_insensitive(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        user_second: User,
+        mock_enqueue_email: MagicMock,
+    ) -> None:
+        result = await email_update_service.request_email_update(
+            user_second.email.upper(), session, auth_subject
+        )
+
+        assert result is None
+        mock_enqueue_email.assert_called_once()
+
+    @pytest.mark.auth
+    async def test_own_email(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        mock_enqueue_email: MagicMock,
+    ) -> None:
+        result = await email_update_service.request_email_update(
+            auth_subject.subject.email, session, auth_subject
+        )
+
+        assert result is not None
+        record, _ = result
+        assert record.email == auth_subject.subject.email
+        mock_enqueue_email.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestVerify:
+    async def test_valid(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        user: User,
+    ) -> None:
+        record, token = await _create_verification(save_fixture, user)
+
+        verified_user = await email_update_service.verify(session, token, user)
+
+        assert verified_user.email == "new@example.com"
+        statement = select(EmailVerification).where(EmailVerification.id == record.id)
+        assert (await session.execute(statement)).scalar_one_or_none() is None
+
+    async def test_email_taken_in_between(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        user: User,
+        user_second: User,
+    ) -> None:
+        old_email = user.email
+        record, token = await _create_verification(save_fixture, user)
+        user_second.email = record.email
+        await save_fixture(user_second)
+
+        with pytest.raises(EmailAlreadyInUse):
+            await email_update_service.verify(session, token, user)
+
+        assert user.email == old_email
+        statement = select(EmailVerification).where(EmailVerification.id == record.id)
+        assert (await session.execute(statement)).scalar_one_or_none() is not None
+
+        with pytest.raises(EmailAlreadyInUse):
+            await email_update_service.verify(session, token, user)
+
+    async def test_wrong_user(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        user: User,
+        user_second: User,
+    ) -> None:
+        _, token = await _create_verification(save_fixture, user_second)
+
+        with pytest.raises(InvalidEmailUpdate):
+            await email_update_service.verify(session, token, user)
+
+    async def test_expired_token(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        user: User,
+    ) -> None:
+        record, token = await _create_verification(save_fixture, user)
+        record.expires_at = utc_now() - timedelta(minutes=1)
+        await save_fixture(record)
+
+        with pytest.raises(InvalidEmailUpdate):
+            await email_update_service.verify(session, token, user)
+
+    async def test_invalid_token(
+        self,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        with pytest.raises(InvalidEmailUpdate):
+            await email_update_service.verify(session, "polar_ev_bogus", user)


### PR DESCRIPTION
This prevents email enumeration via the API, and gives users a way to both deal with someone trying their email as well as if they are trying their own email they get some instructions on what to do instead


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

