### PR TITLE
feat(customer-portal): self-serve pause & resume

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -27891,6 +27891,17 @@ export interface components {
       /** Max Page */
       max_page: number
     }
+    /** PauseResumeNotAllowed */
+    PauseResumeNotAllowed: {
+      /**
+       * Error
+       * @example PauseResumeNotAllowed
+       * @constant
+       */
+      error: 'PauseResumeNotAllowed'
+      /** Detail */
+      detail: string
+    }
     Payment:
       | components['schemas']['CardPayment']
       | components['schemas']['GenericPayment']
@@ -48866,13 +48877,15 @@ export interface operations {
           'application/json': components['schemas']['PaymentFailed']
         }
       }
-      /** @description Customer subscription is already canceled or will be at the end of the period, or the user lacks billing permissions. */
+      /** @description Customer subscription is already canceled or will be at the end of the period, the user lacks billing permissions, or pausing/resuming is not enabled for the organization. */
       403: {
         headers: {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['AlreadyCanceledSubscription']
+          'application/json':
+            | components['schemas']['AlreadyCanceledSubscription']
+            | components['schemas']['PauseResumeNotAllowed']
         }
       }
       /** @description Customer subscription was not found. */

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -17179,6 +17179,8 @@ export interface components {
       update_seats: boolean
       /** Update Plan */
       update_plan: boolean
+      /** Pause */
+      pause?: boolean
     }
     /** CustomerPortalUsageSettings */
     CustomerPortalUsageSettings: {
@@ -18408,6 +18410,22 @@ export interface components {
        */
       name: string
     }
+    /** CustomerSubscriptionPause */
+    CustomerSubscriptionPause: {
+      /**
+       * Pause At Period End
+       * @description Pause an active subscription at the end of the current period.
+       *
+       *     Or cancel a scheduled pause on a subscription set to be paused at
+       *     period end.
+       */
+      pause_at_period_end: boolean
+      /**
+       * Resumes At
+       * @description Date at which the paused subscription should automatically resume. If not set, it stays paused until resumed. Must be after the current period end.
+       */
+      resumes_at?: string | null
+    }
     /** CustomerSubscriptionProduct */
     CustomerSubscriptionProduct: {
       /**
@@ -18496,6 +18514,15 @@ export interface components {
       medias: components['schemas']['ProductMediaFileRead'][]
       organization: components['schemas']['CustomerOrganization']
     }
+    /** CustomerSubscriptionResume */
+    CustomerSubscriptionResume: {
+      /**
+       * Resume
+       * @description Resume a paused subscription immediately, starting a new billing period and charging the customer.
+       * @constant
+       */
+      resume: true
+    }
     /**
      * CustomerSubscriptionSortProperty
      * @enum {string}
@@ -18515,6 +18542,8 @@ export interface components {
       | components['schemas']['CustomerSubscriptionUpdateProduct']
       | components['schemas']['CustomerSubscriptionUpdateSeats']
       | components['schemas']['CustomerSubscriptionCancel']
+      | components['schemas']['CustomerSubscriptionPause']
+      | components['schemas']['CustomerSubscriptionResume']
       | components['schemas']['CustomerSubscriptionUpdateClear']
     /** CustomerSubscriptionUpdateClear */
     CustomerSubscriptionUpdateClear: {

--- a/server/emails/src/types/openapi.ts
+++ b/server/emails/src/types/openapi.ts
@@ -1033,6 +1033,8 @@ export interface components {
       update_seats: boolean
       /** Update Plan */
       update_plan: boolean
+      /** Pause */
+      pause?: boolean
     }
     /** CustomerPortalUsageSettings */
     CustomerPortalUsageSettings: {

--- a/server/polar/customer_portal/endpoints/subscription.py
+++ b/server/polar/customer_portal/endpoints/subscription.py
@@ -20,7 +20,10 @@ from polar.subscription.service import subscription as subscription_service
 
 from .. import auth
 from ..schemas.subscription import CustomerSubscription, CustomerSubscriptionUpdate
-from ..service.subscription import CustomerSubscriptionSortProperty
+from ..service.subscription import (
+    CustomerSubscriptionSortProperty,
+    PauseResumeNotAllowed,
+)
 from ..service.subscription import (
     customer_subscription as customer_subscription_service,
 )
@@ -147,9 +150,11 @@ async def get_charge_preview(
             "description": (
                 "Customer subscription is already canceled "
                 "or will be at the end of the period, "
-                "or the user lacks billing permissions."
+                "the user lacks billing permissions, "
+                "or pausing/resuming is not enabled for the organization."
             ),
-            "model": AlreadyCanceledSubscription.schema(),
+            "model": AlreadyCanceledSubscription.schema()
+            | PauseResumeNotAllowed.schema(),
         },
         404: SubscriptionNotFound,
     },

--- a/server/polar/customer_portal/schemas/subscription.py
+++ b/server/polar/customer_portal/schemas/subscription.py
@@ -1,7 +1,7 @@
 import inspect
-from typing import Annotated
+from typing import Annotated, Literal
 
-from pydantic import UUID4, AliasChoices, AliasPath, Field
+from pydantic import UUID4, AliasChoices, AliasPath, Field, FutureDatetime
 from pydantic.json_schema import SkipJsonSchema
 
 from polar.enums import SubscriptionProrationBehavior
@@ -127,6 +127,36 @@ class CustomerSubscriptionCancel(Schema):
     )
 
 
+class CustomerSubscriptionPause(Schema):
+    pause_at_period_end: bool = Field(
+        description=inspect.cleandoc(
+            """
+        Pause an active subscription at the end of the current period.
+
+        Or cancel a scheduled pause on a subscription set to be paused at
+        period end.
+        """
+        ),
+    )
+    resumes_at: FutureDatetime | None = Field(
+        None,
+        description=(
+            "Date at which the paused subscription should automatically resume. "
+            "If not set, it stays paused until resumed. Must be after the current "
+            "period end."
+        ),
+    )
+
+
+class CustomerSubscriptionResume(Schema):
+    resume: Literal[True] = Field(
+        description=(
+            "Resume a paused subscription immediately, "
+            "starting a new billing period and charging the customer."
+        )
+    )
+
+
 class CustomerSubscriptionUpdateClear(Schema):
     pending_update: None = Field(description="Clear the pending subscription update.")
 
@@ -135,6 +165,8 @@ CustomerSubscriptionUpdate = Annotated[
     CustomerSubscriptionUpdateProduct
     | CustomerSubscriptionUpdateSeats
     | CustomerSubscriptionCancel
+    | CustomerSubscriptionPause
+    | CustomerSubscriptionResume
     | CustomerSubscriptionUpdateClear,
     SetSchemaReference("CustomerSubscriptionUpdate"),
 ]

--- a/server/polar/customer_portal/service/subscription.py
+++ b/server/polar/customer_portal/service/subscription.py
@@ -24,6 +24,8 @@ from polar.subscription.service import SubscriptionUpdateContext
 from polar.subscription.service import subscription as subscription_service
 
 from ..schemas.subscription import (
+    CustomerSubscriptionPause,
+    CustomerSubscriptionResume,
     CustomerSubscriptionUpdate,
     CustomerSubscriptionUpdateClear,
     CustomerSubscriptionUpdateProduct,
@@ -43,6 +45,11 @@ class UpdateSubscriptionPlanNotAllowed(CustomerSubscriptionError):
 class UpdateSubscriptionSeatsNotAllowed(CustomerSubscriptionError):
     def __init__(self) -> None:
         super().__init__("Updating subscription seats is not allowed.", 403)
+
+
+class PauseSubscriptionNotAllowed(CustomerSubscriptionError):
+    def __init__(self) -> None:
+        super().__init__("Pausing a subscription is not allowed.", 403)
 
 
 class CustomerSubscriptionSortProperty(StrEnum):
@@ -183,6 +190,30 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
                 return await subscription_service.clear_pending_update(
                     session, ctx, subscription
                 )
+
+        if isinstance(updates, CustomerSubscriptionPause):
+            if not organization.customer_portal_subscription_pause:
+                raise PauseSubscriptionNotAllowed()
+
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                if updates.pause_at_period_end:
+                    return await subscription_service.pause(
+                        session, ctx, subscription, resumes_at=updates.resumes_at
+                    )
+                return await subscription_service.cancel_scheduled_pause(
+                    session, ctx, subscription
+                )
+
+        if isinstance(updates, CustomerSubscriptionResume):
+            if not organization.customer_portal_subscription_pause:
+                raise PauseSubscriptionNotAllowed()
+
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                return await subscription_service.resume(session, ctx, subscription)
 
         cancel = updates.cancel_at_period_end is True
         uncancel = updates.cancel_at_period_end is False

--- a/server/polar/customer_portal/service/subscription.py
+++ b/server/polar/customer_portal/service/subscription.py
@@ -47,9 +47,9 @@ class UpdateSubscriptionSeatsNotAllowed(CustomerSubscriptionError):
         super().__init__("Updating subscription seats is not allowed.", 403)
 
 
-class PauseSubscriptionNotAllowed(CustomerSubscriptionError):
+class PauseResumeNotAllowed(CustomerSubscriptionError):
     def __init__(self) -> None:
-        super().__init__("Pausing a subscription is not allowed.", 403)
+        super().__init__("Pausing or resuming a subscription is not allowed.", 403)
 
 
 class CustomerSubscriptionSortProperty(StrEnum):
@@ -193,7 +193,7 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
 
         if isinstance(updates, CustomerSubscriptionPause):
             if not organization.customer_portal_subscription_pause:
-                raise PauseSubscriptionNotAllowed()
+                raise PauseResumeNotAllowed()
 
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service
@@ -208,7 +208,7 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
 
         if isinstance(updates, CustomerSubscriptionResume):
             if not organization.customer_portal_subscription_pause:
-                raise PauseSubscriptionNotAllowed()
+                raise PauseResumeNotAllowed()
 
             async with SubscriptionUpdateContext(
                 session, subscription, subscription_service

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -148,6 +148,7 @@ class CustomerPortalUsageSettings(TypedDict):
 class CustomerPortalSubscriptionSettings(TypedDict):
     update_seats: bool
     update_plan: bool
+    pause: NotRequired[bool]
 
 
 class CustomerPortalCustomerSettings(TypedDict):
@@ -819,6 +820,10 @@ class Organization(RateLimitGroupMixin, RecordModel):
         return self.customer_portal_settings.get("subscription", {}).get(
             "update_plan", True
         )
+
+    @property
+    def customer_portal_subscription_pause(self) -> bool:
+        return self.customer_portal_settings.get("subscription", {}).get("pause", False)
 
     @property
     def checkout_require_3ds(self) -> bool:

--- a/server/tests/customer_portal/service/test_subscription.py
+++ b/server/tests/customer_portal/service/test_subscription.py
@@ -12,7 +12,7 @@ from polar.customer_portal.schemas.subscription import (
     CustomerSubscriptionUpdateSeats,
 )
 from polar.customer_portal.service.subscription import (
-    PauseSubscriptionNotAllowed,
+    PauseResumeNotAllowed,
     UpdateSubscriptionPlanNotAllowed,
     UpdateSubscriptionSeatsNotAllowed,
 )
@@ -468,7 +468,7 @@ class TestUpdatePause:
             save_fixture, product=product, customer=customer
         )
 
-        with pytest.raises(PauseSubscriptionNotAllowed):
+        with pytest.raises(PauseResumeNotAllowed):
             await customer_subscription_service.update(
                 session,
                 subscription,
@@ -517,7 +517,7 @@ class TestUpdatePause:
             status=SubscriptionStatus.paused,
         )
 
-        with pytest.raises(PauseSubscriptionNotAllowed):
+        with pytest.raises(PauseResumeNotAllowed):
             await customer_subscription_service.update(
                 session,
                 subscription,

--- a/server/tests/customer_portal/service/test_subscription.py
+++ b/server/tests/customer_portal/service/test_subscription.py
@@ -5,11 +5,14 @@ import pytest
 
 from polar.auth.models import AuthSubject
 from polar.customer_portal.schemas.subscription import (
+    CustomerSubscriptionPause,
+    CustomerSubscriptionResume,
     CustomerSubscriptionUpdateClear,
     CustomerSubscriptionUpdateProduct,
     CustomerSubscriptionUpdateSeats,
 )
 from polar.customer_portal.service.subscription import (
+    PauseSubscriptionNotAllowed,
     UpdateSubscriptionPlanNotAllowed,
     UpdateSubscriptionSeatsNotAllowed,
 )
@@ -450,3 +453,73 @@ class TestClearPendingUpdate:
         assert errors[0]["type"] == "value_error"
         assert errors[0]["loc"] == ("body", "pending_update")
         assert "no pending update" in errors[0]["msg"]
+
+
+@pytest.mark.asyncio
+class TestUpdatePause:
+    async def test_pause_not_allowed(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        with pytest.raises(PauseSubscriptionNotAllowed):
+            await customer_subscription_service.update(
+                session,
+                subscription,
+                updates=CustomerSubscriptionPause(pause_at_period_end=True),
+            )
+
+    async def test_pause_allowed(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        organization.customer_portal_settings = {
+            **organization.customer_portal_settings,
+            "subscription": {
+                **organization.customer_portal_settings["subscription"],
+                "pause": True,
+            },
+        }
+        await save_fixture(organization)
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        updated = await customer_subscription_service.update(
+            session,
+            subscription,
+            updates=CustomerSubscriptionPause(pause_at_period_end=True),
+        )
+
+        assert updated.pause_at_period_end is True
+
+    async def test_resume_not_allowed(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+
+        with pytest.raises(PauseSubscriptionNotAllowed):
+            await customer_subscription_service.update(
+                session,
+                subscription,
+                updates=CustomerSubscriptionResume(resume=True),
+            )

--- a/server/tests/customer_portal/service/test_subscription.py
+++ b/server/tests/customer_portal/service/test_subscription.py
@@ -523,3 +523,34 @@ class TestUpdatePause:
                 subscription,
                 updates=CustomerSubscriptionResume(resume=True),
             )
+
+    async def test_resume_allowed(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        organization.customer_portal_settings = {
+            **organization.customer_portal_settings,
+            "subscription": {
+                **organization.customer_portal_settings["subscription"],
+                "pause": True,
+            },
+        }
+        await save_fixture(organization)
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+
+        updated = await customer_subscription_service.update(
+            session,
+            subscription,
+            updates=CustomerSubscriptionResume(resume=True),
+        )
+
+        assert updated.status == SubscriptionStatus.active


### PR DESCRIPTION
This is the last PR of https://github.com/polarsource/polar/pull/12981 split

- **feat(customer-portal): self-serve pause/resume gated by org flag**
- **test(customer-portal): pause/resume gating tests**
- **fix(customer-portal): accurate pause/resume gating error + regen client**


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

