### PR TITLE
Add explicit AI crawler rules to robots.txt

### DIFF
--- a/clients/apps/web/src/app/robots.ts
+++ b/clients/apps/web/src/app/robots.ts
@@ -11,12 +11,32 @@ export default function robots(): MetadataRoute.Robots {
     }
   }
 
+  const disallow = ['/dashboard/', '/auth/', '/verify-email/']
+
   return {
-    rules: {
-      userAgent: '*',
-      allow: '/',
-      disallow: ['/dashboard/', '/auth/', '/verify-email/'],
-    },
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow,
+      },
+      {
+        userAgent: [
+          'OAI-SearchBot',
+          'ChatGPT-User',
+          'GPTBot',
+          'PerplexityBot',
+          'Perplexity-User',
+          'ClaudeBot',
+          'Claude-Web',
+          'anthropic-ai',
+          'Google-Extended',
+          'Applebot-Extended',
+        ],
+        allow: '/',
+        disallow,
+      },
+    ],
     sitemap: 'https://polar.sh/sitemap.xml',
   }
 }


### PR DESCRIPTION
Add a dedicated robots rule group that explicitly allows LLM and search crawlers while keeping the existing `/dashboard`, `/auth` and `/verify-email` paths disallowed for every agent.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

