### PR TITLE
fix(workflows): pin tinybird cli version

### DIFF
--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -137,7 +137,7 @@ jobs:
         uses: astral-sh/setup-uv@v8.2.0
 
       - name: 🐦 Install Tinybird CLI
-        run: uv tool install "tinybird==4.6.7" && echo "$HOME/.local/bin" >> $GITHUB_PATH
+        run: uv tool install "tinybird==4.6.7" --python 3.11 && echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: 🐦 Validate Tinybird schema
         working-directory: ./server/tinybird
@@ -352,7 +352,7 @@ jobs:
           uv run task generate_dev_jwks
 
       - name: 🐦 Install Tinybird CLI
-        run: uv tool install "tinybird==4.6.7" && echo "$HOME/.local/bin" >> $GITHUB_PATH
+        run: uv tool install "tinybird==4.6.7" --python 3.11 && echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: ⚗️ alembic migrate
         working-directory: ./server

--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -133,8 +133,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.0
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.2.0
+
       - name: 🐦 Install Tinybird CLI
-        run: curl -sSL https://tinybird.co/install.sh | bash && echo "$HOME/.local/bin" >> $GITHUB_PATH
+        run: uv tool install "tinybird==4.6.7" && echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: 🐦 Validate Tinybird schema
         working-directory: ./server/tinybird
@@ -349,7 +352,7 @@ jobs:
           uv run task generate_dev_jwks
 
       - name: 🐦 Install Tinybird CLI
-        run: curl -sSL https://tinybird.co/install.sh | bash && echo "$HOME/.local/bin" >> $GITHUB_PATH
+        run: uv tool install "tinybird==4.6.7" && echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: ⚗️ alembic migrate
         working-directory: ./server


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- issue number -->

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->

## Why

<!-- Explain why this change is needed -->

## How

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the Tinybird CLI and Python versions in CI to ensure reproducible runs and avoid breakage from upstream installer changes. Replace the curl installer with `uv tool install "tinybird==4.6.7" --python 3.11` and add `astral-sh/setup-uv@v8.2.0` in `.github/workflows/test_server.yaml`.

<sup>Written for commit f2a48eb46982aa3de0e95aa8cf2cf94391619c6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

