### PR TITLE
fix(dispute): fixe racing charge.dispute.closed vs created 

### DIFF
--- a/server/polar/dispute/repository.py
+++ b/server/polar/dispute/repository.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 
 from sqlalchemy import Select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import joinedload
 
 from polar.authz.types import AccessibleOrganizationID
@@ -14,7 +15,7 @@ from polar.kit.repository import (
     SortingClause,
 )
 from polar.models import Dispute, Order, Payment
-from polar.models.dispute import DisputeAlertProcessor
+from polar.models.dispute import DisputeAlertProcessor, DisputeStatus
 
 from .sorting import DisputeSortProperty
 
@@ -26,6 +27,44 @@ class DisputeRepository(
     RepositoryBase[Dispute],
 ):
     model = Dispute
+
+    async def get_or_create_from_stripe(
+        self,
+        *,
+        stripe_dispute_id: str,
+        status: DisputeStatus,
+        amount: int,
+        tax_amount: int,
+        currency: str,
+        order: Order,
+        payment: Payment,
+    ) -> tuple[Dispute, bool]:
+        statement = (
+            pg_insert(Dispute)
+            .values(
+                payment_processor=PaymentProcessor.stripe,
+                payment_processor_id=stripe_dispute_id,
+                status=status,
+                amount=amount,
+                tax_amount=tax_amount,
+                currency=currency,
+                order_id=order.id,
+                payment_id=payment.id,
+            )
+            .on_conflict_do_nothing(
+                index_elements=["payment_processor", "payment_processor_id"]
+            )
+            .returning(Dispute.id)
+        )
+        inserted_id = await self.session.scalar(statement)
+
+        dispute = await self.get_by_payment_processor_dispute_id(
+            PaymentProcessor.stripe,
+            stripe_dispute_id,
+            options=(*self.get_eager_options(), joinedload(Dispute.payment)),
+        )
+        assert dispute is not None
+        return dispute, inserted_id is not None
 
     async def get_by_payment_processor_dispute_id(
         self, processor: PaymentProcessor, processor_id: str, *, options: Options = ()

--- a/server/polar/dispute/service.py
+++ b/server/polar/dispute/service.py
@@ -145,6 +145,7 @@ class DisputeService:
     ) -> Dispute:
         repository = DisputeRepository.from_session(session)
         charge_id = get_expandable_id(stripe_dispute.charge)
+        new_status = DisputeStatus.from_stripe(stripe_dispute.status)
 
         # First try to find by Stripe Dispute ID
         dispute = await repository.get_by_payment_processor_dispute_id(
@@ -164,6 +165,7 @@ class DisputeService:
             )
             from_alert = dispute is not None
 
+        created = False
         if dispute is None:
             payment, order = await self._get_payment_and_order_from_processor_id(
                 session, PaymentProcessor.stripe, charge_id
@@ -171,18 +173,21 @@ class DisputeService:
             amount, tax_amount = order.calculate_refunded_tax_from_total(
                 stripe_dispute.amount
             )
-            dispute = await repository.create(
-                Dispute(
-                    amount=amount,
-                    tax_amount=tax_amount,
-                    currency=stripe_dispute.currency,
-                    order=order,
-                    payment=payment,
-                )
+
+            dispute, created = await repository.get_or_create_from_stripe(
+                stripe_dispute_id=stripe_dispute.id,
+                status=new_status,
+                amount=amount,
+                tax_amount=tax_amount,
+                currency=stripe_dispute.currency,
+                order=order,
+                payment=payment,
             )
 
-        was_closed = dispute.closed
-        previous_status = dispute.status
+        if created:
+            was_closed, previous_status = False, None
+        else:
+            was_closed, previous_status = dispute.closed, dispute.status
         dispute.payment_processor = PaymentProcessor.stripe
         dispute.payment_processor_id = stripe_dispute.id
 
@@ -200,8 +205,6 @@ class DisputeService:
         dispute.has_evidence = evidence_details.has_evidence
         dispute.past_due = evidence_details.past_due
         dispute.submission_count = evidence_details.submission_count
-
-        new_status = DisputeStatus.from_stripe(stripe_dispute.status)
 
         # Dispute that we tried to prevent but too late: we need to reopen it
         # The associated refund will be marked as failed through refund.failed


### PR DESCRIPTION
## Summary

Fixes the duplicate-key `IntegrityError` race between `charge.dispute.closed` and `charge.dispute.created` reported in #12972.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

