### PR TITLE
feat(compass): typed insight actions, product margin + cost concentration detectors

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -7317,7 +7317,7 @@ export interface components {
        * Suggested Price Amount
        * @description Reference list price (cents) that would restore the target gross margin at the current cost to serve. Null when no meaningful suggestion can be computed.
        */
-      suggested_price_amount?: number | null
+      suggested_price_amount: number | null
       /**
        * Currency
        * @description ISO currency code of the amounts.

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -7276,6 +7276,54 @@ export interface components {
         | 'ZM'
         | 'ZW'
     }
+    /**
+     * AdjustPriceAction
+     * @description A recommendation to review a product's pricing, with a reference point.
+     *
+     *     The suggested amount is a *reference*, not a mandate: it's the list price
+     *     that would restore the target gross margin at the current cost to serve,
+     *     ignoring demand elasticity. It applies to new customers only — existing
+     *     subscriptions keep their price. The client routes to the product's pricing
+     *     editor; nothing is ever applied automatically.
+     */
+    AdjustPriceAction: {
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'adjust_price'
+      /**
+       * Label
+       * @description Button label.
+       */
+      label: string
+      /**
+       * Product Id
+       * Format: uuid4
+       * @description The product whose pricing to review.
+       */
+      product_id: string
+      /**
+       * Product Name
+       * @description Display name of the product.
+       */
+      product_name: string
+      /**
+       * Current Price Amount
+       * @description The product's current list price, in cents.
+       */
+      current_price_amount: number
+      /**
+       * Suggested Price Amount
+       * @description Reference list price (cents) that would restore the target gross margin at the current cost to serve. Null when no meaningful suggestion can be computed.
+       */
+      suggested_price_amount?: number | null
+      /**
+       * Currency
+       * @description ISO currency code of the amounts.
+       */
+      currency: string
+    }
     AggregateField: string
     /**
      * AggregationFunction
@@ -21111,28 +21159,18 @@ export interface components {
        */
       why?: string | null
       confidence: components['schemas']['ConfidenceLevel']
-      primary_action?: components['schemas']['InsightAction'] | null
+      /** Primary Action */
+      primary_action?:
+        | (
+            | components['schemas']['ViewMetricAction']
+            | components['schemas']['AdjustPriceAction']
+          )
+        | null
       /**
        * Drivers
        * @description Top contributors to the headline change.
        */
       drivers?: components['schemas']['InsightDriver'][]
-    }
-    /**
-     * InsightAction
-     * @description A drill-down that points at the metric behind the insight.
-     */
-    InsightAction: {
-      /**
-       * Label
-       * @description Button label.
-       */
-      label: string
-      /**
-       * Metric
-       * @description Slug of the metric this insight is about (e.g. `monthly_recurring_revenue`). The client owns the routing and resolves it to the matching analytics page.
-       */
-      metric: string
     }
     /**
      * InsightCategory
@@ -34299,6 +34337,27 @@ export interface components {
       p99?: {
         [key: string]: string
       }
+    }
+    /**
+     * ViewMetricAction
+     * @description A drill-down that points at the metric behind the insight.
+     */
+    ViewMetricAction: {
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'view_metric'
+      /**
+       * Label
+       * @description Button label.
+       */
+      label: string
+      /**
+       * Metric
+       * @description Slug of the metric this insight is about (e.g. `monthly_recurring_revenue`). The client owns the routing and resolves it to the matching analytics page.
+       */
+      metric: string
     }
     /**
      * Visibility
@@ -60744,6 +60803,9 @@ export const addressInputCountryValues: ReadonlyArray<
   'ZM',
   'ZW',
 ]
+export const adjustPriceActionTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['AdjustPriceAction']['type']
+> = ['adjust_price']
 export const aggregationFunctionValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['AggregationFunction']
 > = ['count', 'sum', 'max', 'min', 'avg', 'unique']
@@ -64402,6 +64464,9 @@ export const userUpdateCountryAnyOf0Values: ReadonlyArray<
   'ZM',
   'ZW',
 ]
+export const viewMetricActionTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['ViewMetricAction']['type']
+> = ['view_metric']
 export const visibilityValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['Visibility']
 > = ['draft', 'private', 'public']

--- a/server/polar/compass/detectors/__init__.py
+++ b/server/polar/compass/detectors/__init__.py
@@ -11,8 +11,10 @@ from .base import Detector, DetectorContext
 from .churn import ChurnSpikeDetector
 from .conversion import CheckoutConversionDetector
 from .cost_per_user import CostPerUserDetector
+from .customer_cost import CostConcentrationDetector
 from .margin import GrossMarginDetector
 from .mrr import MRRGrowthDetector
+from .product_margin import ProductMarginDetector
 from .subscribers import SubscriberGrowthDetector
 from .trials import TrialConversionDetector
 
@@ -25,6 +27,8 @@ DETECTORS: list[Detector] = [
     GrossMarginDetector(),
     CostPerUserDetector(),
     CheckoutConversionDetector(),
+    ProductMarginDetector(),
+    CostConcentrationDetector(),
 ]
 
 DETECTOR_IDS: frozenset[str] = frozenset(detector.id for detector in DETECTORS)

--- a/server/polar/compass/detectors/arpu.py
+++ b/server/polar/compass/detectors/arpu.py
@@ -1,6 +1,6 @@
 from polar.metrics.aggregation import latest, value_n_periods_ago
 
-from ..schemas import Insight, InsightAction, InsightCategory, InsightSeverity
+from ..schemas import Insight, InsightCategory, InsightSeverity, ViewMetricAction
 from ..signals import MetricSignal, format_currency, format_pct
 from .base import Detector, DetectorContext, confidence_for_sample
 
@@ -80,7 +80,7 @@ class ARPUMovementDetector(Detector):
             body=body,
             why=why,
             confidence=confidence,
-            primary_action=InsightAction(
+            primary_action=ViewMetricAction(
                 label="View ARPU trend",
                 metric="average_revenue_per_user",
             ),

--- a/server/polar/compass/detectors/base.py
+++ b/server/polar/compass/detectors/base.py
@@ -16,6 +16,7 @@ from ..schemas import (
     InsightDriver,
     InsightSeverity,
 )
+from ..signals import CustomerCostSignal, ProductPricing
 
 # Minimum population before an insight is trustworthy enough to surface at all.
 _MIN_SAMPLE = 5
@@ -47,6 +48,12 @@ class DetectorContext:
     timezone: ZoneInfo
     today: date
     metrics: MetricsResponse
+    products: Sequence[ProductPricing] = ()
+    """Per-product pricing + metrics windows. Prefetched only when a selected
+    detector declares `product_metric_slugs` and the organization has cost data."""
+    customer_costs: Sequence[CustomerCostSignal] = ()
+    """Customers ranked by tracked cost over the window. Prefetched only when a
+    selected detector declares `needs_customer_costs`."""
 
 
 class Detector(abc.ABC):
@@ -65,6 +72,14 @@ class Detector(abc.ABC):
     The primary feed order is each insight's `severity`, set per finding."""
     metric_slugs: Sequence[str] = ()
     """Metric slugs this detector reads. The service prefetches their union."""
+    product_metric_slugs: Sequence[str] = ()
+    """Metric slugs this detector reads *per product*. When any selected
+    detector declares these, the service also fetches them filtered to each of
+    the organization's products (capped, and only when org-level cost data
+    exists) into `ctx.products`."""
+    needs_customer_costs: bool = False
+    """When true, the service prefetches `ctx.customer_costs` (per-customer
+    cost ranking from the events statistics)."""
     lookback_days: int = 30
     """History `evaluate` needs. The service fetches the longest lookback."""
 

--- a/server/polar/compass/detectors/churn.py
+++ b/server/polar/compass/detectors/churn.py
@@ -1,6 +1,6 @@
 from polar.metrics.aggregation import latest, series
 
-from ..schemas import Insight, InsightAction, InsightCategory, InsightSeverity
+from ..schemas import Insight, InsightCategory, InsightSeverity, ViewMetricAction
 from ..signals import format_pct
 from .base import Detector, DetectorContext, confidence_for_sample
 
@@ -60,7 +60,7 @@ class ChurnSpikeDetector(Detector):
         title = f"{churned_n} {subscriptions} churned this month"
         body = (
             f"{churned_n} {subscriptions} ended in the last 30 days, "
-            f"{rate_str} of an at-risk base of {at_risk} — you have {active_n} "
+            f"{rate_str} of an at-risk base of {at_risk}. You have {active_n} "
             f"active subscriptions today."
         )
 
@@ -81,7 +81,7 @@ class ChurnSpikeDetector(Detector):
             body=body,
             why=why,
             confidence=confidence,
-            primary_action=InsightAction(
+            primary_action=ViewMetricAction(
                 label="View churn",
                 metric="churned_subscriptions",
             ),

--- a/server/polar/compass/detectors/conversion.py
+++ b/server/polar/compass/detectors/conversion.py
@@ -1,6 +1,6 @@
 from polar.metrics.aggregation import series
 
-from ..schemas import Insight, InsightAction, InsightCategory, InsightSeverity
+from ..schemas import Insight, InsightCategory, InsightSeverity, ViewMetricAction
 from ..signals import format_pct
 from .base import Detector, DetectorContext, confidence_for_sample
 
@@ -88,7 +88,7 @@ class CheckoutConversionDetector(Detector):
             body=body,
             why=why,
             confidence=confidence,
-            primary_action=InsightAction(
+            primary_action=ViewMetricAction(
                 label="View conversion",
                 metric="checkouts_conversion",
             ),

--- a/server/polar/compass/detectors/cost_per_user.py
+++ b/server/polar/compass/detectors/cost_per_user.py
@@ -1,6 +1,6 @@
 from polar.metrics.aggregation import latest, value_n_periods_ago
 
-from ..schemas import Insight, InsightAction, InsightCategory, InsightSeverity
+from ..schemas import Insight, InsightCategory, InsightSeverity, ViewMetricAction
 from ..signals import MetricSignal, format_currency, format_pct
 from .base import Detector, DetectorContext, confidence_for_sample
 
@@ -36,7 +36,9 @@ class CostPerUserDetector(Detector):
             return None
 
         baseline = value_n_periods_ago(response, "cost_per_user", _LOOKBACK_DAYS)
-        if baseline is None or baseline == 0:
+        # A sub-dollar baseline means cost tracking effectively just started —
+        # comparing against it yields absurd percentages, not a trend.
+        if baseline is None or baseline < _MIN_COST_PER_USER:
             return None
 
         sample_n = int(latest(response, "active_subscriptions"))
@@ -83,7 +85,7 @@ class CostPerUserDetector(Detector):
             body=body,
             why=why,
             confidence=confidence,
-            primary_action=InsightAction(
+            primary_action=ViewMetricAction(
                 label="View cost per user",
                 metric="cost_per_user",
             ),

--- a/server/polar/compass/detectors/customer_cost.py
+++ b/server/polar/compass/detectors/customer_cost.py
@@ -1,5 +1,5 @@
 from ..schemas import Insight, InsightCategory, InsightSeverity, ViewMetricAction
-from ..signals import format_pct
+from ..signals import CUSTOMER_COSTS_SAMPLE_LIMIT, format_pct
 from .base import Detector, DetectorContext, confidence_for_sample
 
 # Below this share, cost skew is normal; above the critical bar one outage or
@@ -43,17 +43,22 @@ class CostConcentrationDetector(Detector):
             return None
 
         share_str = format_pct(top.share)
+        count_str = (
+            f"at least {len(ranked)}"
+            if len(ranked) >= CUSTOMER_COSTS_SAMPLE_LIMIT
+            else str(len(ranked))
+        )
         title = f"One customer drives {share_str} of your costs"
         body = (
             f"{top.label} generated {share_str} of all tracked costs in the "
-            f"last {_LOOKBACK_DAYS} days, across {len(ranked)} customers with "
+            f"last {_LOOKBACK_DAYS} days, across {count_str} customers with "
             "costs. A single workload change or churn event would move most "
             "of your cost base."
         )
         why = (
             f"Triggered when one customer exceeds "
             f"{format_pct(_CONCENTRATION_WARNING)} of tracked costs, across "
-            f"{len(ranked)} customers with cost data ({confidence.value} "
+            f"{count_str} customers with cost data ({confidence.value} "
             "confidence). Costs come from `_cost` event metadata."
         )
 

--- a/server/polar/compass/detectors/customer_cost.py
+++ b/server/polar/compass/detectors/customer_cost.py
@@ -1,0 +1,73 @@
+from ..schemas import Insight, InsightCategory, InsightSeverity, ViewMetricAction
+from ..signals import format_pct
+from .base import Detector, DetectorContext, confidence_for_sample
+
+# Below this share, cost skew is normal; above the critical bar one outage or
+# churn event materially moves the whole cost base.
+_CONCENTRATION_WARNING = 0.40
+_CONCENTRATION_CRITICAL = 0.60
+_LOOKBACK_DAYS = 30
+
+
+class CostConcentrationDetector(Detector):
+    """
+    One customer dominating the organization's tracked costs.
+
+    Reads the per-customer cost ranking (from `_cost` event statistics) the
+    service prefetches. Concentration is a *risk* reading: if a single
+    customer drives most of the cost base, their behavior (a runaway workload,
+    a plan change, churn) swings the whole margin. Confidence is gated on how
+    many customers carry costs at all, so a two-customer org doesn't get told
+    its costs are "concentrated".
+    """
+
+    id = "cost_concentration"
+    category = InsightCategory.risk
+    category_label = "Risk"
+    priority = 25
+    metric_slugs = ()
+    needs_customer_costs = True
+    lookback_days = _LOOKBACK_DAYS
+
+    def evaluate(self, ctx: DetectorContext) -> Insight | None:
+        ranked = [signal for signal in ctx.customer_costs if signal.amount > 0]
+        if not ranked:
+            return None
+
+        confidence = confidence_for_sample(len(ranked))
+        if confidence is None:
+            return None
+
+        top = max(ranked, key=lambda signal: signal.share)
+        if top.share < _CONCENTRATION_WARNING:
+            return None
+
+        share_str = format_pct(top.share)
+        title = f"One customer drives {share_str} of your costs"
+        body = (
+            f"{top.label} generated {share_str} of all tracked costs in the "
+            f"last {_LOOKBACK_DAYS} days, across {len(ranked)} customers with "
+            "costs. A single workload change or churn event would move most "
+            "of your cost base."
+        )
+        why = (
+            f"Triggered when one customer exceeds "
+            f"{format_pct(_CONCENTRATION_WARNING)} of tracked costs, across "
+            f"{len(ranked)} customers with cost data ({confidence.value} "
+            "confidence). Costs come from `_cost` event metadata."
+        )
+
+        return self.build_insight(
+            ctx,
+            period_bucket=ctx.today.strftime("%Y-%m"),
+            severity=(
+                InsightSeverity.critical
+                if top.share >= _CONCENTRATION_CRITICAL
+                else InsightSeverity.warning
+            ),
+            title=title,
+            body=body,
+            why=why,
+            confidence=confidence,
+            primary_action=ViewMetricAction(label="View costs", metric="costs"),
+        )

--- a/server/polar/compass/detectors/margin.py
+++ b/server/polar/compass/detectors/margin.py
@@ -1,6 +1,6 @@
 from polar.metrics.aggregation import latest, value_n_periods_ago
 
-from ..schemas import Insight, InsightAction, InsightCategory, InsightSeverity
+from ..schemas import Insight, InsightCategory, InsightSeverity, ViewMetricAction
 from ..signals import format_pct
 from .base import Detector, DetectorContext, confidence_for_sample
 
@@ -95,7 +95,7 @@ class GrossMarginDetector(Detector):
             body=body,
             why=why,
             confidence=confidence,
-            primary_action=InsightAction(
+            primary_action=ViewMetricAction(
                 label="View margin",
                 metric="gross_margin_percentage",
             ),

--- a/server/polar/compass/detectors/mrr.py
+++ b/server/polar/compass/detectors/mrr.py
@@ -1,6 +1,6 @@
 from polar.metrics.aggregation import latest, value_n_periods_ago
 
-from ..schemas import Insight, InsightAction, InsightCategory, InsightSeverity
+from ..schemas import Insight, InsightCategory, InsightSeverity, ViewMetricAction
 from ..signals import MetricSignal
 from .base import Detector, DetectorContext, confidence_for_sample
 
@@ -84,7 +84,7 @@ class MRRGrowthDetector(Detector):
             body=body,
             why=why,
             confidence=confidence,
-            primary_action=InsightAction(
+            primary_action=ViewMetricAction(
                 label="View MRR trend",
                 metric="monthly_recurring_revenue",
             ),

--- a/server/polar/compass/detectors/product_margin.py
+++ b/server/polar/compass/detectors/product_margin.py
@@ -1,6 +1,6 @@
 import math
 
-from polar.kit.currency import get_currency_decimal_factor
+from polar.kit.currency import format_currency, get_currency_decimal_factor
 from polar.metrics.aggregation import latest
 
 from ..schemas import (
@@ -9,7 +9,7 @@ from ..schemas import (
     InsightCategory,
     InsightSeverity,
 )
-from ..signals import ProductPricing, format_currency, format_pct
+from ..signals import ProductPricing, format_pct
 from .base import Detector, DetectorContext, confidence_for_sample
 
 # Below this a product's margin is thin enough to flag; below the critical bar
@@ -95,13 +95,15 @@ class ProductMarginDetector(Detector):
         title = f"{worst.name} margin is down to {margin_str}"
         body = (
             f"{worst.name} keeps {margin_str} of its "
-            f"{format_currency(worst.price_amount)} price after costs. "
-            f"Roughly {format_currency(cost_to_serve)} per customer goes to "
-            f"serving it, across {worst_subs} active subscriptions."
+            f"{format_currency(worst.price_amount, worst.currency)} price "
+            f"after costs. Roughly "
+            f"{format_currency(cost_to_serve, worst.currency)} per customer "
+            f"goes to serving it, across {worst_subs} active subscriptions."
         )
         if suggested is not None:
             body += (
-                f" A list price around {format_currency(suggested)} would "
+                f" A list price around "
+                f"{format_currency(suggested, worst.currency)} would "
                 f"restore a {format_pct(_TARGET_MARGIN)} margin for new "
                 "customers."
             )

--- a/server/polar/compass/detectors/product_margin.py
+++ b/server/polar/compass/detectors/product_margin.py
@@ -1,0 +1,136 @@
+import math
+
+from polar.metrics.aggregation import latest
+
+from ..schemas import (
+    AdjustPriceAction,
+    Insight,
+    InsightCategory,
+    InsightSeverity,
+)
+from ..signals import ProductPricing, format_currency, format_pct
+from .base import Detector, DetectorContext, confidence_for_sample
+
+# Below this a product's margin is thin enough to flag; below the critical bar
+# it leads the feed.
+_HEALTHY_MARGIN = 0.70
+_CRITICAL_MARGIN = 0.40
+# The reference price restores this margin at the current cost to serve.
+_TARGET_MARGIN = 0.70
+
+
+def _suggested_price(price_amount: int, margin: float) -> int | None:
+    """List price (cents) that restores the target margin, or None.
+
+    Derived from the unitless margin — `price * (1 - margin)` is the cost to
+    serve in the price's own currency unit — so it never depends on the raw
+    cost metric's unit. Rounded up to a whole dollar; only a raise is ever
+    suggested (a lower price never *restores* margin).
+    """
+    cost_share = 1 - margin
+    if cost_share <= 0:
+        return None
+    target = price_amount * cost_share / (1 - _TARGET_MARGIN)
+    suggested = math.ceil(target / 100) * 100
+    return suggested if suggested > price_amount else None
+
+
+class ProductMarginDetector(Detector):
+    """
+    The product with the weakest unit economics, with a pricing lever.
+
+    Where the org-level margin detector *announces* compression, this one
+    *attributes* it: it names the product whose gross margin is thinnest and
+    offers a reference price that would restore the target margin at the
+    current cost to serve. The suggestion deliberately ignores demand
+    elasticity — it's a reference point for the merchant, never applied
+    automatically, and affects new customers only.
+
+    Cost attribution: cost events attach to customers, not products, so the
+    service reads costs through the product's active-customer cohort (revenue
+    stays product-filtered). A customer holding several products has their full
+    cost counted toward each, which skews margins pessimistic for orgs whose
+    customers stack products — a product-attributed cost pipe is the eventual
+    fix. Confidence is gated on the product's own subscription count.
+    """
+
+    id = "product_margin"
+    category = InsightCategory.cost
+    category_label = "Margin"
+    priority = 12
+    metric_slugs = ("gross_margin_percentage",)
+    product_metric_slugs = ("gross_margin_percentage", "active_subscriptions")
+
+    def evaluate(self, ctx: DetectorContext) -> Insight | None:
+        worst: ProductPricing | None = None
+        worst_margin = _HEALTHY_MARGIN
+        worst_subs = 0
+        for product in ctx.products:
+            margin = latest(product.metrics, "gross_margin_percentage")
+            # 0 margin means no cost/revenue data for this product, not a
+            # zero-margin business — stay silent rather than mislead.
+            if margin <= 0 or margin >= worst_margin:
+                continue
+            subs = int(latest(product.metrics, "active_subscriptions"))
+            if confidence_for_sample(subs) is None:
+                continue
+            worst = product
+            worst_margin = margin
+            worst_subs = subs
+
+        if worst is None:
+            return None
+
+        confidence = confidence_for_sample(worst_subs)
+        if confidence is None:
+            return None
+
+        cost_to_serve = round(worst.price_amount * (1 - worst_margin))
+        suggested = _suggested_price(worst.price_amount, worst_margin)
+        margin_str = format_pct(worst_margin)
+
+        title = f"{worst.name} margin is down to {margin_str}"
+        body = (
+            f"{worst.name} keeps {margin_str} of its "
+            f"{format_currency(worst.price_amount)} price after costs. "
+            f"Roughly {format_currency(cost_to_serve)} per customer goes to "
+            f"serving it, across {worst_subs} active subscriptions."
+        )
+        if suggested is not None:
+            body += (
+                f" A list price around {format_currency(suggested)} would "
+                f"restore a {format_pct(_TARGET_MARGIN)} margin for new "
+                "customers."
+            )
+        why = (
+            f"Triggered when a product's gross margin falls below "
+            f"{format_pct(_HEALTHY_MARGIN)}, weighted by its "
+            f"{worst_subs} active subscriptions ({confidence.value} "
+            "confidence). Costs are attributed to the customers subscribed to "
+            "the product, so customers holding several products weigh on each "
+            "of them. The suggested price is the level that restores a "
+            f"{format_pct(_TARGET_MARGIN)} margin at the current cost to "
+            "serve; it does not model demand."
+        )
+
+        return self.build_insight(
+            ctx,
+            period_bucket=ctx.today.strftime("%Y-%m"),
+            severity=(
+                InsightSeverity.critical
+                if worst_margin < _CRITICAL_MARGIN
+                else InsightSeverity.warning
+            ),
+            title=title,
+            body=body,
+            why=why,
+            confidence=confidence,
+            primary_action=AdjustPriceAction(
+                label=f"Review {worst.name} pricing",
+                product_id=worst.product_id,
+                product_name=worst.name,
+                current_price_amount=worst.price_amount,
+                suggested_price_amount=suggested,
+                currency=worst.currency,
+            ),
+        )

--- a/server/polar/compass/detectors/product_margin.py
+++ b/server/polar/compass/detectors/product_margin.py
@@ -1,5 +1,6 @@
 import math
 
+from polar.kit.currency import get_currency_decimal_factor
 from polar.metrics.aggregation import latest
 
 from ..schemas import (
@@ -19,19 +20,21 @@ _CRITICAL_MARGIN = 0.40
 _TARGET_MARGIN = 0.70
 
 
-def _suggested_price(price_amount: int, margin: float) -> int | None:
-    """List price (cents) that restores the target margin, or None.
+def _suggested_price(price_amount: int, margin: float, currency: str) -> int | None:
+    """List price (smallest currency unit) restoring the target margin, or None.
 
     Derived from the unitless margin — `price * (1 - margin)` is the cost to
     serve in the price's own currency unit — so it never depends on the raw
-    cost metric's unit. Rounded up to a whole dollar; only a raise is ever
-    suggested (a lower price never *restores* margin).
+    cost metric's unit. Rounded up to a whole major unit (the next dollar for
+    cent-based currencies, the next yen for zero-decimal ones); only a raise
+    is ever suggested (a lower price never *restores* margin).
     """
     cost_share = 1 - margin
     if cost_share <= 0:
         return None
     target = price_amount * cost_share / (1 - _TARGET_MARGIN)
-    suggested = math.ceil(target / 100) * 100
+    factor = get_currency_decimal_factor(currency)
+    suggested = math.ceil(target / factor) * factor
     return suggested if suggested > price_amount else None
 
 
@@ -86,7 +89,7 @@ class ProductMarginDetector(Detector):
             return None
 
         cost_to_serve = round(worst.price_amount * (1 - worst_margin))
-        suggested = _suggested_price(worst.price_amount, worst_margin)
+        suggested = _suggested_price(worst.price_amount, worst_margin, worst.currency)
         margin_str = format_pct(worst_margin)
 
         title = f"{worst.name} margin is down to {margin_str}"

--- a/server/polar/compass/detectors/product_margin.py
+++ b/server/polar/compass/detectors/product_margin.py
@@ -72,6 +72,13 @@ class ProductMarginDetector(Detector):
             margin = latest(product.metrics, "gross_margin_percentage")
             # 0 margin means no cost/revenue data for this product, not a
             # zero-margin business — stay silent rather than mislead.
+            # Negative margins are excluded on purpose too: with cohort-based
+            # cost attribution (a customer's full cost counts toward every
+            # product they hold), a cheap product whose customers also run
+            # expensive workloads reads deeply negative as an artifact, and a
+            # price recommendation built on that would be wrong. Once costs
+            # are product-attributed, negatives should fire as critical with
+            # money-losing copy instead of being skipped.
             if margin <= 0 or margin >= worst_margin:
                 continue
             subs = int(latest(product.metrics, "active_subscriptions"))

--- a/server/polar/compass/detectors/subscribers.py
+++ b/server/polar/compass/detectors/subscribers.py
@@ -1,6 +1,6 @@
 from polar.metrics.aggregation import latest, value_n_periods_ago
 
-from ..schemas import Insight, InsightAction, InsightCategory, InsightSeverity
+from ..schemas import Insight, InsightCategory, InsightSeverity, ViewMetricAction
 from ..signals import MetricSignal, format_pct
 from .base import Detector, DetectorContext, confidence_for_sample
 
@@ -76,7 +76,7 @@ class SubscriberGrowthDetector(Detector):
             body=body,
             why=why,
             confidence=confidence,
-            primary_action=InsightAction(
+            primary_action=ViewMetricAction(
                 label="View subscriptions",
                 metric="active_subscriptions",
             ),

--- a/server/polar/compass/detectors/trials.py
+++ b/server/polar/compass/detectors/trials.py
@@ -1,6 +1,6 @@
 from polar.metrics.aggregation import latest
 
-from ..schemas import Insight, InsightAction, InsightCategory, InsightSeverity
+from ..schemas import Insight, InsightCategory, InsightSeverity, ViewMetricAction
 from ..signals import format_currency, format_pct
 from .base import Detector, DetectorContext, confidence_for_sample
 
@@ -70,7 +70,7 @@ class TrialConversionDetector(Detector):
             body=body,
             why=why,
             confidence=confidence,
-            primary_action=InsightAction(
+            primary_action=ViewMetricAction(
                 label="View trials",
                 metric="trial_monthly_recurring_revenue",
             ),

--- a/server/polar/compass/schemas.py
+++ b/server/polar/compass/schemas.py
@@ -97,7 +97,6 @@ class AdjustPriceAction(Schema):
         description="The product's current list price, in cents."
     )
     suggested_price_amount: int | None = Field(
-        default=None,
         description=(
             "Reference list price (cents) that would restore the target gross "
             "margin at the current cost to serve. Null when no meaningful "

--- a/server/polar/compass/schemas.py
+++ b/server/polar/compass/schemas.py
@@ -1,6 +1,7 @@
 from enum import StrEnum
+from typing import Annotated, Literal
 
-from pydantic import Field
+from pydantic import UUID4, Discriminator, Field
 
 from polar.kit.schemas import Schema
 
@@ -49,9 +50,24 @@ class InsightSeverity(StrEnum):
     """Notable movement; no action required."""
 
 
-class InsightAction(Schema):
+class InsightActionType(StrEnum):
+    """
+    What kind of action an insight offers.
+
+    Actions are a discriminated union on this type: adding a new kind of action
+    is adding one enum member, one schema below (folded into `InsightAction`),
+    and one resolver entry on the client — the client owns all routing, the
+    backend only names the domain object the action concerns.
+    """
+
+    view_metric = "view_metric"
+    adjust_price = "adjust_price"
+
+
+class ViewMetricAction(Schema):
     """A drill-down that points at the metric behind the insight."""
 
+    type: Literal[InsightActionType.view_metric] = InsightActionType.view_metric
     label: str = Field(description="Button label.")
     metric: str = Field(
         description=(
@@ -60,6 +76,41 @@ class InsightAction(Schema):
             "resolves it to the matching analytics page."
         )
     )
+
+
+class AdjustPriceAction(Schema):
+    """
+    A recommendation to review a product's pricing, with a reference point.
+
+    The suggested amount is a *reference*, not a mandate: it's the list price
+    that would restore the target gross margin at the current cost to serve,
+    ignoring demand elasticity. It applies to new customers only — existing
+    subscriptions keep their price. The client routes to the product's pricing
+    editor; nothing is ever applied automatically.
+    """
+
+    type: Literal[InsightActionType.adjust_price] = InsightActionType.adjust_price
+    label: str = Field(description="Button label.")
+    product_id: UUID4 = Field(description="The product whose pricing to review.")
+    product_name: str = Field(description="Display name of the product.")
+    current_price_amount: int = Field(
+        description="The product's current list price, in cents."
+    )
+    suggested_price_amount: int | None = Field(
+        default=None,
+        description=(
+            "Reference list price (cents) that would restore the target gross "
+            "margin at the current cost to serve. Null when no meaningful "
+            "suggestion can be computed."
+        ),
+    )
+    currency: str = Field(description="ISO currency code of the amounts.")
+
+
+InsightAction = Annotated[
+    ViewMetricAction | AdjustPriceAction,
+    Discriminator("type"),
+]
 
 
 class InsightDriver(Schema):

--- a/server/polar/compass/service.py
+++ b/server/polar/compass/service.py
@@ -32,7 +32,11 @@ from .schemas import (
     InsightCategory,
     InsightSeverity,
 )
-from .signals import CustomerCostSignal, ProductPricing
+from .signals import (
+    CUSTOMER_COSTS_SAMPLE_LIMIT,
+    CustomerCostSignal,
+    ProductPricing,
+)
 
 log: Logger = structlog.get_logger()
 
@@ -52,9 +56,10 @@ _MAX_PRODUCTS = 8
 # product-attributed pipe) rather than silently sampled.
 _MAX_COHORT_CUSTOMERS = 150
 
-# Per-customer cost ranking window and depth for concentration detectors.
+# Per-customer cost ranking window for concentration detectors. The fetch
+# depth is CUSTOMER_COSTS_SAMPLE_LIMIT so confidence tiers aren't capped by
+# a truncated ranking.
 _CUSTOMER_COSTS_WINDOW_DAYS = 30
-_MAX_COST_CUSTOMERS = 10
 
 # What the merchant should care about most, first. Detector priority and
 # confidence only break ties within a severity band.
@@ -303,7 +308,7 @@ class CompassService:
                 end_date=today,
                 timezone=timezone,
                 organization_id=[org_id],
-                limit=_MAX_COST_CUSTOMERS,
+                limit=CUSTOMER_COSTS_SAMPLE_LIMIT,
             )
         except Exception:
             log.exception("compass.customer_costs_error", organization_id=str(org_id))

--- a/server/polar/compass/service.py
+++ b/server/polar/compass/service.py
@@ -1,20 +1,29 @@
 import uuid
 from collections.abc import Sequence
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
+from typing import cast
 from zoneinfo import ZoneInfo
 
 import structlog
+from sqlalchemy.orm import selectinload
 
 from polar.auth.models import AuthSubject, Organization, User
 from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
 from polar.authz.types import AccessibleOrganizationID
+from polar.event.service import event as event_service
 from polar.kit.time_queries import TimeInterval
 from polar.logging import Logger
+from polar.metrics.aggregation import latest
+from polar.metrics.schemas import MetricsResponse
 from polar.metrics.service import metrics as metrics_service
+from polar.models import Product
+from polar.models.product_price import ProductPriceFixed
 from polar.organization.repository import OrganizationRepository
-from polar.postgres import AsyncReadSession
+from polar.postgres import AsyncReadSession, AsyncSession
+from polar.product.repository import ProductRepository
 from polar.redis import Redis
+from polar.subscription.repository import SubscriptionRepository
 
 from .detectors import DETECTORS, Detector, DetectorContext
 from .schemas import (
@@ -23,12 +32,29 @@ from .schemas import (
     InsightCategory,
     InsightSeverity,
 )
+from .signals import CustomerCostSignal, ProductPricing
 
 log: Logger = structlog.get_logger()
 
 # Extra days beyond the longest detector lookback so a `value_n_periods_ago`
 # baseline is always present in the fetched series.
 _LOOKBACK_HEADROOM_DAYS = 5
+
+# Per-product metrics cost one metrics query each; cap how many products the
+# per-product detectors read so the feed stays a bounded number of queries.
+_MAX_PRODUCTS = 8
+
+# Cost events are attributed to customers, not products (the Tinybird costs
+# pipe has no product filter), so per-product cost reads go through the
+# product's active-customer cohort as a `customer_id` filter. The filter is a
+# GET query param, which bounds how many customer UUIDs fit in the URL —
+# products with a larger cohort are skipped (their margin needs a dedicated
+# product-attributed pipe) rather than silently sampled.
+_MAX_COHORT_CUSTOMERS = 150
+
+# Per-customer cost ranking window and depth for concentration detectors.
+_CUSTOMER_COSTS_WINDOW_DAYS = 30
+_MAX_COST_CUSTOMERS = 10
 
 # What the merchant should care about most, first. Detector priority and
 # confidence only break ties within a severity band.
@@ -97,11 +123,32 @@ class CompassService:
                 log.exception("compass.metrics_error", organization_id=str(org_id))
                 continue
 
+            products = await self._product_pricing(
+                session,
+                auth_subject,
+                org_id,
+                detectors,
+                org_metrics=response,
+                today=today,
+                timezone=timezone,
+                days=days,
+                redis=redis,
+            )
+            customer_costs = await self._customer_costs(
+                session,
+                auth_subject,
+                org_id,
+                detectors,
+                today=today,
+                timezone=timezone,
+            )
             ctx = DetectorContext(
                 organization_id=org_id,
                 timezone=timezone,
                 today=today,
                 metrics=response,
+                products=products,
+                customer_costs=customer_costs,
             )
             for detector in detectors:
                 try:
@@ -129,6 +176,149 @@ class CompassService:
             )
         )
         return insights
+
+    async def _product_pricing(
+        self,
+        session: AsyncReadSession,
+        auth_subject: AuthSubject[User | Organization],
+        org_id: uuid.UUID,
+        detectors: Sequence[Detector],
+        *,
+        org_metrics: MetricsResponse,
+        today: date,
+        timezone: ZoneInfo,
+        days: int,
+        redis: Redis | None,
+    ) -> list[ProductPricing]:
+        """Per-product pricing + metrics for detectors that declare a need.
+
+        Skipped entirely unless a selected detector declares
+        `product_metric_slugs` AND the organization emits cost data — the
+        org-level gross margin reading 0 means no costs were ingested, so
+        per-product margins would be meaningless (and N wasted queries).
+        """
+        slugs = sorted({s for d in detectors for s in d.product_metric_slugs})
+        if not slugs:
+            return []
+        if latest(org_metrics, "gross_margin_percentage") <= 0:
+            return []
+
+        repository = ProductRepository.from_session(session)
+        products = await repository.get_all_by_organization(
+            org_id,
+            options=(selectinload(Product.all_prices),),
+            limit=_MAX_PRODUCTS,
+        )
+
+        subscription_repository = SubscriptionRepository.from_session(session)
+        pricing: list[ProductPricing] = []
+        for product in products:
+            price = next(
+                (
+                    p
+                    for p in product.all_prices
+                    if isinstance(p, ProductPriceFixed)
+                    and not p.is_archived
+                    and p.price_amount
+                ),
+                None,
+            )
+            if price is None:
+                continue
+            # Cost attribution goes through the product's active-customer
+            # cohort: revenue is filtered by product, costs by these customers
+            # (see _MAX_COHORT_CUSTOMERS). Fetch one past the cap to detect
+            # oversized cohorts and skip them instead of mis-sampling.
+            cohort = list(
+                await subscription_repository.get_active_customer_ids_by_product(
+                    product.id, limit=_MAX_COHORT_CUSTOMERS + 1
+                )
+            )
+            if not cohort:
+                continue
+            if len(cohort) > _MAX_COHORT_CUSTOMERS:
+                log.warning(
+                    "compass.product_cohort_too_large",
+                    organization_id=str(org_id),
+                    product_id=str(product.id),
+                    cap=_MAX_COHORT_CUSTOMERS,
+                )
+                continue
+            try:
+                response = await metrics_service.get_metrics(
+                    session,
+                    auth_subject,
+                    start_date=today - timedelta(days=days),
+                    end_date=today,
+                    timezone=timezone,
+                    interval=TimeInterval.day,
+                    organization_id=[org_id],
+                    product_id=[product.id],
+                    customer_id=cohort,
+                    metrics=slugs,
+                    redis=redis,
+                )
+            except Exception:
+                # One product's metrics failing shouldn't drop the others.
+                log.exception(
+                    "compass.product_metrics_error",
+                    organization_id=str(org_id),
+                    product_id=str(product.id),
+                )
+                continue
+            pricing.append(
+                ProductPricing(
+                    product_id=product.id,
+                    name=product.name,
+                    price_amount=price.price_amount,
+                    currency=price.price_currency,
+                    metrics=response,
+                )
+            )
+        return pricing
+
+    async def _customer_costs(
+        self,
+        session: AsyncReadSession,
+        auth_subject: AuthSubject[User | Organization],
+        org_id: uuid.UUID,
+        detectors: Sequence[Detector],
+        *,
+        today: date,
+        timezone: ZoneInfo,
+    ) -> list[CustomerCostSignal]:
+        """Per-customer cost ranking for detectors that declare a need.
+
+        Backed by the events `by-customer` statistics (summing `_cost.amount`),
+        which return each customer's share of the total — exactly the shape a
+        concentration reading needs. Failures degrade to an empty ranking.
+        """
+        if not any(detector.needs_customer_costs for detector in detectors):
+            return []
+        try:
+            stats = await event_service.list_customer_stats(
+                cast(AsyncSession, session),
+                auth_subject,
+                start_date=today - timedelta(days=_CUSTOMER_COSTS_WINDOW_DAYS),
+                end_date=today,
+                timezone=timezone,
+                organization_id=[org_id],
+                limit=_MAX_COST_CUSTOMERS,
+            )
+        except Exception:
+            log.exception("compass.customer_costs_error", organization_id=str(org_id))
+            return []
+        return [
+            CustomerCostSignal(
+                label=stat.email
+                or stat.name
+                or stat.external_customer_id
+                or str(stat.customer_id),
+                amount=float(stat.totals.get("_cost_amount", 0)),
+                share=float(stat.share),
+            )
+            for stat in stats.items
+        ]
 
     async def _compass_enabled_org_ids(
         self,

--- a/server/polar/compass/signals.py
+++ b/server/polar/compass/signals.py
@@ -13,8 +13,11 @@ signals-layer change, not a detector change.
 The per-period readers (`series`, `latest`, …) live in `polar.metrics.aggregation`.
 """
 
+import uuid
 from dataclasses import dataclass, field
 from enum import StrEnum
+
+from polar.metrics.schemas import MetricsResponse
 
 
 class DriverDimension(StrEnum):
@@ -45,6 +48,41 @@ class MetricSignal:
         if self.baseline == 0:
             return None
         return (self.current - self.baseline) / abs(self.baseline)
+
+
+@dataclass(frozen=True)
+class ProductPricing:
+    """A product's current list price plus its product-filtered metrics window.
+
+    Prefetched by the service for detectors that declare `product_metric_slugs`,
+    so per-product detectors stay pure: pricing + signals in, insight out.
+    """
+
+    product_id: uuid.UUID
+    name: str
+    price_amount: int
+    """Current list price in cents."""
+    currency: str
+    metrics: MetricsResponse
+    """The same metrics window as the organization's, scoped to this product:
+    revenue metrics filtered by product, cost metrics by its active-customer
+    cohort (cost events attach to customers, not products)."""
+
+
+@dataclass(frozen=True)
+class CustomerCostSignal:
+    """One customer's share of tracked costs over the window.
+
+    Prefetched by the service (from the events `by-customer` statistics) for
+    detectors that declare `needs_customer_costs`, keeping them pure.
+    """
+
+    label: str
+    """Customer email, name or external id — whatever identifies them best."""
+    amount: float
+    """Total `_cost.amount` over the window, in the merchant's cost unit."""
+    share: float
+    """This customer's share of all tracked costs (0-1)."""
 
 
 def format_currency(cents: float) -> str:

--- a/server/polar/compass/signals.py
+++ b/server/polar/compass/signals.py
@@ -69,6 +69,13 @@ class ProductPricing:
     cohort (cost events attach to customers, not products)."""
 
 
+# How many cost-ranked customers the service prefetches. Covers the highest
+# confidence threshold (see `confidence_for_sample`), so the cost-bearing
+# customer count is exact up to this depth; at the cap the copy says
+# "at least".
+CUSTOMER_COSTS_SAMPLE_LIMIT = 100
+
+
 @dataclass(frozen=True)
 class CustomerCostSignal:
     """One customer's share of tracked costs over the window.

--- a/server/polar/kit/currency.py
+++ b/server/polar/kit/currency.py
@@ -174,7 +174,7 @@ _ZERO_DECIMAL_CURRENCIES: set[str] = {
 }
 
 
-def _get_currency_decimal_factor(currency: PresentmentCurrency | str) -> int:
+def get_currency_decimal_factor(currency: PresentmentCurrency | str) -> int:
     """Get the decimal factor for a given currency.
 
     Args:
@@ -207,7 +207,7 @@ def format_currency(
         The formatted currency string.
     """
     return _format_currency(
-        amount / _get_currency_decimal_factor(currency),
+        amount / get_currency_decimal_factor(currency),
         currency.upper(),
         locale="en_US",
         decimal_quantization=decimal_quantization,
@@ -352,7 +352,7 @@ MINIMUM_PRICE_PER_CURRENCY: dict[str, int] = {
 MINIMUM_PRICE_PER_CURRENCY_DOCSTRING = "\n".join(
     [
         *(
-            f"- {currency.upper()}: {format_decimal(amount / _get_currency_decimal_factor(currency), locale='en_US', decimal_quantization=False)}"
+            f"- {currency.upper()}: {format_decimal(amount / get_currency_decimal_factor(currency), locale='en_US', decimal_quantization=False)}"
             for currency, amount in MINIMUM_PRICE_PER_CURRENCY.items()
         ),
         f"- Other currencies: {format_decimal(MINIMUM_PRICE_PER_CURRENCY_DEFAULT, locale='en_US', decimal_quantization=False)} minor units",
@@ -383,7 +383,7 @@ MAXIMUM_PRICE_PER_CURRENCY: dict[str, int] = {
 MAXIMUM_PRICE_PER_CURRENCY_DOCSTRING = "\n".join(
     [
         *(
-            f"- {currency.upper()}: {format_decimal(amount / _get_currency_decimal_factor(currency), locale='en_US', decimal_quantization=False)}"
+            f"- {currency.upper()}: {format_decimal(amount / get_currency_decimal_factor(currency), locale='en_US', decimal_quantization=False)}"
             for currency, amount in MAXIMUM_PRICE_PER_CURRENCY.items()
         ),
         f"- Other currencies: {format_decimal(MAXIMUM_PRICE_PER_CURRENCY_DEFAULT, locale='en_US', decimal_quantization=False)} minor units",

--- a/server/polar/product/repository.py
+++ b/server/polar/product/repository.py
@@ -49,6 +49,26 @@ class ProductRepository(
         )
         return await self.get_one_or_none(statement)
 
+    async def get_all_by_organization(
+        self,
+        organization_id: UUID,
+        *,
+        options: Options = (),
+        limit: int | None = None,
+    ) -> Sequence[Product]:
+        statement = (
+            self.get_base_statement()
+            .where(
+                Product.organization_id == organization_id,
+                Product.is_archived.is_(False),
+            )
+            .order_by(Product.created_at.asc())
+            .options(*options)
+        )
+        if limit is not None:
+            statement = statement.limit(limit)
+        return await self.get_all(statement)
+
     async def get_by_id_and_checkout(
         self,
         id: UUID,

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -137,6 +137,23 @@ class SubscriptionRepository(
         result = await self.session.execute(statement)
         return result.scalars().all()
 
+    async def get_active_customer_ids_by_product(
+        self, product_id: UUID, *, limit: int | None = None
+    ) -> Sequence[UUID]:
+        statement = (
+            select(Subscription.customer_id)
+            .where(
+                Subscription.product_id == product_id,
+                Subscription.active.is_(True),
+                Subscription.is_deleted.is_(False),
+            )
+            .distinct()
+        )
+        if limit is not None:
+            statement = statement.limit(limit)
+        result = await self.session.execute(statement)
+        return result.scalars().all()
+
     async def get_by_id_and_organization(
         self,
         id: UUID,

--- a/server/scripts/tax_filing_imports.py
+++ b/server/scripts/tax_filing_imports.py
@@ -20,7 +20,7 @@ from rich.progress import Progress
 from sqlalchemy import and_, or_, select
 from sqlalchemy.orm import contains_eager
 
-from polar.kit.currency import _get_currency_decimal_factor
+from polar.kit.currency import get_currency_decimal_factor
 from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
 from polar.models import Order, Refund, Transaction
 from polar.models.transaction import TransactionType
@@ -97,7 +97,7 @@ def typer_async(f):  # type: ignore
 
 
 def normalize(amount: str, currency: str) -> int:
-    return int(Decimal(amount) * _get_currency_decimal_factor(currency))
+    return int(Decimal(amount) * get_currency_decimal_factor(currency))
 
 
 async def load_transactions_batch(

--- a/server/tests/compass/test_detectors.py
+++ b/server/tests/compass/test_detectors.py
@@ -588,12 +588,13 @@ def _product(
     price_amount: int = 4000,
     margin: float = 0.5,
     subs: float = 50.0,
+    currency: str = "usd",
 ) -> ProductPricing:
     return ProductPricing(
         product_id=uuid.uuid4(),
         name=name,
         price_amount=price_amount,
-        currency="usd",
+        currency=currency,
         metrics=_response_from(
             gross_margin_percentage=[margin] * 36,
             active_subscriptions=[subs] * 36,
@@ -749,6 +750,28 @@ class TestCostConcentrationDetector:
         insight = CostConcentrationDetector().evaluate(_context_with_customer_costs([]))
 
         assert insight is None
+
+
+class TestSuggestedPriceRounding:
+    def test_cent_currency_rounds_to_next_dollar(self) -> None:
+        product = _product(price_amount=5000, margin=0.45, currency="usd")
+
+        insight = ProductMarginDetector().evaluate(_context_with_products([product]))
+
+        assert insight is not None
+        assert isinstance(insight.primary_action, AdjustPriceAction)
+        # target = 5000 * 0.55 / 0.30 = 9166.67 -> next dollar
+        assert insight.primary_action.suggested_price_amount == 9200
+
+    def test_zero_decimal_currency_rounds_to_next_unit(self) -> None:
+        product = _product(price_amount=5000, margin=0.45, currency="jpy")
+
+        insight = ProductMarginDetector().evaluate(_context_with_products([product]))
+
+        assert insight is not None
+        assert isinstance(insight.primary_action, AdjustPriceAction)
+        # same target, but JPY's smallest unit IS the display unit -> next yen
+        assert insight.primary_action.suggested_price_amount == 9167
 
 
 class TestInsightCopy:

--- a/server/tests/compass/test_detectors.py
+++ b/server/tests/compass/test_detectors.py
@@ -772,6 +772,9 @@ class TestSuggestedPriceRounding:
         assert isinstance(insight.primary_action, AdjustPriceAction)
         # same target, but JPY's smallest unit IS the display unit -> next yen
         assert insight.primary_action.suggested_price_amount == 9167
+        # copy formats in the product's currency, not hardcoded USD cents
+        assert "¥5,000" in insight.body
+        assert "$50" not in insight.body
 
 
 class TestInsightCopy:

--- a/server/tests/compass/test_detectors.py
+++ b/server/tests/compass/test_detectors.py
@@ -4,17 +4,28 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
+from polar.compass.detectors import DETECTORS
 from polar.compass.detectors.arpu import ARPUMovementDetector
 from polar.compass.detectors.base import DetectorContext, confidence_for_sample
 from polar.compass.detectors.churn import ChurnSpikeDetector
 from polar.compass.detectors.conversion import CheckoutConversionDetector
 from polar.compass.detectors.cost_per_user import CostPerUserDetector
+from polar.compass.detectors.customer_cost import CostConcentrationDetector
 from polar.compass.detectors.margin import GrossMarginDetector
 from polar.compass.detectors.mrr import MRRGrowthDetector
+from polar.compass.detectors.product_margin import ProductMarginDetector
 from polar.compass.detectors.subscribers import SubscriberGrowthDetector
 from polar.compass.detectors.trials import TrialConversionDetector
 from polar.compass.keys import build_insight_key, parse_insight_key
-from polar.compass.schemas import ConfidenceLevel, InsightCategory, InsightSeverity
+from polar.compass.schemas import (
+    AdjustPriceAction,
+    ConfidenceLevel,
+    Insight,
+    InsightCategory,
+    InsightSeverity,
+    ViewMetricAction,
+)
+from polar.compass.signals import CustomerCostSignal, ProductPricing
 from polar.metrics.schemas import MetricsResponse
 
 
@@ -482,6 +493,18 @@ class TestCostPerUserDetector:
 
         assert insight is None
 
+    def test_silent_when_baseline_negligible(self) -> None:
+        # Cost tracking just started: a near-zero baseline against real costs
+        # would read as an absurd million-percent increase, not a trend.
+        cpu = [1.0] * 6 + [1.0] * 29 + [13_750.0]
+        subs = [50.0] * 36
+
+        insight = CostPerUserDetector().evaluate(
+            _context(_response_from(cost_per_user=cpu, active_subscriptions=subs))
+        )
+
+        assert insight is None
+
 
 class TestCheckoutConversionDetector:
     def test_fires_when_conversion_drops(self) -> None:
@@ -558,3 +581,288 @@ class TestCheckoutConversionDetector:
         )
 
         assert insight is None
+
+
+def _product(
+    name: str = "Pro",
+    price_amount: int = 4000,
+    margin: float = 0.5,
+    subs: float = 50.0,
+) -> ProductPricing:
+    return ProductPricing(
+        product_id=uuid.uuid4(),
+        name=name,
+        price_amount=price_amount,
+        currency="usd",
+        metrics=_response_from(
+            gross_margin_percentage=[margin] * 36,
+            active_subscriptions=[subs] * 36,
+        ),
+    )
+
+
+def _context_with_customer_costs(
+    customer_costs: list[CustomerCostSignal],
+) -> DetectorContext:
+    return DetectorContext(
+        organization_id=uuid.uuid4(),
+        timezone=ZoneInfo("UTC"),
+        today=date(2026, 2, 6),
+        metrics=_response_from(active_subscriptions=[50.0] * 36),
+        customer_costs=tuple(customer_costs),
+    )
+
+
+def _cost_signal(label: str, share: float, amount: float = 100.0) -> CustomerCostSignal:
+    return CustomerCostSignal(label=label, amount=amount, share=share)
+
+
+def _context_with_products(products: list[ProductPricing]) -> DetectorContext:
+    return DetectorContext(
+        organization_id=uuid.uuid4(),
+        timezone=ZoneInfo("UTC"),
+        today=date(2026, 2, 6),
+        metrics=_response_from(gross_margin_percentage=[0.5] * 36),
+        products=tuple(products),
+    )
+
+
+class TestProductMarginDetector:
+    def test_fires_with_price_suggestion(self) -> None:
+        # $40 product at 41% margin: ~$23.60 goes to serving each customer.
+        product = _product(price_amount=4000, margin=0.41)
+
+        insight = ProductMarginDetector().evaluate(_context_with_products([product]))
+
+        assert insight is not None
+        assert insight.category is InsightCategory.cost
+        assert insight.severity is InsightSeverity.warning
+        assert "Pro margin is down to 41%" in insight.title
+        assert "$24 per customer" in insight.body
+        action = insight.primary_action
+        assert isinstance(action, AdjustPriceAction)
+        assert action.product_id == product.product_id
+        assert action.current_price_amount == 4000
+        # ceil(4000 * 0.59 / 0.30 / 100) * 100 — the price restoring 70% margin.
+        assert action.suggested_price_amount == 7900
+        assert "$79" in insight.body
+
+    def test_deep_margin_loss_is_critical(self) -> None:
+        insight = ProductMarginDetector().evaluate(
+            _context_with_products([_product(margin=0.30)])
+        )
+
+        assert insight is not None
+        assert insight.severity is InsightSeverity.critical
+
+    def test_picks_the_worst_product(self) -> None:
+        healthy = _product(name="Starter", margin=0.85)
+        thin = _product(name="Pro", margin=0.55)
+        thinner = _product(name="Enterprise", margin=0.45)
+
+        insight = ProductMarginDetector().evaluate(
+            _context_with_products([healthy, thin, thinner])
+        )
+
+        assert insight is not None
+        assert "Enterprise" in insight.title
+        action = insight.primary_action
+        assert isinstance(action, AdjustPriceAction)
+        assert action.product_id == thinner.product_id
+
+    def test_no_insight_when_margins_healthy(self) -> None:
+        insight = ProductMarginDetector().evaluate(
+            _context_with_products([_product(margin=0.85)])
+        )
+
+        assert insight is None
+
+    def test_silent_without_cost_data(self) -> None:
+        # Margin of 0 means no cost data for the product, not a 0% business.
+        insight = ProductMarginDetector().evaluate(
+            _context_with_products([_product(margin=0.0)])
+        )
+
+        assert insight is None
+
+    def test_suppressed_when_sample_too_small(self) -> None:
+        insight = ProductMarginDetector().evaluate(
+            _context_with_products([_product(margin=0.41, subs=3.0)])
+        )
+
+        assert insight is None
+
+    def test_no_insight_without_products(self) -> None:
+        insight = ProductMarginDetector().evaluate(_context_with_products([]))
+
+        assert insight is None
+
+
+class TestCostConcentrationDetector:
+    def test_fires_on_concentration(self) -> None:
+        signals = [_cost_signal("big@corp.com", 0.55)] + [
+            _cost_signal(f"c{i}@x.com", 0.09) for i in range(5)
+        ]
+
+        insight = CostConcentrationDetector().evaluate(
+            _context_with_customer_costs(signals)
+        )
+
+        assert insight is not None
+        assert insight.category is InsightCategory.risk
+        assert insight.severity is InsightSeverity.warning
+        assert "55% of your costs" in insight.title
+        assert "big@corp.com" in insight.body
+        assert insight.detector_id == "cost_concentration"
+
+    def test_extreme_concentration_is_critical(self) -> None:
+        signals = [_cost_signal("whale@corp.com", 0.7)] + [
+            _cost_signal(f"c{i}@x.com", 0.06) for i in range(5)
+        ]
+
+        insight = CostConcentrationDetector().evaluate(
+            _context_with_customer_costs(signals)
+        )
+
+        assert insight is not None
+        assert insight.severity is InsightSeverity.critical
+
+    def test_silent_when_costs_spread_out(self) -> None:
+        signals = [_cost_signal(f"c{i}@x.com", 0.2) for i in range(5)]
+
+        insight = CostConcentrationDetector().evaluate(
+            _context_with_customer_costs(signals)
+        )
+
+        assert insight is None
+
+    def test_suppressed_when_too_few_customers(self) -> None:
+        signals = [_cost_signal("a@x.com", 0.8), _cost_signal("b@x.com", 0.2)]
+
+        insight = CostConcentrationDetector().evaluate(
+            _context_with_customer_costs(signals)
+        )
+
+        assert insight is None
+
+    def test_silent_without_cost_data(self) -> None:
+        insight = CostConcentrationDetector().evaluate(_context_with_customer_costs([]))
+
+        assert insight is None
+
+
+class TestInsightCopy:
+    def test_no_em_dashes_in_any_emitted_copy(self) -> None:
+        """Em dashes are banned in user-facing copy; use comma, colon or period."""
+        subs = [50.0] * 36
+        firing: list[Insight | None] = [
+            MRRGrowthDetector().evaluate(
+                _context(
+                    _response([100_000.0] * 6 + [110_000.0] * 29 + [120_000.0], subs)
+                )
+            ),
+            SubscriberGrowthDetector().evaluate(
+                _context(
+                    _response_from(
+                        active_subscriptions=[10.0] * 6 + [12.0] * 29 + [16.0]
+                    )
+                )
+            ),
+            ARPUMovementDetector().evaluate(
+                _context(
+                    _response_from(
+                        average_revenue_per_user=[25_000.0] * 6
+                        + [22_000.0] * 29
+                        + [19_400.0],
+                        active_subscriptions=subs,
+                    )
+                )
+            ),
+            # Churn with a rising prior window, so the extra sentence renders too.
+            ChurnSpikeDetector().evaluate(
+                _context(
+                    _response_from(
+                        churned_subscriptions=[0.0] * 6 + [1.0] * 30 + [2.0] * 30,
+                        active_subscriptions=[50.0] * 66,
+                    )
+                )
+            ),
+            TrialConversionDetector().evaluate(
+                _context(
+                    _response_from(
+                        trial_monthly_recurring_revenue=[0.0] * 35 + [100_000.0],
+                        monthly_recurring_revenue=[900_000.0] * 36,
+                        active_subscriptions=subs,
+                    )
+                )
+            ),
+            GrossMarginDetector().evaluate(
+                _context(
+                    _response_from(
+                        gross_margin_percentage=[0.8] * 6 + [0.75] * 29 + [0.55],
+                        active_subscriptions=subs,
+                    )
+                )
+            ),
+            CostPerUserDetector().evaluate(
+                _context(
+                    _response_from(
+                        cost_per_user=[200.0] * 6 + [250.0] * 29 + [300.0],
+                        active_subscriptions=subs,
+                    )
+                )
+            ),
+            CheckoutConversionDetector().evaluate(
+                _context(
+                    _response_from(
+                        checkouts=[0.0] * 6 + [20.0] + [0.0] * 29 + [20.0] + [0.0] * 29,
+                        succeeded_checkouts=[0.0] * 6
+                        + [16.0]
+                        + [0.0] * 29
+                        + [11.0]
+                        + [0.0] * 29,
+                    )
+                )
+            ),
+            ProductMarginDetector().evaluate(
+                _context_with_products([_product(margin=0.41)])
+            ),
+            CostConcentrationDetector().evaluate(
+                _context_with_customer_costs(
+                    [_cost_signal("big@corp.com", 0.62)]
+                    + [_cost_signal(f"c{i}@x.com", 0.076) for i in range(5)]
+                )
+            ),
+        ]
+
+        assert len(firing) == len(DETECTORS)
+        for insight in firing:
+            assert insight is not None, "every registered detector must fire here"
+            copy = [insight.title, insight.body, insight.why or ""]
+            if insight.primary_action is not None:
+                copy.append(insight.primary_action.label)
+            for text in copy:
+                assert "—" not in text, f"em dash in {insight.detector_id}: {text!r}"
+
+
+class TestInsightActionUnion:
+    def test_adjust_price_round_trips_through_the_wire_format(self) -> None:
+        insight = ProductMarginDetector().evaluate(
+            _context_with_products([_product(margin=0.41)])
+        )
+        assert insight is not None
+
+        parsed = Insight.model_validate(insight.model_dump())
+
+        assert isinstance(parsed.primary_action, AdjustPriceAction)
+        assert parsed.primary_action.type == "adjust_price"
+
+    def test_view_metric_round_trips_through_the_wire_format(self) -> None:
+        mrr = [100_000.0] * 6 + [110_000.0] * 29 + [120_000.0]
+        insight = MRRGrowthDetector().evaluate(_context(_response(mrr, [50.0] * 36)))
+        assert insight is not None
+
+        parsed = Insight.model_validate(insight.model_dump())
+
+        assert isinstance(parsed.primary_action, ViewMetricAction)
+        assert parsed.primary_action.type == "view_metric"

--- a/server/tests/compass/test_detectors.py
+++ b/server/tests/compass/test_detectors.py
@@ -25,7 +25,11 @@ from polar.compass.schemas import (
     InsightSeverity,
     ViewMetricAction,
 )
-from polar.compass.signals import CustomerCostSignal, ProductPricing
+from polar.compass.signals import (
+    CUSTOMER_COSTS_SAMPLE_LIMIT,
+    CustomerCostSignal,
+    ProductPricing,
+)
 from polar.metrics.schemas import MetricsResponse
 
 
@@ -423,6 +427,35 @@ class TestGrossMarginDetector:
         assert insight is not None
         assert insight.severity is InsightSeverity.opportunity
         assert "improved to 90%" in insight.title
+
+    def test_confidence_scales_with_cost_bearing_customers(self) -> None:
+        # 60 customers with costs: past the medium threshold (20), so the
+        # insight must not be capped at low confidence by a truncated fetch.
+        signals = [_cost_signal("whale@corp.com", 0.45)] + [
+            _cost_signal(f"c{i}@x.com", 0.009) for i in range(59)
+        ]
+
+        insight = CostConcentrationDetector().evaluate(
+            _context_with_customer_costs(signals)
+        )
+
+        assert insight is not None
+        assert insight.confidence is ConfidenceLevel.medium
+        assert "across 60 customers" in insight.body
+
+    def test_copy_says_at_least_when_sample_is_capped(self) -> None:
+        signals = [_cost_signal("whale@corp.com", 0.45)] + [
+            _cost_signal(f"c{i}@x.com", 0.005)
+            for i in range(CUSTOMER_COSTS_SAMPLE_LIMIT - 1)
+        ]
+
+        insight = CostConcentrationDetector().evaluate(
+            _context_with_customer_costs(signals)
+        )
+
+        assert insight is not None
+        assert insight.confidence is ConfidenceLevel.high
+        assert f"at least {CUSTOMER_COSTS_SAMPLE_LIMIT} customers" in insight.body
 
     def test_silent_without_cost_data(self) -> None:
         # No Tinybird cost/revenue data resolves margin to 0 — stay quiet.

--- a/server/tests/compass/test_detectors.py
+++ b/server/tests/compass/test_detectors.py
@@ -672,7 +672,7 @@ class TestProductMarginDetector:
         assert insight.category is InsightCategory.cost
         assert insight.severity is InsightSeverity.warning
         assert "Pro margin is down to 41%" in insight.title
-        assert "$24 per customer" in insight.body
+        assert "$23.60 per customer" in insight.body
         action = insight.primary_action
         assert isinstance(action, AdjustPriceAction)
         assert action.product_id == product.product_id


### PR DESCRIPTION
First of a 3-PR stack building toward the Compass assistant. This layer is useful standalone: richer detectors and a typed action contract for insights.

## What's in here

**Typed insight actions.** `Insight.primary_action` becomes a discriminated union (`view_metric` | `adjust_price`) instead of a single shape, so the frontend resolves each action type to its own destination and new action types are a schema addition, not a rework.

**ProductMarginDetector.** Per-product margin decline with a concrete price recommendation derived from cost to serve (`adjust_price` action carrying current and suggested price). Product costs are read through the product's active-customer cohort, since cost events attach to customers, not products.

**CostConcentrationDetector** (fills the `risk` category). Fires when one customer exceeds 40% of tracked costs (critical at 60%), fed by a per-customer cost prefetch from the events by-customer statistics. Confidence-gated on at least 5 customers carrying costs, so small orgs aren't told their costs are "concentrated".

**Signal layer + prefetches.** `ProductPricing` and `CustomerCostSignal` dataclasses keep detectors pure (data in, insight out); the service prefetches them only when a selected detector declares the need. Repository helpers for product cohorts and org products with prices.

## Testing

- 57 detector tests, including firing/silent/sample-gate cases for both new detectors and the em-dash copy guard across every registered detector.
- lint + mypy clean.

## Stack

1. **→ this PR** — detectors + typed actions
2. `compass-assistant-backend-2-core` — the assistant core (agent, blocks, SSE endpoint)
3. `compass-assistant-backend-3-tools` — the tool fleet + self-serve inference cost tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

