### PR TITLE
chore(terraform): add POLAR_GOOGLE_SERVICE_ACCOUNT_JSON secret

### DIFF
--- a/terraform/global/production.tf
+++ b/terraform/global/production.tf
@@ -28,6 +28,14 @@ resource "tfe_variable" "google_client_secret_production" {
   variable_set_id = tfe_variable_set.production.id
 }
 
+resource "tfe_variable" "google_service_account_json_production" {
+  key             = "google_service_account_json"
+  category        = "terraform"
+  description     = "Google service account JSON key for fetching the organization review AUP for production"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.production.id
+}
+
 resource "tfe_variable" "openai_api_key_production" {
   key             = "openai_api_key_production"
   category        = "terraform"

--- a/terraform/global/sandbox.tf
+++ b/terraform/global/sandbox.tf
@@ -28,6 +28,14 @@ resource "tfe_variable" "google_client_secret_sandbox" {
   variable_set_id = tfe_variable_set.sandbox.id
 }
 
+resource "tfe_variable" "google_service_account_json_sandbox" {
+  key             = "google_service_account_json"
+  category        = "terraform"
+  description     = "Google service account JSON key for fetching the organization review AUP for sandbox"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.sandbox.id
+}
+
 resource "tfe_variable" "openai_api_key_sandbox" {
   key             = "openai_api_key_sandbox"
   category        = "terraform"

--- a/terraform/global/test.tf
+++ b/terraform/global/test.tf
@@ -28,6 +28,14 @@ resource "tfe_variable" "google_client_secret_test" {
   variable_set_id = tfe_variable_set.test.id
 }
 
+resource "tfe_variable" "google_service_account_json_test" {
+  key             = "google_service_account_json"
+  category        = "terraform"
+  description     = "Google service account JSON key for fetching the organization review AUP for test"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.test.id
+}
+
 resource "tfe_variable" "openai_api_key_test" {
   key             = "openai_api_key"
   category        = "terraform"

--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -11,8 +11,9 @@ resource "render_env_group" "google" {
   environment_id = var.render_environment_id
   name           = "google-${var.environment}"
   env_vars = {
-    POLAR_GOOGLE_CLIENT_ID     = { value = var.google_secrets.client_id }
-    POLAR_GOOGLE_CLIENT_SECRET = { value = var.google_secrets.client_secret }
+    POLAR_GOOGLE_CLIENT_ID            = { value = var.google_secrets.client_id }
+    POLAR_GOOGLE_CLIENT_SECRET        = { value = var.google_secrets.client_secret }
+    POLAR_GOOGLE_SERVICE_ACCOUNT_JSON = { value = var.google_secrets.service_account_json }
   }
 }
 

--- a/terraform/modules/render_service/variables.tf
+++ b/terraform/modules/render_service/variables.tf
@@ -88,8 +88,9 @@ variable "redis_config" {
 variable "google_secrets" {
   description = "Google secrets (sensitive)"
   type = object({
-    client_id     = string
-    client_secret = string
+    client_id            = string
+    client_secret        = string
+    service_account_json = string
   })
   sensitive = true
 }

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -220,8 +220,9 @@ module "production" {
   }
 
   google_secrets = {
-    client_id     = var.google_client_id_production
-    client_secret = var.google_client_secret_production
+    client_id            = var.google_client_id_production
+    client_secret        = var.google_client_secret_production
+    service_account_json = var.google_service_account_json
   }
 
   openai_secrets = {

--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -27,6 +27,12 @@ variable "google_client_secret_production" {
   sensitive   = true
 }
 
+variable "google_service_account_json" {
+  description = "Google service account JSON key for fetching the organization review AUP"
+  type        = string
+  sensitive   = true
+}
+
 # OpenAI
 variable "openai_api_key_production" {
   description = "OpenAI API Key for production"

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -176,8 +176,9 @@ module "sandbox" {
   }
 
   google_secrets = {
-    client_id     = var.google_client_id_sandbox
-    client_secret = var.google_client_secret_sandbox
+    client_id            = var.google_client_id_sandbox
+    client_secret        = var.google_client_secret_sandbox
+    service_account_json = var.google_service_account_json
   }
 
   openai_secrets = {

--- a/terraform/sandbox/variables.tf
+++ b/terraform/sandbox/variables.tf
@@ -26,6 +26,12 @@ variable "google_client_secret_sandbox" {
   sensitive   = true
 }
 
+variable "google_service_account_json" {
+  description = "Google service account JSON key for fetching the organization review AUP"
+  type        = string
+  sensitive   = true
+}
+
 variable "openai_api_key_sandbox" {
   description = "OpenAI API Key for sandbox"
   type        = string

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -161,8 +161,9 @@ module "test" {
   }
 
   google_secrets = {
-    client_id     = var.google_client_id
-    client_secret = var.google_client_secret
+    client_id            = var.google_client_id
+    client_secret        = var.google_client_secret
+    service_account_json = var.google_service_account_json
   }
 
   openai_secrets = {

--- a/terraform/test/variables.tf
+++ b/terraform/test/variables.tf
@@ -23,6 +23,12 @@ variable "google_client_secret" {
   sensitive   = true
 }
 
+variable "google_service_account_json" {
+  description = "Google service account JSON key for fetching the organization review AUP"
+  type        = string
+  sensitive   = true
+}
+
 # OpenAI
 variable "openai_api_key" {
   description = "OpenAI API Key for production"


### PR DESCRIPTION
## Summary

Declares and wires a new sensitive Terraform Cloud variable, `POLAR_GOOGLE_SERVICE_ACCOUNT_JSON`, so a Google service account key can be pasted in the TFC UI and delivered to the Render backend across production, sandbox, and test.

## What

- Adds `tfe_variable "google_service_account_json_{env}"` to each `terraform/global/{env}.tf` (key `google_service_account_json`, sensitive).
- Adds the matching `variable "google_service_account_json"` to each `terraform/{env}/variables.tf`.
- Extends the shared `google_secrets` object (`terraform/modules/render_service/variables.tf`) with `service_account_json` and maps it to `POLAR_GOOGLE_SERVICE_ACCOUNT_JSON` in the `google` env group (`main.tf`).
- Passes the value through each `terraform/{env}/render.tf` `google_secrets` block.

## Why

The organization review agent will fetch its Acceptable Use Policy from a restricted Google Doc via the Drive API, which needs a service account credential. The backend code that consumes this env var ships in a separate PR.

## How

Follows the existing `google_secrets` pattern (`client_id` / `client_secret`), adding a third field so the secret rides the same themed env group. The value is held in TFC (no value baked into code).

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

Note: value must be set in TFC (Production / Sandbox / Test variable sets) before the backend can use it.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

