### PR TITLE
sqs: Handle local credentials

### DIFF
--- a/server/polar/worker/_sqs.py
+++ b/server/polar/worker/_sqs.py
@@ -41,7 +41,11 @@ class SQSSendError(Exception):
 def get_sqs_client() -> "SQSClient":
     access_key_id = settings.WORKER_SQS_AWS_ACCESS_KEY_ID
     secret_access_key = settings.WORKER_SQS_AWS_SECRET_ACCESS_KEY
-    if access_key_id is None and settings.SQS_ENDPOINT_URL is not None:
+    if access_key_id is None and (
+        settings.SQS_ENDPOINT_URL is not None
+        or settings.is_development()
+        or settings.is_testing()
+    ):
         access_key_id = settings.AWS_ACCESS_KEY_ID
         secret_access_key = settings.AWS_SECRET_ACCESS_KEY
     # None credentials: boto3's default chain assumes the Render OIDC role (AWS_ROLE_ARN).

--- a/server/tests/worker/test_sqs_client.py
+++ b/server/tests/worker/test_sqs_client.py
@@ -1,0 +1,79 @@
+from typing import Any
+
+from pytest_mock import MockerFixture
+
+from polar.config import Environment, settings
+from polar.worker import _sqs
+
+
+def get_boto3_client_kwargs(mocker: MockerFixture) -> dict[str, Any]:
+    boto3_client = mocker.patch("polar.worker._sqs.boto3.client")
+
+    _sqs.get_sqs_client()
+
+    boto3_client.assert_called_once()
+    return dict(boto3_client.call_args.kwargs)
+
+
+def test_development_uses_static_aws_credentials(mocker: MockerFixture) -> None:
+    mocker.patch.object(settings, "ENV", Environment.development)
+    mocker.patch.object(settings, "SQS_ENDPOINT_URL", None)
+    mocker.patch.object(settings, "WORKER_SQS_AWS_ACCESS_KEY_ID", None)
+    mocker.patch.object(settings, "WORKER_SQS_AWS_SECRET_ACCESS_KEY", None)
+
+    kwargs = get_boto3_client_kwargs(mocker)
+
+    assert kwargs["aws_access_key_id"] == settings.AWS_ACCESS_KEY_ID
+    assert kwargs["aws_secret_access_key"] == settings.AWS_SECRET_ACCESS_KEY
+
+
+def test_testing_uses_static_aws_credentials(mocker: MockerFixture) -> None:
+    mocker.patch.object(settings, "ENV", Environment.testing)
+    mocker.patch.object(settings, "SQS_ENDPOINT_URL", None)
+    mocker.patch.object(settings, "WORKER_SQS_AWS_ACCESS_KEY_ID", None)
+    mocker.patch.object(settings, "WORKER_SQS_AWS_SECRET_ACCESS_KEY", None)
+
+    kwargs = get_boto3_client_kwargs(mocker)
+
+    assert kwargs["aws_access_key_id"] == settings.AWS_ACCESS_KEY_ID
+    assert kwargs["aws_secret_access_key"] == settings.AWS_SECRET_ACCESS_KEY
+
+
+def test_production_uses_default_aws_credential_chain(mocker: MockerFixture) -> None:
+    mocker.patch.object(settings, "ENV", Environment.production)
+    mocker.patch.object(settings, "SQS_ENDPOINT_URL", None)
+    mocker.patch.object(settings, "WORKER_SQS_AWS_ACCESS_KEY_ID", None)
+    mocker.patch.object(settings, "WORKER_SQS_AWS_SECRET_ACCESS_KEY", None)
+
+    kwargs = get_boto3_client_kwargs(mocker)
+
+    assert kwargs["aws_access_key_id"] is None
+    assert kwargs["aws_secret_access_key"] is None
+
+
+def test_sqs_endpoint_url_uses_static_aws_credentials(
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch.object(settings, "ENV", Environment.production)
+    mocker.patch.object(settings, "SQS_ENDPOINT_URL", "http://127.0.0.1:4566")
+    mocker.patch.object(settings, "WORKER_SQS_AWS_ACCESS_KEY_ID", None)
+    mocker.patch.object(settings, "WORKER_SQS_AWS_SECRET_ACCESS_KEY", None)
+
+    kwargs = get_boto3_client_kwargs(mocker)
+
+    assert kwargs["aws_access_key_id"] == settings.AWS_ACCESS_KEY_ID
+    assert kwargs["aws_secret_access_key"] == settings.AWS_SECRET_ACCESS_KEY
+
+
+def test_explicit_worker_sqs_credentials_win(mocker: MockerFixture) -> None:
+    mocker.patch.object(settings, "ENV", Environment.development)
+    mocker.patch.object(settings, "SQS_ENDPOINT_URL", None)
+    mocker.patch.object(settings, "WORKER_SQS_AWS_ACCESS_KEY_ID", "worker-access-key")
+    mocker.patch.object(
+        settings, "WORKER_SQS_AWS_SECRET_ACCESS_KEY", "worker-secret-key"
+    )
+
+    kwargs = get_boto3_client_kwargs(mocker)
+
+    assert kwargs["aws_access_key_id"] == "worker-access-key"
+    assert kwargs["aws_secret_access_key"] == "worker-secret-key"


### PR DESCRIPTION
Now that we are relying on no credentials (role via OIDC), then the local tests break since we need the credentials specified there.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use static AWS credentials for SQS in development/testing and when `SQS_ENDPOINT_URL` is set, while keeping the default OIDC/no-credentials path in production. Fixes broken local tests and local `boto3` usage.

- **Bug Fixes**
  - Updated `get_sqs_client()` to use `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` when no worker creds are set and env is dev/test or an endpoint URL is provided; explicit `WORKER_SQS_*` creds still take precedence.
  - Added tests for dev, test, prod, endpoint override, and credential precedence.

<sup>Written for commit bf48c713886e7fe291d78c206e1a7a0466a86d8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

