### PR TITLE
ci: Add image-resizer to dependabot scans

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,21 @@ updates:
         dependency-type: "development"
         patterns:
           - "*"
+  - package-ecosystem: "uv"
+    directory: "/lambda/image-resizer"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      image-resizer-production:
+        dependency-type: "production"
+        patterns:
+          - "*"
+      image-resizer-development:
+        dependency-type: "development"
+        patterns:
+          - "*"
   - package-ecosystem: "npm"
     directory: "/clients"
     schedule:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Dependabot coverage for the image-resizer Lambda (`/lambda/image-resizer`) using the `uv` ecosystem. Runs weekly with a 7-day cooldown and groups production and development updates separately.

<sup>Written for commit 6d131d5ed7fcdeb3ab5ab81043ca19d51f01353e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

