### PR TITLE
guard duty: Store results from Guard Duty scans on files

### DIFF
--- a/server/polar/file/repository.py
+++ b/server/polar/file/repository.py
@@ -33,6 +33,10 @@ class FileRepository(
         statement = statement.where(File.organization_id.in_(org_ids))
         return statement
 
+    async def get_by_path(self, path: str) -> File | None:
+        statement = self.get_base_statement().where(File.path == path)
+        return await self.get_one_or_none(statement)
+
     async def get_all_by_organization(
         self,
         organization_id: UUID,

--- a/server/polar/file/service.py
+++ b/server/polar/file/service.py
@@ -1,6 +1,7 @@
 import uuid
 from collections.abc import Sequence
 from datetime import datetime
+from typing import Any
 
 import structlog
 
@@ -8,6 +9,7 @@ from polar.auth.models import AuthSubject
 from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
 from polar.kit.pagination import PaginationParams
+from polar.kit.utils import utc_now
 from polar.models import Organization, ProductMedia, User
 from polar.models.file import File, FileServiceTypes, ProductMediaFile
 from polar.postgres import AsyncReadSession, AsyncSession, sql
@@ -192,6 +194,33 @@ class FileService:
         )
         result = await session.execute(statement)
         return result.scalar_one_or_none()
+
+    async def flag_malicious(
+        self,
+        session: AsyncSession,
+        *,
+        file: File,
+        scan_result_details: dict[str, Any],
+    ) -> File:
+        if file.flagged_malicious_at is not None:
+            return file
+
+        repository = FileRepository.from_session(session)
+        file = await repository.update(
+            file,
+            update_dict={
+                "flagged_malicious_at": utc_now(),
+                "flagged_malicious_details": scan_result_details,
+            },
+        )
+        log.warning(
+            "file.flagged_malicious",
+            file_id=file.id,
+            organization_id=file.organization_id,
+            service=file.service,
+            scan_result_details=scan_result_details,
+        )
+        return file
 
 
 file = FileService()

--- a/server/polar/file/tasks.py
+++ b/server/polar/file/tasks.py
@@ -1,0 +1,44 @@
+from typing import Any
+
+import structlog
+
+from polar.config import settings
+from polar.worker import AsyncSessionMaker, TaskPriority, actor
+
+from .repository import FileRepository
+from .service import file as file_service
+
+log = structlog.get_logger()
+
+
+@actor(actor_name="file.guardduty_scan_result", priority=TaskPriority.MEDIUM)
+async def guardduty_scan_result(scan_result: dict[str, Any]) -> None:
+    s3_object = scan_result["s3ObjectDetails"]
+    bucket_name = s3_object["bucketName"]
+    object_key = s3_object["objectKey"]
+
+    if bucket_name not in (
+        settings.S3_FILES_BUCKET_NAME,
+        settings.S3_FILES_PUBLIC_BUCKET_NAME,
+    ):
+        log.warning(
+            "file.guardduty_scan_result.unexpected_bucket",
+            bucket_name=bucket_name,
+            object_key=object_key,
+        )
+        return
+
+    async with AsyncSessionMaker() as session:
+        repository = FileRepository.from_session(session)
+        file = await repository.get_by_path(object_key)
+        if file is None:
+            log.warning(
+                "file.guardduty_scan_result.file_not_found",
+                bucket_name=bucket_name,
+                object_key=object_key,
+            )
+            return
+
+        await file_service.flag_malicious(
+            session, file=file, scan_result_details=scan_result["scanResultDetails"]
+        )

--- a/server/polar/tasks.py
+++ b/server/polar/tasks.py
@@ -15,6 +15,7 @@ from polar.event import tasks as event
 from polar.eventstream import tasks as eventstream
 from polar.external_event import tasks as external_event
 from polar.feedback import tasks as feedback
+from polar.file import tasks as file
 from polar.integrations.chargeback_stop import tasks as chargeback_stop
 from polar.integrations.polar import tasks as polar_self
 from polar.integrations.stripe import tasks as stripe
@@ -57,6 +58,7 @@ __all__ = [
     "eventstream",
     "external_event",
     "feedback",
+    "file",
     "meter",
     "notifications",
     "oauth2",

--- a/server/tests/file/test_tasks.py
+++ b/server/tests/file/test_tasks.py
@@ -1,0 +1,148 @@
+import contextlib
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+from pytest_mock import MockerFixture
+
+from polar.config import settings
+from polar.file.tasks import guardduty_scan_result
+from polar.kit.utils import utc_now
+from polar.models import File, Organization
+from polar.models.file import FileServiceTypes
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+
+_guardduty_scan_result = guardduty_scan_result.__wrapped__  # type: ignore[attr-defined]
+
+THREATS = [{"name": "EICAR-Test-File (not a virus)"}]
+
+
+@contextlib.asynccontextmanager
+async def _session_maker(session: AsyncSession) -> AsyncIterator[AsyncSession]:
+    yield session
+
+
+def build_scan_result(bucket_name: str, object_key: str) -> dict[str, Any]:
+    return {
+        "schemaVersion": "1.0",
+        "scanStatus": "COMPLETED",
+        "resourceType": "S3_OBJECT",
+        "s3ObjectDetails": {
+            "bucketName": bucket_name,
+            "objectKey": object_key,
+            "eTag": "e0b4e5c5f76b4564d8ee6bbcd6e0e6f2",
+            "versionId": None,
+        },
+        "scanResultDetails": {
+            "scanResultStatus": "THREATS_FOUND",
+            "threats": THREATS,
+        },
+    }
+
+
+async def create_file(
+    save_fixture: SaveFixture,
+    organization: Organization,
+    *,
+    name: str = "whitepaper.pdf",
+) -> File:
+    file_id = uuid.uuid4()
+    file = File(
+        id=file_id,
+        organization=organization,
+        name=name,
+        path=f"downloadable/{organization.id}/{file_id}/{name}",
+        mime_type="application/pdf",
+        size=1234,
+        service=FileServiceTypes.downloadable,
+        is_uploaded=True,
+        is_enabled=True,
+    )
+    await save_fixture(file)
+    return file
+
+
+@pytest.mark.asyncio
+class TestGuardDutyScanResult:
+    async def test_flags_file(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        file = await create_file(save_fixture, organization)
+        mocker.patch(
+            "polar.file.tasks.AsyncSessionMaker",
+            side_effect=lambda: _session_maker(session),
+        )
+
+        await _guardduty_scan_result(
+            build_scan_result(settings.S3_FILES_BUCKET_NAME, file.path)
+        )
+
+        assert file.flagged_malicious_at is not None
+        assert file.flagged_malicious_details == {
+            "scanResultStatus": "THREATS_FOUND",
+            "threats": THREATS,
+        }
+
+    async def test_idempotent(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        file = await create_file(save_fixture, organization)
+        flagged_at = utc_now()
+        file.flagged_malicious_at = flagged_at
+        file.flagged_malicious_details = {"scanResultStatus": "THREATS_FOUND"}
+        await save_fixture(file)
+        mocker.patch(
+            "polar.file.tasks.AsyncSessionMaker",
+            side_effect=lambda: _session_maker(session),
+        )
+
+        await _guardduty_scan_result(
+            build_scan_result(settings.S3_FILES_BUCKET_NAME, file.path)
+        )
+
+        assert file.flagged_malicious_at == flagged_at
+        assert file.flagged_malicious_details == {"scanResultStatus": "THREATS_FOUND"}
+
+    async def test_unknown_object_key(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+    ) -> None:
+        mocker.patch(
+            "polar.file.tasks.AsyncSessionMaker",
+            side_effect=lambda: _session_maker(session),
+        )
+
+        await _guardduty_scan_result(
+            build_scan_result(
+                settings.S3_FILES_BUCKET_NAME, "e2e-artifacts/unknown.bin"
+            )
+        )
+
+    async def test_unexpected_bucket(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        file = await create_file(save_fixture, organization)
+        mocker.patch(
+            "polar.file.tasks.AsyncSessionMaker",
+            side_effect=lambda: _session_maker(session),
+        )
+
+        await _guardduty_scan_result(build_scan_result("some-other-bucket", file.path))
+
+        assert file.flagged_malicious_at is None
+        assert file.flagged_malicious_details is None

--- a/terraform/modules/aws_task_worker/outputs.tf
+++ b/terraform/modules/aws_task_worker/outputs.tf
@@ -8,6 +8,11 @@ output "queue_arn" {
   value       = aws_sqs_queue.task.arn
 }
 
+output "dlq_url" {
+  description = "Dead-letter queue URL."
+  value       = aws_sqs_queue.dlq.url
+}
+
 output "dlq_arn" {
   description = "Dead-letter queue ARN."
   value       = aws_sqs_queue.dlq.arn

--- a/terraform/modules/guardduty_scan_events/main.tf
+++ b/terraform/modules/guardduty_scan_events/main.tf
@@ -1,0 +1,121 @@
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.55"
+    }
+  }
+}
+
+variable "environment" {
+  description = "Environment to run in"
+  type        = string
+
+  validation {
+    condition     = contains(["production", "sandbox", "test"], var.environment)
+    error_message = "Must be either \"production\", \"sandbox\" or \"test\"."
+  }
+}
+
+variable "bucket_names" {
+  description = "S3 bucket names whose GuardDuty scan results are delivered to the task queue"
+  type        = list(string)
+}
+
+variable "queue_arn" {
+  description = "Task queue ARN scan results are delivered to"
+  type        = string
+}
+
+variable "queue_url" {
+  description = "Task queue URL scan results are delivered to"
+  type        = string
+}
+
+variable "dlq_arn" {
+  description = "Dead-letter queue ARN for undeliverable events"
+  type        = string
+}
+
+variable "dlq_url" {
+  description = "Dead-letter queue URL for undeliverable events"
+  type        = string
+}
+
+resource "aws_cloudwatch_event_rule" "threats_found" {
+  name        = "polar-${var.environment}-guardduty-scan-threats-found"
+  description = "GuardDuty Malware Protection THREATS_FOUND results for ${var.environment} buckets, delivered to the task worker."
+  event_pattern = jsonencode({
+    source      = ["aws.guardduty"]
+    detail-type = ["GuardDuty Malware Protection Object Scan Result"]
+    detail = {
+      scanStatus = ["COMPLETED"]
+      s3ObjectDetails = {
+        bucketName = var.bucket_names
+      }
+      scanResultDetails = {
+        scanResultStatus = ["THREATS_FOUND"]
+      }
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "threats_found" {
+  rule = aws_cloudwatch_event_rule.threats_found.name
+  arn  = var.queue_arn
+
+  input_transformer {
+    input_paths = {
+      detail = "$.detail"
+    }
+    input_template = "{\"actor\":\"file.guardduty_scan_result\",\"kwargs\":{\"scan_result\":<detail>}}"
+  }
+
+  dead_letter_config {
+    arn = var.dlq_arn
+  }
+}
+
+resource "aws_sqs_queue_policy" "queue" {
+  queue_url = var.queue_url
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowEventBridgeSend"
+        Effect    = "Allow"
+        Principal = { Service = "events.amazonaws.com" }
+        Action    = "sqs:SendMessage"
+        Resource  = var.queue_arn
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn" = aws_cloudwatch_event_rule.threats_found.arn
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_sqs_queue_policy" "dlq" {
+  queue_url = var.dlq_url
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowEventBridgeSend"
+        Effect    = "Allow"
+        Principal = { Service = "events.amazonaws.com" }
+        Action    = "sqs:SendMessage"
+        Resource  = var.dlq_arn
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn" = aws_cloudwatch_event_rule.threats_found.arn
+          }
+        }
+      },
+    ]
+  })
+}

--- a/terraform/production/aws.tf
+++ b/terraform/production/aws.tf
@@ -163,3 +163,17 @@ module "github_oidc_lambda_worker" {
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
 }
 
+# =============================================================================
+# GuardDuty malware scan results → tasks queue
+# =============================================================================
+
+module "guardduty_scan_events" {
+  source = "../modules/guardduty_scan_events"
+
+  environment  = "production"
+  bucket_names = ["polar-production-files", "polar-public-files"]
+  queue_arn    = module.lambda_worker.queue_arn
+  queue_url    = module.lambda_worker.queue_url
+  dlq_arn      = module.lambda_worker.dlq_arn
+  dlq_url      = module.lambda_worker.dlq_url
+}

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -172,3 +172,18 @@ module "github_oidc_lambda_worker" {
   }
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
 }
+
+# =============================================================================
+# GuardDuty malware scan results → tasks queue
+# =============================================================================
+
+module "guardduty_scan_events" {
+  source = "../modules/guardduty_scan_events"
+
+  environment  = "sandbox"
+  bucket_names = ["polar-sandbox-files", "polar-public-sandbox-files"]
+  queue_arn    = module.lambda_worker.queue_arn
+  queue_url    = module.lambda_worker.queue_url
+  dlq_arn      = module.lambda_worker.dlq_arn
+  dlq_url      = module.lambda_worker.dlq_url
+}

--- a/terraform/test/aws.tf
+++ b/terraform/test/aws.tf
@@ -175,3 +175,18 @@ module "github_oidc_lambda_worker" {
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
 }
 
+# =============================================================================
+# GuardDuty malware scan results → tasks queue
+# =============================================================================
+
+module "guardduty_scan_events" {
+  source = "../modules/guardduty_scan_events"
+  count  = local.test_enabled ? 1 : 0
+
+  environment  = "test"
+  bucket_names = ["polar-test-files", "polar-test-public-files"]
+  queue_arn    = module.lambda_worker[0].queue_arn
+  queue_url    = module.lambda_worker[0].queue_url
+  dlq_arn      = module.lambda_worker[0].dlq_arn
+  dlq_url      = module.lambda_worker[0].dlq_url
+}


### PR DESCRIPTION
This just stores the maliciousness of the files, it doesn't do anything with them yet.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

