### PR TITLE
aws: Forward event-bridge from mgmt to application account

### DIFF
--- a/terraform/modules/guardduty_scan_events/main.tf
+++ b/terraform/modules/guardduty_scan_events/main.tf
@@ -44,9 +44,40 @@ variable "dlq_url" {
   type        = string
 }
 
+variable "source_account_id" {
+  description = "AWS account ID that owns the GuardDuty malware protection plans and forwards scan results to this bus"
+  type        = string
+}
+
+resource "aws_cloudwatch_event_bus" "guardduty" {
+  name = "polar-${var.environment}-guardduty-scan-results"
+}
+
+resource "aws_cloudwatch_event_bus_policy" "guardduty" {
+  event_bus_name = aws_cloudwatch_event_bus.guardduty.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AllowManagementAccountPutEvents"
+        Effect    = "Allow"
+        Principal = { AWS = "arn:aws:iam::${var.source_account_id}:root" }
+        Action    = "events:PutEvents"
+        Resource  = aws_cloudwatch_event_bus.guardduty.arn
+        Condition = {
+          BoolIfExists = {
+            "events:eventBusInvocation" = "true"
+          }
+        }
+      },
+    ]
+  })
+}
+
 resource "aws_cloudwatch_event_rule" "threats_found" {
-  name        = "polar-${var.environment}-guardduty-scan-threats-found"
-  description = "GuardDuty Malware Protection THREATS_FOUND results for ${var.environment} buckets, delivered to the task worker."
+  name           = "polar-${var.environment}-guardduty-scan-threats-found"
+  event_bus_name = aws_cloudwatch_event_bus.guardduty.name
+  description    = "GuardDuty Malware Protection THREATS_FOUND results for ${var.environment} buckets, delivered to the task worker."
   event_pattern = jsonencode({
     source      = ["aws.guardduty"]
     detail-type = ["GuardDuty Malware Protection Object Scan Result"]
@@ -63,8 +94,9 @@ resource "aws_cloudwatch_event_rule" "threats_found" {
 }
 
 resource "aws_cloudwatch_event_target" "threats_found" {
-  rule = aws_cloudwatch_event_rule.threats_found.name
-  arn  = var.queue_arn
+  rule           = aws_cloudwatch_event_rule.threats_found.name
+  event_bus_name = aws_cloudwatch_event_bus.guardduty.name
+  arn            = var.queue_arn
 
   input_transformer {
     input_paths = {

--- a/terraform/modules/guardduty_scan_forwarding/main.tf
+++ b/terraform/modules/guardduty_scan_forwarding/main.tf
@@ -1,0 +1,105 @@
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.55"
+    }
+  }
+}
+
+variable "environment" {
+  description = "Environment to run in"
+  type        = string
+
+  validation {
+    condition     = contains(["production", "sandbox", "test"], var.environment)
+    error_message = "Must be either \"production\", \"sandbox\" or \"test\"."
+  }
+}
+
+variable "bucket_names" {
+  description = "S3 bucket names whose GuardDuty scan results are forwarded to the workload account"
+  type        = list(string)
+}
+
+variable "destination_account_id" {
+  description = "Workload AWS account ID that receives the forwarded scan results"
+  type        = string
+}
+
+variable "permissions_boundary_arn" {
+  description = "Permission boundary applied to the forwarding role"
+  type        = string
+  default     = null
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+locals {
+  destination_bus_arn = "arn:aws:events:${data.aws_region.current.name}:${var.destination_account_id}:event-bus/polar-${var.environment}-guardduty-scan-results"
+}
+
+resource "aws_iam_role" "forward" {
+  name                 = "polar-${var.environment}-guardduty-scan-forwarding"
+  permissions_boundary = var.permissions_boundary_arn
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "events.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "forward" {
+  name = "put-events"
+  role = aws_iam_role.forward.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "events:PutEvents"
+        Resource = local.destination_bus_arn
+      },
+    ]
+  })
+}
+
+resource "aws_cloudwatch_event_rule" "forward" {
+  name        = "polar-${var.environment}-guardduty-scan-forward"
+  description = "Forward GuardDuty Malware Protection THREATS_FOUND results for ${var.environment} buckets to the ${var.environment} workload account."
+  event_pattern = jsonencode({
+    source      = ["aws.guardduty"]
+    detail-type = ["GuardDuty Malware Protection Object Scan Result"]
+    detail = {
+      scanStatus = ["COMPLETED"]
+      s3ObjectDetails = {
+        bucketName = var.bucket_names
+      }
+      scanResultDetails = {
+        scanResultStatus = ["THREATS_FOUND"]
+      }
+    }
+  })
+}
+
+resource "aws_cloudwatch_event_target" "forward" {
+  rule     = aws_cloudwatch_event_rule.forward.name
+  arn      = local.destination_bus_arn
+  role_arn = aws_iam_role.forward.arn
+}

--- a/terraform/organization/guardduty_scan_forwarding.tf
+++ b/terraform/organization/guardduty_scan_forwarding.tf
@@ -1,0 +1,44 @@
+module "production_guardduty_scan_forwarding" {
+  source = "../modules/guardduty_scan_forwarding"
+  providers = {
+    aws = aws.us_east_2
+  }
+
+  environment = "production"
+  bucket_names = [
+    module.production_s3_buckets.files_bucket_id,
+    module.production_s3_buckets.public_files_bucket_id,
+  ]
+  destination_account_id   = local.workload_accounts.production.id
+  permissions_boundary_arn = module.permission_boundary_management.policy_arn
+}
+
+module "sandbox_guardduty_scan_forwarding" {
+  source = "../modules/guardduty_scan_forwarding"
+  providers = {
+    aws = aws.us_east_2
+  }
+
+  environment = "sandbox"
+  bucket_names = [
+    module.sandbox_s3_buckets.files_bucket_id,
+    module.sandbox_s3_buckets.public_files_bucket_id,
+  ]
+  destination_account_id   = local.workload_accounts.sandbox.id
+  permissions_boundary_arn = module.permission_boundary_management.policy_arn
+}
+
+module "test_guardduty_scan_forwarding" {
+  source = "../modules/guardduty_scan_forwarding"
+  providers = {
+    aws = aws.us_east_2
+  }
+
+  environment = "test"
+  bucket_names = [
+    module.test_s3_buckets.files_bucket_id,
+    module.test_s3_buckets.public_files_bucket_id,
+  ]
+  destination_account_id   = local.workload_accounts.test.id
+  permissions_boundary_arn = module.permission_boundary_management.policy_arn
+}

--- a/terraform/production/aws.tf
+++ b/terraform/production/aws.tf
@@ -170,10 +170,11 @@ module "github_oidc_lambda_worker" {
 module "guardduty_scan_events" {
   source = "../modules/guardduty_scan_events"
 
-  environment  = "production"
-  bucket_names = ["polar-production-files", "polar-public-files"]
-  queue_arn    = module.lambda_worker.queue_arn
-  queue_url    = module.lambda_worker.queue_url
-  dlq_arn      = module.lambda_worker.dlq_arn
-  dlq_url      = module.lambda_worker.dlq_url
+  environment       = "production"
+  bucket_names      = ["polar-production-files", "polar-public-files"]
+  source_account_id = "975049931254"
+  queue_arn         = module.lambda_worker.queue_arn
+  queue_url         = module.lambda_worker.queue_url
+  dlq_arn           = module.lambda_worker.dlq_arn
+  dlq_url           = module.lambda_worker.dlq_url
 }

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -180,10 +180,11 @@ module "github_oidc_lambda_worker" {
 module "guardduty_scan_events" {
   source = "../modules/guardduty_scan_events"
 
-  environment  = "sandbox"
-  bucket_names = ["polar-sandbox-files", "polar-public-sandbox-files"]
-  queue_arn    = module.lambda_worker.queue_arn
-  queue_url    = module.lambda_worker.queue_url
-  dlq_arn      = module.lambda_worker.dlq_arn
-  dlq_url      = module.lambda_worker.dlq_url
+  environment       = "sandbox"
+  bucket_names      = ["polar-sandbox-files", "polar-public-sandbox-files"]
+  source_account_id = "975049931254"
+  queue_arn         = module.lambda_worker.queue_arn
+  queue_url         = module.lambda_worker.queue_url
+  dlq_arn           = module.lambda_worker.dlq_arn
+  dlq_url           = module.lambda_worker.dlq_url
 }

--- a/terraform/test/aws.tf
+++ b/terraform/test/aws.tf
@@ -183,10 +183,11 @@ module "guardduty_scan_events" {
   source = "../modules/guardduty_scan_events"
   count  = local.test_enabled ? 1 : 0
 
-  environment  = "test"
-  bucket_names = ["polar-test-files", "polar-test-public-files"]
-  queue_arn    = module.lambda_worker[0].queue_arn
-  queue_url    = module.lambda_worker[0].queue_url
-  dlq_arn      = module.lambda_worker[0].dlq_arn
-  dlq_url      = module.lambda_worker[0].dlq_url
+  environment       = "test"
+  bucket_names      = ["polar-test-files", "polar-test-public-files"]
+  source_account_id = "975049931254"
+  queue_arn         = module.lambda_worker[0].queue_arn
+  queue_url         = module.lambda_worker[0].queue_url
+  dlq_arn           = module.lambda_worker[0].dlq_arn
+  dlq_url           = module.lambda_worker[0].dlq_url
 }


### PR DESCRIPTION
Since the S3 bucket lives inside of the mgmt account (previous only account), the guard duty results end up in event bridge in the mgmt account instead of the respective accounts.

We need the results in the application account to be able to run the correct lambda.

This sets up forwarding from mgmt account to the correct account, and sets up permissions to allow that forwarding to happen.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

