### PR TITLE
tf: Create admin assumable role in security account

### DIFF
--- a/terraform/organization/identity_center.tf
+++ b/terraform/organization/identity_center.tf
@@ -8,9 +8,10 @@ locals {
     sandbox    = local.workload_accounts.sandbox.id
     test       = local.workload_accounts.test.id
     identity   = local.identity_account.id
+    security   = local.security_account.id
   }
 
-  staff_default_accounts = setsubtract(keys(local.staff_target_accounts), ["identity"])
+  staff_default_accounts = setsubtract(keys(local.staff_target_accounts), ["identity", "security"])
 
   identity_center_groups = {
     awsadmins    = { display_name = "AWS Access" }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds the Security account to Identity Center target accounts and excludes it from default staff targets, enabling an admin-assumable role in the security account without granting default access. This provides controlled SSO access while keeping least-privilege defaults.

<sup>Written for commit 46d9dadac1f49f20d6351eab9b4e48afdb9916c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

