### PR TITLE
tf/aws: Prevent worker from being deployed to latest

### DIFF
--- a/terraform/modules/aws_task_worker/main.tf
+++ b/terraform/modules/aws_task_worker/main.tf
@@ -190,6 +190,8 @@ resource "aws_lambda_function" "task" {
   tags = var.tags
 
   lifecycle {
+    ignore_changes = [image_uri]
+
     precondition {
       condition     = length(local.function_name) <= 64
       error_message = "Lambda function name must be 64 characters or fewer: ${local.function_name}"


### PR DESCRIPTION
We want the lambda deploys to be controlled by CI/CD not Terraform cloud. This prevents us from re-applying it to :latest on every apply

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

