### PR TITLE
feat: merchant migration pre-check panel + records drawer

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/MigrationTimeline.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/MigrationTimeline.tsx
@@ -2,6 +2,7 @@ import { schemas } from '@polar-sh/client'
 import { Button, Status, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { Check } from 'lucide-react'
+import { PrecheckPanel } from './PrecheckPanel'
 import {
   MIGRATION_STEPS,
   OWNER_LABELS,
@@ -35,6 +36,8 @@ export function MigrationTimeline({
         const ownerLabel = OWNER_LABELS[def.owner]
         const showConnect =
           state === 'current' && def.step === 'source_setup' && !connected
+        const showPrecheck =
+          state === 'current' && def.step === 'pre_check' && connected
 
         return (
           <Box as="li" key={def.step} display="flex" columnGap="m">
@@ -82,6 +85,7 @@ export function MigrationTimeline({
                   </Button>
                 </Box>
               )}
+              {showPrecheck && <PrecheckPanel migrationId={migration.id} />}
             </Box>
           </Box>
         )

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/PrecheckPanel.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/PrecheckPanel.tsx
@@ -1,0 +1,90 @@
+'use client'
+
+import { useRunMerchantMigrationPrecheck } from '@/hooks/queries/merchantMigrations'
+import { schemas } from '@polar-sh/client'
+import { Button, Status, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { PrecheckSummary } from './PrecheckSummary'
+
+export function PrecheckPanel({ migrationId }: { migrationId: string }) {
+  const precheck = useRunMerchantMigrationPrecheck(migrationId)
+  const report = precheck.data
+
+  return (
+    <Box flexDirection="column" rowGap="l" marginTop="m">
+      {report ? (
+        <PrecheckResult report={report} migrationId={migrationId} />
+      ) : (
+        <Text variant="caption" color="muted">
+          We&apos;ll read your Stripe products, prices, customers and
+          subscriptions and check they can be imported. Nothing is changed in
+          Stripe.
+        </Text>
+      )}
+
+      {precheck.isError && (
+        <Text variant="caption" color="danger">
+          We couldn&apos;t complete the pre-check. Please try again.
+        </Text>
+      )}
+
+      <Box>
+        <Button
+          size="sm"
+          variant={report ? 'ghost' : 'default'}
+          onClick={() => precheck.mutate()}
+          disabled={precheck.isPending}
+        >
+          {precheck.isPending
+            ? 'Checking…'
+            : report
+              ? 'Run again'
+              : 'Run pre-check'}
+        </Button>
+      </Box>
+    </Box>
+  )
+}
+
+function PrecheckResult({
+  report,
+  migrationId,
+}: {
+  report: schemas['PrecheckReport']
+  migrationId: string
+}) {
+  const blockers = report.issues.filter((issue) => issue.level === 'blocker')
+
+  return (
+    <Box flexDirection="column" rowGap="l">
+      <Box alignItems="center" columnGap="s">
+        <Status
+          status={
+            report.can_start
+              ? 'Ready to import'
+              : `${blockers.length} blocker${blockers.length === 1 ? '' : 's'} to resolve`
+          }
+          color={report.can_start ? 'green' : 'red'}
+          size="small"
+        />
+        <Text variant="caption" color="muted">
+          Read from Stripe · nothing changed
+        </Text>
+      </Box>
+
+      {blockers.length > 0 && (
+        <Box as="ul" flexDirection="column" rowGap="xs">
+          {blockers.map((issue, index) => (
+            <Box as="li" key={`${issue.code}-${index}`}>
+              <Text variant="caption" color="danger">
+                {issue.message}
+              </Text>
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      <PrecheckSummary migrationId={migrationId} report={report} />
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/PrecheckRecordsDrawer.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/PrecheckRecordsDrawer.tsx
@@ -1,0 +1,156 @@
+'use client'
+
+import { useMigrationRecords } from '@/hooks/queries/merchantMigrations'
+import { schemas } from '@polar-sh/client'
+import {
+  Button,
+  InlineModalHeader,
+  SegmentedControl,
+  Spinner,
+  Status,
+  Text,
+} from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { useState } from 'react'
+import { ENTITY_LABELS } from './reasons'
+
+const LIMIT = 20
+
+type Entity = schemas['PrecheckEntity']
+type RecordStatus = schemas['PrecheckRecordStatus']
+type Filter = '' | RecordStatus
+
+const FILTERS: { label: string; value: Filter }[] = [
+  { label: 'All', value: '' },
+  { label: 'Importing', value: 'importable' },
+  { label: 'Stay on Stripe', value: 'skipped' },
+]
+
+export function PrecheckRecordsDrawer({
+  migrationId,
+  entity,
+  onClose,
+}: {
+  migrationId: string
+  entity: Entity
+  onClose: () => void
+}) {
+  const [filter, setFilter] = useState<Filter>('')
+  const [page, setPage] = useState(1)
+  const { data, isLoading } = useMigrationRecords(migrationId, {
+    entity,
+    status: filter || undefined,
+    page,
+    limit: LIMIT,
+  })
+
+  const items = data?.items ?? []
+  const total = data?.pagination.total_count ?? 0
+  const maxPage = Math.max(1, Math.ceil(total / LIMIT))
+
+  return (
+    <Box flexDirection="column" height="100%">
+      <InlineModalHeader hide={onClose}>
+        <Text variant="heading-xs" as="h2">
+          {ENTITY_LABELS[entity] ?? entity}
+        </Text>
+      </InlineModalHeader>
+
+      <Box
+        flexDirection="column"
+        rowGap="l"
+        padding="xl"
+        flex={1}
+        overflowY="auto"
+      >
+        <SegmentedControl
+          options={FILTERS}
+          value={filter}
+          onChange={(value) => {
+            setFilter(value)
+            setPage(1)
+          }}
+        />
+
+        {isLoading ? (
+          <Box padding="2xl" alignItems="center" justifyContent="center">
+            <Spinner />
+          </Box>
+        ) : items.length === 0 ? (
+          <Text variant="caption" color="muted">
+            No {ENTITY_LABELS[entity]?.toLowerCase() ?? 'records'} here.
+          </Text>
+        ) : (
+          <Box as="ul" flexDirection="column">
+            {items.map((item) => (
+              <RecordRow key={item.source_id} item={item} />
+            ))}
+          </Box>
+        )}
+
+        {maxPage > 1 && (
+          <Box alignItems="center" justifyContent="between">
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={page <= 1}
+              onClick={() => setPage((value) => value - 1)}
+            >
+              Previous
+            </Button>
+            <Text variant="caption" color="muted">
+              {page} / {maxPage}
+            </Text>
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={page >= maxPage}
+              onClick={() => setPage((value) => value + 1)}
+            >
+              Next
+            </Button>
+          </Box>
+        )}
+      </Box>
+    </Box>
+  )
+}
+
+function RecordRow({ item }: { item: schemas['MerchantMigrationRecordItem'] }) {
+  const skipped = item.status === 'skipped'
+  return (
+    <Box
+      as="li"
+      flexDirection="column"
+      rowGap="xs"
+      paddingVertical="m"
+      borderBottomWidth={1}
+      borderStyle="solid"
+      borderColor="border-secondary"
+    >
+      <Box alignItems="center" justifyContent="between" columnGap="m">
+        <Box flexDirection="column" rowGap="xs" flex={1}>
+          <Text variant="body">{item.title}</Text>
+          {item.subtitle && (
+            <Text variant="caption" color="muted">
+              {item.subtitle}
+            </Text>
+          )}
+        </Box>
+        <Status
+          status={skipped ? 'Stays on Stripe' : 'Importing'}
+          color={skipped ? 'yellow' : 'green'}
+          size="small"
+        />
+      </Box>
+      {item.reason && (
+        <Text variant="caption" color="muted">
+          {item.reason}
+        </Text>
+      )}
+      <Text variant="caption" color="muted" monospace>
+        {item.source_id}
+      </Text>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/PrecheckRecordsDrawer.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/PrecheckRecordsDrawer.tsx
@@ -3,6 +3,7 @@
 import { useMigrationRecords } from '@/hooks/queries/merchantMigrations'
 import { schemas } from '@polar-sh/client'
 import {
+  Alert,
   Button,
   InlineModalHeader,
   SegmentedControl,
@@ -37,7 +38,7 @@ export function PrecheckRecordsDrawer({
 }) {
   const [filter, setFilter] = useState<Filter>('')
   const [page, setPage] = useState(1)
-  const { data, isLoading } = useMigrationRecords(migrationId, {
+  const { data, isLoading, isError } = useMigrationRecords(migrationId, {
     entity,
     status: filter || undefined,
     page,
@@ -76,6 +77,12 @@ export function PrecheckRecordsDrawer({
           <Box padding="2xl" alignItems="center" justifyContent="center">
             <Spinner />
           </Box>
+        ) : isError ? (
+          <Alert
+            variant="danger"
+            title="We couldn't load these records"
+            description="Something went wrong. Please try again."
+          />
         ) : items.length === 0 ? (
           <Text variant="caption" color="muted">
             No {ENTITY_LABELS[entity]?.toLowerCase() ?? 'records'} here.
@@ -121,6 +128,7 @@ function RecordRow({ item }: { item: schemas['MerchantMigrationRecordItem'] }) {
   return (
     <Box
       as="li"
+      display="flex"
       flexDirection="column"
       rowGap="xs"
       paddingVertical="m"

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/PrecheckSummary.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/PrecheckSummary.tsx
@@ -1,0 +1,117 @@
+'use client'
+
+import { useModal } from '@/components/Modal/useModal'
+import { schemas } from '@polar-sh/client'
+import { Grid, InlineModal, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { useState } from 'react'
+import { PrecheckRecordsDrawer } from './PrecheckRecordsDrawer'
+import { ENTITY_LABELS } from './reasons'
+
+type Report = schemas['PrecheckReport']
+type Summary = schemas['PrecheckEntitySummary']
+type Entity = schemas['PrecheckEntity']
+
+const ENTITY_ORDER: Entity[] = [
+  'subscriptions',
+  'customers',
+  'products',
+  'prices',
+]
+
+export function PrecheckSummary({
+  migrationId,
+  report,
+}: {
+  migrationId: string
+  report: Report
+}) {
+  const byEntity = new Map<string, Summary>(
+    report.entities.map((entity) => [entity.entity, entity]),
+  )
+  const drawer = useModal()
+  const [selected, setSelected] = useState<Entity | null>(null)
+
+  const open = (entity: Entity) => {
+    setSelected(entity)
+    drawer.show()
+  }
+
+  return (
+    <Box flexDirection="column" rowGap="l">
+      <Grid templateColumns={{ base: '1fr 1fr', md: 'repeat(4, 1fr)' }} gap="m">
+        {ENTITY_ORDER.map((entity) => (
+          <EntityCell
+            key={entity}
+            summary={byEntity.get(entity)}
+            onOpen={() => open(entity)}
+          />
+        ))}
+      </Grid>
+
+      <Box
+        paddingTop="s"
+        borderTopWidth={1}
+        borderStyle="solid"
+        borderColor="border-secondary"
+      >
+        <Text variant="caption" color="muted">
+          Charges, refunds, disputes and tax history always stay on Stripe.
+        </Text>
+      </Box>
+
+      <InlineModal
+        isShown={drawer.isShown}
+        hide={drawer.hide}
+        className="md:w-[720px]"
+        modalContent={
+          selected ? (
+            <PrecheckRecordsDrawer
+              migrationId={migrationId}
+              entity={selected}
+              onClose={drawer.hide}
+            />
+          ) : null
+        }
+      />
+    </Box>
+  )
+}
+
+function EntityCell({
+  summary,
+  onOpen,
+}: {
+  summary?: Summary
+  onOpen: () => void
+}) {
+  if (!summary) return null
+  const clickable = summary.total > 0
+
+  return (
+    <Box
+      flexDirection="column"
+      rowGap="xs"
+      cursor={clickable ? 'pointer' : 'default'}
+      onClick={clickable ? onOpen : undefined}
+    >
+      <Text variant="heading-m">{summary.importable}</Text>
+      <Text variant="caption" color="muted">
+        {ENTITY_LABELS[summary.entity] ?? summary.entity}
+      </Text>
+      {summary.skipped > 0 ? (
+        <Text variant="caption" color="warning">
+          {summary.skipped} stay on Stripe ›
+        </Text>
+      ) : summary.total > 0 ? (
+        <Text variant="caption" color="success">
+          All importing ›
+        </Text>
+      ) : (
+        <Text variant="caption" color="muted">
+          None found
+        </Text>
+      )}
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/PrecheckSummary.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/PrecheckSummary.tsx
@@ -92,8 +92,21 @@ function EntityCell({
     <Box
       flexDirection="column"
       rowGap="xs"
+      textAlign="left"
       cursor={clickable ? 'pointer' : 'default'}
+      role={clickable ? 'button' : undefined}
+      tabIndex={clickable ? 0 : undefined}
       onClick={clickable ? onOpen : undefined}
+      onKeyDown={
+        clickable
+          ? (event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault()
+                onOpen()
+              }
+            }
+          : undefined
+      }
     >
       <Text variant="heading-m">{summary.importable}</Text>
       <Text variant="caption" color="muted">

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/reasons.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/reasons.ts
@@ -1,4 +1,6 @@
-export const ENTITY_LABELS: Record<string, string> = {
+import { schemas } from '@polar-sh/client'
+
+export const ENTITY_LABELS: Record<schemas['PrecheckEntity'], string> = {
   subscriptions: 'Subscriptions',
   customers: 'Customers',
   products: 'Products',

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/reasons.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/reasons.ts
@@ -1,0 +1,6 @@
+export const ENTITY_LABELS: Record<string, string> = {
+  subscriptions: 'Subscriptions',
+  customers: 'Customers',
+  products: 'Products',
+  prices: 'Prices',
+}

--- a/clients/apps/web/src/hooks/queries/merchantMigrations.ts
+++ b/clients/apps/web/src/hooks/queries/merchantMigrations.ts
@@ -56,6 +56,9 @@ export const useRunMerchantMigrationPrecheck = (id: string) =>
       getQueryClient().invalidateQueries({
         queryKey: ['merchantMigration', { id }],
       })
+      getQueryClient().invalidateQueries({
+        queryKey: ['merchantMigrationRecords'],
+      })
     },
   })
 

--- a/clients/apps/web/src/hooks/queries/merchantMigrations.ts
+++ b/clients/apps/web/src/hooks/queries/merchantMigrations.ts
@@ -43,3 +43,47 @@ export const useCreateMerchantMigration = (organizationId: string) =>
       })
     },
   })
+
+export const useRunMerchantMigrationPrecheck = (id: string) =>
+  useMutation({
+    mutationFn: () =>
+      unwrap(
+        api.POST('/v1/merchant-migrations/{id}/precheck', {
+          params: { path: { id } },
+        }),
+      ),
+    onSuccess: () => {
+      getQueryClient().invalidateQueries({
+        queryKey: ['merchantMigration', { id }],
+      })
+    },
+  })
+
+export const useMigrationRecords = (
+  id: string,
+  params: {
+    entity: schemas['PrecheckEntity']
+    status?: schemas['PrecheckRecordStatus']
+    page: number
+    limit: number
+  },
+) =>
+  useQuery({
+    queryKey: ['merchantMigrationRecords', { id, ...params }],
+    queryFn: () =>
+      unwrap(
+        api.GET('/v1/merchant-migrations/{id}/records', {
+          params: {
+            path: { id },
+            query: {
+              entity: params.entity,
+              ...(params.status ? { status: params.status } : {}),
+              page: params.page,
+              limit: params.limit,
+            },
+          },
+        }),
+      ),
+    retry: defaultRetry,
+    enabled: !!id,
+  })

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -4989,6 +4989,26 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/merchant-migrations/{id}/records': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * List Merchant Migration Records
+     * @description **Scopes**: `organizations:write`
+     */
+    get: operations['merchant-migrations:records']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/email-update/request': {
     parameters: {
       query?: never
@@ -21989,6 +22009,12 @@ export interface components {
       items: components['schemas']['Member'][]
       pagination: components['schemas']['Pagination']
     }
+    /** ListResource[MerchantMigrationRecordItem] */
+    ListResource_MerchantMigrationRecordItem_: {
+      /** Items */
+      items: components['schemas']['MerchantMigrationRecordItem'][]
+      pagination: components['schemas']['Pagination']
+    }
     /** ListResource[MerchantMigration] */
     ListResource_MerchantMigration_: {
       /** Items */
@@ -22580,6 +22606,38 @@ export interface components {
       error: 'MerchantMigrationNotFound'
       /** Detail */
       detail: string
+    }
+    /** MerchantMigrationRecordItem */
+    MerchantMigrationRecordItem: {
+      /** @description The source entity type. */
+      entity: components['schemas']['PrecheckEntity']
+      /**
+       * Source Id
+       * @description The source identifier (e.g. Stripe `sub_…`).
+       */
+      source_id: string
+      /**
+       * Title
+       * @description Primary label (name, email or product).
+       */
+      title: string
+      /**
+       * Subtitle
+       * @description Secondary detail (interval, amount, country, status).
+       */
+      subtitle: string | null
+      /** @description Whether this record will be imported or stays on the source. */
+      status: components['schemas']['PrecheckRecordStatus']
+      /**
+       * Reason
+       * @description Why the record is skipped, if it is.
+       */
+      reason: string | null
+      /**
+       * Reason Code
+       * @description Stable code for the skip reason, if any.
+       */
+      reason_code: string | null
     }
     /**
      * MerchantMigrationSourcePlatform
@@ -28418,6 +28476,31 @@ export interface components {
        */
       role?: string | null
     }
+    /**
+     * PrecheckEntity
+     * @enum {string}
+     */
+    PrecheckEntity: 'products' | 'prices' | 'customers' | 'subscriptions'
+    /** PrecheckEntitySummary */
+    PrecheckEntitySummary: {
+      /** @description The source entity type. */
+      entity: components['schemas']['PrecheckEntity']
+      /**
+       * Total
+       * @description How many were read from the source.
+       */
+      total: number
+      /**
+       * Importable
+       * @description How many will be imported into Polar.
+       */
+      importable: number
+      /**
+       * Skipped
+       * @description How many won't be imported and stay on the source.
+       */
+      skipped: number
+    }
     /** PrecheckIssue */
     PrecheckIssue: {
       level: components['schemas']['PrecheckIssueLevel']
@@ -28433,12 +28516,22 @@ export interface components {
      * @enum {string}
      */
     PrecheckIssueLevel: 'blocker' | 'warning'
+    /**
+     * PrecheckRecordStatus
+     * @enum {string}
+     */
+    PrecheckRecordStatus: 'importable' | 'skipped'
     /** PrecheckReport */
     PrecheckReport: {
       /** Can Start */
       can_start: boolean
       /** Issues */
       issues: components['schemas']['PrecheckIssue'][]
+      /**
+       * Entities
+       * @description Per-entity counts of what will be imported vs stay on the source.
+       */
+      entities: components['schemas']['PrecheckEntitySummary'][]
     }
     /**
      * PresentmentCurrency
@@ -49474,6 +49567,73 @@ export interface operations {
       }
     }
   }
+  'merchant-migrations:records': {
+    parameters: {
+      query: {
+        entity: components['schemas']['PrecheckEntity']
+        status?: components['schemas']['PrecheckRecordStatus'] | null
+        /** @description Page number, defaults to 1. */
+        page?: number
+        /** @description Size of a page, defaults to 10. Maximum is 100. */
+        limit?: number
+      }
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ListResource_MerchantMigrationRecordItem_']
+        }
+      }
+      /** @description The source is not connected or isn't supported. */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json':
+            | components['schemas']['SourceNotConnected']
+            | components['schemas']['UnsupportedMigrationSource']
+        }
+      }
+      /** @description Not allowed to manage this organization. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['NotPermitted']
+        }
+      }
+      /** @description Merchant migration not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
   'email-update:request_email_update': {
     parameters: {
       query?: never
@@ -63473,9 +63633,15 @@ export const pledgeStateValues: ReadonlyArray<
   'charge_disputed',
   'cancelled',
 ]
+export const precheckEntityValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['PrecheckEntity']
+> = ['products', 'prices', 'customers', 'subscriptions']
 export const precheckIssueLevelValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['PrecheckIssueLevel']
 > = ['blocker', 'warning']
+export const precheckRecordStatusValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['PrecheckRecordStatus']
+> = ['importable', 'skipped']
 export const presentmentCurrencyValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['PresentmentCurrency']
 > = [

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -16,7 +16,13 @@ from polar.routing import APIRouter
 
 from .auth import MerchantMigrationRead, MerchantMigrationWrite
 from .schemas import MerchantMigration as MerchantMigrationSchema
-from .schemas import MerchantMigrationCreate, PrecheckReport
+from .schemas import (
+    MerchantMigrationCreate,
+    MerchantMigrationRecordItem,
+    PrecheckEntity,
+    PrecheckRecordStatus,
+    PrecheckReport,
+)
 from .service import (
     MerchantMigrationNotFound,
     SourceNotConnected,
@@ -154,3 +160,41 @@ async def precheck(
     session: AsyncSession = Depends(get_db_session),
 ) -> PrecheckReport:
     return await merchant_migration_service.run_precheck(session, auth_subject, id)
+
+
+@router.get(
+    "/{id}/records",
+    response_model=ListResource[MerchantMigrationRecordItem],
+    summary="List Merchant Migration Records",
+    responses={
+        400: {
+            "description": "The source is not connected or isn't supported.",
+            "model": SourceNotConnected.schema() | UnsupportedMigrationSource.schema(),
+        },
+        403: {
+            "description": "Not allowed to manage this organization.",
+            "model": NotPermitted.schema(),
+        },
+        404: {
+            "description": "Merchant migration not found.",
+            "model": MerchantMigrationNotFound.schema(),
+        },
+    },
+)
+async def records(
+    id: UUID4,
+    auth_subject: MerchantMigrationWrite,
+    pagination: PaginationParamsQuery,
+    entity: Annotated[PrecheckEntity, Query()],
+    status: Annotated[PrecheckRecordStatus | None, Query()] = None,
+    session: AsyncSession = Depends(get_db_session),
+) -> ListResource[MerchantMigrationRecordItem]:
+    items, count = await merchant_migration_service.list_records(
+        session,
+        auth_subject,
+        id,
+        entity=entity,
+        status=status,
+        pagination=pagination,
+    )
+    return ListResource.from_paginated_results(items, count, pagination)

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -1,12 +1,13 @@
-"""Streams CanonicalRecords into a PrecheckReport of blockers and warnings
-(design Appendices A and D).
+"""Turns CanonicalRecords into a PrecheckReport of blockers, warnings and
+per-entity import counts (design Appendices A and D), and classifies individual
+records for the review drawer.
 
-Consumes the records once and keeps only the aggregates the cross-record checks
-need, so it never holds the whole source catalog in memory.
+The per-record classification reuses the same `_check_*` predicates as the
+report, so a record's importable/skipped status always matches the summary.
 """
 
 from collections import Counter
-from collections.abc import AsyncIterable, Iterable
+from collections.abc import AsyncIterable, Iterable, Sequence
 
 from polar.enums import SubscriptionRecurringInterval
 from polar.kit.currency import (
@@ -28,7 +29,15 @@ from .canonical import (
     CanonicalSubscription,
     CanonicalSubscriptionStatus,
 )
-from .schemas import PrecheckIssue, PrecheckIssueLevel, PrecheckReport
+from .schemas import (
+    MerchantMigrationRecordItem,
+    PrecheckEntity,
+    PrecheckEntitySummary,
+    PrecheckIssue,
+    PrecheckIssueLevel,
+    PrecheckRecordStatus,
+    PrecheckReport,
+)
 
 RENEWAL_ENABLED_STATUSES = {OrganizationStatus.REVIEW, OrganizationStatus.ACTIVE}
 SUPPORTED_INTERVALS = {interval.value for interval in SubscriptionRecurringInterval}
@@ -38,6 +47,30 @@ NON_IMPORTABLE_STATUSES = {
     CanonicalSubscriptionStatus.unpaid,
     CanonicalSubscriptionStatus.paused,
 }
+
+# Warning codes that mean a record won't be imported (it stays on the source),
+# grouped by the entity they apply to. Kept in sync with the `_check_*` methods
+# so the per-record classification below matches the report's warnings.
+PRODUCT_DROP_CODES = {"one_time_product", "unsupported_recurring_interval"}
+PRICE_DROP_CODES = {
+    "unsupported_pricing_scheme",
+    "unsupported_price_amount",
+    "unsupported_currency",
+    "price_out_of_bounds",
+}
+SUBSCRIPTION_DROP_CODES = {
+    "multiple_line_items",
+    "unsupported_quantity",
+    "send_invoice_collection",
+    "subscription_not_importable",
+    "subscription_paused_collection",
+}
+_DUPLICATE_PRODUCT_NAME_REASON = (
+    "Another product already uses this name; the duplicate stays on the source."
+)
+_DUPLICATE_CUSTOMER_EMAIL_REASON = (
+    "Another customer already uses this email; the duplicate stays on the source."
+)
 
 
 def _is_supported_currency(currency: str) -> bool:
@@ -55,6 +88,8 @@ class PrecheckEngine:
         organization: Organization,
         source_account: CanonicalAccount,
     ) -> PrecheckReport:
+        record_list = [record async for record in records]
+
         issues: list[PrecheckIssue] = list(self._check_organization(organization))
         issues.extend(self._check_account(source_account))
 
@@ -62,7 +97,7 @@ class PrecheckEngine:
         email_counts: Counter[str] = Counter()
         customers_without_country = 0
 
-        async for record in records:
+        for record in record_list:
             if isinstance(record, CanonicalProduct):
                 products_by_name.setdefault(record.name, set()).add(
                     record.product_source_id
@@ -85,6 +120,7 @@ class PrecheckEngine:
             can_start=not any(
                 issue.level == PrecheckIssueLevel.blocker for issue in issues
             ),
+            entities=summarize_records(record_list),
         )
 
     def _check_organization(
@@ -324,3 +360,212 @@ class PrecheckEngine:
 
 
 precheck_engine = PrecheckEngine()
+
+
+def _interval_label(product: CanonicalProduct) -> str:
+    if product.recurring_interval is None:
+        return "One-time"
+    count = product.recurring_interval_count
+    if count == 1:
+        return f"Every {product.recurring_interval}"
+    return f"Every {count} {product.recurring_interval}s"
+
+
+def _amount_label(amount: int | None, currency: str) -> str:
+    if amount is None:
+        return "No amount"
+    return f"{amount / 100:.2f} {currency.upper()}"
+
+
+def _drop_reason(
+    issues: Iterable[PrecheckIssue], codes: set[str]
+) -> tuple[str | None, str | None]:
+    for issue in issues:
+        if issue.code in codes:
+            return issue.code, issue.message
+    return None, None
+
+
+def _item(
+    entity: PrecheckEntity,
+    source_id: str,
+    title: str,
+    subtitle: str | None,
+    *,
+    reason_code: str | None,
+    reason: str | None,
+) -> MerchantMigrationRecordItem:
+    return MerchantMigrationRecordItem(
+        entity=entity,
+        source_id=source_id,
+        title=title,
+        subtitle=subtitle,
+        status=(
+            PrecheckRecordStatus.skipped
+            if reason_code
+            else PrecheckRecordStatus.importable
+        ),
+        reason=reason,
+        reason_code=reason_code,
+    )
+
+
+def _product_items(
+    products: Sequence[CanonicalProduct],
+) -> list[MerchantMigrationRecordItem]:
+    name_counts = Counter(product.name for product in products)
+    seen: set[str] = set()
+    items: list[MerchantMigrationRecordItem] = []
+    for product in products:
+        code, reason = _drop_reason(
+            precheck_engine._check_product(product), PRODUCT_DROP_CODES
+        )
+        if code is None and name_counts[product.name] > 1 and product.name in seen:
+            code, reason = "duplicate_product_name", _DUPLICATE_PRODUCT_NAME_REASON
+        seen.add(product.name)
+        items.append(
+            _item(
+                PrecheckEntity.products,
+                product.product_source_id,
+                product.name,
+                _interval_label(product),
+                reason_code=code,
+                reason=reason,
+            )
+        )
+    return items
+
+
+def _price_items(
+    products: Sequence[CanonicalProduct],
+) -> list[MerchantMigrationRecordItem]:
+    items: list[MerchantMigrationRecordItem] = []
+    for product in products:
+        for price in product.prices:
+            code, reason = _drop_reason(
+                precheck_engine._check_price(product, price), PRICE_DROP_CODES
+            )
+            items.append(
+                _item(
+                    PrecheckEntity.prices,
+                    price.source_id,
+                    product.name,
+                    _amount_label(price.amount, price.currency),
+                    reason_code=code,
+                    reason=reason,
+                )
+            )
+    return items
+
+
+def _customer_items(
+    customers: Sequence[CanonicalCustomer],
+) -> list[MerchantMigrationRecordItem]:
+    email_counts = Counter(c.email.lower() for c in customers if c.email)
+    seen: set[str] = set()
+    items: list[MerchantMigrationRecordItem] = []
+    for customer in customers:
+        code: str | None = None
+        reason: str | None = None
+        key = customer.email.lower() if customer.email else ""
+        if key and email_counts[key] > 1 and key in seen:
+            code, reason = "duplicate_customer_email", _DUPLICATE_CUSTOMER_EMAIL_REASON
+        if key:
+            seen.add(key)
+        items.append(
+            _item(
+                PrecheckEntity.customers,
+                customer.source_id,
+                customer.email or customer.name or customer.source_id,
+                customer.country or "No billing country",
+                reason_code=code,
+                reason=reason,
+            )
+        )
+    return items
+
+
+def _subscription_items(
+    subscriptions: Sequence[CanonicalSubscription],
+    customers: Sequence[CanonicalCustomer],
+) -> list[MerchantMigrationRecordItem]:
+    email_by_source = {c.source_id: c.email for c in customers if c.email}
+    items: list[MerchantMigrationRecordItem] = []
+    for subscription in subscriptions:
+        code, reason = _drop_reason(
+            precheck_engine._check_subscription(subscription), SUBSCRIPTION_DROP_CODES
+        )
+        title = email_by_source.get(
+            subscription.customer_source_id, subscription.customer_source_id
+        )
+        subtitle = subscription.status.value
+        if subscription.trialing:
+            subtitle = f"{subtitle} · trial"
+        items.append(
+            _item(
+                PrecheckEntity.subscriptions,
+                subscription.source_id,
+                title,
+                subtitle,
+                reason_code=code,
+                reason=reason,
+            )
+        )
+    return items
+
+
+def _split_records(
+    records: Sequence[CanonicalRecord],
+) -> tuple[
+    list[CanonicalProduct],
+    list[CanonicalCustomer],
+    list[CanonicalSubscription],
+]:
+    products: list[CanonicalProduct] = []
+    customers: list[CanonicalCustomer] = []
+    subscriptions: list[CanonicalSubscription] = []
+    for record in records:
+        if isinstance(record, CanonicalProduct):
+            products.append(record)
+        elif isinstance(record, CanonicalCustomer):
+            customers.append(record)
+        elif isinstance(record, CanonicalSubscription):
+            subscriptions.append(record)
+    return products, customers, subscriptions
+
+
+def classify_records(
+    records: Sequence[CanonicalRecord], entity: PrecheckEntity
+) -> list[MerchantMigrationRecordItem]:
+    """Classify the source catalog into per-record rows of one entity type,
+    each marked importable or skipped with a reason."""
+    products, customers, subscriptions = _split_records(records)
+    if entity == PrecheckEntity.products:
+        return _product_items(products)
+    if entity == PrecheckEntity.prices:
+        return _price_items(products)
+    if entity == PrecheckEntity.customers:
+        return _customer_items(customers)
+    return _subscription_items(subscriptions, customers)
+
+
+def summarize_records(
+    records: Sequence[CanonicalRecord],
+) -> list[PrecheckEntitySummary]:
+    """Per-entity counts of total/importable/skipped, computed from the same
+    classification the review drawer shows."""
+    summaries: list[PrecheckEntitySummary] = []
+    for entity in PrecheckEntity:
+        items = classify_records(records, entity)
+        importable = sum(
+            1 for item in items if item.status == PrecheckRecordStatus.importable
+        )
+        summaries.append(
+            PrecheckEntitySummary(
+                entity=entity,
+                total=len(items),
+                importable=importable,
+                skipped=len(items) - importable,
+            )
+        )
+    return summaries

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -468,25 +468,29 @@ def _duplicate_customer_source_ids(
     return duplicates
 
 
-def _skipped_price_source_ids(
+def _importable_price_source_ids(
     products: Sequence[CanonicalProduct],
     first_source_id_by_name: dict[str, str],
     duplicate_names: set[str],
 ) -> set[str]:
-    """Prices that won't import: their product is dropped, or the price itself
-    fails a check."""
-    skipped: set[str] = set()
+    """Prices that will import: their product imports and the price passes its
+    own checks. A subscription whose price is *not* in this set can't import
+    either — whether the price was dropped or never extracted at all (e.g. the
+    subscription runs on an archived price the source no longer lists)."""
+    importable: set[str] = set()
     for product in products:
         product_code, _ = _product_drop(
             product, first_source_id_by_name, duplicate_names
         )
+        if product_code is not None:
+            continue
         for price in product.prices:
             price_code, _ = _drop_reason(
                 precheck_engine._check_price(product, price), PRICE_DROP_CODES
             )
-            if product_code is not None or price_code is not None:
-                skipped.add(price.source_id)
-    return skipped
+            if price_code is None:
+                importable.add(price.source_id)
+    return importable
 
 
 def _product_items(
@@ -571,7 +575,7 @@ def _subscription_items(
     customers: Sequence[CanonicalCustomer],
 ) -> list[MerchantMigrationRecordItem]:
     first_source_id_by_name, duplicate_names = _duplicate_product_names(products)
-    skipped_prices = _skipped_price_source_ids(
+    importable_prices = _importable_price_source_ids(
         products, first_source_id_by_name, duplicate_names
     )
     skipped_customers = _duplicate_customer_source_ids(customers)
@@ -582,7 +586,9 @@ def _subscription_items(
             precheck_engine._check_subscription(subscription), SUBSCRIPTION_DROP_CODES
         )
         # A subscription can't import if the records it depends on won't either.
-        if code is None and subscription.price_source_id in skipped_prices:
+        # `not in importable_prices` also catches prices never extracted (e.g.
+        # the subscription runs on an archived price).
+        if code is None and subscription.price_source_id not in importable_prices:
             code, reason = (
                 "subscription_product_not_importable",
                 _SUBSCRIPTION_PRODUCT_REASON,

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -379,12 +379,6 @@ def _interval_label(product: CanonicalProduct) -> str:
     return f"Every {count} {product.recurring_interval}s"
 
 
-def _amount_label(amount: int | None, currency: str) -> str:
-    if amount is None:
-        return "No amount"
-    return format_currency(amount, currency)
-
-
 def _drop_reason(
     issues: Iterable[PrecheckIssue], codes: set[str]
 ) -> tuple[str | None, str | None]:
@@ -532,12 +526,17 @@ def _price_items(
                 code, reason = _drop_reason(
                     precheck_engine._check_price(product, price), PRICE_DROP_CODES
                 )
+            subtitle = (
+                "No amount"
+                if price.amount is None
+                else format_currency(price.amount, price.currency)
+            )
             items.append(
                 _item(
                     PrecheckEntity.prices,
                     price.source_id,
                     product.name,
-                    _amount_label(price.amount, price.currency),
+                    subtitle,
                     reason_code=code,
                     reason=reason,
                 )

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -12,6 +12,7 @@ from collections.abc import AsyncIterable, Iterable, Sequence
 from polar.enums import SubscriptionRecurringInterval
 from polar.kit.currency import (
     PresentmentCurrency,
+    format_currency,
     get_maximum_currency_amount,
     get_minimum_currency_amount,
 )
@@ -70,6 +71,13 @@ _DUPLICATE_PRODUCT_NAME_REASON = (
 )
 _DUPLICATE_CUSTOMER_EMAIL_REASON = (
     "Another customer already uses this email; the duplicate stays on the source."
+)
+_SUBSCRIPTION_PRODUCT_REASON = (
+    "The product or price for this subscription won't be imported, so it stays "
+    "on the source."
+)
+_SUBSCRIPTION_CUSTOMER_REASON = (
+    "The customer for this subscription won't be imported, so it stays on the source."
 )
 
 
@@ -374,7 +382,7 @@ def _interval_label(product: CanonicalProduct) -> str:
 def _amount_label(amount: int | None, currency: str) -> str:
     if amount is None:
         return "No amount"
-    return f"{amount / 100:.2f} {currency.upper()}"
+    return format_currency(amount, currency)
 
 
 def _drop_reason(
@@ -410,19 +418,84 @@ def _item(
     )
 
 
+def _duplicate_product_names(
+    products: Sequence[CanonicalProduct],
+) -> tuple[dict[str, str], set[str]]:
+    """A name is a duplicate only when two *distinct* source products share it;
+    one product split into several interval rows keeps the same source id and is
+    not a duplicate.
+    """
+    first_source_id_by_name: dict[str, str] = {}
+    duplicate_names: set[str] = set()
+    for product in products:
+        first = first_source_id_by_name.setdefault(
+            product.name, product.product_source_id
+        )
+        if first != product.product_source_id:
+            duplicate_names.add(product.name)
+    return first_source_id_by_name, duplicate_names
+
+
+def _product_drop(
+    product: CanonicalProduct,
+    first_source_id_by_name: dict[str, str],
+    duplicate_names: set[str],
+) -> tuple[str | None, str | None]:
+    code, reason = _drop_reason(
+        precheck_engine._check_product(product), PRODUCT_DROP_CODES
+    )
+    if (
+        code is None
+        and product.name in duplicate_names
+        and product.product_source_id != first_source_id_by_name[product.name]
+    ):
+        return "duplicate_product_name", _DUPLICATE_PRODUCT_NAME_REASON
+    return code, reason
+
+
+def _duplicate_customer_source_ids(
+    customers: Sequence[CanonicalCustomer],
+) -> set[str]:
+    email_counts = Counter(c.email.lower() for c in customers if c.email)
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for customer in customers:
+        key = customer.email.lower() if customer.email else ""
+        if key and email_counts[key] > 1 and key in seen:
+            duplicates.add(customer.source_id)
+        if key:
+            seen.add(key)
+    return duplicates
+
+
+def _skipped_price_source_ids(
+    products: Sequence[CanonicalProduct],
+    first_source_id_by_name: dict[str, str],
+    duplicate_names: set[str],
+) -> set[str]:
+    """Prices that won't import: their product is dropped, or the price itself
+    fails a check."""
+    skipped: set[str] = set()
+    for product in products:
+        product_code, _ = _product_drop(
+            product, first_source_id_by_name, duplicate_names
+        )
+        for price in product.prices:
+            price_code, _ = _drop_reason(
+                precheck_engine._check_price(product, price), PRICE_DROP_CODES
+            )
+            if product_code is not None or price_code is not None:
+                skipped.add(price.source_id)
+    return skipped
+
+
 def _product_items(
     products: Sequence[CanonicalProduct],
 ) -> list[MerchantMigrationRecordItem]:
-    name_counts = Counter(product.name for product in products)
-    seen: set[str] = set()
+    first_source_id_by_name, duplicate_names = _duplicate_product_names(products)
     items: list[MerchantMigrationRecordItem] = []
     for product in products:
-        code, reason = _drop_reason(
-            precheck_engine._check_product(product), PRODUCT_DROP_CODES
-        )
-        if code is None and name_counts[product.name] > 1 and product.name in seen:
-            code, reason = "duplicate_product_name", _DUPLICATE_PRODUCT_NAME_REASON
-        seen.add(product.name)
+        code, reason = _product_drop(product, first_source_id_by_name, duplicate_names)
         items.append(
             _item(
                 PrecheckEntity.products,
@@ -439,12 +512,22 @@ def _product_items(
 def _price_items(
     products: Sequence[CanonicalProduct],
 ) -> list[MerchantMigrationRecordItem]:
+    first_source_id_by_name, duplicate_names = _duplicate_product_names(products)
     items: list[MerchantMigrationRecordItem] = []
     for product in products:
+        # A price under a product that won't import can't import either.
+        product_code, product_reason = _product_drop(
+            product, first_source_id_by_name, duplicate_names
+        )
         for price in product.prices:
-            code, reason = _drop_reason(
-                precheck_engine._check_price(product, price), PRICE_DROP_CODES
-            )
+            code: str | None
+            reason: str | None
+            if product_code is not None:
+                code, reason = product_code, product_reason
+            else:
+                code, reason = _drop_reason(
+                    precheck_engine._check_price(product, price), PRICE_DROP_CODES
+                )
             items.append(
                 _item(
                     PrecheckEntity.prices,
@@ -461,17 +544,14 @@ def _price_items(
 def _customer_items(
     customers: Sequence[CanonicalCustomer],
 ) -> list[MerchantMigrationRecordItem]:
-    email_counts = Counter(c.email.lower() for c in customers if c.email)
-    seen: set[str] = set()
+    duplicates = _duplicate_customer_source_ids(customers)
     items: list[MerchantMigrationRecordItem] = []
     for customer in customers:
-        code: str | None = None
-        reason: str | None = None
-        key = customer.email.lower() if customer.email else ""
-        if key and email_counts[key] > 1 and key in seen:
-            code, reason = "duplicate_customer_email", _DUPLICATE_CUSTOMER_EMAIL_REASON
-        if key:
-            seen.add(key)
+        if customer.source_id in duplicates:
+            code: str | None = "duplicate_customer_email"
+            reason: str | None = _DUPLICATE_CUSTOMER_EMAIL_REASON
+        else:
+            code, reason = None, None
         items.append(
             _item(
                 PrecheckEntity.customers,
@@ -487,14 +567,31 @@ def _customer_items(
 
 def _subscription_items(
     subscriptions: Sequence[CanonicalSubscription],
+    products: Sequence[CanonicalProduct],
     customers: Sequence[CanonicalCustomer],
 ) -> list[MerchantMigrationRecordItem]:
+    first_source_id_by_name, duplicate_names = _duplicate_product_names(products)
+    skipped_prices = _skipped_price_source_ids(
+        products, first_source_id_by_name, duplicate_names
+    )
+    skipped_customers = _duplicate_customer_source_ids(customers)
     email_by_source = {c.source_id: c.email for c in customers if c.email}
     items: list[MerchantMigrationRecordItem] = []
     for subscription in subscriptions:
         code, reason = _drop_reason(
             precheck_engine._check_subscription(subscription), SUBSCRIPTION_DROP_CODES
         )
+        # A subscription can't import if the records it depends on won't either.
+        if code is None and subscription.price_source_id in skipped_prices:
+            code, reason = (
+                "subscription_product_not_importable",
+                _SUBSCRIPTION_PRODUCT_REASON,
+            )
+        elif code is None and subscription.customer_source_id in skipped_customers:
+            code, reason = (
+                "subscription_customer_not_importable",
+                _SUBSCRIPTION_CUSTOMER_REASON,
+            )
         title = email_by_source.get(
             subscription.customer_source_id, subscription.customer_source_id
         )
@@ -546,7 +643,7 @@ def classify_records(
         return _price_items(products)
     if entity == PrecheckEntity.customers:
         return _customer_items(customers)
-    return _subscription_items(subscriptions, customers)
+    return _subscription_items(subscriptions, products, customers)
 
 
 def summarize_records(

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -31,9 +31,49 @@ class PrecheckIssue(Schema):
     source_id: str | None
 
 
+class PrecheckEntity(StrEnum):
+    products = "products"
+    prices = "prices"
+    customers = "customers"
+    subscriptions = "subscriptions"
+
+
+class PrecheckRecordStatus(StrEnum):
+    importable = "importable"
+    skipped = "skipped"
+
+
+class PrecheckEntitySummary(Schema):
+    entity: PrecheckEntity = Field(description="The source entity type.")
+    total: int = Field(description="How many were read from the source.")
+    importable: int = Field(description="How many will be imported into Polar.")
+    skipped: int = Field(
+        description="How many won't be imported and stay on the source."
+    )
+
+
 class PrecheckReport(Schema):
     can_start: bool
     issues: list[PrecheckIssue]
+    entities: list[PrecheckEntitySummary] = Field(
+        description="Per-entity counts of what will be imported vs stay on the source."
+    )
+
+
+class MerchantMigrationRecordItem(Schema):
+    entity: PrecheckEntity = Field(description="The source entity type.")
+    source_id: str = Field(description="The source identifier (e.g. Stripe `sub_…`).")
+    title: str = Field(description="Primary label (name, email or product).")
+    subtitle: str | None = Field(
+        description="Secondary detail (interval, amount, country, status)."
+    )
+    status: PrecheckRecordStatus = Field(
+        description="Whether this record will be imported or stays on the source."
+    )
+    reason: str | None = Field(description="Why the record is skipped, if it is.")
+    reason_code: str | None = Field(
+        description="Stable code for the skip reason, if any."
+    )
 
 
 class MerchantMigration(IDSchema, TimestampedSchema):

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -23,9 +23,15 @@ from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncReadSession
 
 from .adapters import SourceAdapter, StripeAdapter
-from .precheck import precheck_engine
+from .precheck import classify_records, precheck_engine
 from .repository import MerchantMigrationRepository
-from .schemas import MerchantMigrationCreate, PrecheckReport
+from .schemas import (
+    MerchantMigrationCreate,
+    MerchantMigrationRecordItem,
+    PrecheckEntity,
+    PrecheckRecordStatus,
+    PrecheckReport,
+)
 from .stripe_oauth import (
     StripeAppNotConfigured,
     StripeOAuthError,
@@ -199,6 +205,41 @@ class MerchantMigrationService:
             migration, update_dict={"step": MerchantMigrationStep.pre_check}
         )
         return report
+
+    async def list_records(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        migration_id: UUID,
+        *,
+        entity: PrecheckEntity,
+        status: PrecheckRecordStatus | None,
+        pagination: PaginationParams,
+    ) -> tuple[Sequence[MerchantMigrationRecordItem], int]:
+        """Read the connected source on demand and return the records of one
+        entity type, classified importable/skipped and paginated in memory."""
+        repository = MerchantMigrationRepository.from_session(session)
+        statement = repository.get_readable_statement(auth_subject).where(
+            MerchantMigration.id == migration_id
+        )
+        migration = await repository.get_one_or_none(statement)
+        if migration is None:
+            raise MerchantMigrationNotFound()
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            migration.organization_id,
+            OrganizationPermission.organization_manage,
+        )
+
+        adapter = await self._build_adapter(session, migration)
+        records = [record async for record in adapter.extract()]
+        items = classify_records(records, entity)
+        if status is not None:
+            items = [item for item in items if item.status == status]
+
+        start = (pagination.page - 1) * pagination.limit
+        return items[start : start + pagination.limit], len(items)
 
     async def _build_adapter(
         self, session: AsyncSession, migration: MerchantMigration

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -9,7 +9,13 @@ from pytest_mock import MockerFixture
 from polar.auth.scope import Scope
 from polar.config import settings
 from polar.kit import jwt
-from polar.merchant_migration.canonical import CanonicalAccount
+from polar.merchant_migration.canonical import (
+    CanonicalAccount,
+    CanonicalPrice,
+    CanonicalPricingScheme,
+    CanonicalProduct,
+    CanonicalRecord,
+)
 from polar.merchant_migration.repository import MerchantMigrationRepository
 from polar.merchant_migration.stripe_oauth import StripeOAuthError
 from polar.models import MerchantMigration, Organization, UserOrganization
@@ -398,6 +404,86 @@ class TestPrecheck:
 async def _empty_extract() -> AsyncIterator[object]:
     return
     yield
+
+
+async def _catalog_extract() -> AsyncIterator[CanonicalRecord]:
+    yield CanonicalProduct(
+        source_id="prod_1:month:1",
+        product_source_id="prod_1",
+        name="Pro",
+        recurring_interval="month",
+        recurring_interval_count=1,
+        prices=[
+            CanonicalPrice(
+                source_id="price_1",
+                currency="usd",
+                amount=1000,
+                pricing_scheme=CanonicalPricingScheme.fixed,
+            )
+        ],
+    )
+
+
+@pytest.mark.asyncio
+class TestRecords:
+    async def test_anonymous(
+        self, client: AsyncClient, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        migration = await _create_migration(save_fixture, organization)
+        response = await client.get(
+            f"/v1/merchant-migrations/{migration.id}/records",
+            params={"entity": "products"},
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_lists_classified_records(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        _configure_app(mocker)
+        migration = await _create_migration(save_fixture, organization)
+        mocker.patch(
+            "polar.merchant_migration.service.stripe_oauth.exchange_code",
+            return_value=build_stripe_oauth_token(),
+        )
+        mocker.patch(
+            "polar.merchant_migration.service.stripe_oauth.refresh",
+            return_value=build_stripe_oauth_token("rt_new"),
+        )
+        adapter = mocker.MagicMock()
+        adapter.extract.return_value = _catalog_extract()
+        adapter.get_source_account = mocker.AsyncMock(
+            return_value=CanonicalAccount(country="US", is_connect_platform=False)
+        )
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
+        )
+
+        authorize = await client.get(
+            "/v1/merchant-migrations/stripe/authorize",
+            params={"migration_id": str(migration.id), "return_to": "/dashboard"},
+        )
+        state = parse_qs(urlparse(authorize.headers["location"]).query)["state"][0]
+        await client.get(
+            "/v1/merchant-migrations/stripe/callback",
+            params={"state": state, "code": "ac_test"},
+        )
+
+        response = await client.get(
+            f"/v1/merchant-migrations/{migration.id}/records",
+            params={"entity": "products"},
+        )
+        assert response.status_code == 200
+        json_body = response.json()
+        assert json_body["pagination"]["total_count"] == 1
+        assert json_body["items"][0]["source_id"] == "prod_1"
+        assert json_body["items"][0]["status"] == "importable"
 
 
 async def _create_migration(

--- a/server/tests/merchant_migration/test_precheck.py
+++ b/server/tests/merchant_migration/test_precheck.py
@@ -1,4 +1,5 @@
 from collections.abc import AsyncIterator
+from dataclasses import replace
 
 import pytest
 
@@ -412,3 +413,91 @@ class TestSummarizeRecords:
             assert summary.total == len(items)
             assert summary.importable == importable
             assert summary.skipped == len(items) - importable
+
+
+class TestClassifyCascade:
+    def test_same_product_multiple_intervals_not_duplicate(self) -> None:
+        # One source product split into two interval rows keeps its source id and
+        # must not be flagged as a duplicate name.
+        records: list[CanonicalRecord] = [
+            build_product(
+                source_id="prod_1:month:1",
+                product_source_id="prod_1",
+                name="Pro",
+                recurring_interval="month",
+            ),
+            build_product(
+                source_id="prod_1:year:1",
+                product_source_id="prod_1",
+                name="Pro",
+                recurring_interval="year",
+            ),
+        ]
+
+        items = classify_records(records, PrecheckEntity.products)
+
+        assert len(items) == 2
+        assert all(i.status == PrecheckRecordStatus.importable for i in items)
+
+    def test_distinct_products_same_name_duplicate(self) -> None:
+        records: list[CanonicalRecord] = [
+            build_product(product_source_id="prod_1", name="Pro"),
+            build_product(product_source_id="prod_2", name="Pro"),
+        ]
+
+        items = classify_records(records, PrecheckEntity.products)
+
+        by_id = {item.source_id: item for item in items}
+        assert by_id["prod_1"].status == PrecheckRecordStatus.importable
+        assert by_id["prod_2"].status == PrecheckRecordStatus.skipped
+        assert by_id["prod_2"].reason_code == "duplicate_product_name"
+
+    def test_price_skipped_when_parent_product_skipped(self) -> None:
+        records: list[CanonicalRecord] = [
+            build_product(
+                product_source_id="prod_1",
+                name="Legacy",
+                recurring_interval=None,
+                prices=[build_price(source_id="price_1")],
+            ),
+        ]
+
+        items = classify_records(records, PrecheckEntity.prices)
+
+        assert items[0].status == PrecheckRecordStatus.skipped
+        assert items[0].reason_code == "one_time_product"
+
+    def test_subscription_skipped_when_product_skipped(self) -> None:
+        records: list[CanonicalRecord] = [
+            build_product(
+                product_source_id="prod_1",
+                name="Legacy",
+                recurring_interval=None,
+                prices=[build_price(source_id="price_1")],
+            ),
+            build_customer(source_id="cus_1", email="a@example.com"),
+            build_subscription(source_id="sub_1"),
+        ]
+
+        items = classify_records(records, PrecheckEntity.subscriptions)
+
+        assert items[0].status == PrecheckRecordStatus.skipped
+        assert items[0].reason_code == "subscription_product_not_importable"
+
+    def test_subscription_skipped_when_customer_skipped(self) -> None:
+        duplicate_customer_subscription = replace(
+            build_subscription(source_id="sub_2"), customer_source_id="cus_2"
+        )
+        records: list[CanonicalRecord] = [
+            build_product(
+                product_source_id="prod_1", prices=[build_price(source_id="price_1")]
+            ),
+            build_customer(source_id="cus_1", email="dup@example.com"),
+            build_customer(source_id="cus_2", email="dup@example.com"),
+            duplicate_customer_subscription,
+        ]
+
+        items = classify_records(records, PrecheckEntity.subscriptions)
+
+        assert items[0].status == PrecheckRecordStatus.skipped
+        assert items[0].reason_code == "subscription_customer_not_importable"

--- a/server/tests/merchant_migration/test_precheck.py
+++ b/server/tests/merchant_migration/test_precheck.py
@@ -15,8 +15,17 @@ from polar.merchant_migration.canonical import (
     CanonicalSubscription,
     CanonicalSubscriptionStatus,
 )
-from polar.merchant_migration.precheck import precheck_engine
-from polar.merchant_migration.schemas import PrecheckIssueLevel, PrecheckReport
+from polar.merchant_migration.precheck import (
+    classify_records,
+    precheck_engine,
+    summarize_records,
+)
+from polar.merchant_migration.schemas import (
+    PrecheckEntity,
+    PrecheckIssueLevel,
+    PrecheckRecordStatus,
+    PrecheckReport,
+)
 from polar.models import Organization
 from polar.models.organization import OrganizationStatus
 
@@ -303,3 +312,103 @@ class TestPrecheckEngine:
         assert "payment_method_requires_reentry" not in codes(
             report, PrecheckIssueLevel.warning
         )
+
+
+class TestClassifyRecords:
+    def test_products_importable_and_skipped(self) -> None:
+        records: list[CanonicalRecord] = [
+            build_product(product_source_id="prod_1", name="Pro"),
+            build_product(
+                product_source_id="prod_2", name="Legacy", recurring_interval=None
+            ),
+        ]
+
+        items = classify_records(records, PrecheckEntity.products)
+
+        by_id = {item.source_id: item for item in items}
+        assert by_id["prod_1"].status == PrecheckRecordStatus.importable
+        assert by_id["prod_2"].status == PrecheckRecordStatus.skipped
+        assert by_id["prod_2"].reason_code == "one_time_product"
+
+    def test_prices_drop_unsupported_scheme(self) -> None:
+        records: list[CanonicalRecord] = [
+            build_product(
+                product_source_id="prod_1",
+                prices=[build_price(source_id="price_ok")],
+            ),
+            build_product(
+                product_source_id="prod_2",
+                name="Metered",
+                prices=[
+                    build_price(
+                        source_id="price_metered",
+                        pricing_scheme=CanonicalPricingScheme.metered,
+                    )
+                ],
+            ),
+        ]
+
+        items = classify_records(records, PrecheckEntity.prices)
+
+        by_id = {item.source_id: item for item in items}
+        assert by_id["price_ok"].status == PrecheckRecordStatus.importable
+        assert by_id["price_metered"].status == PrecheckRecordStatus.skipped
+        assert by_id["price_metered"].reason_code == "unsupported_pricing_scheme"
+
+    def test_duplicate_customer_email_skipped(self) -> None:
+        records: list[CanonicalRecord] = [
+            build_customer(source_id="cus_1", email="same@example.com"),
+            build_customer(source_id="cus_2", email="same@example.com"),
+        ]
+
+        items = classify_records(records, PrecheckEntity.customers)
+
+        by_id = {item.source_id: item for item in items}
+        assert by_id["cus_1"].status == PrecheckRecordStatus.importable
+        assert by_id["cus_2"].status == PrecheckRecordStatus.skipped
+        assert by_id["cus_2"].reason_code == "duplicate_customer_email"
+
+    def test_subscription_status_drop(self) -> None:
+        records: list[CanonicalRecord] = [
+            build_customer(source_id="cus_1", email="a@example.com"),
+            build_subscription(source_id="sub_1"),
+            build_subscription(
+                source_id="sub_2", status=CanonicalSubscriptionStatus.past_due
+            ),
+        ]
+
+        items = classify_records(records, PrecheckEntity.subscriptions)
+
+        by_id = {item.source_id: item for item in items}
+        assert by_id["sub_1"].status == PrecheckRecordStatus.importable
+        assert by_id["sub_1"].title == "a@example.com"
+        assert by_id["sub_2"].status == PrecheckRecordStatus.skipped
+        assert by_id["sub_2"].reason_code == "subscription_not_importable"
+
+
+class TestSummarizeRecords:
+    def test_counts_match_classification(self) -> None:
+        records: list[CanonicalRecord] = [
+            build_product(product_source_id="prod_1", name="Pro"),
+            build_product(
+                product_source_id="prod_2", name="Legacy", recurring_interval=None
+            ),
+            build_customer(source_id="cus_1", email="a@example.com"),
+        ]
+
+        summaries = {s.entity: s for s in summarize_records(records)}
+
+        assert summaries[PrecheckEntity.products].total == 2
+        assert summaries[PrecheckEntity.products].importable == 1
+        assert summaries[PrecheckEntity.products].skipped == 1
+        assert summaries[PrecheckEntity.customers].total == 1
+        assert summaries[PrecheckEntity.subscriptions].total == 0
+
+        for entity, summary in summaries.items():
+            items = classify_records(records, entity)
+            importable = sum(
+                1 for i in items if i.status == PrecheckRecordStatus.importable
+            )
+            assert summary.total == len(items)
+            assert summary.importable == importable
+            assert summary.skipped == len(items) - importable

--- a/server/tests/merchant_migration/test_precheck.py
+++ b/server/tests/merchant_migration/test_precheck.py
@@ -371,6 +371,9 @@ class TestClassifyRecords:
 
     def test_subscription_status_drop(self) -> None:
         records: list[CanonicalRecord] = [
+            build_product(
+                product_source_id="prod_1", prices=[build_price(source_id="price_1")]
+            ),
             build_customer(source_id="cus_1", email="a@example.com"),
             build_subscription(source_id="sub_1"),
             build_subscription(
@@ -501,3 +504,23 @@ class TestClassifyCascade:
 
         assert items[0].status == PrecheckRecordStatus.skipped
         assert items[0].reason_code == "subscription_customer_not_importable"
+
+    def test_subscription_skipped_when_price_not_extracted(self) -> None:
+        # The subscription runs on a price the source no longer lists (archived),
+        # so no product carrying that price id was extracted.
+        subscription = replace(
+            build_subscription(source_id="sub_1"),
+            price_source_id="price_archived",
+        )
+        records: list[CanonicalRecord] = [
+            build_product(
+                product_source_id="prod_1", prices=[build_price(source_id="price_1")]
+            ),
+            build_customer(source_id="cus_1", email="a@example.com"),
+            subscription,
+        ]
+
+        items = classify_records(records, PrecheckEntity.subscriptions)
+
+        assert items[0].status == PrecheckRecordStatus.skipped
+        assert items[0].reason_code == "subscription_product_not_importable"

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -7,6 +7,7 @@ from pytest_mock import MockerFixture
 from polar.auth.models import AuthSubject
 from polar.config import settings
 from polar.kit import jwt
+from polar.kit.pagination import PaginationParams
 from polar.merchant_migration.canonical import (
     CanonicalAccount,
     CanonicalPrice,
@@ -15,7 +16,11 @@ from polar.merchant_migration.canonical import (
     CanonicalRecord,
 )
 from polar.merchant_migration.repository import MerchantMigrationRepository
-from polar.merchant_migration.schemas import MerchantMigrationCreate
+from polar.merchant_migration.schemas import (
+    MerchantMigrationCreate,
+    PrecheckEntity,
+    PrecheckRecordStatus,
+)
 from polar.merchant_migration.service import (
     SourceNotConnected,
     UnsupportedMigrationSource,
@@ -294,3 +299,106 @@ class TestRunPrecheck:
 
         with pytest.raises(UnsupportedMigrationSource):
             await service.run_precheck(session, auth_subject, migration.id)
+
+
+def _catalog() -> list[CanonicalRecord]:
+    return [
+        CanonicalProduct(
+            source_id="prod_1:month:1",
+            product_source_id="prod_1",
+            name="Pro",
+            recurring_interval="month",
+            recurring_interval_count=1,
+            prices=[
+                CanonicalPrice(
+                    source_id="price_1",
+                    currency="usd",
+                    amount=1000,
+                    pricing_scheme=CanonicalPricingScheme.fixed,
+                )
+            ],
+        ),
+        CanonicalProduct(
+            source_id="prod_2:one_time",
+            product_source_id="prod_2",
+            name="Legacy",
+            recurring_interval=None,
+            recurring_interval_count=1,
+            prices=[
+                CanonicalPrice(
+                    source_id="price_2",
+                    currency="usd",
+                    amount=500,
+                    pricing_scheme=CanonicalPricingScheme.fixed,
+                )
+            ],
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+class TestListRecords:
+    @pytest.mark.auth
+    async def test_classifies_and_paginates(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _create_connected_migration(save_fixture, organization)
+        mocker.patch(
+            "polar.merchant_migration.service.stripe_oauth.refresh",
+            return_value=build_stripe_oauth_token("rt_new"),
+        )
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter",
+            return_value=_FakeAdapter(_catalog()),
+        )
+
+        items, count = await service.list_records(
+            session,
+            auth_subject,
+            migration.id,
+            entity=PrecheckEntity.products,
+            status=None,
+            pagination=PaginationParams(page=1, limit=1),
+        )
+
+        assert count == 2
+        assert len(items) == 1
+
+    @pytest.mark.auth
+    async def test_status_filter(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _create_connected_migration(save_fixture, organization)
+        mocker.patch(
+            "polar.merchant_migration.service.stripe_oauth.refresh",
+            return_value=build_stripe_oauth_token("rt_new"),
+        )
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter",
+            return_value=_FakeAdapter(_catalog()),
+        )
+
+        items, count = await service.list_records(
+            session,
+            auth_subject,
+            migration.id,
+            entity=PrecheckEntity.products,
+            status=PrecheckRecordStatus.skipped,
+            pagination=PaginationParams(page=1, limit=20),
+        )
+
+        assert count == 1
+        assert items[0].source_id == "prod_2"
+        assert items[0].reason_code == "one_time_product"


### PR DESCRIPTION
## Summary

Adds the **pre-check** section to merchant migrations.



## What

**Backend**
- `PrecheckReport` gains an `entities` summary (per-entity `total` / `importable` / `skipped`), computed from the same classification the drawer shows, so counts always match.
- New `GET /v1/merchant-migrations/{id}/records`: reads the connected source on demand, classifies each record importable/skipped by **reusing the pre-check drop predicates**, filters by `entity` + optional `status`, and paginates.
- `classify_records` / `summarize_records` live alongside the pre-check engine so a record's status can't drift from the report's warnings.

**Frontend**
- `PrecheckPanel` renders on the pre_check timeline step: run/re-run pre-check, ready-vs-blockers status, blocker list, and the summary grid.
- `PrecheckSummary` grid → `PrecheckRecordsDrawer`: paginated, filterable (All / Importing / Stay on Stripe) list per entity.

## How

- Records are classified live from the source (not persisted); the endpoint uses a write session because building the adapter rotates the Stripe token.
- The summary is the classification tallied per entity, guaranteeing the grid and the drawer agree.
- UI authored with the Orbit `<Box />` design system.

## Checklist

- [x] This PR addresses a single concern (one feature)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests (classify/summarize unit tests, `list_records` service tests, records endpoint test)
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`, `pnpm lint`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

