### PR TITLE
Compass Assistant: Implements the backend for Compass Assistant and additional Insight tools

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -7276,6 +7276,54 @@ export interface components {
         | 'ZM'
         | 'ZW'
     }
+    /**
+     * AdjustPriceAction
+     * @description A recommendation to review a product's pricing, with a reference point.
+     *
+     *     The suggested amount is a *reference*, not a mandate: it's the list price
+     *     that would restore the target gross margin at the current cost to serve,
+     *     ignoring demand elasticity. It applies to new customers only — existing
+     *     subscriptions keep their price. The client routes to the product's pricing
+     *     editor; nothing is ever applied automatically.
+     */
+    AdjustPriceAction: {
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'adjust_price'
+      /**
+       * Label
+       * @description Button label.
+       */
+      label: string
+      /**
+       * Product Id
+       * Format: uuid4
+       * @description The product whose pricing to review.
+       */
+      product_id: string
+      /**
+       * Product Name
+       * @description Display name of the product.
+       */
+      product_name: string
+      /**
+       * Current Price Amount
+       * @description The product's current list price, in cents.
+       */
+      current_price_amount: number
+      /**
+       * Suggested Price Amount
+       * @description Reference list price (cents) that would restore the target gross margin at the current cost to serve. Null when no meaningful suggestion can be computed.
+       */
+      suggested_price_amount?: number | null
+      /**
+       * Currency
+       * @description ISO currency code of the amounts.
+       */
+      currency: string
+    }
     AggregateField: string
     /**
      * AggregationFunction
@@ -21111,28 +21159,18 @@ export interface components {
        */
       why?: string | null
       confidence: components['schemas']['ConfidenceLevel']
-      primary_action?: components['schemas']['InsightAction'] | null
+      /** Primary Action */
+      primary_action?:
+        | (
+            | components['schemas']['ViewMetricAction']
+            | components['schemas']['AdjustPriceAction']
+          )
+        | null
       /**
        * Drivers
        * @description Top contributors to the headline change.
        */
       drivers?: components['schemas']['InsightDriver'][]
-    }
-    /**
-     * InsightAction
-     * @description A drill-down that points at the metric behind the insight.
-     */
-    InsightAction: {
-      /**
-       * Label
-       * @description Button label.
-       */
-      label: string
-      /**
-       * Metric
-       * @description Slug of the metric this insight is about (e.g. `monthly_recurring_revenue`). The client owns the routing and resolves it to the matching analytics page.
-       */
-      metric: string
     }
     /**
      * InsightCategory
@@ -34299,6 +34337,27 @@ export interface components {
       p99?: {
         [key: string]: string
       }
+    }
+    /**
+     * ViewMetricAction
+     * @description A drill-down that points at the metric behind the insight.
+     */
+    ViewMetricAction: {
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'view_metric'
+      /**
+       * Label
+       * @description Button label.
+       */
+      label: string
+      /**
+       * Metric
+       * @description Slug of the metric this insight is about (e.g. `monthly_recurring_revenue`). The client owns the routing and resolves it to the matching analytics page.
+       */
+      metric: string
     }
     /**
      * Visibility
@@ -60744,6 +60803,9 @@ export const addressInputCountryValues: ReadonlyArray<
   'ZM',
   'ZW',
 ]
+export const adjustPriceActionTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['AdjustPriceAction']['type']
+> = ['adjust_price']
 export const aggregationFunctionValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['AggregationFunction']
 > = ['count', 'sum', 'max', 'min', 'avg', 'unique']
@@ -64402,6 +64464,9 @@ export const userUpdateCountryAnyOf0Values: ReadonlyArray<
   'ZM',
   'ZW',
 ]
+export const viewMetricActionTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['ViewMetricAction']['type']
+> = ['view_metric']
 export const visibilityValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['Visibility']
 > = ['draft', 'private', 'public']

--- a/server/polar/compass/assistant/agent.py
+++ b/server/polar/compass/assistant/agent.py
@@ -1,0 +1,138 @@
+import functools
+from typing import Any, cast
+
+import structlog
+from pydantic_ai import Agent
+
+from polar.auth.scope import Scope
+from polar.config import settings
+
+from .customer_tools import CUSTOMER_TOOLS_WITH_SCOPES
+from .deps import AssistantDeps
+from .entity_tools import ENTITY_TOOLS_WITH_SCOPES
+from .tools import TOOLS_WITH_SCOPES
+
+_ALL_TOOLS_WITH_SCOPES: list[tuple[object, Scope]] = [
+    *TOOLS_WITH_SCOPES,
+    *ENTITY_TOOLS_WITH_SCOPES,
+    *CUSTOMER_TOOLS_WITH_SCOPES,
+]
+
+SYSTEM_PROMPT = """\
+You are Compass, Polar's business assistant, embedded in the merchant's
+dashboard. You answer questions about the merchant's own organization using
+your tools.
+
+How to answer:
+- Answer the exact question that was asked, and answer it first. Lead with
+  the number or fact, then at most two short sentences of context.
+- Tools prepare UI blocks (charts, cards, lists, tables) and tell you each
+  block's placement marker, e.g. [block:1]. Blocks only appear where YOU
+  place their marker: state the claim first, then put the marker on its own
+  line directly under the sentence it supports. Place every prepared block
+  exactly once. Example:
+  "Best customer by revenue: jane@corp.com with $1,240.00 over the last 365
+  days.
+  [block:1]
+  Worst customer by cost: joe@corp.com, 48% of tracked costs.
+  [block:2]"
+- Only call a tool when its output belongs in your answer. Never call tools
+  speculatively to look around; every prepared block ends up on the user's
+  screen.
+- Pick the narrowest tool and the narrowest arguments that answer the
+  question. Filter when a filter exists (e.g. an insight category, a checkout
+  status, a search query). One precise call beats several broad ones.
+- Insights flow: `get_insights` only fetches findings for your reasoning and
+  renders nothing. For broad questions ("how is my business doing?"), give
+  your assessment in prose first — lead with the most severe findings — then
+  call `show_insights` with the one or two ids that directly support your
+  main claims. Only render more cards when the user explicitly asks to see
+  all insights, and never use cards as a substitute for an answer.
+- If none of your tools can answer the question, say so plainly in one
+  sentence, then name the closest related thing you CAN show and offer it.
+  Do not substitute unrelated data for an answer.
+- If a tool reports a missing permission, say which scope is missing and
+  stop.
+
+Follow-ups and judgment questions:
+- Some questions ask for judgment, not data: implications, trade-offs, or
+  risks OF something already discussed ("is there any risk with that?").
+  Answer those by reasoning over the conversation and the data you already
+  fetched; only call a tool if genuinely new data is needed.
+- Never map words in the question onto tool or category names literally.
+  "Risk" in a follow-up usually means the downside of the prior
+  recommendation, not the risk insight category.
+- Tool results from earlier turns remain valid context; do not re-fetch to
+  re-answer.
+- When your answer is analysis rather than measurement, frame it that way
+  (e.g. "the main trade-off is..."), and say what data would confirm it.
+
+Facts and style:
+- Ground every number in tool results; never invent or extrapolate values.
+- Do not repeat rendered content in prose. Narrate what matters: the direct
+  answer, the trend or outlier, and the recommended next step.
+- For entity questions prefer `list` presentation when five or fewer items
+  are asked for, and `table` otherwise.
+- Amounts from tools are in cents unless stated otherwise. Always present
+  money formatted with a currency symbol, two decimals and thousands
+  separators (e.g. $1,234.50), never as raw cents. Rendered tables and lists
+  format amounts themselves; only your prose needs this.
+- Write in short paragraphs of one to three sentences, separated by blank
+  lines. Two to four paragraphs at most. When recommending several actions,
+  give each its own paragraph, lead with the action.
+- Plain text only: no markdown headings, no markdown tables, no em dashes.
+"""
+
+
+def tools_for_scopes(scopes: set[Scope]) -> list[object]:
+    """The tools a caller may use: one entry per tool whose scope is granted."""
+    return [tool for tool, scope in _ALL_TOOLS_WITH_SCOPES if scope in scopes]
+
+
+log = structlog.get_logger()
+
+
+def _safe(tool: Any) -> Any:
+    """Never let a tool exception reach the stream as a raw error.
+
+    Failures are logged and returned to the model as a plain instruction, so
+    the conversation degrades to an apology instead of a traceback.
+    `functools.wraps` preserves the signature and docstring pydantic-ai uses
+    to build the tool schema.
+    """
+
+    @functools.wraps(tool)
+    async def wrapper(*args: Any, **kwargs: Any) -> str:
+        try:
+            return cast(str, await tool(*args, **kwargs))
+        except Exception:
+            log.exception("compass.assistant_tool_error", tool=tool.__name__)
+            return (
+                "This lookup failed unexpectedly. Apologize briefly and "
+                "suggest trying again. Do not show technical details."
+            )
+
+    return wrapper
+
+
+def build_assistant_agent(
+    scopes: set[Scope],
+) -> tuple[Agent[AssistantDeps, str], str, str]:
+    """Build the assistant for one request, with the caller's capabilities.
+
+    The toolset is derived from the caller's granted scopes: a tool whose scope
+    the caller lacks is not registered at all, so a restricted token cannot
+    reach data outside its grants even if the model asks. Runtime checks inside
+    each tool back this up.
+    """
+    model_instance, model_provider, model_name = settings.get_pydantic_gateway_model()
+    tools = [_safe(tool) for tool in tools_for_scopes(scopes)]
+    agent: Agent[AssistantDeps, str] = Agent(
+        model_instance,
+        deps_type=AssistantDeps,
+        system_prompt=SYSTEM_PROMPT,
+        tools=tools,
+        # gpt-5.5+ reasoning models reject any non-default temperature.
+        model_settings=({} if model_name.startswith("gpt-5.5") else {"temperature": 0}),
+    )
+    return agent, model_provider, model_name

--- a/server/polar/compass/assistant/blocks.py
+++ b/server/polar/compass/assistant/blocks.py
@@ -1,0 +1,121 @@
+"""
+Generative-UI blocks: the closed set of things the assistant can render.
+
+The model never produces markup. Tools return typed blocks from this
+discriminated union, the client maps each block type to a predefined component
+in its block registry, and anything outside the union simply cannot be
+expressed. Adding a renderable is adding one schema here and one registry entry
+on the client.
+"""
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Annotated, Literal
+
+from pydantic import Discriminator, Field
+
+from polar.kit.schemas import Schema
+
+from ..schemas import Insight
+
+
+class BlockType(StrEnum):
+    text = "text"
+    metric_chart = "metric_chart"
+    insight_cards = "insight_cards"
+    entity_list = "entity_list"
+    data_table = "data_table"
+    customer_card = "customer_card"
+
+
+class TextBlock(Schema):
+    """Plain narrated text."""
+
+    type: Literal[BlockType.text] = BlockType.text
+    text: str
+
+
+class MetricChartPoint(Schema):
+    timestamp: datetime
+    value: float
+
+
+class MetricChartBlock(Schema):
+    """A single metric's series over the requested window."""
+
+    type: Literal[BlockType.metric_chart] = BlockType.metric_chart
+    metric: str = Field(description="Metric slug, e.g. `monthly_recurring_revenue`.")
+    label: str = Field(description="Human-readable metric name.")
+    unit: str = Field(description="Metric unit type, e.g. `currency` or `scalar`.")
+    points: list[MetricChartPoint]
+
+
+class InsightCardsBlock(Schema):
+    """Compass insights, rendered with the same card as the feed."""
+
+    type: Literal[BlockType.insight_cards] = BlockType.insight_cards
+    insights: list[Insight]
+
+
+class ColumnFormat(StrEnum):
+    text = "text"
+    currency = "currency"
+    datetime = "datetime"
+    badge = "badge"
+    avatar = "avatar"
+    """Value is an avatar URL; the client renders it with the Avatar
+    component, using the row's first text column as the name fallback."""
+
+
+class DataTableColumn(Schema):
+    key: str
+    label: str
+    format: ColumnFormat = ColumnFormat.text
+
+
+class DataTableBlock(Schema):
+    """Tabular entities (orders, subscriptions, customers, ...)."""
+
+    type: Literal[BlockType.data_table] = BlockType.data_table
+    entity: str = Field(description="What the rows are, e.g. `subscriptions`.")
+    title: str | None = Field(
+        default=None, description="Heading rendered above the table."
+    )
+    columns: list[DataTableColumn]
+    rows: list[dict[str, str | int | float | None]]
+    total_count: int
+
+
+class EntityListBlock(Schema):
+    """A few entities as a compact list; same shape as the table so the
+    client formats values (currency, dates) identically in both."""
+
+    type: Literal[BlockType.entity_list] = BlockType.entity_list
+    entity: str = Field(description="What the items are, e.g. `orders`.")
+    title: str | None = Field(
+        default=None, description="Heading rendered above the list."
+    )
+    columns: list[DataTableColumn]
+    rows: list[dict[str, str | int | float | None]]
+    total_count: int
+
+
+class CustomerCardBlock(Schema):
+    """A single customer's identity header, above their orders/subscriptions."""
+
+    type: Literal[BlockType.customer_card] = BlockType.customer_card
+    email: str
+    name: str | None = None
+    avatar_url: str | None = None
+    created_at: datetime
+
+
+AssistantBlock = Annotated[
+    TextBlock
+    | MetricChartBlock
+    | InsightCardsBlock
+    | EntityListBlock
+    | DataTableBlock
+    | CustomerCardBlock,
+    Discriminator("type"),
+]

--- a/server/polar/compass/assistant/customer_tools.py
+++ b/server/polar/compass/assistant/customer_tools.py
@@ -1,0 +1,146 @@
+"""
+Customer drill-down: resolve one customer and stitch their activity together.
+
+The overview needs `customers:read`; the orders and subscriptions sections are
+each gated on their own scope and degrade gracefully — a token without
+`orders:read` still gets the customer card and subscriptions, with a note about
+what was withheld.
+"""
+
+from pydantic_ai import RunContext
+
+from polar.auth.scope import Scope
+from polar.customer.service import customer as customer_service
+from polar.kit.pagination import PaginationParams
+from polar.order.service import order as order_service
+from polar.subscription.service import subscription as subscription_service
+
+from .blocks import ColumnFormat, CustomerCardBlock, DataTableColumn, EntityListBlock
+from .deps import AssistantDeps
+from .tools import _scope_denial
+
+_SECTION_COLUMNS = [
+    DataTableColumn(key="title", label="Item"),
+    DataTableColumn(key="detail", label="Detail"),
+    DataTableColumn(key="amount", label="Amount", format=ColumnFormat.currency),
+]
+
+_SECTION_LIMIT = 5
+
+
+async def get_customer_overview(
+    ctx: RunContext[AssistantDeps],
+    email_or_name: str,
+) -> str:
+    """Look up one customer by email or name and show who they are, what they
+    bought and what they're subscribed to.
+
+    Args:
+        email_or_name: Search over customer email and name; the best match wins.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.customers_read):
+        return denial
+
+    customers, count = await customer_service.list(
+        deps.session,
+        deps.auth_subject,
+        organization_id=[deps.organization_id],
+        query=email_or_name,
+        pagination=PaginationParams(1, 3),
+    )
+    if not customers:
+        return f"No customer matching {email_or_name!r} was found."
+    customer = customers[0]
+
+    card_marker = deps.emit(
+        CustomerCardBlock(
+            email=customer.email or "(no email)",
+            name=customer.name,
+            avatar_url=customer.avatar_url,
+            created_at=customer.created_at,
+        )
+    )
+    summary = [
+        f"Customer card prepared; place it with [block:{card_marker}]. "
+        f"Customer: {customer.email}"
+        f" (name={customer.name!r}, since {customer.created_at.date()})."
+        + (f" {count - 1} other match(es) exist." if count > 1 else "")
+    ]
+
+    if Scope.orders_read in deps.auth_subject.scopes:
+        orders, orders_count = await order_service.list(
+            deps.session,
+            deps.auth_subject,
+            organization_id=[deps.organization_id],
+            customer_id=[customer.id],
+            pagination=PaginationParams(1, _SECTION_LIMIT),
+        )
+        orders_marker = None
+        if orders:
+            orders_marker = deps.emit(
+                EntityListBlock(
+                    entity="orders",
+                    title="Orders",
+                    columns=_SECTION_COLUMNS,
+                    rows=[
+                        {
+                            "title": order.product.name if order.product else "Order",
+                            "detail": order.created_at.isoformat(),
+                            "amount": order.net_amount,
+                        }
+                        for order in orders
+                    ],
+                    total_count=orders_count,
+                )
+            )
+        summary.append(
+            f"Orders: {orders_count} total."
+            + (f" Block prepared: [block:{orders_marker}]." if orders_marker else "")
+        )
+    else:
+        summary.append("Orders withheld: token lacks the `orders:read` scope.")
+
+    if Scope.subscriptions_read in deps.auth_subject.scopes:
+        subscriptions, subs_count = await subscription_service.list(
+            deps.session,
+            deps.auth_subject,
+            organization_id=[deps.organization_id],
+            customer_id=[customer.id],
+            pagination=PaginationParams(1, _SECTION_LIMIT),
+        )
+        subs_marker = None
+        if subscriptions:
+            subs_marker = deps.emit(
+                EntityListBlock(
+                    entity="subscriptions",
+                    title="Subscriptions",
+                    columns=_SECTION_COLUMNS,
+                    rows=[
+                        {
+                            "title": sub.product.name
+                            if sub.product
+                            else "Subscription",
+                            "detail": str(sub.status),
+                            "amount": sub.amount,
+                        }
+                        for sub in subscriptions
+                    ],
+                    total_count=subs_count,
+                )
+            )
+        summary.append(
+            f"Subscriptions: {subs_count} total."
+            + (f" Block prepared: [block:{subs_marker}]." if subs_marker else "")
+        )
+    else:
+        summary.append(
+            "Subscriptions withheld: token lacks the `subscriptions:read` scope."
+        )
+
+    return " ".join(summary)
+
+
+CUSTOMER_TOOLS_WITH_SCOPES: list[tuple[object, Scope]] = [
+    (get_customer_overview, Scope.customers_read),
+]

--- a/server/polar/compass/assistant/deps.py
+++ b/server/polar/compass/assistant/deps.py
@@ -1,0 +1,40 @@
+import uuid
+from dataclasses import dataclass, field
+from datetime import date
+from zoneinfo import ZoneInfo
+
+from polar.auth.models import AuthSubject, Organization, User
+from polar.postgres import AsyncReadSession
+from polar.redis import Redis
+
+from .blocks import AssistantBlock
+
+
+@dataclass
+class AssistantDeps:
+    """Everything a tool call runs against.
+
+    The auth subject is the *caller's* — the assistant is a conduit for the
+    caller's own permissions, never an escalator. Tools derive the organization
+    from here (validated against the subject's accessible organizations before
+    the run starts) and must never accept an organization from model arguments.
+    """
+
+    session: AsyncReadSession
+    auth_subject: AuthSubject[User | Organization]
+    organization_id: uuid.UUID
+    timezone: ZoneInfo
+    today: date
+    redis: Redis | None = None
+    blocks: list[AssistantBlock] = field(default_factory=list)
+    """Renderable blocks produced by tools during the run, in order. The
+    endpoint streams them to the client interleaved with the model's text."""
+
+    def emit(self, block: AssistantBlock) -> int:
+        """Queue a block for rendering; returns its placement marker index.
+
+        Blocks are not shown until the model places them in its answer with a
+        `[block:N]` marker (see `stream.py`), so UI lands under the claim it
+        supports. Unplaced blocks are appended at the end as a fallback."""
+        self.blocks.append(block)
+        return len(self.blocks)

--- a/server/polar/compass/assistant/entity_tools.py
+++ b/server/polar/compass/assistant/entity_tools.py
@@ -1,0 +1,719 @@
+"""
+Entity listing tools: orders, subscriptions, customers, products, disputes.
+
+Same contract as `tools.py`: organization from deps, per-tool scope guard,
+compact text summary back to the model, and a renderable block emitted for the
+client — an entity list for small sets, a data table otherwise. Each tool only
+reads attributes the corresponding public list endpoint serializes, so
+everything touched is eager-loaded.
+"""
+
+from collections.abc import Sequence
+from datetime import datetime, time, timedelta
+from typing import Any, Literal, cast
+
+from pydantic_ai import RunContext
+from sqlalchemy.orm import selectinload
+
+from polar.auth.scope import Scope
+from polar.checkout.service import checkout as checkout_service
+from polar.customer.service import customer as customer_service
+from polar.dispute.service import dispute as dispute_service
+from polar.event.service import event as event_service
+from polar.kit.pagination import PaginationParams
+from polar.kit.time_queries import TimeInterval
+from polar.metrics.service import metrics as metrics_service
+from polar.models import Product
+from polar.models.checkout import CheckoutStatus
+from polar.models.customer import _avatar_url_for_email
+from polar.models.product_price import ProductPriceFixed
+from polar.order.repository import OrderRepository
+from polar.order.service import order as order_service
+from polar.organization.repository import OrganizationRepository
+from polar.payout.service import payout as payout_service
+from polar.postgres import AsyncSession
+from polar.product.repository import ProductRepository
+from polar.product.service import product as product_service
+from polar.refund.service import refund as refund_service
+from polar.subscription.service import subscription as subscription_service
+
+from .blocks import (
+    ColumnFormat,
+    DataTableBlock,
+    DataTableColumn,
+    EntityListBlock,
+)
+from .deps import AssistantDeps
+from .tools import _scope_denial
+
+_MAX_LIMIT = 25
+# Each ranked product costs one metrics query; keep the fan-out small.
+_MAX_RANKED_PRODUCTS = 8
+_LIST_PRESENTATION_MAX = 5
+
+Presentation = Literal["list", "table"]
+Row = dict[str, str | int | float | None]
+
+
+def _emit_entities(
+    deps: AssistantDeps,
+    *,
+    entity: str,
+    title: str,
+    columns: list[DataTableColumn],
+    rows: list[Row],
+    total_count: int,
+    presentation: Presentation,
+) -> str:
+    if presentation == "list" and len(rows) <= _LIST_PRESENTATION_MAX:
+        marker = deps.emit(
+            EntityListBlock(
+                entity=entity,
+                title=title,
+                columns=columns,
+                rows=rows,
+                total_count=total_count,
+            )
+        )
+    else:
+        marker = deps.emit(
+            DataTableBlock(
+                entity=entity,
+                title=title,
+                columns=columns,
+                rows=rows,
+                total_count=total_count,
+            )
+        )
+    shown = len(rows)
+    return (
+        f"Prepared a block with {shown} of {total_count} {entity}; place it "
+        f"with [block:{marker}] directly after the claim it supports. Rows: "
+        + "; ".join(str(row) for row in rows[:_LIST_PRESENTATION_MAX])
+    )
+
+
+def _clamp(limit: int) -> PaginationParams:
+    return PaginationParams(1, max(1, min(_MAX_LIMIT, limit)))
+
+
+async def list_orders(
+    ctx: RunContext[AssistantDeps],
+    limit: int = 10,
+    presentation: Presentation = "table",
+) -> str:
+    """List the most recent orders: customer, product, amount and status.
+
+    Args:
+        limit: How many to fetch (1 to 25).
+        presentation: `list` for a compact list (5 or fewer), else `table`.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.orders_read):
+        return denial
+    items, count = await order_service.list(
+        deps.session,
+        deps.auth_subject,
+        organization_id=[deps.organization_id],
+        pagination=_clamp(limit),
+    )
+    rows: list[Row] = [
+        {
+            "customer": order.customer.email if order.customer else None,
+            "product": order.product.name if order.product else None,
+            "amount": order.net_amount,
+            "status": str(order.status),
+            "date": order.created_at.isoformat(),
+        }
+        for order in items
+    ]
+    columns = [
+        DataTableColumn(key="customer", label="Customer"),
+        DataTableColumn(key="product", label="Product"),
+        DataTableColumn(key="amount", label="Amount", format=ColumnFormat.currency),
+        DataTableColumn(key="status", label="Status", format=ColumnFormat.badge),
+        DataTableColumn(key="date", label="Date", format=ColumnFormat.datetime),
+    ]
+    return _emit_entities(
+        deps,
+        entity="orders",
+        title="Recent orders",
+        columns=columns,
+        rows=rows,
+        total_count=count,
+        presentation=presentation,
+    )
+
+
+async def list_subscriptions(
+    ctx: RunContext[AssistantDeps],
+    limit: int = 10,
+    active: bool | None = None,
+    presentation: Presentation = "table",
+) -> str:
+    """List subscriptions: customer, product, amount, status and start date.
+
+    Args:
+        limit: How many to fetch (1 to 25).
+        active: Only active (true) or only ended (false); omit for all.
+        presentation: `list` for a compact list (5 or fewer), else `table`.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.subscriptions_read):
+        return denial
+    items, count = await subscription_service.list(
+        deps.session,
+        deps.auth_subject,
+        organization_id=[deps.organization_id],
+        active=active,
+        pagination=_clamp(limit),
+    )
+    rows: list[Row] = [
+        {
+            "customer": sub.customer.email if sub.customer else None,
+            "product": sub.product.name if sub.product else None,
+            "amount": sub.amount,
+            "status": str(sub.status),
+            "started": sub.started_at.isoformat() if sub.started_at else None,
+        }
+        for sub in items
+    ]
+    columns = [
+        DataTableColumn(key="customer", label="Customer"),
+        DataTableColumn(key="product", label="Product"),
+        DataTableColumn(key="amount", label="Amount", format=ColumnFormat.currency),
+        DataTableColumn(key="status", label="Status", format=ColumnFormat.badge),
+        DataTableColumn(key="started", label="Started", format=ColumnFormat.datetime),
+    ]
+    return _emit_entities(
+        deps,
+        entity="subscriptions",
+        title="Subscriptions",
+        columns=columns,
+        rows=rows,
+        total_count=count,
+        presentation=presentation,
+    )
+
+
+async def list_customers(
+    ctx: RunContext[AssistantDeps],
+    limit: int = 10,
+    query: str | None = None,
+    presentation: Presentation = "table",
+) -> str:
+    """List customers: email, name and signup date. Optionally search them.
+
+    Args:
+        limit: How many to fetch (1 to 25).
+        query: Optional search over email and name.
+        presentation: `list` for a compact list (5 or fewer), else `table`.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.customers_read):
+        return denial
+    items, count = await customer_service.list(
+        deps.session,
+        deps.auth_subject,
+        organization_id=[deps.organization_id],
+        query=query,
+        pagination=_clamp(limit),
+    )
+    rows: list[Row] = [
+        {
+            "avatar": item.avatar_url,
+            "email": item.email,
+            "name": item.name,
+            "created": item.created_at.isoformat(),
+        }
+        for item in items
+    ]
+    columns = [
+        DataTableColumn(key="avatar", label="", format=ColumnFormat.avatar),
+        DataTableColumn(key="email", label="Email"),
+        DataTableColumn(key="name", label="Name"),
+        DataTableColumn(key="created", label="Created", format=ColumnFormat.datetime),
+    ]
+    return _emit_entities(
+        deps,
+        entity="customers",
+        title="Customers",
+        columns=columns,
+        rows=rows,
+        total_count=count,
+        presentation=presentation,
+    )
+
+
+def _product_price(product: Any) -> int | None:
+    for price in product.all_prices:
+        if isinstance(price, ProductPriceFixed) and not price.is_archived:
+            return price.price_amount
+    return None
+
+
+async def list_products(
+    ctx: RunContext[AssistantDeps],
+    limit: int = 10,
+    presentation: Presentation = "table",
+) -> str:
+    """List products: name, list price and whether they're recurring.
+
+    Args:
+        limit: How many to fetch (1 to 25).
+        presentation: `list` for a compact list (5 or fewer), else `table`.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.products_read):
+        return denial
+    # Loaded via the repository with prices eager-loaded: the price column
+    # reads `all_prices`, which is lazy="raise" and not loaded by the
+    # service's list query.
+    items = await ProductRepository.from_session(deps.session).get_all_by_organization(
+        deps.organization_id,
+        options=(selectinload(Product.all_prices),),
+        limit=max(1, min(_MAX_LIMIT, limit)),
+    )
+    count = len(items)
+    rows: list[Row] = [
+        {
+            "name": item.name,
+            "price": _product_price(item),
+            "recurring": "recurring" if item.is_recurring else "one-time",
+        }
+        for item in items
+    ]
+    columns = [
+        DataTableColumn(key="name", label="Name"),
+        DataTableColumn(key="price", label="Price", format=ColumnFormat.currency),
+        DataTableColumn(key="recurring", label="Billing", format=ColumnFormat.badge),
+    ]
+    return _emit_entities(
+        deps,
+        entity="products",
+        title="Products",
+        columns=columns,
+        rows=rows,
+        total_count=count,
+        presentation=presentation,
+    )
+
+
+async def list_disputes(
+    ctx: RunContext[AssistantDeps],
+    limit: int = 10,
+    presentation: Presentation = "table",
+) -> str:
+    """List disputes: amount, status and when they were opened.
+
+    Args:
+        limit: How many to fetch (1 to 25).
+        presentation: `list` for a compact list (5 or fewer), else `table`.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.disputes_read):
+        return denial
+    items, count = await dispute_service.list(
+        deps.session,
+        deps.auth_subject,
+        organization_id=[deps.organization_id],
+        pagination=_clamp(limit),
+    )
+    rows: list[Row] = [
+        {
+            "amount": item.amount,
+            "status": str(item.status),
+            "opened": item.created_at.isoformat(),
+        }
+        for item in items
+    ]
+    columns = [
+        DataTableColumn(key="amount", label="Amount", format=ColumnFormat.currency),
+        DataTableColumn(key="status", label="Status", format=ColumnFormat.badge),
+        DataTableColumn(key="opened", label="Opened", format=ColumnFormat.datetime),
+    ]
+    return _emit_entities(
+        deps,
+        entity="disputes",
+        title="Disputes",
+        columns=columns,
+        rows=rows,
+        total_count=count,
+        presentation=presentation,
+    )
+
+
+async def list_checkouts(
+    ctx: RunContext[AssistantDeps],
+    limit: int = 10,
+    status: Literal["open", "expired", "confirmed", "succeeded", "failed"]
+    | None = None,
+    presentation: Presentation = "table",
+) -> str:
+    """List checkout sessions: who opened them, amount and outcome. Useful to
+    drill into conversion questions (e.g. expired = abandoned checkouts).
+
+    Args:
+        limit: How many to fetch (1 to 25).
+        status: Only checkouts with this status; omit for all.
+        presentation: `list` for a compact list (5 or fewer), else `table`.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.checkouts_read):
+        return denial
+    items, count = await checkout_service.list(
+        deps.session,
+        deps.auth_subject,
+        organization_id=[deps.organization_id],
+        status=[CheckoutStatus(status)] if status else None,
+        pagination=_clamp(limit),
+    )
+    rows: list[Row] = [
+        {
+            "customer": item.customer_email,
+            "amount": item.net_amount,
+            "status": str(item.status),
+            "created": item.created_at.isoformat(),
+        }
+        for item in items
+    ]
+    columns = [
+        DataTableColumn(key="customer", label="Customer"),
+        DataTableColumn(key="amount", label="Amount", format=ColumnFormat.currency),
+        DataTableColumn(key="status", label="Status", format=ColumnFormat.badge),
+        DataTableColumn(key="created", label="Created", format=ColumnFormat.datetime),
+    ]
+    return _emit_entities(
+        deps,
+        entity="checkouts",
+        title="Checkouts",
+        columns=columns,
+        rows=rows,
+        total_count=count,
+        presentation=presentation,
+    )
+
+
+async def list_refunds(
+    ctx: RunContext[AssistantDeps],
+    limit: int = 10,
+    presentation: Presentation = "table",
+) -> str:
+    """List refunds: amount, reason, status and when they were issued.
+
+    Args:
+        limit: How many to fetch (1 to 25).
+        presentation: `list` for a compact list (5 or fewer), else `table`.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.refunds_read):
+        return denial
+    items, count = await refund_service.list(
+        # Read-only listing; the service annotates the broader session type.
+        cast(AsyncSession, deps.session),
+        deps.auth_subject,
+        organization_id=[deps.organization_id],
+        pagination=_clamp(limit),
+    )
+    rows: list[Row] = [
+        {
+            "amount": item.amount,
+            "reason": str(item.reason),
+            "status": str(item.status),
+            "created": item.created_at.isoformat(),
+        }
+        for item in items
+    ]
+    columns = [
+        DataTableColumn(key="amount", label="Amount", format=ColumnFormat.currency),
+        DataTableColumn(key="reason", label="Reason"),
+        DataTableColumn(key="status", label="Status", format=ColumnFormat.badge),
+        DataTableColumn(key="created", label="Created", format=ColumnFormat.datetime),
+    ]
+    return _emit_entities(
+        deps,
+        entity="refunds",
+        title="Refunds",
+        columns=columns,
+        rows=rows,
+        total_count=count,
+        presentation=presentation,
+    )
+
+
+async def list_payouts(
+    ctx: RunContext[AssistantDeps],
+    limit: int = 10,
+    presentation: Presentation = "table",
+) -> str:
+    """List payouts to the merchant's bank account: amount, fees, status and
+    date. Answers "when do I get paid and how much".
+
+    Args:
+        limit: How many to fetch (1 to 25).
+        presentation: `list` for a compact list (5 or fewer), else `table`.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.payouts_read):
+        return denial
+    organization = await OrganizationRepository.from_session(deps.session).get_by_id(
+        deps.organization_id
+    )
+    account_id = organization.payout_account_id if organization else None
+    if account_id is None:
+        return "This organization has no payout account set up yet."
+    items, count = await payout_service.list(
+        cast(AsyncSession, deps.session),
+        cast(Any, deps.auth_subject),
+        account_id=[account_id],
+        pagination=_clamp(limit),
+    )
+    rows: list[Row] = [
+        {
+            "amount": item.amount,
+            "fees": item.fees_amount,
+            "status": str(item.status),
+            "date": item.created_at.isoformat(),
+        }
+        for item in items
+    ]
+    columns = [
+        DataTableColumn(key="amount", label="Amount", format=ColumnFormat.currency),
+        DataTableColumn(key="fees", label="Fees", format=ColumnFormat.currency),
+        DataTableColumn(key="status", label="Status", format=ColumnFormat.badge),
+        DataTableColumn(key="date", label="Date", format=ColumnFormat.datetime),
+    ]
+    return _emit_entities(
+        deps,
+        entity="payouts",
+        title="Payouts",
+        columns=columns,
+        rows=rows,
+        total_count=count,
+        presentation=presentation,
+    )
+
+
+async def top_products_by_revenue(
+    ctx: RunContext[AssistantDeps],
+    days: int = 365,
+    limit: int = 5,
+    presentation: Presentation = "table",
+) -> str:
+    """Rank products by revenue over a trailing window, via the revenue metric
+    filtered per product. Answers questions like "what is my most successful
+    product" or "which product sells best".
+
+    Args:
+        days: Trailing window in days (7 to 365, default 365).
+        limit: How many products to rank (1 to 8; one metrics query each).
+        presentation: `list` for a compact list (5 or fewer), else `table`.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.metrics_read):
+        return denial
+    days = max(7, min(365, days))
+    limit = max(1, min(_MAX_RANKED_PRODUCTS, limit))
+
+    products, _ = await product_service.list(
+        deps.session,
+        deps.auth_subject,
+        organization_id=[deps.organization_id],
+        is_archived=False,
+        pagination=PaginationParams(1, _MAX_RANKED_PRODUCTS),
+    )
+    if not products:
+        return "This organization has no products."
+
+    ranked: list[tuple[str, float, float]] = []
+    for product in products:
+        response = await metrics_service.get_metrics(
+            deps.session,
+            deps.auth_subject,
+            start_date=deps.today - timedelta(days=days),
+            end_date=deps.today,
+            timezone=deps.timezone,
+            interval=TimeInterval.month,
+            organization_id=[deps.organization_id],
+            product_id=[product.id],
+            metrics=["revenue", "orders"],
+            redis=deps.redis,
+        )
+        revenue = float(getattr(response.totals, "revenue", 0) or 0)
+        orders = float(getattr(response.totals, "orders", 0) or 0)
+        ranked.append((product.name, revenue, orders))
+    ranked.sort(key=lambda entry: entry[1], reverse=True)
+    ranked = ranked[:limit]
+
+    if all(revenue == 0 for _, revenue, _ in ranked):
+        return f"No product revenue was recorded in the last {days} days."
+    rows: list[Row] = [
+        {"product": name, "revenue": revenue, "orders": int(orders)}
+        for name, revenue, orders in ranked
+    ]
+    columns = [
+        DataTableColumn(key="product", label="Product"),
+        DataTableColumn(key="revenue", label="Revenue", format=ColumnFormat.currency),
+        DataTableColumn(key="orders", label="Orders"),
+    ]
+    top = rows[0]
+    summary = _emit_entities(
+        deps,
+        entity="products by revenue",
+        title=f"Top products by revenue, last {days} days",
+        columns=columns,
+        rows=rows,
+        total_count=len(rows),
+        presentation=presentation,
+    )
+    return (
+        f"Top product by revenue over the last {days} days: {top['product']} "
+        f"({top['orders']} orders). " + summary
+    )
+
+
+async def top_customers_by_revenue(
+    ctx: RunContext[AssistantDeps],
+    days: int | None = 365,
+    limit: int = 5,
+    presentation: Presentation = "table",
+) -> str:
+    """Rank customers by paid net revenue. Answers questions like "who is my
+    best customer" or "which customers bring in the most revenue".
+
+    Args:
+        days: Trailing window in days (up to 365); omit for all time.
+        limit: How many customers to rank (1 to 25).
+        presentation: `list` for a compact list (5 or fewer), else `table`.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.orders_read):
+        return denial
+    start = None
+    if days is not None:
+        days = max(1, min(365, days))
+        start = datetime.combine(
+            deps.today - timedelta(days=days), time.min, deps.timezone
+        )
+    ranked = await OrderRepository.from_session(deps.session).get_revenue_by_customer(
+        deps.organization_id,
+        start=start,
+        limit=max(1, min(_MAX_LIMIT, limit)),
+    )
+    window = f"the last {days} days" if days is not None else "all time"
+    if not ranked:
+        return f"No paid orders were found for {window}."
+    rows: list[Row] = [
+        {
+            "avatar": _avatar_url_for_email(email) if email else None,
+            "customer": email or name,
+            "revenue": net_revenue,
+            "orders": order_count,
+        }
+        for _, email, name, order_count, net_revenue in ranked
+    ]
+    columns = [
+        DataTableColumn(key="avatar", label="", format=ColumnFormat.avatar),
+        DataTableColumn(key="customer", label="Customer"),
+        DataTableColumn(
+            key="revenue", label="Net revenue", format=ColumnFormat.currency
+        ),
+        DataTableColumn(key="orders", label="Orders"),
+    ]
+    top = rows[0]
+    summary = _emit_entities(
+        deps,
+        entity="customers by revenue",
+        title=f"Top customers by net revenue, {window}",
+        columns=columns,
+        rows=rows,
+        total_count=len(rows),
+        presentation=presentation,
+    )
+    return (
+        f"Best customer by paid net revenue over {window}: {top['customer']} "
+        f"({top['orders']} orders). " + summary
+    )
+
+
+async def top_customers_by_cost(
+    ctx: RunContext[AssistantDeps],
+    days: int = 30,
+    limit: int = 5,
+    presentation: Presentation = "table",
+) -> str:
+    """Rank customers by the cost they generate (from `_cost` event metadata).
+    Answers questions like "which customer drives the most cost".
+
+    Args:
+        days: Trailing window length in days (7 to 90, default 30).
+        limit: How many customers to rank (1 to 25).
+        presentation: `list` for a compact list (5 or fewer), else `table`.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.events_read):
+        return denial
+    days = max(7, min(90, days))
+    stats = await event_service.list_customer_stats(
+        cast(AsyncSession, deps.session),
+        deps.auth_subject,
+        start_date=deps.today - timedelta(days=days),
+        end_date=deps.today,
+        timezone=deps.timezone,
+        organization_id=[deps.organization_id],
+        limit=max(1, min(_MAX_LIMIT, limit)),
+    )
+    ranked = [
+        stat for stat in stats.items if float(stat.totals.get("_cost_amount", 0)) > 0
+    ]
+    if not ranked:
+        return (
+            f"No customer costs were tracked in the last {days} days. Costs "
+            "come from `_cost` metadata on ingested events."
+        )
+    rows: list[Row] = [
+        {
+            "avatar": _avatar_url_for_email(stat.email) if stat.email else None,
+            "customer": stat.email or stat.name or stat.external_customer_id,
+            "cost": float(stat.totals.get("_cost_amount", 0)),
+            "share": f"{float(stat.share) * 100:.0f}%",
+            "events": stat.occurrences,
+        }
+        for stat in ranked
+    ]
+    columns = [
+        DataTableColumn(key="avatar", label="", format=ColumnFormat.avatar),
+        DataTableColumn(key="customer", label="Customer"),
+        DataTableColumn(key="cost", label="Cost", format=ColumnFormat.currency),
+        DataTableColumn(key="share", label="Share of costs"),
+        DataTableColumn(key="events", label="Events"),
+    ]
+    top = rows[0]
+    summary = _emit_entities(
+        deps,
+        entity="customers by cost",
+        title=f"Top customers by tracked cost, last {days} days",
+        columns=columns,
+        rows=rows,
+        total_count=len(rows),
+        presentation=presentation,
+    )
+    return (
+        f"Top cost driver over the last {days} days: {top['customer']} with "
+        f"{top['share']} of all tracked costs. " + summary
+    )
+
+
+ENTITY_TOOLS_WITH_SCOPES: Sequence[tuple[object, Scope]] = [
+    (list_orders, Scope.orders_read),
+    (list_subscriptions, Scope.subscriptions_read),
+    (list_customers, Scope.customers_read),
+    (list_products, Scope.products_read),
+    (list_disputes, Scope.disputes_read),
+    (list_checkouts, Scope.checkouts_read),
+    (list_refunds, Scope.refunds_read),
+    (list_payouts, Scope.payouts_read),
+    (top_customers_by_cost, Scope.events_read),
+    (top_products_by_revenue, Scope.metrics_read),
+    (top_customers_by_revenue, Scope.orders_read),
+]

--- a/server/polar/compass/assistant/schemas.py
+++ b/server/polar/compass/assistant/schemas.py
@@ -1,0 +1,21 @@
+from pydantic import UUID4, Field
+
+from polar.kit.schemas import Schema
+
+
+class AssistantChatRequest(Schema):
+    """One turn of the Compass assistant conversation."""
+
+    organization_id: UUID4 = Field(
+        description="Organization the conversation is about. Must be accessible "
+        "to the caller; tools are always scoped to it."
+    )
+    prompt: str = Field(min_length=1, max_length=4000)
+    message_history: str | None = Field(
+        default=None,
+        description=(
+            "Opaque conversation state from the previous turn's `done` event. "
+            "Send it back verbatim to continue the conversation; omit to start "
+            "a new one."
+        ),
+    )

--- a/server/polar/compass/assistant/stream.py
+++ b/server/polar/compass/assistant/stream.py
@@ -1,0 +1,195 @@
+"""
+Run the assistant agent and turn it into an SSE event stream.
+
+Events, in order of appearance:
+- `text`   {"delta": str}         — model output, streamed as it generates
+- `block`  {<AssistantBlock>}     — a renderable block, placed by the model
+- `done`   {"message_history": str} — opaque state to send back next turn
+- `error`  {"message": str}
+"""
+
+import json
+import re
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import structlog
+from pydantic_ai import Agent
+from pydantic_ai.messages import (
+    ModelMessagesTypeAdapter,
+    PartDeltaEvent,
+    PartStartEvent,
+    TextPart,
+    TextPartDelta,
+)
+
+from polar.integrations.polar.service import polar_self
+from polar.logging import Logger
+from polar.organization_review.schemas import UsageInfo
+
+from .deps import AssistantDeps
+
+log: Logger = structlog.get_logger()
+
+
+def _event(event: str, data: Any) -> dict[str, str]:
+    return {"event": event, "data": json.dumps(data)}
+
+
+def _track_usage(
+    deps: AssistantDeps, usage: Any, model_provider: str, model_name: str
+) -> None:
+    """Polar-for-Polar dogfooding: ingest this run's inference cost as a span
+    on the Polar organization, mirroring organization reviews. Best-effort —
+    tracking must never break the conversation."""
+    try:
+        info = UsageInfo.from_agent_usage(usage, model_provider, model_name)
+        polar_self.enqueue_track_compass_assistant_usage(
+            external_customer_id=str(deps.organization_id),
+            vendor=model_provider,
+            model=model_name,
+            input_tokens=info.input_tokens,
+            output_tokens=info.output_tokens,
+            cost_usd=info.estimated_cost_usd,
+        )
+    except Exception:
+        log.exception(
+            "compass.assistant_usage_tracking_error",
+            organization_id=str(deps.organization_id),
+        )
+
+
+_MARKER_RE = re.compile(r"\s*\[block:(\d+)\]\s*")
+_MARKER_PREFIX = "[block:"
+_MAX_MARKER_LEN = 12
+
+
+class _BlockPlacer:
+    """Splits streamed text around `[block:N]` placement markers.
+
+    Text before a marker flows through as-is; the marker itself becomes a
+    block reference. A possible partial marker at the end of a delta is held
+    back until the next delta resolves it.
+    """
+
+    def __init__(self) -> None:
+        self._buffer = ""
+
+    def feed(self, delta: str) -> list[tuple[str, str | int]]:
+        self._buffer += delta
+        out: list[tuple[str, str | int]] = []
+        while True:
+            match = _MARKER_RE.search(self._buffer)
+            if match:
+                if pre := self._buffer[: match.start()]:
+                    out.append(("text", pre))
+                out.append(("block", int(match.group(1))))
+                self._buffer = self._buffer[match.end() :]
+                continue
+            cut = self._buffer.rfind("[")
+            if cut != -1:
+                candidate = self._buffer[cut:]
+                partial = _MARKER_PREFIX.startswith(candidate) or (
+                    candidate.startswith(_MARKER_PREFIX)
+                    and len(candidate) <= _MAX_MARKER_LEN
+                )
+                if partial:
+                    if safe := self._buffer[:cut]:
+                        out.append(("text", safe))
+                    self._buffer = candidate
+                    return out
+            if self._buffer:
+                out.append(("text", self._buffer))
+                self._buffer = ""
+            return out
+
+    def flush(self) -> str:
+        tail, self._buffer = self._buffer, ""
+        return tail
+
+
+async def stream_assistant_run(
+    agent: Agent[AssistantDeps, str],
+    deps: AssistantDeps,
+    prompt: str,
+    message_history_json: str | None,
+    *,
+    model_provider: str,
+    model_name: str,
+) -> AsyncGenerator[dict[str, str]]:
+    history = None
+    if message_history_json:
+        try:
+            history = ModelMessagesTypeAdapter.validate_json(message_history_json)
+        except ValueError:
+            yield _event("error", {"message": "Invalid message history."})
+            return
+
+    placer = _BlockPlacer()
+    placed: set[int] = set()
+
+    def block_event(index: int) -> dict[str, str] | None:
+        # Markers are 1-based indexes into the run's prepared blocks.
+        if index in placed or not (1 <= index <= len(deps.blocks)):
+            return None
+        placed.add(index)
+        return _event("block", deps.blocks[index - 1].model_dump(mode="json"))
+
+    def placed_events(delta: str) -> list[dict[str, str]]:
+        events: list[dict[str, str]] = []
+        for kind, value in placer.feed(delta):
+            if kind == "text":
+                events.append(_event("text", {"delta": str(value)}))
+            else:
+                placed_block = block_event(int(value))
+                if placed_block is not None:
+                    events.append(placed_block)
+        return events
+
+    try:
+        async with agent.iter(prompt, deps=deps, message_history=history) as run:
+            async for node in run:
+                if Agent.is_model_request_node(node):
+                    async with node.stream(run.ctx) as request_stream:
+                        async for event in request_stream:
+                            if isinstance(event, PartStartEvent) and isinstance(
+                                event.part, TextPart
+                            ):
+                                if event.part.content:
+                                    for out in placed_events(event.part.content):
+                                        yield out
+                            elif isinstance(event, PartDeltaEvent) and isinstance(
+                                event.delta, TextPartDelta
+                            ):
+                                if event.delta.content_delta:
+                                    for out in placed_events(event.delta.content_delta):
+                                        yield out
+                    if tail := placer.flush():
+                        yield _event("text", {"delta": tail})
+
+            # Fallback: blocks the model never placed still reach the user,
+            # after the text.
+            for index in range(1, len(deps.blocks) + 1):
+                unplaced = block_event(index)
+                if unplaced is not None:
+                    yield unplaced
+
+            result = run.result
+            assert result is not None
+            _track_usage(deps, result.usage, model_provider, model_name)
+            yield _event(
+                "done",
+                {
+                    "message_history": ModelMessagesTypeAdapter.dump_json(
+                        result.all_messages()
+                    ).decode()
+                },
+            )
+    except Exception:
+        log.exception(
+            "compass.assistant_error", organization_id=str(deps.organization_id)
+        )
+        yield _event(
+            "error",
+            {"message": "The assistant hit an unexpected error. Try again."},
+        )

--- a/server/polar/compass/assistant/tools.py
+++ b/server/polar/compass/assistant/tools.py
@@ -1,0 +1,191 @@
+"""
+Assistant tools: thin, scope-guarded wrappers over Polar's internal services.
+
+Every tool follows the same contract:
+- The organization comes from `AssistantDeps`, never from model arguments.
+- The caller's scopes are checked before any data access — tools a caller
+  lacks the scope for are not registered at all (see `agent.py`); the runtime
+  check here is belt-and-suspenders.
+- Data flows back to the model as a compact textual summary to narrate, and to
+  the client as typed blocks via `deps.emit(...)` for the block registry.
+"""
+
+from datetime import timedelta
+from typing import Literal
+
+from pydantic_ai import RunContext
+
+from polar.auth.scope import Scope
+from polar.kit.time_queries import TimeInterval
+from polar.metrics.metrics import METRICS
+from polar.metrics.service import metrics as metrics_service
+
+from ..schemas import InsightCategory
+from ..service import compass as compass_service
+from .blocks import InsightCardsBlock, MetricChartBlock, MetricChartPoint
+from .deps import AssistantDeps
+
+_METRIC_BY_SLUG = {metric.slug: metric for metric in METRICS}
+
+_MAX_WINDOW_DAYS = 90
+_MIN_WINDOW_DAYS = 7
+_MAX_SLUGS = 5
+
+
+def _scope_denial(deps: AssistantDeps, scope: Scope) -> str | None:
+    if scope in deps.auth_subject.scopes:
+        return None
+    return (
+        f"Permission denied: this request's token lacks the `{scope.value}` "
+        "scope, so this data cannot be accessed. Tell the user which scope "
+        "is missing."
+    )
+
+
+async def get_metrics(
+    ctx: RunContext[AssistantDeps],
+    metric_slugs: list[str],
+    days: int = 30,
+) -> str:
+    """Fetch daily values for up to five metrics over a trailing window.
+
+    Args:
+        metric_slugs: Metric slugs to fetch, e.g. `monthly_recurring_revenue`,
+            `active_subscriptions`, `churned_subscriptions`, `revenue`,
+            `checkouts_conversion`, `gross_margin_percentage`, `cost_per_user`.
+        days: Trailing window length in days (7 to 90, default 30).
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.metrics_read):
+        return denial
+
+    unknown = [slug for slug in metric_slugs if slug not in _METRIC_BY_SLUG]
+    if unknown:
+        known = ", ".join(sorted(_METRIC_BY_SLUG))
+        return f"Unknown metric slugs {unknown}. Available slugs: {known}"
+    slugs = metric_slugs[:_MAX_SLUGS]
+    days = max(_MIN_WINDOW_DAYS, min(_MAX_WINDOW_DAYS, days))
+
+    today = deps.today
+    response = await metrics_service.get_metrics(
+        deps.session,
+        deps.auth_subject,
+        start_date=today - timedelta(days=days),
+        end_date=today,
+        timezone=deps.timezone,
+        interval=TimeInterval.day,
+        organization_id=[deps.organization_id],
+        metrics=slugs,
+        redis=deps.redis,
+    )
+
+    summaries: list[str] = []
+    for slug in slugs:
+        metric = _METRIC_BY_SLUG[slug]
+        points = [
+            MetricChartPoint(
+                timestamp=period.timestamp,
+                value=getattr(period, slug, None) or 0,
+            )
+            for period in response.periods
+        ]
+        marker = deps.emit(
+            MetricChartBlock(
+                metric=slug,
+                label=metric.display_name,
+                unit=metric.type.value,
+                points=points,
+            )
+        )
+        first = points[0].value if points else 0
+        last = points[-1].value if points else 0
+        summaries.append(
+            f"{slug} ({metric.type.value}): start={first} latest={last} "
+            f"over the last {days} days. Chart prepared; place it with "
+            f"[block:{marker}]."
+        )
+    return "\n".join(summaries)
+
+
+async def get_insights(
+    ctx: RunContext[AssistantDeps],
+    category: Literal["revenue", "retention", "growth", "risk", "cost", "product"]
+    | None = None,
+) -> str:
+    """Fetch Compass insights for your own reasoning: computed, narrated
+    findings about the business, each with a severity and an id. Renders
+    NOTHING to the user — form your assessment from the findings, then call
+    `show_insights` with the one or two ids that support it.
+
+    Args:
+        category: Only insights in this area — `revenue`, `retention` (churn),
+            `growth`, `risk`, `cost` (margins, cost to serve) or `product`
+            (conversion). Omit for a whole-business view.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.metrics_read):
+        return denial
+
+    insights = await compass_service.list_insights(
+        deps.session,
+        deps.auth_subject,
+        timezone=deps.timezone,
+        organization_id=[deps.organization_id],
+        category=[InsightCategory(category)] if category else None,
+        redis=deps.redis,
+    )
+    if not insights:
+        area = f" in the {category} category" if category else ""
+        return f"No insights are currently firing{area} for this organization."
+
+    lines = [
+        f"[{insight.severity.value}] id={insight.id} {insight.title}: "
+        f"{insight.body}" + (f" (Method: {insight.why})" if insight.why else "")
+        for insight in insights
+    ]
+    return (
+        "Findings (nothing rendered yet; use show_insights to display the "
+        "relevant ones, usually one or two):\n" + "\n".join(lines)
+    )
+
+
+async def show_insights(
+    ctx: RunContext[AssistantDeps],
+    insight_ids: list[str],
+) -> str:
+    """Render insight cards to the user, by id (from `get_insights`).
+
+    Default to the one or two cards that directly support your assessment;
+    render more only when the user explicitly asked to see all insights.
+
+    Args:
+        insight_ids: Ids of the insights to display, most important first.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.metrics_read):
+        return denial
+
+    wanted = insight_ids
+    insights = await compass_service.list_insights(
+        deps.session,
+        deps.auth_subject,
+        timezone=deps.timezone,
+        organization_id=[deps.organization_id],
+        redis=deps.redis,
+    )
+    selected = [insight for insight in insights if insight.id in wanted]
+    if not selected:
+        return "None of those insight ids are currently firing."
+
+    marker = deps.emit(InsightCardsBlock(insights=selected))
+    return (
+        f"Prepared {len(selected)} insight card(s); place them with "
+        f"[block:{marker}]. Cards: " + ", ".join(insight.title for insight in selected)
+    )
+
+
+TOOLS_WITH_SCOPES: list[tuple[object, Scope]] = [
+    (get_metrics, Scope.metrics_read),
+    (get_insights, Scope.metrics_read),
+    (show_insights, Scope.metrics_read),
+]

--- a/server/polar/compass/detectors/__init__.py
+++ b/server/polar/compass/detectors/__init__.py
@@ -11,8 +11,10 @@ from .base import Detector, DetectorContext
 from .churn import ChurnSpikeDetector
 from .conversion import CheckoutConversionDetector
 from .cost_per_user import CostPerUserDetector
+from .customer_cost import CostConcentrationDetector
 from .margin import GrossMarginDetector
 from .mrr import MRRGrowthDetector
+from .product_margin import ProductMarginDetector
 from .subscribers import SubscriberGrowthDetector
 from .trials import TrialConversionDetector
 
@@ -25,6 +27,8 @@ DETECTORS: list[Detector] = [
     GrossMarginDetector(),
     CostPerUserDetector(),
     CheckoutConversionDetector(),
+    ProductMarginDetector(),
+    CostConcentrationDetector(),
 ]
 
 DETECTOR_IDS: frozenset[str] = frozenset(detector.id for detector in DETECTORS)

--- a/server/polar/compass/detectors/arpu.py
+++ b/server/polar/compass/detectors/arpu.py
@@ -1,6 +1,6 @@
 from polar.metrics.aggregation import latest, value_n_periods_ago
 
-from ..schemas import Insight, InsightAction, InsightCategory, InsightSeverity
+from ..schemas import Insight, InsightCategory, InsightSeverity, ViewMetricAction
 from ..signals import MetricSignal, format_currency, format_pct
 from .base import Detector, DetectorContext, confidence_for_sample
 
@@ -80,7 +80,7 @@ class ARPUMovementDetector(Detector):
             body=body,
             why=why,
             confidence=confidence,
-            primary_action=InsightAction(
+            primary_action=ViewMetricAction(
                 label="View ARPU trend",
                 metric="average_revenue_per_user",
             ),

--- a/server/polar/compass/detectors/base.py
+++ b/server/polar/compass/detectors/base.py
@@ -16,6 +16,7 @@ from ..schemas import (
     InsightDriver,
     InsightSeverity,
 )
+from ..signals import CustomerCostSignal, ProductPricing
 
 # Minimum population before an insight is trustworthy enough to surface at all.
 _MIN_SAMPLE = 5
@@ -47,6 +48,12 @@ class DetectorContext:
     timezone: ZoneInfo
     today: date
     metrics: MetricsResponse
+    products: Sequence[ProductPricing] = ()
+    """Per-product pricing + metrics windows. Prefetched only when a selected
+    detector declares `product_metric_slugs` and the organization has cost data."""
+    customer_costs: Sequence[CustomerCostSignal] = ()
+    """Customers ranked by tracked cost over the window. Prefetched only when a
+    selected detector declares `needs_customer_costs`."""
 
 
 class Detector(abc.ABC):
@@ -65,6 +72,14 @@ class Detector(abc.ABC):
     The primary feed order is each insight's `severity`, set per finding."""
     metric_slugs: Sequence[str] = ()
     """Metric slugs this detector reads. The service prefetches their union."""
+    product_metric_slugs: Sequence[str] = ()
+    """Metric slugs this detector reads *per product*. When any selected
+    detector declares these, the service also fetches them filtered to each of
+    the organization's products (capped, and only when org-level cost data
+    exists) into `ctx.products`."""
+    needs_customer_costs: bool = False
+    """When true, the service prefetches `ctx.customer_costs` (per-customer
+    cost ranking from the events statistics)."""
     lookback_days: int = 30
     """History `evaluate` needs. The service fetches the longest lookback."""
 

--- a/server/polar/compass/detectors/churn.py
+++ b/server/polar/compass/detectors/churn.py
@@ -1,6 +1,6 @@
 from polar.metrics.aggregation import latest, series
 
-from ..schemas import Insight, InsightAction, InsightCategory, InsightSeverity
+from ..schemas import Insight, InsightCategory, InsightSeverity, ViewMetricAction
 from ..signals import format_pct
 from .base import Detector, DetectorContext, confidence_for_sample
 
@@ -60,7 +60,7 @@ class ChurnSpikeDetector(Detector):
         title = f"{churned_n} {subscriptions} churned this month"
         body = (
             f"{churned_n} {subscriptions} ended in the last 30 days, "
-            f"{rate_str} of an at-risk base of {at_risk} — you have {active_n} "
+            f"{rate_str} of an at-risk base of {at_risk}. You have {active_n} "
             f"active subscriptions today."
         )
 
@@ -81,7 +81,7 @@ class ChurnSpikeDetector(Detector):
             body=body,
             why=why,
             confidence=confidence,
-            primary_action=InsightAction(
+            primary_action=ViewMetricAction(
                 label="View churn",
                 metric="churned_subscriptions",
             ),

--- a/server/polar/compass/detectors/conversion.py
+++ b/server/polar/compass/detectors/conversion.py
@@ -1,6 +1,6 @@
 from polar.metrics.aggregation import series
 
-from ..schemas import Insight, InsightAction, InsightCategory, InsightSeverity
+from ..schemas import Insight, InsightCategory, InsightSeverity, ViewMetricAction
 from ..signals import format_pct
 from .base import Detector, DetectorContext, confidence_for_sample
 
@@ -88,7 +88,7 @@ class CheckoutConversionDetector(Detector):
             body=body,
             why=why,
             confidence=confidence,
-            primary_action=InsightAction(
+            primary_action=ViewMetricAction(
                 label="View conversion",
                 metric="checkouts_conversion",
             ),

--- a/server/polar/compass/detectors/cost_per_user.py
+++ b/server/polar/compass/detectors/cost_per_user.py
@@ -1,6 +1,6 @@
 from polar.metrics.aggregation import latest, value_n_periods_ago
 
-from ..schemas import Insight, InsightAction, InsightCategory, InsightSeverity
+from ..schemas import Insight, InsightCategory, InsightSeverity, ViewMetricAction
 from ..signals import MetricSignal, format_currency, format_pct
 from .base import Detector, DetectorContext, confidence_for_sample
 
@@ -36,7 +36,9 @@ class CostPerUserDetector(Detector):
             return None
 
         baseline = value_n_periods_ago(response, "cost_per_user", _LOOKBACK_DAYS)
-        if baseline is None or baseline == 0:
+        # A sub-dollar baseline means cost tracking effectively just started —
+        # comparing against it yields absurd percentages, not a trend.
+        if baseline is None or baseline < _MIN_COST_PER_USER:
             return None
 
         sample_n = int(latest(response, "active_subscriptions"))
@@ -83,7 +85,7 @@ class CostPerUserDetector(Detector):
             body=body,
             why=why,
             confidence=confidence,
-            primary_action=InsightAction(
+            primary_action=ViewMetricAction(
                 label="View cost per user",
                 metric="cost_per_user",
             ),

--- a/server/polar/compass/detectors/customer_cost.py
+++ b/server/polar/compass/detectors/customer_cost.py
@@ -1,0 +1,73 @@
+from ..schemas import Insight, InsightCategory, InsightSeverity, ViewMetricAction
+from ..signals import format_pct
+from .base import Detector, DetectorContext, confidence_for_sample
+
+# Below this share, cost skew is normal; above the critical bar one outage or
+# churn event materially moves the whole cost base.
+_CONCENTRATION_WARNING = 0.40
+_CONCENTRATION_CRITICAL = 0.60
+_LOOKBACK_DAYS = 30
+
+
+class CostConcentrationDetector(Detector):
+    """
+    One customer dominating the organization's tracked costs.
+
+    Reads the per-customer cost ranking (from `_cost` event statistics) the
+    service prefetches. Concentration is a *risk* reading: if a single
+    customer drives most of the cost base, their behavior (a runaway workload,
+    a plan change, churn) swings the whole margin. Confidence is gated on how
+    many customers carry costs at all, so a two-customer org doesn't get told
+    its costs are "concentrated".
+    """
+
+    id = "cost_concentration"
+    category = InsightCategory.risk
+    category_label = "Risk"
+    priority = 25
+    metric_slugs = ()
+    needs_customer_costs = True
+    lookback_days = _LOOKBACK_DAYS
+
+    def evaluate(self, ctx: DetectorContext) -> Insight | None:
+        ranked = [signal for signal in ctx.customer_costs if signal.amount > 0]
+        if not ranked:
+            return None
+
+        confidence = confidence_for_sample(len(ranked))
+        if confidence is None:
+            return None
+
+        top = max(ranked, key=lambda signal: signal.share)
+        if top.share < _CONCENTRATION_WARNING:
+            return None
+
+        share_str = format_pct(top.share)
+        title = f"One customer drives {share_str} of your costs"
+        body = (
+            f"{top.label} generated {share_str} of all tracked costs in the "
+            f"last {_LOOKBACK_DAYS} days, across {len(ranked)} customers with "
+            "costs. A single workload change or churn event would move most "
+            "of your cost base."
+        )
+        why = (
+            f"Triggered when one customer exceeds "
+            f"{format_pct(_CONCENTRATION_WARNING)} of tracked costs, across "
+            f"{len(ranked)} customers with cost data ({confidence.value} "
+            "confidence). Costs come from `_cost` event metadata."
+        )
+
+        return self.build_insight(
+            ctx,
+            period_bucket=ctx.today.strftime("%Y-%m"),
+            severity=(
+                InsightSeverity.critical
+                if top.share >= _CONCENTRATION_CRITICAL
+                else InsightSeverity.warning
+            ),
+            title=title,
+            body=body,
+            why=why,
+            confidence=confidence,
+            primary_action=ViewMetricAction(label="View costs", metric="costs"),
+        )

--- a/server/polar/compass/detectors/margin.py
+++ b/server/polar/compass/detectors/margin.py
@@ -1,6 +1,6 @@
 from polar.metrics.aggregation import latest, value_n_periods_ago
 
-from ..schemas import Insight, InsightAction, InsightCategory, InsightSeverity
+from ..schemas import Insight, InsightCategory, InsightSeverity, ViewMetricAction
 from ..signals import format_pct
 from .base import Detector, DetectorContext, confidence_for_sample
 
@@ -95,7 +95,7 @@ class GrossMarginDetector(Detector):
             body=body,
             why=why,
             confidence=confidence,
-            primary_action=InsightAction(
+            primary_action=ViewMetricAction(
                 label="View margin",
                 metric="gross_margin_percentage",
             ),

--- a/server/polar/compass/detectors/mrr.py
+++ b/server/polar/compass/detectors/mrr.py
@@ -1,6 +1,6 @@
 from polar.metrics.aggregation import latest, value_n_periods_ago
 
-from ..schemas import Insight, InsightAction, InsightCategory, InsightSeverity
+from ..schemas import Insight, InsightCategory, InsightSeverity, ViewMetricAction
 from ..signals import MetricSignal
 from .base import Detector, DetectorContext, confidence_for_sample
 
@@ -84,7 +84,7 @@ class MRRGrowthDetector(Detector):
             body=body,
             why=why,
             confidence=confidence,
-            primary_action=InsightAction(
+            primary_action=ViewMetricAction(
                 label="View MRR trend",
                 metric="monthly_recurring_revenue",
             ),

--- a/server/polar/compass/detectors/product_margin.py
+++ b/server/polar/compass/detectors/product_margin.py
@@ -1,0 +1,136 @@
+import math
+
+from polar.metrics.aggregation import latest
+
+from ..schemas import (
+    AdjustPriceAction,
+    Insight,
+    InsightCategory,
+    InsightSeverity,
+)
+from ..signals import ProductPricing, format_currency, format_pct
+from .base import Detector, DetectorContext, confidence_for_sample
+
+# Below this a product's margin is thin enough to flag; below the critical bar
+# it leads the feed.
+_HEALTHY_MARGIN = 0.70
+_CRITICAL_MARGIN = 0.40
+# The reference price restores this margin at the current cost to serve.
+_TARGET_MARGIN = 0.70
+
+
+def _suggested_price(price_amount: int, margin: float) -> int | None:
+    """List price (cents) that restores the target margin, or None.
+
+    Derived from the unitless margin — `price * (1 - margin)` is the cost to
+    serve in the price's own currency unit — so it never depends on the raw
+    cost metric's unit. Rounded up to a whole dollar; only a raise is ever
+    suggested (a lower price never *restores* margin).
+    """
+    cost_share = 1 - margin
+    if cost_share <= 0:
+        return None
+    target = price_amount * cost_share / (1 - _TARGET_MARGIN)
+    suggested = math.ceil(target / 100) * 100
+    return suggested if suggested > price_amount else None
+
+
+class ProductMarginDetector(Detector):
+    """
+    The product with the weakest unit economics, with a pricing lever.
+
+    Where the org-level margin detector *announces* compression, this one
+    *attributes* it: it names the product whose gross margin is thinnest and
+    offers a reference price that would restore the target margin at the
+    current cost to serve. The suggestion deliberately ignores demand
+    elasticity — it's a reference point for the merchant, never applied
+    automatically, and affects new customers only.
+
+    Cost attribution: cost events attach to customers, not products, so the
+    service reads costs through the product's active-customer cohort (revenue
+    stays product-filtered). A customer holding several products has their full
+    cost counted toward each, which skews margins pessimistic for orgs whose
+    customers stack products — a product-attributed cost pipe is the eventual
+    fix. Confidence is gated on the product's own subscription count.
+    """
+
+    id = "product_margin"
+    category = InsightCategory.cost
+    category_label = "Margin"
+    priority = 12
+    metric_slugs = ("gross_margin_percentage",)
+    product_metric_slugs = ("gross_margin_percentage", "active_subscriptions")
+
+    def evaluate(self, ctx: DetectorContext) -> Insight | None:
+        worst: ProductPricing | None = None
+        worst_margin = _HEALTHY_MARGIN
+        worst_subs = 0
+        for product in ctx.products:
+            margin = latest(product.metrics, "gross_margin_percentage")
+            # 0 margin means no cost/revenue data for this product, not a
+            # zero-margin business — stay silent rather than mislead.
+            if margin <= 0 or margin >= worst_margin:
+                continue
+            subs = int(latest(product.metrics, "active_subscriptions"))
+            if confidence_for_sample(subs) is None:
+                continue
+            worst = product
+            worst_margin = margin
+            worst_subs = subs
+
+        if worst is None:
+            return None
+
+        confidence = confidence_for_sample(worst_subs)
+        if confidence is None:
+            return None
+
+        cost_to_serve = round(worst.price_amount * (1 - worst_margin))
+        suggested = _suggested_price(worst.price_amount, worst_margin)
+        margin_str = format_pct(worst_margin)
+
+        title = f"{worst.name} margin is down to {margin_str}"
+        body = (
+            f"{worst.name} keeps {margin_str} of its "
+            f"{format_currency(worst.price_amount)} price after costs. "
+            f"Roughly {format_currency(cost_to_serve)} per customer goes to "
+            f"serving it, across {worst_subs} active subscriptions."
+        )
+        if suggested is not None:
+            body += (
+                f" A list price around {format_currency(suggested)} would "
+                f"restore a {format_pct(_TARGET_MARGIN)} margin for new "
+                "customers."
+            )
+        why = (
+            f"Triggered when a product's gross margin falls below "
+            f"{format_pct(_HEALTHY_MARGIN)}, weighted by its "
+            f"{worst_subs} active subscriptions ({confidence.value} "
+            "confidence). Costs are attributed to the customers subscribed to "
+            "the product, so customers holding several products weigh on each "
+            "of them. The suggested price is the level that restores a "
+            f"{format_pct(_TARGET_MARGIN)} margin at the current cost to "
+            "serve; it does not model demand."
+        )
+
+        return self.build_insight(
+            ctx,
+            period_bucket=ctx.today.strftime("%Y-%m"),
+            severity=(
+                InsightSeverity.critical
+                if worst_margin < _CRITICAL_MARGIN
+                else InsightSeverity.warning
+            ),
+            title=title,
+            body=body,
+            why=why,
+            confidence=confidence,
+            primary_action=AdjustPriceAction(
+                label=f"Review {worst.name} pricing",
+                product_id=worst.product_id,
+                product_name=worst.name,
+                current_price_amount=worst.price_amount,
+                suggested_price_amount=suggested,
+                currency=worst.currency,
+            ),
+        )

--- a/server/polar/compass/detectors/subscribers.py
+++ b/server/polar/compass/detectors/subscribers.py
@@ -1,6 +1,6 @@
 from polar.metrics.aggregation import latest, value_n_periods_ago
 
-from ..schemas import Insight, InsightAction, InsightCategory, InsightSeverity
+from ..schemas import Insight, InsightCategory, InsightSeverity, ViewMetricAction
 from ..signals import MetricSignal, format_pct
 from .base import Detector, DetectorContext, confidence_for_sample
 
@@ -76,7 +76,7 @@ class SubscriberGrowthDetector(Detector):
             body=body,
             why=why,
             confidence=confidence,
-            primary_action=InsightAction(
+            primary_action=ViewMetricAction(
                 label="View subscriptions",
                 metric="active_subscriptions",
             ),

--- a/server/polar/compass/detectors/trials.py
+++ b/server/polar/compass/detectors/trials.py
@@ -1,6 +1,6 @@
 from polar.metrics.aggregation import latest
 
-from ..schemas import Insight, InsightAction, InsightCategory, InsightSeverity
+from ..schemas import Insight, InsightCategory, InsightSeverity, ViewMetricAction
 from ..signals import format_currency, format_pct
 from .base import Detector, DetectorContext, confidence_for_sample
 
@@ -70,7 +70,7 @@ class TrialConversionDetector(Detector):
             body=body,
             why=why,
             confidence=confidence,
-            primary_action=InsightAction(
+            primary_action=ViewMetricAction(
                 label="View trials",
                 metric="trial_monthly_recurring_revenue",
             ),

--- a/server/polar/compass/endpoints.py
+++ b/server/polar/compass/endpoints.py
@@ -1,16 +1,26 @@
+from datetime import datetime
 from zoneinfo import ZoneInfo
 
-from fastapi import Depends, Query
+from fastapi import Depends, Query, Request
 from pydantic_extra_types.timezone_name import TimeZoneName
+from sse_starlette.sse import EventSourceResponse
 
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import get_accessible_org_ids
+from polar.exceptions import ResourceNotFound
 from polar.kit.schemas import MultipleQueryFilter
 from polar.openapi import APITag
+from polar.organization.repository import OrganizationRepository
 from polar.organization.schemas import OrganizationID
 from polar.postgres import AsyncReadSession, get_db_read_session
 from polar.redis import Redis, get_redis
 from polar.routing import APIRouter
 
 from . import auth
+from .assistant.agent import build_assistant_agent
+from .assistant.deps import AssistantDeps
+from .assistant.schemas import AssistantChatRequest
+from .assistant.stream import stream_assistant_run
 from .schemas import Insight, InsightCategory
 from .service import compass as compass_service
 
@@ -47,3 +57,65 @@ async def list_insights(
         category=category,
         redis=redis,
     )
+
+
+@router.post(
+    "/assistant",
+    summary="Ask the Compass Assistant",
+    include_in_schema=False,
+)
+async def assistant_chat(
+    request: Request,
+    body: AssistantChatRequest,
+    auth_subject: auth.CompassRead,
+    timezone: TimeZoneName = Query(
+        default="UTC",
+        description="Timezone used to resolve metric windows. Default is UTC.",
+    ),
+    session: AsyncReadSession = Depends(get_db_read_session),
+    redis: Redis | None = Depends(get_redis),
+) -> EventSourceResponse:
+    """Stream one assistant turn as SSE: `text` deltas, renderable `block`
+    events, then `done` with opaque conversation state for the next turn.
+
+    The agent runs under the caller's auth subject: its toolset is derived
+    from the token's granted scopes, so a restricted token can only reach the
+    data those scopes allow.
+    """
+    org_ids = await get_accessible_org_ids(
+        session, auth_subject, permission=OrganizationPermission.analytics_read
+    )
+    if body.organization_id not in org_ids:
+        raise ResourceNotFound()
+    organization_repository = OrganizationRepository.from_session(session)
+    organization = await organization_repository.get_by_id(body.organization_id)
+    if organization is None or not organization.is_compass_enabled:
+        raise ResourceNotFound()
+
+    tz = ZoneInfo(timezone)
+    agent, model_provider, model_name = build_assistant_agent(auth_subject.scopes)
+    # The request-scoped session closes when this handler returns, before the
+    # response streams — the generator opens its own session for tool calls.
+    read_sessionmaker = request.state.async_read_sessionmaker
+
+    async def event_stream():  # type: ignore[no-untyped-def]
+        async with read_sessionmaker() as stream_session:
+            deps = AssistantDeps(
+                session=stream_session,
+                auth_subject=auth_subject,
+                organization_id=body.organization_id,
+                timezone=tz,
+                today=datetime.now(tz=tz).date(),
+                redis=redis,
+            )
+            async for event in stream_assistant_run(
+                agent,
+                deps,
+                body.prompt,
+                body.message_history,
+                model_provider=model_provider,
+                model_name=model_name,
+            ):
+                yield event
+
+    return EventSourceResponse(event_stream())

--- a/server/polar/compass/schemas.py
+++ b/server/polar/compass/schemas.py
@@ -1,6 +1,7 @@
 from enum import StrEnum
+from typing import Annotated, Literal
 
-from pydantic import Field
+from pydantic import UUID4, Discriminator, Field
 
 from polar.kit.schemas import Schema
 
@@ -49,9 +50,24 @@ class InsightSeverity(StrEnum):
     """Notable movement; no action required."""
 
 
-class InsightAction(Schema):
+class InsightActionType(StrEnum):
+    """
+    What kind of action an insight offers.
+
+    Actions are a discriminated union on this type: adding a new kind of action
+    is adding one enum member, one schema below (folded into `InsightAction`),
+    and one resolver entry on the client — the client owns all routing, the
+    backend only names the domain object the action concerns.
+    """
+
+    view_metric = "view_metric"
+    adjust_price = "adjust_price"
+
+
+class ViewMetricAction(Schema):
     """A drill-down that points at the metric behind the insight."""
 
+    type: Literal[InsightActionType.view_metric] = InsightActionType.view_metric
     label: str = Field(description="Button label.")
     metric: str = Field(
         description=(
@@ -60,6 +76,41 @@ class InsightAction(Schema):
             "resolves it to the matching analytics page."
         )
     )
+
+
+class AdjustPriceAction(Schema):
+    """
+    A recommendation to review a product's pricing, with a reference point.
+
+    The suggested amount is a *reference*, not a mandate: it's the list price
+    that would restore the target gross margin at the current cost to serve,
+    ignoring demand elasticity. It applies to new customers only — existing
+    subscriptions keep their price. The client routes to the product's pricing
+    editor; nothing is ever applied automatically.
+    """
+
+    type: Literal[InsightActionType.adjust_price] = InsightActionType.adjust_price
+    label: str = Field(description="Button label.")
+    product_id: UUID4 = Field(description="The product whose pricing to review.")
+    product_name: str = Field(description="Display name of the product.")
+    current_price_amount: int = Field(
+        description="The product's current list price, in cents."
+    )
+    suggested_price_amount: int | None = Field(
+        default=None,
+        description=(
+            "Reference list price (cents) that would restore the target gross "
+            "margin at the current cost to serve. Null when no meaningful "
+            "suggestion can be computed."
+        ),
+    )
+    currency: str = Field(description="ISO currency code of the amounts.")
+
+
+InsightAction = Annotated[
+    ViewMetricAction | AdjustPriceAction,
+    Discriminator("type"),
+]
 
 
 class InsightDriver(Schema):

--- a/server/polar/compass/service.py
+++ b/server/polar/compass/service.py
@@ -1,20 +1,29 @@
 import uuid
 from collections.abc import Sequence
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
+from typing import cast
 from zoneinfo import ZoneInfo
 
 import structlog
+from sqlalchemy.orm import selectinload
 
 from polar.auth.models import AuthSubject, Organization, User
 from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
 from polar.authz.types import AccessibleOrganizationID
+from polar.event.service import event as event_service
 from polar.kit.time_queries import TimeInterval
 from polar.logging import Logger
+from polar.metrics.aggregation import latest
+from polar.metrics.schemas import MetricsResponse
 from polar.metrics.service import metrics as metrics_service
+from polar.models import Product
+from polar.models.product_price import ProductPriceFixed
 from polar.organization.repository import OrganizationRepository
-from polar.postgres import AsyncReadSession
+from polar.postgres import AsyncReadSession, AsyncSession
+from polar.product.repository import ProductRepository
 from polar.redis import Redis
+from polar.subscription.repository import SubscriptionRepository
 
 from .detectors import DETECTORS, Detector, DetectorContext
 from .schemas import (
@@ -23,12 +32,29 @@ from .schemas import (
     InsightCategory,
     InsightSeverity,
 )
+from .signals import CustomerCostSignal, ProductPricing
 
 log: Logger = structlog.get_logger()
 
 # Extra days beyond the longest detector lookback so a `value_n_periods_ago`
 # baseline is always present in the fetched series.
 _LOOKBACK_HEADROOM_DAYS = 5
+
+# Per-product metrics cost one metrics query each; cap how many products the
+# per-product detectors read so the feed stays a bounded number of queries.
+_MAX_PRODUCTS = 8
+
+# Cost events are attributed to customers, not products (the Tinybird costs
+# pipe has no product filter), so per-product cost reads go through the
+# product's active-customer cohort as a `customer_id` filter. The filter is a
+# GET query param, which bounds how many customer UUIDs fit in the URL —
+# products with a larger cohort are skipped (their margin needs a dedicated
+# product-attributed pipe) rather than silently sampled.
+_MAX_COHORT_CUSTOMERS = 150
+
+# Per-customer cost ranking window and depth for concentration detectors.
+_CUSTOMER_COSTS_WINDOW_DAYS = 30
+_MAX_COST_CUSTOMERS = 10
 
 # What the merchant should care about most, first. Detector priority and
 # confidence only break ties within a severity band.
@@ -97,11 +123,32 @@ class CompassService:
                 log.exception("compass.metrics_error", organization_id=str(org_id))
                 continue
 
+            products = await self._product_pricing(
+                session,
+                auth_subject,
+                org_id,
+                detectors,
+                org_metrics=response,
+                today=today,
+                timezone=timezone,
+                days=days,
+                redis=redis,
+            )
+            customer_costs = await self._customer_costs(
+                session,
+                auth_subject,
+                org_id,
+                detectors,
+                today=today,
+                timezone=timezone,
+            )
             ctx = DetectorContext(
                 organization_id=org_id,
                 timezone=timezone,
                 today=today,
                 metrics=response,
+                products=products,
+                customer_costs=customer_costs,
             )
             for detector in detectors:
                 try:
@@ -129,6 +176,149 @@ class CompassService:
             )
         )
         return insights
+
+    async def _product_pricing(
+        self,
+        session: AsyncReadSession,
+        auth_subject: AuthSubject[User | Organization],
+        org_id: uuid.UUID,
+        detectors: Sequence[Detector],
+        *,
+        org_metrics: MetricsResponse,
+        today: date,
+        timezone: ZoneInfo,
+        days: int,
+        redis: Redis | None,
+    ) -> list[ProductPricing]:
+        """Per-product pricing + metrics for detectors that declare a need.
+
+        Skipped entirely unless a selected detector declares
+        `product_metric_slugs` AND the organization emits cost data — the
+        org-level gross margin reading 0 means no costs were ingested, so
+        per-product margins would be meaningless (and N wasted queries).
+        """
+        slugs = sorted({s for d in detectors for s in d.product_metric_slugs})
+        if not slugs:
+            return []
+        if latest(org_metrics, "gross_margin_percentage") <= 0:
+            return []
+
+        repository = ProductRepository.from_session(session)
+        products = await repository.get_all_by_organization(
+            org_id,
+            options=(selectinload(Product.all_prices),),
+            limit=_MAX_PRODUCTS,
+        )
+
+        subscription_repository = SubscriptionRepository.from_session(session)
+        pricing: list[ProductPricing] = []
+        for product in products:
+            price = next(
+                (
+                    p
+                    for p in product.all_prices
+                    if isinstance(p, ProductPriceFixed)
+                    and not p.is_archived
+                    and p.price_amount
+                ),
+                None,
+            )
+            if price is None:
+                continue
+            # Cost attribution goes through the product's active-customer
+            # cohort: revenue is filtered by product, costs by these customers
+            # (see _MAX_COHORT_CUSTOMERS). Fetch one past the cap to detect
+            # oversized cohorts and skip them instead of mis-sampling.
+            cohort = list(
+                await subscription_repository.get_active_customer_ids_by_product(
+                    product.id, limit=_MAX_COHORT_CUSTOMERS + 1
+                )
+            )
+            if not cohort:
+                continue
+            if len(cohort) > _MAX_COHORT_CUSTOMERS:
+                log.warning(
+                    "compass.product_cohort_too_large",
+                    organization_id=str(org_id),
+                    product_id=str(product.id),
+                    cap=_MAX_COHORT_CUSTOMERS,
+                )
+                continue
+            try:
+                response = await metrics_service.get_metrics(
+                    session,
+                    auth_subject,
+                    start_date=today - timedelta(days=days),
+                    end_date=today,
+                    timezone=timezone,
+                    interval=TimeInterval.day,
+                    organization_id=[org_id],
+                    product_id=[product.id],
+                    customer_id=cohort,
+                    metrics=slugs,
+                    redis=redis,
+                )
+            except Exception:
+                # One product's metrics failing shouldn't drop the others.
+                log.exception(
+                    "compass.product_metrics_error",
+                    organization_id=str(org_id),
+                    product_id=str(product.id),
+                )
+                continue
+            pricing.append(
+                ProductPricing(
+                    product_id=product.id,
+                    name=product.name,
+                    price_amount=price.price_amount,
+                    currency=price.price_currency,
+                    metrics=response,
+                )
+            )
+        return pricing
+
+    async def _customer_costs(
+        self,
+        session: AsyncReadSession,
+        auth_subject: AuthSubject[User | Organization],
+        org_id: uuid.UUID,
+        detectors: Sequence[Detector],
+        *,
+        today: date,
+        timezone: ZoneInfo,
+    ) -> list[CustomerCostSignal]:
+        """Per-customer cost ranking for detectors that declare a need.
+
+        Backed by the events `by-customer` statistics (summing `_cost.amount`),
+        which return each customer's share of the total — exactly the shape a
+        concentration reading needs. Failures degrade to an empty ranking.
+        """
+        if not any(detector.needs_customer_costs for detector in detectors):
+            return []
+        try:
+            stats = await event_service.list_customer_stats(
+                cast(AsyncSession, session),
+                auth_subject,
+                start_date=today - timedelta(days=_CUSTOMER_COSTS_WINDOW_DAYS),
+                end_date=today,
+                timezone=timezone,
+                organization_id=[org_id],
+                limit=_MAX_COST_CUSTOMERS,
+            )
+        except Exception:
+            log.exception("compass.customer_costs_error", organization_id=str(org_id))
+            return []
+        return [
+            CustomerCostSignal(
+                label=stat.email
+                or stat.name
+                or stat.external_customer_id
+                or str(stat.customer_id),
+                amount=float(stat.totals.get("_cost_amount", 0)),
+                share=float(stat.share),
+            )
+            for stat in stats.items
+        ]
 
     async def _compass_enabled_org_ids(
         self,

--- a/server/polar/compass/signals.py
+++ b/server/polar/compass/signals.py
@@ -13,8 +13,11 @@ signals-layer change, not a detector change.
 The per-period readers (`series`, `latest`, …) live in `polar.metrics.aggregation`.
 """
 
+import uuid
 from dataclasses import dataclass, field
 from enum import StrEnum
+
+from polar.metrics.schemas import MetricsResponse
 
 
 class DriverDimension(StrEnum):
@@ -45,6 +48,41 @@ class MetricSignal:
         if self.baseline == 0:
             return None
         return (self.current - self.baseline) / abs(self.baseline)
+
+
+@dataclass(frozen=True)
+class ProductPricing:
+    """A product's current list price plus its product-filtered metrics window.
+
+    Prefetched by the service for detectors that declare `product_metric_slugs`,
+    so per-product detectors stay pure: pricing + signals in, insight out.
+    """
+
+    product_id: uuid.UUID
+    name: str
+    price_amount: int
+    """Current list price in cents."""
+    currency: str
+    metrics: MetricsResponse
+    """The same metrics window as the organization's, scoped to this product:
+    revenue metrics filtered by product, cost metrics by its active-customer
+    cohort (cost events attach to customers, not products)."""
+
+
+@dataclass(frozen=True)
+class CustomerCostSignal:
+    """One customer's share of tracked costs over the window.
+
+    Prefetched by the service (from the events `by-customer` statistics) for
+    detectors that declare `needs_customer_costs`, keeping them pure.
+    """
+
+    label: str
+    """Customer email, name or external id — whatever identifies them best."""
+    amount: float
+    """Total `_cost.amount` over the window, in the merchant's cost unit."""
+    share: float
+    """This customer's share of all tracked costs (0-1)."""
 
 
 def format_currency(cents: float) -> str:

--- a/server/polar/integrations/polar/client.py
+++ b/server/polar/integrations/polar/client.py
@@ -667,25 +667,28 @@ class PolarSelfClient:
             except httpx.RequestError as e:
                 _raise_network_error(span, e, "track_event_ingestion")
 
-    async def track_organization_review_usage(
+    async def _track_llm_span_usage(
         self,
         *,
+        operation: str,
+        root_name: str,
+        child_name: str,
         external_customer_id: str,
-        review_context: str,
         vendor: str,
         model: str,
         input_tokens: int,
         output_tokens: int,
         cost_usd: Decimal,
     ) -> None:
+        """Ingest one LLM usage reading as a cost span: a per-customer root
+        event plus a child carrying `_llm` and `_cost` (cents) metadata."""
         total_tokens = input_tokens + output_tokens
         cost_cents = (cost_usd * Decimal(100)).quantize(Decimal("0.000001"))
-        root_external_id = f"organization_review-{external_customer_id}"
+        root_external_id = f"{root_name}-{external_customer_id}"
 
         with logfire.span(
-            "polar.track_organization_review_usage",
+            f"polar.{operation}",
             external_customer_id=external_customer_id,
-            review_context=review_context,
             vendor=vendor,
             model=model,
             input_tokens=input_tokens,
@@ -697,12 +700,12 @@ class PolarSelfClient:
                     request=EventsIngest(
                         events=[
                             EventCreateExternalCustomer(
-                                name="organization_review",
+                                name=root_name,
                                 external_customer_id=external_customer_id,
                                 external_id=root_external_id,
                             ),
                             EventCreateExternalCustomer(
-                                name=f"organization_review.{review_context}",
+                                name=child_name,
                                 external_customer_id=external_customer_id,
                                 parent_id=root_external_id,
                                 metadata={
@@ -726,9 +729,54 @@ class PolarSelfClient:
                 if e.status_code == 409:
                     span.set_attribute("conflict", True)
                     return
-                _raise_error(span, e, "track_organization_review_usage")
+                _raise_error(span, e, operation)
             except httpx.RequestError as e:
-                _raise_network_error(span, e, "track_organization_review_usage")
+                _raise_network_error(span, e, operation)
+
+    async def track_organization_review_usage(
+        self,
+        *,
+        external_customer_id: str,
+        review_context: str,
+        vendor: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: Decimal,
+    ) -> None:
+        await self._track_llm_span_usage(
+            operation="track_organization_review_usage",
+            root_name="organization_review",
+            child_name=f"organization_review.{review_context}",
+            external_customer_id=external_customer_id,
+            vendor=vendor,
+            model=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=cost_usd,
+        )
+
+    async def track_compass_assistant_usage(
+        self,
+        *,
+        external_customer_id: str,
+        vendor: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: Decimal,
+    ) -> None:
+        await self._track_llm_span_usage(
+            operation="track_compass_assistant_usage",
+            root_name="compass_assistant",
+            child_name="compass_assistant.chat",
+            external_customer_id=external_customer_id,
+            vendor=vendor,
+            model=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=cost_usd,
+        )
 
     # Customer-portal-scoped operations: create a per-call customer session
     # and act AS THE CUSTOMER. Used for fields the admin API doesn't expose.

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -224,6 +224,35 @@ class PolarSelfService:
             cost_usd=str(cost_decimal),
         )
 
+    def enqueue_track_compass_assistant_usage(
+        self,
+        *,
+        external_customer_id: str,
+        vendor: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: Decimal | float | None,
+    ) -> None:
+        if not self.is_configured:
+            return
+        if external_customer_id == settings.POLAR_ORGANIZATION_ID:
+            return
+        if cost_usd is None:
+            return
+        cost_decimal = Decimal(str(cost_usd))
+        if cost_decimal <= 0:
+            return
+        enqueue_job(
+            "polar_self.track_compass_assistant_usage",
+            external_customer_id=external_customer_id,
+            vendor=vendor,
+            model=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=str(cost_decimal),
+        )
+
     async def list_plans(self) -> list["Product"]:
         if not self.is_configured:
             raise PolarSelfNotConfigured()

--- a/server/polar/integrations/polar/tasks.py
+++ b/server/polar/integrations/polar/tasks.py
@@ -204,6 +204,28 @@ async def track_organization_review_usage(
     )
 
 
+@actor(
+    actor_name="polar_self.track_compass_assistant_usage",
+    priority=TaskPriority.LOW,
+)
+async def track_compass_assistant_usage(
+    external_customer_id: str,
+    vendor: str,
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cost_usd: str,
+) -> None:
+    await get_client().track_compass_assistant_usage(
+        external_customer_id=external_customer_id,
+        vendor=vendor,
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cost_usd=Decimal(cost_usd),
+    )
+
+
 @actor(actor_name="polar_self.webhook.benefit_grant.created", priority=TaskPriority.LOW)
 async def webhook_benefit_grant_created(event_id: uuid.UUID) -> None:
     async with AsyncSessionMaker() as session:

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -1,8 +1,9 @@
 from collections.abc import Sequence
+from datetime import datetime
 from typing import TYPE_CHECKING, cast
 from uuid import UUID
 
-from sqlalchemy import CursorResult, Select, case, select, update
+from sqlalchemy import CursorResult, Select, case, func, select, update
 from sqlalchemy.orm import joinedload, selectinload
 
 from polar.auth.models import (
@@ -52,6 +53,46 @@ class OrderRepository(
     RepositoryBase[Order],
 ):
     model = Order
+
+    async def get_revenue_by_customer(
+        self,
+        organization_id: UUID,
+        *,
+        start: datetime | None = None,
+        limit: int = 10,
+    ) -> Sequence[tuple[UUID, str | None, str | None, int, int]]:
+        """Customers ranked by paid net revenue: (customer_id, email, name,
+        order count, net revenue in cents), descending.
+
+        A repository aggregation (not the metrics layer) on purpose: ranking
+        across all customers cannot be expressed as bounded per-entity metric
+        queries the way products can.
+        """
+        net_revenue = func.coalesce(func.sum(Order.net_amount), 0)
+        statement = (
+            select(
+                Customer.id,
+                Customer.email,
+                Customer.name,
+                func.count(Order.id),
+                net_revenue,
+            )
+            .join(Customer, Customer.id == Order.customer_id)
+            .where(
+                Order.organization_id == organization_id,
+                Order.status.in_(OrderStatus.paid_statuses()),
+                Order.is_deleted.is_(False),
+            )
+            .group_by(Customer.id, Customer.email, Customer.name)
+            .order_by(net_revenue.desc())
+            .limit(limit)
+        )
+        if start is not None:
+            statement = statement.where(Order.created_at >= start)
+        result = await self.session.execute(statement)
+        return [
+            (row[0], row[1], row[2], int(row[3]), int(row[4])) for row in result.all()
+        ]
 
     async def get_all_by_customer(
         self,

--- a/server/polar/product/repository.py
+++ b/server/polar/product/repository.py
@@ -49,6 +49,26 @@ class ProductRepository(
         )
         return await self.get_one_or_none(statement)
 
+    async def get_all_by_organization(
+        self,
+        organization_id: UUID,
+        *,
+        options: Options = (),
+        limit: int | None = None,
+    ) -> Sequence[Product]:
+        statement = (
+            self.get_base_statement()
+            .where(
+                Product.organization_id == organization_id,
+                Product.is_archived.is_(False),
+            )
+            .order_by(Product.created_at.asc())
+            .options(*options)
+        )
+        if limit is not None:
+            statement = statement.limit(limit)
+        return await self.get_all(statement)
+
     async def get_by_id_and_checkout(
         self,
         id: UUID,

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -137,6 +137,23 @@ class SubscriptionRepository(
         result = await self.session.execute(statement)
         return result.scalars().all()
 
+    async def get_active_customer_ids_by_product(
+        self, product_id: UUID, *, limit: int | None = None
+    ) -> Sequence[UUID]:
+        statement = (
+            select(Subscription.customer_id)
+            .where(
+                Subscription.product_id == product_id,
+                Subscription.active.is_(True),
+                Subscription.is_deleted.is_(False),
+            )
+            .distinct()
+        )
+        if limit is not None:
+            statement = statement.limit(limit)
+        result = await self.session.execute(statement)
+        return result.scalars().all()
+
     async def get_by_id_and_organization(
         self,
         id: UUID,

--- a/server/tests/compass/test_assistant.py
+++ b/server/tests/compass/test_assistant.py
@@ -1,0 +1,201 @@
+import uuid
+from datetime import date
+from types import SimpleNamespace
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import pytest
+from pydantic import TypeAdapter
+
+from polar.auth.scope import Scope
+from polar.compass.assistant.agent import tools_for_scopes
+from polar.compass.assistant.blocks import (
+    AssistantBlock,
+    InsightCardsBlock,
+    MetricChartBlock,
+    MetricChartPoint,
+    TextBlock,
+)
+from polar.compass.assistant.customer_tools import get_customer_overview
+from polar.compass.assistant.deps import AssistantDeps
+from polar.compass.assistant.entity_tools import (
+    list_checkouts,
+    list_customers,
+    list_disputes,
+    list_orders,
+    list_payouts,
+    list_products,
+    list_refunds,
+    list_subscriptions,
+    top_customers_by_cost,
+    top_customers_by_revenue,
+    top_products_by_revenue,
+)
+from polar.compass.assistant.tools import get_insights, get_metrics, show_insights
+
+
+def _deps(scopes: set[Scope]) -> AssistantDeps:
+    return AssistantDeps(
+        session=None,  # type: ignore[arg-type] — denial paths never touch it
+        auth_subject=SimpleNamespace(scopes=scopes),  # type: ignore[arg-type]
+        organization_id=uuid.uuid4(),
+        timezone=ZoneInfo("UTC"),
+        today=date(2026, 7, 6),
+    )
+
+
+def _ctx(deps: AssistantDeps) -> Any:
+    return SimpleNamespace(deps=deps)
+
+
+class TestToolsForScopes:
+    def test_metrics_read_grants_the_read_tools(self) -> None:
+        tools = tools_for_scopes({Scope.metrics_read})
+
+        assert get_metrics in tools
+        assert get_insights in tools
+        assert show_insights in tools
+        assert top_products_by_revenue in tools
+
+    def test_scopes_grant_exactly_their_tools(self) -> None:
+        tools = tools_for_scopes({Scope.orders_read})
+
+        assert tools == [list_orders, top_customers_by_revenue]
+
+    def test_each_entity_scope_maps_to_its_tool(self) -> None:
+        cases: dict[Scope, list[object]] = {
+            Scope.subscriptions_read: [list_subscriptions],
+            Scope.customers_read: [list_customers, get_customer_overview],
+            Scope.products_read: [list_products],
+            Scope.disputes_read: [list_disputes],
+            Scope.checkouts_read: [list_checkouts],
+            Scope.refunds_read: [list_refunds],
+            Scope.payouts_read: [list_payouts],
+            Scope.events_read: [top_customers_by_cost],
+        }
+        for scope, tools in cases.items():
+            assert tools_for_scopes({scope}) == tools
+
+    def test_no_scopes_grant_nothing(self) -> None:
+        assert tools_for_scopes(set()) == []
+
+
+@pytest.mark.asyncio
+class TestToolScopeGuards:
+    async def test_get_metrics_denies_without_scope(self) -> None:
+        deps = _deps(scopes=set())
+
+        result = await get_metrics(_ctx(deps), ["monthly_recurring_revenue"])
+
+        assert "Permission denied" in result
+        assert "metrics:read" in result
+        assert deps.blocks == []
+
+    async def test_get_insights_denies_without_scope(self) -> None:
+        deps = _deps(scopes=set())
+
+        result = await get_insights(_ctx(deps))
+
+        assert "Permission denied" in result
+        assert deps.blocks == []
+
+    async def test_show_insights_denies_without_scope(self) -> None:
+        deps = _deps(scopes=set())
+
+        result = await show_insights(_ctx(deps), ["x"])
+
+        assert "Permission denied" in result
+        assert deps.blocks == []
+
+    async def test_entity_tools_deny_without_their_scope(self) -> None:
+        deps = _deps(scopes={Scope.metrics_read})
+
+        for tool in (
+            list_orders,
+            list_subscriptions,
+            list_customers,
+            list_products,
+            list_disputes,
+        ):
+            result = await tool(_ctx(deps))
+            assert "Permission denied" in result
+        assert deps.blocks == []
+
+    async def test_get_metrics_rejects_unknown_slugs_before_fetching(self) -> None:
+        deps = _deps(scopes={Scope.metrics_read})
+
+        result = await get_metrics(_ctx(deps), ["not_a_metric"])
+
+        assert "Unknown metric slugs" in result
+        assert deps.blocks == []
+
+
+class TestAssistantBlocks:
+    def test_union_round_trips_on_type(self) -> None:
+        adapter: TypeAdapter[AssistantBlock] = TypeAdapter(AssistantBlock)
+        chart = MetricChartBlock(
+            metric="monthly_recurring_revenue",
+            label="Monthly Recurring Revenue",
+            unit="currency",
+            points=[MetricChartPoint(timestamp="2026-07-01T00:00:00Z", value=1.0)],  # type: ignore[arg-type]
+        )
+
+        parsed = adapter.validate_python(chart.model_dump(mode="json"))
+
+        assert isinstance(parsed, MetricChartBlock)
+        assert parsed.type == "metric_chart"
+
+    def test_text_and_cards_discriminate(self) -> None:
+        adapter: TypeAdapter[AssistantBlock] = TypeAdapter(AssistantBlock)
+
+        text = adapter.validate_python({"type": "text", "text": "hi"})
+        cards = adapter.validate_python({"type": "insight_cards", "insights": []})
+
+        assert isinstance(text, TextBlock)
+        assert isinstance(cards, InsightCardsBlock)
+
+
+class TestBlockPlacer:
+    def test_splits_text_around_marker(self) -> None:
+        from polar.compass.assistant.stream import _BlockPlacer
+
+        placer = _BlockPlacer()
+
+        out = placer.feed("Best customer: jane. [block:1] Next up")
+
+        assert out == [
+            ("text", "Best customer: jane."),
+            ("block", 1),
+            ("text", "Next up"),
+        ]
+
+    def test_marker_split_across_deltas(self) -> None:
+        from polar.compass.assistant.stream import _BlockPlacer
+
+        placer = _BlockPlacer()
+
+        first = placer.feed("claim one [blo")
+        second = placer.feed("ck:2] tail")
+
+        assert first == [("text", "claim one ")]
+        assert second == [("block", 2), ("text", "tail")]
+
+    def test_plain_bracket_is_not_held_forever(self) -> None:
+        from polar.compass.assistant.stream import _BlockPlacer
+
+        placer = _BlockPlacer()
+
+        out = placer.feed("ranges [1, 2] are fine")
+
+        assert ("block", 1) not in out
+        assert (
+            "".join(str(v) for k, v in out if k == "text") == "ranges [1, 2] are fine"
+        )
+
+    def test_flush_returns_held_partial(self) -> None:
+        from polar.compass.assistant.stream import _BlockPlacer
+
+        placer = _BlockPlacer()
+        placer.feed("ends with [block:")
+
+        assert placer.flush() == "[block:"

--- a/server/tests/compass/test_detectors.py
+++ b/server/tests/compass/test_detectors.py
@@ -4,17 +4,28 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
+from polar.compass.detectors import DETECTORS
 from polar.compass.detectors.arpu import ARPUMovementDetector
 from polar.compass.detectors.base import DetectorContext, confidence_for_sample
 from polar.compass.detectors.churn import ChurnSpikeDetector
 from polar.compass.detectors.conversion import CheckoutConversionDetector
 from polar.compass.detectors.cost_per_user import CostPerUserDetector
+from polar.compass.detectors.customer_cost import CostConcentrationDetector
 from polar.compass.detectors.margin import GrossMarginDetector
 from polar.compass.detectors.mrr import MRRGrowthDetector
+from polar.compass.detectors.product_margin import ProductMarginDetector
 from polar.compass.detectors.subscribers import SubscriberGrowthDetector
 from polar.compass.detectors.trials import TrialConversionDetector
 from polar.compass.keys import build_insight_key, parse_insight_key
-from polar.compass.schemas import ConfidenceLevel, InsightCategory, InsightSeverity
+from polar.compass.schemas import (
+    AdjustPriceAction,
+    ConfidenceLevel,
+    Insight,
+    InsightCategory,
+    InsightSeverity,
+    ViewMetricAction,
+)
+from polar.compass.signals import CustomerCostSignal, ProductPricing
 from polar.metrics.schemas import MetricsResponse
 
 
@@ -482,6 +493,18 @@ class TestCostPerUserDetector:
 
         assert insight is None
 
+    def test_silent_when_baseline_negligible(self) -> None:
+        # Cost tracking just started: a near-zero baseline against real costs
+        # would read as an absurd million-percent increase, not a trend.
+        cpu = [1.0] * 6 + [1.0] * 29 + [13_750.0]
+        subs = [50.0] * 36
+
+        insight = CostPerUserDetector().evaluate(
+            _context(_response_from(cost_per_user=cpu, active_subscriptions=subs))
+        )
+
+        assert insight is None
+
 
 class TestCheckoutConversionDetector:
     def test_fires_when_conversion_drops(self) -> None:
@@ -558,3 +581,288 @@ class TestCheckoutConversionDetector:
         )
 
         assert insight is None
+
+
+def _product(
+    name: str = "Pro",
+    price_amount: int = 4000,
+    margin: float = 0.5,
+    subs: float = 50.0,
+) -> ProductPricing:
+    return ProductPricing(
+        product_id=uuid.uuid4(),
+        name=name,
+        price_amount=price_amount,
+        currency="usd",
+        metrics=_response_from(
+            gross_margin_percentage=[margin] * 36,
+            active_subscriptions=[subs] * 36,
+        ),
+    )
+
+
+def _context_with_customer_costs(
+    customer_costs: list[CustomerCostSignal],
+) -> DetectorContext:
+    return DetectorContext(
+        organization_id=uuid.uuid4(),
+        timezone=ZoneInfo("UTC"),
+        today=date(2026, 2, 6),
+        metrics=_response_from(active_subscriptions=[50.0] * 36),
+        customer_costs=tuple(customer_costs),
+    )
+
+
+def _cost_signal(label: str, share: float, amount: float = 100.0) -> CustomerCostSignal:
+    return CustomerCostSignal(label=label, amount=amount, share=share)
+
+
+def _context_with_products(products: list[ProductPricing]) -> DetectorContext:
+    return DetectorContext(
+        organization_id=uuid.uuid4(),
+        timezone=ZoneInfo("UTC"),
+        today=date(2026, 2, 6),
+        metrics=_response_from(gross_margin_percentage=[0.5] * 36),
+        products=tuple(products),
+    )
+
+
+class TestProductMarginDetector:
+    def test_fires_with_price_suggestion(self) -> None:
+        # $40 product at 41% margin: ~$23.60 goes to serving each customer.
+        product = _product(price_amount=4000, margin=0.41)
+
+        insight = ProductMarginDetector().evaluate(_context_with_products([product]))
+
+        assert insight is not None
+        assert insight.category is InsightCategory.cost
+        assert insight.severity is InsightSeverity.warning
+        assert "Pro margin is down to 41%" in insight.title
+        assert "$24 per customer" in insight.body
+        action = insight.primary_action
+        assert isinstance(action, AdjustPriceAction)
+        assert action.product_id == product.product_id
+        assert action.current_price_amount == 4000
+        # ceil(4000 * 0.59 / 0.30 / 100) * 100 — the price restoring 70% margin.
+        assert action.suggested_price_amount == 7900
+        assert "$79" in insight.body
+
+    def test_deep_margin_loss_is_critical(self) -> None:
+        insight = ProductMarginDetector().evaluate(
+            _context_with_products([_product(margin=0.30)])
+        )
+
+        assert insight is not None
+        assert insight.severity is InsightSeverity.critical
+
+    def test_picks_the_worst_product(self) -> None:
+        healthy = _product(name="Starter", margin=0.85)
+        thin = _product(name="Pro", margin=0.55)
+        thinner = _product(name="Enterprise", margin=0.45)
+
+        insight = ProductMarginDetector().evaluate(
+            _context_with_products([healthy, thin, thinner])
+        )
+
+        assert insight is not None
+        assert "Enterprise" in insight.title
+        action = insight.primary_action
+        assert isinstance(action, AdjustPriceAction)
+        assert action.product_id == thinner.product_id
+
+    def test_no_insight_when_margins_healthy(self) -> None:
+        insight = ProductMarginDetector().evaluate(
+            _context_with_products([_product(margin=0.85)])
+        )
+
+        assert insight is None
+
+    def test_silent_without_cost_data(self) -> None:
+        # Margin of 0 means no cost data for the product, not a 0% business.
+        insight = ProductMarginDetector().evaluate(
+            _context_with_products([_product(margin=0.0)])
+        )
+
+        assert insight is None
+
+    def test_suppressed_when_sample_too_small(self) -> None:
+        insight = ProductMarginDetector().evaluate(
+            _context_with_products([_product(margin=0.41, subs=3.0)])
+        )
+
+        assert insight is None
+
+    def test_no_insight_without_products(self) -> None:
+        insight = ProductMarginDetector().evaluate(_context_with_products([]))
+
+        assert insight is None
+
+
+class TestCostConcentrationDetector:
+    def test_fires_on_concentration(self) -> None:
+        signals = [_cost_signal("big@corp.com", 0.55)] + [
+            _cost_signal(f"c{i}@x.com", 0.09) for i in range(5)
+        ]
+
+        insight = CostConcentrationDetector().evaluate(
+            _context_with_customer_costs(signals)
+        )
+
+        assert insight is not None
+        assert insight.category is InsightCategory.risk
+        assert insight.severity is InsightSeverity.warning
+        assert "55% of your costs" in insight.title
+        assert "big@corp.com" in insight.body
+        assert insight.detector_id == "cost_concentration"
+
+    def test_extreme_concentration_is_critical(self) -> None:
+        signals = [_cost_signal("whale@corp.com", 0.7)] + [
+            _cost_signal(f"c{i}@x.com", 0.06) for i in range(5)
+        ]
+
+        insight = CostConcentrationDetector().evaluate(
+            _context_with_customer_costs(signals)
+        )
+
+        assert insight is not None
+        assert insight.severity is InsightSeverity.critical
+
+    def test_silent_when_costs_spread_out(self) -> None:
+        signals = [_cost_signal(f"c{i}@x.com", 0.2) for i in range(5)]
+
+        insight = CostConcentrationDetector().evaluate(
+            _context_with_customer_costs(signals)
+        )
+
+        assert insight is None
+
+    def test_suppressed_when_too_few_customers(self) -> None:
+        signals = [_cost_signal("a@x.com", 0.8), _cost_signal("b@x.com", 0.2)]
+
+        insight = CostConcentrationDetector().evaluate(
+            _context_with_customer_costs(signals)
+        )
+
+        assert insight is None
+
+    def test_silent_without_cost_data(self) -> None:
+        insight = CostConcentrationDetector().evaluate(_context_with_customer_costs([]))
+
+        assert insight is None
+
+
+class TestInsightCopy:
+    def test_no_em_dashes_in_any_emitted_copy(self) -> None:
+        """Em dashes are banned in user-facing copy; use comma, colon or period."""
+        subs = [50.0] * 36
+        firing: list[Insight | None] = [
+            MRRGrowthDetector().evaluate(
+                _context(
+                    _response([100_000.0] * 6 + [110_000.0] * 29 + [120_000.0], subs)
+                )
+            ),
+            SubscriberGrowthDetector().evaluate(
+                _context(
+                    _response_from(
+                        active_subscriptions=[10.0] * 6 + [12.0] * 29 + [16.0]
+                    )
+                )
+            ),
+            ARPUMovementDetector().evaluate(
+                _context(
+                    _response_from(
+                        average_revenue_per_user=[25_000.0] * 6
+                        + [22_000.0] * 29
+                        + [19_400.0],
+                        active_subscriptions=subs,
+                    )
+                )
+            ),
+            # Churn with a rising prior window, so the extra sentence renders too.
+            ChurnSpikeDetector().evaluate(
+                _context(
+                    _response_from(
+                        churned_subscriptions=[0.0] * 6 + [1.0] * 30 + [2.0] * 30,
+                        active_subscriptions=[50.0] * 66,
+                    )
+                )
+            ),
+            TrialConversionDetector().evaluate(
+                _context(
+                    _response_from(
+                        trial_monthly_recurring_revenue=[0.0] * 35 + [100_000.0],
+                        monthly_recurring_revenue=[900_000.0] * 36,
+                        active_subscriptions=subs,
+                    )
+                )
+            ),
+            GrossMarginDetector().evaluate(
+                _context(
+                    _response_from(
+                        gross_margin_percentage=[0.8] * 6 + [0.75] * 29 + [0.55],
+                        active_subscriptions=subs,
+                    )
+                )
+            ),
+            CostPerUserDetector().evaluate(
+                _context(
+                    _response_from(
+                        cost_per_user=[200.0] * 6 + [250.0] * 29 + [300.0],
+                        active_subscriptions=subs,
+                    )
+                )
+            ),
+            CheckoutConversionDetector().evaluate(
+                _context(
+                    _response_from(
+                        checkouts=[0.0] * 6 + [20.0] + [0.0] * 29 + [20.0] + [0.0] * 29,
+                        succeeded_checkouts=[0.0] * 6
+                        + [16.0]
+                        + [0.0] * 29
+                        + [11.0]
+                        + [0.0] * 29,
+                    )
+                )
+            ),
+            ProductMarginDetector().evaluate(
+                _context_with_products([_product(margin=0.41)])
+            ),
+            CostConcentrationDetector().evaluate(
+                _context_with_customer_costs(
+                    [_cost_signal("big@corp.com", 0.62)]
+                    + [_cost_signal(f"c{i}@x.com", 0.076) for i in range(5)]
+                )
+            ),
+        ]
+
+        assert len(firing) == len(DETECTORS)
+        for insight in firing:
+            assert insight is not None, "every registered detector must fire here"
+            copy = [insight.title, insight.body, insight.why or ""]
+            if insight.primary_action is not None:
+                copy.append(insight.primary_action.label)
+            for text in copy:
+                assert "—" not in text, f"em dash in {insight.detector_id}: {text!r}"
+
+
+class TestInsightActionUnion:
+    def test_adjust_price_round_trips_through_the_wire_format(self) -> None:
+        insight = ProductMarginDetector().evaluate(
+            _context_with_products([_product(margin=0.41)])
+        )
+        assert insight is not None
+
+        parsed = Insight.model_validate(insight.model_dump())
+
+        assert isinstance(parsed.primary_action, AdjustPriceAction)
+        assert parsed.primary_action.type == "adjust_price"
+
+    def test_view_metric_round_trips_through_the_wire_format(self) -> None:
+        mrr = [100_000.0] * 6 + [110_000.0] * 29 + [120_000.0]
+        insight = MRRGrowthDetector().evaluate(_context(_response(mrr, [50.0] * 36)))
+        assert insight is not None
+
+        parsed = Insight.model_validate(insight.model_dump())
+
+        assert isinstance(parsed.primary_action, ViewMetricAction)
+        assert parsed.primary_action.type == "view_metric"

--- a/server/tests/compass/test_endpoints.py
+++ b/server/tests/compass/test_endpoints.py
@@ -1,0 +1,47 @@
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from polar.models import Organization, UserOrganization
+from tests.fixtures.database import SaveFixture
+
+
+@pytest.mark.asyncio
+class TestAssistantChat:
+    async def test_anonymous(
+        self, client: AsyncClient, organization: Organization
+    ) -> None:
+        response = await client.post(
+            "/v1/compass/assistant",
+            json={"organization_id": str(organization.id), "prompt": "hi"},
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_inaccessible_organization(self, client: AsyncClient) -> None:
+        response = await client.post(
+            "/v1/compass/assistant",
+            json={"organization_id": str(uuid.uuid4()), "prompt": "hi"},
+        )
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_compass_disabled_organization(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        organization.feature_settings = {}
+        await save_fixture(organization)
+
+        response = await client.post(
+            "/v1/compass/assistant",
+            json={"organization_id": str(organization.id), "prompt": "hi"},
+        )
+
+        assert response.status_code == 404

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -367,6 +367,67 @@ class TestEnqueueTrackOrganizationReviewUsage:
         assert enqueue.call_args.kwargs["cost_usd"] == "0.5"
 
 
+class TestEnqueueTrackCompassAssistantUsage:
+    def _call(
+        self,
+        *,
+        external_customer_id: str = str(ORG_A),
+        cost_usd: Decimal | float | None = Decimal("0.0042"),
+    ) -> None:
+        polar_self.enqueue_track_compass_assistant_usage(
+            external_customer_id=external_customer_id,
+            vendor="openai",
+            model="gpt-5.5",
+            input_tokens=1200,
+            output_tokens=300,
+            cost_usd=cost_usd,
+        )
+
+    def test_noop_when_not_configured(self, mocker: MockerFixture) -> None:
+        settings = mocker.patch("polar.integrations.polar.service.settings")
+        settings.POLAR_SELF_ENABLED = False
+        enqueue = mocker.patch("polar.integrations.polar.service.enqueue_job")
+
+        self._call()
+
+        enqueue.assert_not_called()
+
+    def test_noop_for_self_organization(
+        self, configured: None, mocker: MockerFixture
+    ) -> None:
+        enqueue = mocker.patch("polar.integrations.polar.service.enqueue_job")
+
+        self._call(external_customer_id=str(SELF_ORG_ID))
+
+        enqueue.assert_not_called()
+
+    def test_noop_when_cost_is_none(
+        self, configured: None, mocker: MockerFixture
+    ) -> None:
+        enqueue = mocker.patch("polar.integrations.polar.service.enqueue_job")
+
+        self._call(cost_usd=None)
+
+        enqueue.assert_not_called()
+
+    def test_enqueues_job_with_serialized_cost(
+        self, configured: None, mocker: MockerFixture
+    ) -> None:
+        enqueue = mocker.patch("polar.integrations.polar.service.enqueue_job")
+
+        self._call(cost_usd=Decimal("0.0042"))
+
+        enqueue.assert_called_once_with(
+            "polar_self.track_compass_assistant_usage",
+            external_customer_id=str(ORG_A),
+            vendor="openai",
+            model="gpt-5.5",
+            input_tokens=1200,
+            output_tokens=300,
+            cost_usd="0.0042",
+        )
+
+
 @pytest.mark.asyncio
 class TestResolveFreePlan:
     async def test_subscribed_org_gets_standard_free(


### PR DESCRIPTION
**All work is gated behind the compass feature flag**

Add the Compass assistant backend: an agentic chat endpoint over the
merchant's own organization, built on Pydantic AI + the Pydantic AI Gateway
(the organization_review pattern).

- SSE endpoint POST /v1/compass/assistant streaming text deltas, renderable
  block events and opaque conversation state; gated per organization by the
  compass_enabled feature flag before any model call.
- Scope safety: the agent runs under the caller's auth subject. Its toolset
  is derived from the token's granted scopes (a tool whose scope the caller
  lacks is not registered), each tool re-checks its scope at runtime, and
  the organization always comes from validated deps, never model arguments.
- Generative UI: tools return typed blocks from a closed discriminated
  union (text, metric chart, insight cards, entity list, data table,
  customer card) that the client maps to predefined components. The model
  places blocks under the claims they support via [block:N] markers parsed
  out of the token stream.
- Tools: metrics, insights (fetch/render split with a show step), entity
  listings (orders, subscriptions, customers, products, disputes,
  checkouts, refunds, payouts), customer overview, and rankings (products
  by revenue via per-product metric queries, customers by revenue,
  customers by cost).
- Compass additions: cost-concentration detector (risk category) fed by a
  per-customer cost prefetch from the events statistics.
- Polar-for-Polar: each assistant run ingests its own inference cost as a
  span on the Polar organization, mirroring organization reviews.

Frontend follows in a separate PR.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

