### PR TITLE
feat(compass): scope-aware assistant core with generative UI blocks

### DIFF
--- a/server/polar/compass/assistant/agent.py
+++ b/server/polar/compass/assistant/agent.py
@@ -7,11 +7,15 @@ from pydantic_ai import Agent
 from polar.auth.scope import Scope
 from polar.config import settings
 
+from .customer_tools import CUSTOMER_TOOLS_WITH_SCOPES
 from .deps import AssistantDeps
+from .entity_tools import ENTITY_TOOLS_WITH_SCOPES
 from .tools import TOOLS_WITH_SCOPES
 
 _ALL_TOOLS_WITH_SCOPES: list[tuple[object, Scope]] = [
     *TOOLS_WITH_SCOPES,
+    *ENTITY_TOOLS_WITH_SCOPES,
+    *CUSTOMER_TOOLS_WITH_SCOPES,
 ]
 
 SYSTEM_PROMPT = """\
@@ -111,7 +115,9 @@ def _safe(tool: Any) -> Any:
     return wrapper
 
 
-def build_assistant_agent(scopes: set[Scope]) -> Agent[AssistantDeps, str]:
+def build_assistant_agent(
+    scopes: set[Scope],
+) -> tuple[Agent[AssistantDeps, str], str, str]:
     """Build the assistant for one request, with the caller's capabilities.
 
     The toolset is derived from the caller's granted scopes: a tool whose scope
@@ -119,9 +125,9 @@ def build_assistant_agent(scopes: set[Scope]) -> Agent[AssistantDeps, str]:
     reach data outside its grants even if the model asks. Runtime checks inside
     each tool back this up.
     """
-    model_instance, _, model_name = settings.get_pydantic_gateway_model()
+    model_instance, model_provider, model_name = settings.get_pydantic_gateway_model()
     tools = [_safe(tool) for tool in tools_for_scopes(scopes)]
-    return Agent(
+    agent: Agent[AssistantDeps, str] = Agent(
         model_instance,
         deps_type=AssistantDeps,
         system_prompt=SYSTEM_PROMPT,
@@ -129,3 +135,4 @@ def build_assistant_agent(scopes: set[Scope]) -> Agent[AssistantDeps, str]:
         # gpt-5.5+ reasoning models reject any non-default temperature.
         model_settings=({} if model_name.startswith("gpt-5.5") else {"temperature": 0}),
     )
+    return agent, model_provider, model_name

--- a/server/polar/compass/assistant/agent.py
+++ b/server/polar/compass/assistant/agent.py
@@ -1,0 +1,131 @@
+import functools
+from typing import Any, cast
+
+import structlog
+from pydantic_ai import Agent
+
+from polar.auth.scope import Scope
+from polar.config import settings
+
+from .deps import AssistantDeps
+from .tools import TOOLS_WITH_SCOPES
+
+_ALL_TOOLS_WITH_SCOPES: list[tuple[object, Scope]] = [
+    *TOOLS_WITH_SCOPES,
+]
+
+SYSTEM_PROMPT = """\
+You are Compass, Polar's business assistant, embedded in the merchant's
+dashboard. You answer questions about the merchant's own organization using
+your tools.
+
+How to answer:
+- Answer the exact question that was asked, and answer it first. Lead with
+  the number or fact, then at most two short sentences of context.
+- Tools prepare UI blocks (charts, cards, lists, tables) and tell you each
+  block's placement marker, e.g. [block:1]. Blocks only appear where YOU
+  place their marker: state the claim first, then put the marker on its own
+  line directly under the sentence it supports. Place every prepared block
+  exactly once. Example:
+  "Best customer by revenue: jane@corp.com with $1,240.00 over the last 365
+  days.
+  [block:1]
+  Worst customer by cost: joe@corp.com, 48% of tracked costs.
+  [block:2]"
+- Only call a tool when its output belongs in your answer. Never call tools
+  speculatively to look around; every prepared block ends up on the user's
+  screen.
+- Pick the narrowest tool and the narrowest arguments that answer the
+  question. Filter when a filter exists (e.g. an insight category, a checkout
+  status, a search query). One precise call beats several broad ones.
+- Insights flow: `get_insights` only fetches findings for your reasoning and
+  renders nothing. For broad questions ("how is my business doing?"), give
+  your assessment in prose first — lead with the most severe findings — then
+  call `show_insights` with the one or two ids that directly support your
+  main claims. Only render more cards when the user explicitly asks to see
+  all insights, and never use cards as a substitute for an answer.
+- If none of your tools can answer the question, say so plainly in one
+  sentence, then name the closest related thing you CAN show and offer it.
+  Do not substitute unrelated data for an answer.
+- If a tool reports a missing permission, say which scope is missing and
+  stop.
+
+Follow-ups and judgment questions:
+- Some questions ask for judgment, not data: implications, trade-offs, or
+  risks OF something already discussed ("is there any risk with that?").
+  Answer those by reasoning over the conversation and the data you already
+  fetched; only call a tool if genuinely new data is needed.
+- Never map words in the question onto tool or category names literally.
+  "Risk" in a follow-up usually means the downside of the prior
+  recommendation, not the risk insight category.
+- Tool results from earlier turns remain valid context; do not re-fetch to
+  re-answer.
+- When your answer is analysis rather than measurement, frame it that way
+  (e.g. "the main trade-off is..."), and say what data would confirm it.
+
+Facts and style:
+- Ground every number in tool results; never invent or extrapolate values.
+- Do not repeat rendered content in prose. Narrate what matters: the direct
+  answer, the trend or outlier, and the recommended next step.
+- For entity questions prefer `list` presentation when five or fewer items
+  are asked for, and `table` otherwise.
+- Amounts from tools are in cents unless stated otherwise. Always present
+  money formatted with a currency symbol, two decimals and thousands
+  separators (e.g. $1,234.50), never as raw cents. Rendered tables and lists
+  format amounts themselves; only your prose needs this.
+- Write in short paragraphs of one to three sentences, separated by blank
+  lines. Two to four paragraphs at most. When recommending several actions,
+  give each its own paragraph, lead with the action.
+- Plain text only: no markdown headings, no markdown tables, no em dashes.
+"""
+
+
+def tools_for_scopes(scopes: set[Scope]) -> list[object]:
+    """The tools a caller may use: one entry per tool whose scope is granted."""
+    return [tool for tool, scope in _ALL_TOOLS_WITH_SCOPES if scope in scopes]
+
+
+log = structlog.get_logger()
+
+
+def _safe(tool: Any) -> Any:
+    """Never let a tool exception reach the stream as a raw error.
+
+    Failures are logged and returned to the model as a plain instruction, so
+    the conversation degrades to an apology instead of a traceback.
+    `functools.wraps` preserves the signature and docstring pydantic-ai uses
+    to build the tool schema.
+    """
+
+    @functools.wraps(tool)
+    async def wrapper(*args: Any, **kwargs: Any) -> str:
+        try:
+            return cast(str, await tool(*args, **kwargs))
+        except Exception:
+            log.exception("compass.assistant_tool_error", tool=tool.__name__)
+            return (
+                "This lookup failed unexpectedly. Apologize briefly and "
+                "suggest trying again. Do not show technical details."
+            )
+
+    return wrapper
+
+
+def build_assistant_agent(scopes: set[Scope]) -> Agent[AssistantDeps, str]:
+    """Build the assistant for one request, with the caller's capabilities.
+
+    The toolset is derived from the caller's granted scopes: a tool whose scope
+    the caller lacks is not registered at all, so a restricted token cannot
+    reach data outside its grants even if the model asks. Runtime checks inside
+    each tool back this up.
+    """
+    model_instance, _, model_name = settings.get_pydantic_gateway_model()
+    tools = [_safe(tool) for tool in tools_for_scopes(scopes)]
+    return Agent(
+        model_instance,
+        deps_type=AssistantDeps,
+        system_prompt=SYSTEM_PROMPT,
+        tools=tools,
+        # gpt-5.5+ reasoning models reject any non-default temperature.
+        model_settings=({} if model_name.startswith("gpt-5.5") else {"temperature": 0}),
+    )

--- a/server/polar/compass/assistant/blocks.py
+++ b/server/polar/compass/assistant/blocks.py
@@ -78,9 +78,7 @@ class DataTableBlock(Schema):
 
     type: Literal[BlockType.data_table] = BlockType.data_table
     entity: str = Field(description="What the rows are, e.g. `subscriptions`.")
-    title: str | None = Field(
-        default=None, description="Heading rendered above the table."
-    )
+    title: str | None = Field(description="Heading rendered above the table.")
     columns: list[DataTableColumn]
     rows: list[dict[str, str | int | float | None]]
     total_count: int
@@ -92,9 +90,7 @@ class EntityListBlock(Schema):
 
     type: Literal[BlockType.entity_list] = BlockType.entity_list
     entity: str = Field(description="What the items are, e.g. `orders`.")
-    title: str | None = Field(
-        default=None, description="Heading rendered above the list."
-    )
+    title: str | None = Field(description="Heading rendered above the list.")
     columns: list[DataTableColumn]
     rows: list[dict[str, str | int | float | None]]
     total_count: int
@@ -105,8 +101,8 @@ class CustomerCardBlock(Schema):
 
     type: Literal[BlockType.customer_card] = BlockType.customer_card
     email: str
-    name: str | None = None
-    avatar_url: str | None = None
+    name: str | None
+    avatar_url: str | None
     created_at: datetime
 
 

--- a/server/polar/compass/assistant/blocks.py
+++ b/server/polar/compass/assistant/blocks.py
@@ -1,0 +1,121 @@
+"""
+Generative-UI blocks: the closed set of things the assistant can render.
+
+The model never produces markup. Tools return typed blocks from this
+discriminated union, the client maps each block type to a predefined component
+in its block registry, and anything outside the union simply cannot be
+expressed. Adding a renderable is adding one schema here and one registry entry
+on the client.
+"""
+
+from datetime import datetime
+from enum import StrEnum
+from typing import Annotated, Literal
+
+from pydantic import Discriminator, Field
+
+from polar.kit.schemas import Schema
+
+from ..schemas import Insight
+
+
+class BlockType(StrEnum):
+    text = "text"
+    metric_chart = "metric_chart"
+    insight_cards = "insight_cards"
+    entity_list = "entity_list"
+    data_table = "data_table"
+    customer_card = "customer_card"
+
+
+class TextBlock(Schema):
+    """Plain narrated text."""
+
+    type: Literal[BlockType.text] = BlockType.text
+    text: str
+
+
+class MetricChartPoint(Schema):
+    timestamp: datetime
+    value: float
+
+
+class MetricChartBlock(Schema):
+    """A single metric's series over the requested window."""
+
+    type: Literal[BlockType.metric_chart] = BlockType.metric_chart
+    metric: str = Field(description="Metric slug, e.g. `monthly_recurring_revenue`.")
+    label: str = Field(description="Human-readable metric name.")
+    unit: str = Field(description="Metric unit type, e.g. `currency` or `scalar`.")
+    points: list[MetricChartPoint]
+
+
+class InsightCardsBlock(Schema):
+    """Compass insights, rendered with the same card as the feed."""
+
+    type: Literal[BlockType.insight_cards] = BlockType.insight_cards
+    insights: list[Insight]
+
+
+class ColumnFormat(StrEnum):
+    text = "text"
+    currency = "currency"
+    datetime = "datetime"
+    badge = "badge"
+    avatar = "avatar"
+    """Value is an avatar URL; the client renders it with the Avatar
+    component, using the row's first text column as the name fallback."""
+
+
+class DataTableColumn(Schema):
+    key: str
+    label: str
+    format: ColumnFormat = ColumnFormat.text
+
+
+class DataTableBlock(Schema):
+    """Tabular entities (orders, subscriptions, customers, ...)."""
+
+    type: Literal[BlockType.data_table] = BlockType.data_table
+    entity: str = Field(description="What the rows are, e.g. `subscriptions`.")
+    title: str | None = Field(
+        default=None, description="Heading rendered above the table."
+    )
+    columns: list[DataTableColumn]
+    rows: list[dict[str, str | int | float | None]]
+    total_count: int
+
+
+class EntityListBlock(Schema):
+    """A few entities as a compact list; same shape as the table so the
+    client formats values (currency, dates) identically in both."""
+
+    type: Literal[BlockType.entity_list] = BlockType.entity_list
+    entity: str = Field(description="What the items are, e.g. `orders`.")
+    title: str | None = Field(
+        default=None, description="Heading rendered above the list."
+    )
+    columns: list[DataTableColumn]
+    rows: list[dict[str, str | int | float | None]]
+    total_count: int
+
+
+class CustomerCardBlock(Schema):
+    """A single customer's identity header, above their orders/subscriptions."""
+
+    type: Literal[BlockType.customer_card] = BlockType.customer_card
+    email: str
+    name: str | None = None
+    avatar_url: str | None = None
+    created_at: datetime
+
+
+AssistantBlock = Annotated[
+    TextBlock
+    | MetricChartBlock
+    | InsightCardsBlock
+    | EntityListBlock
+    | DataTableBlock
+    | CustomerCardBlock,
+    Discriminator("type"),
+]

--- a/server/polar/compass/assistant/customer_tools.py
+++ b/server/polar/compass/assistant/customer_tools.py
@@ -47,11 +47,32 @@ async def get_customer_overview(
         deps.auth_subject,
         organization_id=[deps.organization_id],
         query=email_or_name,
-        pagination=PaginationParams(1, 3),
+        pagination=PaginationParams(1, 5),
     )
     if not customers:
         return f"No customer matching {email_or_name!r} was found."
-    customer = customers[0]
+    # The search is recency-sorted, so "first match" would be the newest
+    # customer, not the best one. Prefer an exact email/name match; with
+    # several inexact matches, ask instead of guessing.
+    needle = email_or_name.strip().lower()
+    exact = [
+        c
+        for c in customers
+        if (c.email or "").lower() == needle or (c.name or "").lower() == needle
+    ]
+    if exact:
+        customer = exact[0]
+    elif count == 1:
+        customer = customers[0]
+    else:
+        options = "; ".join(
+            f"{c.email or c.name} (since {c.created_at.date()})" for c in customers
+        )
+        return (
+            f"{count} customers match {email_or_name!r}: {options}. Nothing "
+            "was rendered. Ask the user which one they mean, or call this "
+            "tool again with the exact email."
+        )
 
     card_marker = deps.emit(
         CustomerCardBlock(

--- a/server/polar/compass/assistant/customer_tools.py
+++ b/server/polar/compass/assistant/customer_tools.py
@@ -1,0 +1,146 @@
+"""
+Customer drill-down: resolve one customer and stitch their activity together.
+
+The overview needs `customers:read`; the orders and subscriptions sections are
+each gated on their own scope and degrade gracefully — a token without
+`orders:read` still gets the customer card and subscriptions, with a note about
+what was withheld.
+"""
+
+from pydantic_ai import RunContext
+
+from polar.auth.scope import Scope
+from polar.customer.service import customer as customer_service
+from polar.kit.pagination import PaginationParams
+from polar.order.service import order as order_service
+from polar.subscription.service import subscription as subscription_service
+
+from .blocks import ColumnFormat, CustomerCardBlock, DataTableColumn, EntityListBlock
+from .deps import AssistantDeps
+from .tools import _scope_denial
+
+_SECTION_COLUMNS = [
+    DataTableColumn(key="title", label="Item"),
+    DataTableColumn(key="detail", label="Detail"),
+    DataTableColumn(key="amount", label="Amount", format=ColumnFormat.currency),
+]
+
+_SECTION_LIMIT = 5
+
+
+async def get_customer_overview(
+    ctx: RunContext[AssistantDeps],
+    email_or_name: str,
+) -> str:
+    """Look up one customer by email or name and show who they are, what they
+    bought and what they're subscribed to.
+
+    Args:
+        email_or_name: Search over customer email and name; the best match wins.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.customers_read):
+        return denial
+
+    customers, count = await customer_service.list(
+        deps.session,
+        deps.auth_subject,
+        organization_id=[deps.organization_id],
+        query=email_or_name,
+        pagination=PaginationParams(1, 3),
+    )
+    if not customers:
+        return f"No customer matching {email_or_name!r} was found."
+    customer = customers[0]
+
+    card_marker = deps.emit(
+        CustomerCardBlock(
+            email=customer.email or "(no email)",
+            name=customer.name,
+            avatar_url=customer.avatar_url,
+            created_at=customer.created_at,
+        )
+    )
+    summary = [
+        f"Customer card prepared; place it with [block:{card_marker}]. "
+        f"Customer: {customer.email}"
+        f" (name={customer.name!r}, since {customer.created_at.date()})."
+        + (f" {count - 1} other match(es) exist." if count > 1 else "")
+    ]
+
+    if Scope.orders_read in deps.auth_subject.scopes:
+        orders, orders_count = await order_service.list(
+            deps.session,
+            deps.auth_subject,
+            organization_id=[deps.organization_id],
+            customer_id=[customer.id],
+            pagination=PaginationParams(1, _SECTION_LIMIT),
+        )
+        orders_marker = None
+        if orders:
+            orders_marker = deps.emit(
+                EntityListBlock(
+                    entity="orders",
+                    title="Orders",
+                    columns=_SECTION_COLUMNS,
+                    rows=[
+                        {
+                            "title": order.product.name if order.product else "Order",
+                            "detail": order.created_at.isoformat(),
+                            "amount": order.net_amount,
+                        }
+                        for order in orders
+                    ],
+                    total_count=orders_count,
+                )
+            )
+        summary.append(
+            f"Orders: {orders_count} total."
+            + (f" Block prepared: [block:{orders_marker}]." if orders_marker else "")
+        )
+    else:
+        summary.append("Orders withheld: token lacks the `orders:read` scope.")
+
+    if Scope.subscriptions_read in deps.auth_subject.scopes:
+        subscriptions, subs_count = await subscription_service.list(
+            deps.session,
+            deps.auth_subject,
+            organization_id=[deps.organization_id],
+            customer_id=[customer.id],
+            pagination=PaginationParams(1, _SECTION_LIMIT),
+        )
+        subs_marker = None
+        if subscriptions:
+            subs_marker = deps.emit(
+                EntityListBlock(
+                    entity="subscriptions",
+                    title="Subscriptions",
+                    columns=_SECTION_COLUMNS,
+                    rows=[
+                        {
+                            "title": sub.product.name
+                            if sub.product
+                            else "Subscription",
+                            "detail": str(sub.status),
+                            "amount": sub.amount,
+                        }
+                        for sub in subscriptions
+                    ],
+                    total_count=subs_count,
+                )
+            )
+        summary.append(
+            f"Subscriptions: {subs_count} total."
+            + (f" Block prepared: [block:{subs_marker}]." if subs_marker else "")
+        )
+    else:
+        summary.append(
+            "Subscriptions withheld: token lacks the `subscriptions:read` scope."
+        )
+
+    return " ".join(summary)
+
+
+CUSTOMER_TOOLS_WITH_SCOPES: list[tuple[object, Scope]] = [
+    (get_customer_overview, Scope.customers_read),
+]

--- a/server/polar/compass/assistant/deps.py
+++ b/server/polar/compass/assistant/deps.py
@@ -1,0 +1,40 @@
+import uuid
+from dataclasses import dataclass, field
+from datetime import date
+from zoneinfo import ZoneInfo
+
+from polar.auth.models import AuthSubject, Organization, User
+from polar.postgres import AsyncReadSession
+from polar.redis import Redis
+
+from .blocks import AssistantBlock
+
+
+@dataclass
+class AssistantDeps:
+    """Everything a tool call runs against.
+
+    The auth subject is the *caller's* — the assistant is a conduit for the
+    caller's own permissions, never an escalator. Tools derive the organization
+    from here (validated against the subject's accessible organizations before
+    the run starts) and must never accept an organization from model arguments.
+    """
+
+    session: AsyncReadSession
+    auth_subject: AuthSubject[User | Organization]
+    organization_id: uuid.UUID
+    timezone: ZoneInfo
+    today: date
+    redis: Redis | None = None
+    blocks: list[AssistantBlock] = field(default_factory=list)
+    """Renderable blocks produced by tools during the run, in order. The
+    endpoint streams them to the client interleaved with the model's text."""
+
+    def emit(self, block: AssistantBlock) -> int:
+        """Queue a block for rendering; returns its placement marker index.
+
+        Blocks are not shown until the model places them in its answer with a
+        `[block:N]` marker (see `stream.py`), so UI lands under the claim it
+        supports. Unplaced blocks are appended at the end as a fallback."""
+        self.blocks.append(block)
+        return len(self.blocks)

--- a/server/polar/compass/assistant/entity_tools.py
+++ b/server/polar/compass/assistant/entity_tools.py
@@ -269,12 +269,18 @@ async def list_products(
     # Loaded via the repository with prices eager-loaded: the price column
     # reads `all_prices`, which is lazy="raise" and not loaded by the
     # service's list query.
-    items = await ProductRepository.from_session(deps.session).get_all_by_organization(
+    product_repository = ProductRepository.from_session(deps.session)
+    items = await product_repository.get_all_by_organization(
         deps.organization_id,
         options=(selectinload(Product.all_prices),),
         limit=max(1, min(_MAX_LIMIT, limit)),
     )
-    count = len(items)
+    count = await product_repository.count(
+        product_repository.get_base_statement().where(
+            Product.organization_id == deps.organization_id,
+            Product.is_archived.is_(False),
+        )
+    )
     rows: list[Row] = [
         {
             "name": item.name,
@@ -515,13 +521,35 @@ async def top_products_by_revenue(
     days = max(7, min(365, days))
     limit = max(1, min(_MAX_RANKED_PRODUCTS, limit))
 
-    products, _ = await product_service.list(
-        deps.session,
-        deps.auth_subject,
-        organization_id=[deps.organization_id],
-        is_archived=False,
-        pagination=PaginationParams(1, _MAX_RANKED_PRODUCTS),
+    # Candidate selection is revenue-based (order aggregation, ids only) so
+    # orgs with more products than the metric-query budget still rank their
+    # actual top sellers; the displayed numbers below come from the metrics
+    # layer and match the dashboard.
+    candidate_ids = await OrderRepository.from_session(
+        deps.session
+    ).get_top_product_ids_by_revenue(
+        deps.organization_id,
+        start=datetime.combine(
+            deps.today - timedelta(days=days - 1), time.min, deps.timezone
+        ),
+        limit=_MAX_RANKED_PRODUCTS,
     )
+    if candidate_ids:
+        products, _ = await product_service.list(
+            deps.session,
+            deps.auth_subject,
+            id=list(candidate_ids),
+            organization_id=[deps.organization_id],
+            pagination=PaginationParams(1, _MAX_RANKED_PRODUCTS),
+        )
+    else:
+        products, _ = await product_service.list(
+            deps.session,
+            deps.auth_subject,
+            organization_id=[deps.organization_id],
+            is_archived=False,
+            pagination=PaginationParams(1, _MAX_RANKED_PRODUCTS),
+        )
     if not products:
         return "This organization has no products."
 

--- a/server/polar/compass/assistant/entity_tools.py
+++ b/server/polar/compass/assistant/entity_tools.py
@@ -558,7 +558,10 @@ async def top_products_by_revenue(
         response = await metrics_service.get_metrics(
             deps.session,
             deps.auth_subject,
-            start_date=deps.today - timedelta(days=days),
+            # Inclusive range: the same days-1 window as candidate selection,
+            # so a product's boundary-day revenue can't rank it without also
+            # being counted (or vice versa).
+            start_date=deps.today - timedelta(days=days - 1),
             end_date=deps.today,
             timezone=deps.timezone,
             interval=TimeInterval.month,
@@ -621,7 +624,7 @@ async def top_customers_by_revenue(
     if days is not None:
         days = max(1, min(365, days))
         start = datetime.combine(
-            deps.today - timedelta(days=days), time.min, deps.timezone
+            deps.today - timedelta(days=days - 1), time.min, deps.timezone
         )
     ranked = await OrderRepository.from_session(deps.session).get_revenue_by_customer(
         deps.organization_id,
@@ -685,7 +688,7 @@ async def top_customers_by_cost(
     stats = await event_service.list_customer_stats(
         cast(AsyncSession, deps.session),
         deps.auth_subject,
-        start_date=deps.today - timedelta(days=days),
+        start_date=deps.today - timedelta(days=days - 1),
         end_date=deps.today,
         timezone=deps.timezone,
         organization_id=[deps.organization_id],

--- a/server/polar/compass/assistant/entity_tools.py
+++ b/server/polar/compass/assistant/entity_tools.py
@@ -1,0 +1,719 @@
+"""
+Entity listing tools: orders, subscriptions, customers, products, disputes.
+
+Same contract as `tools.py`: organization from deps, per-tool scope guard,
+compact text summary back to the model, and a renderable block emitted for the
+client — an entity list for small sets, a data table otherwise. Each tool only
+reads attributes the corresponding public list endpoint serializes, so
+everything touched is eager-loaded.
+"""
+
+from collections.abc import Sequence
+from datetime import datetime, time, timedelta
+from typing import Any, Literal, cast
+
+from pydantic_ai import RunContext
+from sqlalchemy.orm import selectinload
+
+from polar.auth.scope import Scope
+from polar.checkout.service import checkout as checkout_service
+from polar.customer.service import customer as customer_service
+from polar.dispute.service import dispute as dispute_service
+from polar.event.service import event as event_service
+from polar.kit.pagination import PaginationParams
+from polar.kit.time_queries import TimeInterval
+from polar.metrics.service import metrics as metrics_service
+from polar.models import Product
+from polar.models.checkout import CheckoutStatus
+from polar.models.customer import _avatar_url_for_email
+from polar.models.product_price import ProductPriceFixed
+from polar.order.repository import OrderRepository
+from polar.order.service import order as order_service
+from polar.organization.repository import OrganizationRepository
+from polar.payout.service import payout as payout_service
+from polar.postgres import AsyncSession
+from polar.product.repository import ProductRepository
+from polar.product.service import product as product_service
+from polar.refund.service import refund as refund_service
+from polar.subscription.service import subscription as subscription_service
+
+from .blocks import (
+    ColumnFormat,
+    DataTableBlock,
+    DataTableColumn,
+    EntityListBlock,
+)
+from .deps import AssistantDeps
+from .tools import _scope_denial
+
+_MAX_LIMIT = 25
+# Each ranked product costs one metrics query; keep the fan-out small.
+_MAX_RANKED_PRODUCTS = 8
+_LIST_PRESENTATION_MAX = 5
+
+Presentation = Literal["list", "table"]
+Row = dict[str, str | int | float | None]
+
+
+def _emit_entities(
+    deps: AssistantDeps,
+    *,
+    entity: str,
+    title: str,
+    columns: list[DataTableColumn],
+    rows: list[Row],
+    total_count: int,
+    presentation: Presentation,
+) -> str:
+    if presentation == "list" and len(rows) <= _LIST_PRESENTATION_MAX:
+        marker = deps.emit(
+            EntityListBlock(
+                entity=entity,
+                title=title,
+                columns=columns,
+                rows=rows,
+                total_count=total_count,
+            )
+        )
+    else:
+        marker = deps.emit(
+            DataTableBlock(
+                entity=entity,
+                title=title,
+                columns=columns,
+                rows=rows,
+                total_count=total_count,
+            )
+        )
+    shown = len(rows)
+    return (
+        f"Prepared a block with {shown} of {total_count} {entity}; place it "
+        f"with [block:{marker}] directly after the claim it supports. Rows: "
+        + "; ".join(str(row) for row in rows[:_LIST_PRESENTATION_MAX])
+    )
+
+
+def _clamp(limit: int) -> PaginationParams:
+    return PaginationParams(1, max(1, min(_MAX_LIMIT, limit)))
+
+
+async def list_orders(
+    ctx: RunContext[AssistantDeps],
+    limit: int = 10,
+    presentation: Presentation = "table",
+) -> str:
+    """List the most recent orders: customer, product, amount and status.
+
+    Args:
+        limit: How many to fetch (1 to 25).
+        presentation: `list` for a compact list (5 or fewer), else `table`.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.orders_read):
+        return denial
+    items, count = await order_service.list(
+        deps.session,
+        deps.auth_subject,
+        organization_id=[deps.organization_id],
+        pagination=_clamp(limit),
+    )
+    rows: list[Row] = [
+        {
+            "customer": order.customer.email if order.customer else None,
+            "product": order.product.name if order.product else None,
+            "amount": order.net_amount,
+            "status": str(order.status),
+            "date": order.created_at.isoformat(),
+        }
+        for order in items
+    ]
+    columns = [
+        DataTableColumn(key="customer", label="Customer"),
+        DataTableColumn(key="product", label="Product"),
+        DataTableColumn(key="amount", label="Amount", format=ColumnFormat.currency),
+        DataTableColumn(key="status", label="Status", format=ColumnFormat.badge),
+        DataTableColumn(key="date", label="Date", format=ColumnFormat.datetime),
+    ]
+    return _emit_entities(
+        deps,
+        entity="orders",
+        title="Recent orders",
+        columns=columns,
+        rows=rows,
+        total_count=count,
+        presentation=presentation,
+    )
+
+
+async def list_subscriptions(
+    ctx: RunContext[AssistantDeps],
+    limit: int = 10,
+    active: bool | None = None,
+    presentation: Presentation = "table",
+) -> str:
+    """List subscriptions: customer, product, amount, status and start date.
+
+    Args:
+        limit: How many to fetch (1 to 25).
+        active: Only active (true) or only ended (false); omit for all.
+        presentation: `list` for a compact list (5 or fewer), else `table`.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.subscriptions_read):
+        return denial
+    items, count = await subscription_service.list(
+        deps.session,
+        deps.auth_subject,
+        organization_id=[deps.organization_id],
+        active=active,
+        pagination=_clamp(limit),
+    )
+    rows: list[Row] = [
+        {
+            "customer": sub.customer.email if sub.customer else None,
+            "product": sub.product.name if sub.product else None,
+            "amount": sub.amount,
+            "status": str(sub.status),
+            "started": sub.started_at.isoformat() if sub.started_at else None,
+        }
+        for sub in items
+    ]
+    columns = [
+        DataTableColumn(key="customer", label="Customer"),
+        DataTableColumn(key="product", label="Product"),
+        DataTableColumn(key="amount", label="Amount", format=ColumnFormat.currency),
+        DataTableColumn(key="status", label="Status", format=ColumnFormat.badge),
+        DataTableColumn(key="started", label="Started", format=ColumnFormat.datetime),
+    ]
+    return _emit_entities(
+        deps,
+        entity="subscriptions",
+        title="Subscriptions",
+        columns=columns,
+        rows=rows,
+        total_count=count,
+        presentation=presentation,
+    )
+
+
+async def list_customers(
+    ctx: RunContext[AssistantDeps],
+    limit: int = 10,
+    query: str | None = None,
+    presentation: Presentation = "table",
+) -> str:
+    """List customers: email, name and signup date. Optionally search them.
+
+    Args:
+        limit: How many to fetch (1 to 25).
+        query: Optional search over email and name.
+        presentation: `list` for a compact list (5 or fewer), else `table`.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.customers_read):
+        return denial
+    items, count = await customer_service.list(
+        deps.session,
+        deps.auth_subject,
+        organization_id=[deps.organization_id],
+        query=query,
+        pagination=_clamp(limit),
+    )
+    rows: list[Row] = [
+        {
+            "avatar": item.avatar_url,
+            "email": item.email,
+            "name": item.name,
+            "created": item.created_at.isoformat(),
+        }
+        for item in items
+    ]
+    columns = [
+        DataTableColumn(key="avatar", label="", format=ColumnFormat.avatar),
+        DataTableColumn(key="email", label="Email"),
+        DataTableColumn(key="name", label="Name"),
+        DataTableColumn(key="created", label="Created", format=ColumnFormat.datetime),
+    ]
+    return _emit_entities(
+        deps,
+        entity="customers",
+        title="Customers",
+        columns=columns,
+        rows=rows,
+        total_count=count,
+        presentation=presentation,
+    )
+
+
+def _product_price(product: Any) -> int | None:
+    for price in product.all_prices:
+        if isinstance(price, ProductPriceFixed) and not price.is_archived:
+            return price.price_amount
+    return None
+
+
+async def list_products(
+    ctx: RunContext[AssistantDeps],
+    limit: int = 10,
+    presentation: Presentation = "table",
+) -> str:
+    """List products: name, list price and whether they're recurring.
+
+    Args:
+        limit: How many to fetch (1 to 25).
+        presentation: `list` for a compact list (5 or fewer), else `table`.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.products_read):
+        return denial
+    # Loaded via the repository with prices eager-loaded: the price column
+    # reads `all_prices`, which is lazy="raise" and not loaded by the
+    # service's list query.
+    items = await ProductRepository.from_session(deps.session).get_all_by_organization(
+        deps.organization_id,
+        options=(selectinload(Product.all_prices),),
+        limit=max(1, min(_MAX_LIMIT, limit)),
+    )
+    count = len(items)
+    rows: list[Row] = [
+        {
+            "name": item.name,
+            "price": _product_price(item),
+            "recurring": "recurring" if item.is_recurring else "one-time",
+        }
+        for item in items
+    ]
+    columns = [
+        DataTableColumn(key="name", label="Name"),
+        DataTableColumn(key="price", label="Price", format=ColumnFormat.currency),
+        DataTableColumn(key="recurring", label="Billing", format=ColumnFormat.badge),
+    ]
+    return _emit_entities(
+        deps,
+        entity="products",
+        title="Products",
+        columns=columns,
+        rows=rows,
+        total_count=count,
+        presentation=presentation,
+    )
+
+
+async def list_disputes(
+    ctx: RunContext[AssistantDeps],
+    limit: int = 10,
+    presentation: Presentation = "table",
+) -> str:
+    """List disputes: amount, status and when they were opened.
+
+    Args:
+        limit: How many to fetch (1 to 25).
+        presentation: `list` for a compact list (5 or fewer), else `table`.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.disputes_read):
+        return denial
+    items, count = await dispute_service.list(
+        deps.session,
+        deps.auth_subject,
+        organization_id=[deps.organization_id],
+        pagination=_clamp(limit),
+    )
+    rows: list[Row] = [
+        {
+            "amount": item.amount,
+            "status": str(item.status),
+            "opened": item.created_at.isoformat(),
+        }
+        for item in items
+    ]
+    columns = [
+        DataTableColumn(key="amount", label="Amount", format=ColumnFormat.currency),
+        DataTableColumn(key="status", label="Status", format=ColumnFormat.badge),
+        DataTableColumn(key="opened", label="Opened", format=ColumnFormat.datetime),
+    ]
+    return _emit_entities(
+        deps,
+        entity="disputes",
+        title="Disputes",
+        columns=columns,
+        rows=rows,
+        total_count=count,
+        presentation=presentation,
+    )
+
+
+async def list_checkouts(
+    ctx: RunContext[AssistantDeps],
+    limit: int = 10,
+    status: Literal["open", "expired", "confirmed", "succeeded", "failed"]
+    | None = None,
+    presentation: Presentation = "table",
+) -> str:
+    """List checkout sessions: who opened them, amount and outcome. Useful to
+    drill into conversion questions (e.g. expired = abandoned checkouts).
+
+    Args:
+        limit: How many to fetch (1 to 25).
+        status: Only checkouts with this status; omit for all.
+        presentation: `list` for a compact list (5 or fewer), else `table`.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.checkouts_read):
+        return denial
+    items, count = await checkout_service.list(
+        deps.session,
+        deps.auth_subject,
+        organization_id=[deps.organization_id],
+        status=[CheckoutStatus(status)] if status else None,
+        pagination=_clamp(limit),
+    )
+    rows: list[Row] = [
+        {
+            "customer": item.customer_email,
+            "amount": item.net_amount,
+            "status": str(item.status),
+            "created": item.created_at.isoformat(),
+        }
+        for item in items
+    ]
+    columns = [
+        DataTableColumn(key="customer", label="Customer"),
+        DataTableColumn(key="amount", label="Amount", format=ColumnFormat.currency),
+        DataTableColumn(key="status", label="Status", format=ColumnFormat.badge),
+        DataTableColumn(key="created", label="Created", format=ColumnFormat.datetime),
+    ]
+    return _emit_entities(
+        deps,
+        entity="checkouts",
+        title="Checkouts",
+        columns=columns,
+        rows=rows,
+        total_count=count,
+        presentation=presentation,
+    )
+
+
+async def list_refunds(
+    ctx: RunContext[AssistantDeps],
+    limit: int = 10,
+    presentation: Presentation = "table",
+) -> str:
+    """List refunds: amount, reason, status and when they were issued.
+
+    Args:
+        limit: How many to fetch (1 to 25).
+        presentation: `list` for a compact list (5 or fewer), else `table`.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.refunds_read):
+        return denial
+    items, count = await refund_service.list(
+        # Read-only listing; the service annotates the broader session type.
+        cast(AsyncSession, deps.session),
+        deps.auth_subject,
+        organization_id=[deps.organization_id],
+        pagination=_clamp(limit),
+    )
+    rows: list[Row] = [
+        {
+            "amount": item.amount,
+            "reason": str(item.reason),
+            "status": str(item.status),
+            "created": item.created_at.isoformat(),
+        }
+        for item in items
+    ]
+    columns = [
+        DataTableColumn(key="amount", label="Amount", format=ColumnFormat.currency),
+        DataTableColumn(key="reason", label="Reason"),
+        DataTableColumn(key="status", label="Status", format=ColumnFormat.badge),
+        DataTableColumn(key="created", label="Created", format=ColumnFormat.datetime),
+    ]
+    return _emit_entities(
+        deps,
+        entity="refunds",
+        title="Refunds",
+        columns=columns,
+        rows=rows,
+        total_count=count,
+        presentation=presentation,
+    )
+
+
+async def list_payouts(
+    ctx: RunContext[AssistantDeps],
+    limit: int = 10,
+    presentation: Presentation = "table",
+) -> str:
+    """List payouts to the merchant's bank account: amount, fees, status and
+    date. Answers "when do I get paid and how much".
+
+    Args:
+        limit: How many to fetch (1 to 25).
+        presentation: `list` for a compact list (5 or fewer), else `table`.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.payouts_read):
+        return denial
+    organization = await OrganizationRepository.from_session(deps.session).get_by_id(
+        deps.organization_id
+    )
+    account_id = organization.payout_account_id if organization else None
+    if account_id is None:
+        return "This organization has no payout account set up yet."
+    items, count = await payout_service.list(
+        cast(AsyncSession, deps.session),
+        cast(Any, deps.auth_subject),
+        account_id=[account_id],
+        pagination=_clamp(limit),
+    )
+    rows: list[Row] = [
+        {
+            "amount": item.amount,
+            "fees": item.fees_amount,
+            "status": str(item.status),
+            "date": item.created_at.isoformat(),
+        }
+        for item in items
+    ]
+    columns = [
+        DataTableColumn(key="amount", label="Amount", format=ColumnFormat.currency),
+        DataTableColumn(key="fees", label="Fees", format=ColumnFormat.currency),
+        DataTableColumn(key="status", label="Status", format=ColumnFormat.badge),
+        DataTableColumn(key="date", label="Date", format=ColumnFormat.datetime),
+    ]
+    return _emit_entities(
+        deps,
+        entity="payouts",
+        title="Payouts",
+        columns=columns,
+        rows=rows,
+        total_count=count,
+        presentation=presentation,
+    )
+
+
+async def top_products_by_revenue(
+    ctx: RunContext[AssistantDeps],
+    days: int = 365,
+    limit: int = 5,
+    presentation: Presentation = "table",
+) -> str:
+    """Rank products by revenue over a trailing window, via the revenue metric
+    filtered per product. Answers questions like "what is my most successful
+    product" or "which product sells best".
+
+    Args:
+        days: Trailing window in days (7 to 365, default 365).
+        limit: How many products to rank (1 to 8; one metrics query each).
+        presentation: `list` for a compact list (5 or fewer), else `table`.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.metrics_read):
+        return denial
+    days = max(7, min(365, days))
+    limit = max(1, min(_MAX_RANKED_PRODUCTS, limit))
+
+    products, _ = await product_service.list(
+        deps.session,
+        deps.auth_subject,
+        organization_id=[deps.organization_id],
+        is_archived=False,
+        pagination=PaginationParams(1, _MAX_RANKED_PRODUCTS),
+    )
+    if not products:
+        return "This organization has no products."
+
+    ranked: list[tuple[str, float, float]] = []
+    for product in products:
+        response = await metrics_service.get_metrics(
+            deps.session,
+            deps.auth_subject,
+            start_date=deps.today - timedelta(days=days),
+            end_date=deps.today,
+            timezone=deps.timezone,
+            interval=TimeInterval.month,
+            organization_id=[deps.organization_id],
+            product_id=[product.id],
+            metrics=["revenue", "orders"],
+            redis=deps.redis,
+        )
+        revenue = float(getattr(response.totals, "revenue", 0) or 0)
+        orders = float(getattr(response.totals, "orders", 0) or 0)
+        ranked.append((product.name, revenue, orders))
+    ranked.sort(key=lambda entry: entry[1], reverse=True)
+    ranked = ranked[:limit]
+
+    if all(revenue == 0 for _, revenue, _ in ranked):
+        return f"No product revenue was recorded in the last {days} days."
+    rows: list[Row] = [
+        {"product": name, "revenue": revenue, "orders": int(orders)}
+        for name, revenue, orders in ranked
+    ]
+    columns = [
+        DataTableColumn(key="product", label="Product"),
+        DataTableColumn(key="revenue", label="Revenue", format=ColumnFormat.currency),
+        DataTableColumn(key="orders", label="Orders"),
+    ]
+    top = rows[0]
+    summary = _emit_entities(
+        deps,
+        entity="products by revenue",
+        title=f"Top products by revenue, last {days} days",
+        columns=columns,
+        rows=rows,
+        total_count=len(rows),
+        presentation=presentation,
+    )
+    return (
+        f"Top product by revenue over the last {days} days: {top['product']} "
+        f"({top['orders']} orders). " + summary
+    )
+
+
+async def top_customers_by_revenue(
+    ctx: RunContext[AssistantDeps],
+    days: int | None = 365,
+    limit: int = 5,
+    presentation: Presentation = "table",
+) -> str:
+    """Rank customers by paid net revenue. Answers questions like "who is my
+    best customer" or "which customers bring in the most revenue".
+
+    Args:
+        days: Trailing window in days (up to 365); omit for all time.
+        limit: How many customers to rank (1 to 25).
+        presentation: `list` for a compact list (5 or fewer), else `table`.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.orders_read):
+        return denial
+    start = None
+    if days is not None:
+        days = max(1, min(365, days))
+        start = datetime.combine(
+            deps.today - timedelta(days=days), time.min, deps.timezone
+        )
+    ranked = await OrderRepository.from_session(deps.session).get_revenue_by_customer(
+        deps.organization_id,
+        start=start,
+        limit=max(1, min(_MAX_LIMIT, limit)),
+    )
+    window = f"the last {days} days" if days is not None else "all time"
+    if not ranked:
+        return f"No paid orders were found for {window}."
+    rows: list[Row] = [
+        {
+            "avatar": _avatar_url_for_email(email) if email else None,
+            "customer": email or name,
+            "revenue": net_revenue,
+            "orders": order_count,
+        }
+        for _, email, name, order_count, net_revenue in ranked
+    ]
+    columns = [
+        DataTableColumn(key="avatar", label="", format=ColumnFormat.avatar),
+        DataTableColumn(key="customer", label="Customer"),
+        DataTableColumn(
+            key="revenue", label="Net revenue", format=ColumnFormat.currency
+        ),
+        DataTableColumn(key="orders", label="Orders"),
+    ]
+    top = rows[0]
+    summary = _emit_entities(
+        deps,
+        entity="customers by revenue",
+        title=f"Top customers by net revenue, {window}",
+        columns=columns,
+        rows=rows,
+        total_count=len(rows),
+        presentation=presentation,
+    )
+    return (
+        f"Best customer by paid net revenue over {window}: {top['customer']} "
+        f"({top['orders']} orders). " + summary
+    )
+
+
+async def top_customers_by_cost(
+    ctx: RunContext[AssistantDeps],
+    days: int = 30,
+    limit: int = 5,
+    presentation: Presentation = "table",
+) -> str:
+    """Rank customers by the cost they generate (from `_cost` event metadata).
+    Answers questions like "which customer drives the most cost".
+
+    Args:
+        days: Trailing window length in days (7 to 90, default 30).
+        limit: How many customers to rank (1 to 25).
+        presentation: `list` for a compact list (5 or fewer), else `table`.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.events_read):
+        return denial
+    days = max(7, min(90, days))
+    stats = await event_service.list_customer_stats(
+        cast(AsyncSession, deps.session),
+        deps.auth_subject,
+        start_date=deps.today - timedelta(days=days),
+        end_date=deps.today,
+        timezone=deps.timezone,
+        organization_id=[deps.organization_id],
+        limit=max(1, min(_MAX_LIMIT, limit)),
+    )
+    ranked = [
+        stat for stat in stats.items if float(stat.totals.get("_cost_amount", 0)) > 0
+    ]
+    if not ranked:
+        return (
+            f"No customer costs were tracked in the last {days} days. Costs "
+            "come from `_cost` metadata on ingested events."
+        )
+    rows: list[Row] = [
+        {
+            "avatar": _avatar_url_for_email(stat.email) if stat.email else None,
+            "customer": stat.email or stat.name or stat.external_customer_id,
+            "cost": float(stat.totals.get("_cost_amount", 0)),
+            "share": f"{float(stat.share) * 100:.0f}%",
+            "events": stat.occurrences,
+        }
+        for stat in ranked
+    ]
+    columns = [
+        DataTableColumn(key="avatar", label="", format=ColumnFormat.avatar),
+        DataTableColumn(key="customer", label="Customer"),
+        DataTableColumn(key="cost", label="Cost", format=ColumnFormat.currency),
+        DataTableColumn(key="share", label="Share of costs"),
+        DataTableColumn(key="events", label="Events"),
+    ]
+    top = rows[0]
+    summary = _emit_entities(
+        deps,
+        entity="customers by cost",
+        title=f"Top customers by tracked cost, last {days} days",
+        columns=columns,
+        rows=rows,
+        total_count=len(rows),
+        presentation=presentation,
+    )
+    return (
+        f"Top cost driver over the last {days} days: {top['customer']} with "
+        f"{top['share']} of all tracked costs. " + summary
+    )
+
+
+ENTITY_TOOLS_WITH_SCOPES: Sequence[tuple[object, Scope]] = [
+    (list_orders, Scope.orders_read),
+    (list_subscriptions, Scope.subscriptions_read),
+    (list_customers, Scope.customers_read),
+    (list_products, Scope.products_read),
+    (list_disputes, Scope.disputes_read),
+    (list_checkouts, Scope.checkouts_read),
+    (list_refunds, Scope.refunds_read),
+    (list_payouts, Scope.payouts_read),
+    (top_customers_by_cost, Scope.events_read),
+    (top_products_by_revenue, Scope.metrics_read),
+    (top_customers_by_revenue, Scope.orders_read),
+]

--- a/server/polar/compass/assistant/schemas.py
+++ b/server/polar/compass/assistant/schemas.py
@@ -1,0 +1,21 @@
+from pydantic import UUID4, Field
+
+from polar.kit.schemas import Schema
+
+
+class AssistantChatRequest(Schema):
+    """One turn of the Compass assistant conversation."""
+
+    organization_id: UUID4 = Field(
+        description="Organization the conversation is about. Must be accessible "
+        "to the caller; tools are always scoped to it."
+    )
+    prompt: str = Field(min_length=1, max_length=4000)
+    message_history: str | None = Field(
+        default=None,
+        description=(
+            "Opaque conversation state from the previous turn's `done` event. "
+            "Send it back verbatim to continue the conversation; omit to start "
+            "a new one."
+        ),
+    )

--- a/server/polar/compass/assistant/stream.py
+++ b/server/polar/compass/assistant/stream.py
@@ -12,6 +12,7 @@ import hashlib
 import hmac
 import json
 import re
+import uuid
 from collections.abc import AsyncGenerator
 from typing import Any
 
@@ -54,6 +55,9 @@ def _track_usage(
             input_tokens=info.input_tokens,
             output_tokens=info.output_tokens,
             cost_usd=info.estimated_cost_usd,
+            # Idempotency key: a task retry after a lost response re-ingests
+            # the same child event instead of double-counting the cost.
+            usage_id=str(uuid.uuid4()),
         )
     except Exception:
         log.exception(

--- a/server/polar/compass/assistant/stream.py
+++ b/server/polar/compass/assistant/stream.py
@@ -8,6 +8,8 @@ Events, in order of appearance:
 - `error`  {"message": str}
 """
 
+import hashlib
+import hmac
 import json
 import re
 from collections.abc import AsyncGenerator
@@ -23,6 +25,7 @@ from pydantic_ai.messages import (
     TextPartDelta,
 )
 
+from polar.config import settings
 from polar.logging import Logger
 
 from .deps import AssistantDeps
@@ -32,6 +35,55 @@ log: Logger = structlog.get_logger()
 
 def _event(event: str, data: Any) -> dict[str, str]:
     return {"event": event, "data": json.dumps(data)}
+
+
+def _scopes_digest(deps: AssistantDeps) -> str:
+    joined = ",".join(sorted(scope.value for scope in deps.auth_subject.scopes))
+    return hashlib.sha256(joined.encode()).hexdigest()
+
+
+def _history_mac(organization_id: str, scopes: str, messages: str) -> str:
+    payload = f"{organization_id}|{scopes}|{messages}".encode()
+    return hmac.new(settings.SECRET.encode(), payload, hashlib.sha256).hexdigest()
+
+
+def seal_history(deps: AssistantDeps, messages_json: str) -> str:
+    """Bind conversation state to the caller's organization and scopes.
+
+    The state round-trips through the client, so it is signed with claims:
+    replaying it against another organization, or after the token's scopes
+    changed, fails verification instead of leaking prior context (including
+    old tool results) into a conversation it does not belong to.
+    """
+    organization_id = str(deps.organization_id)
+    scopes = _scopes_digest(deps)
+    return json.dumps(
+        {
+            "org": organization_id,
+            "scopes": scopes,
+            "messages": messages_json,
+            "mac": _history_mac(organization_id, scopes, messages_json),
+        }
+    )
+
+
+def open_history(deps: AssistantDeps, sealed: str) -> str | None:
+    """The messages JSON if the seal verifies for this caller, else None."""
+    try:
+        envelope = json.loads(sealed)
+        organization_id = envelope["org"]
+        scopes = envelope["scopes"]
+        messages = envelope["messages"]
+        mac = envelope["mac"]
+    except (ValueError, TypeError, KeyError):
+        return None
+    if not hmac.compare_digest(mac, _history_mac(organization_id, scopes, messages)):
+        return None
+    if organization_id != str(deps.organization_id):
+        return None
+    if scopes != _scopes_digest(deps):
+        return None
+    return str(messages)
 
 
 _MARKER_RE = re.compile(r"\s*\[block:(\d+)\]\s*")
@@ -91,8 +143,18 @@ async def stream_assistant_run(
 ) -> AsyncGenerator[dict[str, str]]:
     history = None
     if message_history_json:
+        messages_json = open_history(deps, message_history_json)
+        if messages_json is None:
+            yield _event(
+                "error",
+                {
+                    "message": "This conversation state is invalid or from a "
+                    "different context. Start a new conversation."
+                },
+            )
+            return
         try:
-            history = ModelMessagesTypeAdapter.validate_json(message_history_json)
+            history = ModelMessagesTypeAdapter.validate_json(messages_json)
         except ValueError:
             yield _event("error", {"message": "Invalid message history."})
             return
@@ -151,9 +213,12 @@ async def stream_assistant_run(
             yield _event(
                 "done",
                 {
-                    "message_history": ModelMessagesTypeAdapter.dump_json(
-                        result.all_messages()
-                    ).decode()
+                    "message_history": seal_history(
+                        deps,
+                        ModelMessagesTypeAdapter.dump_json(
+                            result.all_messages()
+                        ).decode(),
+                    )
                 },
             )
     except Exception:

--- a/server/polar/compass/assistant/stream.py
+++ b/server/polar/compass/assistant/stream.py
@@ -1,0 +1,166 @@
+"""
+Run the assistant agent and turn it into an SSE event stream.
+
+Events, in order of appearance:
+- `text`   {"delta": str}         — model output, streamed as it generates
+- `block`  {<AssistantBlock>}     — a renderable block, placed by the model
+- `done`   {"message_history": str} — opaque state to send back next turn
+- `error`  {"message": str}
+"""
+
+import json
+import re
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import structlog
+from pydantic_ai import Agent
+from pydantic_ai.messages import (
+    ModelMessagesTypeAdapter,
+    PartDeltaEvent,
+    PartStartEvent,
+    TextPart,
+    TextPartDelta,
+)
+
+from polar.logging import Logger
+
+from .deps import AssistantDeps
+
+log: Logger = structlog.get_logger()
+
+
+def _event(event: str, data: Any) -> dict[str, str]:
+    return {"event": event, "data": json.dumps(data)}
+
+
+_MARKER_RE = re.compile(r"\s*\[block:(\d+)\]\s*")
+_MARKER_PREFIX = "[block:"
+_MAX_MARKER_LEN = 12
+
+
+class _BlockPlacer:
+    """Splits streamed text around `[block:N]` placement markers.
+
+    Text before a marker flows through as-is; the marker itself becomes a
+    block reference. A possible partial marker at the end of a delta is held
+    back until the next delta resolves it.
+    """
+
+    def __init__(self) -> None:
+        self._buffer = ""
+
+    def feed(self, delta: str) -> list[tuple[str, str | int]]:
+        self._buffer += delta
+        out: list[tuple[str, str | int]] = []
+        while True:
+            match = _MARKER_RE.search(self._buffer)
+            if match:
+                if pre := self._buffer[: match.start()]:
+                    out.append(("text", pre))
+                out.append(("block", int(match.group(1))))
+                self._buffer = self._buffer[match.end() :]
+                continue
+            cut = self._buffer.rfind("[")
+            if cut != -1:
+                candidate = self._buffer[cut:]
+                partial = _MARKER_PREFIX.startswith(candidate) or (
+                    candidate.startswith(_MARKER_PREFIX)
+                    and len(candidate) <= _MAX_MARKER_LEN
+                )
+                if partial:
+                    if safe := self._buffer[:cut]:
+                        out.append(("text", safe))
+                    self._buffer = candidate
+                    return out
+            if self._buffer:
+                out.append(("text", self._buffer))
+                self._buffer = ""
+            return out
+
+    def flush(self) -> str:
+        tail, self._buffer = self._buffer, ""
+        return tail
+
+
+async def stream_assistant_run(
+    agent: Agent[AssistantDeps, str],
+    deps: AssistantDeps,
+    prompt: str,
+    message_history_json: str | None,
+) -> AsyncGenerator[dict[str, str]]:
+    history = None
+    if message_history_json:
+        try:
+            history = ModelMessagesTypeAdapter.validate_json(message_history_json)
+        except ValueError:
+            yield _event("error", {"message": "Invalid message history."})
+            return
+
+    placer = _BlockPlacer()
+    placed: set[int] = set()
+
+    def block_event(index: int) -> dict[str, str] | None:
+        # Markers are 1-based indexes into the run's prepared blocks.
+        if index in placed or not (1 <= index <= len(deps.blocks)):
+            return None
+        placed.add(index)
+        return _event("block", deps.blocks[index - 1].model_dump(mode="json"))
+
+    def placed_events(delta: str) -> list[dict[str, str]]:
+        events: list[dict[str, str]] = []
+        for kind, value in placer.feed(delta):
+            if kind == "text":
+                events.append(_event("text", {"delta": str(value)}))
+            else:
+                placed_block = block_event(int(value))
+                if placed_block is not None:
+                    events.append(placed_block)
+        return events
+
+    try:
+        async with agent.iter(prompt, deps=deps, message_history=history) as run:
+            async for node in run:
+                if Agent.is_model_request_node(node):
+                    async with node.stream(run.ctx) as request_stream:
+                        async for event in request_stream:
+                            if isinstance(event, PartStartEvent) and isinstance(
+                                event.part, TextPart
+                            ):
+                                if event.part.content:
+                                    for out in placed_events(event.part.content):
+                                        yield out
+                            elif isinstance(event, PartDeltaEvent) and isinstance(
+                                event.delta, TextPartDelta
+                            ):
+                                if event.delta.content_delta:
+                                    for out in placed_events(event.delta.content_delta):
+                                        yield out
+                    if tail := placer.flush():
+                        yield _event("text", {"delta": tail})
+
+            # Fallback: blocks the model never placed still reach the user,
+            # after the text.
+            for index in range(1, len(deps.blocks) + 1):
+                unplaced = block_event(index)
+                if unplaced is not None:
+                    yield unplaced
+
+            result = run.result
+            assert result is not None
+            yield _event(
+                "done",
+                {
+                    "message_history": ModelMessagesTypeAdapter.dump_json(
+                        result.all_messages()
+                    ).decode()
+                },
+            )
+    except Exception:
+        log.exception(
+            "compass.assistant_error", organization_id=str(deps.organization_id)
+        )
+        yield _event(
+            "error",
+            {"message": "The assistant hit an unexpected error. Try again."},
+        )

--- a/server/polar/compass/assistant/stream.py
+++ b/server/polar/compass/assistant/stream.py
@@ -26,7 +26,9 @@ from pydantic_ai.messages import (
 )
 
 from polar.config import settings
+from polar.integrations.polar.service import polar_self
 from polar.logging import Logger
+from polar.organization_review.schemas import UsageInfo
 
 from .deps import AssistantDeps
 
@@ -35,6 +37,29 @@ log: Logger = structlog.get_logger()
 
 def _event(event: str, data: Any) -> dict[str, str]:
     return {"event": event, "data": json.dumps(data)}
+
+
+def _track_usage(
+    deps: AssistantDeps, usage: Any, model_provider: str, model_name: str
+) -> None:
+    """Polar-for-Polar dogfooding: ingest this run's inference cost as a span
+    on the Polar organization, mirroring organization reviews. Best-effort —
+    tracking must never break the conversation."""
+    try:
+        info = UsageInfo.from_agent_usage(usage, model_provider, model_name)
+        polar_self.enqueue_track_compass_assistant_usage(
+            external_customer_id=str(deps.organization_id),
+            vendor=model_provider,
+            model=model_name,
+            input_tokens=info.input_tokens,
+            output_tokens=info.output_tokens,
+            cost_usd=info.estimated_cost_usd,
+        )
+    except Exception:
+        log.exception(
+            "compass.assistant_usage_tracking_error",
+            organization_id=str(deps.organization_id),
+        )
 
 
 def _scopes_digest(deps: AssistantDeps) -> str:
@@ -140,6 +165,9 @@ async def stream_assistant_run(
     deps: AssistantDeps,
     prompt: str,
     message_history_json: str | None,
+    *,
+    model_provider: str,
+    model_name: str,
 ) -> AsyncGenerator[dict[str, str]]:
     history = None
     if message_history_json:
@@ -210,6 +238,7 @@ async def stream_assistant_run(
 
             result = run.result
             assert result is not None
+            _track_usage(deps, result.usage, model_provider, model_name)
             yield _event(
                 "done",
                 {

--- a/server/polar/compass/assistant/tools.py
+++ b/server/polar/compass/assistant/tools.py
@@ -70,7 +70,9 @@ async def get_metrics(
     response = await metrics_service.get_metrics(
         deps.session,
         deps.auth_subject,
-        start_date=today - timedelta(days=days),
+        # The metrics range is inclusive of both endpoints, so a trailing
+        # window of N days starts N-1 days before today.
+        start_date=today - timedelta(days=days - 1),
         end_date=today,
         timezone=deps.timezone,
         interval=TimeInterval.day,

--- a/server/polar/compass/assistant/tools.py
+++ b/server/polar/compass/assistant/tools.py
@@ -1,0 +1,191 @@
+"""
+Assistant tools: thin, scope-guarded wrappers over Polar's internal services.
+
+Every tool follows the same contract:
+- The organization comes from `AssistantDeps`, never from model arguments.
+- The caller's scopes are checked before any data access — tools a caller
+  lacks the scope for are not registered at all (see `agent.py`); the runtime
+  check here is belt-and-suspenders.
+- Data flows back to the model as a compact textual summary to narrate, and to
+  the client as typed blocks via `deps.emit(...)` for the block registry.
+"""
+
+from datetime import timedelta
+from typing import Literal
+
+from pydantic_ai import RunContext
+
+from polar.auth.scope import Scope
+from polar.kit.time_queries import TimeInterval
+from polar.metrics.metrics import METRICS
+from polar.metrics.service import metrics as metrics_service
+
+from ..schemas import InsightCategory
+from ..service import compass as compass_service
+from .blocks import InsightCardsBlock, MetricChartBlock, MetricChartPoint
+from .deps import AssistantDeps
+
+_METRIC_BY_SLUG = {metric.slug: metric for metric in METRICS}
+
+_MAX_WINDOW_DAYS = 90
+_MIN_WINDOW_DAYS = 7
+_MAX_SLUGS = 5
+
+
+def _scope_denial(deps: AssistantDeps, scope: Scope) -> str | None:
+    if scope in deps.auth_subject.scopes:
+        return None
+    return (
+        f"Permission denied: this request's token lacks the `{scope.value}` "
+        "scope, so this data cannot be accessed. Tell the user which scope "
+        "is missing."
+    )
+
+
+async def get_metrics(
+    ctx: RunContext[AssistantDeps],
+    metric_slugs: list[str],
+    days: int = 30,
+) -> str:
+    """Fetch daily values for up to five metrics over a trailing window.
+
+    Args:
+        metric_slugs: Metric slugs to fetch, e.g. `monthly_recurring_revenue`,
+            `active_subscriptions`, `churned_subscriptions`, `revenue`,
+            `checkouts_conversion`, `gross_margin_percentage`, `cost_per_user`.
+        days: Trailing window length in days (7 to 90, default 30).
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.metrics_read):
+        return denial
+
+    unknown = [slug for slug in metric_slugs if slug not in _METRIC_BY_SLUG]
+    if unknown:
+        known = ", ".join(sorted(_METRIC_BY_SLUG))
+        return f"Unknown metric slugs {unknown}. Available slugs: {known}"
+    slugs = metric_slugs[:_MAX_SLUGS]
+    days = max(_MIN_WINDOW_DAYS, min(_MAX_WINDOW_DAYS, days))
+
+    today = deps.today
+    response = await metrics_service.get_metrics(
+        deps.session,
+        deps.auth_subject,
+        start_date=today - timedelta(days=days),
+        end_date=today,
+        timezone=deps.timezone,
+        interval=TimeInterval.day,
+        organization_id=[deps.organization_id],
+        metrics=slugs,
+        redis=deps.redis,
+    )
+
+    summaries: list[str] = []
+    for slug in slugs:
+        metric = _METRIC_BY_SLUG[slug]
+        points = [
+            MetricChartPoint(
+                timestamp=period.timestamp,
+                value=getattr(period, slug, None) or 0,
+            )
+            for period in response.periods
+        ]
+        marker = deps.emit(
+            MetricChartBlock(
+                metric=slug,
+                label=metric.display_name,
+                unit=metric.type.value,
+                points=points,
+            )
+        )
+        first = points[0].value if points else 0
+        last = points[-1].value if points else 0
+        summaries.append(
+            f"{slug} ({metric.type.value}): start={first} latest={last} "
+            f"over the last {days} days. Chart prepared; place it with "
+            f"[block:{marker}]."
+        )
+    return "\n".join(summaries)
+
+
+async def get_insights(
+    ctx: RunContext[AssistantDeps],
+    category: Literal["revenue", "retention", "growth", "risk", "cost", "product"]
+    | None = None,
+) -> str:
+    """Fetch Compass insights for your own reasoning: computed, narrated
+    findings about the business, each with a severity and an id. Renders
+    NOTHING to the user — form your assessment from the findings, then call
+    `show_insights` with the one or two ids that support it.
+
+    Args:
+        category: Only insights in this area — `revenue`, `retention` (churn),
+            `growth`, `risk`, `cost` (margins, cost to serve) or `product`
+            (conversion). Omit for a whole-business view.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.metrics_read):
+        return denial
+
+    insights = await compass_service.list_insights(
+        deps.session,
+        deps.auth_subject,
+        timezone=deps.timezone,
+        organization_id=[deps.organization_id],
+        category=[InsightCategory(category)] if category else None,
+        redis=deps.redis,
+    )
+    if not insights:
+        area = f" in the {category} category" if category else ""
+        return f"No insights are currently firing{area} for this organization."
+
+    lines = [
+        f"[{insight.severity.value}] id={insight.id} {insight.title}: "
+        f"{insight.body}" + (f" (Method: {insight.why})" if insight.why else "")
+        for insight in insights
+    ]
+    return (
+        "Findings (nothing rendered yet; use show_insights to display the "
+        "relevant ones, usually one or two):\n" + "\n".join(lines)
+    )
+
+
+async def show_insights(
+    ctx: RunContext[AssistantDeps],
+    insight_ids: list[str],
+) -> str:
+    """Render insight cards to the user, by id (from `get_insights`).
+
+    Default to the one or two cards that directly support your assessment;
+    render more only when the user explicitly asked to see all insights.
+
+    Args:
+        insight_ids: Ids of the insights to display, most important first.
+    """
+    deps = ctx.deps
+    if denial := _scope_denial(deps, Scope.metrics_read):
+        return denial
+
+    wanted = insight_ids
+    insights = await compass_service.list_insights(
+        deps.session,
+        deps.auth_subject,
+        timezone=deps.timezone,
+        organization_id=[deps.organization_id],
+        redis=deps.redis,
+    )
+    selected = [insight for insight in insights if insight.id in wanted]
+    if not selected:
+        return "None of those insight ids are currently firing."
+
+    marker = deps.emit(InsightCardsBlock(insights=selected))
+    return (
+        f"Prepared {len(selected)} insight card(s); place them with "
+        f"[block:{marker}]. Cards: " + ", ".join(insight.title for insight in selected)
+    )
+
+
+TOOLS_WITH_SCOPES: list[tuple[object, Scope]] = [
+    (get_metrics, Scope.metrics_read),
+    (get_insights, Scope.metrics_read),
+    (show_insights, Scope.metrics_read),
+]

--- a/server/polar/compass/endpoints.py
+++ b/server/polar/compass/endpoints.py
@@ -1,16 +1,26 @@
+from datetime import datetime
 from zoneinfo import ZoneInfo
 
-from fastapi import Depends, Query
+from fastapi import Depends, Query, Request
 from pydantic_extra_types.timezone_name import TimeZoneName
+from sse_starlette.sse import EventSourceResponse
 
+from polar.auth.permission import OrganizationPermission
+from polar.authz.service import get_accessible_org_ids
+from polar.exceptions import ResourceNotFound
 from polar.kit.schemas import MultipleQueryFilter
 from polar.openapi import APITag
+from polar.organization.repository import OrganizationRepository
 from polar.organization.schemas import OrganizationID
 from polar.postgres import AsyncReadSession, get_db_read_session
 from polar.redis import Redis, get_redis
 from polar.routing import APIRouter
 
 from . import auth
+from .assistant.agent import build_assistant_agent
+from .assistant.deps import AssistantDeps
+from .assistant.schemas import AssistantChatRequest
+from .assistant.stream import stream_assistant_run
 from .schemas import Insight, InsightCategory
 from .service import compass as compass_service
 
@@ -47,3 +57,60 @@ async def list_insights(
         category=category,
         redis=redis,
     )
+
+
+@router.post(
+    "/assistant",
+    summary="Ask the Compass Assistant",
+    include_in_schema=False,
+)
+async def assistant_chat(
+    request: Request,
+    body: AssistantChatRequest,
+    auth_subject: auth.CompassRead,
+    timezone: TimeZoneName = Query(
+        default="UTC",
+        description="Timezone used to resolve metric windows. Default is UTC.",
+    ),
+    session: AsyncReadSession = Depends(get_db_read_session),
+    redis: Redis | None = Depends(get_redis),
+) -> EventSourceResponse:
+    """Stream one assistant turn as SSE: `text` deltas, renderable `block`
+    events, then `done` with opaque conversation state for the next turn.
+
+    The agent runs under the caller's auth subject: its toolset is derived
+    from the token's granted scopes, so a restricted token can only reach the
+    data those scopes allow.
+    """
+    org_ids = await get_accessible_org_ids(
+        session, auth_subject, permission=OrganizationPermission.analytics_read
+    )
+    if body.organization_id not in org_ids:
+        raise ResourceNotFound()
+    organization_repository = OrganizationRepository.from_session(session)
+    organization = await organization_repository.get_by_id(body.organization_id)
+    if organization is None or not organization.is_compass_enabled:
+        raise ResourceNotFound()
+
+    tz = ZoneInfo(timezone)
+    agent = build_assistant_agent(auth_subject.scopes)
+    # The request-scoped session closes when this handler returns, before the
+    # response streams — the generator opens its own session for tool calls.
+    read_sessionmaker = request.state.async_read_sessionmaker
+
+    async def event_stream():  # type: ignore[no-untyped-def]
+        async with read_sessionmaker() as stream_session:
+            deps = AssistantDeps(
+                session=stream_session,
+                auth_subject=auth_subject,
+                organization_id=body.organization_id,
+                timezone=tz,
+                today=datetime.now(tz=tz).date(),
+                redis=redis,
+            )
+            async for event in stream_assistant_run(
+                agent, deps, body.prompt, body.message_history
+            ):
+                yield event
+
+    return EventSourceResponse(event_stream())

--- a/server/polar/compass/endpoints.py
+++ b/server/polar/compass/endpoints.py
@@ -93,7 +93,7 @@ async def assistant_chat(
         raise ResourceNotFound()
 
     tz = ZoneInfo(timezone)
-    agent = build_assistant_agent(auth_subject.scopes)
+    agent, model_provider, model_name = build_assistant_agent(auth_subject.scopes)
     # The request-scoped session closes when this handler returns, before the
     # response streams — the generator opens its own session for tool calls.
     read_sessionmaker = request.state.async_read_sessionmaker
@@ -109,7 +109,12 @@ async def assistant_chat(
                 redis=redis,
             )
             async for event in stream_assistant_run(
-                agent, deps, body.prompt, body.message_history
+                agent,
+                deps,
+                body.prompt,
+                body.message_history,
+                model_provider=model_provider,
+                model_name=model_name,
             ):
                 yield event
 

--- a/server/polar/integrations/polar/client.py
+++ b/server/polar/integrations/polar/client.py
@@ -679,12 +679,19 @@ class PolarSelfClient:
         input_tokens: int,
         output_tokens: int,
         cost_usd: Decimal,
+        usage_id: str | None = None,
     ) -> None:
         """Ingest one LLM usage reading as a cost span: a per-customer root
-        event plus a child carrying `_llm` and `_cost` (cents) metadata."""
+        event plus a child carrying `_llm` and `_cost` (cents) metadata.
+
+        `usage_id` makes the cost-carrying child idempotent: ingestion
+        deduplicates on `external_id`, so a task retry after a successful
+        ingest with a lost response doesn't double-count the cost.
+        """
         total_tokens = input_tokens + output_tokens
         cost_cents = (cost_usd * Decimal(100)).quantize(Decimal("0.000001"))
         root_external_id = f"{root_name}-{external_customer_id}"
+        child_external_id = f"{child_name}-{usage_id}" if usage_id else None
 
         with logfire.span(
             f"polar.{operation}",
@@ -707,6 +714,7 @@ class PolarSelfClient:
                             EventCreateExternalCustomer(
                                 name=child_name,
                                 external_customer_id=external_customer_id,
+                                external_id=child_external_id,
                                 parent_id=root_external_id,
                                 metadata={
                                     "_llm": LLMMetadata(
@@ -765,6 +773,7 @@ class PolarSelfClient:
         input_tokens: int,
         output_tokens: int,
         cost_usd: Decimal,
+        usage_id: str,
     ) -> None:
         await self._track_llm_span_usage(
             operation="track_compass_assistant_usage",
@@ -776,6 +785,7 @@ class PolarSelfClient:
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             cost_usd=cost_usd,
+            usage_id=usage_id,
         )
 
     # Customer-portal-scoped operations: create a per-call customer session

--- a/server/polar/integrations/polar/client.py
+++ b/server/polar/integrations/polar/client.py
@@ -667,25 +667,28 @@ class PolarSelfClient:
             except httpx.RequestError as e:
                 _raise_network_error(span, e, "track_event_ingestion")
 
-    async def track_organization_review_usage(
+    async def _track_llm_span_usage(
         self,
         *,
+        operation: str,
+        root_name: str,
+        child_name: str,
         external_customer_id: str,
-        review_context: str,
         vendor: str,
         model: str,
         input_tokens: int,
         output_tokens: int,
         cost_usd: Decimal,
     ) -> None:
+        """Ingest one LLM usage reading as a cost span: a per-customer root
+        event plus a child carrying `_llm` and `_cost` (cents) metadata."""
         total_tokens = input_tokens + output_tokens
         cost_cents = (cost_usd * Decimal(100)).quantize(Decimal("0.000001"))
-        root_external_id = f"organization_review-{external_customer_id}"
+        root_external_id = f"{root_name}-{external_customer_id}"
 
         with logfire.span(
-            "polar.track_organization_review_usage",
+            f"polar.{operation}",
             external_customer_id=external_customer_id,
-            review_context=review_context,
             vendor=vendor,
             model=model,
             input_tokens=input_tokens,
@@ -697,12 +700,12 @@ class PolarSelfClient:
                     request=EventsIngest(
                         events=[
                             EventCreateExternalCustomer(
-                                name="organization_review",
+                                name=root_name,
                                 external_customer_id=external_customer_id,
                                 external_id=root_external_id,
                             ),
                             EventCreateExternalCustomer(
-                                name=f"organization_review.{review_context}",
+                                name=child_name,
                                 external_customer_id=external_customer_id,
                                 parent_id=root_external_id,
                                 metadata={
@@ -726,9 +729,54 @@ class PolarSelfClient:
                 if e.status_code == 409:
                     span.set_attribute("conflict", True)
                     return
-                _raise_error(span, e, "track_organization_review_usage")
+                _raise_error(span, e, operation)
             except httpx.RequestError as e:
-                _raise_network_error(span, e, "track_organization_review_usage")
+                _raise_network_error(span, e, operation)
+
+    async def track_organization_review_usage(
+        self,
+        *,
+        external_customer_id: str,
+        review_context: str,
+        vendor: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: Decimal,
+    ) -> None:
+        await self._track_llm_span_usage(
+            operation="track_organization_review_usage",
+            root_name="organization_review",
+            child_name=f"organization_review.{review_context}",
+            external_customer_id=external_customer_id,
+            vendor=vendor,
+            model=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=cost_usd,
+        )
+
+    async def track_compass_assistant_usage(
+        self,
+        *,
+        external_customer_id: str,
+        vendor: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: Decimal,
+    ) -> None:
+        await self._track_llm_span_usage(
+            operation="track_compass_assistant_usage",
+            root_name="compass_assistant",
+            child_name="compass_assistant.chat",
+            external_customer_id=external_customer_id,
+            vendor=vendor,
+            model=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=cost_usd,
+        )
 
     # Customer-portal-scoped operations: create a per-call customer session
     # and act AS THE CUSTOMER. Used for fields the admin API doesn't expose.

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -233,6 +233,7 @@ class PolarSelfService:
         input_tokens: int,
         output_tokens: int,
         cost_usd: Decimal | float | None,
+        usage_id: str,
     ) -> None:
         if not self.is_configured:
             return
@@ -251,6 +252,7 @@ class PolarSelfService:
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             cost_usd=str(cost_decimal),
+            usage_id=usage_id,
         )
 
     async def list_plans(self) -> list["Product"]:

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -224,6 +224,35 @@ class PolarSelfService:
             cost_usd=str(cost_decimal),
         )
 
+    def enqueue_track_compass_assistant_usage(
+        self,
+        *,
+        external_customer_id: str,
+        vendor: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        cost_usd: Decimal | float | None,
+    ) -> None:
+        if not self.is_configured:
+            return
+        if external_customer_id == settings.POLAR_ORGANIZATION_ID:
+            return
+        if cost_usd is None:
+            return
+        cost_decimal = Decimal(str(cost_usd))
+        if cost_decimal <= 0:
+            return
+        enqueue_job(
+            "polar_self.track_compass_assistant_usage",
+            external_customer_id=external_customer_id,
+            vendor=vendor,
+            model=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cost_usd=str(cost_decimal),
+        )
+
     async def list_plans(self) -> list["Product"]:
         if not self.is_configured:
             raise PolarSelfNotConfigured()

--- a/server/polar/integrations/polar/tasks.py
+++ b/server/polar/integrations/polar/tasks.py
@@ -215,6 +215,7 @@ async def track_compass_assistant_usage(
     input_tokens: int,
     output_tokens: int,
     cost_usd: str,
+    usage_id: str,
 ) -> None:
     await get_client().track_compass_assistant_usage(
         external_customer_id=external_customer_id,
@@ -223,6 +224,7 @@ async def track_compass_assistant_usage(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         cost_usd=Decimal(cost_usd),
+        usage_id=usage_id,
     )
 
 

--- a/server/polar/integrations/polar/tasks.py
+++ b/server/polar/integrations/polar/tasks.py
@@ -204,6 +204,28 @@ async def track_organization_review_usage(
     )
 
 
+@actor(
+    actor_name="polar_self.track_compass_assistant_usage",
+    priority=TaskPriority.LOW,
+)
+async def track_compass_assistant_usage(
+    external_customer_id: str,
+    vendor: str,
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cost_usd: str,
+) -> None:
+    await get_client().track_compass_assistant_usage(
+        external_customer_id=external_customer_id,
+        vendor=vendor,
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cost_usd=Decimal(cost_usd),
+    )
+
+
 @actor(actor_name="polar_self.webhook.benefit_grant.created", priority=TaskPriority.LOW)
 async def webhook_benefit_grant_created(event_id: uuid.UUID) -> None:
     async with AsyncSessionMaker() as session:

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -1,8 +1,9 @@
 from collections.abc import Sequence
+from datetime import datetime
 from typing import TYPE_CHECKING, cast
 from uuid import UUID
 
-from sqlalchemy import CursorResult, Select, case, select, update
+from sqlalchemy import CursorResult, Select, case, func, select, update
 from sqlalchemy.orm import joinedload, selectinload
 
 from polar.auth.models import (
@@ -52,6 +53,46 @@ class OrderRepository(
     RepositoryBase[Order],
 ):
     model = Order
+
+    async def get_revenue_by_customer(
+        self,
+        organization_id: UUID,
+        *,
+        start: datetime | None = None,
+        limit: int = 10,
+    ) -> Sequence[tuple[UUID, str | None, str | None, int, int]]:
+        """Customers ranked by paid net revenue: (customer_id, email, name,
+        order count, net revenue in cents), descending.
+
+        A repository aggregation (not the metrics layer) on purpose: ranking
+        across all customers cannot be expressed as bounded per-entity metric
+        queries the way products can.
+        """
+        net_revenue = func.coalesce(func.sum(Order.net_amount), 0)
+        statement = (
+            select(
+                Customer.id,
+                Customer.email,
+                Customer.name,
+                func.count(Order.id),
+                net_revenue,
+            )
+            .join(Customer, Customer.id == Order.customer_id)
+            .where(
+                Order.organization_id == organization_id,
+                Order.status.in_(OrderStatus.paid_statuses()),
+                Order.is_deleted.is_(False),
+            )
+            .group_by(Customer.id, Customer.email, Customer.name)
+            .order_by(net_revenue.desc())
+            .limit(limit)
+        )
+        if start is not None:
+            statement = statement.where(Order.created_at >= start)
+        result = await self.session.execute(statement)
+        return [
+            (row[0], row[1], row[2], int(row[3]), int(row[4])) for row in result.all()
+        ]
 
     async def get_all_by_customer(
         self,

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -121,6 +121,9 @@ class OrderRepository(
                 Order.organization_id == organization_id,
                 Order.status.in_(OrderStatus.paid_statuses()),
                 Order.is_deleted.is_(False),
+                # product_id is nullable; a NULL revenue group would waste a
+                # candidate slot and poison the returned id list.
+                Order.product_id.is_not(None),
             )
             .group_by(Order.product_id)
             .order_by(net_revenue.desc())

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -64,11 +64,16 @@ class OrderRepository(
         """Customers ranked by paid net revenue: (customer_id, email, name,
         order count, net revenue in cents), descending.
 
+        Partially refunded orders count with the refunded portion subtracted,
+        so the ranking reflects money actually kept.
+
         A repository aggregation (not the metrics layer) on purpose: ranking
         across all customers cannot be expressed as bounded per-entity metric
         queries the way products can.
         """
-        net_revenue = func.coalesce(func.sum(Order.net_amount), 0)
+        net_revenue = func.coalesce(
+            func.sum(Order.net_amount - Order.refunded_amount), 0
+        )
         statement = (
             select(
                 Customer.id,
@@ -93,6 +98,38 @@ class OrderRepository(
         return [
             (row[0], row[1], row[2], int(row[3]), int(row[4])) for row in result.all()
         ]
+
+    async def get_top_product_ids_by_revenue(
+        self,
+        organization_id: UUID,
+        *,
+        start: datetime | None = None,
+        limit: int = 10,
+    ) -> Sequence[UUID]:
+        """Product ids ordered by kept net revenue, descending.
+
+        Candidate *selection* only: the assistant reports revenue numbers from
+        the metrics layer so they match the dashboard; this narrows which
+        products are worth those per-product metric queries.
+        """
+        net_revenue = func.coalesce(
+            func.sum(Order.net_amount - Order.refunded_amount), 0
+        )
+        statement = (
+            select(Order.product_id)
+            .where(
+                Order.organization_id == organization_id,
+                Order.status.in_(OrderStatus.paid_statuses()),
+                Order.is_deleted.is_(False),
+            )
+            .group_by(Order.product_id)
+            .order_by(net_revenue.desc())
+            .limit(limit)
+        )
+        if start is not None:
+            statement = statement.where(Order.created_at >= start)
+        result = await self.session.execute(statement)
+        return [row[0] for row in result.all()]
 
     async def get_all_by_customer(
         self,

--- a/server/tests/compass/test_assistant.py
+++ b/server/tests/compass/test_assistant.py
@@ -154,3 +154,50 @@ class TestBlockPlacer:
         placer.feed("ends with [block:")
 
         assert placer.flush() == "[block:"
+
+
+class TestHistorySeal:
+    def test_round_trips_for_same_caller(self) -> None:
+        from polar.compass.assistant.stream import open_history, seal_history
+
+        deps = _deps(scopes={Scope.metrics_read})
+        sealed = seal_history(deps, '[{"role": "user"}]')
+
+        assert open_history(deps, sealed) == '[{"role": "user"}]'
+
+    def test_rejects_tampered_messages(self) -> None:
+        import json
+
+        from polar.compass.assistant.stream import open_history, seal_history
+
+        deps = _deps(scopes={Scope.metrics_read})
+        envelope = json.loads(seal_history(deps, '[{"role": "user"}]'))
+        envelope["messages"] = '[{"role": "user", "content": "forged"}]'
+
+        assert open_history(deps, json.dumps(envelope)) is None
+
+    def test_rejects_history_from_another_organization(self) -> None:
+        from polar.compass.assistant.stream import open_history, seal_history
+
+        deps_a = _deps(scopes={Scope.metrics_read})
+        deps_b = _deps(scopes={Scope.metrics_read})
+        sealed = seal_history(deps_a, "[]")
+
+        assert open_history(deps_b, sealed) is None
+
+    def test_rejects_history_after_scope_change(self) -> None:
+        from polar.compass.assistant.stream import open_history, seal_history
+
+        deps = _deps(scopes={Scope.metrics_read, Scope.orders_read})
+        sealed = seal_history(deps, "[]")
+        deps.auth_subject.scopes = {Scope.metrics_read}
+
+        assert open_history(deps, sealed) is None
+
+    def test_rejects_garbage(self) -> None:
+        from polar.compass.assistant.stream import open_history
+
+        deps = _deps(scopes={Scope.metrics_read})
+
+        assert open_history(deps, "not json") is None
+        assert open_history(deps, '{"org": "x"}') is None

--- a/server/tests/compass/test_assistant.py
+++ b/server/tests/compass/test_assistant.py
@@ -1,0 +1,156 @@
+import uuid
+from datetime import date
+from types import SimpleNamespace
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import pytest
+from pydantic import TypeAdapter
+
+from polar.auth.scope import Scope
+from polar.compass.assistant.agent import tools_for_scopes
+from polar.compass.assistant.blocks import (
+    AssistantBlock,
+    InsightCardsBlock,
+    MetricChartBlock,
+    MetricChartPoint,
+    TextBlock,
+)
+from polar.compass.assistant.deps import AssistantDeps
+from polar.compass.assistant.tools import get_insights, get_metrics, show_insights
+
+
+def _deps(scopes: set[Scope]) -> AssistantDeps:
+    return AssistantDeps(
+        session=None,  # type: ignore[arg-type] — denial paths never touch it
+        auth_subject=SimpleNamespace(scopes=scopes),  # type: ignore[arg-type]
+        organization_id=uuid.uuid4(),
+        timezone=ZoneInfo("UTC"),
+        today=date(2026, 7, 6),
+    )
+
+
+def _ctx(deps: AssistantDeps) -> Any:
+    return SimpleNamespace(deps=deps)
+
+
+class TestToolsForScopes:
+    def test_metrics_read_grants_the_read_tools(self) -> None:
+        tools = tools_for_scopes({Scope.metrics_read})
+
+        assert get_metrics in tools
+        assert get_insights in tools
+        assert show_insights in tools
+
+    def test_unrelated_scopes_grant_nothing(self) -> None:
+        assert tools_for_scopes({Scope.webhooks_read}) == []
+
+    def test_no_scopes_grant_nothing(self) -> None:
+        assert tools_for_scopes(set()) == []
+
+
+@pytest.mark.asyncio
+class TestToolScopeGuards:
+    async def test_get_metrics_denies_without_scope(self) -> None:
+        deps = _deps(scopes=set())
+
+        result = await get_metrics(_ctx(deps), ["monthly_recurring_revenue"])
+
+        assert "Permission denied" in result
+        assert "metrics:read" in result
+        assert deps.blocks == []
+
+    async def test_get_insights_denies_without_scope(self) -> None:
+        deps = _deps(scopes=set())
+
+        result = await get_insights(_ctx(deps))
+
+        assert "Permission denied" in result
+        assert deps.blocks == []
+
+    async def test_show_insights_denies_without_scope(self) -> None:
+        deps = _deps(scopes=set())
+
+        result = await show_insights(_ctx(deps), ["x"])
+
+        assert "Permission denied" in result
+        assert deps.blocks == []
+
+    async def test_get_metrics_rejects_unknown_slugs_before_fetching(self) -> None:
+        deps = _deps(scopes={Scope.metrics_read})
+
+        result = await get_metrics(_ctx(deps), ["not_a_metric"])
+
+        assert "Unknown metric slugs" in result
+        assert deps.blocks == []
+
+
+class TestAssistantBlocks:
+    def test_union_round_trips_on_type(self) -> None:
+        adapter: TypeAdapter[AssistantBlock] = TypeAdapter(AssistantBlock)
+        chart = MetricChartBlock(
+            metric="monthly_recurring_revenue",
+            label="Monthly Recurring Revenue",
+            unit="currency",
+            points=[MetricChartPoint(timestamp="2026-07-01T00:00:00Z", value=1.0)],  # type: ignore[arg-type]
+        )
+
+        parsed = adapter.validate_python(chart.model_dump(mode="json"))
+
+        assert isinstance(parsed, MetricChartBlock)
+        assert parsed.type == "metric_chart"
+
+    def test_text_and_cards_discriminate(self) -> None:
+        adapter: TypeAdapter[AssistantBlock] = TypeAdapter(AssistantBlock)
+
+        text = adapter.validate_python({"type": "text", "text": "hi"})
+        cards = adapter.validate_python({"type": "insight_cards", "insights": []})
+
+        assert isinstance(text, TextBlock)
+        assert isinstance(cards, InsightCardsBlock)
+
+
+class TestBlockPlacer:
+    def test_splits_text_around_marker(self) -> None:
+        from polar.compass.assistant.stream import _BlockPlacer
+
+        placer = _BlockPlacer()
+
+        out = placer.feed("Best customer: jane. [block:1] Next up")
+
+        assert out == [
+            ("text", "Best customer: jane."),
+            ("block", 1),
+            ("text", "Next up"),
+        ]
+
+    def test_marker_split_across_deltas(self) -> None:
+        from polar.compass.assistant.stream import _BlockPlacer
+
+        placer = _BlockPlacer()
+
+        first = placer.feed("claim one [blo")
+        second = placer.feed("ck:2] tail")
+
+        assert first == [("text", "claim one ")]
+        assert second == [("block", 2), ("text", "tail")]
+
+    def test_plain_bracket_is_not_held_forever(self) -> None:
+        from polar.compass.assistant.stream import _BlockPlacer
+
+        placer = _BlockPlacer()
+
+        out = placer.feed("ranges [1, 2] are fine")
+
+        assert ("block", 1) not in out
+        assert (
+            "".join(str(v) for k, v in out if k == "text") == "ranges [1, 2] are fine"
+        )
+
+    def test_flush_returns_held_partial(self) -> None:
+        from polar.compass.assistant.stream import _BlockPlacer
+
+        placer = _BlockPlacer()
+        placer.feed("ends with [block:")
+
+        assert placer.flush() == "[block:"

--- a/server/tests/compass/test_assistant.py
+++ b/server/tests/compass/test_assistant.py
@@ -16,7 +16,21 @@ from polar.compass.assistant.blocks import (
     MetricChartPoint,
     TextBlock,
 )
+from polar.compass.assistant.customer_tools import get_customer_overview
 from polar.compass.assistant.deps import AssistantDeps
+from polar.compass.assistant.entity_tools import (
+    list_checkouts,
+    list_customers,
+    list_disputes,
+    list_orders,
+    list_payouts,
+    list_products,
+    list_refunds,
+    list_subscriptions,
+    top_customers_by_cost,
+    top_customers_by_revenue,
+    top_products_by_revenue,
+)
 from polar.compass.assistant.tools import get_insights, get_metrics, show_insights
 
 
@@ -41,9 +55,26 @@ class TestToolsForScopes:
         assert get_metrics in tools
         assert get_insights in tools
         assert show_insights in tools
+        assert top_products_by_revenue in tools
 
-    def test_unrelated_scopes_grant_nothing(self) -> None:
-        assert tools_for_scopes({Scope.webhooks_read}) == []
+    def test_scopes_grant_exactly_their_tools(self) -> None:
+        tools = tools_for_scopes({Scope.orders_read})
+
+        assert tools == [list_orders, top_customers_by_revenue]
+
+    def test_each_entity_scope_maps_to_its_tool(self) -> None:
+        cases: dict[Scope, list[object]] = {
+            Scope.subscriptions_read: [list_subscriptions],
+            Scope.customers_read: [list_customers, get_customer_overview],
+            Scope.products_read: [list_products],
+            Scope.disputes_read: [list_disputes],
+            Scope.checkouts_read: [list_checkouts],
+            Scope.refunds_read: [list_refunds],
+            Scope.payouts_read: [list_payouts],
+            Scope.events_read: [top_customers_by_cost],
+        }
+        for scope, tools in cases.items():
+            assert tools_for_scopes({scope}) == tools
 
     def test_no_scopes_grant_nothing(self) -> None:
         assert tools_for_scopes(set()) == []
@@ -74,6 +105,20 @@ class TestToolScopeGuards:
         result = await show_insights(_ctx(deps), ["x"])
 
         assert "Permission denied" in result
+        assert deps.blocks == []
+
+    async def test_entity_tools_deny_without_their_scope(self) -> None:
+        deps = _deps(scopes={Scope.metrics_read})
+
+        for tool in (
+            list_orders,
+            list_subscriptions,
+            list_customers,
+            list_products,
+            list_disputes,
+        ):
+            result = await tool(_ctx(deps))
+            assert "Permission denied" in result
         assert deps.blocks == []
 
     async def test_get_metrics_rejects_unknown_slugs_before_fetching(self) -> None:

--- a/server/tests/compass/test_endpoints.py
+++ b/server/tests/compass/test_endpoints.py
@@ -1,0 +1,47 @@
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from polar.models import Organization, UserOrganization
+from tests.fixtures.database import SaveFixture
+
+
+@pytest.mark.asyncio
+class TestAssistantChat:
+    async def test_anonymous(
+        self, client: AsyncClient, organization: Organization
+    ) -> None:
+        response = await client.post(
+            "/v1/compass/assistant",
+            json={"organization_id": str(organization.id), "prompt": "hi"},
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_inaccessible_organization(self, client: AsyncClient) -> None:
+        response = await client.post(
+            "/v1/compass/assistant",
+            json={"organization_id": str(uuid.uuid4()), "prompt": "hi"},
+        )
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_compass_disabled_organization(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        organization.feature_settings = {}
+        await save_fixture(organization)
+
+        response = await client.post(
+            "/v1/compass/assistant",
+            json={"organization_id": str(organization.id), "prompt": "hi"},
+        )
+
+        assert response.status_code == 404

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -381,6 +381,7 @@ class TestEnqueueTrackCompassAssistantUsage:
             input_tokens=1200,
             output_tokens=300,
             cost_usd=cost_usd,
+            usage_id="run-1",
         )
 
     def test_noop_when_not_configured(self, mocker: MockerFixture) -> None:
@@ -425,7 +426,25 @@ class TestEnqueueTrackCompassAssistantUsage:
             input_tokens=1200,
             output_tokens=300,
             cost_usd="0.0042",
+            usage_id="run-1",
         )
+
+    def test_noop_when_cost_is_zero(
+        self, configured: None, mocker: MockerFixture
+    ) -> None:
+        enqueue = mocker.patch("polar.integrations.polar.service.enqueue_job")
+
+        self._call(cost_usd=Decimal(0))
+
+        enqueue.assert_not_called()
+
+    def test_accepts_float_cost(self, configured: None, mocker: MockerFixture) -> None:
+        enqueue = mocker.patch("polar.integrations.polar.service.enqueue_job")
+
+        self._call(cost_usd=0.5)
+
+        assert enqueue.call_count == 1
+        assert enqueue.call_args.kwargs["cost_usd"] == "0.5"
 
 
 @pytest.mark.asyncio

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -367,6 +367,67 @@ class TestEnqueueTrackOrganizationReviewUsage:
         assert enqueue.call_args.kwargs["cost_usd"] == "0.5"
 
 
+class TestEnqueueTrackCompassAssistantUsage:
+    def _call(
+        self,
+        *,
+        external_customer_id: str = str(ORG_A),
+        cost_usd: Decimal | float | None = Decimal("0.0042"),
+    ) -> None:
+        polar_self.enqueue_track_compass_assistant_usage(
+            external_customer_id=external_customer_id,
+            vendor="openai",
+            model="gpt-5.5",
+            input_tokens=1200,
+            output_tokens=300,
+            cost_usd=cost_usd,
+        )
+
+    def test_noop_when_not_configured(self, mocker: MockerFixture) -> None:
+        settings = mocker.patch("polar.integrations.polar.service.settings")
+        settings.POLAR_SELF_ENABLED = False
+        enqueue = mocker.patch("polar.integrations.polar.service.enqueue_job")
+
+        self._call()
+
+        enqueue.assert_not_called()
+
+    def test_noop_for_self_organization(
+        self, configured: None, mocker: MockerFixture
+    ) -> None:
+        enqueue = mocker.patch("polar.integrations.polar.service.enqueue_job")
+
+        self._call(external_customer_id=str(SELF_ORG_ID))
+
+        enqueue.assert_not_called()
+
+    def test_noop_when_cost_is_none(
+        self, configured: None, mocker: MockerFixture
+    ) -> None:
+        enqueue = mocker.patch("polar.integrations.polar.service.enqueue_job")
+
+        self._call(cost_usd=None)
+
+        enqueue.assert_not_called()
+
+    def test_enqueues_job_with_serialized_cost(
+        self, configured: None, mocker: MockerFixture
+    ) -> None:
+        enqueue = mocker.patch("polar.integrations.polar.service.enqueue_job")
+
+        self._call(cost_usd=Decimal("0.0042"))
+
+        enqueue.assert_called_once_with(
+            "polar_self.track_compass_assistant_usage",
+            external_customer_id=str(ORG_A),
+            vendor="openai",
+            model="gpt-5.5",
+            input_tokens=1200,
+            output_tokens=300,
+            cost_usd="0.0042",
+        )
+
+
 @pytest.mark.asyncio
 class TestResolveFreePlan:
     async def test_subscribed_org_gets_standard_free(


### PR DESCRIPTION
The Compass assistant: an agentic chat endpoint over the merchant's own
organization, built on Pydantic AI + the Pydantic AI Gateway (the
organization_review pattern).

- SSE endpoint POST /v1/compass/assistant streaming text deltas, renderable
  block events and opaque conversation state; gated per organization by the
  compass_enabled feature flag before any model call.
- Scope safety: the agent runs under the caller's auth subject. Its toolset
  is derived from the token's granted scopes, each tool re-checks its scope
  at runtime, and the organization always comes from validated deps, never
  model arguments. Tool exceptions degrade to a polite message, never a
  traceback.
- Generative UI: tools return typed blocks from a closed discriminated
  union that the client maps to predefined components. The model places
  blocks under the claims they support via [block:N] markers parsed out of
  the token stream.
- Core tools: metrics charts, and insights with a fetch/render split so a
  broad question yields an assessment plus one or two supporting cards, not
  a card dump.

Stacked on compass-assistant-backend-1-actions. The wider tool fleet and
inference cost tracking follow in the next PR.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

