### PR TITLE
feat(subscription): pause/resume notifications

### DIFF
--- a/clients/apps/web/src/components/Settings/OrganizationCustomerEmailSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationCustomerEmailSettings.tsx
@@ -76,6 +76,16 @@ const customerEmails: {
     title: 'Subscription past due',
     description: 'Sent when a subscription payment fails and becomes overdue',
   },
+  {
+    key: 'subscription_paused',
+    title: 'Subscription paused',
+    description: 'Sent when a customer pauses their subscription',
+  },
+  {
+    key: 'subscription_resumed',
+    title: 'Subscription resumed',
+    description: 'Sent when a paused subscription resumes and billing restarts',
+  },
 ]
 
 const OrganizationCustomerEmailSettings: React.FC<

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -6346,6 +6346,55 @@ export interface webhooks {
     patch?: never
     trace?: never
   }
+  'subscription.paused': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * subscription.paused
+     * @description Sent when a subscription is paused and the customer temporarily loses access.
+     *
+     *     No order is created while paused. The subscription resumes either on its
+     *     scheduled resume date or when resumed manually, starting a new billing period.
+     *
+     *     **Discord & Slack support:** Full
+     */
+    post: operations['_endpointsubscription_paused_post']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  'subscription.resumed': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * subscription.resumed
+     * @description Sent when a paused subscription resumes, restoring the customer's access.
+     *
+     *     Resuming starts a new billing period and charges the customer immediately.
+     *
+     *     **Discord & Slack support:** Full
+     */
+    post: operations['_endpointsubscription_resumed_post']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   'refund.created': {
     parameters: {
       query?: never
@@ -25803,6 +25852,10 @@ export interface components {
       subscription_cycled_after_trial: boolean
       /** Subscription Past Due */
       subscription_past_due: boolean
+      /** Subscription Paused */
+      subscription_paused: boolean
+      /** Subscription Resumed */
+      subscription_resumed: boolean
       /** Subscription Renewal Reminder */
       subscription_renewal_reminder: boolean
       /** Subscription Revoked */
@@ -31891,6 +31944,100 @@ export interface components {
       resumes_at?: string | null
     }
     /**
+     * SubscriptionPausedEvent
+     * @description An event created by Polar when a subscription is paused.
+     */
+    SubscriptionPausedEvent: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the object.
+       */
+      id: string
+      /**
+       * Timestamp
+       * Format: date-time
+       * @description The timestamp of the event.
+       */
+      timestamp: string
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description The ID of the organization owning the event.
+       * @example 1dbfc517-0bbf-4301-9ba8-555ca42b9737
+       */
+      organization_id: string
+      /**
+       * Customer Id
+       * @description ID of the customer in your Polar organization associated with the event.
+       */
+      customer_id: string | null
+      /** @description The customer associated with the event. */
+      customer: components['schemas']['Customer'] | null
+      /**
+       * External Customer Id
+       * @description ID of the customer in your system associated with the event.
+       */
+      external_customer_id: string | null
+      /**
+       * Member Id
+       * @description ID of the member within the customer's organization who performed the action inside B2B.
+       */
+      member_id?: string | null
+      /**
+       * External Member Id
+       * @description ID of the member in your system within the customer's organization who performed the action inside B2B.
+       */
+      external_member_id?: string | null
+      /**
+       * Child Count
+       * @description Number of direct child events linked to this event.
+       * @default 0
+       */
+      child_count: number
+      /**
+       * Parent Id
+       * @description The ID of the parent event.
+       */
+      parent_id?: string | null
+      /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
+      /**
+       * Source
+       * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
+       * @constant
+       */
+      source: 'system'
+      /**
+       * @description The name of the event. (enum property replaced by openapi-typescript)
+       * @enum {string}
+       */
+      name: 'subscription.paused'
+      metadata: components['schemas']['SubscriptionPausedMetadata']
+    }
+    /** SubscriptionPausedMetadata */
+    SubscriptionPausedMetadata: {
+      /** Subscription Id */
+      subscription_id: string
+      /** Product Id */
+      product_id?: string
+      /** Amount */
+      amount?: number
+      /** Currency */
+      currency?: string
+      /** Recurring Interval */
+      recurring_interval?: string
+      /** Recurring Interval Count */
+      recurring_interval_count?: number
+      /** Paused At */
+      paused_at: string
+      /** Resumes At */
+      resumes_at?: string
+    }
+    /**
      * SubscriptionProductUpdatedEvent
      * @description An event created by Polar when a subscription changes the product.
      */
@@ -32081,6 +32228,96 @@ export interface components {
        * @constant
        */
       resume: true
+    }
+    /**
+     * SubscriptionResumedEvent
+     * @description An event created by Polar when a paused subscription is resumed.
+     */
+    SubscriptionResumedEvent: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the object.
+       */
+      id: string
+      /**
+       * Timestamp
+       * Format: date-time
+       * @description The timestamp of the event.
+       */
+      timestamp: string
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description The ID of the organization owning the event.
+       * @example 1dbfc517-0bbf-4301-9ba8-555ca42b9737
+       */
+      organization_id: string
+      /**
+       * Customer Id
+       * @description ID of the customer in your Polar organization associated with the event.
+       */
+      customer_id: string | null
+      /** @description The customer associated with the event. */
+      customer: components['schemas']['Customer'] | null
+      /**
+       * External Customer Id
+       * @description ID of the customer in your system associated with the event.
+       */
+      external_customer_id: string | null
+      /**
+       * Member Id
+       * @description ID of the member within the customer's organization who performed the action inside B2B.
+       */
+      member_id?: string | null
+      /**
+       * External Member Id
+       * @description ID of the member in your system within the customer's organization who performed the action inside B2B.
+       */
+      external_member_id?: string | null
+      /**
+       * Child Count
+       * @description Number of direct child events linked to this event.
+       * @default 0
+       */
+      child_count: number
+      /**
+       * Parent Id
+       * @description The ID of the parent event.
+       */
+      parent_id?: string | null
+      /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
+      /**
+       * Source
+       * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
+       * @constant
+       */
+      source: 'system'
+      /**
+       * @description The name of the event. (enum property replaced by openapi-typescript)
+       * @enum {string}
+       */
+      name: 'subscription.resumed'
+      metadata: components['schemas']['SubscriptionResumedMetadata']
+    }
+    /** SubscriptionResumedMetadata */
+    SubscriptionResumedMetadata: {
+      /** Subscription Id */
+      subscription_id: string
+      /** Product Id */
+      product_id?: string
+      /** Amount */
+      amount?: number
+      /** Currency */
+      currency?: string
+      /** Recurring Interval */
+      recurring_interval?: string
+      /** Recurring Interval Count */
+      recurring_interval_count?: number
     }
     /** SubscriptionRevoke */
     SubscriptionRevoke: {
@@ -32906,6 +33143,8 @@ export interface components {
       | components['schemas']['SubscriptionRevokedEvent']
       | components['schemas']['SubscriptionPastDueEvent']
       | components['schemas']['SubscriptionReactivatedEvent']
+      | components['schemas']['SubscriptionPausedEvent']
+      | components['schemas']['SubscriptionResumedEvent']
       | components['schemas']['SubscriptionUncanceledEvent']
       | components['schemas']['SubscriptionProductUpdatedEvent']
       | components['schemas']['SubscriptionSeatsUpdatedEvent']
@@ -34717,6 +34956,8 @@ export interface components {
       | 'subscription.uncanceled'
       | 'subscription.revoked'
       | 'subscription.past_due'
+      | 'subscription.paused'
+      | 'subscription.resumed'
       | 'refund.created'
       | 'refund.updated'
       | 'product.created'
@@ -35083,6 +35324,51 @@ export interface components {
        * @constant
        */
       type: 'subscription.past_due'
+      /**
+       * Timestamp
+       * Format: date-time
+       */
+      timestamp: string
+      data: components['schemas']['Subscription']
+    }
+    /**
+     * WebhookSubscriptionPausedPayload
+     * @description Sent when a subscription is paused and the customer temporarily loses access.
+     *
+     *     No order is created while paused. The subscription resumes either on its
+     *     scheduled resume date or when resumed manually, starting a new billing period.
+     *
+     *     **Discord & Slack support:** Full
+     */
+    WebhookSubscriptionPausedPayload: {
+      /**
+       * Type
+       * @example subscription.paused
+       * @constant
+       */
+      type: 'subscription.paused'
+      /**
+       * Timestamp
+       * Format: date-time
+       */
+      timestamp: string
+      data: components['schemas']['Subscription']
+    }
+    /**
+     * WebhookSubscriptionResumedPayload
+     * @description Sent when a paused subscription resumes, restoring the customer's access.
+     *
+     *     Resuming starts a new billing period and charges the customer immediately.
+     *
+     *     **Discord & Slack support:** Full
+     */
+    WebhookSubscriptionResumedPayload: {
+      /**
+       * Type
+       * @example subscription.resumed
+       * @constant
+       */
+      type: 'subscription.resumed'
       /**
        * Timestamp
        * Format: date-time
@@ -54698,6 +54984,72 @@ export interface operations {
       }
     }
   }
+  _endpointsubscription_paused_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['WebhookSubscriptionPausedPayload']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  _endpointsubscription_resumed_post: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['WebhookSubscriptionResumedPayload']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': unknown
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
   _endpointrefund_created_post: {
     parameters: {
       query?: never
@@ -63579,6 +63931,9 @@ export const subscriptionCycledEventNameValues: ReadonlyArray<
 export const subscriptionPastDueEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SubscriptionPastDueEvent']['name']
 > = ['subscription.past_due']
+export const subscriptionPausedEventNameValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['SubscriptionPausedEvent']['name']
+> = ['subscription.paused']
 export const subscriptionProductUpdatedEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SubscriptionProductUpdatedEvent']['name']
 > = ['subscription.product_updated']
@@ -63588,6 +63943,9 @@ export const subscriptionProrationBehaviorValues: ReadonlyArray<
 export const subscriptionReactivatedEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SubscriptionReactivatedEvent']['name']
 > = ['subscription.reactivated']
+export const subscriptionResumedEventNameValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['SubscriptionResumedEvent']['name']
+> = ['subscription.resumed']
 export const subscriptionRevokedEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SubscriptionRevokedEvent']['name']
 > = ['subscription.revoked']
@@ -64080,6 +64438,8 @@ export const webhookEventTypeValues: ReadonlyArray<
   'subscription.uncanceled',
   'subscription.revoked',
   'subscription.past_due',
+  'subscription.paused',
+  'subscription.resumed',
   'refund.created',
   'refund.updated',
   'product.created',

--- a/server/emails/src/emails/index.ts
+++ b/server/emails/src/emails/index.ts
@@ -27,7 +27,9 @@ import { SubscriptionCycled } from './subscription_cycled'
 import { SubscriptionCycledAfterTrial } from './subscription_cycled_after_trial'
 import { SubscriptionFinalInvoice } from './subscription_final_invoice'
 import { SubscriptionPastDue } from './subscription_past_due'
+import { SubscriptionPaused } from './subscription_paused'
 import { SubscriptionRenewalReminder } from './subscription_renewal_reminder'
+import { SubscriptionResumed } from './subscription_resumed'
 import { SubscriptionRevoked } from './subscription_revoked'
 import { SubscriptionTrialConversionReminder } from './subscription_trial_conversion_reminder'
 import { SubscriptionUncanceled } from './subscription_uncanceled'
@@ -55,6 +57,8 @@ const TEMPLATES: Record<string, React.FC<never>> = {
   subscription_cycled_after_trial: SubscriptionCycledAfterTrial,
   subscription_final_invoice: SubscriptionFinalInvoice,
   subscription_past_due: SubscriptionPastDue,
+  subscription_paused: SubscriptionPaused,
+  subscription_resumed: SubscriptionResumed,
   subscription_renewal_reminder: SubscriptionRenewalReminder,
   subscription_revoked: SubscriptionRevoked,
   subscription_trial_conversion_reminder: SubscriptionTrialConversionReminder,

--- a/server/emails/src/emails/subscription_paused.tsx
+++ b/server/emails/src/emails/subscription_paused.tsx
@@ -1,0 +1,67 @@
+import {
+  Button,
+  FooterCustomer,
+  Intro,
+  Text,
+  WrapperOrganization,
+} from '../components/foundation'
+import { organization, product } from '../preview'
+import type { schemas } from '../types'
+
+export function SubscriptionPaused({
+  email,
+  organization,
+  product,
+  subscription,
+  url,
+}: schemas['SubscriptionPausedProps']) {
+  const formatDate = (value: string) =>
+    new Date(value).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
+  const accessUntil = formatDate(subscription.current_period_end!)
+  const resumeDate = subscription.resumes_at
+    ? formatDate(subscription.resumes_at)
+    : null
+
+  return (
+    <WrapperOrganization
+      organization={organization}
+      preview={`Your ${product.name} subscription will pause`}
+    >
+      <Intro headline="Your subscription is set to pause">
+        Your{' '}
+        <Text as="span" weight="medium">
+          {product.name}
+        </Text>{' '}
+        subscription will pause at the end of your current period. You keep full
+        access until {accessUntil}, and you won&rsquo;t be charged while
+        it&rsquo;s paused.
+      </Intro>
+      <Text>
+        {resumeDate
+          ? `Your subscription will automatically resume on ${resumeDate}.`
+          : 'Your subscription will stay paused until you resume it.'}
+      </Text>
+      <Button href={url}>Manage subscription</Button>
+      <FooterCustomer organization={organization} email={email} />
+    </WrapperOrganization>
+  )
+}
+
+SubscriptionPaused.PreviewProps = {
+  email: 'john@example.com',
+  organization,
+  product,
+  subscription: {
+    current_period_end: new Date(
+      Date.now() + 10 * 24 * 60 * 60 * 1000,
+    ).toISOString(),
+    resumes_at: new Date(Date.now() + 40 * 24 * 60 * 60 * 1000).toISOString(),
+  },
+  url: 'https://polar.sh/acme-inc/portal/subscriptions/12345',
+}
+
+export default SubscriptionPaused

--- a/server/emails/src/emails/subscription_resumed.tsx
+++ b/server/emails/src/emails/subscription_resumed.tsx
@@ -1,0 +1,43 @@
+import {
+  Button,
+  FooterCustomer,
+  Intro,
+  Text,
+  WrapperOrganization,
+} from '../components/foundation'
+import { organization, product } from '../preview'
+import type { schemas } from '../types'
+
+export function SubscriptionResumed({
+  email,
+  organization,
+  product,
+  url,
+}: schemas['SubscriptionResumedProps']) {
+  return (
+    <WrapperOrganization
+      organization={organization}
+      preview={`Your ${product.name} subscription has resumed`}
+    >
+      <Intro headline="Your subscription has resumed">
+        Your{' '}
+        <Text as="span" weight="medium">
+          {product.name}
+        </Text>{' '}
+        subscription is active again and your access has been restored. Regular
+        billing has resumed.
+      </Intro>
+      <Button href={url}>Manage subscription</Button>
+      <FooterCustomer organization={organization} email={email} />
+    </WrapperOrganization>
+  )
+}
+
+SubscriptionResumed.PreviewProps = {
+  email: 'john@example.com',
+  organization,
+  product,
+  url: 'https://polar.sh/acme-inc/portal/subscriptions/12345',
+}
+
+export default SubscriptionResumed

--- a/server/emails/src/types/openapi.ts
+++ b/server/emails/src/types/openapi.ts
@@ -1476,6 +1476,12 @@ export interface components {
       subscription_id: string | null
       /** Checkout Id */
       checkout_id: string | null
+      /**
+       * Next Payment Attempt At
+       * @description When the next automatic payment retry is scheduled. `null` if the order is not in dunning or all retries have been exhausted.
+       * @default null
+       */
+      next_payment_attempt_at: string | null
       /** Description */
       description: string
       /** Items */
@@ -1619,6 +1625,11 @@ export interface components {
        * @description When the business details were submitted for review.
        */
       details_submitted_at: string | null
+      /**
+       * Sso Enforced
+       * @description Whether members must access this organization through its SSO connection.
+       */
+      sso_enforced: boolean
       /**
        * Default Presentment Currency
        * @description Default presentment currency. Used as fallback in checkout and customer portal, if the customer's local currency is not available.
@@ -1927,25 +1938,6 @@ export interface components {
       /** Url */
       url: string
     }
-    /** OrganizationAccountUnlinkEmail */
-    OrganizationAccountUnlinkEmail: {
-      /**
-       * Template
-       * @default organization_account_unlink
-       * @constant
-       */
-      template: 'organization_account_unlink'
-      props: components['schemas']['OrganizationAccountUnlinkProps']
-    }
-    /** OrganizationAccountUnlinkProps */
-    OrganizationAccountUnlinkProps: {
-      /** Email */
-      email: string
-      /** Organization Kept Name */
-      organization_kept_name: string
-      /** Organizations Unlinked */
-      organizations_unlinked: string[]
-    }
     /** OrganizationCapabilities */
     OrganizationCapabilities: {
       /**
@@ -1993,6 +1985,10 @@ export interface components {
       subscription_cycled_after_trial: boolean
       /** Subscription Past Due */
       subscription_past_due: boolean
+      /** Subscription Paused */
+      subscription_paused: boolean
+      /** Subscription Resumed */
+      subscription_resumed: boolean
       /** Subscription Renewal Reminder */
       subscription_renewal_reminder: boolean
       /** Subscription Revoked */
@@ -2072,6 +2068,24 @@ export interface components {
        * @default false
        */
       preview_access_enabled: boolean
+      /**
+       * Disputes Enabled
+       * @description If this organization has the disputes dashboard enabled
+       * @default false
+       */
+      disputes_enabled: boolean
+      /**
+       * Sso Enabled
+       * @description If this organization has single sign-on configuration enabled
+       * @default false
+       */
+      sso_enabled: boolean
+      /**
+       * Compass Enabled
+       * @description If this organization has the split product navigation (Billing / Compass / Customers) enabled in the dashboard
+       * @default false
+       */
+      compass_enabled: boolean
     }
     /** OrganizationInviteEmail */
     OrganizationInviteEmail: {
@@ -2337,14 +2351,19 @@ export interface components {
       /** @description The visibility of the product. */
       visibility: components['schemas']['ProductVisibility']
       /** @description The recurring interval of the product. If `None`, the product is a one-time purchase. */
-      recurring_interval:
-        | components['schemas']['SubscriptionRecurringInterval']
-        | null
+      recurring_interval: components['schemas']['RecurringInterval'] | null
       /**
        * Recurring Interval Count
        * @description Number of interval units of the subscription. If this is set to 1 the charge will happen every interval (e.g. every month), if set to 2 it will be every other month, and so on. None for one-time products.
        */
       recurring_interval_count: number | null
+      /** @description The meter cycle of the product, independent of the billing interval. If `None`, metered concerns follow the billing interval. */
+      meter_interval: components['schemas']['RecurringInterval'] | null
+      /**
+       * Meter Interval Count
+       * @description Number of meter interval units. None when no meter cycle is set.
+       */
+      meter_interval_count: number | null
       /**
        * Is Recurring
        * @description Whether the product is a subscription.
@@ -2372,6 +2391,11 @@ export interface components {
      * @enum {string}
      */
     ProductVisibility: 'draft' | 'private' | 'public'
+    /**
+     * RecurringInterval
+     * @enum {string}
+     */
+    RecurringInterval: 'day' | 'week' | 'month' | 'year'
     /** SeatInvitationEmail */
     SeatInvitationEmail: {
       /**
@@ -2512,7 +2536,7 @@ export interface components {
        * @description The interval at which the subscription recurs.
        * @example month
        */
-      recurring_interval: components['schemas']['SubscriptionRecurringInterval']
+      recurring_interval: components['schemas']['RecurringInterval']
       /**
        * Recurring Interval Count
        * @description Number of interval units of the subscription. If this is set to 1 the charge will happen every interval (e.g. every month), if set to 2 it will be every other month, and so on.
@@ -2535,6 +2559,16 @@ export interface components {
        * @description The end timestamp of the current billing period.
        */
       current_period_end: string
+      /**
+       * Current Meter Period Start
+       * @description The start timestamp of the current meter period, if the product has a meter cycle set. Metered credits are granted and overage is settled on this cadence.
+       */
+      current_meter_period_start: string | null
+      /**
+       * Current Meter Period End
+       * @description The end timestamp of the current meter period, if the product has a meter cycle set. This is when credits next renew.
+       */
+      current_meter_period_end: string | null
       /**
        * Trial Start
        * @description The start timestamp of the trial period, if any.
@@ -2570,6 +2604,29 @@ export interface components {
        * @description The timestamp when the subscription ended.
        */
       ended_at: string | null
+      /**
+       * Past Due At
+       * @description The timestamp when the subscription entered `past_due` status.
+       * @default null
+       */
+      past_due_at: string | null
+      /**
+       * Pause At Period End
+       * @description Whether the subscription will be paused at the end of the current period.
+       */
+      pause_at_period_end: boolean
+      /**
+       * Paused At
+       * @description The timestamp when the subscription was paused.
+       * @default null
+       */
+      paused_at: string | null
+      /**
+       * Resumes At
+       * @description The timestamp when a paused subscription is scheduled to automatically resume, if set.
+       * @default null
+       */
+      resumes_at: string | null
       /**
        * Customer Id
        * Format: uuid4
@@ -2647,6 +2704,26 @@ export interface components {
        */
       payment_url: string | null
     }
+    /** SubscriptionPausedEmail */
+    SubscriptionPausedEmail: {
+      /**
+       * Template
+       * @default subscription_paused
+       * @constant
+       */
+      template: 'subscription_paused'
+      props: components['schemas']['SubscriptionPausedProps']
+    }
+    /** SubscriptionPausedProps */
+    SubscriptionPausedProps: {
+      /** Email */
+      email: string
+      organization: components['schemas']['Organization']
+      product: components['schemas']['ProductEmail']
+      subscription: components['schemas']['SubscriptionEmail']
+      /** Url */
+      url: string
+    }
     /**
      * SubscriptionProrationBehavior
      * @enum {string}
@@ -2656,11 +2733,6 @@ export interface components {
       | 'prorate'
       | 'next_period'
       | 'reset'
-    /**
-     * SubscriptionRecurringInterval
-     * @enum {string}
-     */
-    SubscriptionRecurringInterval: 'day' | 'week' | 'month' | 'year'
     /** SubscriptionRenewalReminderEmail */
     SubscriptionRenewalReminderEmail: {
       /**
@@ -2682,6 +2754,26 @@ export interface components {
       url: string
       /** Renewal Date */
       renewal_date: string
+    }
+    /** SubscriptionResumedEmail */
+    SubscriptionResumedEmail: {
+      /**
+       * Template
+       * @default subscription_resumed
+       * @constant
+       */
+      template: 'subscription_resumed'
+      props: components['schemas']['SubscriptionResumedProps']
+    }
+    /** SubscriptionResumedProps */
+    SubscriptionResumedProps: {
+      /** Email */
+      email: string
+      organization: components['schemas']['Organization']
+      product: components['schemas']['ProductEmail']
+      subscription: components['schemas']['SubscriptionEmail']
+      /** Url */
+      url: string
     }
     /** SubscriptionRevokedEmail */
     SubscriptionRevokedEmail: {
@@ -2715,6 +2807,7 @@ export interface components {
       | 'past_due'
       | 'canceled'
       | 'unpaid'
+      | 'paused'
     /** SubscriptionTrialConversionReminderEmail */
     SubscriptionTrialConversionReminderEmail: {
       /**

--- a/server/polar/email/schemas.py
+++ b/server/polar/email/schemas.py
@@ -46,6 +46,8 @@ class EmailTemplate(StrEnum):
     subscription_cycled_after_trial = "subscription_cycled_after_trial"
     subscription_final_invoice = "subscription_final_invoice"
     subscription_past_due = "subscription_past_due"
+    subscription_paused = "subscription_paused"
+    subscription_resumed = "subscription_resumed"
     subscription_revoked = "subscription_revoked"
     subscription_uncanceled = "subscription_uncanceled"
     subscription_renewal_reminder = "subscription_renewal_reminder"
@@ -372,6 +374,26 @@ class SubscriptionUncanceledEmail(BaseModel):
     props: SubscriptionUncanceledProps
 
 
+class SubscriptionPausedProps(SubscriptionPropsBase): ...
+
+
+class SubscriptionPausedEmail(BaseModel):
+    template: Literal[EmailTemplate.subscription_paused] = (
+        EmailTemplate.subscription_paused
+    )
+    props: SubscriptionPausedProps
+
+
+class SubscriptionResumedProps(SubscriptionPropsBase): ...
+
+
+class SubscriptionResumedEmail(BaseModel):
+    template: Literal[EmailTemplate.subscription_resumed] = (
+        EmailTemplate.subscription_resumed
+    )
+    props: SubscriptionResumedProps
+
+
 class SubscriptionUpdatedProps(SubscriptionPropsBase):
     order: OrderEmail | None
 
@@ -538,6 +560,8 @@ Email = Annotated[
     | SubscriptionCycledAfterTrialEmail
     | SubscriptionFinalInvoiceEmail
     | SubscriptionPastDueEmail
+    | SubscriptionPausedEmail
+    | SubscriptionResumedEmail
     | SubscriptionRenewalReminderEmail
     | SubscriptionTrialConversionReminderEmail
     | SubscriptionRevokedEmail

--- a/server/polar/event/schemas.py
+++ b/server/polar/event/schemas.py
@@ -35,8 +35,10 @@ from polar.event.system import (
     SubscriptionCreatedMetadata,
     SubscriptionCycledMetadata,
     SubscriptionPastDueMetadata,
+    SubscriptionPausedMetadata,
     SubscriptionProductUpdatedMetadata,
     SubscriptionReactivatedMetadata,
+    SubscriptionResumedMetadata,
     SubscriptionRevokedMetadata,
     SubscriptionSeatsUpdatedMetadata,
     SubscriptionUncanceledMetadata,
@@ -414,6 +416,28 @@ class SubscriptionReactivatedEvent(SystemEventBase):
     )
 
 
+class SubscriptionPausedEvent(SystemEventBase):
+    """An event created by Polar when a subscription is paused."""
+
+    name: Literal[SystemEventEnum.subscription_paused] = Field(
+        description=_NAME_DESCRIPTION
+    )
+    metadata: SubscriptionPausedMetadata = Field(
+        validation_alias=AliasChoices("user_metadata", "metadata")
+    )
+
+
+class SubscriptionResumedEvent(SystemEventBase):
+    """An event created by Polar when a paused subscription is resumed."""
+
+    name: Literal[SystemEventEnum.subscription_resumed] = Field(
+        description=_NAME_DESCRIPTION
+    )
+    metadata: SubscriptionResumedMetadata = Field(
+        validation_alias=AliasChoices("user_metadata", "metadata")
+    )
+
+
 class SubscriptionProductUpdatedEvent(SystemEventBase):
     """An event created by Polar when a subscription changes the product."""
 
@@ -605,6 +629,8 @@ SystemEvent = Annotated[
     | SubscriptionRevokedEvent
     | SubscriptionPastDueEvent
     | SubscriptionReactivatedEvent
+    | SubscriptionPausedEvent
+    | SubscriptionResumedEvent
     | SubscriptionUncanceledEvent
     | SubscriptionProductUpdatedEvent
     | SubscriptionSeatsUpdatedEvent

--- a/server/polar/event/system.py
+++ b/server/polar/event/system.py
@@ -26,6 +26,8 @@ class SystemEvent(StrEnum):
     subscription_revoked = "subscription.revoked"
     subscription_past_due = "subscription.past_due"
     subscription_reactivated = "subscription.reactivated"
+    subscription_paused = "subscription.paused"
+    subscription_resumed = "subscription.resumed"
     subscription_uncanceled = "subscription.uncanceled"
     subscription_product_updated = "subscription.product_updated"
     subscription_seats_updated = "subscription.seats_updated"
@@ -58,6 +60,8 @@ SYSTEM_EVENT_LABELS: dict[str, str] = {
     "subscription.revoked": "Subscription Revoked",
     "subscription.past_due": "Subscription Past Due",
     "subscription.reactivated": "Subscription Reactivated",
+    "subscription.paused": "Subscription Paused",
+    "subscription.resumed": "Subscription Resumed",
     "subscription.uncanceled": "Subscription Uncanceled",
     "subscription.product_updated": "Subscription Product Updated",
     "order.paid": "Order Paid",
@@ -313,6 +317,40 @@ class SubscriptionReactivatedEvent(Event):
         source: Mapped[Literal[EventSource.system]]
         name: Mapped[Literal[SystemEvent.subscription_reactivated]]
         user_metadata: Mapped[SubscriptionReactivatedMetadata]  # type: ignore[assignment]
+
+
+class SubscriptionPausedMetadata(TypedDict):
+    subscription_id: str
+    product_id: NotRequired[str]
+    amount: NotRequired[int]
+    currency: NotRequired[str]
+    recurring_interval: NotRequired[str]
+    recurring_interval_count: NotRequired[int]
+    paused_at: str
+    resumes_at: NotRequired[str]
+
+
+class SubscriptionPausedEvent(Event):
+    if TYPE_CHECKING:
+        source: Mapped[Literal[EventSource.system]]
+        name: Mapped[Literal[SystemEvent.subscription_paused]]
+        user_metadata: Mapped[SubscriptionPausedMetadata]  # type: ignore[assignment]
+
+
+class SubscriptionResumedMetadata(TypedDict):
+    subscription_id: str
+    product_id: NotRequired[str]
+    amount: NotRequired[int]
+    currency: NotRequired[str]
+    recurring_interval: NotRequired[str]
+    recurring_interval_count: NotRequired[int]
+
+
+class SubscriptionResumedEvent(Event):
+    if TYPE_CHECKING:
+        source: Mapped[Literal[EventSource.system]]
+        name: Mapped[Literal[SystemEvent.subscription_resumed]]
+        user_metadata: Mapped[SubscriptionResumedMetadata]  # type: ignore[assignment]
 
 
 class SubscriptionUncanceledMetadata(TypedDict):
@@ -699,6 +737,24 @@ def build_system_event(
     customer: Customer,
     organization: Organization,
     metadata: SubscriptionReactivatedMetadata,
+) -> Event: ...
+
+
+@overload
+def build_system_event(
+    name: Literal[SystemEvent.subscription_paused],
+    customer: Customer,
+    organization: Organization,
+    metadata: SubscriptionPausedMetadata,
+) -> Event: ...
+
+
+@overload
+def build_system_event(
+    name: Literal[SystemEvent.subscription_resumed],
+    customer: Customer,
+    organization: Organization,
+    metadata: SubscriptionResumedMetadata,
 ) -> Event: ...
 
 

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -115,6 +115,8 @@ class OrganizationCustomerEmailSettings(TypedDict):
     subscription_cycled: bool
     subscription_cycled_after_trial: bool
     subscription_past_due: bool
+    subscription_paused: bool
+    subscription_resumed: bool
     subscription_renewal_reminder: bool
     subscription_revoked: bool
     subscription_trial_conversion_reminder: bool
@@ -129,6 +131,8 @@ _default_customer_email_settings: OrganizationCustomerEmailSettings = {
     "subscription_cycled": True,
     "subscription_cycled_after_trial": True,
     "subscription_past_due": True,
+    "subscription_paused": True,
+    "subscription_resumed": True,
     "subscription_renewal_reminder": True,
     "subscription_revoked": True,
     "subscription_trial_conversion_reminder": True,

--- a/server/polar/models/webhook_endpoint.py
+++ b/server/polar/models/webhook_endpoint.py
@@ -37,6 +37,8 @@ class WebhookEventType(StrEnum):
     subscription_uncanceled = "subscription.uncanceled"
     subscription_revoked = "subscription.revoked"
     subscription_past_due = "subscription.past_due"
+    subscription_paused = "subscription.paused"
+    subscription_resumed = "subscription.resumed"
     refund_created = "refund.created"
     refund_updated = "refund.updated"
     product_created = "product.created"

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -36,6 +36,7 @@ from polar.models.organization import (
     OrganizationCustomerPortalSettings,
     OrganizationStatus,
     OrganizationSubscriptionSettings,
+    _default_customer_email_settings,
 )
 from polar.models.organization_review import OrganizationReview
 from polar.models.support_case import ReviewAppealSupportCase
@@ -327,6 +328,20 @@ class OrganizationSocialLink(Schema):
         return data
 
 
+def _merge_customer_email_settings_defaults(value: Any) -> Any:
+    """Complete stored settings with defaults so reads tolerate keys added after
+    an organization's settings were last written (lazy materialization)."""
+    if isinstance(value, dict):
+        return {**_default_customer_email_settings, **value}
+    return value
+
+
+CustomerEmailSettings = Annotated[
+    OrganizationCustomerEmailSettings,
+    BeforeValidator(_merge_customer_email_settings_defaults),
+]
+
+
 class OrganizationBase(IDSchema, TimestampedSchema):
     name: str = Field(
         description="Organization name shown in checkout, customer portal, emails etc.",
@@ -414,7 +429,7 @@ class OrganizationPublicBase(OrganizationBase):
 
     feature_settings: SkipJsonSchema[OrganizationFeatureSettings | None]
     subscription_settings: SkipJsonSchema[OrganizationSubscriptionSettings]
-    customer_email_settings: SkipJsonSchema[OrganizationCustomerEmailSettings]
+    customer_email_settings: SkipJsonSchema[CustomerEmailSettings]
 
 
 class Organization(OrganizationBase):
@@ -449,7 +464,7 @@ class Organization(OrganizationBase):
     subscription_settings: OrganizationSubscriptionSettings = Field(
         description="Settings related to subscriptions management",
     )
-    customer_email_settings: OrganizationCustomerEmailSettings = Field(
+    customer_email_settings: CustomerEmailSettings = Field(
         description="Settings related to customer emails",
     )
     customer_portal_settings: OrganizationCustomerPortalSettings = Field(

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -40,8 +40,8 @@ from polar.event.system import (
     SubscriptionCanceledMetadata,
     SubscriptionCreatedMetadata,
     SubscriptionCycledMetadata,
-    SubscriptionPausedMetadata,
     SubscriptionPastDueMetadata,
+    SubscriptionPausedMetadata,
     SubscriptionReactivatedMetadata,
     SubscriptionResumedMetadata,
     SubscriptionRevokedMetadata,
@@ -1930,6 +1930,12 @@ class SubscriptionService:
         subscription.pause_at_period_end = True
         subscription.resumes_at = resumes_at
         session.add(subscription)
+
+        # Notify the customer at request time, while the subscription is still
+        # active until the end of the current period.
+        # The actual`paused` transition happens later in `cycle()`.
+        await self.send_paused_email(session, subscription)
+
         return subscription
 
     async def cancel_scheduled_pause(
@@ -2463,6 +2469,8 @@ class SubscriptionService:
             ),
         )
 
+        await self.send_resumed_email(session, subscription)
+
     async def _on_subscription_past_due(
         self, session: AsyncSession, subscription: Subscription
     ) -> None:
@@ -2811,6 +2819,26 @@ class SubscriptionService:
             template_name="subscription_past_due",
         )
 
+    async def send_paused_email(
+        self, session: AsyncSession, subscription: Subscription
+    ) -> None:
+        return await self._send_customer_email(
+            session,
+            subscription,
+            subject_template="Your {product.name} subscription is paused",
+            template_name="subscription_paused",
+        )
+
+    async def send_resumed_email(
+        self, session: AsyncSession, subscription: Subscription
+    ) -> None:
+        return await self._send_customer_email(
+            session,
+            subscription,
+            subject_template="Your {product.name} subscription has resumed",
+            template_name="subscription_resumed",
+        )
+
     async def send_subscription_updated_email(
         self,
         session: AsyncSession,
@@ -2882,6 +2910,8 @@ class SubscriptionService:
         template_name: Literal[
             "subscription_cancellation",
             "subscription_past_due",
+            "subscription_paused",
+            "subscription_resumed",
             "subscription_renewal_reminder",
             "subscription_revoked",
             "subscription_trial_conversion_reminder",
@@ -2907,7 +2937,10 @@ class SubscriptionService:
         )
         assert organization is not None
 
-        if not organization.customer_email_settings[template_name]:
+        # Read-default to enabled: the key is absent from the stored settings of
+        # organizations created before this template existed, and is materialized
+        # only when an admin next edits their notification settings.
+        if not organization.customer_email_settings.get(template_name, True):
             return
 
         customer = subscription.customer

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -40,8 +40,10 @@ from polar.event.system import (
     SubscriptionCanceledMetadata,
     SubscriptionCreatedMetadata,
     SubscriptionCycledMetadata,
+    SubscriptionPausedMetadata,
     SubscriptionPastDueMetadata,
     SubscriptionReactivatedMetadata,
+    SubscriptionResumedMetadata,
     SubscriptionRevokedMetadata,
     SubscriptionUncanceledMetadata,
     SubscriptionUpdatedMetadataFields,
@@ -2303,11 +2305,22 @@ class SubscriptionService:
     ) -> None:
         await self._on_subscription_updated(session, subscription)
 
-        became_activated = subscription.active and not SubscriptionStatus.is_active(
-            previous_status
+        became_resumed = (
+            subscription.active and previous_status == SubscriptionStatus.paused
+        )
+        # A resume re-activates the subscription but is not a first activation:
+        # exclude it so the "new subscription" notification isn't sent again.
+        became_activated = (
+            subscription.active
+            and not SubscriptionStatus.is_active(previous_status)
+            and not became_resumed
         )
         became_reactivated = (
             became_activated and previous_status == SubscriptionStatus.past_due
+        )
+        became_paused = (
+            subscription.status == SubscriptionStatus.paused
+            and previous_status != SubscriptionStatus.paused
         )
         became_past_due = (
             subscription.status == SubscriptionStatus.past_due
@@ -2323,6 +2336,12 @@ class SubscriptionService:
             await self._on_subscription_activated(
                 session, subscription, became_reactivated
             )
+
+        if became_paused:
+            await self._on_subscription_paused(session, subscription)
+
+        if became_resumed:
+            await self._on_subscription_resumed(session, subscription)
 
         if became_uncanceled:
             await self._on_subscription_uncanceled(session, subscription)
@@ -2389,6 +2408,60 @@ class SubscriptionService:
                     ),
                 ),
             )
+
+    async def _on_subscription_paused(
+        self, session: AsyncSession, subscription: Subscription
+    ) -> None:
+        await self._send_webhook(
+            session, subscription, WebhookEventType.subscription_paused
+        )
+
+        assert subscription.paused_at is not None
+        metadata = SubscriptionPausedMetadata(
+            subscription_id=str(subscription.id),
+            product_id=str(subscription.product_id),
+            amount=subscription.amount,
+            currency=subscription.currency,
+            recurring_interval=subscription.recurring_interval.value,
+            recurring_interval_count=subscription.recurring_interval_count,
+            paused_at=subscription.paused_at.isoformat(),
+        )
+        if subscription.resumes_at is not None:
+            metadata["resumes_at"] = subscription.resumes_at.isoformat()
+
+        await event_service.create_event(
+            session,
+            build_system_event(
+                SystemEvent.subscription_paused,
+                customer=subscription.customer,
+                organization=subscription.organization,
+                metadata=metadata,
+            ),
+        )
+
+    async def _on_subscription_resumed(
+        self, session: AsyncSession, subscription: Subscription
+    ) -> None:
+        await self._send_webhook(
+            session, subscription, WebhookEventType.subscription_resumed
+        )
+
+        await event_service.create_event(
+            session,
+            build_system_event(
+                SystemEvent.subscription_resumed,
+                customer=subscription.customer,
+                organization=subscription.organization,
+                metadata=SubscriptionResumedMetadata(
+                    subscription_id=str(subscription.id),
+                    product_id=str(subscription.product_id),
+                    amount=subscription.amount,
+                    currency=subscription.currency,
+                    recurring_interval=subscription.recurring_interval.value,
+                    recurring_interval_count=subscription.recurring_interval_count,
+                ),
+            ),
+        )
 
     async def _on_subscription_past_due(
         self, session: AsyncSession, subscription: Subscription
@@ -2566,6 +2639,8 @@ class SubscriptionService:
             WebhookEventType.subscription_uncanceled,
             WebhookEventType.subscription_revoked,
             WebhookEventType.subscription_past_due,
+            WebhookEventType.subscription_paused,
+            WebhookEventType.subscription_resumed,
         ],
     ) -> None:
         repository = SubscriptionRepository.from_session(session)

--- a/server/polar/webhook/service.py
+++ b/server/polar/webhook/service.py
@@ -684,6 +684,24 @@ class WebhookService:
         self,
         session: AsyncSession,
         target: Organization,
+        event: Literal[WebhookEventType.subscription_paused],
+        data: Subscription,
+    ) -> list[WebhookEvent]: ...
+
+    @overload
+    async def send(
+        self,
+        session: AsyncSession,
+        target: Organization,
+        event: Literal[WebhookEventType.subscription_resumed],
+        data: Subscription,
+    ) -> list[WebhookEvent]: ...
+
+    @overload
+    async def send(
+        self,
+        session: AsyncSession,
+        target: Organization,
         event: Literal[WebhookEventType.refund_created],
         data: Refund,
     ) -> list[WebhookEvent]: ...

--- a/server/polar/webhook/webhooks.py
+++ b/server/polar/webhook/webhooks.py
@@ -713,6 +713,13 @@ class WebhookSubscriptionUpdatedPayloadBase(BaseWebhookPayload):
 
     def _get_paused_slack_payload(self, target: User | Organization) -> str:
         fields = self._get_slack_fields(target)
+        if self.data.resumes_at:
+            fields.append(
+                {
+                    "type": "mrkdwn",
+                    "text": f"*Resumes At*\n{format_date(self.data.resumes_at, locale='en_US')}",
+                }
+            )
         payload: SlackPayload = get_branded_slack_payload(
             {
                 "text": "Subscription has been paused.",

--- a/server/polar/webhook/webhooks.py
+++ b/server/polar/webhook/webhooks.py
@@ -682,8 +682,91 @@ class WebhookSubscriptionUpdatedPayloadBase(BaseWebhookPayload):
         | Literal[WebhookEventType.subscription_uncanceled]
         | Literal[WebhookEventType.subscription_revoked]
         | Literal[WebhookEventType.subscription_past_due]
+        | Literal[WebhookEventType.subscription_paused]
+        | Literal[WebhookEventType.subscription_resumed]
     )
     data: SubscriptionSchema
+
+    def _get_paused_discord_payload(self, target: User | Organization) -> str:
+        fields = self._get_discord_fields(target)
+        if self.data.resumes_at:
+            fields.append(
+                {
+                    "name": "Resumes At",
+                    "value": format_date(self.data.resumes_at, locale="en_US"),
+                }
+            )
+        payload: DiscordPayload = {
+            "content": "Subscription has been paused.",
+            "embeds": [
+                get_branded_discord_embed(
+                    {
+                        "title": "Paused Subscription",
+                        "description": "Subscription has been paused.",
+                        "fields": fields,
+                    }
+                )
+            ],
+        }
+
+        return json.dumps(payload)
+
+    def _get_paused_slack_payload(self, target: User | Organization) -> str:
+        fields = self._get_slack_fields(target)
+        payload: SlackPayload = get_branded_slack_payload(
+            {
+                "text": "Subscription has been paused.",
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "Subscription has been paused.",
+                        },
+                        "fields": fields,
+                    }
+                ],
+            }
+        )
+
+        return json.dumps(payload)
+
+    def _get_resumed_discord_payload(self, target: User | Organization) -> str:
+        fields = self._get_discord_fields(target)
+        payload: DiscordPayload = {
+            "content": "Subscription has resumed.",
+            "embeds": [
+                get_branded_discord_embed(
+                    {
+                        "title": "Resumed Subscription",
+                        "description": "Subscription has resumed.",
+                        "fields": fields,
+                    }
+                )
+            ],
+        }
+
+        return json.dumps(payload)
+
+    def _get_resumed_slack_payload(self, target: User | Organization) -> str:
+        fields = self._get_slack_fields(target)
+        payload: SlackPayload = get_branded_slack_payload(
+            {
+                "text": "Subscription has resumed.",
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "Subscription has resumed.",
+                        },
+                        "fields": fields,
+                    }
+                ],
+            }
+        )
+
+        return json.dumps(payload)
 
     def _get_active_discord_payload(self, target: User | Organization) -> str:
         fields = self._get_discord_fields(target)
@@ -1085,6 +1168,57 @@ class WebhookSubscriptionPastDuePayload(WebhookSubscriptionUpdatedPayloadBase):
         return self._get_past_due_slack_payload(target)
 
 
+class WebhookSubscriptionPausedPayload(WebhookSubscriptionUpdatedPayloadBase):
+    """
+    Sent when a subscription is paused and the customer temporarily loses access.
+
+    No order is created while paused. The subscription resumes either on its
+    scheduled resume date or when resumed manually, starting a new billing period.
+
+    **Discord & Slack support:** Full
+    """
+
+    type: Literal[WebhookEventType.subscription_paused]
+    data: SubscriptionSchema
+
+    def get_discord_payload(self, target: User | Organization) -> str:
+        if isinstance(target, User):
+            raise UnsupportedTarget(target, self.__class__, WebhookFormat.discord)
+
+        return self._get_paused_discord_payload(target)
+
+    def get_slack_payload(self, target: User | Organization) -> str:
+        if isinstance(target, User):
+            raise UnsupportedTarget(target, self.__class__, WebhookFormat.slack)
+
+        return self._get_paused_slack_payload(target)
+
+
+class WebhookSubscriptionResumedPayload(WebhookSubscriptionUpdatedPayloadBase):
+    """
+    Sent when a paused subscription resumes, restoring the customer's access.
+
+    Resuming starts a new billing period and charges the customer immediately.
+
+    **Discord & Slack support:** Full
+    """
+
+    type: Literal[WebhookEventType.subscription_resumed]
+    data: SubscriptionSchema
+
+    def get_discord_payload(self, target: User | Organization) -> str:
+        if isinstance(target, User):
+            raise UnsupportedTarget(target, self.__class__, WebhookFormat.discord)
+
+        return self._get_resumed_discord_payload(target)
+
+    def get_slack_payload(self, target: User | Organization) -> str:
+        if isinstance(target, User):
+            raise UnsupportedTarget(target, self.__class__, WebhookFormat.slack)
+
+        return self._get_resumed_slack_payload(target)
+
+
 class WebhookRefundBase(BaseWebhookPayload):
     """
     Base Refund
@@ -1340,6 +1474,8 @@ WebhookPayload = Annotated[
     | WebhookSubscriptionUncanceledPayload
     | WebhookSubscriptionRevokedPayload
     | WebhookSubscriptionPastDuePayload
+    | WebhookSubscriptionPausedPayload
+    | WebhookSubscriptionResumedPayload
     | WebhookRefundCreatedPayload
     | WebhookRefundUpdatedPayload
     | WebhookProductCreatedPayload

--- a/server/scripts/seeds_load.py
+++ b/server/scripts/seeds_load.py
@@ -1595,6 +1595,8 @@ async def create_seed_data(
                 "subscription_trial_conversion_reminder": False,
                 "subscription_uncanceled": False,
                 "subscription_updated": False,
+                "subscription_paused": False,
+                "subscription_resumed": False,
             },
             "products": [],
         },

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -86,10 +86,13 @@ from polar.subscription.service import (
     AboveMaximumSeats,
     AlreadyCanceledSubscription,
     BelowMinimumSeats,
+    CannotPauseSubscription,
     InactiveSubscription,
     MissingCheckoutCustomer,
+    NoScheduledPause,
     NotARecurringProduct,
     NotASeatBasedSubscription,
+    NotPausedSubscription,
     SeatsAlreadyAssigned,
     SubscriptionUpdateContext,
 )
@@ -118,7 +121,9 @@ from tests.fixtures.random_objects import (
     set_product_benefits,
 )
 
-Hooks = namedtuple("Hooks", "updated activated canceled uncanceled revoked")
+Hooks = namedtuple(
+    "Hooks", "updated activated canceled uncanceled revoked paused resumed"
+)
 HookNames = frozenset(Hooks._fields)
 
 
@@ -190,12 +195,16 @@ def subscription_hooks(mocker: MockerFixture) -> Hooks:
         subscription_service, "_on_subscription_uncanceled"
     )
     revoked = mocker.patch.object(subscription_service, "_on_subscription_revoked")
+    paused = mocker.patch.object(subscription_service, "_on_subscription_paused")
+    resumed = mocker.patch.object(subscription_service, "_on_subscription_resumed")
     return Hooks(
         updated=updated,
         activated=activated,
         canceled=canceled,
         uncanceled=uncanceled,
         revoked=revoked,
+        paused=paused,
+        resumed=resumed,
     )
 
 
@@ -2300,6 +2309,288 @@ class TestUncancel:
         assert updated_subscription.cancel_at_period_end is False
         assert updated_subscription.ends_at is None
         assert updated_subscription.canceled_at is None
+
+
+@pytest.mark.asyncio
+class TestPause:
+    async def test_not_active(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.past_due,
+        )
+
+        with pytest.raises(CannotPauseSubscription):
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.pause(session, ctx, subscription)
+
+    async def test_scheduled_to_cancel(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            cancel_at_period_end=True,
+        )
+
+        with pytest.raises(CannotPauseSubscription):
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.pause(session, ctx, subscription)
+
+    async def test_resumes_at_before_period_end(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        mocker.patch.object(subscription_service, "send_paused_email")
+        current_period_end = utc_now() + timedelta(days=30)
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            current_period_end=current_period_end,
+        )
+
+        with pytest.raises(PolarRequestValidationError):
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.pause(
+                    session,
+                    ctx,
+                    subscription,
+                    resumes_at=current_period_end - timedelta(days=1),
+                )
+
+    async def test_valid(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        enqueue_benefits_grants_mock: MagicMock,
+        subscription_hooks: Hooks,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        send_paused_email_mock = mocker.patch.object(
+            subscription_service, "send_paused_email"
+        )
+        current_period_end = utc_now() + timedelta(days=30)
+        resumes_at = current_period_end + timedelta(days=30)
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            current_period_end=current_period_end,
+        )
+        reset_hooks(subscription_hooks)
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.pause(
+                session, ctx, subscription, resumes_at=resumes_at
+            )
+
+        # Still active until the end of the current period, only scheduled to pause.
+        assert updated.status == SubscriptionStatus.active
+        assert updated.pause_at_period_end is True
+        assert updated.resumes_at == resumes_at
+        assert updated.paused_at is None
+        # Benefits stay granted; the customer is notified at request time.
+        enqueue_benefits_grants_mock.assert_not_called()
+        send_paused_email_mock.assert_called_once()
+        assert_hooks_called_once(subscription_hooks, {"updated"})
+
+    async def test_valid_indefinite(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        mocker.patch.object(subscription_service, "send_paused_email")
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.pause(session, ctx, subscription)
+
+        assert updated.pause_at_period_end is True
+        assert updated.resumes_at is None
+
+    async def test_cycle_pauses_at_period_end(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        enqueue_job_mock: MagicMock,
+        enqueue_benefits_grants_mock: MagicMock,
+        subscription_hooks: Hooks,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            scheduler_locked_at=utc_now(),
+        )
+        subscription.pause_at_period_end = True
+        subscription.resumes_at = utc_now() + timedelta(days=60)
+        await save_fixture(subscription)
+        reset_hooks(subscription_hooks)
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.cycle(session, ctx, subscription)
+
+        assert updated.status == SubscriptionStatus.paused
+        assert updated.paused_at is not None
+        assert updated.pause_at_period_end is False
+        assert updated.scheduler_locked_at is None
+        # Benefits revoked, no order created for the paused period.
+        enqueue_benefits_grants_mock.assert_called_once_with(session, updated)
+        order_calls = [
+            call
+            for call in enqueue_job_mock.call_args_list
+            if call.args and call.args[0] == "order.create_subscription_order"
+        ]
+        assert order_calls == []
+        assert_hooks_called_once(subscription_hooks, {"updated", "paused"})
+
+
+@pytest.mark.asyncio
+class TestCancelScheduledPause:
+    async def test_not_scheduled(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        with pytest.raises(NoScheduledPause):
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.cancel_scheduled_pause(
+                    session, ctx, subscription
+                )
+
+    async def test_valid(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        subscription_hooks: Hooks,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        subscription.pause_at_period_end = True
+        subscription.resumes_at = utc_now() + timedelta(days=30)
+        await save_fixture(subscription)
+        reset_hooks(subscription_hooks)
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.cancel_scheduled_pause(
+                session, ctx, subscription
+            )
+
+        assert updated.status == SubscriptionStatus.active
+        assert updated.pause_at_period_end is False
+        assert updated.resumes_at is None
+        assert_hooks_called_once(subscription_hooks, {"updated"})
+
+
+@pytest.mark.asyncio
+class TestResume:
+    async def test_not_paused(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        with pytest.raises(NotPausedSubscription):
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.resume(session, ctx, subscription)
+
+    async def test_valid(
+        self,
+        frozen_time: datetime,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        enqueue_job_mock: MagicMock,
+        enqueue_benefits_grants_mock: MagicMock,
+        subscription_hooks: Hooks,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+        subscription.paused_at = frozen_time - timedelta(days=10)
+        subscription.resumes_at = frozen_time
+        await save_fixture(subscription)
+        reset_hooks(subscription_hooks)
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.resume(session, ctx, subscription)
+
+        # A fresh billing period starts now and the customer is charged.
+        assert updated.status == SubscriptionStatus.active
+        assert updated.paused_at is None
+        assert updated.resumes_at is None
+        assert updated.current_period_start == frozen_time
+        assert updated.current_period_end is not None
+        assert updated.current_period_end > frozen_time
+        enqueue_benefits_grants_mock.assert_called_once_with(session, updated)
+        enqueue_job_mock.assert_any_call(
+            "order.create_subscription_order", subscription.id, ANY
+        )
+        assert_hooks_called_once(subscription_hooks, {"updated", "resumed"})
 
 
 async def create_event_billing_entry(

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -2429,7 +2429,9 @@ class TestPause:
         product: Product,
         customer: Customer,
     ) -> None:
-        mocker.patch.object(subscription_service, "send_paused_email")
+        send_paused_email_mock = mocker.patch.object(
+            subscription_service, "send_paused_email"
+        )
         subscription = await create_active_subscription(
             save_fixture, product=product, customer=customer
         )
@@ -2441,6 +2443,7 @@ class TestPause:
 
         assert updated.pause_at_period_end is True
         assert updated.resumes_at is None
+        send_paused_email_mock.assert_called_once()
 
     async def test_cycle_pauses_at_period_end(
         self,


### PR DESCRIPTION
- **feat(webhook): add subscription paused/resumed events**
- **feat(subscription): dispatch paused/resumed transitions**
- **feat(subscription): send pause/resume customer emails**
- **feat(emails): add pause/resume subscription templates**
- **feat(web): pause/resume email notification settings**
- **fix(organization): tolerate missing customer email settings keys on read**
- **fix seeds script**
- **test(subscription): pause/resume/cancel-pause service tests**
- **feat(subscription): paused/resumed system event schemas + Slack resumes-at parity, regen client**

 New subscription.paused / subscription.resumed webhooks (plus system events and Discord/Slack payloads). A pause email is sent at request time (it states access continues until the current period end and that no charge is made) and a resume email on resume; both are toggleable in customer notification settings.

| Pause email | Resume email | Notification settings |
|:---:|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/98bb5f8c-fa10-4cbc-ab47-0472345fa60f" width="320" /> | <img src="https://github.com/user-attachments/assets/b5ddf095-7ece-4beb-ad62-ab8176be67ce" width="320" /> | <img src="https://github.com/user-attachments/assets/b09377d9-10f7-4bd9-ac79-fd02aaad9b45" width="320" /> |

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

