### PR TITLE
docs: add ADR for encrypting secrets at rest

### DIFF
--- a/handbook/docs.json
+++ b/handbook/docs.json
@@ -103,7 +103,9 @@
               "engineering/decisions/0003-request-scoped-unit-of-work",
               "engineering/decisions/0004-orbit-box-design-system",
               "engineering/decisions/0005-auth-subject-and-scopes",
-              "engineering/decisions/0006-migration-and-backfill-safety"
+              "engineering/decisions/0006-migration-and-backfill-safety",
+              "engineering/decisions/0007-no-default-in-output-schemas",
+              "engineering/decisions/0008-encrypt-secrets-at-rest"
             ]
           },
           "engineering/tech-notes",

--- a/handbook/engineering/decisions/0008-encrypt-secrets-at-rest.mdx
+++ b/handbook/engineering/decisions/0008-encrypt-secrets-at-rest.mdx
@@ -1,0 +1,68 @@
+---
+title: "ADR-0008: Encrypt secrets at rest"
+description: "How to model a secret column: envelope-encrypted by default, a keyed hash when it is compared or looked up by value."
+---
+
+<Info>
+**Status**: Accepted
+
+**Area**: Backend
+
+**Date**: 2026-07-06
+</Info>
+
+## Context
+
+Secrets we persist — OAuth tokens, OAuth2 client secrets, Slack secrets — used to live in plain
+`String`/`Text` columns, so any database-level leak (a dump, a replica, a backup, a
+SQL-injection read) exposed them directly. We now encrypt them, and this ADR fixes **how a
+secret column is modelled** so every new one is done the same way. The
+[secrets-encryption design](/engineering/design-documents/secrets-encryption) covers the threat
+model, KMS mechanics, key rotation, and migration; this ADR is the column-shape rule.
+
+## Decision
+
+A secret is never a plain-text column. Choose the column(s) from how the secret is read:
+
+- **Read by row id only → one `EncryptedString` column.** Map it with `EncryptedStringType`
+  (`polar/kit/encryption.py`). It stores the envelope ciphertext (data key wrapped by a KMS
+  master key in prod/sandbox, a static key in local/CI); loading a row does no crypto, and
+  decryption is an explicit `await value.decrypt(id=...)`. The column's context (`{table,
+  column}`) plus the row `id` bind each ciphertext to its row.
+- **Compared synchronously or looked up by value → a `*_hash` column.** Non-deterministic
+  ciphertext can't be `WHERE`-matched or compared without decrypting, so store a deterministic
+  keyed hash (`get_token_hash`, HMAC-SHA256 with `settings.SECRET`) and query/compare against it.
+- **Both (looked up *and* revealable) → a hybrid: `*_hash` **and** `*_encrypted`.** The hash
+  serves verification and lookup; the envelope column reveals the plaintext.
+
+Add the columns nullable and roll out per column without downtime — dual-write, backfill, cut
+reads over, drop the plain column (design doc, Appendix C). Set the columns through the model
+helpers (`encrypt_*`, `hash_secret`, `set_*`), never by hand-rolling crypto at the call site.
+
+## Consequences
+
+- A database-only leak yields ciphertext or hashes, not usable secrets; the KMS key never sits
+  in the database.
+- New rule when adding a secret column: decide the access shape first, then pick
+  `EncryptedString`, `*_hash`, or both — and reuse the model helpers.
+- `encrypt`/`decrypt` are async (a KMS call), so they can't run in synchronous code paths (e.g.
+  authlib's flow). There, dual-write the `*_hash` synchronously and fill the `*_encrypted`
+  column from a backfill, accepting a temporary window where the ciphertext is `NULL`.
+- More columns and write paths per secret than a single plain column — deliberate.
+
+## Alternatives considered
+
+- **`sqlalchemy-utils` `EncryptedType`**: keeps the key in the app, with no rotation or audit log.
+- **In-house symmetric key in the app or env**: the key sits with the data it protects — local
+  and CI only.
+- **A single hash column for everything**: one-way, so a secret that must be revealed again (e.g.
+  an OAuth2 client secret re-read via RFC 7592) can't use it — hence the hybrid.
+- **AWS Secrets Manager**: per-secret cost is prohibitive at our row counts.
+
+## References
+
+- Design doc: [Encrypting secrets at rest](/engineering/design-documents/secrets-encryption).
+- Primitives: `polar/kit/encryption.py` (`EncryptedString`, `EncryptedStringType`),
+  `polar/kit/crypto.py` (`get_token_hash`).
+- Applications: `OAuthAccount`, `SlackApp` — `EncryptedString` columns; `OAuth2Client` —
+  `*_hash` + `*_encrypted` hybrid.

--- a/handbook/engineering/decisions/index.mdx
+++ b/handbook/engineering/decisions/index.mdx
@@ -87,3 +87,5 @@ To check a diff against these ADRs, run the `adr-check` skill.
 - [ADR-0004: Frontend UI is authored with Orbit Box and design tokens](/engineering/decisions/0004-orbit-box-design-system) · Frontend · Accepted
 - [ADR-0005: Authorization is AuthSubject plus scopes](/engineering/decisions/0005-auth-subject-and-scopes) · Backend · Accepted
 - [ADR-0006: Migrations and backfills are deploy-safe by construction](/engineering/decisions/0006-migration-and-backfill-safety) · Backend · Accepted
+- [ADR-0007: No default in output schemas](/engineering/decisions/0007-no-default-in-output-schemas) · Backend · Accepted
+- [ADR-0008: Encrypt secrets at rest](/engineering/decisions/0008-encrypt-secrets-at-rest) · Backend · Accepted

--- a/handbook/engineering/design-documents/secrets-encryption.mdx
+++ b/handbook/engineering/design-documents/secrets-encryption.mdx
@@ -3,7 +3,7 @@
 
 **Created**: 2026-06-23
 
-**Last Updated**: 2026-07-01
+**Last Updated**: 2026-07-06
 
 **Author**: Petru Rares Sincraian
 </Info>
@@ -283,6 +283,23 @@ Order of columns, highest value first:
 |---|---|---|
 | 1 | `OAuthAccount.access_token`, `refresh_token` | Account takeover; one per user |
 | 2 | `SlackApp.client_secret`, `signing_secret`, `bot_token` | Workspace takeover |
-| 3 | `OAuth2Client.client_secret`, `registration_access_token` | Low cardinality, lower urgency |
+| 3 | `OAuth2Client.client_secret`, `registration_access_token` | Low cardinality, lower urgency; **hybrid** (see below) |
+
+### OAuth2Client is a hybrid, not envelope-only
+
+`OAuth2Client.client_secret` and `registration_access_token` cannot use the envelope-only
+pattern above. authlib compares them **synchronously** (`check_client_secret`, and the RFC 7592
+`compare_digest`) inside its sync `Session` flow, and `revoke_leaked` **looks them up by value** —
+neither works with an async, non-deterministic ciphertext. But they must also stay re-readable via
+the RFC 7592 management endpoint, so a one-way hash alone won't do either.
+
+So each of these two secrets gets **two** columns: a deterministic `*_hash`
+(`get_token_hash`, HMAC-SHA256 with `settings.SECRET`) for synchronous verification and value
+lookup, plus an envelope-encrypted `*_encrypted` for reveal. This is recorded in
+[ADR-0008](/engineering/decisions/0008-encrypt-secrets-at-rest). The rollout is the
+same dual-write → backfill → cut-over → drop, with one wrinkle: registration runs inside authlib's
+synchronous flow, which cannot make the async KMS call, so it dual-writes only the `*_hash`; the
+`*_encrypted` copy is filled by `server/scripts/backfill_oauth2_client_encrypted_secrets.py`. The
+async write paths (`revoke_leaked`, the MCP client script) dual-write both copies inline.
 
 ---


### PR DESCRIPTION
## Summary

Add ADR-0008 recording how we protect secrets at rest. So, cubic and agent reviews pick this up

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

