### PR TITLE
tb: Get workspace scoped tokens

### DIFF
--- a/.github/workflows/test_server.yaml
+++ b/.github/workflows/test_server.yaml
@@ -133,11 +133,8 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.0
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v8.2.0
-
       - name: 🐦 Install Tinybird CLI
-        run: uv tool install "tinybird==4.6.7" --python 3.11 && echo "$HOME/.local/bin" >> $GITHUB_PATH
+        run: curl -sSL https://tinybird.co/install.sh | bash && echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: 🐦 Validate Tinybird schema
         working-directory: ./server/tinybird
@@ -352,7 +349,7 @@ jobs:
           uv run task generate_dev_jwks
 
       - name: 🐦 Install Tinybird CLI
-        run: uv tool install "tinybird==4.6.7" --python 3.11 && echo "$HOME/.local/bin" >> $GITHUB_PATH
+        run: curl -sSL https://tinybird.co/install.sh | bash && echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: ⚗️ alembic migrate
         working-directory: ./server

--- a/server/tests/fixtures/tinybird.py
+++ b/server/tests/fixtures/tinybird.py
@@ -44,27 +44,42 @@ def tinybird_workspace() -> Generator[str, None, None]:
     host = settings.TINYBIRD_API_URL
     workspace_name = f"test_{uuid.uuid4().hex[:8]}"
 
+    organization_response = httpx.get(
+        f"{host}/v1/user/workspaces",
+        params={"with_organization": "true", "token": admin_token},
+    )
+    organization_response.raise_for_status()
+    organization_id = organization_response.json()["organization_id"]
+
     ws_response = httpx.post(
-        f"{host}/v0/workspaces",
-        params={"name": workspace_name},
+        f"{host}/v1/workspaces",
+        params={"name": workspace_name, "assign_to_organization_id": organization_id},
         headers={"Authorization": f"Bearer {user_token}"},
     )
     ws_response.raise_for_status()
     workspace_id = ws_response.json()["id"]
 
-    token_name = f"admin_{workspace_name}"
-    token_response = httpx.post(
-        f"{host}/v0/tokens",
-        params={"name": token_name, "scope": "ADMIN"},
-        headers={
-            "Authorization": f"Bearer {admin_token}",
-            "X-Workspace-ID": workspace_id,
-        },
+    workspaces_response = httpx.get(
+        f"{host}/v1/user/workspaces",
+        params={"token": user_token},
     )
-    token_response.raise_for_status()
-    workspace_token = token_response.json()["token"]
+    workspaces_response.raise_for_status()
+    workspace_token = next(
+        workspace["token"]
+        for workspace in workspaces_response.json()["workspaces"]
+        if workspace["id"] == workspace_id
+    )
 
-    deploy_cmd = ["tb", "--host", host, "--token", workspace_token, "deploy", "--wait"]
+    deploy_cmd = [
+        "tb",
+        "--cloud",
+        "--host",
+        host,
+        "--token",
+        workspace_token,
+        "deploy",
+        "--wait",
+    ]
     for attempt in range(3):
         result = subprocess.run(
             deploy_cmd,
@@ -106,7 +121,8 @@ def tinybird_workspace() -> Generator[str, None, None]:
     yield workspace_token
 
     httpx.delete(
-        f"{host}/v0/workspaces/{workspace_id}",
+        f"{host}/v1/workspaces/{workspace_id}",
+        params={"hard_delete_confirmation": "yes"},
         headers={"Authorization": f"Bearer {user_token}"},
     )
 


### PR DESCRIPTION
This should ensure that we try to access the correct workspace for Tinybird, since the x-workspace-id was obviously hallucinated


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

