### PR TITLE
files: Add index on path

### DIFF
--- a/server/migrations/versions/2026-07-08-1636_add_index_on_files_path.py
+++ b/server/migrations/versions/2026-07-08-1636_add_index_on_files_path.py
@@ -1,0 +1,48 @@
+"""add index on files path
+
+Revision ID: 40d0bc3f9994
+Revises: f2f377ed2cf5
+Create Date: 2026-07-08 16:36:03.674781
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "40d0bc3f9994"
+down_revision = "f2f377ed2cf5"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+INDEX = "ix_files_path"
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        # Drop any INVALID leftover from an interrupted concurrent build first.
+        op.drop_index(
+            INDEX,
+            table_name="files",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            INDEX,
+            "files",
+            ["path"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            INDEX,
+            table_name="files",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )

--- a/server/polar/models/file.py
+++ b/server/polar/models/file.py
@@ -50,7 +50,7 @@ class File(RecordModel):
 
     name: Mapped[str] = mapped_column(String, nullable=False)
     version: Mapped[str | None] = mapped_column(String, nullable=True)
-    path: Mapped[str] = mapped_column(String, nullable=False)
+    path: Mapped[str] = mapped_column(String, nullable=False, index=True)
     mime_type: Mapped[str] = mapped_column(String, nullable=False)
     size: Mapped[int] = mapped_column(BigInteger, nullable=False)
 


### PR DESCRIPTION
To avoid a full table scan when looking up a file by it's path

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Postgres index on `files.path` to speed up path lookups and avoid full table scans. The model column is set to `index=True`, and the migration creates the index concurrently after dropping any leftover invalid `ix_files_path`.

<sup>Written for commit b0d1044c291cf2e676ce0543ea58b733204e5ddd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

