### PR TITLE
Improve UX for already active trial in checkout

### DIFF
--- a/clients/packages/checkout/src/components/CheckoutBanner.tsx
+++ b/clients/packages/checkout/src/components/CheckoutBanner.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { cn } from '@polar-sh/ui/lib/utils'
+
+interface CheckoutBannerProps {
+  title: string
+  description?: string
+  className?: string
+}
+
+export const CheckoutBanner = ({
+  title,
+  description,
+  className,
+}: CheckoutBannerProps) => {
+  return (
+    <div
+      className={cn(
+        'dark:border-polar-700 dark:bg-polar-800 flex w-full flex-col gap-1 rounded-lg border border-gray-200 bg-gray-50 p-3 text-left',
+        className,
+      )}
+    >
+      <p className="text-sm font-medium">{title}</p>
+      {description && (
+        <p className="dark:text-polar-400 text-sm text-gray-500">
+          {description}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/clients/packages/checkout/src/components/CheckoutForm.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.test.tsx
@@ -6,6 +6,10 @@ import type { UseFormReturn } from 'react-hook-form'
 import { useForm } from 'react-hook-form'
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import type { ProductCheckoutPublic } from '../guards'
+import {
+  CheckoutFormContext,
+  type CheckoutFormContextProps,
+} from '../providers/CheckoutFormProvider'
 import { createCheckout } from '../test-utils/makeCheckout'
 import CheckoutForm from './CheckoutForm'
 
@@ -263,6 +267,40 @@ describe('CheckoutForm', () => {
       )
 
       expect(screen.getByRole('button')).toBeDisabled()
+    })
+  })
+
+  describe('trial unavailable notice', () => {
+    const renderWithTrialUnavailable = (trialUnavailable: boolean) => {
+      const checkout = createCheckout({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        payment_processor: 'dummy' as any,
+      })
+
+      render(
+        <CheckoutFormContext.Provider
+          value={{ trialUnavailable } as CheckoutFormContextProps}
+        >
+          <FormWrapper checkout={checkout} {...defaultProps} locale="en" />
+        </CheckoutFormContext.Provider>,
+      )
+    }
+
+    it('shows the banner when trialUnavailable is true', () => {
+      renderWithTrialUnavailable(true)
+
+      expect(
+        screen.getByText('No free trial for this purchase'),
+      ).toBeInTheDocument()
+      expect(screen.getByText(/you'll be charged today/i)).toBeInTheDocument()
+    })
+
+    it('does not show the banner when trialUnavailable is false', () => {
+      renderWithTrialUnavailable(false)
+
+      expect(
+        screen.queryByText('No free trial for this purchase'),
+      ).not.toBeInTheDocument()
     })
   })
 

--- a/clients/packages/checkout/src/components/CheckoutForm.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.tsx
@@ -39,8 +39,10 @@ import { hasProductCheckout, isLegacyRecurringProductPrice } from '../guards'
 import { useDebouncedCallback } from '../hooks/debounce'
 import { isDisplayedField, isRequiredField } from '../utils/address'
 import { convertLocaleToStripeElementLocale } from '../utils/locale'
+import { useCheckoutForm } from '../providers/CheckoutFormProvider'
 import CustomFieldInput from './CustomFieldInput'
 import PolarLogo from './PolarLogo'
+import { CheckoutBanner } from './CheckoutBanner'
 
 const WALLET_PAYMENT_METHODS = ['apple_pay', 'google_pay', 'link']
 
@@ -111,6 +113,8 @@ const BaseCheckoutForm = ({
     resetField,
     formState: { errors },
   } = form
+
+  const { trialUnavailable } = useCheckoutForm()
 
   const discount = checkout.discount
   const isDiscountWithoutCode = discount && discount.code === null
@@ -681,6 +685,13 @@ const BaseCheckoutForm = ({
                 )}
             </div>
             {beforeSubmit}
+            {trialUnavailable && (
+              <CheckoutBanner
+                title={t('checkout.trialUnavailable.title')}
+                description={t('checkout.trialUnavailable.description')}
+                className={embed ? '-my-4' : '-my-6'}
+              />
+            )}
             <div className="flex w-full flex-col items-center justify-center gap-y-2">
               <Button
                 type="submit"

--- a/clients/packages/checkout/src/providers/CheckoutFormProvider.test.tsx
+++ b/clients/packages/checkout/src/providers/CheckoutFormProvider.test.tsx
@@ -330,7 +330,7 @@ describe('CheckoutFormProvider', () => {
       expect(getCtx().form.formState.errors.root).toBeUndefined()
     })
 
-    it('on TrialAlreadyRedeemed, sets root error and retries with allow_trial=false', async () => {
+    it('on TrialAlreadyRedeemed, flags trialUnavailable and retries with allow_trial=false without a root error', async () => {
       const update = vi.fn<CheckoutContextProps['update']>(
         async () => ({ ok: true, value: { id: 'ch_retry' } }) as UpdateResult,
       )
@@ -353,10 +353,50 @@ describe('CheckoutFormProvider', () => {
         ).rejects.toBeDefined()
       })
 
-      expect(getCtx().form.formState.errors.root?.message).toBe(
-        'trial already used',
-      )
+      expect(getCtx().trialUnavailable).toBe(true)
+      expect(getCtx().form.formState.errors.root).toBeUndefined()
       expect(update).toHaveBeenCalledWith({ allow_trial: false })
+    })
+
+    it('resets trialUnavailable when a new confirm is attempted', async () => {
+      const update = vi.fn<CheckoutContextProps['update']>(
+        async () => ({ ok: true, value: { id: 'ch_retry' } }) as UpdateResult,
+      )
+      const confirm = vi
+        .fn<CheckoutContextProps['confirm']>()
+        .mockImplementationOnce(async () =>
+          confirmErrorResult({
+            error: 'TrialAlreadyRedeemed',
+            detail: 'trial already used',
+          }),
+        )
+        .mockImplementationOnce(
+          async () =>
+            ({
+              ok: true,
+              value: { id: 'ch_confirmed', status: 'confirmed' },
+            }) as ConfirmResult,
+        )
+
+      const getCtx = renderWithCheckout({
+        checkout: freeCheckout,
+        update,
+        confirm,
+      })
+
+      await act(async () => {
+        await expect(
+          getCtx().confirm({ customer_email: 'a@b.com' }, null, null),
+        ).rejects.toBeDefined()
+      })
+
+      expect(getCtx().trialUnavailable).toBe(true)
+
+      await act(async () => {
+        await getCtx().confirm({ customer_email: 'a@b.com' }, null, null)
+      })
+
+      expect(getCtx().trialUnavailable).toBe(false)
     })
   })
 })

--- a/clients/packages/checkout/src/providers/CheckoutFormProvider.tsx
+++ b/clients/packages/checkout/src/providers/CheckoutFormProvider.tsx
@@ -39,6 +39,7 @@ export interface CheckoutFormContextProps {
   loading: boolean
   loadingLabel: string | undefined
   isUpdatePending: boolean
+  trialUnavailable: boolean
 }
 
 // @ts-expect-error - Allow to throw an error if the context is used without a provider
@@ -53,6 +54,7 @@ export const CheckoutFormProvider = ({
   const [loading, setLoading] = useState(false)
   const [loadingLabel, setLoadingLabel] = useState<string | undefined>()
   const [isUpdatePending, setIsUpdatePending] = useState(false)
+  const [trialUnavailable, setTrialUnavailable] = useState(false)
 
   const form = useForm<schemas['CheckoutUpdatePublic']>({
     defaultValues: {
@@ -125,7 +127,7 @@ export const CheckoutFormProvider = ({
             setError('root', { message: error.detail })
             break
           case 'TrialAlreadyRedeemed':
-            setError('root', { message: error.detail })
+            setTrialUnavailable(true)
             await update({ allow_trial: false })
             break
           case 'ResourceNotFound':
@@ -136,7 +138,7 @@ export const CheckoutFormProvider = ({
 
       throw error
     },
-    [confirmOuter, setError, update],
+    [confirmOuter, setError, update, setTrialUnavailable],
   )
 
   const confirm = useCallback(
@@ -146,6 +148,7 @@ export const CheckoutFormProvider = ({
       elements: StripeElements | null,
     ): Promise<schemas['CheckoutPublicConfirmed']> => {
       setLoading(true)
+      setTrialUnavailable(false)
 
       if (!checkout.is_payment_form_required) {
         setLoadingLabel(t('checkout.loading.processingOrder'))
@@ -249,7 +252,7 @@ export const CheckoutFormProvider = ({
       setLoading(false)
       return updatedCheckout
     },
-    [checkout, setError, _confirm, t],
+    [checkout, setError, _confirm, t, setTrialUnavailable],
   )
 
   return (
@@ -262,6 +265,7 @@ export const CheckoutFormProvider = ({
         loading,
         loadingLabel,
         isUpdatePending,
+        trialUnavailable,
       }}
     >
       {children}

--- a/clients/packages/i18n/src/locales/config/.cache.json
+++ b/clients/packages/i18n/src/locales/config/.cache.json
@@ -176,7 +176,9 @@
     "intervals.short.month.=1": "mo",
     "intervals.short.month.other": "# mo",
     "intervals.short.year.=1": "yr",
-    "intervals.short.year.other": "# yr"
+    "intervals.short.year.other": "# yr",
+    "checkout.trialUnavailable.title": "No free trial for this purchase",
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
   },
   "fr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -355,7 +357,9 @@
     "intervals.short.month.=1": "mo",
     "intervals.short.month.other": "# mo",
     "intervals.short.year.=1": "yr",
-    "intervals.short.year.other": "# yr"
+    "intervals.short.year.other": "# yr",
+    "checkout.trialUnavailable.title": "No free trial for this purchase",
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
   },
   "sv": {
     "checkout.footer.poweredBy": "Powered by",
@@ -534,7 +538,9 @@
     "intervals.short.month.=1": "mo",
     "intervals.short.month.other": "# mo",
     "intervals.short.year.=1": "yr",
-    "intervals.short.year.other": "# yr"
+    "intervals.short.year.other": "# yr",
+    "checkout.trialUnavailable.title": "No free trial for this purchase",
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
   },
   "es": {
     "checkout.footer.poweredBy": "Powered by",
@@ -713,7 +719,9 @@
     "intervals.short.month.=1": "mo",
     "intervals.short.month.other": "# mo",
     "intervals.short.year.=1": "yr",
-    "intervals.short.year.other": "# yr"
+    "intervals.short.year.other": "# yr",
+    "checkout.trialUnavailable.title": "No free trial for this purchase",
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
   },
   "de": {
     "checkout.footer.poweredBy": "Powered by",
@@ -892,7 +900,9 @@
     "intervals.short.month.=1": "mo",
     "intervals.short.month.other": "# mo",
     "intervals.short.year.=1": "yr",
-    "intervals.short.year.other": "# yr"
+    "intervals.short.year.other": "# yr",
+    "checkout.trialUnavailable.title": "No free trial for this purchase",
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
   },
   "hu": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1063,7 +1073,9 @@
     "intervals.short.month.=1": "mo",
     "intervals.short.month.other": "# mo",
     "intervals.short.year.=1": "yr",
-    "intervals.short.year.other": "# yr"
+    "intervals.short.year.other": "# yr",
+    "checkout.trialUnavailable.title": "No free trial for this purchase",
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
   },
   "it": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1234,7 +1246,9 @@
     "intervals.short.month.=1": "mo",
     "intervals.short.month.other": "# mo",
     "intervals.short.year.=1": "yr",
-    "intervals.short.year.other": "# yr"
+    "intervals.short.year.other": "# yr",
+    "checkout.trialUnavailable.title": "No free trial for this purchase",
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
   },
   "ko": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1405,7 +1419,9 @@
     "intervals.short.month.=1": "mo",
     "intervals.short.month.other": "# mo",
     "intervals.short.year.=1": "yr",
-    "intervals.short.year.other": "# yr"
+    "intervals.short.year.other": "# yr",
+    "checkout.trialUnavailable.title": "No free trial for this purchase",
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
   },
   "pt": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1576,7 +1592,9 @@
     "intervals.short.month.=1": "mo",
     "intervals.short.month.other": "# mo",
     "intervals.short.year.=1": "yr",
-    "intervals.short.year.other": "# yr"
+    "intervals.short.year.other": "# yr",
+    "checkout.trialUnavailable.title": "No free trial for this purchase",
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
   },
   "pt-PT": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1747,7 +1765,9 @@
     "intervals.short.month.=1": "mo",
     "intervals.short.month.other": "# mo",
     "intervals.short.year.=1": "yr",
-    "intervals.short.year.other": "# yr"
+    "intervals.short.year.other": "# yr",
+    "checkout.trialUnavailable.title": "No free trial for this purchase",
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
   },
   "ja": {
     "checkout.footer.poweredBy": "Powered by",
@@ -1918,7 +1938,9 @@
     "intervals.short.month.=1": "mo",
     "intervals.short.month.other": "# mo",
     "intervals.short.year.=1": "yr",
-    "intervals.short.year.other": "# yr"
+    "intervals.short.year.other": "# yr",
+    "checkout.trialUnavailable.title": "No free trial for this purchase",
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
   },
   "tr": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2089,7 +2111,9 @@
     "intervals.short.month.=1": "mo",
     "intervals.short.month.other": "# mo",
     "intervals.short.year.=1": "yr",
-    "intervals.short.year.other": "# yr"
+    "intervals.short.year.other": "# yr",
+    "checkout.trialUnavailable.title": "No free trial for this purchase",
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
   },
   "pl": {
     "checkout.footer.poweredBy": "Powered by",
@@ -2260,6 +2284,8 @@
     "intervals.short.month.=1": "mo",
     "intervals.short.month.other": "# mo",
     "intervals.short.year.=1": "yr",
-    "intervals.short.year.other": "# yr"
+    "intervals.short.year.other": "# yr",
+    "checkout.trialUnavailable.title": "No free trial for this purchase",
+    "checkout.trialUnavailable.description": "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase."
   }
 }

--- a/clients/packages/i18n/src/locales/de.ts
+++ b/clients/packages/i18n/src/locales/de.ts
@@ -228,28 +228,33 @@ export default {
     productDescription: {
       readMore: 'Mehr anzeigen',
     },
+    trialUnavailable: {
+      title: 'Keine kostenlose Testversion für diesen Kauf',
+      description:
+        'Sie haben bereits eine kostenlose Testversion für dieses Produkt genutzt, daher wird Ihnen heute der Preis berechnet. Fahren Sie unten fort, um Ihren Kauf abzuschließen.',
+    },
   },
   intervals: {
     short: {
       day: {
-        _mode: 'plural',
         '=1': 'T.',
         other: '# T.',
+        _mode: 'plural',
       },
       week: {
-        _mode: 'plural',
         '=1': 'W.',
         other: '# W.',
+        _mode: 'plural',
       },
       month: {
-        _mode: 'plural',
         '=1': 'M.',
         other: '# M.',
+        _mode: 'plural',
       },
       year: {
-        _mode: 'plural',
         '=1': 'J',
         other: '# J.',
+        _mode: 'plural',
       },
     },
   },

--- a/clients/packages/i18n/src/locales/en.ts
+++ b/clients/packages/i18n/src/locales/en.ts
@@ -273,6 +273,11 @@ export default {
       getFree: 'Get for free',
       paymentsUnavailable: 'Payments are currently unavailable',
     },
+    trialUnavailable: {
+      title: 'No free trial for this purchase',
+      description:
+        "You've already used a free trial for this product, so you'll be charged today. Continue below to complete your purchase.",
+    },
   },
   intervals: {
     short: {

--- a/clients/packages/i18n/src/locales/es.ts
+++ b/clients/packages/i18n/src/locales/es.ts
@@ -224,28 +224,33 @@ export default {
     productDescription: {
       readMore: 'Leer más',
     },
+    trialUnavailable: {
+      title: 'No hay prueba gratis para esta compra',
+      description:
+        'Ya has usado una prueba gratis para este producto, así que se te cobrará hoy. Continúa abajo para completar tu compra.',
+    },
   },
   intervals: {
     short: {
       day: {
-        _mode: 'plural',
         '=1': 'd',
         other: '# días',
+        _mode: 'plural',
       },
       week: {
-        _mode: 'plural',
         '=1': 'sem',
         other: '# sem',
+        _mode: 'plural',
       },
       month: {
-        _mode: 'plural',
         '=1': 'm',
         other: '# meses',
+        _mode: 'plural',
       },
       year: {
-        _mode: 'plural',
         '=1': 'a',
         other: '# años',
+        _mode: 'plural',
       },
     },
   },

--- a/clients/packages/i18n/src/locales/fr.ts
+++ b/clients/packages/i18n/src/locales/fr.ts
@@ -226,28 +226,33 @@ export default {
     productDescription: {
       readMore: 'Lire la suite',
     },
+    trialUnavailable: {
+      title: 'Aucun essai gratuit pour cet achat',
+      description:
+        "Vous avez déjà utilisé un essai gratuit pour ce produit, vous serez donc facturé aujourd'hui. Continuez ci-dessous pour finaliser votre achat.",
+    },
   },
   intervals: {
     short: {
       day: {
-        _mode: 'plural',
         '=1': 'j',
         other: '# j',
+        _mode: 'plural',
       },
       week: {
-        _mode: 'plural',
         '=1': 'sem',
         other: '# sem',
+        _mode: 'plural',
       },
       month: {
-        _mode: 'plural',
         '=1': 'mois',
         other: '# mois',
+        _mode: 'plural',
       },
       year: {
-        _mode: 'plural',
         '=1': 'an',
         other: '# ans',
+        _mode: 'plural',
       },
     },
   },

--- a/clients/packages/i18n/src/locales/hu.ts
+++ b/clients/packages/i18n/src/locales/hu.ts
@@ -223,28 +223,33 @@ export default {
     productDescription: {
       readMore: 'Bővebben',
     },
+    trialUnavailable: {
+      title: 'Ehhez a vásárláshoz nincs ingyenes próbaidőszak',
+      description:
+        'Ehhez a termékhez már felhasznált egy ingyenes próbaidőszakot, így ma kiszámlázzuk az összeget. A vásárlás befejezéséhez folytassa lent.',
+    },
   },
   intervals: {
     short: {
       day: {
-        _mode: 'plural',
         '=1': 'nap',
         other: '# nap',
+        _mode: 'plural',
       },
       week: {
-        _mode: 'plural',
         '=1': 'hét',
         other: '# hét',
+        _mode: 'plural',
       },
       month: {
-        _mode: 'plural',
         '=1': 'hó',
         other: '# hó',
+        _mode: 'plural',
       },
       year: {
-        _mode: 'plural',
         '=1': 'év',
         other: '# év',
+        _mode: 'plural',
       },
     },
   },

--- a/clients/packages/i18n/src/locales/it.ts
+++ b/clients/packages/i18n/src/locales/it.ts
@@ -225,28 +225,33 @@ export default {
     productDescription: {
       readMore: 'Leggi di più',
     },
+    trialUnavailable: {
+      title: 'Nessuna prova gratuita per questo acquisto',
+      description:
+        "Hai già utilizzato una prova gratuita per questo prodotto, quindi ti verrà addebitato oggi. Continua qui sotto per completare l'acquisto.",
+    },
   },
   intervals: {
     short: {
       day: {
-        _mode: 'plural',
         '=1': 'g',
         other: '# giorni',
+        _mode: 'plural',
       },
       week: {
-        _mode: 'plural',
         '=1': 'sett',
         other: '# settimane',
+        _mode: 'plural',
       },
       month: {
-        _mode: 'plural',
         '=1': 'mese',
         other: '# mesi',
+        _mode: 'plural',
       },
       year: {
-        _mode: 'plural',
         '=1': 'anno',
         other: '# anni',
+        _mode: 'plural',
       },
     },
   },

--- a/clients/packages/i18n/src/locales/ja.ts
+++ b/clients/packages/i18n/src/locales/ja.ts
@@ -226,28 +226,33 @@ export default {
       getFree: '無料で入手',
       paymentsUnavailable: '現在、支払いはご利用いただけません',
     },
+    trialUnavailable: {
+      title: 'この購入では無料トライアルは利用できません',
+      description:
+        'この商品ではすでに無料トライアルを利用済みのため、本日ご請求されます。以下から続行して購入を完了してください。',
+    },
   },
   intervals: {
     short: {
       day: {
-        _mode: 'plural',
         '=1': '日',
         other: '#日',
+        _mode: 'plural',
       },
       week: {
-        _mode: 'plural',
         '=1': '週',
         other: '#週間',
+        _mode: 'plural',
       },
       month: {
-        _mode: 'plural',
         '=1': '月',
         other: '#ヶ月',
+        _mode: 'plural',
       },
       year: {
-        _mode: 'plural',
         '=1': '年',
         other: '#年',
+        _mode: 'plural',
       },
     },
   },

--- a/clients/packages/i18n/src/locales/ko.ts
+++ b/clients/packages/i18n/src/locales/ko.ts
@@ -221,28 +221,33 @@ export default {
     productDescription: {
       readMore: '더 보기',
     },
+    trialUnavailable: {
+      title: '이 구매에는 무료 체험이 제공되지 않습니다',
+      description:
+        '이 제품의 무료 체험을 이미 사용하셨으므로 오늘 결제가 진행됩니다. 아래에서 계속하여 구매를 완료하세요.',
+    },
   },
   intervals: {
     short: {
       day: {
-        _mode: 'plural',
         '=1': '일',
         other: '#일',
+        _mode: 'plural',
       },
       week: {
-        _mode: 'plural',
         '=1': '주',
         other: '#주',
+        _mode: 'plural',
       },
       month: {
-        _mode: 'plural',
         '=1': '월',
         other: '#개월',
+        _mode: 'plural',
       },
       year: {
-        _mode: 'plural',
         '=1': '년',
         other: '#년',
+        _mode: 'plural',
       },
     },
   },

--- a/clients/packages/i18n/src/locales/nl.ts
+++ b/clients/packages/i18n/src/locales/nl.ts
@@ -225,28 +225,33 @@ export default {
     productDescription: {
       readMore: 'Lees meer',
     },
+    trialUnavailable: {
+      title: 'Geen gratis proefperiode voor deze aankoop',
+      description:
+        'Je hebt al een gratis proefperiode voor dit product gebruikt, dus er wordt vandaag kosten in rekening gebracht. Ga hieronder verder om je aankoop af te ronden.',
+    },
   },
   intervals: {
     short: {
       day: {
-        _mode: 'plural',
         '=1': 'dg',
         other: '# dg',
+        _mode: 'plural',
       },
       week: {
-        _mode: 'plural',
         '=1': 'wk',
         other: '# wk',
+        _mode: 'plural',
       },
       month: {
-        _mode: 'plural',
         '=1': 'mnd',
         other: '# mnd',
+        _mode: 'plural',
       },
       year: {
-        _mode: 'plural',
         '=1': 'jr',
         other: '# jr',
+        _mode: 'plural',
       },
     },
   },

--- a/clients/packages/i18n/src/locales/pl.ts
+++ b/clients/packages/i18n/src/locales/pl.ts
@@ -225,28 +225,33 @@ export default {
     productDescription: {
       readMore: 'Czytaj więcej',
     },
+    trialUnavailable: {
+      title: 'Brak bezpłatnego okresu próbnego dla tego zakupu',
+      description:
+        'Już skorzystano z bezpłatnego okresu próbnego tego produktu, więc opłata zostanie naliczona dzisiaj. Kontynuuj poniżej, aby dokończyć zakup.',
+    },
   },
   intervals: {
     short: {
       day: {
-        _mode: 'plural',
         '=1': 'dz.',
         other: '# dz.',
+        _mode: 'plural',
       },
       week: {
-        _mode: 'plural',
         '=1': 'tyg.',
         other: '# tyg.',
+        _mode: 'plural',
       },
       month: {
-        _mode: 'plural',
         '=1': 'mies.',
         other: '# mies.',
+        _mode: 'plural',
       },
       year: {
-        _mode: 'plural',
         '=1': 'r.',
         other: '# l.',
+        _mode: 'plural',
       },
     },
   },

--- a/clients/packages/i18n/src/locales/pt-PT.ts
+++ b/clients/packages/i18n/src/locales/pt-PT.ts
@@ -223,28 +223,33 @@ export default {
     productDescription: {
       readMore: 'Ler mais',
     },
+    trialUnavailable: {
+      title: 'Não há avaliação gratuita para esta compra',
+      description:
+        'Já utilizou uma avaliação gratuita para este produto, por isso será cobrado hoje. Continue abaixo para concluir a compra.',
+    },
   },
   intervals: {
     short: {
       day: {
-        _mode: 'plural',
         '=1': 'dia',
         other: '# dias',
+        _mode: 'plural',
       },
       week: {
-        _mode: 'plural',
         '=1': 'sem',
         other: '# sem',
+        _mode: 'plural',
       },
       month: {
-        _mode: 'plural',
         '=1': 'mês',
         other: '# meses',
+        _mode: 'plural',
       },
       year: {
-        _mode: 'plural',
         '=1': 'ano',
         other: '# anos',
+        _mode: 'plural',
       },
     },
   },

--- a/clients/packages/i18n/src/locales/pt.ts
+++ b/clients/packages/i18n/src/locales/pt.ts
@@ -223,28 +223,33 @@ export default {
     productDescription: {
       readMore: 'Ler mais',
     },
+    trialUnavailable: {
+      title: 'Sem teste grátis para esta compra',
+      description:
+        'Você já usou um teste grátis para este produto, então a cobrança será feita hoje. Continue abaixo para concluir sua compra.',
+    },
   },
   intervals: {
     short: {
       day: {
-        _mode: 'plural',
         '=1': 'dia',
         other: '# dias',
+        _mode: 'plural',
       },
       week: {
-        _mode: 'plural',
         '=1': 'sem',
         other: '# sem',
+        _mode: 'plural',
       },
       month: {
-        _mode: 'plural',
         '=1': 'mês',
         other: '# meses',
+        _mode: 'plural',
       },
       year: {
-        _mode: 'plural',
         '=1': 'ano',
         other: '# anos',
+        _mode: 'plural',
       },
     },
   },

--- a/clients/packages/i18n/src/locales/sv.ts
+++ b/clients/packages/i18n/src/locales/sv.ts
@@ -222,28 +222,33 @@ export default {
     productDescription: {
       readMore: 'Läs mer',
     },
+    trialUnavailable: {
+      title: 'Ingen gratis provperiod för det här köpet',
+      description:
+        'Du har redan använt en gratis provperiod för den här produkten, så du debiteras idag. Fortsätt nedan för att slutföra köpet.',
+    },
   },
   intervals: {
     short: {
       day: {
-        _mode: 'plural',
         '=1': 'd',
         other: '# d',
+        _mode: 'plural',
       },
       week: {
-        _mode: 'plural',
         '=1': 'v',
         other: '# v',
+        _mode: 'plural',
       },
       month: {
-        _mode: 'plural',
         '=1': 'mån',
         other: '# mån',
+        _mode: 'plural',
       },
       year: {
-        _mode: 'plural',
         '=1': 'år',
         other: '# år',
+        _mode: 'plural',
       },
     },
   },

--- a/clients/packages/i18n/src/locales/tr.ts
+++ b/clients/packages/i18n/src/locales/tr.ts
@@ -223,28 +223,33 @@ export default {
       getFree: 'Ücretsiz al',
       paymentsUnavailable: 'Ödemeler şu anda kullanılamıyor',
     },
+    trialUnavailable: {
+      title: 'Bu satın alma için ücretsiz deneme yok',
+      description:
+        'Bu ürün için ücretsiz denemeyi zaten kullandınız, bu yüzden bugün ücretlendirileceksiniz. Satın alma işleminizi tamamlamak için aşağıdan devam edin.',
+    },
   },
   intervals: {
     short: {
       day: {
-        _mode: 'plural',
         '=1': 'g',
         other: '# gün',
+        _mode: 'plural',
       },
       week: {
-        _mode: 'plural',
         '=1': 'h',
         other: '# hafta',
+        _mode: 'plural',
       },
       month: {
-        _mode: 'plural',
         '=1': 'a',
         other: '# ay',
+        _mode: 'plural',
       },
       year: {
-        _mode: 'plural',
         '=1': 'y',
         other: '# yıl',
+        _mode: 'plural',
       },
     },
   },


### PR DESCRIPTION
## Summary

If a merchant has the **Prevent trial abuse** setting enabled and a customer subscribes to a free trial, cancels and then tries to cancel again we show an error-like message in the checkout.

This causes some confusion since it seems that the user cannot subscribe again, which is not true. This PR fixes that by adding a more notice like warning.

Closes https://github.com/polarsource/feedback/issues/234

## Screenshots

### Comparison
| Before | After  |
|--------|--------|
| <img width="1840" height="1134" alt="Screenshot 2026-07-07 at 13 05 51" src="https://github.com/user-attachments/assets/6058a060-dce3-49e1-bb5d-a40cfc998af0" /> | <img width="1840" height="1133" alt="Screenshot 2026-07-07 at 13 04 06" src="https://github.com/user-attachments/assets/443ced58-bcb1-45aa-84a8-374206efcc36" /> |

### Embed
<img width="1840" height="1134" alt="Screenshot 2026-07-07 at 13 19 18" src="https://github.com/user-attachments/assets/9f44ae52-641a-4305-95b6-56bcc22ae3b3" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

