### PR TITLE
rate-limit: use UTF-8 encode for the digest

### DIFF
--- a/server/polar/rate_limit.py
+++ b/server/polar/rate_limit.py
@@ -59,7 +59,7 @@ def _token_hash(token: str) -> str:
 
 
 def _identity_cache_key(token: str) -> str:
-    digest = hashlib.blake2b(token.encode("ascii"), digest_size=16).hexdigest()
+    digest = hashlib.blake2b(token.encode(), digest_size=16).hexdigest()
     return f"{_IDENTITY_KEY_PREFIX}{digest}"
 
 

--- a/server/tests/test_rate_limit.py
+++ b/server/tests/test_rate_limit.py
@@ -143,6 +143,20 @@ class TestAuthenticate:
             RateLimitGroup.pending_auth,
         )
 
+    async def test_non_ascii_token_uses_token_hash_pending_auth(
+        self, redis: Redis
+    ) -> None:
+        header = "Bearer polar_pat_abc…".encode()
+        token = header.decode("latin-1").removeprefix("Bearer ")
+        identity = await _authenticate(
+            _http_scope(headers=[(b"authorization", header)], client=("8.8.8.8", 1234)),
+            redis=redis,
+        )
+        assert identity == (
+            f"token:{_token_hash(token)}",
+            RateLimitGroup.pending_auth,
+        )
+
     async def test_no_token_uses_client_ip(self, redis: Redis) -> None:
         identity = await _authenticate(_http_scope(client=("1.1.1.1", 80)), redis=redis)
         assert identity == ("1.1.1.1", RateLimitGroup.default)


### PR DESCRIPTION
Solves [SERVER-4TZ](https://polar-sh.sentry.io/issues/7598102355/?alert_rule_id=16426328&alert_type=issue&notification_uuid=62532c62-7f6a-459b-832a-0237cc7bdbeb&project=4505046565519360&referrer=slack)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch rate-limit identity hashing to UTF-8 so non-ASCII tokens in Authorization headers don’t crash and are hashed consistently. Prevents UnicodeEncodeError and avoids unexpected fallbacks to IP-based limits.

- **Bug Fixes**
  - Use UTF-8 (`token.encode()`) when computing the `blake2b` digest in `_identity_cache_key`.
  - Add test to ensure a token containing “…” is hashed and classified as `pending_auth`.

<sup>Written for commit 401ac78dba0a9c44bc34dd24eefc90b320dc69cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

