### PR TITLE
lint: Merge server linters + add frontend_url linter

### DIFF
--- a/server/polar/authz/repository.py
+++ b/server/polar/authz/repository.py
@@ -28,7 +28,7 @@ def select_user_org_ids(
     stmt = (
         # The one blessed place that expands user memberships into org ids;
         # every other caller must go through this helper.
-        select(UserOrganization.organization_id)  # noqa: org-scope
+        select(UserOrganization.organization_id)  # lint-skip: org-scope
         .join(Organization, UserOrganization.organization_id == Organization.id)
         .where(
             UserOrganization.user_id == user_id,
@@ -63,7 +63,9 @@ def select_accessible_org_ids(
     Personal access tokens remain exempt from SSO enforcement.
     """
     # Composes the raw helper, then applies the session down-scope right below.
-    stmt = select_user_org_ids(auth_subject.subject.id, permission=permission)  # noqa: org-scope
+    stmt = select_user_org_ids(  # lint-skip: org-scope
+        auth_subject.subject.id, permission=permission
+    )
     if auth_subject.organization_ids is not None:
         stmt = stmt.where(
             UserOrganization.organization_id.in_(auth_subject.organization_ids)

--- a/server/polar/user/endpoints.py
+++ b/server/polar/user/endpoints.py
@@ -71,7 +71,11 @@ async def get_authenticated(
     # set (session scope + SSO enforcement) via the shared authz chokepoint,
     # while `member_organizations` exposes every membership so the frontend can
     # tell "no access" apart from "not a member".
-    org_with_roles = await repository.get_organizations_with_role(user.id)  # noqa: org-scope
+    org_with_roles = (
+        await repository.get_organizations_with_role(  # lint-skip: org-scope
+            user.id
+        )
+    )
     accessible_ids = await AuthzRepository.from_session(session).get_user_org_ids(
         auth_subject
     )

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -111,11 +111,11 @@ worker = { cmd = "dramatiq -p 1 -t 1 --watch polar -f polar.worker.scheduler:sta
 test = { cmd = "POLAR_ENV=testing python -m pytest --cov polar/ --cov-report=term-missing", help = "run all tests" }
 test_fast = { cmd = "POLAR_ENV=testing python -m pytest -n auto -p no:sugar --no-cov", help = "run all tests, but fast" }
 loadtest = { cmd = "locust -f load_tests/locustfile.py --host=http://127.0.0.1:8000", help = "run load tests (interactive)" }
-lint = { cmd = "ruff format . && ruff check --fix . && task lint_subquery && task lint_org_scope && task lint_frontend_url", help = "run linters with autofix" }
-lint_check = { cmd = "ruff format --check . && ruff check . && task lint_subquery && task lint_org_scope && task lint_frontend_url", help = "run ruff linter" }
-lint_subquery = { cmd = "python scripts/lint_subquery.py", help = "flag .subquery() calls that don't narrow columns" }
-lint_org_scope = { cmd = "python scripts/lint_org_scope.py", help = "flag inline UserOrganization filters that bypass select_user_org_ids" }
-lint_frontend_url = { cmd = "python scripts/lint_frontend_url.py", help = "flag request-derived values passed to generate_frontend_url" }
+lint = { cmd = "ruff format . && ruff check --fix . && task lint_ast", help = "run linters with autofix" }
+lint_check = { cmd = "ruff format --check . && ruff check . && task lint_ast", help = "run ruff linter" }
+lint_ast = { cmd = "python -m scripts.linters", help = "run all custom AST lint rules" }
+lint_subquery = { cmd = "python -m scripts.linters --only subquery", help = "flag .subquery() calls that don't narrow columns" }
+lint_org_scope = { cmd = "python -m scripts.linters --only org-scope", help = "flag inline UserOrganization filters that bypass select_user_org_ids" }
 lint_types = { cmd = "mypy --num-workers 2 polar scripts tests", help = "run mypy type verify" }
 db_migrate = { cmd = "python -m scripts.db upgrade", help = "run alembic upgrade" }
 db_recreate = { cmd = "python -m scripts.db recreate", help = "drop and recreate database" }

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -111,10 +111,11 @@ worker = { cmd = "dramatiq -p 1 -t 1 --watch polar -f polar.worker.scheduler:sta
 test = { cmd = "POLAR_ENV=testing python -m pytest --cov polar/ --cov-report=term-missing", help = "run all tests" }
 test_fast = { cmd = "POLAR_ENV=testing python -m pytest -n auto -p no:sugar --no-cov", help = "run all tests, but fast" }
 loadtest = { cmd = "locust -f load_tests/locustfile.py --host=http://127.0.0.1:8000", help = "run load tests (interactive)" }
-lint = { cmd = "ruff format . && ruff check --fix . && task lint_subquery && task lint_org_scope", help = "run linters with autofix" }
-lint_check = { cmd = "ruff format --check . && ruff check . && task lint_subquery && task lint_org_scope", help = "run ruff linter" }
+lint = { cmd = "ruff format . && ruff check --fix . && task lint_subquery && task lint_org_scope && task lint_frontend_url", help = "run linters with autofix" }
+lint_check = { cmd = "ruff format --check . && ruff check . && task lint_subquery && task lint_org_scope && task lint_frontend_url", help = "run ruff linter" }
 lint_subquery = { cmd = "python scripts/lint_subquery.py", help = "flag .subquery() calls that don't narrow columns" }
 lint_org_scope = { cmd = "python scripts/lint_org_scope.py", help = "flag inline UserOrganization filters that bypass select_user_org_ids" }
+lint_frontend_url = { cmd = "python scripts/lint_frontend_url.py", help = "flag request-derived values passed to generate_frontend_url" }
 lint_types = { cmd = "mypy --num-workers 2 polar scripts tests", help = "run mypy type verify" }
 db_migrate = { cmd = "python -m scripts.db upgrade", help = "run alembic upgrade" }
 db_recreate = { cmd = "python -m scripts.db recreate", help = "drop and recreate database" }

--- a/server/scripts/lint_frontend_url.py
+++ b/server/scripts/lint_frontend_url.py
@@ -1,0 +1,220 @@
+"""Flag request-derived values flowing into frontend URL construction.
+
+`settings.generate_frontend_url()` concatenates its argument onto
+`FRONTEND_BASE_URL` with no validation, so a request-derived value passed to it
+is an open redirect: `?return_path=@evil.com` yields
+`https://polar.sh@evil.com`, which browsers navigate to as `evil.com` (`@` is
+the userinfo delimiter). Request-derived paths must go through
+`get_safe_return_url` (`polar.kit.http`) instead.
+
+Rules (per function, intra-procedural):
+- A parameter is *tainted* when declared with a FastAPI request marker
+  (`Query`/`Path`/`Form`/`Header`/`Cookie`/`Body`), either as a default value
+  or inside `Annotated[...]` metadata. Assigning an expression that references
+  a tainted name to a local taints that local (fixed-point propagation).
+- Flag `generate_frontend_url(...)` calls whose arguments reference a tainted
+  name.
+- Flag f-strings or `+` concatenations that combine `FRONTEND_BASE_URL` with a
+  tainted name — the inlined form of the same bug.
+- `# noqa: frontend-url` on the offending line is an explicit escape for
+  values already validated upstream.
+
+Exits 1 on any violation.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+NOQA_MARKER = "frontend-url"
+TARGET_CALL = "generate_frontend_url"
+BASE_URL_SETTING = "FRONTEND_BASE_URL"
+FASTAPI_PARAM_MARKERS = frozenset({"Query", "Path", "Form", "Header", "Cookie", "Body"})
+
+CALL_MESSAGE = (
+    "request-derived value passed to generate_frontend_url — it concatenates "
+    "without validation (open redirect). Route it through get_safe_return_url "
+    "(polar.kit.http). Escape with `# noqa: frontend-url` if already validated."
+)
+
+CONCAT_MESSAGE = (
+    "request-derived value concatenated with FRONTEND_BASE_URL — open "
+    "redirect. Route it through get_safe_return_url (polar.kit.http). Escape "
+    "with `# noqa: frontend-url` if already validated."
+)
+
+_NOQA_RE = re.compile(r"#\s*noqa(?::\s*(?P<codes>[^#]*))?", re.IGNORECASE)
+
+FunctionNode = ast.FunctionDef | ast.AsyncFunctionDef
+
+
+def _is_fastapi_marker(node: ast.AST | None) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id in FASTAPI_PARAM_MARKERS
+    if isinstance(func, ast.Attribute):
+        return func.attr in FASTAPI_PARAM_MARKERS
+    return False
+
+
+def _annotation_has_marker(node: ast.AST | None) -> bool:
+    if node is None:
+        return False
+    return any(_is_fastapi_marker(child) for child in ast.walk(node))
+
+
+def _tainted_params(func: FunctionNode) -> set[str]:
+    """Parameters declared with a FastAPI request marker."""
+    args = func.args
+    positional = args.posonlyargs + args.args
+    defaults: list[ast.expr | None] = [None] * (
+        len(positional) - len(args.defaults)
+    ) + list(args.defaults)
+    tainted: set[str] = set()
+    for arg, default in zip(
+        positional + args.kwonlyargs, defaults + list(args.kw_defaults)
+    ):
+        if _is_fastapi_marker(default) or _annotation_has_marker(arg.annotation):
+            tainted.add(arg.arg)
+    return tainted
+
+
+def _references_any(node: ast.AST, names: set[str]) -> bool:
+    return any(
+        isinstance(child, ast.Name) and child.id in names for child in ast.walk(node)
+    )
+
+
+def _propagate(func: FunctionNode, tainted: set[str]) -> set[str]:
+    """Fixed-point: a local assigned from a tainted expression is tainted."""
+    changed = True
+    while changed:
+        changed = False
+        for node in ast.walk(func):
+            value: ast.expr | None
+            targets: list[ast.expr]
+            if isinstance(node, ast.Assign):
+                value, targets = node.value, node.targets
+            elif isinstance(node, (ast.AnnAssign, ast.AugAssign)):
+                value, targets = node.value, [node.target]
+            elif isinstance(node, ast.NamedExpr):
+                value, targets = node.value, [node.target]
+            else:
+                continue
+            if value is None or not _references_any(value, tainted):
+                continue
+            for target in targets:
+                for child in ast.walk(target):
+                    if isinstance(child, ast.Name) and child.id not in tainted:
+                        tainted.add(child.id)
+                        changed = True
+    return tainted
+
+
+def _is_target_call(node: ast.Call) -> bool:
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr == TARGET_CALL
+    return isinstance(func, ast.Name) and func.id == TARGET_CALL
+
+
+def _references_base_url(node: ast.AST) -> bool:
+    return any(
+        isinstance(child, ast.Attribute) and child.attr == BASE_URL_SETTING
+        for child in ast.walk(node)
+    )
+
+
+def check_function(func: FunctionNode) -> list[tuple[int, str]]:
+    tainted = _tainted_params(func)
+    if not tainted:
+        return []
+    tainted = _propagate(func, tainted)
+
+    violations: list[tuple[int, str]] = []
+    seen_lines: set[int] = set()
+    for node in ast.walk(func):
+        if isinstance(node, ast.Call) and _is_target_call(node):
+            if not any(_references_any(arg, tainted) for arg in node.args):
+                continue
+            message = CALL_MESSAGE
+        elif isinstance(node, (ast.JoinedStr, ast.BinOp)):
+            if not (_references_base_url(node) and _references_any(node, tainted)):
+                continue
+            message = CONCAT_MESSAGE
+        else:
+            continue
+        if node.lineno in seen_lines:
+            continue
+        seen_lines.add(node.lineno)
+        violations.append((node.lineno, message))
+    return violations
+
+
+def _line_has_noqa(source_lines: list[str], lineno: int) -> bool:
+    idx = lineno - 1
+    if not (0 <= idx < len(source_lines)):
+        return False
+    match = _NOQA_RE.search(source_lines[idx])
+    if match is None:
+        return False
+    codes = match.group("codes")
+    if codes is None:
+        return True
+    return NOQA_MARKER in {code.strip() for code in codes.split(",")}
+
+
+def check_file(path: Path) -> list[tuple[Path, int, str]]:
+    source = path.read_text()
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError as exc:
+        return [(path, exc.lineno or 0, f"syntax error: {exc.msg}")]
+
+    source_lines = source.splitlines()
+    violations: list[tuple[Path, int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for lineno, message in check_function(node):
+            if _line_has_noqa(source_lines, lineno):
+                continue
+            violations.append((path, lineno, message))
+    return violations
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent / "polar"
+    if not root.exists():
+        print(f"error: {root} not found", file=sys.stderr)
+        return 2
+
+    checked = 0
+    violations: list[tuple[Path, int, str]] = []
+    for path in sorted(root.rglob("*.py")):
+        if "migrations" in path.parts:
+            continue
+        checked += 1
+        violations.extend(check_file(path))
+
+    if violations:
+        for path, lineno, message in violations:
+            try:
+                rel = path.relative_to(Path.cwd())
+            except ValueError:
+                rel = path
+            print(f"{rel}:{lineno}: {message}")
+        print(f"\n{len(violations)} violation(s) across {checked} file(s).")
+        return 1
+
+    print(f"OK: {checked} file(s) checked, no frontend-url violations.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server/scripts/linters/__main__.py
+++ b/server/scripts/linters/__main__.py
@@ -51,7 +51,7 @@ def main() -> int:
         if "migrations" in path.parts:
             continue
         checked += 1
-        source = path.read_text()
+        source = path.read_text(encoding="utf-8")
         try:
             tree = ast.parse(source, filename=str(path))
         except SyntaxError as exc:

--- a/server/scripts/linters/__main__.py
+++ b/server/scripts/linters/__main__.py
@@ -1,0 +1,85 @@
+"""Run the custom AST lint rules over polar/ with a single shared parse.
+
+Each rule lives in its own module and registers a `Rule` with a name (for
+`--only`), a noqa code, and a `check(tree)` callable. Suppress a violation
+with `# noqa: <code>` on the offending line. Exits 1 on any violation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import sys
+from pathlib import Path
+
+from . import frontend_url, org_scope, subquery
+from .base import Rule, line_has_noqa
+
+RULES: tuple[Rule, ...] = (subquery.RULE, org_scope.RULE, frontend_url.RULE)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--only",
+        metavar="RULE",
+        help=f"comma-separated rule names to run ({', '.join(r.name for r in RULES)})",
+    )
+    args = parser.parse_args()
+
+    if args.only is None:
+        rules = RULES
+    else:
+        names = {name.strip() for name in args.only.split(",")}
+        unknown = names - {rule.name for rule in RULES}
+        if unknown:
+            print(
+                f"error: unknown rule(s): {', '.join(sorted(unknown))}", file=sys.stderr
+            )
+            return 2
+        rules = tuple(rule for rule in RULES if rule.name in names)
+
+    root = Path(__file__).resolve().parents[2] / "polar"
+    if not root.exists():
+        print(f"error: {root} not found", file=sys.stderr)
+        return 2
+
+    checked = 0
+    violations: list[tuple[Path, int, str, str]] = []
+    for path in sorted(root.rglob("*.py")):
+        if "migrations" in path.parts:
+            continue
+        checked += 1
+        source = path.read_text()
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError as exc:
+            violations.append(
+                (path, exc.lineno or 0, "syntax", f"syntax error: {exc.msg}")
+            )
+            continue
+        source_lines = source.splitlines()
+        for rule in rules:
+            for lineno, message in rule.check(tree):
+                if line_has_noqa(source_lines, lineno, rule.noqa_code):
+                    continue
+                violations.append((path, lineno, rule.name, message))
+
+    if violations:
+        violations.sort(key=lambda v: (v[0], v[1]))
+        for path, lineno, name, message in violations:
+            try:
+                rel = path.relative_to(Path.cwd())
+            except ValueError:
+                rel = path
+            print(f"{rel}:{lineno}: [{name}] {message}")
+        print(f"\n{len(violations)} violation(s) across {checked} file(s).")
+        return 1
+
+    rule_names = ", ".join(rule.name for rule in rules)
+    print(f"OK: {checked} file(s) checked against {rule_names}, no violations.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server/scripts/linters/__main__.py
+++ b/server/scripts/linters/__main__.py
@@ -1,8 +1,9 @@
 """Run the custom AST lint rules over polar/ with a single shared parse.
 
 Each rule lives in its own module and registers a `Rule` with a name (for
-`--only`), a noqa code, and a `check(tree)` callable. Suppress a violation
-with `# noqa: <code>` on the offending line. Exits 1 on any violation.
+`--only`), a skip code, and a `check(tree)` callable. Suppress a violation
+with `# lint-skip: <code>` on the offending line (`# noqa` is ruff's directive
+and rejects our hyphenated codes). Exits 1 on any violation.
 """
 
 from __future__ import annotations
@@ -13,7 +14,7 @@ import sys
 from pathlib import Path
 
 from . import frontend_url, org_scope, subquery
-from .base import Rule, line_has_noqa
+from .base import Rule, line_has_skip
 
 RULES: tuple[Rule, ...] = (subquery.RULE, org_scope.RULE, frontend_url.RULE)
 
@@ -61,7 +62,7 @@ def main() -> int:
         source_lines = source.splitlines()
         for rule in rules:
             for lineno, message in rule.check(tree):
-                if line_has_noqa(source_lines, lineno, rule.noqa_code):
+                if line_has_skip(source_lines, lineno, rule.skip_code):
                     continue
                 violations.append((path, lineno, rule.name, message))
 

--- a/server/scripts/linters/base.py
+++ b/server/scripts/linters/base.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import ast
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+
+Violation = tuple[int, str]
+
+
+@dataclass(frozen=True)
+class Rule:
+    name: str
+    noqa_code: str
+    summary: str
+    check: Callable[[ast.Module], list[Violation]]
+
+
+_NOQA_RE = re.compile(r"#\s*noqa(?::\s*(?P<codes>[^#]*))?", re.IGNORECASE)
+
+
+def line_has_noqa(source_lines: list[str], lineno: int, noqa_code: str) -> bool:
+    idx = lineno - 1
+    if not (0 <= idx < len(source_lines)):
+        return False
+    match = _NOQA_RE.search(source_lines[idx])
+    if match is None:
+        return False
+    codes = match.group("codes")
+    if codes is None:
+        return True
+    return noqa_code in {code.strip() for code in codes.split(",")}

--- a/server/scripts/linters/base.py
+++ b/server/scripts/linters/base.py
@@ -11,22 +11,22 @@ Violation = tuple[int, str]
 @dataclass(frozen=True)
 class Rule:
     name: str
-    noqa_code: str
+    skip_code: str
     summary: str
     check: Callable[[ast.Module], list[Violation]]
 
 
-_NOQA_RE = re.compile(r"#\s*noqa(?::\s*(?P<codes>[^#]*))?", re.IGNORECASE)
+_SKIP_RE = re.compile(r"#\s*lint-skip(?::\s*(?P<codes>[^#]*))?")
 
 
-def line_has_noqa(source_lines: list[str], lineno: int, noqa_code: str) -> bool:
+def line_has_skip(source_lines: list[str], lineno: int, skip_code: str) -> bool:
     idx = lineno - 1
     if not (0 <= idx < len(source_lines)):
         return False
-    match = _NOQA_RE.search(source_lines[idx])
+    match = _SKIP_RE.search(source_lines[idx])
     if match is None:
         return False
     codes = match.group("codes")
     if codes is None:
         return True
-    return noqa_code in {code.strip() for code in codes.split(",")}
+    return skip_code in {code.strip() for code in codes.split(",")}

--- a/server/scripts/linters/frontend_url.py
+++ b/server/scripts/linters/frontend_url.py
@@ -12,24 +12,22 @@ Rules (per function, intra-procedural):
   (`Query`/`Path`/`Form`/`Header`/`Cookie`/`Body`), either as a default value
   or inside `Annotated[...]` metadata. Assigning an expression that references
   a tainted name to a local taints that local (fixed-point propagation).
+  References inside comparisons don't propagate — comparing against user input
+  selects a value, it doesn't let the input construct it.
 - Flag `generate_frontend_url(...)` calls whose arguments reference a tainted
   name.
 - Flag f-strings or `+` concatenations that combine `FRONTEND_BASE_URL` with a
   tainted name — the inlined form of the same bug.
 - `# noqa: frontend-url` on the offending line is an explicit escape for
   values already validated upstream.
-
-Exits 1 on any violation.
 """
 
 from __future__ import annotations
 
 import ast
-import re
-import sys
-from pathlib import Path
 
-NOQA_MARKER = "frontend-url"
+from .base import Rule, Violation
+
 TARGET_CALL = "generate_frontend_url"
 BASE_URL_SETTING = "FRONTEND_BASE_URL"
 FASTAPI_PARAM_MARKERS = frozenset({"Query", "Path", "Form", "Header", "Cookie", "Body"})
@@ -45,8 +43,6 @@ CONCAT_MESSAGE = (
     "redirect. Route it through get_safe_return_url (polar.kit.http). Escape "
     "with `# noqa: frontend-url` if already validated."
 )
-
-_NOQA_RE = re.compile(r"#\s*noqa(?::\s*(?P<codes>[^#]*))?", re.IGNORECASE)
 
 FunctionNode = ast.FunctionDef | ast.AsyncFunctionDef
 
@@ -90,6 +86,19 @@ def _references_any(node: ast.AST, names: set[str]) -> bool:
     )
 
 
+def _references_any_outside_compare(node: ast.AST, names: set[str]) -> bool:
+    inside_compare: set[int] = set()
+    for child in ast.walk(node):
+        if isinstance(child, ast.Compare):
+            inside_compare.update(id(sub) for sub in ast.walk(child))
+    return any(
+        isinstance(child, ast.Name)
+        and child.id in names
+        and id(child) not in inside_compare
+        for child in ast.walk(node)
+    )
+
+
 def _propagate(func: FunctionNode, tainted: set[str]) -> set[str]:
     """Fixed-point: a local assigned from a tainted expression is tainted."""
     changed = True
@@ -106,7 +115,7 @@ def _propagate(func: FunctionNode, tainted: set[str]) -> set[str]:
                 value, targets = node.value, [node.target]
             else:
                 continue
-            if value is None or not _references_any(value, tainted):
+            if value is None or not _references_any_outside_compare(value, tainted):
                 continue
             for target in targets:
                 for child in ast.walk(target):
@@ -130,13 +139,13 @@ def _references_base_url(node: ast.AST) -> bool:
     )
 
 
-def check_function(func: FunctionNode) -> list[tuple[int, str]]:
+def _check_function(func: FunctionNode) -> list[Violation]:
     tainted = _tainted_params(func)
     if not tainted:
         return []
     tainted = _propagate(func, tainted)
 
-    violations: list[tuple[int, str]] = []
+    violations: list[Violation] = []
     seen_lines: set[int] = set()
     for node in ast.walk(func):
         if isinstance(node, ast.Call) and _is_target_call(node):
@@ -156,65 +165,17 @@ def check_function(func: FunctionNode) -> list[tuple[int, str]]:
     return violations
 
 
-def _line_has_noqa(source_lines: list[str], lineno: int) -> bool:
-    idx = lineno - 1
-    if not (0 <= idx < len(source_lines)):
-        return False
-    match = _NOQA_RE.search(source_lines[idx])
-    if match is None:
-        return False
-    codes = match.group("codes")
-    if codes is None:
-        return True
-    return NOQA_MARKER in {code.strip() for code in codes.split(",")}
-
-
-def check_file(path: Path) -> list[tuple[Path, int, str]]:
-    source = path.read_text()
-    try:
-        tree = ast.parse(source, filename=str(path))
-    except SyntaxError as exc:
-        return [(path, exc.lineno or 0, f"syntax error: {exc.msg}")]
-
-    source_lines = source.splitlines()
-    violations: list[tuple[Path, int, str]] = []
+def check(tree: ast.Module) -> list[Violation]:
+    violations: list[Violation] = []
     for node in ast.walk(tree):
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            continue
-        for lineno, message in check_function(node):
-            if _line_has_noqa(source_lines, lineno):
-                continue
-            violations.append((path, lineno, message))
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            violations.extend(_check_function(node))
     return violations
 
 
-def main() -> int:
-    root = Path(__file__).resolve().parent.parent / "polar"
-    if not root.exists():
-        print(f"error: {root} not found", file=sys.stderr)
-        return 2
-
-    checked = 0
-    violations: list[tuple[Path, int, str]] = []
-    for path in sorted(root.rglob("*.py")):
-        if "migrations" in path.parts:
-            continue
-        checked += 1
-        violations.extend(check_file(path))
-
-    if violations:
-        for path, lineno, message in violations:
-            try:
-                rel = path.relative_to(Path.cwd())
-            except ValueError:
-                rel = path
-            print(f"{rel}:{lineno}: {message}")
-        print(f"\n{len(violations)} violation(s) across {checked} file(s).")
-        return 1
-
-    print(f"OK: {checked} file(s) checked, no frontend-url violations.")
-    return 0
-
-
-if __name__ == "__main__":
-    sys.exit(main())
+RULE = Rule(
+    name="frontend-url",
+    noqa_code="frontend-url",
+    summary="flag request-derived values passed to generate_frontend_url",
+    check=check,
+)

--- a/server/scripts/linters/frontend_url.py
+++ b/server/scripts/linters/frontend_url.py
@@ -10,15 +10,22 @@ the userinfo delimiter). Request-derived paths must go through
 Rules (per function, intra-procedural):
 - A parameter is *tainted* when declared with a FastAPI request marker
   (`Query`/`Path`/`Form`/`Header`/`Cookie`/`Body`), either as a default value
-  or inside `Annotated[...]` metadata. Assigning an expression that references
-  a tainted name to a local taints that local (fixed-point propagation).
-  References inside comparisons don't propagate — comparing against user input
-  selects a value, it doesn't let the input construct it.
+  or inside `Annotated[...]` metadata. In route handlers (functions decorated
+  with `@router.get(...)` etc.) every parameter is tainted unless it is a
+  dependency (`Depends`/`Security`) or a framework object (`Request`, ...) —
+  FastAPI treats bare `param: str` as a query parameter. Assigning an
+  expression that references a tainted name to a local taints that local
+  (fixed-point propagation). References inside comparisons don't propagate —
+  comparing against user input selects a value, it doesn't let the input
+  construct it.
 - Flag `generate_frontend_url(...)` calls whose arguments reference a tainted
   name.
 - Flag f-strings or `+` concatenations that combine `FRONTEND_BASE_URL` with a
   tainted name — the inlined form of the same bug.
-- `# noqa: frontend-url` on the offending line is an explicit escape for
+- *Anchored* constructions are safe and not flagged: when the tainted value
+  can only appear after a literal starting with "/" (`f"/auth/sso/{slug}"`),
+  the resulting URL stays on the frontend origin no matter the value.
+- `# lint-skip: frontend-url` on the offending line is an explicit escape for
   values already validated upstream.
 """
 
@@ -31,6 +38,23 @@ from .base import Rule, Violation
 TARGET_CALL = "generate_frontend_url"
 BASE_URL_SETTING = "FRONTEND_BASE_URL"
 FASTAPI_PARAM_MARKERS = frozenset({"Query", "Path", "Form", "Header", "Cookie", "Body"})
+ROUTE_METHODS = frozenset(
+    {
+        "get",
+        "post",
+        "put",
+        "patch",
+        "delete",
+        "head",
+        "options",
+        "api_route",
+        "websocket",
+    }
+)
+DEPENDENCY_MARKERS = frozenset({"Depends", "Security"})
+FRAMEWORK_PARAM_TYPES = frozenset(
+    {"Request", "WebSocket", "Response", "BackgroundTasks"}
+)
 
 CALL_MESSAGE = (
     "request-derived value passed to generate_frontend_url — it concatenates "
@@ -64,8 +88,29 @@ def _annotation_has_marker(node: ast.AST | None) -> bool:
     return any(_is_fastapi_marker(child) for child in ast.walk(node))
 
 
+def _is_route_handler(func: FunctionNode) -> bool:
+    return any(
+        isinstance(decorator, ast.Call)
+        and isinstance(decorator.func, ast.Attribute)
+        and decorator.func.attr in ROUTE_METHODS
+        for decorator in func.decorator_list
+    )
+
+
+def _mentions(node: ast.AST | None, names: frozenset[str]) -> bool:
+    if node is None:
+        return False
+    return any(
+        (isinstance(child, ast.Name) and child.id in names)
+        or (isinstance(child, ast.Attribute) and child.attr in names)
+        for child in ast.walk(node)
+    )
+
+
 def _tainted_params(func: FunctionNode) -> set[str]:
-    """Parameters declared with a FastAPI request marker."""
+    """Parameters carrying request input: FastAPI-marker-declared ones, and in
+    route handlers every non-dependency, non-framework parameter."""
+    route_handler = _is_route_handler(func)
     args = func.args
     positional = args.posonlyargs + args.args
     defaults: list[ast.expr | None] = [None] * (
@@ -77,6 +122,14 @@ def _tainted_params(func: FunctionNode) -> set[str]:
     ):
         if _is_fastapi_marker(default) or _annotation_has_marker(arg.annotation):
             tainted.add(arg.arg)
+            continue
+        if not route_handler or arg.arg in ("self", "cls"):
+            continue
+        if _mentions(default, DEPENDENCY_MARKERS):
+            continue
+        if _mentions(arg.annotation, DEPENDENCY_MARKERS | FRAMEWORK_PARAM_TYPES):
+            continue
+        tainted.add(arg.arg)
     return tainted
 
 
@@ -115,7 +168,9 @@ def _propagate(func: FunctionNode, tainted: set[str]) -> set[str]:
                 value, targets = node.value, [node.target]
             else:
                 continue
-            if value is None or not _references_any_outside_compare(value, tainted):
+            if value is None or _is_anchored(value):
+                continue
+            if not _references_any_outside_compare(value, tainted):
                 continue
             for target in targets:
                 for child in ast.walk(target):
@@ -123,6 +178,44 @@ def _propagate(func: FunctionNode, tainted: set[str]) -> set[str]:
                         tainted.add(child.id)
                         changed = True
     return tainted
+
+
+def _concat_terms(node: ast.expr) -> list[ast.expr]:
+    """Flatten a string construction into its ordered terms: f-string parts
+    (formatted values unwrapped) and `+` concatenation operands."""
+    if isinstance(node, ast.JoinedStr):
+        return [
+            term
+            for value in node.values
+            for term in _concat_terms(
+                value.value if isinstance(value, ast.FormattedValue) else value
+            )
+        ]
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        return _concat_terms(node.left) + _concat_terms(node.right)
+    return [node]
+
+
+def _is_path_literal(node: ast.expr) -> bool:
+    return (
+        isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and node.value.startswith("/")
+    )
+
+
+def _is_anchored(node: ast.expr) -> bool:
+    terms = _concat_terms(node)
+    return bool(terms) and _is_path_literal(terms[0])
+
+
+def _is_anchored_after_base_url(node: ast.expr) -> bool:
+    terms = _concat_terms(node)
+    for index, term in enumerate(terms):
+        if _references_base_url(term):
+            rest = terms[index + 1 :]
+            return bool(rest) and _is_path_literal(rest[0])
+    return False
 
 
 def _is_target_call(node: ast.Call) -> bool:
@@ -149,11 +242,17 @@ def _check_function(func: FunctionNode) -> list[Violation]:
     seen_lines: set[int] = set()
     for node in ast.walk(func):
         if isinstance(node, ast.Call) and _is_target_call(node):
-            if not any(_references_any(arg, tainted) for arg in node.args):
+            operands = [*node.args, *(keyword.value for keyword in node.keywords)]
+            if not any(
+                not _is_anchored(operand) and _references_any(operand, tainted)
+                for operand in operands
+            ):
                 continue
             message = CALL_MESSAGE
         elif isinstance(node, (ast.JoinedStr, ast.BinOp)):
             if not (_references_base_url(node) and _references_any(node, tainted)):
+                continue
+            if _is_anchored_after_base_url(node):
                 continue
             message = CONCAT_MESSAGE
         else:

--- a/server/scripts/linters/frontend_url.py
+++ b/server/scripts/linters/frontend_url.py
@@ -59,13 +59,13 @@ FRAMEWORK_PARAM_TYPES = frozenset(
 CALL_MESSAGE = (
     "request-derived value passed to generate_frontend_url — it concatenates "
     "without validation (open redirect). Route it through get_safe_return_url "
-    "(polar.kit.http). Escape with `# noqa: frontend-url` if already validated."
+    "(polar.kit.http). Escape with `# lint-skip: frontend-url` if already validated."
 )
 
 CONCAT_MESSAGE = (
     "request-derived value concatenated with FRONTEND_BASE_URL — open "
     "redirect. Route it through get_safe_return_url (polar.kit.http). Escape "
-    "with `# noqa: frontend-url` if already validated."
+    "with `# lint-skip: frontend-url` if already validated."
 )
 
 FunctionNode = ast.FunctionDef | ast.AsyncFunctionDef
@@ -274,7 +274,7 @@ def check(tree: ast.Module) -> list[Violation]:
 
 RULE = Rule(
     name="frontend-url",
-    noqa_code="frontend-url",
+    skip_code="frontend-url",
     summary="flag request-derived values passed to generate_frontend_url",
     check=check,
 )

--- a/server/scripts/linters/org_scope.py
+++ b/server/scripts/linters/org_scope.py
@@ -23,19 +23,15 @@ Rules:
   parameter, not `auth_subject`, and not projecting `organization_id`) is NOT
   flagged by the first two rules.
 - `# noqa: org-scope` on the offending line is an explicit escape.
-
-Exits 1 on any violation.
 """
 
 from __future__ import annotations
 
 import ast
-import re
-import sys
-from pathlib import Path
 from typing import TypeGuard
 
-NOQA_MARKER = "org-scope"
+from .base import Rule, Violation
+
 MODEL_NAME = "UserOrganization"
 SUBJECT_NAME = "auth_subject"
 
@@ -57,10 +53,6 @@ RAW_CALL_MESSAGE = (
     "scope-aware helper, manual intersection, or membership management), mark it "
     "`# noqa: org-scope`."
 )
-
-# Matches `# noqa` optionally followed by `: code1, code2`. A bare `# noqa`
-# suppresses everything; a coded form only suppresses the listed codes.
-_NOQA_RE = re.compile(r"#\s*noqa(?::\s*(?P<codes>[^#]*))?", re.IGNORECASE)
 
 
 def _is_model_attr(node: ast.AST) -> TypeGuard[ast.Attribute]:
@@ -116,29 +108,8 @@ def _is_raw_membership_call(node: ast.Call) -> bool:
     return False
 
 
-def _line_has_noqa(source_lines: list[str], lineno: int) -> bool:
-    idx = lineno - 1
-    if not (0 <= idx < len(source_lines)):
-        return False
-    match = _NOQA_RE.search(source_lines[idx])
-    if match is None:
-        return False
-    codes = match.group("codes")
-    if codes is None:  # bare `# noqa` suppresses everything
-        return True
-    return NOQA_MARKER in {code.strip() for code in codes.split(",")}
-
-
-def check_file(path: Path) -> list[tuple[Path, int, str]]:
-    """Return a list of (path, lineno, message) violations."""
-    source = path.read_text()
-    try:
-        tree = ast.parse(source, filename=str(path))
-    except SyntaxError as exc:
-        return [(path, exc.lineno or 0, f"syntax error: {exc.msg}")]
-
-    source_lines = source.splitlines()
-    violations: list[tuple[Path, int, str]] = []
+def check(tree: ast.Module) -> list[Violation]:
+    violations: list[Violation] = []
     seen_lines: set[int] = set()
 
     for node in ast.walk(tree):
@@ -160,45 +131,18 @@ def check_file(path: Path) -> list[tuple[Path, int, str]]:
         else:
             continue
 
-        if _line_has_noqa(source_lines, node.lineno):
-            continue
-
         if node.lineno in seen_lines:  # one query can match multiple branches
             continue
         seen_lines.add(node.lineno)
 
-        violations.append((path, node.lineno, message))
+        violations.append((node.lineno, message))
 
     return violations
 
 
-def main() -> int:
-    root = Path(__file__).resolve().parent.parent / "polar"
-    if not root.exists():
-        print(f"error: {root} not found", file=sys.stderr)
-        return 2
-
-    checked = 0
-    violations: list[tuple[Path, int, str]] = []
-    for path in sorted(root.rglob("*.py")):
-        if "migrations" in path.parts:
-            continue
-        checked += 1
-        violations.extend(check_file(path))
-
-    if violations:
-        for path, lineno, message in violations:
-            try:
-                rel = path.relative_to(Path.cwd())
-            except ValueError:
-                rel = path
-            print(f"{rel}:{lineno}: {message}")
-        print(f"\n{len(violations)} violation(s) across {checked} file(s).")
-        return 1
-
-    print(f"OK: {checked} file(s) checked, no org-scope violations.")
-    return 0
-
-
-if __name__ == "__main__":
-    sys.exit(main())
+RULE = Rule(
+    name="org-scope",
+    noqa_code="org-scope",
+    summary="flag inline UserOrganization filters that bypass select_user_org_ids",
+    check=check,
+)

--- a/server/scripts/linters/org_scope.py
+++ b/server/scripts/linters/org_scope.py
@@ -12,17 +12,17 @@ using them where an `auth_subject` is in play silently leaks other orgs (see the
 Rules:
 - Flag `select(UserOrganization.organization_id)` — hand-building the
   user→accessible-orgs subquery. `select_user_org_ids` is the sole blessed
-  definition and marks itself with `# noqa: org-scope`.
+  definition and marks itself with `# lint-skip: org-scope`.
 - Flag a comparison where one operand is `UserOrganization.<col>` and another
   references `auth_subject` — the join-form bypass.
 - Flag a **call** to a raw membership helper (`select_user_org_ids`,
   `get_organizations_with_role`). Prefer the scope-aware helpers; if the raw use
   is intentional (composing the scope-aware helper, manual intersection, or
-  membership management on a plain `user_id`), mark it `# noqa: org-scope`.
+  membership management on a plain `user_id`), mark it `# lint-skip: org-scope`.
 - Membership *management* code (filtering by a plain `user_id`/`user.id`
   parameter, not `auth_subject`, and not projecting `organization_id`) is NOT
   flagged by the first two rules.
-- `# noqa: org-scope` on the offending line is an explicit escape.
+- `# lint-skip: org-scope` on the offending line is an explicit escape.
 """
 
 from __future__ import annotations
@@ -43,7 +43,7 @@ EXPANSION_MESSAGE = (
     "hand-rolled UserOrganization membership expansion bypasses org-scope "
     "enforcement. Use select_accessible_org_ids(auth_subject) from "
     "polar.authz.repository (or get_accessible_org_ids). Escape with "
-    "`# noqa: org-scope` if intentional."
+    "`# lint-skip: org-scope` if intentional."
 )
 
 RAW_CALL_MESSAGE = (
@@ -51,7 +51,7 @@ RAW_CALL_MESSAGE = (
     "select_accessible_org_ids / get_accessible_org_ids / "
     "get_accessible_organization. If the raw use is intentional (composing the "
     "scope-aware helper, manual intersection, or membership management), mark it "
-    "`# noqa: org-scope`."
+    "`# lint-skip: org-scope`."
 )
 
 
@@ -142,7 +142,7 @@ def check(tree: ast.Module) -> list[Violation]:
 
 RULE = Rule(
     name="org-scope",
-    noqa_code="org-scope",
+    skip_code="org-scope",
     summary="flag inline UserOrganization filters that bypass select_user_org_ids",
     check=check,
 )

--- a/server/scripts/linters/subquery.py
+++ b/server/scripts/linters/subquery.py
@@ -15,7 +15,7 @@ Rules:
   statically determine the root. Those cases rely on the CLAUDE.md rule and
   code review. If you introduce a new variable-rooted `.subquery()` on an
   entity select, call `.with_only_columns(...)` explicitly.
-- `# noqa: subquery-all-columns` on the call line is an explicit escape for
+- `# lint-skip: subquery-all-columns` on the call line is an explicit escape for
   cases where full-column projection is intentional.
 """
 
@@ -31,7 +31,7 @@ MESSAGE = (
     "call .with_only_columns(...) before .subquery(), or use "
     "count_subquery() from polar.kit.pagination. "
     "`deferred=True` does not propagate into .subquery(). "
-    "Escape with `# noqa: subquery-all-columns` if full-column "
+    "Escape with `# lint-skip: subquery-all-columns` if full-column "
     "projection is intentional."
 )
 
@@ -81,7 +81,7 @@ def _chain_is_safe(receiver: ast.AST) -> bool:
 
     # Find the root of the chain. If the root isn't a recognizable
     # `select(...)` on a single model-like Name, we can't confidently flag —
-    # default to safe and let code review / noqa handle rare cases.
+    # default to safe and let code review / lint-skip handle rare cases.
     if not calls:
         return True
     root = calls[-1]
@@ -119,7 +119,7 @@ def check(tree: ast.Module) -> list[Violation]:
 
 RULE = Rule(
     name="subquery",
-    noqa_code="subquery-all-columns",
+    skip_code="subquery-all-columns",
     summary="flag .subquery() calls that don't narrow columns",
     check=check,
 )

--- a/server/scripts/linters/subquery.py
+++ b/server/scripts/linters/subquery.py
@@ -17,18 +17,23 @@ Rules:
   entity select, call `.with_only_columns(...)` explicitly.
 - `# noqa: subquery-all-columns` on the call line is an explicit escape for
   cases where full-column projection is intentional.
-
-Exits 1 on any violation.
 """
 
 from __future__ import annotations
 
 import ast
-import sys
-from pathlib import Path
 
-NOQA_MARKER = "subquery-all-columns"
+from .base import Rule, Violation
+
 SAFE_NAMES = frozenset({"with_only_columns", "union", "union_all", "intersect"})
+
+MESSAGE = (
+    "call .with_only_columns(...) before .subquery(), or use "
+    "count_subquery() from polar.kit.pagination. "
+    "`deferred=True` does not propagate into .subquery(). "
+    "Escape with `# noqa: subquery-all-columns` if full-column "
+    "projection is intentional."
+)
 
 
 def _iter_chain_calls(node: ast.AST) -> list[ast.Call]:
@@ -98,77 +103,23 @@ def _chain_is_safe(receiver: ast.AST) -> bool:
     return True
 
 
-def _line_has_noqa(source_lines: list[str], lineno: int) -> bool:
-    idx = lineno - 1
-    return 0 <= idx < len(source_lines) and NOQA_MARKER in source_lines[idx]
-
-
-def check_file(path: Path) -> list[tuple[Path, int, str]]:
-    """Return a list of (path, lineno, message) violations."""
-    source = path.read_text()
-    try:
-        tree = ast.parse(source, filename=str(path))
-    except SyntaxError as exc:
-        return [(path, exc.lineno or 0, f"syntax error: {exc.msg}")]
-
-    source_lines = source.splitlines()
-    violations: list[tuple[Path, int, str]] = []
-
+def check(tree: ast.Module) -> list[Violation]:
+    violations: list[Violation] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Call):
             continue
         func = node.func
         if not isinstance(func, ast.Attribute) or func.attr != "subquery":
             continue
-
-        if _line_has_noqa(source_lines, node.lineno):
-            continue
-
         if _chain_is_safe(func.value):
             continue
-
-        violations.append(
-            (
-                path,
-                node.lineno,
-                "call .with_only_columns(...) before .subquery(), or use "
-                "count_subquery() from polar.kit.pagination. "
-                "`deferred=True` does not propagate into .subquery(). "
-                "Escape with `# noqa: subquery-all-columns` if full-column "
-                "projection is intentional.",
-            )
-        )
-
+        violations.append((node.lineno, MESSAGE))
     return violations
 
 
-def main() -> int:
-    root = Path(__file__).resolve().parent.parent / "polar"
-    if not root.exists():
-        print(f"error: {root} not found", file=sys.stderr)
-        return 2
-
-    checked = 0
-    violations: list[tuple[Path, int, str]] = []
-    for path in sorted(root.rglob("*.py")):
-        if "migrations" in path.parts:
-            continue
-        checked += 1
-        violations.extend(check_file(path))
-
-    if violations:
-        for path, lineno, message in violations:
-            try:
-                rel = path.relative_to(Path.cwd())
-            except ValueError:
-                rel = path
-            print(f"{rel}:{lineno}: {message}")
-        print(f"\n{len(violations)} violation(s) across {checked} file(s).")
-        return 1
-
-    print(f"OK: {checked} file(s) checked, no .subquery() violations.")
-    return 0
-
-
-if __name__ == "__main__":
-    sys.exit(main())
+RULE = Rule(
+    name="subquery",
+    noqa_code="subquery-all-columns",
+    summary="flag .subquery() calls that don't narrow columns",
+    check=check,
+)


### PR DESCRIPTION
This merges all server linters into a unified runner that allows us to only parse the AST once and apply all rules after that.

It will still allow you to run a single linter (similar as the previous behaviour). 

This also adds a new linter for checking the use of request derived values in generate_frontend_url to prevent open redirect issues.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

