### PR TITLE
Generate the sitemap dynamically

### DIFF
--- a/clients/apps/web/src/app/sitemap.ts
+++ b/clients/apps/web/src/app/sitemap.ts
@@ -1,5 +1,42 @@
+import { getAllContent, getLegalSlugs } from '@/utils/blog'
 import { CONFIG } from '@/utils/config'
+import fs from 'fs'
 import { MetadataRoute } from 'next'
+import path from 'path'
+
+const baseUrl = 'https://polar.sh'
+
+const LANDING_DIR = path.join(
+  process.cwd(),
+  'src/app/(main)/(website)/(landing)',
+)
+
+const EXTRA_ROUTES = ['/docs', '/brand']
+
+function collectLandingRoutes(): string[] {
+  const routes: string[] = []
+
+  const walk = (dir: string, segments: string[]) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isFile()) {
+        if (entry.name === 'page.tsx') {
+          routes.push('/' + segments.join('/'))
+        }
+        continue
+      }
+      if (!entry.isDirectory()) continue
+
+      const { name } = entry
+      if (name.startsWith('_') || name.startsWith('[')) continue
+
+      const isRouteGroup = name.startsWith('(') && name.endsWith(')')
+      walk(path.join(dir, name), isRouteGroup ? segments : [...segments, name])
+    }
+  }
+
+  walk(LANDING_DIR, [])
+  return routes
+}
 
 export default function sitemap(): MetadataRoute.Sitemap {
   // Don't generate sitemap for sandbox environment
@@ -7,128 +44,29 @@ export default function sitemap(): MetadataRoute.Sitemap {
     return []
   }
 
-  const baseUrl = 'https://polar.sh'
+  const pageRoutes = [
+    ...new Set([...collectLandingRoutes(), ...EXTRA_ROUTES]),
+  ].sort()
 
-  return [
-    {
-      url: baseUrl,
-      lastModified: new Date(),
-      changeFrequency: 'daily',
-      priority: 1,
-    },
-    {
-      url: `${baseUrl}/company`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/blog`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/features/usage-billing`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/features/subscriptions`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/features/seats`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/features/credits`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/features/trials`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/features/discounts`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/features/cost-insights`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/features/finance`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/features/merchant-of-record`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/resources/why`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/resources/pricing`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/resources/merchant-of-record`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/docs`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/careers`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.7,
-    },
-    {
-      url: `${baseUrl}/resources/comparison/stripe`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/resources/comparison/paddle`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/resources/comparison/lemon-squeezy`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
-      priority: 0.8,
-    },
-  ]
+  const pageEntries: MetadataRoute.Sitemap = pageRoutes.map((route) => ({
+    url: `${baseUrl}${route === '/' ? '' : route}`,
+  }))
+
+  const contentEntries: MetadataRoute.Sitemap = getAllContent().map((post) => {
+    const lastModified = post.date ? new Date(post.date) : null
+    const hasValidDate = lastModified !== null && !isNaN(lastModified.getTime())
+
+    return {
+      url: `${baseUrl}${post.href}`,
+      ...(hasValidDate ? { lastModified } : {}),
+    }
+  })
+
+  const legalEntries: MetadataRoute.Sitemap = getLegalSlugs()
+    .sort()
+    .map((slug) => ({
+      url: `${baseUrl}/legal/${slug}`,
+    }))
+
+  return [...pageEntries, ...contentEntries, ...legalEntries]
 }

--- a/clients/apps/web/src/utils/blog.ts
+++ b/clients/apps/web/src/utils/blog.ts
@@ -51,6 +51,11 @@ const STORIES_DIR = path.join(
 
 const PUBLIC_POSTS_DIR = path.join(process.cwd(), 'public/posts')
 
+const LEGAL_DIR = path.join(
+  process.cwd(),
+  'src/app/(main)/(website)/(landing)/(mdx)/legal',
+)
+
 function readPostsFromDir(
   dir: string,
   type: 'blog' | 'story',
@@ -90,5 +95,15 @@ export function getAllContent(): ContentPost[] {
     if (!a.date) return 1
     if (!b.date) return -1
     return new Date(b.date).getTime() - new Date(a.date).getTime()
+  })
+}
+
+export function getLegalSlugs(): string[] {
+  return fs.readdirSync(LEGAL_DIR).filter((name) => {
+    const fullPath = path.join(LEGAL_DIR, name)
+    return (
+      fs.statSync(fullPath).isDirectory() &&
+      fs.existsSync(path.join(fullPath, 'page.mdx'))
+    )
   })
 }


### PR DESCRIPTION
Instead of manually defining each new route to our sitemap, this PR will dynamically create it, fetching from `src/app/(main)/(website)/(landing)` as well as `/docs` and `/brand`

```xml
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
<url>
<loc>https://polar.sh/legal</loc>
</url>
<url>
<loc>https://polar.sh/blog</loc>
</url>
<url>
<loc>https://polar.sh/company</loc>
</url>
<url>
<loc>https://polar.sh/downloads</loc>
</url>
<url>
<loc>https://polar.sh/features/cost-insights</loc>
</url>
<url>
<loc>https://polar.sh/features/credits</loc>
</url>
<url>
<loc>https://polar.sh/features/discounts</loc>
</url>
<url>
<loc>https://polar.sh/features/finance</loc>
</url>
<url>
<loc>https://polar.sh/features/merchant-of-record</loc>
</url>
<url>
<loc>https://polar.sh/features/seats</loc>
</url>
<url>
<loc>https://polar.sh/features/subscriptions</loc>
</url>
<url>
<loc>https://polar.sh/features/trials</loc>
</url>
<url>
<loc>https://polar.sh/features/usage-billing</loc>
</url>
<url>
<loc>https://polar.sh</loc>
</url>
<url>
<loc>https://polar.sh/resources/comparison/lemon-squeezy</loc>
</url>
<url>
<loc>https://polar.sh/resources/comparison/paddle</loc>
</url>
<url>
<loc>https://polar.sh/resources/comparison/stripe</loc>
</url>
<url>
<loc>https://polar.sh/resources/merchant-of-record</loc>
</url>
<url>
<loc>https://polar.sh/resources</loc>
</url>
<url>
<loc>https://polar.sh/resources/pricing</loc>
</url>
<url>
<loc>https://polar.sh/resources/why</loc>
</url>
<url>
<loc>https://polar.sh/startup-program</loc>
</url>
<url>
<loc>https://polar.sh/docs</loc>
</url>
<url>
<loc>https://polar.sh/brand</loc>
</url>
<url>
<loc>https://polar.sh/blog/orbit-llm-safe-design-system</loc>
<lastmod>2026-06-16T12:00:00.000Z</lastmod>
</url>
<url>
<loc>https://polar.sh/blog/introducing-polar-plans</loc>
<lastmod>2026-05-20T12:00:00.000Z</lastmod>
</url>
<url>
<loc>https://polar.sh/blog/prompt-a-startup-2026</loc>
<lastmod>2026-03-13T00:00:00.000Z</lastmod>
</url>
<url>
<loc>https://polar.sh/customers/stilla-ai</loc>
<lastmod>2025-11-01T00:00:00.000Z</lastmod>
</url>
<url>
<loc>https://polar.sh/blog/polar-seed-announcement</loc>
<lastmod>2025-06-17T00:00:00.000Z</lastmod>
</url>
<url>
<loc>https://polar.sh/blog/mitchell-hashimoto-joins-polar-as-an-advisor</loc>
<lastmod>2024-04-02T13:45:56.717Z</lastmod>
</url>
<url>
<loc>https://polar.sh/legal/acceptable-use-policy</loc>
</url>
<url>
<loc>https://polar.sh/legal/checkout-buyer-terms</loc>
</url>
<url>
<loc>https://polar.sh/legal/data-processing-addendum</loc>
</url>
<url>
<loc>https://polar.sh/legal/master-services-terms</loc>
</url>
<url>
<loc>https://polar.sh/legal/payment-processor-partners</loc>
</url>
<url>
<loc>https://polar.sh/legal/privacy-policy</loc>
</url>
<url>
<loc>https://polar.sh/legal/sub-processors</loc>
</url>
</urlset>
```

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

