### PR TITLE
feat(oauth2): dual-write hashed and encrypted OAuth2Client secrets

### DIFF
--- a/server/migrations/versions/2026-07-08-1700_add_oauth2_client_encrypted_secrets.py
+++ b/server/migrations/versions/2026-07-08-1700_add_oauth2_client_encrypted_secrets.py
@@ -1,0 +1,69 @@
+"""add OAuth2Client encrypted secret columns
+
+Revision ID: cddb6a1cfd92
+Revises: 40d0bc3f9994
+Create Date: 2026-07-08 17:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "cddb6a1cfd92"
+down_revision = "40d0bc3f9994"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.add_column(
+        "oauth2_clients",
+        sa.Column("client_secret_hash", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "oauth2_clients",
+        sa.Column("client_secret_encrypted", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "oauth2_clients",
+        sa.Column(
+            "registration_access_token_hash", sa.String(length=64), nullable=True
+        ),
+    )
+    op.add_column(
+        "oauth2_clients",
+        sa.Column("registration_access_token_encrypted", sa.Text(), nullable=True),
+    )
+    op.create_index(
+        op.f("ix_oauth2_clients_client_secret_hash"),
+        "oauth2_clients",
+        ["client_secret_hash"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_oauth2_clients_registration_access_token_hash"),
+        "oauth2_clients",
+        ["registration_access_token_hash"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.drop_index(
+        op.f("ix_oauth2_clients_registration_access_token_hash"),
+        table_name="oauth2_clients",
+    )
+    op.drop_index(
+        op.f("ix_oauth2_clients_client_secret_hash"),
+        table_name="oauth2_clients",
+    )
+    op.drop_column("oauth2_clients", "registration_access_token_encrypted")
+    op.drop_column("oauth2_clients", "registration_access_token_hash")
+    op.drop_column("oauth2_clients", "client_secret_encrypted")
+    op.drop_column("oauth2_clients", "client_secret_hash")

--- a/server/polar/kit/encryption.py
+++ b/server/polar/kit/encryption.py
@@ -50,6 +50,10 @@ class KeyProvider(Protocol):
         """Return a fresh ``(plaintext_data_key, wrapped_data_key)`` pair."""
         ...
 
+    def generate_data_key_sync(self, context: dict[str, str]) -> tuple[bytes, bytes]:
+        """Blocking variant of :meth:`generate_data_key` for callers that cannot await."""
+        ...
+
     async def decrypt_data_key(self, wrapped: bytes, context: dict[str, str]) -> bytes:
         """Unwrap a previously wrapped data key."""
         ...
@@ -62,11 +66,14 @@ class LocalKeyProvider:
     def __init__(self, key: str) -> None:
         self._key = AESGCM(hashlib.sha256(key.encode("utf-8")).digest())
 
-    async def generate_data_key(self, context: dict[str, str]) -> tuple[bytes, bytes]:
+    def generate_data_key_sync(self, context: dict[str, str]) -> tuple[bytes, bytes]:
         data_key = os.urandom(DATA_KEY_SIZE)
         nonce = os.urandom(NONCE_SIZE)
         wrapped = nonce + self._key.encrypt(nonce, data_key, _encode_context(context))
         return data_key, wrapped
+
+    async def generate_data_key(self, context: dict[str, str]) -> tuple[bytes, bytes]:
+        return self.generate_data_key_sync(context)
 
     async def decrypt_data_key(self, wrapped: bytes, context: dict[str, str]) -> bytes:
         nonce, ciphertext = wrapped[:NONCE_SIZE], wrapped[NONCE_SIZE:]
@@ -82,17 +89,28 @@ class KMSKeyProvider:
     @functools.cached_property
     def _client(self) -> Any:
         import boto3
+        from botocore.config import Config
 
-        return boto3.client("kms", region_name=settings.AWS_REGION)
+        # Bound the blocking KMS calls: the sync encryption path can run on the
+        # event loop, so a slow or throttled KMS must fail fast, not stall it.
+        return boto3.client(
+            "kms",
+            region_name=settings.AWS_REGION,
+            config=Config(
+                connect_timeout=3,
+                read_timeout=5,
+                retries={"max_attempts": 3, "mode": "standard"},
+            ),
+        )
 
-    async def generate_data_key(self, context: dict[str, str]) -> tuple[bytes, bytes]:
-        response = await asyncio.to_thread(
-            self._client.generate_data_key,
-            KeyId=self._key_id,
-            KeySpec="AES_256",
-            EncryptionContext=context,
+    def generate_data_key_sync(self, context: dict[str, str]) -> tuple[bytes, bytes]:
+        response = self._client.generate_data_key(
+            KeyId=self._key_id, KeySpec="AES_256", EncryptionContext=context
         )
         return response["Plaintext"], response["CiphertextBlob"]
+
+    async def generate_data_key(self, context: dict[str, str]) -> tuple[bytes, bytes]:
+        return await asyncio.to_thread(self.generate_data_key_sync, context)
 
     async def decrypt_data_key(self, wrapped: bytes, context: dict[str, str]) -> bytes:
         response = await asyncio.to_thread(
@@ -122,20 +140,35 @@ class EncryptedString:
         self.encrypted_value = encrypted_value
         self.context = dict(context)
 
+    @staticmethod
+    def _seal(
+        data_key: bytes, wrapped: bytes, plaintext: str, context: dict[str, str]
+    ) -> str:
+        nonce = os.urandom(NONCE_SIZE)
+        ciphertext = AESGCM(data_key).encrypt(
+            nonce, plaintext.encode("utf-8"), _encode_context(context)
+        )
+        return ".".join(
+            (VERSION, _b64encode(wrapped), _b64encode(nonce), _b64encode(ciphertext))
+        )
+
     @classmethod
     async def encrypt(
         cls, plaintext: str, *, context: dict[str, str]
     ) -> "EncryptedString":
         provider = get_key_provider()
         data_key, wrapped = await provider.generate_data_key(context)
-        nonce = os.urandom(NONCE_SIZE)
-        ciphertext = AESGCM(data_key).encrypt(
-            nonce, plaintext.encode("utf-8"), _encode_context(context)
-        )
-        encoded = ".".join(
-            (VERSION, _b64encode(wrapped), _b64encode(nonce), _b64encode(ciphertext))
-        )
-        return cls(encoded, context)
+        return cls(cls._seal(data_key, wrapped, plaintext, context), context)
+
+    @classmethod
+    def encrypt_sync(
+        cls, plaintext: str, *, context: dict[str, str]
+    ) -> "EncryptedString":
+        """Blocking encryption for callers that cannot await; keep it to
+        low-volume paths since it blocks on the KMS call."""
+        provider = get_key_provider()
+        data_key, wrapped = provider.generate_data_key_sync(context)
+        return cls(cls._seal(data_key, wrapped, plaintext, context), context)
 
     async def decrypt(self, *, id: str | None = None) -> str:
         context = {**self.context, "id": id} if id is not None else self.context

--- a/server/polar/models/oauth2_client.py
+++ b/server/polar/models/oauth2_client.py
@@ -5,11 +5,23 @@ from authlib.integrations.sqla_oauth2 import OAuth2ClientMixin
 from sqlalchemy import ForeignKey, String, UniqueConstraint, Uuid
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
+from polar.config import settings
+from polar.kit.crypto import get_token_hash
 from polar.kit.db.models import RateLimitGroupMixin, RecordModel
+from polar.kit.encryption import EncryptedString, EncryptedStringType
 from polar.oauth2.sub_type import SubType
 
 if TYPE_CHECKING:
     from polar.models import User
+
+OAUTH2_CLIENT_SECRET_CONTEXT = {
+    "table": "oauth2_clients",
+    "column": "client_secret",
+}
+OAUTH2_CLIENT_REGISTRATION_ACCESS_TOKEN_CONTEXT = {
+    "table": "oauth2_clients",
+    "column": "registration_access_token",
+}
 
 
 class OAuth2Client(RateLimitGroupMixin, RecordModel, OAuth2ClientMixin):
@@ -18,8 +30,26 @@ class OAuth2Client(RateLimitGroupMixin, RecordModel, OAuth2ClientMixin):
 
     client_id: Mapped[str] = mapped_column(String(52), nullable=False)
     client_secret: Mapped[str] = mapped_column(String(52), nullable=False)
+    # HMAC for synchronous verification and value lookup; the encrypted
+    # column reveals the plaintext. See the secrets-encryption design doc.
+    client_secret_hash: Mapped[str | None] = mapped_column(
+        String(64), nullable=True, default=None, index=True
+    )
+    client_secret_encrypted: Mapped[EncryptedString | None] = mapped_column(
+        EncryptedStringType(OAUTH2_CLIENT_SECRET_CONTEXT),
+        nullable=True,
+        default=None,
+    )
     registration_access_token: Mapped[str] = mapped_column(
         String, index=True, nullable=False
+    )
+    registration_access_token_hash: Mapped[str | None] = mapped_column(
+        String(64), nullable=True, default=None, index=True
+    )
+    registration_access_token_encrypted: Mapped[EncryptedString | None] = mapped_column(
+        EncryptedStringType(OAUTH2_CLIENT_REGISTRATION_ACCESS_TOKEN_CONTEXT),
+        nullable=True,
+        default=None,
     )
     first_party: Mapped[bool] = mapped_column(nullable=False, default=False)
 
@@ -37,3 +67,107 @@ class OAuth2Client(RateLimitGroupMixin, RecordModel, OAuth2ClientMixin):
             return SubType(self.client_metadata["default_sub_type"])
         except KeyError:
             return SubType.user
+
+    @staticmethod
+    def hash_secret(value: str | None) -> str | None:
+        if value is None:
+            return None
+        return get_token_hash(value, secret=settings.SECRET)
+
+    @classmethod
+    async def encrypt_client_secret(
+        cls, id: UUID, client_secret: str | None
+    ) -> EncryptedString | None:
+        if client_secret is None:
+            return None
+        return await EncryptedString.encrypt(
+            client_secret,
+            context={**OAUTH2_CLIENT_SECRET_CONTEXT, "id": str(id)},
+        )
+
+    @classmethod
+    async def encrypt_registration_access_token(
+        cls, id: UUID, registration_access_token: str | None
+    ) -> EncryptedString | None:
+        if registration_access_token is None:
+            return None
+        return await EncryptedString.encrypt(
+            registration_access_token,
+            context={
+                **OAUTH2_CLIENT_REGISTRATION_ACCESS_TOKEN_CONTEXT,
+                "id": str(id),
+            },
+        )
+
+    @classmethod
+    def encrypt_client_secret_sync(
+        cls, id: UUID, client_secret: str | None
+    ) -> EncryptedString | None:
+        if client_secret is None:
+            return None
+        return EncryptedString.encrypt_sync(
+            client_secret,
+            context={**OAUTH2_CLIENT_SECRET_CONTEXT, "id": str(id)},
+        )
+
+    @classmethod
+    def encrypt_registration_access_token_sync(
+        cls, id: UUID, registration_access_token: str | None
+    ) -> EncryptedString | None:
+        if registration_access_token is None:
+            return None
+        return EncryptedString.encrypt_sync(
+            registration_access_token,
+            context={
+                **OAUTH2_CLIENT_REGISTRATION_ACCESS_TOKEN_CONTEXT,
+                "id": str(id),
+            },
+        )
+
+    async def set_client_secret(self, client_secret: str) -> None:
+        if self.id is None:
+            self.id = self.generate_id()
+        self.client_secret = client_secret  # pyright: ignore
+        self.client_secret_hash = self.hash_secret(client_secret)
+        self.client_secret_encrypted = await self.encrypt_client_secret(
+            self.id, client_secret
+        )
+
+    async def set_registration_access_token(
+        self, registration_access_token: str
+    ) -> None:
+        if self.id is None:
+            self.id = self.generate_id()
+        self.registration_access_token = registration_access_token
+        self.registration_access_token_hash = self.hash_secret(
+            registration_access_token
+        )
+        self.registration_access_token_encrypted = (
+            await self.encrypt_registration_access_token(
+                self.id, registration_access_token
+            )
+        )
+
+    def set_client_secret_sync(self, client_secret: str) -> None:
+        if self.id is None:
+            self.id = self.generate_id()
+        self.client_secret = client_secret  # pyright: ignore
+        self.client_secret_hash = self.hash_secret(client_secret)
+        self.client_secret_encrypted = self.encrypt_client_secret_sync(
+            self.id, client_secret
+        )
+
+    def set_registration_access_token_sync(
+        self, registration_access_token: str
+    ) -> None:
+        if self.id is None:
+            self.id = self.generate_id()
+        self.registration_access_token = registration_access_token
+        self.registration_access_token_hash = self.hash_secret(
+            registration_access_token
+        )
+        self.registration_access_token_encrypted = (
+            self.encrypt_registration_access_token_sync(
+                self.id, registration_access_token
+            )
+        )

--- a/server/polar/oauth2/authorization_server.py
+++ b/server/polar/oauth2/authorization_server.py
@@ -114,8 +114,11 @@ class ClientRegistrationEndpoint(_ClientRegistrationEndpoint):
 
         if request.user is not None:
             oauth2_client.user_id = request.user.id
-        oauth2_client.registration_access_token = generate_token(
-            prefix=CLIENT_REGISTRATION_TOKEN_PREFIX
+
+        # Sync: must run while we hold the plaintext, and authlib can't await.
+        oauth2_client.set_client_secret_sync(oauth2_client.client_secret)
+        oauth2_client.set_registration_access_token_sync(
+            generate_token(prefix=CLIENT_REGISTRATION_TOKEN_PREFIX)
         )
 
         self.server.session.add(oauth2_client)

--- a/server/polar/oauth2/mcp_client.py
+++ b/server/polar/oauth2/mcp_client.py
@@ -25,11 +25,13 @@ async def create_client(add_to_env_file: bool) -> None:
     async with sessionmaker() as session:
         oauth2_client = OAuth2Client(
             client_id=generate_token(prefix=CLIENT_ID_PREFIX),
-            client_secret=generate_token(prefix=CLIENT_SECRET_PREFIX),
-            registration_access_token=generate_token(
-                prefix=CLIENT_REGISTRATION_TOKEN_PREFIX
-            ),
             user=None,
+        )
+        await oauth2_client.set_client_secret(
+            generate_token(prefix=CLIENT_SECRET_PREFIX)
+        )
+        await oauth2_client.set_registration_access_token(
+            generate_token(prefix=CLIENT_REGISTRATION_TOKEN_PREFIX)
         )
         oauth2_client.set_client_metadata(
             {

--- a/server/polar/oauth2/service/oauth2_client.py
+++ b/server/polar/oauth2/service/oauth2_client.py
@@ -74,13 +74,13 @@ class OAuth2ClientService(ResourceServiceReader[OAuth2Client]):
 
         subject: str
         if token_type == TokenType.client_secret:
-            client.client_secret = generate_token(prefix=CLIENT_SECRET_PREFIX)  # pyright: ignore
+            await client.set_client_secret(generate_token(prefix=CLIENT_SECRET_PREFIX))
             subject = (
                 "Security Notice - Your Polar OAuth2 Client Secret has been leaked"
             )
         elif token_type == TokenType.client_registration_token:
-            client.registration_access_token = generate_token(
-                prefix=CLIENT_REGISTRATION_TOKEN_PREFIX
+            await client.set_registration_access_token(
+                generate_token(prefix=CLIENT_REGISTRATION_TOKEN_PREFIX)
             )
             subject = (
                 "Security Notice - "

--- a/server/scripts/backfill_oauth2_client_encrypted_secrets.py
+++ b/server/scripts/backfill_oauth2_client_encrypted_secrets.py
@@ -1,0 +1,210 @@
+"""Hash and encrypt legacy OAuth2Client secrets.
+
+OAuth2Client uses a hybrid: a deterministic HMAC (``*_hash``) for synchronous
+verification and value lookup, plus an envelope-encrypted copy (``*_encrypted``)
+to reveal the plaintext. New rows dual-write both columns at write time; this
+script fills them for rows created before that (which have plaintext only).
+
+Dry-run by default (counts rows only). Pass --execute to write:
+
+    uv run python -m scripts.backfill_oauth2_client_encrypted_secrets --execute
+"""
+
+import asyncio
+
+import typer
+from rich.progress import (
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeElapsedColumn,
+)
+from sqlalchemy import func, or_, select
+from sqlalchemy.sql.elements import ColumnElement
+
+from polar.config import settings
+from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
+from polar.kit.db.postgres import create_async_engine as _create_async_engine
+from polar.models import OAuth2Client
+
+from .helper import configure_script_logging, typer_async
+
+cli = typer.Typer()
+
+
+def _needs_backfill() -> ColumnElement[bool]:
+    """A row still to backfill: any hash or ciphertext column is NULL. Both
+    plaintext secrets are non-nullable, so a missing derived column is the only
+    thing that qualifies a row."""
+    return or_(
+        OAuth2Client.client_secret_hash.is_(None),
+        OAuth2Client.client_secret_encrypted.is_(None),
+        OAuth2Client.registration_access_token_hash.is_(None),
+        OAuth2Client.registration_access_token_encrypted.is_(None),
+    )
+
+
+async def run_backfill(
+    batch_size: int = 500,
+    sleep_seconds: float = 0.1,
+    dry_run: bool = False,
+    session: AsyncSession | None = None,
+) -> int:
+    """
+    Hash and encrypt OAuth2Client secrets written before dual-write (rollout
+    step for OAuth2Client; see the design document, Appendix C).
+
+    Encryption calls the key provider once per secret, so this loops in Python
+    rather than a set-based SQL update. Each backfilled secret fills its hash
+    and ciphertext columns, so the row falls out of the predicate; the loop
+    terminates and reruns are safe.
+    """
+    engine = None
+    own_session = False
+
+    if session is None:
+        engine = _create_async_engine(
+            dsn=str(settings.get_postgres_dsn("asyncpg")),
+            application_name=f"{settings.ENV.value}.script",
+            debug=False,
+            pool_size=settings.DATABASE_POOL_SIZE,
+            pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
+            command_timeout=settings.DATABASE_COMMAND_TIMEOUT_SECONDS,
+        )
+        sessionmaker = create_async_sessionmaker(engine)
+        session = sessionmaker()
+        own_session = True
+
+    total_encrypted = 0
+    batch_number = 0
+
+    try:
+        if dry_run:
+            count = (
+                await session.scalar(
+                    select(func.count())
+                    .select_from(OAuth2Client)
+                    .where(_needs_backfill())
+                )
+                or 0
+            )
+            typer.echo(f"[dry-run] {count} oauth2 clients would be encrypted")
+            return count
+
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            TimeElapsedColumn(),
+            transient=False,
+        ) as progress:
+            task = progress.add_task("[cyan]Batch 0: 0 rows encrypted", total=None)
+
+            while True:
+                # Lock the batch so a concurrent secret rotation can't be
+                # overwritten with stale values; skip rows it holds, retry later.
+                statement = (
+                    select(OAuth2Client)
+                    .where(_needs_backfill())
+                    .order_by(OAuth2Client.id)
+                    .limit(batch_size)
+                    .with_for_update(skip_locked=True)
+                )
+                result = await session.execute(statement)
+                clients = list(result.scalars().all())
+
+                if not clients:
+                    # An empty batch can also mean the rest are held by a
+                    # concurrent rotation (skip_locked); say so instead of "done".
+                    remaining = (
+                        await session.scalar(
+                            select(func.count())
+                            .select_from(OAuth2Client)
+                            .where(_needs_backfill())
+                        )
+                        or 0
+                    )
+                    if remaining > 0:
+                        progress.update(
+                            task,
+                            description=(
+                                f"[yellow]⚠ {total_encrypted} encrypted, {remaining} "
+                                "skipped (locked) — rerun to finish"
+                            ),
+                        )
+                    else:
+                        progress.update(
+                            task,
+                            description=(
+                                f"[green]✓ Complete: {total_encrypted} rows encrypted"
+                            ),
+                        )
+                    break
+
+                for client in clients:
+                    if client.client_secret_hash is None:
+                        client.client_secret_hash = OAuth2Client.hash_secret(
+                            client.client_secret
+                        )
+                    if client.client_secret_encrypted is None:
+                        client.client_secret_encrypted = (
+                            await OAuth2Client.encrypt_client_secret(
+                                client.id, client.client_secret
+                            )
+                        )
+                    if client.registration_access_token_hash is None:
+                        client.registration_access_token_hash = (
+                            OAuth2Client.hash_secret(client.registration_access_token)
+                        )
+                    if client.registration_access_token_encrypted is None:
+                        client.registration_access_token_encrypted = (
+                            await OAuth2Client.encrypt_registration_access_token(
+                                client.id, client.registration_access_token
+                            )
+                        )
+
+                await session.commit()
+                session.expunge_all()
+
+                batch_number += 1
+                total_encrypted += len(clients)
+                progress.update(
+                    task,
+                    description=(
+                        f"[cyan]Batch {batch_number}: {total_encrypted} rows encrypted"
+                    ),
+                )
+
+                if sleep_seconds > 0:
+                    await asyncio.sleep(sleep_seconds)
+
+        return total_encrypted
+
+    finally:
+        if own_session:
+            await session.close()
+        if engine is not None:
+            await engine.dispose()
+
+
+@cli.command()
+@typer_async
+async def backfill(
+    batch_size: int = typer.Option(
+        500, min=1, help="Number of rows to process per batch"
+    ),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+    execute: bool = typer.Option(
+        False, "--execute", help="Write encrypted secrets; without it, only counts rows"
+    ),
+) -> None:
+    """Hash and encrypt OAuth2Client secrets written before dual-write."""
+    configure_script_logging()
+    total_encrypted = await run_backfill(
+        batch_size=batch_size, sleep_seconds=sleep_seconds, dry_run=not execute
+    )
+    if execute:
+        typer.echo(f"Encrypted {total_encrypted} oauth2 clients")
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/tests/kit/test_encryption.py
+++ b/server/tests/kit/test_encryption.py
@@ -21,6 +21,14 @@ async def test_encrypt_decrypt_roundtrip() -> None:
 
 
 @pytest.mark.asyncio
+async def test_encrypt_sync_roundtrips_through_async_decrypt() -> None:
+    secret = EncryptedString.encrypt_sync("xoxb-1234", context=CONTEXT)
+    assert secret.encrypted_value.startswith("v1.")
+    assert "xoxb-1234" not in secret.encrypted_value
+    assert await secret.decrypt() == "xoxb-1234"
+
+
+@pytest.mark.asyncio
 async def test_each_encryption_uses_a_fresh_data_key() -> None:
     first = await EncryptedString.encrypt("same", context=CONTEXT)
     second = await EncryptedString.encrypt("same", context=CONTEXT)

--- a/server/tests/models/test_oauth2_client.py
+++ b/server/tests/models/test_oauth2_client.py
@@ -1,0 +1,157 @@
+import pytest
+from cryptography.exceptions import InvalidTag
+from sqlalchemy import select
+
+from polar.config import settings
+from polar.kit.crypto import get_token_hash
+from polar.kit.encryption import EncryptedString
+from polar.models import OAuth2Client, User
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+
+
+def _build(user: User) -> OAuth2Client:
+    client = OAuth2Client(
+        client_id="polar_ci_test",
+        client_secret="polar_cs_test",
+        registration_access_token="polar_crt_test",
+        user=user,
+    )
+    client.id = OAuth2Client.generate_id()
+    return client
+
+
+class TestHashSecret:
+    def test_hashes_with_secret(self) -> None:
+        assert OAuth2Client.hash_secret("polar_cs_test") == get_token_hash(
+            "polar_cs_test", secret=settings.SECRET
+        )
+
+    def test_is_deterministic(self) -> None:
+        assert OAuth2Client.hash_secret("polar_cs_test") == OAuth2Client.hash_secret(
+            "polar_cs_test"
+        )
+
+    def test_none_returns_none(self) -> None:
+        assert OAuth2Client.hash_secret(None) is None
+
+
+@pytest.mark.asyncio
+class TestEncryptClassmethods:
+    async def test_encrypt_client_secret(self, user: User) -> None:
+        client = _build(user)
+
+        encrypted = await OAuth2Client.encrypt_client_secret(client.id, "cs-test")
+
+        assert isinstance(encrypted, EncryptedString)
+        assert await encrypted.decrypt(id=str(client.id)) == "cs-test"
+
+    async def test_encrypt_registration_access_token(self, user: User) -> None:
+        client = _build(user)
+
+        encrypted = await OAuth2Client.encrypt_registration_access_token(
+            client.id, "crt-test"
+        )
+
+        assert isinstance(encrypted, EncryptedString)
+        assert await encrypted.decrypt(id=str(client.id)) == "crt-test"
+
+    async def test_encrypt_none_returns_none(self) -> None:
+        row_id = OAuth2Client.generate_id()
+        assert await OAuth2Client.encrypt_client_secret(row_id, None) is None
+        assert (
+            await OAuth2Client.encrypt_registration_access_token(row_id, None) is None
+        )
+
+    async def test_binds_ciphertext_to_row_id(self, user: User) -> None:
+        client = _build(user)
+
+        encrypted = await OAuth2Client.encrypt_client_secret(client.id, "cs-test")
+
+        assert isinstance(encrypted, EncryptedString)
+        with pytest.raises(InvalidTag):
+            await encrypted.decrypt(id="not-the-row-id")
+
+    async def test_encrypt_sync_variants_roundtrip(self, user: User) -> None:
+        client = _build(user)
+
+        client_secret = OAuth2Client.encrypt_client_secret_sync(client.id, "cs-test")
+        registration_access_token = OAuth2Client.encrypt_registration_access_token_sync(
+            client.id, "crt-test"
+        )
+
+        assert isinstance(client_secret, EncryptedString)
+        assert isinstance(registration_access_token, EncryptedString)
+        assert await client_secret.decrypt(id=str(client.id)) == "cs-test"
+        assert await registration_access_token.decrypt(id=str(client.id)) == "crt-test"
+
+    def test_encrypt_sync_none_returns_none(self) -> None:
+        row_id = OAuth2Client.generate_id()
+        assert OAuth2Client.encrypt_client_secret_sync(row_id, None) is None
+        assert OAuth2Client.encrypt_registration_access_token_sync(row_id, None) is None
+
+
+@pytest.mark.asyncio
+class TestSetters:
+    async def test_set_client_secret_writes_all_copies(self, user: User) -> None:
+        client = _build(user)
+
+        await client.set_client_secret("cs-new")
+
+        assert client.client_secret == "cs-new"
+        assert client.client_secret_hash == OAuth2Client.hash_secret("cs-new")
+        assert isinstance(client.client_secret_encrypted, EncryptedString)
+        assert (
+            await client.client_secret_encrypted.decrypt(id=str(client.id)) == "cs-new"
+        )
+
+    async def test_set_registration_access_token_writes_all_copies(
+        self, user: User
+    ) -> None:
+        client = _build(user)
+
+        await client.set_registration_access_token("crt-new")
+
+        assert client.registration_access_token == "crt-new"
+        assert client.registration_access_token_hash == OAuth2Client.hash_secret(
+            "crt-new"
+        )
+        assert isinstance(client.registration_access_token_encrypted, EncryptedString)
+        assert (
+            await client.registration_access_token_encrypted.decrypt(id=str(client.id))
+            == "crt-new"
+        )
+
+
+@pytest.mark.asyncio
+class TestPersistence:
+    async def test_round_trip_through_database(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        client = _build(user)
+        await client.set_client_secret("cs-test")
+        await client.set_registration_access_token("crt-test")
+        await save_fixture(client)
+        client_id = client.id
+
+        session.expunge_all()
+        loaded = await session.scalar(
+            select(OAuth2Client).where(OAuth2Client.id == client_id)
+        )
+
+        assert loaded is not None
+        assert loaded.client_secret_hash == OAuth2Client.hash_secret("cs-test")
+        assert isinstance(loaded.client_secret_encrypted, EncryptedString)
+        assert await loaded.client_secret_encrypted.decrypt(id=str(loaded.id)) == (
+            "cs-test"
+        )
+        assert loaded.registration_access_token_hash == OAuth2Client.hash_secret(
+            "crt-test"
+        )
+        assert isinstance(loaded.registration_access_token_encrypted, EncryptedString)
+        assert await loaded.registration_access_token_encrypted.decrypt(
+            id=str(loaded.id)
+        ) == ("crt-test")

--- a/server/tests/oauth2/endpoints/test_oauth2.py
+++ b/server/tests/oauth2/endpoints/test_oauth2.py
@@ -11,6 +11,7 @@ from polar.auth.service import USER_SESSION_TOKEN_PREFIX
 from polar.config import settings
 from polar.kit.crypto import generate_token_hash_pair, get_token_hash
 from polar.kit.db.postgres import Session
+from polar.kit.encryption import EncryptedString
 from polar.kit.utils import utc_now
 from polar.models import (
     OAuth2AuthorizationCode,
@@ -229,6 +230,52 @@ class TestOAuth2Register:
         assert "client_id" in json
         assert "registration_access_token" in json
         assert json["scope"] == "openid email"
+
+    @pytest.mark.auth(AuthSubjectFixture(subject="user"))
+    async def test_writes_hashed_and_encrypted_secrets(
+        self, client: AsyncClient, sync_session: Session
+    ) -> None:
+        response = await client.post(
+            "/v1/oauth2/register",
+            json={
+                "client_name": "Test Client",
+                "redirect_uris": ["https://example.com/callback"],
+            },
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+
+        oauth2_client = (
+            sync_session.execute(
+                select(OAuth2Client).where(OAuth2Client.client_id == data["client_id"])
+            )
+            .unique()
+            .scalar_one()
+        )
+
+        assert oauth2_client.client_secret_hash == OAuth2Client.hash_secret(
+            data["client_secret"]
+        )
+        assert oauth2_client.registration_access_token_hash == OAuth2Client.hash_secret(
+            data["registration_access_token"]
+        )
+        assert isinstance(oauth2_client.client_secret_encrypted, EncryptedString)
+        assert isinstance(
+            oauth2_client.registration_access_token_encrypted, EncryptedString
+        )
+        assert (
+            await oauth2_client.client_secret_encrypted.decrypt(
+                id=str(oauth2_client.id)
+            )
+            == data["client_secret"]
+        )
+        assert (
+            await oauth2_client.registration_access_token_encrypted.decrypt(
+                id=str(oauth2_client.id)
+            )
+            == data["registration_access_token"]
+        )
 
 
 @pytest.mark.asyncio

--- a/server/tests/scripts/test_backfill_oauth2_client_encrypted_secrets.py
+++ b/server/tests/scripts/test_backfill_oauth2_client_encrypted_secrets.py
@@ -1,0 +1,194 @@
+import pytest
+from sqlalchemy import or_, select
+
+from polar.kit.db.postgres import AsyncSession
+from polar.kit.encryption import EncryptedString
+from polar.models import OAuth2Client, User
+from scripts.backfill_oauth2_client_encrypted_secrets import run_backfill
+from tests.fixtures.database import SaveFixture
+
+
+async def _create_legacy_client(
+    save_fixture: SaveFixture,
+    user: User,
+    *,
+    client_id: str,
+    client_secret: str = "polar_cs_legacy",
+    registration_access_token: str = "polar_crt_legacy",
+) -> OAuth2Client:
+    """A row written before dual-write: plaintext secrets, NULL hash and
+    encrypted columns."""
+    client = OAuth2Client(
+        client_id=client_id,
+        client_secret=client_secret,
+        registration_access_token=registration_access_token,
+        user=user,
+    )
+    await save_fixture(client)
+    return client
+
+
+async def _reload(session: AsyncSession, client: OAuth2Client) -> OAuth2Client:
+    session.expunge_all()
+    loaded = await session.scalar(
+        select(OAuth2Client).where(OAuth2Client.id == client.id)
+    )
+    assert loaded is not None
+    return loaded
+
+
+@pytest.mark.asyncio
+class TestBackfillOAuth2ClientEncryptedSecrets:
+    async def test_encrypts_legacy_rows(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        client = await _create_legacy_client(
+            save_fixture,
+            user,
+            client_id="polar_ci_1",
+            client_secret="cs-legacy",
+            registration_access_token="crt-legacy",
+        )
+        assert client.client_secret_hash is None
+        assert client.client_secret_encrypted is None
+        assert client.registration_access_token_hash is None
+        assert client.registration_access_token_encrypted is None
+
+        encrypted = await run_backfill(batch_size=10, sleep_seconds=0, session=session)
+
+        assert encrypted == 1
+        loaded = await _reload(session, client)
+        assert loaded.client_secret_hash == OAuth2Client.hash_secret("cs-legacy")
+        assert isinstance(loaded.client_secret_encrypted, EncryptedString)
+        assert (
+            await loaded.client_secret_encrypted.decrypt(id=str(loaded.id))
+            == "cs-legacy"
+        )
+        assert loaded.registration_access_token_hash == OAuth2Client.hash_secret(
+            "crt-legacy"
+        )
+        assert isinstance(loaded.registration_access_token_encrypted, EncryptedString)
+        assert (
+            await loaded.registration_access_token_encrypted.decrypt(id=str(loaded.id))
+            == "crt-legacy"
+        )
+
+    async def test_fills_missing_encrypted_when_hash_present(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        """Registration dual-writes the hash synchronously but not the
+        ciphertext; the backfill fills only the missing ciphertext."""
+        client = await _create_legacy_client(
+            save_fixture,
+            user,
+            client_id="polar_ci_2",
+            client_secret="cs-hashed",
+            registration_access_token="crt-hashed",
+        )
+        client.client_secret_hash = OAuth2Client.hash_secret("cs-hashed")
+        client.registration_access_token_hash = OAuth2Client.hash_secret("crt-hashed")
+        await save_fixture(client)
+
+        await run_backfill(batch_size=10, sleep_seconds=0, session=session)
+
+        loaded = await _reload(session, client)
+        assert isinstance(loaded.client_secret_encrypted, EncryptedString)
+        assert isinstance(loaded.registration_access_token_encrypted, EncryptedString)
+        assert (
+            await loaded.client_secret_encrypted.decrypt(id=str(loaded.id))
+            == "cs-hashed"
+        )
+        assert (
+            await loaded.registration_access_token_encrypted.decrypt(id=str(loaded.id))
+            == "crt-hashed"
+        )
+
+    async def test_does_not_overwrite_already_encrypted_secret(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        client = await _create_legacy_client(save_fixture, user, client_id="polar_ci_3")
+        client.client_secret_encrypted = await OAuth2Client.encrypt_client_secret(
+            client.id, "cs-already-encrypted"
+        )
+        await save_fixture(client)
+        assert isinstance(client.client_secret_encrypted, EncryptedString)
+        existing_ciphertext = client.client_secret_encrypted.encrypted_value
+
+        await run_backfill(batch_size=10, sleep_seconds=0, session=session)
+
+        loaded = await _reload(session, client)
+        assert isinstance(loaded.client_secret_encrypted, EncryptedString)
+        assert loaded.client_secret_encrypted.encrypted_value == existing_ciphertext
+        assert (
+            await loaded.client_secret_encrypted.decrypt(id=str(loaded.id))
+            == "cs-already-encrypted"
+        )
+
+    async def test_processes_multiple_batches(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        for i in range(5):
+            await _create_legacy_client(
+                save_fixture, user, client_id=f"polar_ci_batch_{i}"
+            )
+
+        encrypted = await run_backfill(batch_size=2, sleep_seconds=0, session=session)
+
+        assert encrypted == 5
+        remaining = await session.execute(
+            select(OAuth2Client).where(
+                or_(
+                    OAuth2Client.client_secret_encrypted.is_(None),
+                    OAuth2Client.registration_access_token_encrypted.is_(None),
+                )
+            )
+        )
+        assert remaining.scalars().first() is None
+
+    async def test_is_idempotent(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        client = await _create_legacy_client(
+            save_fixture, user, client_id="polar_ci_rerun"
+        )
+
+        assert await run_backfill(batch_size=10, sleep_seconds=0, session=session) == 1
+        loaded = await _reload(session, client)
+        assert isinstance(loaded.client_secret_encrypted, EncryptedString)
+        first_ciphertext = loaded.client_secret_encrypted.encrypted_value
+
+        assert await run_backfill(batch_size=10, sleep_seconds=0, session=session) == 0
+        loaded = await _reload(session, client)
+        assert isinstance(loaded.client_secret_encrypted, EncryptedString)
+        assert loaded.client_secret_encrypted.encrypted_value == first_ciphertext
+
+    async def test_dry_run_counts_without_writing(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        client = await _create_legacy_client(
+            save_fixture, user, client_id="polar_ci_dry_run"
+        )
+
+        count = await run_backfill(dry_run=True, session=session)
+
+        assert count == 1
+        loaded = await _reload(session, client)
+        assert loaded.client_secret_encrypted is None


### PR DESCRIPTION
## Summary

Encrypt `OAuth2Client.client_secret` and `registration_access_token` at rest. This is the additive first phase: the app dual-writes new columns and a backfill fills existing rows, with no behavior change yet.

## What

- Add four nullable columns: a deterministic HMAC (`*_hash`) and an envelope-encrypted copy (`*_encrypted`) for each of the two secrets, plus a migration and a batched backfill script.
- Dual-write on the write paths: registration writes the hash synchronously (authlib's sync flow can't make the async KMS call); rotation and the MCP client write both copies.
- Reads, client authentication, and value lookups are unchanged and still use the plaintext columns.

## Why

Stored in plaintext, these secrets are exposed by any database-level leak. Unlike the other encrypted secrets, they are compared synchronously and looked up by value, so they need a deterministic hash for verification and an encrypted copy to stay revealable.

## How

The hybrid follows the pattern already used for `OAuthAccount` and `SlackApp`, with the hash borrowed from how `OAuth2Token` hashes its tokens. Rollout is per column (dual-write → backfill → cut over → drop plaintext); this PR ships only dual-write and backfill.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

