### PR TITLE
Add Organization and WebSite JSON-LD structured data

### DIFF
--- a/clients/apps/web/src/app/(main)/(website)/(landing)/layout.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/layout.tsx
@@ -6,9 +6,30 @@ export const dynamicParams = false
 
 const jsonLd = {
   '@context': 'https://schema.org',
-  '@type': 'WebSite',
-  name: 'Polar',
-  url: 'https://polar.sh/',
+  '@graph': [
+    {
+      '@type': 'Organization',
+      '@id': 'https://polar.sh/#organization',
+      name: 'Polar',
+      url: 'https://polar.sh/',
+      logo: {
+        '@type': 'ImageObject',
+        url: 'https://polar.sh/assets/brand/app-icon.png',
+      },
+      description:
+        'Polar is an open source, developer-first monetization platform and Merchant of Record for software companies — handling payments, subscriptions, usage-based billing, and global tax compliance.',
+      sameAs: ['https://github.com/polarsource', 'https://x.com/polar_sh'],
+    },
+    {
+      '@type': 'WebSite',
+      '@id': 'https://polar.sh/#website',
+      name: 'Polar',
+      url: 'https://polar.sh/',
+      publisher: {
+        '@id': 'https://polar.sh/#organization',
+      },
+    },
+  ],
 }
 
 export default function Layout({ children }: PropsWithChildren) {


### PR DESCRIPTION
Replace the minimal WebSite-only JSON-LD on the marketing site with a schema.org @graph containing an Organization node (logo, description, and sameAs social profiles) plus a WebSite node that references the Organization as its publisher. This gives LLM's a canonical, readable description to cite. 


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

