### PR TITLE
tf: Split s3:DeleteObjectTagging action into its own block

### DIFF
--- a/terraform/modules/s3_buckets/main.tf
+++ b/terraform/modules/s3_buckets/main.tf
@@ -78,13 +78,24 @@ locals {
         Action = [
           "s3:PutObject",
           "s3:PutObjectTagging",
-          "s3:DeleteObjectTagging",
         ]
         Resource = "${bucket_arn}/*"
         Condition = {
           "ForAnyValue:StringEquals" = {
             "s3:RequestObjectTagKeys" = "GuardDutyMalwareScanStatus"
           }
+          ArnNotLike = {
+            "aws:PrincipalArn" = var.malware_protection_role_arn
+          }
+        }
+      },
+      {
+        Sid       = "DenyScanStatusTagDeletion"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:DeleteObjectTagging"
+        Resource  = "${bucket_arn}/*"
+        Condition = {
           ArnNotLike = {
             "aws:PrincipalArn" = var.malware_protection_role_arn
           }


### PR DESCRIPTION
To ensure that we only apply conditions that are relevant to all actions


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the S3 bucket policy so `s3:DeleteObjectTagging` is handled in its own statement. This avoids applying put/tagging conditions to delete-tagging and explicitly denies tag deletion by anyone except the malware protection role.

- **Bug Fixes**
  - Removed `s3:DeleteObjectTagging` from the put/tagging statement and added a new "DenyScanStatusTagDeletion" statement for `bucket_arn/*`.
  - Only `var.malware_protection_role_arn` can delete object tags; all other principals are denied via `ArnNotLike` on `aws:PrincipalArn`.

<sup>Written for commit 8e2e32854fabe98ab9f508112376c1b87ee68b5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

