### PR TITLE
Fix canonical meta data

### DIFF
--- a/clients/apps/web/eslint-rules/index.mjs
+++ b/clients/apps/web/eslint-rules/index.mjs
@@ -8,6 +8,7 @@ import noRawHtmlLayout from './no-raw-html-layout.mjs'
 import noStyleBox from './no-style-box.mjs'
 import noStyleText from './no-style-text.mjs'
 import noToastErrorDetail from './no-toast-error-detail.mjs'
+import requireCanonicalMetadata from './require-canonical-metadata.mjs'
 import requireCustomerPortalPage from './require-customer-portal-page.mjs'
 import requireExternalLinkRel from './require-external-link-rel.mjs'
 
@@ -28,6 +29,7 @@ const polarPlugin = {
     'no-style-box': noStyleBox,
     'no-style-text': noStyleText,
     'no-toast-error-detail': noToastErrorDetail,
+    'require-canonical-metadata': requireCanonicalMetadata,
     'require-customer-portal-page': requireCustomerPortalPage,
     'require-external-link-rel': requireExternalLinkRel,
   },

--- a/clients/apps/web/eslint-rules/require-canonical-metadata.mjs
+++ b/clients/apps/web/eslint-rules/require-canonical-metadata.mjs
@@ -1,0 +1,76 @@
+const MARKETING_PATH_SEGMENT = '/(website)/'
+
+function isMarketingFile(context) {
+  const filename = context.filename ?? context.getFilename?.() ?? ''
+  return filename.includes(MARKETING_PATH_SEGMENT)
+}
+
+function isCanonicalKey(key) {
+  if (!key) return false
+  if (key.type === 'Identifier') return key.name === 'canonical'
+  if (key.type === 'Literal') return key.value === 'canonical'
+  return false
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+const requireCanonicalMetadata = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Require public marketing pages that export metadata to declare a canonical URL (via buildMetadata or alternates.canonical).',
+    },
+    schema: [],
+    messages: {
+      missingCanonical:
+        'This marketing page exports metadata but never sets a canonical URL. Use buildMetadata({ path, ... }) from @/utils/metadata, or set alternates.canonical — otherwise the page inherits the homepage canonical and is dropped from search.',
+    },
+  },
+  create(context) {
+    if (!isMarketingFile(context)) return {}
+
+    let metadataExport = null
+    let hasCanonical = false
+
+    return {
+      ExportNamedDeclaration(node) {
+        const decl = node.declaration
+        if (!decl) return
+
+        if (decl.type === 'VariableDeclaration') {
+          const declaresMetadata = decl.declarations.some(
+            (d) => d.id.type === 'Identifier' && d.id.name === 'metadata',
+          )
+          if (declaresMetadata) metadataExport = node
+        } else if (
+          (decl.type === 'FunctionDeclaration' ||
+            decl.type === 'TSDeclareFunction') &&
+          decl.id?.name === 'generateMetadata'
+        ) {
+          metadataExport = node
+        }
+      },
+      Property(node) {
+        if (isCanonicalKey(node.key)) hasCanonical = true
+      },
+      CallExpression(node) {
+        if (
+          node.callee.type === 'Identifier' &&
+          node.callee.name === 'buildMetadata'
+        ) {
+          hasCanonical = true
+        }
+      },
+      'Program:exit'() {
+        if (metadataExport && !hasCanonical) {
+          context.report({
+            node: metadataExport,
+            messageId: 'missingCanonical',
+          })
+        }
+      },
+    }
+  },
+}
+
+export default requireCanonicalMetadata

--- a/clients/apps/web/eslint.config.mjs
+++ b/clients/apps/web/eslint.config.mjs
@@ -80,6 +80,12 @@ export default [
     },
   },
   {
+    files: ['src/app/(main)/(website)/**/*.{ts,tsx}'],
+    rules: {
+      'polar/require-canonical-metadata': 'error',
+    },
+  },
+  {
     ignores: [
       'node_modules/**',
       '.next/**',

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/(mdx)/blog/(header)/[slug]/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/(mdx)/blog/(header)/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { getAllContent } from '@/utils/blog'
+import { buildMetadata } from '@/utils/metadata'
 import type { Metadata } from 'next'
 
 export const dynamic = 'force-static'
@@ -16,26 +17,15 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { slug } = await params
   const post = getAllContent().find((p) => p.slug === slug)
-  const imageUrl = post?.image ?? undefined
 
-  return {
+  return buildMetadata({
+    path: `/blog/${slug}`,
     title: post?.title,
     description: post?.description,
-    ...(post?.date && { publishedTime: post.date }),
-    openGraph: {
-      type: 'article',
-      title: post?.title,
-      description: post?.description,
-      ...(post?.date && { publishedTime: post.date }),
-      ...(imageUrl && { images: [imageUrl] }),
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title: post?.title,
-      description: post?.description,
-      ...(imageUrl && { images: [imageUrl] }),
-    },
-  }
+    type: 'article',
+    ...(post?.image ? { image: post.image } : {}),
+    ...(post?.date ? { publishedTime: post.date } : {}),
+  })
 }
 
 export default async function BlogPost({

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/(mdx)/legal/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/(mdx)/legal/page.tsx
@@ -1,36 +1,15 @@
 import { BlogHero } from '@/components/Blog/BlogHero'
 import ArrowOutwardOutlined from '@mui/icons-material/ArrowOutwardOutlined'
-import { Metadata } from 'next'
+import { buildMetadata } from '@/utils/metadata'
 import Link from 'next/link'
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
+  path: '/legal',
   title: 'Legal',
   description: 'Legal documents',
   keywords:
     'legal, privacy, tos, terms of service, merchant of record, saas, digital products, platform, developer, open source, funding, open source, economy',
-  openGraph: {
-    siteName: 'Polar',
-    type: 'website',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-        alt: 'Polar',
-      },
-    ],
-  },
-}
+})
 
 const resourceLinks = [
   {

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/company/layout.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/company/layout.tsx
@@ -1,31 +1,13 @@
-import { Metadata } from 'next'
+import { buildMetadata } from '@/utils/metadata'
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
+  path: '/company',
   title: 'Company',
   description:
     'Small team, big ambitions. Learn about Polar, our open roles, and the investors who back us.',
-  openGraph: {
-    title: 'Company',
-    description:
-      'Small team, big ambitions. Learn about Polar, our open roles, and the investors who back us.',
-    images: [
-      {
-        url: 'https://polar.sh/api/og?title=Company&description=Small+team%2C+big+ambitions.',
-        width: 1200,
-        height: 630,
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'Company',
-    description:
-      'Small team, big ambitions. Learn about Polar, our open roles, and the investors who back us.',
-    images: [
-      'https://polar.sh/api/og?title=Company&description=Small+team%2C+big+ambitions.',
-    ],
-  },
-}
+  image:
+    'https://polar.sh/api/og?title=Company&description=Small+team%2C+big+ambitions.',
+})
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return children

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/downloads/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/downloads/page.tsx
@@ -1,38 +1,17 @@
 import { StaticImage } from '@/components/Image/StaticImage'
 import { Apple, Framer, Google, Raycast } from '@/components/Landing/Logos'
 import { Box } from '@polar-sh/orbit/Box'
-import { Metadata } from 'next'
+import { buildMetadata } from '@/utils/metadata'
 import Link from 'next/link'
 import { twMerge } from 'tailwind-merge'
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
+  path: '/downloads',
   title: 'Downloads',
   description: 'Use Polar in a variety of different environments',
   keywords:
     'downloads, ios, android, raycast, framer, binaries, saas, digital products, platform, developer, open source, funding, open source, economy',
-  openGraph: {
-    siteName: 'Polar',
-    type: 'website',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-        alt: 'Polar',
-      },
-    ],
-  },
-}
+})
 
 const downloads = [
   {

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/features/cost-insights/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/features/cost-insights/page.tsx
@@ -1,35 +1,14 @@
 import { CostInsightsPage } from '@/components/Landing/features/CostInsightsPage'
-import { Metadata } from 'next'
+import { buildMetadata } from '@/utils/metadata'
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
+  path: '/features/cost-insights',
   title: 'Cost Insights — Polar',
   description:
     'Track cost, profit, and customer LTV by annotating events with cost data.',
   keywords:
     'cost insights, profit tracking, LTV, customer lifetime value, cost events, llm cost tracking',
-  openGraph: {
-    siteName: 'Polar',
-    type: 'website',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-        alt: 'Polar',
-      },
-    ],
-  },
-}
+})
 
 export default function Page() {
   return <CostInsightsPage />

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/features/credits/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/features/credits/page.tsx
@@ -1,35 +1,14 @@
 import { CreditsPage } from '@/components/Landing/features/CreditsPage'
-import { Metadata } from 'next'
+import { buildMetadata } from '@/utils/metadata'
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
+  path: '/features/credits',
   title: 'Credits — Polar',
   description:
     'Prepaid usage for your API. Issue credits, draw down balances, and let metered pricing handle the overage.',
   keywords:
     'prepaid billing, api credits, usage credits, wallet, prepay, metered billing',
-  openGraph: {
-    siteName: 'Polar',
-    type: 'website',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-        alt: 'Polar',
-      },
-    ],
-  },
-}
+})
 
 export default function Page() {
   return <CreditsPage />

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/features/discounts/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/features/discounts/page.tsx
@@ -1,35 +1,14 @@
 import { DiscountsPage } from '@/components/Landing/features/DiscountsPage'
-import { Metadata } from 'next'
+import { buildMetadata } from '@/utils/metadata'
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
+  path: '/features/discounts',
   title: 'Discounts — Polar',
   description:
     'Coupons, promo codes, and recurring discounts. Apply automatically at checkout, prefill via URL, or via the API.',
   keywords:
     'discounts, coupons, promo codes, percentage discount, fixed amount discount, recurring discount',
-  openGraph: {
-    siteName: 'Polar',
-    type: 'website',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-        alt: 'Polar',
-      },
-    ],
-  },
-}
+})
 
 export default function Page() {
   return <DiscountsPage />

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/features/finance/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/features/finance/page.tsx
@@ -1,35 +1,14 @@
 import { FinancePage } from '@/components/Landing/features/FinancePage'
-import { Metadata } from 'next'
+import { buildMetadata } from '@/utils/metadata'
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
+  path: '/features/finance',
   title: 'Finance — Polar',
   description:
     'Live balance, transactions ledger, transparent fees, and manual payouts. All visible.',
   keywords:
     'finance, payouts, transactions, ledger, balance, fees, stripe connect, multi-currency',
-  openGraph: {
-    siteName: 'Polar',
-    type: 'website',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-        alt: 'Polar',
-      },
-    ],
-  },
-}
+})
 
 export default function Page() {
   return <FinancePage />

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/features/merchant-of-record/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/features/merchant-of-record/page.tsx
@@ -1,35 +1,14 @@
 import { MerchantOfRecordPage } from '@/components/Landing/features/MerchantOfRecordPage'
-import { Metadata } from 'next'
+import { buildMetadata } from '@/utils/metadata'
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
+  path: '/features/merchant-of-record',
   title: 'Merchant of Record — Polar',
   description:
     'Polar is your reseller. We handle international sales taxes globally so you can focus on the product.',
   keywords:
     'merchant of record, MoR, sales tax, VAT, GST, international taxes, reseller, EU OSS, tax compliance',
-  openGraph: {
-    siteName: 'Polar',
-    type: 'website',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-        alt: 'Polar',
-      },
-    ],
-  },
-}
+})
 
 export default function Page() {
   return <MerchantOfRecordPage />

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/features/seats/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/features/seats/page.tsx
@@ -1,35 +1,14 @@
 import { SeatsPage } from '@/components/Landing/features/SeatsPage'
-import { Metadata } from 'next'
+import { buildMetadata } from '@/utils/metadata'
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
+  path: '/features/seats',
   title: 'Seats — Polar',
   description:
     'Pricing that scales with the team. Sell seat-based products with assignable seats, claim links, and automatic proration.',
   keywords:
     'seat-based pricing, team subscriptions, per-seat billing, volume discounts, graduated pricing',
-  openGraph: {
-    siteName: 'Polar',
-    type: 'website',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-        alt: 'Polar',
-      },
-    ],
-  },
-}
+})
 
 export default function Page() {
   return <SeatsPage />

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/features/subscriptions/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/features/subscriptions/page.tsx
@@ -1,35 +1,14 @@
 import { SubscriptionsPage } from '@/components/Landing/features/SubscriptionsPage'
-import { Metadata } from 'next'
+import { buildMetadata } from '@/utils/metadata'
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
+  path: '/features/subscriptions',
   title: 'Subscriptions — Polar',
   description:
     'Recurring revenue on autopilot. Renewals, proration, dunning, and customer self-service — all handled.',
   keywords:
     'subscriptions, recurring billing, saas billing, proration, dunning, renewal, customer portal',
-  openGraph: {
-    siteName: 'Polar',
-    type: 'website',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-        alt: 'Polar',
-      },
-    ],
-  },
-}
+})
 
 export default function Page() {
   return <SubscriptionsPage />

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/features/trials/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/features/trials/page.tsx
@@ -1,35 +1,14 @@
 import { TrialsPage } from '@/components/Landing/features/TrialsPage'
-import { Metadata } from 'next'
+import { buildMetadata } from '@/utils/metadata'
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
+  path: '/features/trials',
   title: 'Trials — Polar',
   description:
     'Free or paid trials with automatic conversion, conversion reminders, and abuse protection — built into your subscriptions.',
   keywords:
     'free trial, trial period, trial conversion, trial abuse prevention, saas trial',
-  openGraph: {
-    siteName: 'Polar',
-    type: 'website',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-        alt: 'Polar',
-      },
-    ],
-  },
-}
+})
 
 export default function Page() {
   return <TrialsPage />

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/features/usage-billing/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/features/usage-billing/page.tsx
@@ -1,35 +1,14 @@
 import { UsageBillingPage } from '@/components/Landing/features/UsageBillingPage'
-import { Metadata } from 'next'
+import { buildMetadata } from '@/utils/metadata'
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
+  path: '/features/usage-billing',
   title: 'Usage Billing — Polar',
   description:
     'Bill what your customers actually use. Ingest events, aggregate them into meters, and charge with precision — built for tokens, API calls, and compute.',
   keywords:
     'usage billing, metered billing, consumption billing, pay-as-you-go, event ingestion, saas billing',
-  openGraph: {
-    siteName: 'Polar',
-    type: 'website',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-        alt: 'Polar',
-      },
-    ],
-  },
-}
+})
 
 export default function Page() {
   return <UsageBillingPage />

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/page.tsx
@@ -1,33 +1,12 @@
-import { Metadata } from 'next'
+import { buildMetadata } from '@/utils/metadata'
 import LandingPage from '../../../../components/Landing/LandingPage'
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
+  path: '/',
   title: 'Polar — A billing platform for the intelligence era',
   description: 'A billing platform for the intelligence era',
   keywords:
     'monetization, merchant of record, saas, digital products, platform, developer, open source, funding, open source, economy',
-  openGraph: {
-    siteName: 'Polar',
-    type: 'website',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-        alt: 'Polar',
-      },
-    ],
-  },
-}
+})
 
 export default function Page() {
   return <LandingPage />

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/resources/comparison/lemon-squeezy/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/resources/comparison/lemon-squeezy/page.tsx
@@ -1,34 +1,13 @@
 import { PolarVsLemonSqueezyPage } from '@/components/Landing/comparison/PolarLemonSqueezyPage'
-import { Metadata } from 'next'
+import { buildMetadata } from '@/utils/metadata'
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
+  path: '/resources/comparison/lemon-squeezy',
   title: 'Polar vs Lemon Squeezy',
   description: 'Comparing Polar and Lemon Squeezy',
   keywords:
     'polar vs lemon squeezy, lemon squeezy, polar, comparison, pricing, pricing for polar, pricing for polar, pricing for polar',
-  openGraph: {
-    siteName: 'Polar',
-    type: 'website',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-        alt: 'Polar',
-      },
-    ],
-  },
-}
+})
 
 export default function Page() {
   return <PolarVsLemonSqueezyPage />

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/resources/comparison/paddle/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/resources/comparison/paddle/page.tsx
@@ -1,34 +1,13 @@
 import { PolarVsPaddlePage } from '@/components/Landing/comparison/PolarPaddlePage'
-import { Metadata } from 'next'
+import { buildMetadata } from '@/utils/metadata'
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
+  path: '/resources/comparison/paddle',
   title: 'Polar vs Paddle',
   description: 'Comparing Polar and Paddle',
   keywords:
     'polar vs paddle, paddle, polar, comparison, pricing, pricing for polar, pricing for polar, pricing for polar',
-  openGraph: {
-    siteName: 'Polar',
-    type: 'website',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-        alt: 'Polar',
-      },
-    ],
-  },
-}
+})
 
 export default function Page() {
   return <PolarVsPaddlePage />

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/resources/comparison/stripe/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/resources/comparison/stripe/page.tsx
@@ -1,34 +1,13 @@
 import { PolarVsStripePage } from '@/components/Landing/comparison/PolarStripePage'
-import { Metadata } from 'next'
+import { buildMetadata } from '@/utils/metadata'
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
+  path: '/resources/comparison/stripe',
   title: 'Polar vs Stripe',
   description: 'Comparing Polar and Stripe',
   keywords:
     'polar vs stripe, stripe, polar, comparison, pricing, pricing for polar, pricing for polar, pricing for polar',
-  openGraph: {
-    siteName: 'Polar',
-    type: 'website',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-        alt: 'Polar',
-      },
-    ],
-  },
-}
+})
 
 export default function Page() {
   return <PolarVsStripePage />

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/resources/merchant-of-record/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/resources/merchant-of-record/page.tsx
@@ -1,34 +1,13 @@
 import { MORPage } from '@/components/Landing/resources/MORPage'
-import { Metadata } from 'next'
+import { buildMetadata } from '@/utils/metadata'
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
+  path: '/resources/merchant-of-record',
   title: 'Merchant of Record',
   description: 'A deep dive into Merchant of Records & what they mean for you',
   keywords:
     'mor, merchant of record, lemon squeezy, paddle, taxes, compliance, monetization',
-  openGraph: {
-    siteName: 'Polar',
-    type: 'website',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-        alt: 'Polar',
-      },
-    ],
-  },
-}
+})
 
 export default function Page() {
   return <MORPage />

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/resources/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/resources/page.tsx
@@ -1,35 +1,14 @@
 import ArrowOutwardOutlined from '@mui/icons-material/ArrowOutwardOutlined'
-import { Metadata } from 'next'
+import { buildMetadata } from '@/utils/metadata'
 import Link from 'next/link'
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
+  path: '/resources',
   title: 'Resources',
   description: 'Handy links related to the Polar platform',
   keywords:
     'monetization, merchant of record, saas, digital products, platform, developer, open source, funding, open source, economy',
-  openGraph: {
-    siteName: 'Polar',
-    type: 'website',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-        alt: 'Polar',
-      },
-    ],
-  },
-}
+})
 
 const resourceLinks = [
   {

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/resources/pricing/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/resources/pricing/page.tsx
@@ -1,34 +1,13 @@
 import { PricingPage } from '@/components/Landing/resources/PricingPage'
-import { Metadata } from 'next'
+import { buildMetadata } from '@/utils/metadata'
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
+  path: '/resources/pricing',
   title: 'Pricing',
   description: 'Transparent pricing for every stage of growth',
   keywords:
     'pricing, price, usage billing, polar, pricing, pricing for polar, pricing for polar, pricing for polar',
-  openGraph: {
-    siteName: 'Polar',
-    type: 'website',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-        alt: 'Polar',
-      },
-    ],
-  },
-}
+})
 
 export default function Page() {
   return <PricingPage />

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/resources/why/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/resources/why/page.tsx
@@ -1,34 +1,13 @@
 import { WhyPolarPage } from '@/components/Landing/resources/WhyPolarPage'
-import { Metadata } from 'next'
+import { buildMetadata } from '@/utils/metadata'
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
+  path: '/resources/why',
   title: 'Why Polar is the best way to monetize your software',
   description: 'Learn why Polar is the best way to monetize your software',
   keywords:
     'monetize, monetization, switch, migration, payment infrastructure, saas, monetization, developer tools',
-  openGraph: {
-    siteName: 'Polar',
-    type: 'website',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-        alt: 'Polar',
-      },
-    ],
-  },
-}
+})
 
 export default function Page() {
   return <WhyPolarPage />

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/startup-program/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/startup-program/page.tsx
@@ -1,33 +1,12 @@
 import { StartupProgramPage } from '@/components/Landing/startup-program/StartupProgramPage'
-import { Metadata } from 'next'
+import { buildMetadata } from '@/utils/metadata'
 
-export const metadata: Metadata = {
+export const metadata = buildMetadata({
+  path: '/startup-program',
   title: 'Polar Startup Program',
   description:
     'Scale-tier pricing for a full year, free. For AI and SaaS startups building on Polar.',
-  openGraph: {
-    siteName: 'Polar',
-    type: 'website',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-      },
-    ],
-  },
-  twitter: {
-    card: 'summary_large_image',
-    images: [
-      {
-        url: 'https://polar.sh/assets/brand/polar_og.jpg',
-        width: 1200,
-        height: 630,
-        alt: 'Polar',
-      },
-    ],
-  },
-}
+})
 
 export default function Page() {
   return <StartupProgramPage />

--- a/clients/apps/web/src/app/(main)/layout.tsx
+++ b/clients/apps/web/src/app/(main)/layout.tsx
@@ -28,9 +28,6 @@ export async function generateMetadata(): Promise<Metadata> {
         'Create digital products and SaaS billing with flexible pricing models and seamless payment processing.',
     },
     metadataBase: new URL('https://polar.sh/'),
-    alternates: {
-      canonical: 'https://polar.sh/',
-    },
   }
 
   if (CONFIG.IS_SANDBOX) {

--- a/clients/apps/web/src/utils/metadata.ts
+++ b/clients/apps/web/src/utils/metadata.ts
@@ -1,0 +1,59 @@
+import type { Metadata } from 'next'
+
+const DEFAULT_OG_IMAGE = 'https://polar.sh/assets/brand/polar_og.jpg'
+
+interface BuildMetadataParams {
+  path: string
+  title?: string
+  description?: string
+  keywords?: string
+  image?: string
+  type?: 'website' | 'article'
+  publishedTime?: string
+}
+
+export function buildMetadata({
+  path,
+  title,
+  description,
+  keywords,
+  image = DEFAULT_OG_IMAGE,
+  type = 'website',
+  publishedTime,
+}: BuildMetadataParams): Metadata {
+  const images = [{ url: image, width: 1200, height: 630 }]
+
+  const openGraph: Metadata['openGraph'] =
+    type === 'article'
+      ? {
+          siteName: 'Polar',
+          type: 'article',
+          title,
+          description,
+          images,
+          ...(publishedTime ? { publishedTime } : {}),
+        }
+      : {
+          siteName: 'Polar',
+          type: 'website',
+          title,
+          description,
+          images,
+        }
+
+  return {
+    title,
+    description,
+    keywords,
+    alternates: {
+      canonical: path,
+    },
+    openGraph,
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [{ ...images[0], alt: title ?? 'Polar' }],
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Currently we tell Google that all of our marketing pages should be ignored in favor of https://polar.sh/. This PR fixes that and adds an ESLint rule to prevent us from doing that in upcoming marketing pages

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

