### PR TITLE
fix(web): subscription detail page crashes after update/cancel/resume

### DIFF
--- a/clients/apps/web/src/components/Subscriptions/SubscriptionInvoicePreview.tsx
+++ b/clients/apps/web/src/components/Subscriptions/SubscriptionInvoicePreview.tsx
@@ -62,7 +62,7 @@ const SubscriptionInvoicePreview = ({
 
   const items: InvoiceLineItem[] = [
     { id: 'base', label: baseLabel, amount: chargePreview.base_amount },
-    ...chargePreview.prorations.map((proration, index) => ({
+    ...(chargePreview.prorations ?? []).map((proration, index) => ({
       id: `proration-${index}`,
       label: proration.label,
       amount: proration.amount,

--- a/clients/apps/web/src/hooks/queries/subscriptions.ts
+++ b/clients/apps/web/src/hooks/queries/subscriptions.ts
@@ -75,6 +75,7 @@ export const useUpdateSubscription = (id: string) =>
       queryClient.setQueriesData<schemas['Subscription']>(
         {
           queryKey: ['subscriptions', { id }],
+          exact: true,
         },
         data,
       )
@@ -130,6 +131,7 @@ export const useUncancelSubscription = (id: string) =>
       queryClient.setQueriesData<schemas['Subscription']>(
         {
           queryKey: ['subscriptions', { id }],
+          exact: true,
         },
         data,
       )
@@ -185,6 +187,7 @@ export const useClearPendingSubscriptionUpdate = (id: string) =>
       queryClient.setQueriesData<schemas['Subscription']>(
         {
           queryKey: ['subscriptions', { id }],
+          exact: true,
         },
         data,
       )

--- a/clients/apps/web/src/hooks/queries/subscriptions.ts
+++ b/clients/apps/web/src/hooks/queries/subscriptions.ts
@@ -217,5 +217,9 @@ export const useClearPendingSubscriptionUpdate = (id: string) =>
           }
         },
       )
+
+      queryClient.invalidateQueries({
+        queryKey: ['subscriptions', { id }, 'charge-preview'],
+      })
     },
   })


### PR DESCRIPTION
## Summary

Fixes a `Cannot read properties of undefined (reading 'map')` crash in
`SubscriptionInvoicePreview` (the subscription detail page white-screens) that
triggers after **any** subscription mutation — update, uncancel, or clearing a
pending update.

### 1. Cache write clobbers the charge-preview query

`useUpdateSubscription`, `useUncancelSubscription`, and `useClearPendingSubscriptionUpdate` write the fresh subscription into the cache with `setQueriesData({ queryKey: ['subscriptions', { id }] }, data)`. `setQueriesData` matches by **prefix**, so `['subscriptions', { id }]` also matches `['subscriptions', { id }, 'charge-preview']` — it overwrites the charge-preview cache with the `Subscription` object (which has no `prorations`). The follow-up `invalidateQueries` refetches the correct value a moment later, but the component re-renders on the corrupted cache first and crashes.

→ Fixed by adding `exact: true` so the write only touches the detail query.

### 2. Missing `prorations` guard (regressed in #12848)

`SubscriptionInvoicePreview` does `chargePreview.prorations.map(...)` unguarded. The component it replaced (`UpcomingChargeCard`, removed in #12848) had `const prorations = chargePreview?.prorations ?? []`. The rewrite dropped that defensiveness, turning the latent cache corruption above into a hard crash.

→ Restored the `?? []` guard.

Belt (don't corrupt the cache) + suspenders (tolerate a malformed preview, as the code did before #12848).

## Checklist

- [x] This PR addresses a single concern
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`pnpm --filter web typecheck`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

