### PR TITLE
Fix double branded titles and improve keyword meta's

### DIFF
--- a/clients/apps/web/src/app/(main)/(website)/(landing)/features/cost-insights/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/features/cost-insights/page.tsx
@@ -2,7 +2,7 @@ import { CostInsightsPage } from '@/components/Landing/features/CostInsightsPage
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Cost Insights — Polar',
+  title: 'Cost Insights',
   description:
     'Track cost, profit, and customer LTV by annotating events with cost data.',
   keywords:

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/features/credits/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/features/credits/page.tsx
@@ -2,7 +2,7 @@ import { CreditsPage } from '@/components/Landing/features/CreditsPage'
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Credits — Polar',
+  title: 'Credits & Prepaid Balances',
   description:
     'Prepaid usage for your API. Issue credits, draw down balances, and let metered pricing handle the overage.',
   keywords:

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/features/discounts/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/features/discounts/page.tsx
@@ -2,7 +2,7 @@ import { DiscountsPage } from '@/components/Landing/features/DiscountsPage'
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Discounts — Polar',
+  title: 'Discounts & Coupons',
   description:
     'Coupons, promo codes, and recurring discounts. Apply automatically at checkout, prefill via URL, or via the API.',
   keywords:

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/features/finance/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/features/finance/page.tsx
@@ -2,7 +2,7 @@ import { FinancePage } from '@/components/Landing/features/FinancePage'
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Finance — Polar',
+  title: 'Finance & Payouts',
   description:
     'Live balance, transactions ledger, transparent fees, and manual payouts. All visible.',
   keywords:

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/features/merchant-of-record/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/features/merchant-of-record/page.tsx
@@ -2,7 +2,7 @@ import { MerchantOfRecordPage } from '@/components/Landing/features/MerchantOfRe
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Merchant of Record — Polar',
+  title: 'Merchant of Record',
   description:
     'Polar is your reseller. We handle international sales taxes globally so you can focus on the product.',
   keywords:

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/features/seats/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/features/seats/page.tsx
@@ -2,7 +2,7 @@ import { SeatsPage } from '@/components/Landing/features/SeatsPage'
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Seats — Polar',
+  title: 'Seat-Based Billing',
   description:
     'Pricing that scales with the team. Sell seat-based products with assignable seats, claim links, and automatic proration.',
   keywords:

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/features/subscriptions/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/features/subscriptions/page.tsx
@@ -2,7 +2,7 @@ import { SubscriptionsPage } from '@/components/Landing/features/SubscriptionsPa
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Subscriptions — Polar',
+  title: 'Subscriptions',
   description:
     'Recurring revenue on autopilot. Renewals, proration, dunning, and customer self-service — all handled.',
   keywords:

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/features/trials/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/features/trials/page.tsx
@@ -2,7 +2,7 @@ import { TrialsPage } from '@/components/Landing/features/TrialsPage'
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Trials — Polar',
+  title: 'Free Trials',
   description:
     'Free or paid trials with automatic conversion, conversion reminders, and abuse protection — built into your subscriptions.',
   keywords:

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/features/usage-billing/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/features/usage-billing/page.tsx
@@ -2,7 +2,7 @@ import { UsageBillingPage } from '@/components/Landing/features/UsageBillingPage
 import { Metadata } from 'next'
 
 export const metadata: Metadata = {
-  title: 'Usage Billing — Polar',
+  title: 'Usage-Based Billing',
   description:
     'Bill what your customers actually use. Ingest events, aggregate them into meters, and charge with precision — built for tokens, API calls, and compute.',
   keywords:

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/resources/comparison/lemon-squeezy/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/resources/comparison/lemon-squeezy/page.tsx
@@ -3,9 +3,10 @@ import { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: 'Polar vs Lemon Squeezy',
-  description: 'Comparing Polar and Lemon Squeezy',
+  description:
+    'Polar vs Lemon Squeezy: compare two Merchant of Record platforms for developers, including open-source billing, usage-based pricing and transaction fees.',
   keywords:
-    'polar vs lemon squeezy, lemon squeezy, polar, comparison, pricing, pricing for polar, pricing for polar, pricing for polar',
+    'polar vs lemon squeezy, lemon squeezy alternative, merchant of record, saas billing, digital products',
   openGraph: {
     siteName: 'Polar',
     type: 'website',

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/resources/comparison/paddle/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/resources/comparison/paddle/page.tsx
@@ -3,9 +3,10 @@ import { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: 'Polar vs Paddle',
-  description: 'Comparing Polar and Paddle',
+  description:
+    'Polar vs Paddle: compare two Merchant of Record platforms for SaaS and digital products, including billing models, usage-based pricing and transaction fees.',
   keywords:
-    'polar vs paddle, paddle, polar, comparison, pricing, pricing for polar, pricing for polar, pricing for polar',
+    'polar vs paddle, paddle alternative, merchant of record, saas billing, subscriptions, usage-based billing',
   openGraph: {
     siteName: 'Polar',
     type: 'website',

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/resources/comparison/stripe/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/resources/comparison/stripe/page.tsx
@@ -3,9 +3,10 @@ import { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: 'Polar vs Stripe',
-  description: 'Comparing Polar and Stripe',
+  description:
+    'Polar vs Stripe: Polar is a Merchant of Record that handles payments, subscriptions, usage-based billing and global sales tax for you, while Stripe leaves tax and compliance to you.',
   keywords:
-    'polar vs stripe, stripe, polar, comparison, pricing, pricing for polar, pricing for polar, pricing for polar',
+    'polar vs stripe, stripe alternative, merchant of record, saas billing, usage-based billing, payment infrastructure',
   openGraph: {
     siteName: 'Polar',
     type: 'website',

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/resources/pricing/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/resources/pricing/page.tsx
@@ -5,7 +5,7 @@ export const metadata: Metadata = {
   title: 'Pricing',
   description: 'Transparent pricing for every stage of growth',
   keywords:
-    'pricing, price, usage billing, polar, pricing, pricing for polar, pricing for polar, pricing for polar',
+    'polar pricing, merchant of record fees, usage-based billing pricing, saas billing costs, transaction fees',
   openGraph: {
     siteName: 'Polar',
     type: 'website',


### PR DESCRIPTION
From `'Usage Billing — Polar | Polar'` to `'Usage Billing | Polar'`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

