### PR TITLE
feat(sso): require slug confirmation to enforce SSO

### DIFF
--- a/clients/apps/web/src/components/Settings/SSO/SSOSettings.tsx
+++ b/clients/apps/web/src/components/Settings/SSO/SSOSettings.tsx
@@ -122,9 +122,10 @@ const SSOSettings = ({ org }: { org: schemas['Organization'] }) => {
         hide={hideEnforceModal}
         onConfirm={() => applyEnforced(true)}
         title="Enforce SSO"
-        description="Members will have to sign in through SSO to access this organization. Third-party apps they authorized for this organization will be disconnected and must be re-authorized through SSO."
+        description="All members and authorized third-party apps will be disconnected and must be re-authorized through SSO."
         destructive
         destructiveText="Enforce"
+        confirmPrompt={org.slug}
       />
       <InlineModal
         isShown={isShown}


### PR DESCRIPTION
## What

Makes the **Enforce SSO** confirmation modal harder to trigger accidentally.

- **Copy:** reworded to "All members and authorized third-party apps will be
  disconnected and must be re-authorized through SSO." — makes the third-party
  OAuth disconnection explicit so there's no surprise about logged-out accounts.
- **Slug confirmation:** the admin now has to type the organization slug before
  the destructive **Enforce** button becomes clickable.

## Why

Enforcing SSO logs every member out and disconnects authorized third-party
apps, all of which must re-authorize through SSO. That's a high-blast-radius,
easy-to-fire-by-accident action, so we gate it behind the same type-the-slug
confirmation pattern we already use for deleting an organization and revoking
access tokens.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

