### PR TITLE
Improve appeal button visiblity

### DIFF
--- a/clients/apps/web/src/components/Organization/AppealForm.tsx
+++ b/clients/apps/web/src/components/Organization/AppealForm.tsx
@@ -131,17 +131,15 @@ const AppealForm: React.FC<AppealFormProps> = ({
           <p className="dark:text-polar-400 text-sm text-gray-600">{reason}</p>
         )}
         {!showForm && (
-          <p className="dark:text-polar-400 text-sm text-gray-600">
-            If you believe this is incorrect, you can{' '}
-            <button
-              type="button"
-              onClick={() => setShowForm(true)}
-              className="cursor-pointer underline hover:no-underline"
-            >
-              submit an appeal
-            </button>
-            .
-          </p>
+          <div className="flex flex-col items-start gap-3">
+            <p className="dark:text-polar-400 text-sm text-gray-600">
+              If you believe this decision is incorrect, you can appeal it for a
+              manual review.
+            </p>
+            <Button type="button" onClick={() => setShowForm(true)}>
+              Submit an appeal
+            </Button>
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
## Summary

The appeal button is very hidden in the account review flow, this PR will make it a bit more prominent

| Before | After  |
|--------|--------|
| <img width="1840" height="1134" alt="Screenshot 2026-07-07 at 12 17 40" src="https://github.com/user-attachments/assets/01edbba0-e764-4db2-adad-7cf955db0fd9" /> | <img width="1840" height="1134" alt="Screenshot 2026-07-07 at 12 15 01" src="https://github.com/user-attachments/assets/3aebc6ba-82b0-40b5-a6f5-d401db0cdfb7" /> |







<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

