### PR TITLE
aws/sqs: enable in prod and test

### DIFF
--- a/server/polar/worker/_sqs.py
+++ b/server/polar/worker/_sqs.py
@@ -39,15 +39,17 @@ class SQSSendError(Exception):
 
 
 def get_sqs_client() -> "SQSClient":
+    access_key_id = settings.WORKER_SQS_AWS_ACCESS_KEY_ID
+    secret_access_key = settings.WORKER_SQS_AWS_SECRET_ACCESS_KEY
+    if access_key_id is None and settings.SQS_ENDPOINT_URL is not None:
+        access_key_id = settings.AWS_ACCESS_KEY_ID
+        secret_access_key = settings.AWS_SECRET_ACCESS_KEY
+    # None credentials: boto3's default chain assumes the Render OIDC role (AWS_ROLE_ARN).
     return boto3.client(
         "sqs",
         endpoint_url=settings.SQS_ENDPOINT_URL,
-        aws_access_key_id=(
-            settings.WORKER_SQS_AWS_ACCESS_KEY_ID or settings.AWS_ACCESS_KEY_ID
-        ),
-        aws_secret_access_key=(
-            settings.WORKER_SQS_AWS_SECRET_ACCESS_KEY or settings.AWS_SECRET_ACCESS_KEY
-        ),
+        aws_access_key_id=access_key_id,
+        aws_secret_access_key=secret_access_key,
         config=Config(
             region_name=settings.AWS_REGION,
             signature_version=settings.AWS_SIGNATURE_VERSION,

--- a/terraform/modules/render_secrets_kms/main.tf
+++ b/terraform/modules/render_secrets_kms/main.tf
@@ -122,3 +122,8 @@ output "role_arn" {
   description = "ARN of the role the Render backend assumes via OIDC. Passed to the app as AWS_ROLE_ARN."
   value       = aws_iam_role.secrets.arn
 }
+
+output "role_name" {
+  description = "Name of the role the Render backend assumes via OIDC, for attaching additional policies."
+  value       = aws_iam_role.secrets.name
+}

--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -142,13 +142,17 @@ resource "render_env_group" "worker_sqs" {
   count          = var.worker_sqs_config != null ? 1 : 0
   environment_id = var.render_environment_id
   name           = "worker-sqs-${var.environment}"
-  env_vars = {
-    POLAR_WORKER_SQS_ENABLED               = { value = var.worker_sqs_config.enabled }
-    POLAR_WORKER_SQS_ACTORS                = { value = var.worker_sqs_config.actors }
-    POLAR_WORKER_SQS_QUEUE_PREFIX          = { value = var.worker_sqs_config.queue_prefix }
-    POLAR_WORKER_SQS_AWS_ACCESS_KEY_ID     = { value = var.worker_sqs_config.aws_access_key_id }
-    POLAR_WORKER_SQS_AWS_SECRET_ACCESS_KEY = { value = var.worker_sqs_config.aws_secret_access_key }
-  }
+  env_vars = merge(
+    {
+      POLAR_WORKER_SQS_ENABLED      = { value = var.worker_sqs_config.enabled }
+      POLAR_WORKER_SQS_ACTORS       = { value = var.worker_sqs_config.actors }
+      POLAR_WORKER_SQS_QUEUE_PREFIX = { value = var.worker_sqs_config.queue_prefix }
+    },
+    var.worker_sqs_config.aws_access_key_id != null ? {
+      POLAR_WORKER_SQS_AWS_ACCESS_KEY_ID     = { value = var.worker_sqs_config.aws_access_key_id }
+      POLAR_WORKER_SQS_AWS_SECRET_ACCESS_KEY = { value = var.worker_sqs_config.aws_secret_access_key }
+    } : {}
+  )
 }
 
 resource "render_env_group" "github" {

--- a/terraform/modules/render_service/terraform.tf
+++ b/terraform/modules/render_service/terraform.tf
@@ -16,5 +16,5 @@ terraform {
     }
   }
 
-  required_version = ">= 1.2"
+  required_version = ">= 1.3"
 }

--- a/terraform/modules/render_service/variables.tf
+++ b/terraform/modules/render_service/variables.tf
@@ -204,13 +204,13 @@ variable "aws_kms_config" {
 }
 
 variable "worker_sqs_config" {
-  description = "Worker SQS execution engine config and producer credentials (optional). null skips the env group."
+  description = "Worker SQS execution engine config (optional). null skips the env group. Omit the static credentials to send via the Render OIDC role instead."
   type = object({
     enabled               = string
     actors                = string
     queue_prefix          = string
-    aws_access_key_id     = string
-    aws_secret_access_key = string
+    aws_access_key_id     = optional(string)
+    aws_secret_access_key = optional(string)
   })
   default   = null
   sensitive = true

--- a/terraform/production/aws.tf
+++ b/terraform/production/aws.tf
@@ -91,6 +91,27 @@ module "lambda_worker" {
 }
 
 # =============================================================================
+# Task producer policy (SQS send-only, attached to the Render backend OIDC role)
+# =============================================================================
+
+data "aws_iam_policy_document" "tasks_producer" {
+  statement {
+    sid = "SendTasks"
+    actions = [
+      "sqs:SendMessage",
+      "sqs:GetQueueUrl",
+    ]
+    resources = [module.lambda_worker.queue_arn]
+  }
+}
+
+resource "aws_iam_role_policy" "tasks_producer" {
+  name   = "polar-production-tasks-producer"
+  role   = module.secrets_kms.role_name
+  policy = data.aws_iam_policy_document.tasks_producer.json
+}
+
+# =============================================================================
 # GitHub Actions OIDC role (builds the task-worker image and deploys it)
 # =============================================================================
 

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -356,6 +356,12 @@ module "production" {
     role_arn = module.secrets_kms.role_arn
   }
 
+  worker_sqs_config = {
+    enabled      = "true"
+    actors       = var.worker_sqs_actors
+    queue_prefix = "polar-production-tasks"
+  }
+
   github_secrets = {
     client_id                           = var.github_client_id_production
     client_secret                       = var.github_client_secret_production

--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -509,6 +509,12 @@ variable "next_public_stripe_payment_method_configuration" {
   sensitive   = true
 }
 
+variable "worker_sqs_actors" {
+  description = "JSON array of Dramatiq actor names routed to the SQS execution engine"
+  type        = string
+  default     = "[\"dummy\"]"
+}
+
 variable "stripe_app_client_id" {
   description = "Stripe App OAuth client ID"
   type        = string

--- a/terraform/test/aws.tf
+++ b/terraform/test/aws.tf
@@ -96,6 +96,30 @@ module "lambda_worker" {
 }
 
 # =============================================================================
+# Task producer policy (SQS send-only, attached to the Render backend OIDC role)
+# =============================================================================
+
+data "aws_iam_policy_document" "tasks_producer" {
+  count = local.test_enabled ? 1 : 0
+
+  statement {
+    sid = "SendTasks"
+    actions = [
+      "sqs:SendMessage",
+      "sqs:GetQueueUrl",
+    ]
+    resources = [module.lambda_worker[0].queue_arn]
+  }
+}
+
+resource "aws_iam_role_policy" "tasks_producer" {
+  count  = local.test_enabled ? 1 : 0
+  name   = "polar-test-tasks-producer"
+  role   = module.secrets_kms[0].role_name
+  policy = data.aws_iam_policy_document.tasks_producer[0].json
+}
+
+# =============================================================================
 # GitHub Actions OIDC role (builds the task-worker image and deploys it)
 # =============================================================================
 

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -236,6 +236,12 @@ module "test" {
     role_arn = one(module.secrets_kms[*].role_arn)
   }
 
+  worker_sqs_config = {
+    enabled      = "true"
+    actors       = var.worker_sqs_actors
+    queue_prefix = "polar-test-tasks"
+  }
+
   github_secrets = {
     client_id                           = var.github_client_id
     client_secret                       = var.github_client_secret

--- a/terraform/test/variables.tf
+++ b/terraform/test/variables.tf
@@ -404,6 +404,12 @@ variable "next_public_stripe_payment_method_configuration" {
   sensitive   = true
 }
 
+variable "worker_sqs_actors" {
+  description = "JSON array of Dramatiq actor names routed to the SQS execution engine"
+  type        = string
+  default     = "[\"dummy\"]"
+}
+
 variable "stripe_app_client_id" {
   description = "Stripe App OAuth client ID"
   type        = string


### PR DESCRIPTION
This enables SQS in prod and test, utilising the Render<>AWS OIDC role setup. 

Will clean up the IAM user in sandbox after this is rolled out

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

