### PR TITLE
feat(subscription): cycle-style auto-resume scheduler

### DIFF
--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -327,24 +327,6 @@ class SubscriptionRepository(
         )
         return await self.get_all(statement)
 
-    async def get_subscriptions_to_resume(
-        self,
-        now: datetime,
-        *,
-        options: Options = (),
-    ) -> Sequence[Subscription]:
-        """Find paused subscriptions whose scheduled resume time has passed."""
-        statement = (
-            self.get_base_statement()
-            .where(
-                Subscription.status == SubscriptionStatus.paused,
-                Subscription.resumes_at.isnot(None),
-                Subscription.resumes_at <= now,
-            )
-            .options(*options)
-        )
-        return await self.get_all(statement)
-
     async def get_subscriptions_needing_trial_conversion_reminder(
         self,
         now: datetime,

--- a/server/polar/subscription/scheduler.py
+++ b/server/polar/subscription/scheduler.py
@@ -1,11 +1,12 @@
 import datetime
+from typing import ClassVar, cast
 
 import dramatiq
 import structlog
 from apscheduler.job import Job
 from apscheduler.jobstores.base import BaseJobStore
 from apscheduler.triggers.date import DateTrigger
-from sqlalchemy import Select, select, update
+from sqlalchemy import ColumnElement, Select, select, update
 from sqlalchemy.orm import Session
 
 from polar.kit.utils import utc_now
@@ -16,11 +17,13 @@ from polar.postgres import create_sync_engine
 log: Logger = structlog.get_logger()
 
 
-class SubscriptionJobStore(BaseJobStore):
-    """
-    A custom job store for APScheduler that uses our subscription data to trigger
-    cycle jobs based on subscription dates
-    """
+class _SubscriptionScheduleJobStore(BaseJobStore):
+    """APScheduler job store that turns subscription rows into date-triggered jobs,
+    dispatched under an atomic ``scheduler_locked_at`` claim."""
+
+    trigger_column: ClassVar[ColumnElement[datetime.datetime | None]]
+    job_id_prefix: ClassVar[str]
+    actor_name: ClassVar[str]
 
     def __init__(self, executor: str = "default") -> None:
         self.engine = create_sync_engine("scheduler")
@@ -34,29 +37,27 @@ class SubscriptionJobStore(BaseJobStore):
         return None
 
     def get_due_jobs(self, now: datetime.datetime) -> list[Job]:
-        statement = self.scheduling_statement().where(
-            Subscription.current_period_end <= now,
-        )
+        statement = self.scheduling_statement().where(self.trigger_column <= now)
         jobs = self._list_jobs_from_statement(statement)
-        log.debug("Due jobs", count=len(jobs))
+        log.debug("Due jobs", count=len(jobs), store=self.job_id_prefix)
         return jobs
 
     def get_next_run_time(self) -> datetime.datetime | None:
         statement = (
-            self.scheduling_statement()
-            .with_only_columns(Subscription.current_period_end)
-            .limit(1)
+            self.scheduling_statement().with_only_columns(self.trigger_column).limit(1)
         )
         with self.engine.connect() as connection:
             result = connection.execute(statement)
             next_run_time = result.scalar_one_or_none()
-            log.debug("Next run time", next_run_time=next_run_time)
+            log.debug(
+                "Next run time", next_run_time=next_run_time, store=self.job_id_prefix
+            )
             return next_run_time
 
     def get_all_jobs(self) -> list[Job]:
         statement = self.scheduling_statement()
         jobs = self._list_jobs_from_statement(statement)
-        log.debug("All jobs", count=len(jobs))
+        log.debug("All jobs", count=len(jobs), store=self.job_id_prefix)
         return jobs
 
     def remove_job(self, job_id: str) -> None:
@@ -73,7 +74,7 @@ class SubscriptionJobStore(BaseJobStore):
         with self.engine.begin() as connection:
             if connection.execute(statement).rowcount == 0:
                 return
-        actor = dramatiq.get_broker().get_actor("subscription.cycle")
+        actor = dramatiq.get_broker().get_actor(self.actor_name)
         actor.send(subscription_id=subscription_id)
 
     def add_job(self, job: Job) -> None:
@@ -92,12 +93,12 @@ class SubscriptionJobStore(BaseJobStore):
         with Session(self.engine) as session:
             results = session.execute(
                 statement.with_only_columns(
-                    Subscription.id, Subscription.current_period_end
+                    Subscription.id, self.trigger_column
                 ).execution_options(stream_results=True, max_row_buffer=250)
             )
             for result in results.yield_per(250):
-                subscription_id, current_period_end = result._tuple()
-                trigger = DateTrigger(current_period_end, datetime.UTC)
+                subscription_id, run_date = result._tuple()
+                trigger = DateTrigger(run_date, datetime.UTC)
                 job_kwargs = {
                     **(self._scheduler._job_defaults if self._scheduler else {}),
                     "trigger": trigger,
@@ -105,7 +106,7 @@ class SubscriptionJobStore(BaseJobStore):
                     "func": lambda: None,
                     "args": (),
                     "kwargs": {},
-                    "id": f"subscriptions:cycle:{subscription_id}",
+                    "id": f"{self.job_id_prefix}:{subscription_id}",
                     "name": None,
                     "next_run_time": trigger.run_date,
                     "misfire_grace_time": None,
@@ -115,7 +116,21 @@ class SubscriptionJobStore(BaseJobStore):
 
     @staticmethod
     def scheduling_statement() -> Select[tuple[Subscription]]:
-        """Base query for subscriptions eligible for scheduler processing.
+        raise NotImplementedError
+
+
+class SubscriptionJobStore(_SubscriptionScheduleJobStore):
+    """Triggers ``subscription.cycle`` at each active subscription's period end."""
+
+    trigger_column = cast(
+        ColumnElement[datetime.datetime | None], Subscription.current_period_end
+    )
+    job_id_prefix = "subscriptions:cycle"
+    actor_name = "subscription.cycle"
+
+    @staticmethod
+    def scheduling_statement() -> Select[tuple[Subscription]]:
+        """Base query for subscriptions eligible for cycle scheduling.
 
         Returns an engine-agnostic ``Select`` — safe to execute via either
         a sync ``Session`` (production APScheduler) or an async ``AsyncSession``

--- a/server/polar/subscription/scheduler.py
+++ b/server/polar/subscription/scheduler.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 from polar.kit.utils import utc_now
 from polar.logging import Logger
 from polar.models import Customer, Organization, Subscription
+from polar.models.subscription import SubscriptionStatus
 from polar.postgres import create_sync_engine
 
 log: Logger = structlog.get_logger()
@@ -149,4 +150,33 @@ class SubscriptionJobStore(_SubscriptionScheduleJobStore):
                 Subscription.current_period_end.is_not(None),
             )
             .order_by(Subscription.current_period_end.asc())
+        )
+
+
+class SubscriptionResumeJobStore(_SubscriptionScheduleJobStore):
+    """Triggers ``subscription.resume`` at each paused subscription's ``resumes_at``."""
+
+    trigger_column = cast(
+        ColumnElement[datetime.datetime | None], Subscription.resumes_at
+    )
+    job_id_prefix = "subscriptions:resume"
+    actor_name = "subscription.resume"
+
+    @staticmethod
+    def scheduling_statement() -> Select[tuple[Subscription]]:
+        """Paused subscriptions eligible for auto-resume. Excludes renewals-disabled
+        orgs — resuming charges immediately (the API path guards separately)."""
+        return (
+            select(Subscription)
+            .join(Customer, onclause=Customer.id == Subscription.customer_id)
+            .join(Organization, onclause=Organization.id == Customer.organization_id)
+            .where(
+                Customer.is_deleted.is_(False),
+                Organization.is_deleted.is_(False),
+                Organization.can_renew_subscriptions.is_(True),
+                Subscription.scheduler_locked_at.is_(None),
+                Subscription.status == SubscriptionStatus.paused,
+                Subscription.resumes_at.is_not(None),
+            )
+            .order_by(Subscription.resumes_at.asc())
         )

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1957,6 +1957,7 @@ class SubscriptionService:
         subscription.status = SubscriptionStatus.active
         subscription.paused_at = None
         subscription.resumes_at = None
+        subscription.scheduler_locked_at = None
 
         # Start a fresh billing period from now and charge immediately.
         subscription.current_period_start = now

--- a/server/polar/subscription/tasks.py
+++ b/server/polar/subscription/tasks.py
@@ -149,24 +149,10 @@ async def subscription_cancel_customer(customer_id: uuid.UUID) -> None:
         await subscription_service.cancel_customer(session, customer_id)
 
 
-@actor(
-    actor_name="subscription.scan_paused_resumptions",
-    cron_trigger=CronTrigger.from_crontab("15 * * * *"),
-    priority=TaskPriority.LOW,
-)
-async def scan_paused_resumptions() -> None:
-    """Scan for paused subscriptions due to resume and fan out."""
-    now = utc_now()
-    async with AsyncSessionMaker() as session:
-        repository = SubscriptionRepository.from_session(session)
-        subscriptions = await repository.get_subscriptions_to_resume(now)
-
-    for sub in subscriptions:
-        enqueue_job("subscription.resume", sub.id)
-
-
 @actor(actor_name="subscription.resume", priority=TaskPriority.MEDIUM)
 async def subscription_resume(subscription_id: uuid.UUID) -> None:
+    """Resume a paused subscription. Enqueued by the resume scheduler once its
+    ``resumes_at`` is reached (see ``SubscriptionResumeJobStore``)."""
     async with AsyncSessionMaker() as session:
         repository = SubscriptionRepository.from_session(session)
         subscription = await repository.get_by_id(
@@ -177,10 +163,19 @@ async def subscription_resume(subscription_id: uuid.UUID) -> None:
         if subscription is None:
             raise SubscriptionDoesNotExist(subscription_id)
 
-        if not subscription.can_resume():
+        now = utc_now()
+        is_due = (
+            subscription.can_resume()
+            and subscription.resumes_at is not None
+            and subscription.resumes_at <= now
+        )
+        if not is_due:
             log.info(
-                "Subscription is no longer paused, skipping resume",
+                "Subscription is not due for resume, skipping",
                 subscription_id=subscription_id,
+            )
+            await repository.update(
+                subscription, update_dict={"scheduler_locked_at": None}
             )
             return
 

--- a/server/polar/worker/scheduler.py
+++ b/server/polar/worker/scheduler.py
@@ -10,7 +10,10 @@ from polar import tasks
 from polar.logfire import configure_logfire
 from polar.logging import configure as configure_logging
 from polar.sentry import configure_sentry
-from polar.subscription.scheduler import SubscriptionJobStore
+from polar.subscription.scheduler import (
+    SubscriptionJobStore,
+    SubscriptionResumeJobStore,
+)
 
 from ._broker import scheduler_middleware
 from ._health import _run_exposition_server, set_heartbeat_checker
@@ -50,6 +53,7 @@ def start() -> None:
 
     scheduler.add_jobstore(MemoryJobStore(), "memory")
     scheduler.add_jobstore(SubscriptionJobStore(), "subscription")
+    scheduler.add_jobstore(SubscriptionResumeJobStore(), "subscription_resume")
 
     for func, cron_trigger in scheduler_middleware.cron_triggers:
         scheduler.add_job(func, cron_trigger, jobstore="memory")

--- a/server/tests/subscription/test_tasks.py
+++ b/server/tests/subscription/test_tasks.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 import pytest
 from pytest_mock import MockerFixture
@@ -9,11 +9,11 @@ from polar.models import Customer, Organization, Product, Subscription
 from polar.models.organization import OrganizationStatus
 from polar.models.subscription import SubscriptionStatus
 from polar.postgres import AsyncSession
+from polar.subscription.scheduler import SubscriptionResumeJobStore
 from polar.subscription.service import SubscriptionService
 from polar.subscription.tasks import (  # type: ignore[attr-defined]
     SubscriptionDoesNotExist,
     SubscriptionTierDoesNotExist,
-    scan_paused_resumptions,
     subscription_cancel_for_organization,
     subscription_enqueue_benefits_grants,
     subscription_resume,
@@ -153,16 +153,25 @@ class TestSubscriptionEnqueueBenefitsGrants:
 
 
 @pytest.mark.asyncio
-class TestScanPausedResumptions:
-    async def test_enqueues_only_due_subscriptions(
+class TestSubscriptionResumeJobStore:
+    async def _due_ids(self, session: AsyncSession, now: datetime) -> set[uuid.UUID]:
+        statement = (
+            SubscriptionResumeJobStore.scheduling_statement()
+            .where(Subscription.resumes_at <= now)
+            .with_only_columns(Subscription.id)
+        )
+        result = await session.execute(statement)
+        return set(result.scalars().all())
+
+    async def test_selects_only_due_paused_subscriptions(
         self,
-        mocker: MockerFixture,
         save_fixture: SaveFixture,
         session: AsyncSession,
         product: Product,
         customer: Customer,
     ) -> None:
         now = utc_now()
+
         due = await create_subscription(
             save_fixture,
             product=product,
@@ -189,12 +198,39 @@ class TestScanPausedResumptions:
             status=SubscriptionStatus.paused,
         )
 
-        enqueue_job_mock = mocker.patch("polar.subscription.tasks.enqueue_job")
-        session.expunge_all()
+        # Active — not a resume candidate.
+        await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
 
-        await scan_paused_resumptions()
+        assert await self._due_ids(session, now) == {due.id}
 
-        enqueue_job_mock.assert_called_once_with("subscription.resume", due.id)
+    async def test_excludes_renewals_disabled_organization(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        organization.capabilities = {
+            **organization.capabilities,
+            "subscription_renewals": False,
+        }
+        await save_fixture(organization)
+
+        now = utc_now()
+        due = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+        due.resumes_at = now - timedelta(hours=1)
+        await save_fixture(due)
+
+        # Renewals disabled → the org's paused sub is never auto-resumed.
+        assert await self._due_ids(session, now) == set()
 
 
 @pytest.mark.asyncio
@@ -205,7 +241,7 @@ class TestSubscriptionResume:
         with pytest.raises(SubscriptionDoesNotExist):
             await subscription_resume(uuid.uuid4())
 
-    async def test_paused_subscription_is_resumed(
+    async def test_due_paused_subscription_is_resumed(
         self,
         mocker: MockerFixture,
         save_fixture: SaveFixture,
@@ -219,6 +255,8 @@ class TestSubscriptionResume:
             customer=customer,
             status=SubscriptionStatus.paused,
         )
+        subscription.resumes_at = utc_now() - timedelta(hours=1)
+        await save_fixture(subscription)
         resume_mock = mocker.patch.object(
             subscription_service, "resume", spec=SubscriptionService.resume
         )
@@ -239,6 +277,55 @@ class TestSubscriptionResume:
         subscription = await create_active_subscription(
             save_fixture, product=product, customer=customer
         )
+        resume_mock = mocker.patch.object(
+            subscription_service, "resume", spec=SubscriptionService.resume
+        )
+        session.expunge_all()
+
+        await subscription_resume(subscription.id)
+
+        resume_mock.assert_not_called()
+
+    async def test_indefinite_pause_is_skipped(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+        resume_mock = mocker.patch.object(
+            subscription_service, "resume", spec=SubscriptionService.resume
+        )
+        session.expunge_all()
+
+        await subscription_resume(subscription.id)
+
+        resume_mock.assert_not_called()
+
+    async def test_postponed_resume_is_skipped(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+            scheduler_locked_at=utc_now(),
+        )
+        subscription.resumes_at = utc_now() + timedelta(days=1)
+        await save_fixture(subscription)
         resume_mock = mocker.patch.object(
             subscription_service, "resume", spec=SubscriptionService.resume
         )


### PR DESCRIPTION
## Summary

Replaces the naive hourly auto-resume cron with the same scheduler machinery `cycle` uses

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

