### PR TITLE
aws/security: Link up to allow tf cloud to run in security account

### DIFF
--- a/terraform/global/aws.tf
+++ b/terraform/global/aws.tf
@@ -22,6 +22,10 @@ locals {
       account_id = "986542260309"
       workspace  = "identity"
     }
+    security = {
+      account_id = "297245370456"
+      workspace  = "security"
+    }
   }
 }
 

--- a/terraform/organization/guardduty.tf
+++ b/terraform/organization/guardduty.tf
@@ -22,6 +22,20 @@ resource "aws_guardduty_detector_feature" "management_us_east_2_s3_data_events" 
   status      = "ENABLED"
 }
 
+resource "aws_guardduty_organization_admin_account" "us_east_1" {
+  admin_account_id = aws_organizations_account.security.id
+
+  depends_on = [aws_guardduty_detector.management]
+}
+
+resource "aws_guardduty_organization_admin_account" "us_east_2" {
+  provider = aws.us_east_2
+
+  admin_account_id = aws_organizations_account.security.id
+
+  depends_on = [aws_guardduty_detector.management_us_east_2]
+}
+
 resource "aws_cloudwatch_event_rule" "malware_scan_threats_found" {
   provider = aws.us_east_2
 

--- a/terraform/organization/outputs.tf
+++ b/terraform/organization/outputs.tf
@@ -52,6 +52,7 @@ output "terraform_cloud_run_roles" {
     sandbox    = module.terraform_cloud_run_role_sandbox.role_arn
     test       = module.terraform_cloud_run_role_test.role_arn
     identity   = module.terraform_cloud_run_role_identity.role_arn
+    security   = module.terraform_cloud_run_role_security.role_arn
   }
 }
 

--- a/terraform/organization/security_account.tf
+++ b/terraform/organization/security_account.tf
@@ -1,5 +1,12 @@
+locals {
+  security_account = {
+    name = "security"
+    id   = "297245370456"
+  }
+}
+
 resource "aws_organizations_account" "security" {
-  name              = "security"
+  name              = local.security_account.name
   email             = var.security_account_email
   parent_id         = aws_organizations_organizational_unit.security.id
   close_on_deletion = false

--- a/terraform/organization/terraform_cloud.tf
+++ b/terraform/organization/terraform_cloud.tf
@@ -20,6 +20,10 @@ locals {
         project   = "Polar"
         workspace = "identity"
       }
+      security = {
+        project   = "Polar"
+        workspace = "security"
+      }
     }
 
     run_role_policy_arns = {
@@ -61,6 +65,15 @@ provider "aws" {
 
   assume_role {
     role_arn = "arn:aws:iam::${local.identity_account.id}:role/${var.member_account_bootstrap_role_name}"
+  }
+}
+
+provider "aws" {
+  alias  = "security"
+  region = "us-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.security_account.id}:role/${var.member_account_bootstrap_role_name}"
   }
 }
 
@@ -113,5 +126,18 @@ module "terraform_cloud_run_role_identity" {
   terraform_cloud_organization = local.terraform_cloud.organization
   terraform_cloud_project      = local.terraform_cloud.workspaces.identity.project
   terraform_cloud_workspace    = local.terraform_cloud.workspaces.identity.workspace
+  policy_arns                  = local.terraform_cloud.run_role_policy_arns
+}
+
+module "terraform_cloud_run_role_security" {
+  source = "../modules/terraform_cloud_run_role"
+  providers = {
+    aws = aws.security
+  }
+
+  role_name                    = local.terraform_cloud.role_name
+  terraform_cloud_organization = local.terraform_cloud.organization
+  terraform_cloud_project      = local.terraform_cloud.workspaces.security.project
+  terraform_cloud_workspace    = local.terraform_cloud.workspaces.security.workspace
   policy_arns                  = local.terraform_cloud.run_role_policy_arns
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable Terraform Cloud to assume a run role in the Security AWS account and set that account as the GuardDuty delegated admin in us-east-1 and us-east-2. Adds provider wiring and outputs for the new `security` workspace.

- **New Features**
  - Added `security` account/workspace to locals and outputs (`terraform_cloud_run_roles.security`).
  - Introduced `aws.security` provider (us-east-1) assuming the member bootstrap role in the security account.
  - Created `terraform_cloud_run_role_security` to grant Terraform Cloud access to the `security` workspace.
  - Set GuardDuty organization admin to the security account in us-east-1 and us-east-2 with detector dependencies.

<sup>Written for commit da6f505633eaf92ee9eda400ef11a8b1ed1c83fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/12996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

