### PR TITLE
tf/aws: Roll out VPC + lambda in production and test

### DIFF
--- a/terraform/production/aws.tf
+++ b/terraform/production/aws.tf
@@ -10,3 +10,135 @@ module "secrets_kms" {
   render_environment_id    = render_project.polar.environments["Production"].id
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
 }
+
+module "lambda_worker_ecr" {
+  source = "../modules/ecr_repository"
+
+  name = "polar-production-lambda-worker"
+}
+
+module "redis" {
+  source = "../modules/aws_redis"
+
+  name       = "polar-production-worker"
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnet_ids
+}
+
+resource "aws_vpc_security_group_ingress_rule" "redis_lambda" {
+  security_group_id            = module.redis.security_group_id
+  referenced_security_group_id = aws_security_group.lambda.id
+  from_port                    = module.redis.port
+  to_port                      = module.redis.port
+  ip_protocol                  = "tcp"
+}
+
+locals {
+  lambda_worker_environment = {
+    POLAR_ENV                     = "production"
+    POLAR_BASE_URL                = "https://api.polar.sh"
+    POLAR_FRONTEND_BASE_URL       = "https://polar.sh"
+    POLAR_CHECKOUT_BASE_URL       = "https://buy.polar.sh/{client_secret}"
+    POLAR_JWKS                    = "/tmp/jwks.json"
+    POLAR_LOG_LEVEL               = "INFO"
+    POLAR_TESTING                 = "0"
+    POLAR_POSTGRES_DATABASE       = "polar_cpit_p9lf"
+    POLAR_POSTGRES_HOST           = local.db_external_host
+    POLAR_POSTGRES_PORT           = local.db_port
+    POLAR_POSTGRES_USER           = local.db_user
+    POLAR_POSTGRES_SSL            = "true"
+    POLAR_REDIS_HOST              = module.redis.host
+    POLAR_REDIS_PORT              = tostring(module.redis.port)
+    POLAR_REDIS_DB                = "1"
+    POLAR_AWS_REGION              = "us-east-2"
+    POLAR_EMAIL_SENDER            = "resend"
+    POLAR_EMAIL_FROM_NAME         = "Polar"
+    POLAR_EMAIL_FROM_DOMAIN       = "notifications.polar.sh"
+    POLAR_WORKER_SQS_ENABLED      = "true"
+    POLAR_WORKER_SQS_QUEUE_PREFIX = "polar-production-tasks"
+  }
+
+  lambda_worker_secrets = {
+    POLAR_CURRENT_JWK_KID = var.backend_current_jwk_kid_production
+    POLAR_JWKS_CONTENT    = var.backend_jwks_production
+    POLAR_LOGFIRE_TOKEN   = var.logfire_token
+    POLAR_POSTGRES_PWD    = local.db_password
+    POLAR_RESEND_API_KEY  = var.backend_resend_api_key_production
+    POLAR_SECRET          = var.backend_secret_production
+    POLAR_SENTRY_DSN      = var.backend_sentry_dsn_production
+    TAILSCALE_AUTHKEY     = var.lambda_worker_tailscale_token
+  }
+
+  lambda_worker_name                 = "default"
+  lambda_worker_reserved_concurrency = null
+}
+
+module "lambda_worker" {
+  source = "../modules/aws_task_worker"
+
+  environment              = "production"
+  name                     = local.lambda_worker_name
+  queue_name               = "polar-production-tasks-${local.lambda_worker_name}"
+  image_uri                = "${module.lambda_worker_ecr.repository_url}:latest"
+  enabled                  = true
+  reserved_concurrency     = local.lambda_worker_reserved_concurrency
+  subnet_ids               = local.lambda_subnet_ids
+  security_group_ids       = local.lambda_security_group_ids
+  permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
+
+  environment_variables        = local.lambda_worker_environment
+  secret_environment_variables = local.lambda_worker_secrets
+}
+
+# =============================================================================
+# GitHub Actions OIDC role (builds the task-worker image and deploys it)
+# =============================================================================
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "lambda_worker_deploy" {
+  statement {
+    sid       = "EcrAuthorization"
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "EcrPush"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:CompleteLayerUpload",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:InitiateLayerUpload",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart",
+    ]
+    resources = [module.lambda_worker_ecr.repository_arn]
+  }
+
+  statement {
+    sid       = "UpdateFunctionCode"
+    actions   = ["lambda:UpdateFunctionCode"]
+    resources = ["arn:aws:lambda:us-east-2:${data.aws_caller_identity.current.account_id}:function:${module.lambda_worker.function_name}"]
+  }
+}
+
+resource "aws_iam_policy" "lambda_worker_deploy" {
+  name   = "github-actions-lambda-worker-deploy-production"
+  policy = data.aws_iam_policy_document.lambda_worker_deploy.json
+}
+
+module "github_oidc_lambda_worker" {
+  source = "../modules/github_oidc"
+
+  role_name       = "github-actions-lambda-worker-production"
+  github_org      = "polarsource"
+  github_repo     = "polar"
+  github_subjects = ["ref:refs/heads/main"]
+  policy_arns = {
+    deploy = aws_iam_policy.lambda_worker_deploy.arn
+  }
+  permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
+}
+

--- a/terraform/production/network.tf
+++ b/terraform/production/network.tf
@@ -1,0 +1,35 @@
+# =============================================================================
+# Shared Lambda networking
+# =============================================================================
+
+module "egress_ip" {
+  source = "../modules/static_egress_ip"
+
+  name = "polar-production-egress"
+}
+
+module "vpc" {
+  source = "../modules/vpc"
+
+  name               = "polar-production"
+  availability_zones = ["us-east-2a", "us-east-2b", "us-east-2c"]
+  eip_allocation_id  = module.egress_ip.allocation_id
+}
+
+resource "aws_security_group" "lambda" {
+  name        = "polar-production-lambda"
+  description = "Shared egress security group for production Lambdas."
+  vpc_id      = module.vpc.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+locals {
+  lambda_subnet_ids         = module.vpc.private_subnet_ids
+  lambda_security_group_ids = [aws_security_group.lambda.id]
+}

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -23,6 +23,8 @@ locals {
   db_user     = render_postgres.db.database_user
   db_password = render_postgres.db.connection_info.password
 
+  db_external_host = nonsensitive(regex("@([^/:]+)", render_postgres.db.connection_info.external_connection_string)[0])
+
   # Read replica connection info
   read_replica = [for r in render_postgres.db.read_replicas : r if r.name == "polar-read"][0]
 

--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -404,11 +404,11 @@ variable "tailscale_advertise_routes" {
   type        = string
 }
 
-# variable "lambda_worker_tailscale_token" {
-#   description = "Tailscale auth token for production Lambda workers"
-#   type        = string
-#   sensitive   = true
-# }
+variable "lambda_worker_tailscale_token" {
+  description = "Tailscale auth token for production Lambda workers"
+  type        = string
+  sensitive   = true
+}
 
 variable "plain_default_tier_external_id" {
   description = "Default Plain tier external ID used as a fallback for the polar-self support benefit"

--- a/terraform/test/aws.tf
+++ b/terraform/test/aws.tf
@@ -18,3 +18,136 @@ module "secrets_kms" {
   render_environment_id    = local.environment_id
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
 }
+
+module "redis" {
+  count  = local.test_enabled ? 1 : 0
+  source = "../modules/aws_redis"
+
+  name       = "polar-test-worker"
+  vpc_id     = module.vpc[0].vpc_id
+  subnet_ids = module.vpc[0].private_subnet_ids
+}
+
+resource "aws_vpc_security_group_ingress_rule" "redis_lambda" {
+  count                        = local.test_enabled ? 1 : 0
+  security_group_id            = module.redis[0].security_group_id
+  referenced_security_group_id = aws_security_group.lambda[0].id
+  from_port                    = module.redis[0].port
+  to_port                      = module.redis[0].port
+  ip_protocol                  = "tcp"
+}
+
+locals {
+  lambda_worker_environment = local.test_enabled ? {
+    POLAR_ENV                     = "test"
+    POLAR_BASE_URL                = "https://test-api.polar.sh"
+    POLAR_FRONTEND_BASE_URL       = "https://test.polar.sh"
+    POLAR_CHECKOUT_BASE_URL       = "https://test-api.polar.sh/v1/checkout-links/{client_secret}/redirect"
+    POLAR_JWKS                    = "/tmp/jwks.json"
+    POLAR_LOG_LEVEL               = "INFO"
+    POLAR_TESTING                 = "0"
+    POLAR_POSTGRES_DATABASE       = local.db_name
+    POLAR_POSTGRES_HOST           = local.db_external_host
+    POLAR_POSTGRES_PORT           = local.db_port
+    POLAR_POSTGRES_USER           = local.db_user
+    POLAR_POSTGRES_SSL            = "true"
+    POLAR_REDIS_HOST              = module.redis[0].host
+    POLAR_REDIS_PORT              = tostring(module.redis[0].port)
+    POLAR_REDIS_DB                = "1"
+    POLAR_AWS_REGION              = "us-east-2"
+    POLAR_EMAIL_SENDER            = "resend"
+    POLAR_EMAIL_FROM_NAME         = "[TEST] Polar"
+    POLAR_EMAIL_FROM_DOMAIN       = "notifications.test.polar.sh"
+    POLAR_WORKER_SQS_ENABLED      = "true"
+    POLAR_WORKER_SQS_QUEUE_PREFIX = "polar-test-tasks"
+  } : {}
+
+  lambda_worker_secrets = local.test_enabled ? {
+    POLAR_CURRENT_JWK_KID = var.backend_current_jwk_kid
+    POLAR_JWKS_CONTENT    = var.backend_jwks
+    POLAR_LOGFIRE_TOKEN   = var.logfire_token
+    POLAR_POSTGRES_PWD    = local.db_password
+    POLAR_RESEND_API_KEY  = var.backend_resend_api_key
+    POLAR_SECRET          = var.backend_secret
+    POLAR_SENTRY_DSN      = var.backend_sentry_dsn
+    TAILSCALE_AUTHKEY     = var.lambda_worker_tailscale_token
+  } : {}
+
+  lambda_worker_name                 = "default"
+  lambda_worker_reserved_concurrency = null
+}
+
+module "lambda_worker" {
+  count  = local.test_enabled ? 1 : 0
+  source = "../modules/aws_task_worker"
+
+  environment              = "test"
+  name                     = local.lambda_worker_name
+  queue_name               = "polar-test-tasks-${local.lambda_worker_name}"
+  image_uri                = "${module.lambda_worker_ecr[0].repository_url}:latest"
+  enabled                  = true
+  reserved_concurrency     = local.lambda_worker_reserved_concurrency
+  subnet_ids               = local.lambda_subnet_ids
+  security_group_ids       = local.lambda_security_group_ids
+  permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
+
+  environment_variables        = local.lambda_worker_environment
+  secret_environment_variables = local.lambda_worker_secrets
+}
+
+# =============================================================================
+# GitHub Actions OIDC role (builds the task-worker image and deploys it)
+# =============================================================================
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "lambda_worker_deploy" {
+  count = local.test_enabled ? 1 : 0
+
+  statement {
+    sid       = "EcrAuthorization"
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "EcrPush"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:BatchGetImage",
+      "ecr:CompleteLayerUpload",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:InitiateLayerUpload",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart",
+    ]
+    resources = [module.lambda_worker_ecr[0].repository_arn]
+  }
+
+  statement {
+    sid       = "UpdateFunctionCode"
+    actions   = ["lambda:UpdateFunctionCode"]
+    resources = ["arn:aws:lambda:us-east-2:${data.aws_caller_identity.current.account_id}:function:${module.lambda_worker[0].function_name}"]
+  }
+}
+
+resource "aws_iam_policy" "lambda_worker_deploy" {
+  count  = local.test_enabled ? 1 : 0
+  name   = "github-actions-lambda-worker-deploy-test"
+  policy = data.aws_iam_policy_document.lambda_worker_deploy[0].json
+}
+
+module "github_oidc_lambda_worker" {
+  count  = local.test_enabled ? 1 : 0
+  source = "../modules/github_oidc"
+
+  role_name       = "github-actions-lambda-worker-test"
+  github_org      = "polarsource"
+  github_repo     = "polar"
+  github_subjects = ["ref:refs/heads/main"]
+  policy_arns = {
+    deploy = aws_iam_policy.lambda_worker_deploy[0].arn
+  }
+  permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
+}
+

--- a/terraform/test/network.tf
+++ b/terraform/test/network.tf
@@ -1,0 +1,38 @@
+# =============================================================================
+# Shared Lambda networking
+# =============================================================================
+
+module "egress_ip" {
+  count  = local.test_enabled ? 1 : 0
+  source = "../modules/static_egress_ip"
+
+  name = "polar-test-egress"
+}
+
+module "vpc" {
+  count  = local.test_enabled ? 1 : 0
+  source = "../modules/vpc"
+
+  name               = "polar-test"
+  availability_zones = ["us-east-2a", "us-east-2b", "us-east-2c"]
+  eip_allocation_id  = module.egress_ip[0].allocation_id
+}
+
+resource "aws_security_group" "lambda" {
+  count       = local.test_enabled ? 1 : 0
+  name        = "polar-test-lambda"
+  description = "Shared egress security group for test Lambdas."
+  vpc_id      = module.vpc[0].vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+locals {
+  lambda_subnet_ids         = local.test_enabled ? module.vpc[0].private_subnet_ids : []
+  lambda_security_group_ids = local.test_enabled ? [aws_security_group.lambda[0].id] : []
+}

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -91,6 +91,8 @@ locals {
   db_user          = render_postgres.db.database_user
   db_password      = render_postgres.db.connection_info.password
 
+  db_external_host = nonsensitive(regex("@([^/:]+)", render_postgres.db.connection_info.external_connection_string)[0])
+
   # Extract actual database name from internal connection string
   # Render appends a suffix to database_name, so we parse it from the connection string
   # Format: postgresql://user:pass@host/dbname

--- a/terraform/test/variables.tf
+++ b/terraform/test/variables.tf
@@ -100,11 +100,11 @@ variable "backend_jwks" {
   sensitive   = true
 }
 
-# variable "lambda_worker_tailscale_token" {
-#   description = "Tailscale auth token for test Lambda workers"
-#   type        = string
-#   sensitive   = true
-# }
+variable "lambda_worker_tailscale_token" {
+  description = "Tailscale auth token for test Lambda workers"
+  type        = string
+  sensitive   = true
+}
 
 # AWS S3
 variable "aws_access_key_id" {


### PR DESCRIPTION
This sets up the infra for lambda workers in prod and test, however it's not used yet.

This is a pre-req to being able to roll out the Guard Duty virus scanning

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

