### PR TITLE
feat(subscription): pause & resume behavior

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -16742,6 +16742,21 @@ export interface components {
        */
       past_due_at?: string | null
       /**
+       * Pause At Period End
+       * @description Whether the subscription will be paused at the end of the current period.
+       */
+      pause_at_period_end: boolean
+      /**
+       * Paused At
+       * @description The timestamp when the subscription was paused.
+       */
+      paused_at: string | null
+      /**
+       * Resumes At
+       * @description The timestamp when a paused subscription is scheduled to automatically resume, if set.
+       */
+      resumes_at: string | null
+      /**
        * Customer Id
        * Format: uuid4
        * @description The ID of the subscribed customer.
@@ -18182,6 +18197,21 @@ export interface components {
        * @description The timestamp when the subscription entered `past_due` status.
        */
       past_due_at?: string | null
+      /**
+       * Pause At Period End
+       * @description Whether the subscription will be paused at the end of the current period.
+       */
+      pause_at_period_end: boolean
+      /**
+       * Paused At
+       * @description The timestamp when the subscription was paused.
+       */
+      paused_at: string | null
+      /**
+       * Resumes At
+       * @description The timestamp when a paused subscription is scheduled to automatically resume, if set.
+       */
+      resumes_at: string | null
       /**
        * Customer Id
        * Format: uuid4
@@ -24630,6 +24660,21 @@ export interface components {
        */
       past_due_at?: string | null
       /**
+       * Pause At Period End
+       * @description Whether the subscription will be paused at the end of the current period.
+       */
+      pause_at_period_end: boolean
+      /**
+       * Paused At
+       * @description The timestamp when the subscription was paused.
+       */
+      paused_at: string | null
+      /**
+       * Resumes At
+       * @description The timestamp when a paused subscription is scheduled to automatically resume, if set.
+       */
+      resumes_at: string | null
+      /**
        * Customer Id
        * Format: uuid4
        * @description The ID of the subscribed customer.
@@ -30961,6 +31006,21 @@ export interface components {
        */
       past_due_at?: string | null
       /**
+       * Pause At Period End
+       * @description Whether the subscription will be paused at the end of the current period.
+       */
+      pause_at_period_end: boolean
+      /**
+       * Paused At
+       * @description The timestamp when the subscription was paused.
+       */
+      paused_at: string | null
+      /**
+       * Resumes At
+       * @description The timestamp when a paused subscription is scheduled to automatically resume, if set.
+       */
+      resumes_at: string | null
+      /**
        * Customer Id
        * Format: uuid4
        * @description The ID of the subscribed customer.
@@ -31811,6 +31871,25 @@ export interface components {
       /** Recurring Interval Count */
       recurring_interval_count?: number
     }
+    /** SubscriptionPause */
+    SubscriptionPause: {
+      /**
+       * Pause At Period End
+       * @description Pause an active subscription at the end of the current period.
+       *
+       *     Or cancel a scheduled pause on a subscription set to be paused at
+       *     period end.
+       */
+      pause_at_period_end: boolean
+      /**
+       * Resumes At
+       * @description Date at which the paused subscription should automatically resume.
+       *
+       *     If not set, the subscription stays paused until it is resumed manually.
+       *     Must be after the current period end.
+       */
+      resumes_at?: string | null
+    }
     /**
      * SubscriptionProductUpdatedEvent
      * @description An event created by Polar when a subscription changes the product.
@@ -31993,6 +32072,15 @@ export interface components {
       recurring_interval?: string
       /** Recurring Interval Count */
       recurring_interval_count?: number
+    }
+    /** SubscriptionResume */
+    SubscriptionResume: {
+      /**
+       * Resume
+       * @description Resume a paused subscription immediately, starting a new billing period and charging the customer.
+       * @constant
+       */
+      resume: true
     }
     /** SubscriptionRevoke */
     SubscriptionRevoke: {
@@ -32346,6 +32434,8 @@ export interface components {
       | components['schemas']['SubscriptionUpdateBillingPeriod']
       | components['schemas']['SubscriptionCancel']
       | components['schemas']['SubscriptionRevoke']
+      | components['schemas']['SubscriptionPause']
+      | components['schemas']['SubscriptionResume']
       | components['schemas']['SubscriptionUpdateClear']
     /** SubscriptionUpdateBase */
     SubscriptionUpdateBase: {

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -316,11 +316,30 @@ class SubscriptionRepository(
             .where(
                 Subscription.status == SubscriptionStatus.active,
                 Subscription.cancel_at_period_end.is_(False),
+                Subscription.pause_at_period_end.is_(False),
                 Subscription.current_period_end.isnot(None),
                 Subscription.current_period_end > now,
                 Subscription.current_period_end <= reminder_window_end,
                 long_cycle_condition,
                 ~dedup_subquery,
+            )
+            .options(*options)
+        )
+        return await self.get_all(statement)
+
+    async def get_subscriptions_to_resume(
+        self,
+        now: datetime,
+        *,
+        options: Options = (),
+    ) -> Sequence[Subscription]:
+        """Find paused subscriptions whose scheduled resume time has passed."""
+        statement = (
+            self.get_base_statement()
+            .where(
+                Subscription.status == SubscriptionStatus.paused,
+                Subscription.resumes_at.isnot(None),
+                Subscription.resumes_at <= now,
             )
             .options(*options)
         )

--- a/server/polar/subscription/schemas.py
+++ b/server/polar/subscription/schemas.py
@@ -131,6 +131,23 @@ class SubscriptionBase(IDSchema, TimestampedSchema):
         None,
         description=("The timestamp when the subscription entered `past_due` status."),
     )
+    pause_at_period_end: bool = Field(
+        description=(
+            "Whether the subscription will be paused "
+            "at the end of the current period."
+        )
+    )
+    paused_at: datetime | None = Field(
+        None,
+        description="The timestamp when the subscription was paused.",
+    )
+    resumes_at: datetime | None = Field(
+        None,
+        description=(
+            "The timestamp when a paused subscription is scheduled to "
+            "automatically resume, if set."
+        ),
+    )
 
     customer_id: UUID4 = Field(description="The ID of the subscribed customer.")
     product_id: UUID4 = Field(description="The ID of the subscribed product.")
@@ -435,6 +452,43 @@ class SubscriptionRevoke(SubscriptionCancelBase):
     )
 
 
+class SubscriptionPause(Schema):
+    model_config = ConfigDict(extra="forbid")
+
+    pause_at_period_end: bool = Field(
+        description=inspect.cleandoc(
+            """
+        Pause an active subscription at the end of the current period.
+
+        Or cancel a scheduled pause on a subscription set to be paused at
+        period end.
+        """
+        ),
+    )
+    resumes_at: FutureDatetime | None = Field(
+        None,
+        description=inspect.cleandoc(
+            """
+        Date at which the paused subscription should automatically resume.
+
+        If not set, the subscription stays paused until it is resumed manually.
+        Must be after the current period end.
+        """
+        ),
+    )
+
+
+class SubscriptionResume(Schema):
+    model_config = ConfigDict(extra="forbid")
+
+    resume: Literal[True] = Field(
+        description=(
+            "Resume a paused subscription immediately, "
+            "starting a new billing period and charging the customer."
+        )
+    )
+
+
 class SubscriptionUpdateClear(Schema):
     model_config = ConfigDict(extra="forbid")
 
@@ -449,6 +503,8 @@ SubscriptionUpdate = Annotated[
     | SubscriptionUpdateBillingPeriod
     | SubscriptionCancel
     | SubscriptionRevoke
+    | SubscriptionPause
+    | SubscriptionResume
     | SubscriptionUpdateClear,
     SetSchemaReference("SubscriptionUpdate"),
 ]

--- a/server/polar/subscription/schemas.py
+++ b/server/polar/subscription/schemas.py
@@ -133,16 +133,13 @@ class SubscriptionBase(IDSchema, TimestampedSchema):
     )
     pause_at_period_end: bool = Field(
         description=(
-            "Whether the subscription will be paused "
-            "at the end of the current period."
+            "Whether the subscription will be paused at the end of the current period."
         )
     )
     paused_at: datetime | None = Field(
-        None,
         description="The timestamp when the subscription was paused.",
     )
     resumes_at: datetime | None = Field(
-        None,
         description=(
             "The timestamp when a paused subscription is scheduled to "
             "automatically resume, if set."

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -857,49 +857,7 @@ class SubscriptionService:
                 ):
                     subscription.discount = None
 
-            event = event = await event_service.create_event(
-                session,
-                build_system_event(
-                    SystemEvent.subscription_cycled,
-                    customer=subscription.customer,
-                    organization=subscription.organization,
-                    metadata=SubscriptionCycledMetadata(
-                        subscription_id=str(subscription.id),
-                        product_id=str(subscription.product_id),
-                        amount=subscription.amount,
-                        currency=subscription.currency,
-                        recurring_interval=subscription.recurring_interval.value,
-                        recurring_interval_count=subscription.recurring_interval_count,
-                    ),
-                ),
-            )
-            # Add a billing entry for a new period
-            billing_entry_repository = BillingEntryRepository.from_session(session)
-            for subscription_product_price in subscription.subscription_product_prices:
-                product_price = subscription_product_price.product_price
-                if is_static_price(product_price):
-                    discount_amount = 0
-                    if subscription.discount:
-                        discount_amount = subscription.discount.get_discount_amount(
-                            subscription_product_price.amount, subscription.currency
-                        )
-
-                    await billing_entry_repository.create(
-                        BillingEntry(
-                            start_timestamp=subscription.current_period_start,
-                            end_timestamp=subscription.current_period_end,
-                            type=BillingEntryType.cycle,
-                            direction=BillingEntryDirection.debit,
-                            amount=subscription_product_price.amount,
-                            currency=subscription.currency,
-                            customer=subscription.customer,
-                            product_price=product_price,
-                            discount=subscription.discount,
-                            discount_amount=discount_amount,
-                            subscription=subscription,
-                            event=event,
-                        ),
-                    )
+            await self._create_cycle_billing_entries(session, subscription)
 
         if previous_status == SubscriptionStatus.trialing:
             subscription.status = SubscriptionStatus.active
@@ -930,6 +888,53 @@ class SubscriptionService:
         )
 
         return subscription
+
+    async def _create_cycle_billing_entries(
+        self, session: AsyncSession, subscription: Subscription
+    ) -> None:
+        event = await event_service.create_event(
+            session,
+            build_system_event(
+                SystemEvent.subscription_cycled,
+                customer=subscription.customer,
+                organization=subscription.organization,
+                metadata=SubscriptionCycledMetadata(
+                    subscription_id=str(subscription.id),
+                    product_id=str(subscription.product_id),
+                    amount=subscription.amount,
+                    currency=subscription.currency,
+                    recurring_interval=subscription.recurring_interval.value,
+                    recurring_interval_count=subscription.recurring_interval_count,
+                ),
+            ),
+        )
+        # Add a billing entry for a new period
+        billing_entry_repository = BillingEntryRepository.from_session(session)
+        for subscription_product_price in subscription.subscription_product_prices:
+            product_price = subscription_product_price.product_price
+            if is_static_price(product_price):
+                discount_amount = 0
+                if subscription.discount:
+                    discount_amount = subscription.discount.get_discount_amount(
+                        subscription_product_price.amount, subscription.currency
+                    )
+
+                await billing_entry_repository.create(
+                    BillingEntry(
+                        start_timestamp=subscription.current_period_start,
+                        end_timestamp=subscription.current_period_end,
+                        type=BillingEntryType.cycle,
+                        direction=BillingEntryDirection.debit,
+                        amount=subscription_product_price.amount,
+                        currency=subscription.currency,
+                        customer=subscription.customer,
+                        product_price=product_price,
+                        discount=subscription.discount,
+                        discount_amount=discount_amount,
+                        subscription=subscription,
+                        event=event,
+                    ),
+                )
 
     async def reset_meters(
         self, session: AsyncSession, subscription: Subscription

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -798,6 +798,21 @@ class SubscriptionService:
             return subscription
 
         revoke = subscription.cancel_at_period_end
+
+        # Subscription is due to pause: it enters the paused state at the end of
+        # its current period instead of renewing. Benefits are revoked and no
+        # order is created; a scheduled or manual resume starts a new period. A
+        # scheduled cancellation takes precedence over a scheduled pause.
+        if not revoke and subscription.pause_at_period_end:
+            subscription.status = SubscriptionStatus.paused
+            subscription.paused_at = utc_now()
+            subscription.pause_at_period_end = False
+            await self.enqueue_benefits_grants(session, subscription)
+            repository = SubscriptionRepository.from_session(session)
+            return await repository.update(
+                subscription, update_dict={"scheduler_locked_at": None}
+            )
+
         previous_status = subscription.status
         previous_canceled = subscription.canceled
 

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -115,6 +115,8 @@ from .schemas import (
     SubscriptionChargePreviewProration,
     SubscriptionCreate,
     SubscriptionCreateCustomer,
+    SubscriptionPause,
+    SubscriptionResume,
     SubscriptionRevoke,
     SubscriptionUpdate,
     SubscriptionUpdateBase,
@@ -174,6 +176,27 @@ class SubscriptionLocked(SubscriptionError):
     def __init__(self, subscription: Subscription) -> None:
         self.subscription = subscription
         message = "This subscription is pending an update."
+        super().__init__(message, 409)
+
+
+class CannotPauseSubscription(SubscriptionError):
+    def __init__(self, subscription: Subscription) -> None:
+        self.subscription = subscription
+        message = "This subscription cannot be paused."
+        super().__init__(message, 409)
+
+
+class NoScheduledPause(SubscriptionError):
+    def __init__(self, subscription: Subscription) -> None:
+        self.subscription = subscription
+        message = "This subscription is not scheduled to be paused."
+        super().__init__(message, 409)
+
+
+class NotPausedSubscription(SubscriptionError):
+    def __init__(self, subscription: Subscription) -> None:
+        self.subscription = subscription
+        message = "This subscription is not paused."
         super().__init__(message, 409)
 
 
@@ -1105,6 +1128,19 @@ class SubscriptionService:
                 immediately=True,
             )
 
+        if isinstance(update, SubscriptionPause):
+            if update.pause_at_period_end:
+                subscription = await self.pause(
+                    session, ctx, subscription, resumes_at=update.resumes_at
+                )
+            else:
+                subscription = await self.cancel_scheduled_pause(
+                    session, ctx, subscription
+                )
+
+        if isinstance(update, SubscriptionResume):
+            subscription = await self.resume(session, ctx, subscription)
+
         if isinstance(update, SubscriptionUpdateClear):
             subscription = await self.clear_pending_update(session, ctx, subscription)
 
@@ -1850,6 +1886,91 @@ class SubscriptionService:
             customer_reason=customer_reason,
             customer_comment=customer_comment,
         )
+
+    async def pause(
+        self,
+        session: AsyncSession,
+        ctx: SubscriptionUpdateContext,
+        subscription: Subscription,
+        *,
+        resumes_at: datetime | None = None,
+    ) -> Subscription:
+        if not subscription.can_pause():
+            raise CannotPauseSubscription(subscription)
+
+        if resumes_at is not None and resumes_at <= subscription.current_period_end:
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "resumes_at"),
+                        "msg": "resumes_at must be after the current period end.",
+                        "input": resumes_at,
+                    }
+                ]
+            )
+
+        subscription.pause_at_period_end = True
+        subscription.resumes_at = resumes_at
+        session.add(subscription)
+        return subscription
+
+    async def cancel_scheduled_pause(
+        self,
+        session: AsyncSession,
+        ctx: SubscriptionUpdateContext,
+        subscription: Subscription,
+    ) -> Subscription:
+        if not subscription.can_cancel_scheduled_pause():
+            raise NoScheduledPause(subscription)
+
+        subscription.pause_at_period_end = False
+        subscription.resumes_at = None
+        session.add(subscription)
+        return subscription
+
+    async def resume(
+        self,
+        session: AsyncSession,
+        ctx: SubscriptionUpdateContext,
+        subscription: Subscription,
+    ) -> Subscription:
+        if not subscription.can_resume():
+            raise NotPausedSubscription(subscription)
+
+        now = utc_now()
+        subscription.status = SubscriptionStatus.active
+        subscription.paused_at = None
+        subscription.resumes_at = None
+
+        # Start a fresh billing period from now and charge immediately.
+        subscription.current_period_start = now
+        subscription.anchor_day = now.day
+        subscription.current_period_end = (
+            subscription.recurring_interval.get_next_period(
+                now, subscription.anchor_day, subscription.recurring_interval_count
+            )
+        )
+        subscription.initialize_meter_period(now)
+
+        await self.enqueue_benefits_grants(session, subscription)
+        await self._create_cycle_billing_entries(session, subscription)
+
+        repository = SubscriptionRepository.from_session(session)
+        subscription = await repository.update(subscription)
+
+        enqueue_job(
+            "order.create_subscription_order",
+            subscription.id,
+            OrderBillingReasonInternal.subscription_cycle,
+        )
+
+        log.info(
+            "subscription.resumed",
+            id=subscription.id,
+            current_period_end=subscription.current_period_end,
+        )
+        return subscription
 
     async def cancel_customer(
         self, session: AsyncSession, customer_id: uuid.UUID

--- a/server/polar/subscription/tasks.py
+++ b/server/polar/subscription/tasks.py
@@ -150,6 +150,47 @@ async def subscription_cancel_customer(customer_id: uuid.UUID) -> None:
 
 
 @actor(
+    actor_name="subscription.scan_paused_resumptions",
+    cron_trigger=CronTrigger.from_crontab("15 * * * *"),
+    priority=TaskPriority.LOW,
+)
+async def scan_paused_resumptions() -> None:
+    """Scan for paused subscriptions due to resume and fan out."""
+    now = utc_now()
+    async with AsyncSessionMaker() as session:
+        repository = SubscriptionRepository.from_session(session)
+        subscriptions = await repository.get_subscriptions_to_resume(now)
+
+    for sub in subscriptions:
+        enqueue_job("subscription.resume", sub.id)
+
+
+@actor(actor_name="subscription.resume", priority=TaskPriority.MEDIUM)
+async def subscription_resume(subscription_id: uuid.UUID) -> None:
+    async with AsyncSessionMaker() as session:
+        repository = SubscriptionRepository.from_session(session)
+        subscription = await repository.get_by_id(
+            subscription_id,
+            options=repository.get_eager_options(),
+            for_update=True,
+        )
+        if subscription is None:
+            raise SubscriptionDoesNotExist(subscription_id)
+
+        if not subscription.can_resume():
+            log.info(
+                "Subscription is no longer paused, skipping resume",
+                subscription_id=subscription_id,
+            )
+            return
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.resume(session, ctx, subscription)
+
+
+@actor(
     actor_name="subscription.scan_renewal_reminders",
     cron_trigger=CronTrigger.from_crontab("30 * * * *"),
     priority=TaskPriority.LOW,

--- a/server/tests/subscription/test_endpoints.py
+++ b/server/tests/subscription/test_endpoints.py
@@ -1454,7 +1454,7 @@ class TestSubscriptionUpdatePause:
         data = response.json()
         assert data["status"] == SubscriptionStatus.active
         assert data["pause_at_period_end"] is True
-        assert data["resumes_at"] is not None
+        assert datetime.fromisoformat(data["resumes_at"]) == resumes_at
 
     @pytest.mark.auth
     async def test_cancel_scheduled_pause(
@@ -1526,6 +1526,7 @@ class TestSubscriptionUpdateResume:
             status=SubscriptionStatus.paused,
         )
         subscription.paused_at = utc_now() - timedelta(days=10)
+        subscription.resumes_at = utc_now() + timedelta(days=20)
         await save_fixture(subscription)
 
         response = await client.patch(
@@ -1536,6 +1537,8 @@ class TestSubscriptionUpdateResume:
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == SubscriptionStatus.active
+        assert data["paused_at"] is None
+        assert data["resumes_at"] is None
 
     @pytest.mark.auth
     async def test_not_paused(

--- a/server/tests/subscription/test_endpoints.py
+++ b/server/tests/subscription/test_endpoints.py
@@ -1404,3 +1404,155 @@ class TestGetChargePreview:
         )
 
         assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestSubscriptionUpdatePause:
+    async def test_anonymous(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        response = await client.patch(
+            f"/v1/subscriptions/{subscription.id}",
+            json={"pause_at_period_end": True},
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_valid(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        current_period_end = utc_now() + timedelta(days=30)
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            current_period_end=current_period_end,
+        )
+        resumes_at = current_period_end + timedelta(days=30)
+
+        response = await client.patch(
+            f"/v1/subscriptions/{subscription.id}",
+            json={
+                "pause_at_period_end": True,
+                "resumes_at": resumes_at.isoformat(),
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == SubscriptionStatus.active
+        assert data["pause_at_period_end"] is True
+        assert data["resumes_at"] is not None
+
+    @pytest.mark.auth
+    async def test_cancel_scheduled_pause(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        subscription.pause_at_period_end = True
+        subscription.resumes_at = utc_now() + timedelta(days=30)
+        await save_fixture(subscription)
+
+        response = await client.patch(
+            f"/v1/subscriptions/{subscription.id}",
+            json={"pause_at_period_end": False},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["pause_at_period_end"] is False
+        assert data["resumes_at"] is None
+
+    @pytest.mark.auth
+    async def test_not_pausable(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            started_at=utc_now(),
+            status=SubscriptionStatus.past_due,
+        )
+
+        response = await client.patch(
+            f"/v1/subscriptions/{subscription.id}",
+            json={"pause_at_period_end": True},
+        )
+
+        assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+class TestSubscriptionUpdateResume:
+    @pytest.mark.auth
+    async def test_valid(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            started_at=utc_now(),
+            status=SubscriptionStatus.paused,
+        )
+        subscription.paused_at = utc_now() - timedelta(days=10)
+        await save_fixture(subscription)
+
+        response = await client.patch(
+            f"/v1/subscriptions/{subscription.id}",
+            json={"resume": True},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == SubscriptionStatus.active
+
+    @pytest.mark.auth
+    async def test_not_paused(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        response = await client.patch(
+            f"/v1/subscriptions/{subscription.id}",
+            json={"resume": True},
+        )
+
+        assert response.status_code == 409

--- a/server/tests/subscription/test_tasks.py
+++ b/server/tests/subscription/test_tasks.py
@@ -1,8 +1,10 @@
 import uuid
+from datetime import timedelta
 
 import pytest
 from pytest_mock import MockerFixture
 
+from polar.kit.utils import utc_now
 from polar.models import Customer, Organization, Product, Subscription
 from polar.models.organization import OrganizationStatus
 from polar.models.subscription import SubscriptionStatus
@@ -11,8 +13,10 @@ from polar.subscription.service import SubscriptionService
 from polar.subscription.tasks import (  # type: ignore[attr-defined]
     SubscriptionDoesNotExist,
     SubscriptionTierDoesNotExist,
+    scan_paused_resumptions,
     subscription_cancel_for_organization,
     subscription_enqueue_benefits_grants,
+    subscription_resume,
     subscription_service,
     subscription_update_product_benefits_grants,
 )
@@ -146,3 +150,100 @@ class TestSubscriptionEnqueueBenefitsGrants:
         await subscription_enqueue_benefits_grants(subscription.id)
 
         enqueue_benefits_grants_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+class TestScanPausedResumptions:
+    async def test_enqueues_only_due_subscriptions(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        now = utc_now()
+        due = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+        due.resumes_at = now - timedelta(hours=1)
+        await save_fixture(due)
+
+        not_yet_due = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+        not_yet_due.resumes_at = now + timedelta(days=1)
+        await save_fixture(not_yet_due)
+
+        # Paused indefinitely (no resumes_at) — never auto-resumed.
+        await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+
+        enqueue_job_mock = mocker.patch("polar.subscription.tasks.enqueue_job")
+        session.expunge_all()
+
+        await scan_paused_resumptions()
+
+        enqueue_job_mock.assert_called_once_with("subscription.resume", due.id)
+
+
+@pytest.mark.asyncio
+class TestSubscriptionResume:
+    async def test_not_existing_subscription(self, session: AsyncSession) -> None:
+        session.expunge_all()
+
+        with pytest.raises(SubscriptionDoesNotExist):
+            await subscription_resume(uuid.uuid4())
+
+    async def test_paused_subscription_is_resumed(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+        resume_mock = mocker.patch.object(
+            subscription_service, "resume", spec=SubscriptionService.resume
+        )
+        session.expunge_all()
+
+        await subscription_resume(subscription.id)
+
+        resume_mock.assert_called_once()
+
+    async def test_not_paused_subscription_is_skipped(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        resume_mock = mocker.patch.object(
+            subscription_service, "resume", spec=SubscriptionService.resume
+        )
+        session.expunge_all()
+
+        await subscription_resume(subscription.id)
+
+        resume_mock.assert_not_called()


### PR DESCRIPTION
- **refactor(subscription): extract cycle billing entries helper**
- **feat(subscription): add pause/resume/cancel-pause service methods**
- **feat(subscription): pause subscription at period end in cycle**
- **feat(subscription): auto-resume paused subscriptions**
- **feat(subscription): add pause/resume update schemas**
- **test(subscription): auto-resume scan + resume task tests**
- **test(subscription): pause/resume endpoint tests**
- **fix(subscription): required-nullable pause output fields + resume assertions, regen client**


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

