### PR TITLE
Add default SEO metatags to docs and fix broken /suppport link

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -20,6 +20,15 @@
     }
   },
   "favicon": "./logo/favicon.png",
+  "seo": {
+    "metatags": {
+      "og:site_name": "Polar",
+      "og:image": "https://polar.sh/assets/brand/polar_og.jpg",
+      "og:type": "website",
+      "twitter:card": "summary_large_image",
+      "twitter:site": "@polar_sh"
+    }
+  },
   "integrations": {
     "ga4": {
       "measurementId": "G-MBYW1QZFHE"
@@ -684,7 +693,7 @@
     },
     {
       "source": "/docs/support",
-      "destination": "/suppport"
+      "destination": "/support"
     },
     {
       "source": "/documentation/welcome-to-polar",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add default SEO metatags to docs for consistent OG/Twitter previews across all pages. Fix the broken /docs/support redirect to point to the correct /support page.

- **New Features**
  - Added `seo.metatags` to `docs/docs.json`: `og:site_name=Polar`, `og:image=https://polar.sh/assets/brand/polar_og.jpg`, `og:type=website`, `twitter:card=summary_large_image`, `twitter:site=@polar_sh`.

- **Bug Fixes**
  - Corrected redirect from `/docs/support` to `/support` (was `/suppport`).

<sup>Written for commit 6dbac2183803de3ebe7ea35d094689ed16e1565c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

