### PR TITLE
Increase length of meta description

### DIFF
--- a/clients/apps/web/src/app/(main)/(website)/(landing)/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/page.tsx
@@ -2,7 +2,8 @@ import { Metadata } from 'next'
 import LandingPage from '../../../../components/Landing/LandingPage'
 export const metadata: Metadata = {
   title: 'Polar — A billing platform for the intelligence era',
-  description: 'A billing platform for the intelligence era',
+  description:
+    'Polar is the Merchant of Record for developers building AI-era software: payments, subscriptions, and usage-based billing, with global tax handled for you.',
   keywords:
     'monetization, merchant of record, saas, digital products, platform, developer, open source, funding, open source, economy',
   openGraph: {


### PR DESCRIPTION
## Summary

This surfaced on X:

<img width="1772" height="572" alt="HMtka37XUAAgLsS" src="https://github.com/user-attachments/assets/c2ecf3b0-bab7-4199-b8dd-7a3299b862ef" />

And apparently Google can sometimes just ignore showing our `meta.description` if they deem that it's bad, and instead just show something they think is relevant:

* https://ahrefs.com/blog/meta-description-study/
* https://portent.com/blog/seo/how-often-google-ignores-our-meta-descriptions.htm
* https://www.searchenginejournal.com/google-rewrites-meta-descriptions-over-70-of-the-time/382140/

Our current meta description is kinda bad since it just say what the title is (and is really short). So this PR will try to circumvent this issue by adding a longer, more descriptive, description

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

