### PR TITLE
Noindex the customer portal

### DIFF
--- a/clients/apps/web/src/app/(main)/[organization]/portal/layout.tsx
+++ b/clients/apps/web/src/app/(main)/[organization]/portal/layout.tsx
@@ -1,7 +1,16 @@
+import { Metadata } from 'next'
+
 import { Toaster } from '@/components/Toast/Toaster'
 import { getServerSideAPI } from '@/utils/client/serverside'
 import { getOrganizationOrNotFound } from '@/utils/customerPortal'
 import { CustomerPortalLayoutWrapper } from './CustomerPortalLayoutWrapper'
+
+export const metadata: Metadata = {
+  robots: {
+    index: false,
+    follow: false,
+  },
+}
 
 export const dynamic = 'force-dynamic'
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Noindex the authenticated customer portal by exporting robots metadata (index: false, follow: false) from its layout, preventing /[organization]/portal/* pages from appearing in search. This keeps the portal crawlable enough for engines to see the noindex directive while avoiding slug leakage and thin-page indexing.

<sup>Written for commit 526483e1e5dc6ab7760d6f4862ad1055320b5bba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

