### PR TITLE
Add FAQPage structured data to startup program and "Why Polar?" page

### DIFF
--- a/clients/apps/web/src/components/Landing/resources/WhyPolarPage.tsx
+++ b/clients/apps/web/src/components/Landing/resources/WhyPolarPage.tsx
@@ -71,6 +71,58 @@ const logos = [
   },
 ]
 
+const FAQS = [
+  {
+    number: '01',
+    question: 'Do I still pay Stripe fees if I use Polar?',
+    answer:
+      "Polar's platform fee covers Stripe's processing costs. Stripe's additional fees, like +1.5% for international cards, are passed through at cost. Your platform fee depends on your plan; see the pricing guide for details.",
+  },
+  {
+    number: '02',
+    question: 'Is Polar built on Stripe? Why not just use Stripe directly?',
+    answer:
+      "We use Stripe rails for processing reliability and coverage. Processing ≠ the business layer. Polar is the MoR + billing + entitlements + unit-economics layer you'd otherwise build or buy on top of Stripe.",
+  },
+  {
+    number: '03',
+    question: 'How are payouts handled internationally?',
+    answer:
+      'All payments are made to Polar as the Merchant of Record. We use Stripe Connect Express to make payouts across more countries than Stripe Payments supports directly.',
+  },
+  {
+    number: '04',
+    question: 'Do you handle EU VAT reverse charge for B2B?',
+    answer:
+      'Yes, EU B2B reverse charge is handled correctly under our MoR model, ensuring compliance with EU tax regulations.',
+  },
+  {
+    number: '05',
+    question: 'What about lock-in? Can I leave later?',
+    answer:
+      'We deliberately architect for continuity (Stripe on the inside) and provide import/export plus migration tooling, so you always retain a pragmatic exit path.',
+  },
+  {
+    number: '06',
+    question: 'What happens during account reviews or disputes?',
+    answer:
+      "We run standard MoR/KYC reviews (typically within a week) and follow card-network norms: disputes cost $15 and gateway fees aren't refunded on refunds.",
+  },
+]
+
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: FAQS.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: {
+      '@type': 'Answer',
+      text: faq.answer,
+    },
+  })),
+}
+
 export const WhyPolarPage = () => {
   const tocItems = [
     { id: 'introduction', title: 'Introduction' },
@@ -277,38 +329,17 @@ export const WhyPolarPage = () => {
         </div>
       </ResourceSection>
 
+      <script
+        type="application/ld+json"
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(faqJsonLd).replace(/</g, '\\u003c'),
+        }}
+      />
       <div className="dark:border-polar-700 flex flex-col border-t border-gray-200 pt-16">
-        <FAQItem
-          number="01"
-          question="Do I still pay Stripe fees if I use Polar?"
-          answer="Polar's platform fee covers Stripe's processing costs. Stripe's additional fees, like +1.5% for international cards, are passed through at cost. Your platform fee depends on your plan; see the pricing guide for details."
-        />
-        <FAQItem
-          number="02"
-          question="Is Polar built on Stripe? Why not just use Stripe directly?"
-          answer="We use Stripe rails for processing reliability and coverage. Processing ≠ the business layer. Polar is the MoR + billing + entitlements + unit-economics layer you'd otherwise build or buy on top of Stripe."
-        />
-        <FAQItem
-          number="03"
-          question="How are payouts handled internationally?"
-          answer="All payments are made to Polar as the Merchant of Record. We use Stripe Connect Express to make payouts across more countries than Stripe Payments supports directly."
-        />
-        <FAQItem
-          number="04"
-          question="Do you handle EU VAT reverse charge for B2B?"
-          answer="Yes, EU B2B reverse charge is handled correctly under our MoR model, ensuring compliance with EU tax regulations."
-        />
-        <FAQItem
-          number="05"
-          question="What about lock-in? Can I leave later?"
-          answer="We deliberately architect for continuity (Stripe on the inside) and provide import/export plus migration tooling, so you always retain a pragmatic exit path."
-        />
-
-        <FAQItem
-          number="06"
-          question="What happens during account reviews or disputes?"
-          answer="We run standard MoR/KYC reviews (typically within a week) and follow card-network norms: disputes cost $15 and gateway fees aren't refunded on refunds."
-        />
+        {FAQS.map((faq) => (
+          <FAQItem key={faq.number} {...faq} />
+        ))}
       </div>
 
       {/* Call to Action */}

--- a/clients/apps/web/src/components/Landing/startup-program/StartupProgramFAQ.tsx
+++ b/clients/apps/web/src/components/Landing/startup-program/StartupProgramFAQ.tsx
@@ -56,38 +56,60 @@ const FAQS: FAQItem[] = [
   },
 ]
 
+const faqJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: FAQS.map((faq) => ({
+    '@type': 'Question',
+    name: faq.question,
+    acceptedAnswer: {
+      '@type': 'Answer',
+      text: faq.answer,
+    },
+  })),
+}
+
 export const StartupProgramFAQ = () => {
   return (
-    <Box
-      display="grid"
-      gridTemplateColumns={{ base: '1fr', md: 'repeat(3, 1fr)' }}
-      gap={{ base: 'xl', md: '3xl' }}
-    >
-      <Text as="h2" variant="heading-l" wrap="balance">
-        Questions and answers
-      </Text>
-      <Box display="block" gridColumn={{ md: 'span 2' }}>
-        <Accordion type="multiple" className="flex flex-col">
-          {FAQS.map((faq, i) => (
-            <AccordionItem
-              key={faq.question}
-              value={`faq-${i}`}
-              className="dark:border-polar-700 rounded-none! border-b border-gray-200 px-0!"
-            >
-              <AccordionTrigger className="py-6 text-left text-base hover:no-underline md:text-lg">
-                {faq.question}
-              </AccordionTrigger>
-              <AccordionContent>
-                <Box display="block" paddingBottom="m" maxWidth="42rem">
-                  <Text variant="body" color="muted">
-                    {faq.answer}
-                  </Text>
-                </Box>
-              </AccordionContent>
-            </AccordionItem>
-          ))}
-        </Accordion>
+    <>
+      <script
+        type="application/ld+json"
+        // eslint-disable-next-line react/no-danger
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(faqJsonLd).replace(/</g, '\\u003c'),
+        }}
+      />
+      <Box
+        display="grid"
+        gridTemplateColumns={{ base: '1fr', md: 'repeat(3, 1fr)' }}
+        gap={{ base: 'xl', md: '3xl' }}
+      >
+        <Text as="h2" variant="heading-l" wrap="balance">
+          Questions and answers
+        </Text>
+        <Box display="block" gridColumn={{ md: 'span 2' }}>
+          <Accordion type="multiple" className="flex flex-col">
+            {FAQS.map((faq, i) => (
+              <AccordionItem
+                key={faq.question}
+                value={`faq-${i}`}
+                className="dark:border-polar-700 rounded-none! border-b border-gray-200 px-0!"
+              >
+                <AccordionTrigger className="py-6 text-left text-base hover:no-underline md:text-lg">
+                  {faq.question}
+                </AccordionTrigger>
+                <AccordionContent>
+                  <Box display="block" paddingBottom="m" maxWidth="42rem">
+                    <Text variant="body" color="muted">
+                      {faq.answer}
+                    </Text>
+                  </Box>
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        </Box>
       </Box>
-    </Box>
+    </>
   )
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds schema.org FAQ structured data to the Startup Program and Why Polar pages to enable FAQ rich results and keep Q&A content in sync. No UI changes.

- **New Features**
  - Emit `FAQPage` JSON-LD on both pages from the existing FAQ content.
  - Inject via `<script type="application/ld+json">` for search engines.

- **Refactors**
  - Why Polar FAQs moved into a single `FAQS` array used for both rendering and JSON-LD to prevent drift.

<sup>Written for commit c21c4a706a8f14413fbf8b7c2e3b69cdbf78d69e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

