### PR TITLE
ci: Add email check to the openapi CI job

### DIFF
--- a/.github/workflows/openapi-generate-check.yml
+++ b/.github/workflows/openapi-generate-check.yml
@@ -26,6 +26,9 @@ jobs:
           filters: |
             relevant:
               - 'server/polar/**'
+              - 'server/emails/src/types/openapi.ts'
+              - 'server/emails/package.json'
+              - 'server/emails/pnpm-lock.yaml'
               - 'clients/packages/client/src/v1.ts'
               - 'clients/packages/client/package.json'
               - '.github/workflows/openapi-generate-check.yml'
@@ -82,7 +85,9 @@ jobs:
         with:
           node-version-file: clients/.node-version
           cache: "pnpm"
-          cache-dependency-path: "clients/pnpm-lock.yaml"
+          cache-dependency-path: |
+            clients/pnpm-lock.yaml
+            server/emails/pnpm-lock.yaml
 
       - name: Create mock email renderer binary
         run: touch /tmp/email-renderer
@@ -101,13 +106,29 @@ jobs:
         working-directory: ./clients
         run: pnpm generate
 
+      - name: Install emails dependencies
+        working-directory: ./server/emails
+        run: pnpm install --frozen-lockfile
+
+      - name: Regenerate emails OpenAPI types
+        working-directory: ./server/emails
+        run: pnpm run types
+
       - name: Build PR comment body
         id: body
         run: |
           stale=false
+          client_stale=false
+          emails_stale=false
           if [[ -n "$(git status --porcelain clients/packages/client/src/v1.ts)" ]]; then
+            client_stale=true
             stale=true
             echo "::warning::Generated client (clients/packages/client/src/v1.ts) is out of date. Run 'pnpm generate' in clients/."
+          fi
+          if [[ -n "$(git status --porcelain server/emails/src/types/openapi.ts)" ]]; then
+            emails_stale=true
+            stale=true
+            echo "::warning::Generated email types (server/emails/src/types/openapi.ts) are out of date. Run 'pnpm run types' in server/emails/."
           fi
           echo "stale=$stale" >> "$GITHUB_OUTPUT"
           if [[ "$stale" == "true" ]]; then
@@ -115,24 +136,46 @@ jobs:
               echo 'body<<COMMENT_EOF'
               echo '<!-- __OPENAPI_CLIENT_REGEN -->'
               echo '## Generated OpenAPI Client'
-              echo ''
-              echo '⚠️ **`clients/packages/client/src/v1.ts` is out of date.**'
-              echo ''
-              echo 'The OpenAPI schema has changed but the generated client has not been regenerated. Please run:'
-              echo ''
-              echo '```bash'
-              echo 'cd clients && pnpm generate'
-              echo '```'
-              echo ''
-              echo 'and commit the updated `clients/packages/client/src/v1.ts`.'
-              echo ''
-              echo '<details><summary>Diff stat</summary>'
-              echo ''
-              echo '```'
-              git diff -- clients/packages/client/src/v1.ts
-              echo '```'
-              echo ''
-              echo '</details>'
+              if [[ "$client_stale" == "true" ]]; then
+                echo ''
+                echo '⚠️ **`clients/packages/client/src/v1.ts` is out of date.**'
+                echo ''
+                echo 'The OpenAPI schema has changed but the generated client has not been regenerated. Please run:'
+                echo ''
+                echo '```bash'
+                echo 'cd clients && pnpm generate'
+                echo '```'
+                echo ''
+                echo 'and commit the updated `clients/packages/client/src/v1.ts`.'
+                echo ''
+                echo '<details><summary>Diff stat</summary>'
+                echo ''
+                echo '```'
+                git diff -- clients/packages/client/src/v1.ts
+                echo '```'
+                echo ''
+                echo '</details>'
+              fi
+              if [[ "$emails_stale" == "true" ]]; then
+                echo ''
+                echo '⚠️ **`server/emails/src/types/openapi.ts` is out of date.**'
+                echo ''
+                echo 'The email schemas have changed but the generated types have not been regenerated. Please run:'
+                echo ''
+                echo '```bash'
+                echo 'cd server/emails && pnpm run types'
+                echo '```'
+                echo ''
+                echo 'and commit the updated `server/emails/src/types/openapi.ts`.'
+                echo ''
+                echo '<details><summary>Diff stat</summary>'
+                echo ''
+                echo '```'
+                git diff -- server/emails/src/types/openapi.ts
+                echo '```'
+                echo ''
+                echo '</details>'
+              fi
               echo 'COMMENT_EOF'
             } >> "$GITHUB_OUTPUT"
           fi
@@ -165,8 +208,8 @@ jobs:
               comment_id: ${{ steps.fc.outputs.comment-id }},
             });
 
-      - name: Fail if generated client is out of date
+      - name: Fail if generated files are out of date
         if: steps.body.outputs.stale == 'true'
         run: |
-          echo "Generated OpenAPI client is out of date. Run 'pnpm generate' in clients/ and commit the result."
+          echo "Generated OpenAPI files are out of date. Run 'pnpm generate' in clients/ and/or 'pnpm run types' in server/emails/ and commit the result."
           exit 1

--- a/server/emails/src/types/openapi.ts
+++ b/server/emails/src/types/openapi.ts
@@ -1476,6 +1476,12 @@ export interface components {
       subscription_id: string | null
       /** Checkout Id */
       checkout_id: string | null
+      /**
+       * Next Payment Attempt At
+       * @description When the next automatic payment retry is scheduled. `null` if the order is not in dunning or all retries have been exhausted.
+       * @default null
+       */
+      next_payment_attempt_at: string | null
       /** Description */
       description: string
       /** Items */
@@ -1619,6 +1625,11 @@ export interface components {
        * @description When the business details were submitted for review.
        */
       details_submitted_at: string | null
+      /**
+       * Sso Enforced
+       * @description Whether members must access this organization through its SSO connection.
+       */
+      sso_enforced: boolean
       /**
        * Default Presentment Currency
        * @description Default presentment currency. Used as fallback in checkout and customer portal, if the customer's local currency is not available.
@@ -1927,25 +1938,6 @@ export interface components {
       /** Url */
       url: string
     }
-    /** OrganizationAccountUnlinkEmail */
-    OrganizationAccountUnlinkEmail: {
-      /**
-       * Template
-       * @default organization_account_unlink
-       * @constant
-       */
-      template: 'organization_account_unlink'
-      props: components['schemas']['OrganizationAccountUnlinkProps']
-    }
-    /** OrganizationAccountUnlinkProps */
-    OrganizationAccountUnlinkProps: {
-      /** Email */
-      email: string
-      /** Organization Kept Name */
-      organization_kept_name: string
-      /** Organizations Unlinked */
-      organizations_unlinked: string[]
-    }
     /** OrganizationCapabilities */
     OrganizationCapabilities: {
       /**
@@ -2072,6 +2064,30 @@ export interface components {
        * @default false
        */
       preview_access_enabled: boolean
+      /**
+       * Disputes Enabled
+       * @description If this organization has the disputes dashboard enabled
+       * @default false
+       */
+      disputes_enabled: boolean
+      /**
+       * Sso Enabled
+       * @description If this organization has single sign-on configuration enabled
+       * @default false
+       */
+      sso_enabled: boolean
+      /**
+       * Compass Enabled
+       * @description If this organization has the split product navigation (Billing / Compass / Customers) enabled in the dashboard
+       * @default false
+       */
+      compass_enabled: boolean
+      /**
+       * Merchant Migration Enabled
+       * @description If this organization can migrate its billing from another provider (e.g. Stripe) to Polar.
+       * @default false
+       */
+      merchant_migration_enabled: boolean
     }
     /** OrganizationInviteEmail */
     OrganizationInviteEmail: {
@@ -2337,14 +2353,19 @@ export interface components {
       /** @description The visibility of the product. */
       visibility: components['schemas']['ProductVisibility']
       /** @description The recurring interval of the product. If `None`, the product is a one-time purchase. */
-      recurring_interval:
-        | components['schemas']['SubscriptionRecurringInterval']
-        | null
+      recurring_interval: components['schemas']['RecurringInterval'] | null
       /**
        * Recurring Interval Count
        * @description Number of interval units of the subscription. If this is set to 1 the charge will happen every interval (e.g. every month), if set to 2 it will be every other month, and so on. None for one-time products.
        */
       recurring_interval_count: number | null
+      /** @description The meter cycle of the product, independent of the billing interval. If `None`, metered concerns follow the billing interval. */
+      meter_interval: components['schemas']['RecurringInterval'] | null
+      /**
+       * Meter Interval Count
+       * @description Number of meter interval units. None when no meter cycle is set.
+       */
+      meter_interval_count: number | null
       /**
        * Is Recurring
        * @description Whether the product is a subscription.
@@ -2372,6 +2393,11 @@ export interface components {
      * @enum {string}
      */
     ProductVisibility: 'draft' | 'private' | 'public'
+    /**
+     * RecurringInterval
+     * @enum {string}
+     */
+    RecurringInterval: 'day' | 'week' | 'month' | 'year'
     /** SeatInvitationEmail */
     SeatInvitationEmail: {
       /**
@@ -2512,7 +2538,7 @@ export interface components {
        * @description The interval at which the subscription recurs.
        * @example month
        */
-      recurring_interval: components['schemas']['SubscriptionRecurringInterval']
+      recurring_interval: components['schemas']['RecurringInterval']
       /**
        * Recurring Interval Count
        * @description Number of interval units of the subscription. If this is set to 1 the charge will happen every interval (e.g. every month), if set to 2 it will be every other month, and so on.
@@ -2535,6 +2561,16 @@ export interface components {
        * @description The end timestamp of the current billing period.
        */
       current_period_end: string
+      /**
+       * Current Meter Period Start
+       * @description The start timestamp of the current meter period, if the product has a meter cycle set. Metered credits are granted and overage is settled on this cadence.
+       */
+      current_meter_period_start: string | null
+      /**
+       * Current Meter Period End
+       * @description The end timestamp of the current meter period, if the product has a meter cycle set. This is when credits next renew.
+       */
+      current_meter_period_end: string | null
       /**
        * Trial Start
        * @description The start timestamp of the trial period, if any.
@@ -2570,6 +2606,27 @@ export interface components {
        * @description The timestamp when the subscription ended.
        */
       ended_at: string | null
+      /**
+       * Past Due At
+       * @description The timestamp when the subscription entered `past_due` status.
+       * @default null
+       */
+      past_due_at: string | null
+      /**
+       * Pause At Period End
+       * @description Whether the subscription will be paused at the end of the current period.
+       */
+      pause_at_period_end: boolean
+      /**
+       * Paused At
+       * @description The timestamp when the subscription was paused.
+       */
+      paused_at: string | null
+      /**
+       * Resumes At
+       * @description The timestamp when a paused subscription is scheduled to automatically resume, if set.
+       */
+      resumes_at: string | null
       /**
        * Customer Id
        * Format: uuid4
@@ -2656,11 +2713,6 @@ export interface components {
       | 'prorate'
       | 'next_period'
       | 'reset'
-    /**
-     * SubscriptionRecurringInterval
-     * @enum {string}
-     */
-    SubscriptionRecurringInterval: 'day' | 'week' | 'month' | 'year'
     /** SubscriptionRenewalReminderEmail */
     SubscriptionRenewalReminderEmail: {
       /**
@@ -2715,6 +2767,7 @@ export interface components {
       | 'past_due'
       | 'canceled'
       | 'unpaid'
+      | 'paused'
     /** SubscriptionTrialConversionReminderEmail */
     SubscriptionTrialConversionReminderEmail: {
       /**


### PR DESCRIPTION
To prevent the emails openapi spec from drifting

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add email type checks to the OpenAPI CI and sync `server/emails` types to the latest schema. This prevents drift and fails the build when types are stale.

- New Features
  - Trigger on changes to `server/emails/src/types/openapi.ts`, `server/emails/package.json`, `server/emails/pnpm-lock.yaml`; cache `server/emails/pnpm-lock.yaml`.
  - Install `server/emails` deps and run `pnpm run types`; synced types add `next_payment_attempt_at`, `sso_enforced`, org capability flags (`disputes_enabled`, `sso_enabled`, `compass_enabled`, `merchant_migration_enabled`), product `meter_interval`/`meter_interval_count`, meter period timestamps, unify `RecurringInterval` (drop `SubscriptionRecurringInterval`), add subscription `past_due_at`, pause fields (`pause_at_period_end`, `paused_at`, `resumes_at`), and `paused` status; remove `OrganizationAccountUnlink*`.
  - Detect drift for both client (`clients/packages/client/src/v1.ts`) and email types, post targeted PR comments with diffs, and fail the job if either is out of date.

<sup>Written for commit e2aadf4bbe4ed69129ef115f59ac74821bd7f718. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

