### PR TITLE
tf/aws/security: Import auto-created GuardDuty detectors

### DIFF
--- a/terraform/security/guardduty.tf
+++ b/terraform/security/guardduty.tf
@@ -1,3 +1,13 @@
+import {
+  to = aws_guardduty_detector.us_east_1
+  id = "56cf9e143c422ea8000cad4a80678a5a"
+}
+
+import {
+  to = aws_guardduty_detector.us_east_2
+  id = "d6cf9e143d2cc1b55f1ce549b8799da3"
+}
+
 resource "aws_guardduty_detector" "us_east_1" {
   enable = true
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Import the auto-created AWS GuardDuty detectors in us-east-1 and us-east-2 into Terraform state via `import` blocks. This fixes plan/apply errors and prevents Terraform from attempting to recreate these detectors.

<sup>Written for commit 6772bc50ac1914fdbfeca602762a55214c1e09fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

