### PR TITLE
rate-limit: Specifically rate limit email update endpoints

### DIFF
--- a/server/polar/rate_limit.py
+++ b/server/polar/rate_limit.py
@@ -172,6 +172,16 @@ _BASE_RULES: dict[str, Sequence[Rule]] = {
             zone="auth-backup-codes",
         ),
     ],
+    "^/v1/email-update/(request|verify)": [
+        Rule(minute=6, hour=12, block_time=900, zone="email-update"),
+        Rule(
+            group=RateLimitGroup.web,
+            minute=6,
+            hour=12,
+            block_time=900,
+            zone="email-update",
+        ),
+    ],
     "^/v1/customer-portal/customer-session/(request|authenticate)": [
         Rule(minute=6, hour=12, block_time=900, zone="customer-session-login"),
         Rule(

--- a/server/tests/test_rate_limit.py
+++ b/server/tests/test_rate_limit.py
@@ -270,3 +270,21 @@ class TestSensitiveEndpointZoneIsolation:
             f"Path {path!r} for group {group.value!r} resolved to "
             f"zone {rule.zone!r}, expected {expected_zone!r}"
         )
+
+
+@pytest.mark.parametrize("rules", [_PRODUCTION_RULES, _SANDBOX_RULES])
+@pytest.mark.parametrize(
+    "path", ["/v1/email-update/request", "/v1/email-update/verify"]
+)
+@pytest.mark.parametrize("group", [RateLimitGroup.default, RateLimitGroup.web])
+class TestEmailUpdateZone:
+    """Email update is a web-session-only endpoint, so its callers resolve to
+    the `web` group; without a dedicated `web` rule they would fall through to
+    the catch-all "api" zone and its permissive per-second limits."""
+
+    def test_resolves_to_email_update_zone(
+        self, rules: dict[str, Sequence[Rule]], path: str, group: RateLimitGroup
+    ) -> None:
+        rule = _select_rule(rules, path, group)
+        assert rule is not None
+        assert rule.zone == "email-update"


### PR DESCRIPTION
To prevent an easy way to enumerate emails on the API

Alternative approach to #12987

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add dedicated rate limits to the email update endpoints to reduce email enumeration risk. Adds stricter limits and routes web sessions to the `email-update` zone.

- **Bug Fixes**
  - Added `email-update` rules for `/v1/email-update/(request|verify)` with 6/min, 12/hour, 15m block for `default` and `web` groups.
  - Tests: verify in both prod and sandbox that `default` and `web` resolve these paths to `email-update` (avoids falling back to permissive API limits).

<sup>Written for commit d644d775e055282cc09695698ec513044c6a92bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

