### PR TITLE
session: Introduce SesssionNotFresh exception

### DIFF
--- a/clients/apps/web/src/components/Form/EmailUpdateForm.tsx
+++ b/clients/apps/web/src/components/Form/EmailUpdateForm.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useSessionRefreshPrompt } from '@/components/Settings/SessionRefreshModal'
 import { useSendEmailUpdate } from '@/hooks/emailUpdate'
 import { setValidationErrors } from '@/utils/api/errors'
 import { Button } from '@polar-sh/orbit'
@@ -27,6 +28,8 @@ const EmailUpdateForm = ({
   const [loading, setLoading] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const sendEmailUpdate = useSendEmailUpdate()
+  const { promptIfSessionNotFresh, sessionRefreshModal } =
+    useSessionRefreshPrompt()
 
   const onSubmit: SubmitHandler<{ email: string }> = async ({ email }) => {
     setErrorMessage(null) // Clear previous errors
@@ -34,6 +37,9 @@ const EmailUpdateForm = ({
     const { error } = await sendEmailUpdate(email, returnTo)
     setLoading(false)
     if (error) {
+      if (promptIfSessionNotFresh(error)) {
+        return
+      }
       let errMsg = 'An error occurred while updating your email.'
       if (error.detail && Array.isArray(error.detail)) {
         const emailError = error.detail.find(
@@ -101,6 +107,7 @@ const EmailUpdateForm = ({
             {errorMessage}
           </div>
         )}
+        {sessionRefreshModal}
       </form>
     </Form>
   )

--- a/clients/apps/web/src/components/Settings/AuthenticationSettings.tsx
+++ b/clients/apps/web/src/components/Settings/AuthenticationSettings.tsx
@@ -19,6 +19,7 @@ import { ListGroup } from '@polar-sh/orbit'
 import { usePathname, useSearchParams } from 'next/navigation'
 import { useEffect, useRef, useState } from 'react'
 import EmailUpdateForm from '../Form/EmailUpdateForm'
+import { useSessionRefreshPrompt } from './SessionRefreshModal'
 import { twMerge } from 'tailwind-merge'
 
 const AuthenticationMethod = ({
@@ -162,6 +163,15 @@ const AuthenticationSettings = () => {
   const googleAccount = useGoogleAccount()
   const disconnectOAuth = useDisconnectOAuthAccount()
   const listGroupRef = useRef<HTMLDivElement>(null)
+  const { promptIfSessionNotFresh, sessionRefreshModal } =
+    useSessionRefreshPrompt()
+
+  const handleDisconnect = async (platform: schemas['OAuthPlatform']) => {
+    const { error } = await disconnectOAuth.mutateAsync(platform)
+    if (error) {
+      promptIfSessionNotFresh(error)
+    }
+  }
 
   const searchParams = useSearchParams()
   const [updateEmailStage, setUpdateEmailStage] = useState<
@@ -230,7 +240,7 @@ const AuthenticationSettings = () => {
           <GitHubAuthenticationMethod
             oauthAccount={githubAccount}
             returnTo={pathname || '/start'}
-            onDisconnect={() => disconnectOAuth.mutate('github')}
+            onDisconnect={() => handleDisconnect('github')}
             isDisconnecting={disconnectOAuth.isPending}
             error={
               oauthLinkError && oauthLinkFactor === 'github'
@@ -244,7 +254,7 @@ const AuthenticationSettings = () => {
           <GoogleAuthenticationMethod
             oauthAccount={googleAccount}
             returnTo={pathname || '/start'}
-            onDisconnect={() => disconnectOAuth.mutate('google')}
+            onDisconnect={() => handleDisconnect('google')}
             isDisconnecting={disconnectOAuth.isPending}
             error={
               oauthLinkError && oauthLinkFactor === 'google'
@@ -264,6 +274,8 @@ const AuthenticationSettings = () => {
           />
         </ListGroup.Item>
       </ListGroup>
+
+      {sessionRefreshModal}
     </div>
   )
 }

--- a/clients/apps/web/src/components/Settings/AuthenticationSettings.tsx
+++ b/clients/apps/web/src/components/Settings/AuthenticationSettings.tsx
@@ -6,6 +6,7 @@ import {
   useGitHubAccount,
   useGoogleAccount,
 } from '@/hooks'
+import { extractApiErrorMessage } from '@/utils/api/errors'
 import {
   getGitHubAuthorizeLinkURL,
   getGoogleAuthorizeLinkURL,
@@ -19,6 +20,7 @@ import { ListGroup } from '@polar-sh/orbit'
 import { usePathname, useSearchParams } from 'next/navigation'
 import { useEffect, useRef, useState } from 'react'
 import EmailUpdateForm from '../Form/EmailUpdateForm'
+import { toast } from '../Toast/use-toast'
 import { useSessionRefreshPrompt } from './SessionRefreshModal'
 import { twMerge } from 'tailwind-merge'
 
@@ -167,9 +169,24 @@ const AuthenticationSettings = () => {
     useSessionRefreshPrompt()
 
   const handleDisconnect = async (platform: schemas['OAuthPlatform']) => {
-    const { error } = await disconnectOAuth.mutateAsync(platform)
-    if (error) {
-      promptIfSessionNotFresh(error)
+    try {
+      const { error } = await disconnectOAuth.mutateAsync(platform)
+      if (error) {
+        if (promptIfSessionNotFresh(error)) {
+          return
+        }
+        toast({
+          title: 'Error',
+          description: extractApiErrorMessage(error),
+          variant: 'error',
+        })
+      }
+    } catch {
+      toast({
+        title: 'Error',
+        description: 'Failed to disconnect account. Please try again.',
+        variant: 'error',
+      })
     }
   }
 

--- a/clients/apps/web/src/components/Settings/SessionRefreshModal.tsx
+++ b/clients/apps/web/src/components/Settings/SessionRefreshModal.tsx
@@ -3,12 +3,13 @@
 import { ConfirmModal } from '@/components/Modal/ConfirmModal'
 import { useModal } from '@/components/Modal/useModal'
 import { isSessionNotFreshError } from '@/utils/api/errors'
-import { usePathname, useRouter } from 'next/navigation'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { useCallback } from 'react'
 
 export const useSessionRefreshPrompt = () => {
   const router = useRouter()
   const pathname = usePathname()
+  const searchParams = useSearchParams()
   const { isShown, show, hide } = useModal()
 
   const promptIfSessionNotFresh = useCallback(
@@ -28,9 +29,11 @@ export const useSessionRefreshPrompt = () => {
       hide={hide}
       title="Please sign in again"
       description="For your security, this action requires that you signed in recently. Sign in again to continue."
-      onConfirm={() =>
-        router.push(`/auth?return_to=${encodeURIComponent(pathname ?? '/')}`)
-      }
+      onConfirm={() => {
+        const query = searchParams?.toString()
+        const returnTo = `${pathname ?? '/'}${query ? `?${query}` : ''}`
+        router.push(`/auth?return_to=${encodeURIComponent(returnTo)}`)
+      }}
     />
   )
 

--- a/clients/apps/web/src/components/Settings/SessionRefreshModal.tsx
+++ b/clients/apps/web/src/components/Settings/SessionRefreshModal.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { ConfirmModal } from '@/components/Modal/ConfirmModal'
+import { useModal } from '@/components/Modal/useModal'
+import { isSessionNotFreshError } from '@/utils/api/errors'
+import { usePathname, useRouter } from 'next/navigation'
+import { useCallback } from 'react'
+
+export const useSessionRefreshPrompt = () => {
+  const router = useRouter()
+  const pathname = usePathname()
+  const { isShown, show, hide } = useModal()
+
+  const promptIfSessionNotFresh = useCallback(
+    (error: unknown): boolean => {
+      if (!isSessionNotFreshError(error)) {
+        return false
+      }
+      show()
+      return true
+    },
+    [show],
+  )
+
+  const sessionRefreshModal = (
+    <ConfirmModal
+      isShown={isShown}
+      hide={hide}
+      title="Please sign in again"
+      description="For your security, this action requires that you signed in recently. Sign in again to continue."
+      onConfirm={() =>
+        router.push(`/auth?return_to=${encodeURIComponent(pathname ?? '/')}`)
+      }
+    />
+  )
+
+  return { promptIfSessionNotFresh, sessionRefreshModal }
+}

--- a/clients/apps/web/src/components/Settings/TOTPSetupModal.tsx
+++ b/clients/apps/web/src/components/Settings/TOTPSetupModal.tsx
@@ -13,6 +13,7 @@ import QRCode from 'react-qr-code'
 import { useState } from 'react'
 import CopyToClipboardInput from '@polar-sh/ui/components/atoms/CopyToClipboardInput'
 import { toast } from '../Toast/use-toast'
+import { useSessionRefreshPrompt } from './SessionRefreshModal'
 
 export interface TOTPSetupModalProps {
   isShown: boolean
@@ -32,6 +33,8 @@ const TOTPSetupContent = ({ onEnabled }: { onEnabled: () => void }) => {
 
   const totpEnroll = useTOTPEnroll()
   const totpEnable = useTOTPEnable()
+  const { promptIfSessionNotFresh, sessionRefreshModal } =
+    useSessionRefreshPrompt()
 
   const renderContent = () => {
     if (!enrollment) {
@@ -135,7 +138,7 @@ const TOTPSetupContent = ({ onEnabled }: { onEnabled: () => void }) => {
       onSuccess: (response) => {
         if (response.data) {
           setEnrollment(response.data)
-        } else {
+        } else if (!promptIfSessionNotFresh(response.error)) {
           setError('Failed to start TOTP setup. Please try again.')
         }
       },
@@ -152,6 +155,9 @@ const TOTPSetupContent = ({ onEnabled }: { onEnabled: () => void }) => {
     setError(null)
     const { error } = await totpEnable.mutateAsync(code)
     if (error) {
+      if (promptIfSessionNotFresh(error)) {
+        return
+      }
       setError('Invalid code. Please try again.')
       setInvalidCodeError(true)
       return
@@ -165,7 +171,12 @@ const TOTPSetupContent = ({ onEnabled }: { onEnabled: () => void }) => {
     if (error) setError(null)
   }
 
-  return renderContent()
+  return (
+    <>
+      {renderContent()}
+      {sessionRefreshModal}
+    </>
+  )
 }
 
 const TOTPSetupModal = ({ isShown, hide, onEnabled }: TOTPSetupModalProps) => {

--- a/clients/apps/web/src/components/Settings/TwoFactorSettings.tsx
+++ b/clients/apps/web/src/components/Settings/TwoFactorSettings.tsx
@@ -15,6 +15,7 @@ import { useState } from 'react'
 import TOTPSetupModal from './TOTPSetupModal'
 import BackupCodesModal from './BackupCodesModal'
 import BackupCodesRegenerateModal from './BackupCodesRegenerateModal'
+import { useSessionRefreshPrompt } from './SessionRefreshModal'
 import { toast } from '../Toast/use-toast'
 import { KeyRoundIcon, ShieldCheckIcon } from 'lucide-react'
 
@@ -77,9 +78,15 @@ const TwoFactorSettings = () => {
 
   const [newBackupCodes, setNewBackupCodes] = useState<string[] | null>(null)
 
+  const { promptIfSessionNotFresh, sessionRefreshModal } =
+    useSessionRefreshPrompt()
+
   const handleDeleteTOTP = async () => {
     const { error } = await totpDelete.mutateAsync()
     if (error) {
+      if (promptIfSessionNotFresh(error)) {
+        return
+      }
       toast({
         title: 'Error',
         description: extractApiErrorMessage(error),
@@ -146,6 +153,9 @@ const TwoFactorSettings = () => {
                       const { data, error } =
                         await backupCodesEnroll.mutateAsync()
                       if (error) {
+                        if (promptIfSessionNotFresh(error)) {
+                          return
+                        }
                         toast({
                           title: 'Error',
                           description: extractApiErrorMessage(error),
@@ -178,6 +188,9 @@ const TwoFactorSettings = () => {
           await totpStatus.refetch()
           const { data, error } = await backupCodesEnroll.mutateAsync()
           if (error) {
+            if (promptIfSessionNotFresh(error)) {
+              return
+            }
             toast({
               title: 'Error',
               description: extractApiErrorMessage(error),
@@ -209,6 +222,10 @@ const TwoFactorSettings = () => {
         onRegenerate={async () => {
           const { data, error } = await backupCodesEnroll.mutateAsync()
           if (error) {
+            if (promptIfSessionNotFresh(error)) {
+              hideBackupCodesRegenerateModal()
+              return null
+            }
             toast({
               title: 'Error',
               description: extractApiErrorMessage(error),
@@ -231,6 +248,8 @@ const TwoFactorSettings = () => {
         hide={hideBackupCodesModal}
         codes={newBackupCodes || []}
       />
+
+      {sessionRefreshModal}
     </div>
   )
 }

--- a/clients/apps/web/src/utils/api/errors.ts
+++ b/clients/apps/web/src/utils/api/errors.ts
@@ -115,6 +115,12 @@ export const setProductValidationErrors = <TFieldValues extends FieldValues>(
   })
 }
 
+export const isSessionNotFreshError = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  'error' in error &&
+  error.error === 'SessionNotFreshError'
+
 export const extractApiErrorMessage = (
   error: { detail?: string | { msg?: string }[] | unknown },
   fallback: string = 'An unexpected error occurred',

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -28317,6 +28317,17 @@ export interface components {
       | 'disputed'
       | 'charge_disputed'
       | 'cancelled'
+    /** PolarAuthError */
+    PolarAuthError: {
+      /**
+       * Error
+       * @example PolarAuthError
+       * @constant
+       */
+      error: 'PolarAuthError'
+      /** Detail */
+      detail: string
+    }
     /** PolarSelfPaymentMethodInUse */
     PolarSelfPaymentMethodInUse: {
       /**
@@ -39246,13 +39257,15 @@ export interface operations {
           'application/json': unknown
         }
       }
-      /** @description Forbidden */
+      /** @description Session is not fresh, TOTP factor not enrolled, or invalid TOTP code. */
       403: {
         headers: {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['SessionNotFreshError']
+          'application/json':
+            | components['schemas']['SessionNotFreshError']
+            | components['schemas']['PolarAuthError']
         }
       }
       /** @description Validation Error */

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -30542,6 +30542,17 @@ export interface components {
        */
       total_seats: number
     }
+    /** SessionNotFreshError */
+    SessionNotFreshError: {
+      /**
+       * Error
+       * @example SessionNotFreshError
+       * @constant
+       */
+      error: 'SessionNotFreshError'
+      /** Detail */
+      detail: string
+    }
     /** SlackIntegration */
     SlackIntegration: {
       /**
@@ -35523,6 +35534,15 @@ export interface operations {
         }
         content?: never
       }
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['SessionNotFreshError']
+        }
+      }
       /** @description OAuth account not found */
       404: {
         headers: {
@@ -39166,6 +39186,15 @@ export interface operations {
           'application/json': components['schemas']['TOTPEnrollment']
         }
       }
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['SessionNotFreshError']
+        }
+      }
     }
   }
   'auth:totp_delete': {
@@ -39183,6 +39212,15 @@ export interface operations {
           [name: string]: unknown
         }
         content?: never
+      }
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['SessionNotFreshError']
+        }
       }
     }
   }
@@ -39206,6 +39244,15 @@ export interface operations {
         }
         content: {
           'application/json': unknown
+        }
+      }
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['SessionNotFreshError']
         }
       }
       /** @description Validation Error */
@@ -39295,6 +39342,15 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['BackupCodesEnrollment']
+        }
+      }
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['SessionNotFreshError']
         }
       }
     }
@@ -49208,6 +49264,15 @@ export interface operations {
         }
         content: {
           'application/json': unknown
+        }
+      }
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['SessionNotFreshError']
         }
       }
       /** @description Validation Error */

--- a/server/polar/auth/endpoints.py
+++ b/server/polar/auth/endpoints.py
@@ -282,8 +282,7 @@ async def totp_enroll(
     responses={
         403: {
             "description": (
-                "Session is not fresh, TOTP factor not enrolled, "
-                "or invalid TOTP code."
+                "Session is not fresh, TOTP factor not enrolled, or invalid TOTP code."
             ),
             "model": SessionNotFreshError.schema() | PolarAuthError.schema(),
         }

--- a/server/polar/auth/endpoints.py
+++ b/server/polar/auth/endpoints.py
@@ -23,11 +23,12 @@ from reauth.factors.totp import (
 from polar.auth.exceptions import (
     PolarAuthError,
     PolarAuthRedirectionError,
+    SessionNotFreshError,
     UnavailableFactorError,
 )
 from polar.auth.oauth2.github import get_github_factor
 from polar.auth.oauth2.google import get_google_factor
-from polar.authz.dependencies import AuthorizeWebUserRead, AuthorizeWebUserWrite
+from polar.authz.dependencies import AuthorizeWebUserRead, AuthorizeWebUserWriteFresh
 from polar.exceptions import NotPermitted, ResourceNotFound
 from polar.models import UserSession as UserSession
 from polar.openapi import APITag
@@ -250,9 +251,13 @@ async def totp_status(
     return TOTPStatus(enabled=enrollment.enabled)
 
 
-@router.post("/totp", status_code=201)
+@router.post(
+    "/totp",
+    status_code=201,
+    responses={403: {"model": SessionNotFreshError.schema()}},
+)
 async def totp_enroll(
-    auth_subject: AuthorizeWebUserWrite,
+    auth_subject: AuthorizeWebUserWriteFresh,
     totp_factor: TOTPFactor = Depends(get_totp_factor),
 ) -> TOTPEnrollment:
     user = auth_subject.subject
@@ -271,10 +276,14 @@ async def totp_enroll(
     )
 
 
-@router.post("/totp/enable", status_code=202)
+@router.post(
+    "/totp/enable",
+    status_code=202,
+    responses={403: {"model": SessionNotFreshError.schema()}},
+)
 async def totp_enable(
     enable: TOTPEnable,
-    auth_subject: AuthorizeWebUserWrite,
+    auth_subject: AuthorizeWebUserWriteFresh,
     totp_factor: TOTPFactor = Depends(get_totp_factor),
 ) -> None:
     user = auth_subject.subject
@@ -289,9 +298,13 @@ async def totp_enable(
     return None
 
 
-@router.delete("/totp", status_code=204)
+@router.delete(
+    "/totp",
+    status_code=204,
+    responses={403: {"model": SessionNotFreshError.schema()}},
+)
 async def totp_delete(
-    auth_subject: AuthorizeWebUserWrite,
+    auth_subject: AuthorizeWebUserWriteFresh,
     totp_factor: TOTPFactor = Depends(get_totp_factor),
     backup_codes_factor: BackupCodesFactor = Depends(get_backup_codes_factor),
 ) -> None:
@@ -354,9 +367,13 @@ async def backup_codes_status(
     )
 
 
-@router.post("/backup-codes", status_code=201)
+@router.post(
+    "/backup-codes",
+    status_code=201,
+    responses={403: {"model": SessionNotFreshError.schema()}},
+)
 async def backup_codes_enroll(
-    auth_subject: AuthorizeWebUserWrite,
+    auth_subject: AuthorizeWebUserWriteFresh,
     backup_codes_factor: BackupCodesFactor = Depends(get_backup_codes_factor),
 ) -> BackupCodesEnrollment:
     user = auth_subject.subject

--- a/server/polar/auth/endpoints.py
+++ b/server/polar/auth/endpoints.py
@@ -279,7 +279,15 @@ async def totp_enroll(
 @router.post(
     "/totp/enable",
     status_code=202,
-    responses={403: {"model": SessionNotFreshError.schema()}},
+    responses={
+        403: {
+            "description": (
+                "Session is not fresh, TOTP factor not enrolled, "
+                "or invalid TOTP code."
+            ),
+            "model": SessionNotFreshError.schema() | PolarAuthError.schema(),
+        }
+    },
 )
 async def totp_enable(
     enable: TOTPEnable,

--- a/server/polar/auth/exceptions.py
+++ b/server/polar/auth/exceptions.py
@@ -22,6 +22,19 @@ class UnavailableFactorError(PolarAuthError):
         super().__init__(message, 403)
 
 
+class SessionNotFreshError(PolarAuthError):
+    """
+    Exception raised when an operation requires a recently authenticated session.
+    """
+
+    def __init__(self) -> None:
+        message = (
+            "This action requires a recently authenticated session. "
+            "Please sign in again."
+        )
+        super().__init__(message, 403)
+
+
 class GetEmailError(PolarAuthError):
     """
     Exception raised when there's an error getting the email from an OAuth2 provider.

--- a/server/polar/authz/dependencies.py
+++ b/server/polar/authz/dependencies.py
@@ -6,11 +6,15 @@ from fastapi import Depends
 
 from polar.account.repository import AccountRepository
 from polar.auth.dependencies import Authenticator, WebUserSession
+from polar.auth.exceptions import SessionNotFreshError
 from polar.auth.models import AuthSubject, Organization, User
 from polar.auth.scope import Scope
+from polar.config import settings
 from polar.exceptions import NotPermitted, ResourceNotFound
+from polar.kit.utils import utc_now
 from polar.models import Organization as OrganizationModel
 from polar.models import PayoutAccount as PayoutAccountModel
+from polar.models import UserSession
 from polar.models.account import Account as AccountModel
 from polar.oauth2.exceptions import InsufficientScopeError
 from polar.organization.repository import OrganizationRepository
@@ -238,6 +242,35 @@ def WebUserAuthorizer(required_scopes: set[Scope]) -> Any:
     return dependency
 
 
+def ensure_session_fresh(auth_subject: AuthSubject[User]) -> None:
+    """Require a recently authenticated web session for sensitive operations.
+
+    Logging in always creates a new ``UserSession``, so ``created_at`` is the
+    time of the last authentication.
+    """
+    if not isinstance(auth_subject.session, UserSession):
+        raise NotPermitted()
+    if (
+        utc_now() - auth_subject.session.created_at
+        > settings.USER_SESSION_FRESHNESS_TTL
+    ):
+        raise SessionNotFreshError()
+
+
+def WebUserAuthorizerFresh(required_scopes: set[Scope]) -> Any:
+    """Like ``WebUserAuthorizer``, but additionally requires a fresh session."""
+
+    async def dependency(
+        auth_subject: Annotated[
+            AuthSubject[User], Depends(WebUserAuthorizer(required_scopes))
+        ],
+    ) -> AuthSubject[User]:
+        ensure_session_fresh(auth_subject)
+        return auth_subject
+
+    return dependency
+
+
 AuthorizeWebUserRead = Annotated[
     AuthSubject[User],
     Depends(WebUserAuthorizer({Scope.user_read, Scope.user_write})),
@@ -245,6 +278,10 @@ AuthorizeWebUserRead = Annotated[
 AuthorizeWebUserWrite = Annotated[
     AuthSubject[User],
     Depends(WebUserAuthorizer({Scope.user_write})),
+]
+AuthorizeWebUserWriteFresh = Annotated[
+    AuthSubject[User],
+    Depends(WebUserAuthorizerFresh({Scope.user_write})),
 ]
 AuthorizeWebPayoutsRead = Annotated[
     AuthSubject[User],

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -142,6 +142,7 @@ class Settings(BaseSettings):
 
     # User session
     USER_SESSION_TTL: timedelta = timedelta(days=31)
+    USER_SESSION_FRESHNESS_TTL: timedelta = timedelta(minutes=5)
     USER_SESSION_COOKIE_KEY: str = "polar_session"
     USER_SESSION_COOKIE_DOMAIN: str = "127.0.0.1"
 

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -142,7 +142,7 @@ class Settings(BaseSettings):
 
     # User session
     USER_SESSION_TTL: timedelta = timedelta(days=31)
-    USER_SESSION_FRESHNESS_TTL: timedelta = timedelta(minutes=5)
+    USER_SESSION_FRESHNESS_TTL: timedelta = timedelta(hours=1)
     USER_SESSION_COOKIE_KEY: str = "polar_session"
     USER_SESSION_COOKIE_DOMAIN: str = "127.0.0.1"
 

--- a/server/polar/email_update/endpoints.py
+++ b/server/polar/email_update/endpoints.py
@@ -1,7 +1,8 @@
 from fastapi import Depends, Form
 from fastapi.responses import RedirectResponse
 
-from polar.authz.dependencies import AuthorizeWebUserWrite
+from polar.auth.exceptions import SessionNotFreshError
+from polar.authz.dependencies import AuthorizeWebUserWrite, AuthorizeWebUserWriteFresh
 from polar.config import settings
 from polar.exceptions import PolarRedirectionError
 from polar.kit.db.postgres import AsyncSession
@@ -17,10 +18,13 @@ from .service import email_update as email_update_service
 router = APIRouter(prefix="/email-update", tags=["email-update", APITag.private])
 
 
-@router.post("/request")
+@router.post(
+    "/request",
+    responses={403: {"model": SessionNotFreshError.schema()}},
+)
 async def request_email_update(
     email_update_request: EmailUpdateRequest,
-    auth_subject: AuthorizeWebUserWrite,
+    auth_subject: AuthorizeWebUserWriteFresh,
     session: AsyncSession = Depends(get_db_session),
 ) -> None:
     email_update_record, token = await email_update_service.request_email_update(

--- a/server/polar/user/endpoints.py
+++ b/server/polar/user/endpoints.py
@@ -3,12 +3,14 @@ from uuid import UUID
 from fastapi import Depends, Request
 
 from polar.auth.dependencies import Authenticator
+from polar.auth.exceptions import SessionNotFreshError
 from polar.auth.models import AuthSubject
 from polar.authz.dependencies import (
     AuthorizeUserRead,
     AuthorizeUserWrite,
     AuthorizeWebUserRead,
     AuthorizeWebUserWrite,
+    AuthorizeWebUserWriteFresh,
 )
 from polar.authz.repository import AuthzRepository
 from polar.customer_portal.endpoints.downloadables import router as downloadables_router
@@ -223,11 +225,12 @@ async def delete_authenticated_user(
     responses={
         404: {"description": "OAuth account not found"},
         400: {"description": "Cannot disconnect last authentication method"},
+        403: {"model": SessionNotFreshError.schema()},
     },
 )
 async def disconnect_oauth_account(
     platform: OAuthPlatform,
-    auth_subject: AuthorizeWebUserWrite,
+    auth_subject: AuthorizeWebUserWriteFresh,
     session: AsyncSession = Depends(get_db_session),
 ) -> None:
     """

--- a/server/tests/auth/test_endpoints.py
+++ b/server/tests/auth/test_endpoints.py
@@ -1,0 +1,103 @@
+from datetime import timedelta
+
+import pytest
+from httpx import AsyncClient
+
+from polar.auth.models import AuthSubject
+from polar.kit.utils import utc_now
+from polar.models import User, UserSession
+
+
+def make_session_stale(auth_subject: AuthSubject[User]) -> None:
+    assert isinstance(auth_subject.session, UserSession)
+    auth_subject.session.created_at = utc_now() - timedelta(minutes=10)
+
+
+@pytest.mark.asyncio
+class TestTOTPEnroll:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.post("/v1/auth/totp")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_stale_session(
+        self, client: AsyncClient, auth_subject: AuthSubject[User]
+    ) -> None:
+        make_session_stale(auth_subject)
+
+        response = await client.post("/v1/auth/totp")
+
+        assert response.status_code == 403
+        assert response.json()["error"] == "SessionNotFreshError"
+
+    @pytest.mark.auth
+    async def test_fresh_session(self, client: AsyncClient) -> None:
+        response = await client.post("/v1/auth/totp")
+
+        assert response.status_code == 201
+        json = response.json()
+        assert json["secret"]
+        assert json["provisioning_uri"]
+
+
+@pytest.mark.asyncio
+class TestTOTPEnable:
+    @pytest.mark.auth
+    async def test_stale_session(
+        self, client: AsyncClient, auth_subject: AuthSubject[User]
+    ) -> None:
+        make_session_stale(auth_subject)
+
+        response = await client.post("/v1/auth/totp/enable", json={"code": "123456"})
+
+        assert response.status_code == 403
+        assert response.json()["error"] == "SessionNotFreshError"
+
+    @pytest.mark.auth
+    async def test_fresh_session_not_enrolled(self, client: AsyncClient) -> None:
+        response = await client.post("/v1/auth/totp/enable", json={"code": "123456"})
+
+        assert response.status_code == 403
+        assert response.json()["error"] != "SessionNotFreshError"
+
+
+@pytest.mark.asyncio
+class TestTOTPDelete:
+    @pytest.mark.auth
+    async def test_stale_session(
+        self, client: AsyncClient, auth_subject: AuthSubject[User]
+    ) -> None:
+        make_session_stale(auth_subject)
+
+        response = await client.delete("/v1/auth/totp")
+
+        assert response.status_code == 403
+        assert response.json()["error"] == "SessionNotFreshError"
+
+    @pytest.mark.auth
+    async def test_fresh_session_not_enrolled(self, client: AsyncClient) -> None:
+        response = await client.delete("/v1/auth/totp")
+
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestBackupCodesEnroll:
+    @pytest.mark.auth
+    async def test_stale_session(
+        self, client: AsyncClient, auth_subject: AuthSubject[User]
+    ) -> None:
+        make_session_stale(auth_subject)
+
+        response = await client.post("/v1/auth/backup-codes")
+
+        assert response.status_code == 403
+        assert response.json()["error"] == "SessionNotFreshError"
+
+    @pytest.mark.auth
+    async def test_fresh_session(self, client: AsyncClient) -> None:
+        response = await client.post("/v1/auth/backup-codes")
+
+        assert response.status_code == 201
+        assert len(response.json()["codes"]) > 0

--- a/server/tests/auth/test_endpoints.py
+++ b/server/tests/auth/test_endpoints.py
@@ -4,13 +4,16 @@ import pytest
 from httpx import AsyncClient
 
 from polar.auth.models import AuthSubject
+from polar.config import settings
 from polar.kit.utils import utc_now
 from polar.models import User, UserSession
 
 
 def make_session_stale(auth_subject: AuthSubject[User]) -> None:
     assert isinstance(auth_subject.session, UserSession)
-    auth_subject.session.created_at = utc_now() - timedelta(minutes=10)
+    auth_subject.session.created_at = utc_now() - (
+        settings.USER_SESSION_FRESHNESS_TTL + timedelta(minutes=1)
+    )
 
 
 @pytest.mark.asyncio

--- a/server/tests/auth/test_endpoints.py
+++ b/server/tests/auth/test_endpoints.py
@@ -1,19 +1,9 @@
-from datetime import timedelta
-
 import pytest
 from httpx import AsyncClient
 
 from polar.auth.models import AuthSubject
-from polar.config import settings
-from polar.kit.utils import utc_now
-from polar.models import User, UserSession
-
-
-def make_session_stale(auth_subject: AuthSubject[User]) -> None:
-    assert isinstance(auth_subject.session, UserSession)
-    auth_subject.session.created_at = utc_now() - (
-        settings.USER_SESSION_FRESHNESS_TTL + timedelta(minutes=1)
-    )
+from polar.models import User
+from tests.fixtures.auth import make_session_stale
 
 
 @pytest.mark.asyncio

--- a/server/tests/email_update/test_endpoints.py
+++ b/server/tests/email_update/test_endpoints.py
@@ -6,6 +6,7 @@ from httpx import AsyncClient
 from pytest_mock import MockerFixture
 
 from polar.auth.models import AuthSubject
+from polar.config import settings
 from polar.kit.utils import utc_now
 from polar.models import User, UserSession
 
@@ -29,7 +30,9 @@ class TestRequestEmailUpdate:
         self, client: AsyncClient, auth_subject: AuthSubject[User]
     ) -> None:
         assert isinstance(auth_subject.session, UserSession)
-        auth_subject.session.created_at = utc_now() - timedelta(minutes=10)
+        auth_subject.session.created_at = utc_now() - (
+            settings.USER_SESSION_FRESHNESS_TTL + timedelta(minutes=1)
+        )
 
         response = await client.post(
             "/v1/email-update/request", json={"email": "new.email@example.com"}

--- a/server/tests/email_update/test_endpoints.py
+++ b/server/tests/email_update/test_endpoints.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 from unittest.mock import MagicMock
 
 import pytest
@@ -6,9 +5,8 @@ from httpx import AsyncClient
 from pytest_mock import MockerFixture
 
 from polar.auth.models import AuthSubject
-from polar.config import settings
-from polar.kit.utils import utc_now
-from polar.models import User, UserSession
+from polar.models import User
+from tests.fixtures.auth import make_session_stale
 
 
 @pytest.fixture(autouse=True)
@@ -29,10 +27,7 @@ class TestRequestEmailUpdate:
     async def test_stale_session(
         self, client: AsyncClient, auth_subject: AuthSubject[User]
     ) -> None:
-        assert isinstance(auth_subject.session, UserSession)
-        auth_subject.session.created_at = utc_now() - (
-            settings.USER_SESSION_FRESHNESS_TTL + timedelta(minutes=1)
-        )
+        make_session_stale(auth_subject)
 
         response = await client.post(
             "/v1/email-update/request", json={"email": "new.email@example.com"}

--- a/server/tests/email_update/test_endpoints.py
+++ b/server/tests/email_update/test_endpoints.py
@@ -1,0 +1,50 @@
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from httpx import AsyncClient
+from pytest_mock import MockerFixture
+
+from polar.auth.models import AuthSubject
+from polar.kit.utils import utc_now
+from polar.models import User, UserSession
+
+
+@pytest.fixture(autouse=True)
+def mock_enqueue_email(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("polar.email_update.service.enqueue_email_template")
+
+
+@pytest.mark.asyncio
+class TestRequestEmailUpdate:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.post(
+            "/v1/email-update/request", json={"email": "new.email@example.com"}
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_stale_session(
+        self, client: AsyncClient, auth_subject: AuthSubject[User]
+    ) -> None:
+        assert isinstance(auth_subject.session, UserSession)
+        auth_subject.session.created_at = utc_now() - timedelta(minutes=10)
+
+        response = await client.post(
+            "/v1/email-update/request", json={"email": "new.email@example.com"}
+        )
+
+        assert response.status_code == 403
+        assert response.json()["error"] == "SessionNotFreshError"
+
+    @pytest.mark.auth
+    async def test_fresh_session(
+        self, client: AsyncClient, mock_enqueue_email: MagicMock
+    ) -> None:
+        response = await client.post(
+            "/v1/email-update/request", json={"email": "new.email@example.com"}
+        )
+
+        assert response.status_code == 200
+        mock_enqueue_email.assert_called_once()

--- a/server/tests/fixtures/auth.py
+++ b/server/tests/fixtures/auth.py
@@ -106,9 +106,11 @@ def auth_subject(
     if isinstance(subject, User):
         from unittest.mock import MagicMock
 
+        from polar.kit.utils import utc_now
         from polar.models import UserSession
 
         session = MagicMock(spec=UserSession)
+        session.created_at = utc_now()
 
     return AuthSubject(subject, auth_subject_fixture.scopes, session)
 

--- a/server/tests/fixtures/auth.py
+++ b/server/tests/fixtures/auth.py
@@ -1,10 +1,20 @@
+from datetime import timedelta
 from typing import Any, Literal
 
 import pytest
 
 from polar.auth.models import Anonymous, AuthSubject, Subject
 from polar.auth.scope import Scope
-from polar.models import Customer, Member, Organization, User
+from polar.config import settings
+from polar.kit.utils import utc_now
+from polar.models import Customer, Member, Organization, User, UserSession
+
+
+def make_session_stale(auth_subject: AuthSubject[User]) -> None:
+    assert isinstance(auth_subject.session, UserSession)
+    auth_subject.session.created_at = utc_now() - (
+        settings.USER_SESSION_FRESHNESS_TTL + timedelta(minutes=1)
+    )
 
 
 class AuthSubjectFixture:
@@ -105,9 +115,6 @@ def auth_subject(
     session: Any = None
     if isinstance(subject, User):
         from unittest.mock import MagicMock
-
-        from polar.kit.utils import utc_now
-        from polar.models import UserSession
 
         session = MagicMock(spec=UserSession)
         session.created_at = utc_now()


### PR DESCRIPTION
This exception triggers a 403 and prompts the user to re-login to authenticate the session again. We can set this to be required for specific actions via the auth subject (AuthorizeWebUserWriteFresh), which automatically handles the exception triggering.

The frontend catches this and redirects the user to the login to let them login again, and then redirects them back with a fresh session.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

