### PR TITLE
fix(subscription): skip resume when org renewals disabled

### DIFF
--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1961,6 +1961,17 @@ class SubscriptionService:
         if not subscription.can_resume():
             raise NotPausedSubscription(subscription)
 
+        # Defensive: renewals may have been disabled while the subscription was
+        # paused. Resuming starts a fresh period and charges immediately, so skip
+        # rather than bill a subscription the organization can no longer renew.
+        if not subscription.organization.can_renew_subscriptions:
+            log.info(
+                "Subscription renewals disabled for organization, skipping resume",
+                subscription_id=subscription.id,
+                organization_id=subscription.organization.id,
+            )
+            return subscription
+
         now = utc_now()
         subscription.status = SubscriptionStatus.active
         subscription.paused_at = None

--- a/server/tests/subscription/test_endpoints.py
+++ b/server/tests/subscription/test_endpoints.py
@@ -1455,6 +1455,7 @@ class TestSubscriptionUpdatePause:
         assert data["status"] == SubscriptionStatus.active
         assert data["pause_at_period_end"] is True
         assert datetime.fromisoformat(data["resumes_at"]) == resumes_at
+        assert data["paused_at"] is None
 
     @pytest.mark.auth
     async def test_cancel_scheduled_pause(
@@ -1479,8 +1480,10 @@ class TestSubscriptionUpdatePause:
 
         assert response.status_code == 200
         data = response.json()
+        assert data["status"] == SubscriptionStatus.active
         assert data["pause_at_period_end"] is False
         assert data["resumes_at"] is None
+        assert data["paused_at"] is None
 
     @pytest.mark.auth
     async def test_not_pausable(
@@ -1539,6 +1542,45 @@ class TestSubscriptionUpdateResume:
         assert data["status"] == SubscriptionStatus.active
         assert data["paused_at"] is None
         assert data["resumes_at"] is None
+
+    @pytest.mark.auth
+    async def test_renewals_disabled_skips_resume(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        organization.capabilities = {
+            **organization.capabilities,
+            "subscription_renewals": False,
+        }
+        await save_fixture(organization)
+
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            started_at=utc_now(),
+            status=SubscriptionStatus.paused,
+        )
+        subscription.paused_at = utc_now() - timedelta(days=10)
+        subscription.resumes_at = utc_now() + timedelta(days=20)
+        await save_fixture(subscription)
+
+        response = await client.patch(
+            f"/v1/subscriptions/{subscription.id}",
+            json={"resume": True},
+        )
+
+        # Guard skips the resume: the subscription stays paused, nothing is charged.
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == SubscriptionStatus.paused
+        assert data["paused_at"] is not None
+        assert data["resumes_at"] is not None
 
     @pytest.mark.auth
     async def test_not_paused(


### PR DESCRIPTION
## Summary

`resume()` starts a fresh billing period and charges immediately, but — unlike `cycle()` — it didn't check  organization.can_renew_subscriptions`, so a renewals-disabled org could be charged on resume. 

This mirrors `cycle()`'s defensive skip: when renewals are disabled, `resume()` logs and returns the still-paused subscription without starting a period or enqueuing a charge.
## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/12999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

