### PR TITLE
tf: Ensure that lambda has correct bucket names

### DIFF
--- a/terraform/production/aws.tf
+++ b/terraform/production/aws.tf
@@ -34,28 +34,33 @@ resource "aws_vpc_security_group_ingress_rule" "redis_lambda" {
 }
 
 locals {
+  files_bucket_name        = "polar-production-files"
+  files_public_bucket_name = "polar-public-files"
+
   lambda_worker_environment = {
-    POLAR_ENV                     = "production"
-    POLAR_BASE_URL                = "https://api.polar.sh"
-    POLAR_FRONTEND_BASE_URL       = "https://polar.sh"
-    POLAR_CHECKOUT_BASE_URL       = "https://buy.polar.sh/{client_secret}"
-    POLAR_JWKS                    = "/tmp/jwks.json"
-    POLAR_LOG_LEVEL               = "INFO"
-    POLAR_TESTING                 = "0"
-    POLAR_POSTGRES_DATABASE       = "polar_cpit_p9lf"
-    POLAR_POSTGRES_HOST           = local.db_external_host
-    POLAR_POSTGRES_PORT           = local.db_port
-    POLAR_POSTGRES_USER           = local.db_user
-    POLAR_POSTGRES_SSL            = "true"
-    POLAR_REDIS_HOST              = module.redis.host
-    POLAR_REDIS_PORT              = tostring(module.redis.port)
-    POLAR_REDIS_DB                = "1"
-    POLAR_AWS_REGION              = "us-east-2"
-    POLAR_EMAIL_SENDER            = "resend"
-    POLAR_EMAIL_FROM_NAME         = "Polar"
-    POLAR_EMAIL_FROM_DOMAIN       = "notifications.polar.sh"
-    POLAR_WORKER_SQS_ENABLED      = "true"
-    POLAR_WORKER_SQS_QUEUE_PREFIX = "polar-production-tasks"
+    POLAR_ENV                         = "production"
+    POLAR_BASE_URL                    = "https://api.polar.sh"
+    POLAR_FRONTEND_BASE_URL           = "https://polar.sh"
+    POLAR_CHECKOUT_BASE_URL           = "https://buy.polar.sh/{client_secret}"
+    POLAR_JWKS                        = "/tmp/jwks.json"
+    POLAR_LOG_LEVEL                   = "INFO"
+    POLAR_TESTING                     = "0"
+    POLAR_POSTGRES_DATABASE           = "polar_cpit_p9lf"
+    POLAR_POSTGRES_HOST               = local.db_external_host
+    POLAR_POSTGRES_PORT               = local.db_port
+    POLAR_POSTGRES_USER               = local.db_user
+    POLAR_POSTGRES_SSL                = "true"
+    POLAR_REDIS_HOST                  = module.redis.host
+    POLAR_REDIS_PORT                  = tostring(module.redis.port)
+    POLAR_REDIS_DB                    = "1"
+    POLAR_AWS_REGION                  = "us-east-2"
+    POLAR_S3_FILES_BUCKET_NAME        = local.files_bucket_name
+    POLAR_S3_FILES_PUBLIC_BUCKET_NAME = local.files_public_bucket_name
+    POLAR_EMAIL_SENDER                = "resend"
+    POLAR_EMAIL_FROM_NAME             = "Polar"
+    POLAR_EMAIL_FROM_DOMAIN           = "notifications.polar.sh"
+    POLAR_WORKER_SQS_ENABLED          = "true"
+    POLAR_WORKER_SQS_QUEUE_PREFIX     = "polar-production-tasks"
   }
 
   lambda_worker_secrets = {
@@ -171,7 +176,7 @@ module "guardduty_scan_events" {
   source = "../modules/guardduty_scan_events"
 
   environment       = "production"
-  bucket_names      = ["polar-production-files", "polar-public-files"]
+  bucket_names      = [local.files_bucket_name, local.files_public_bucket_name]
   source_account_id = "975049931254"
   queue_arn         = module.lambda_worker.queue_arn
   queue_url         = module.lambda_worker.queue_url

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -337,7 +337,7 @@ module "production" {
     region                        = "us-east-2"
     signature_version             = "v4"
     files_presign_ttl             = "3600"
-    files_public_bucket_name      = "polar-public-files"
+    files_public_bucket_name      = local.files_public_bucket_name
     customer_invoices_bucket_name = "polar-customer-invoices"
     customer_receipts_bucket_name = "polar-customer-receipts"
     payout_invoices_bucket_name   = "polar-payout-invoices"

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -34,28 +34,33 @@ resource "aws_vpc_security_group_ingress_rule" "redis_lambda" {
 }
 
 locals {
+  files_bucket_name        = "polar-sandbox-files"
+  files_public_bucket_name = "polar-public-sandbox-files"
+
   lambda_worker_environment = {
-    POLAR_ENV                     = "sandbox"
-    POLAR_BASE_URL                = "https://sandbox-api.polar.sh"
-    POLAR_FRONTEND_BASE_URL       = "https://sandbox.polar.sh"
-    POLAR_CHECKOUT_BASE_URL       = "https://sandbox-api.polar.sh/v1/checkout-links/{client_secret}/redirect"
-    POLAR_JWKS                    = "/tmp/jwks.json"
-    POLAR_LOG_LEVEL               = "INFO"
-    POLAR_TESTING                 = "0"
-    POLAR_POSTGRES_DATABASE       = "polar_sandbox"
-    POLAR_POSTGRES_HOST           = local.db_external_host
-    POLAR_POSTGRES_PORT           = local.db_port
-    POLAR_POSTGRES_USER           = local.db_user
-    POLAR_POSTGRES_SSL            = "true"
-    POLAR_REDIS_HOST              = module.redis.host
-    POLAR_REDIS_PORT              = tostring(module.redis.port)
-    POLAR_REDIS_DB                = "1"
-    POLAR_AWS_REGION              = "us-east-2"
-    POLAR_EMAIL_SENDER            = "resend"
-    POLAR_EMAIL_FROM_NAME         = "[SANDBOX] Polar"
-    POLAR_EMAIL_FROM_DOMAIN       = "notifications.sandbox.polar.sh"
-    POLAR_WORKER_SQS_ENABLED      = "true"
-    POLAR_WORKER_SQS_QUEUE_PREFIX = "polar-sandbox-tasks"
+    POLAR_ENV                         = "sandbox"
+    POLAR_BASE_URL                    = "https://sandbox-api.polar.sh"
+    POLAR_FRONTEND_BASE_URL           = "https://sandbox.polar.sh"
+    POLAR_CHECKOUT_BASE_URL           = "https://sandbox-api.polar.sh/v1/checkout-links/{client_secret}/redirect"
+    POLAR_JWKS                        = "/tmp/jwks.json"
+    POLAR_LOG_LEVEL                   = "INFO"
+    POLAR_TESTING                     = "0"
+    POLAR_POSTGRES_DATABASE           = "polar_sandbox"
+    POLAR_POSTGRES_HOST               = local.db_external_host
+    POLAR_POSTGRES_PORT               = local.db_port
+    POLAR_POSTGRES_USER               = local.db_user
+    POLAR_POSTGRES_SSL                = "true"
+    POLAR_REDIS_HOST                  = module.redis.host
+    POLAR_REDIS_PORT                  = tostring(module.redis.port)
+    POLAR_REDIS_DB                    = "1"
+    POLAR_AWS_REGION                  = "us-east-2"
+    POLAR_S3_FILES_BUCKET_NAME        = local.files_bucket_name
+    POLAR_S3_FILES_PUBLIC_BUCKET_NAME = local.files_public_bucket_name
+    POLAR_EMAIL_SENDER                = "resend"
+    POLAR_EMAIL_FROM_NAME             = "[SANDBOX] Polar"
+    POLAR_EMAIL_FROM_DOMAIN           = "notifications.sandbox.polar.sh"
+    POLAR_WORKER_SQS_ENABLED          = "true"
+    POLAR_WORKER_SQS_QUEUE_PREFIX     = "polar-sandbox-tasks"
   }
 
   lambda_worker_secrets = {
@@ -181,7 +186,7 @@ module "guardduty_scan_events" {
   source = "../modules/guardduty_scan_events"
 
   environment       = "sandbox"
-  bucket_names      = ["polar-sandbox-files", "polar-public-sandbox-files"]
+  bucket_names      = [local.files_bucket_name, local.files_public_bucket_name]
   source_account_id = "975049931254"
   queue_arn         = module.lambda_worker.queue_arn
   queue_url         = module.lambda_worker.queue_url

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -232,7 +232,7 @@ module "sandbox" {
     region                        = "us-east-2"
     signature_version             = "v4"
     files_presign_ttl             = "3600"
-    files_public_bucket_name      = "polar-public-sandbox-files"
+    files_public_bucket_name      = local.files_public_bucket_name
     customer_invoices_bucket_name = "polar-sandbox-customer-invoices"
     customer_receipts_bucket_name = "polar-sandbox-customer-receipts"
     payout_invoices_bucket_name   = "polar-sandbox-payout-invoices"

--- a/terraform/test/aws.tf
+++ b/terraform/test/aws.tf
@@ -38,28 +38,33 @@ resource "aws_vpc_security_group_ingress_rule" "redis_lambda" {
 }
 
 locals {
+  files_bucket_name        = "polar-test-files"
+  files_public_bucket_name = "polar-test-public-files"
+
   lambda_worker_environment = local.test_enabled ? {
-    POLAR_ENV                     = "test"
-    POLAR_BASE_URL                = "https://test-api.polar.sh"
-    POLAR_FRONTEND_BASE_URL       = "https://test.polar.sh"
-    POLAR_CHECKOUT_BASE_URL       = "https://test-api.polar.sh/v1/checkout-links/{client_secret}/redirect"
-    POLAR_JWKS                    = "/tmp/jwks.json"
-    POLAR_LOG_LEVEL               = "INFO"
-    POLAR_TESTING                 = "0"
-    POLAR_POSTGRES_DATABASE       = local.db_name
-    POLAR_POSTGRES_HOST           = local.db_external_host
-    POLAR_POSTGRES_PORT           = local.db_port
-    POLAR_POSTGRES_USER           = local.db_user
-    POLAR_POSTGRES_SSL            = "true"
-    POLAR_REDIS_HOST              = module.redis[0].host
-    POLAR_REDIS_PORT              = tostring(module.redis[0].port)
-    POLAR_REDIS_DB                = "1"
-    POLAR_AWS_REGION              = "us-east-2"
-    POLAR_EMAIL_SENDER            = "resend"
-    POLAR_EMAIL_FROM_NAME         = "[TEST] Polar"
-    POLAR_EMAIL_FROM_DOMAIN       = "notifications.test.polar.sh"
-    POLAR_WORKER_SQS_ENABLED      = "true"
-    POLAR_WORKER_SQS_QUEUE_PREFIX = "polar-test-tasks"
+    POLAR_ENV                         = "test"
+    POLAR_BASE_URL                    = "https://test-api.polar.sh"
+    POLAR_FRONTEND_BASE_URL           = "https://test.polar.sh"
+    POLAR_CHECKOUT_BASE_URL           = "https://test-api.polar.sh/v1/checkout-links/{client_secret}/redirect"
+    POLAR_JWKS                        = "/tmp/jwks.json"
+    POLAR_LOG_LEVEL                   = "INFO"
+    POLAR_TESTING                     = "0"
+    POLAR_POSTGRES_DATABASE           = local.db_name
+    POLAR_POSTGRES_HOST               = local.db_external_host
+    POLAR_POSTGRES_PORT               = local.db_port
+    POLAR_POSTGRES_USER               = local.db_user
+    POLAR_POSTGRES_SSL                = "true"
+    POLAR_REDIS_HOST                  = module.redis[0].host
+    POLAR_REDIS_PORT                  = tostring(module.redis[0].port)
+    POLAR_REDIS_DB                    = "1"
+    POLAR_AWS_REGION                  = "us-east-2"
+    POLAR_S3_FILES_BUCKET_NAME        = local.files_bucket_name
+    POLAR_S3_FILES_PUBLIC_BUCKET_NAME = local.files_public_bucket_name
+    POLAR_EMAIL_SENDER                = "resend"
+    POLAR_EMAIL_FROM_NAME             = "[TEST] Polar"
+    POLAR_EMAIL_FROM_DOMAIN           = "notifications.test.polar.sh"
+    POLAR_WORKER_SQS_ENABLED          = "true"
+    POLAR_WORKER_SQS_QUEUE_PREFIX     = "polar-test-tasks"
   } : {}
 
   lambda_worker_secrets = local.test_enabled ? {
@@ -184,7 +189,7 @@ module "guardduty_scan_events" {
   count  = local.test_enabled ? 1 : 0
 
   environment       = "test"
-  bucket_names      = ["polar-test-files", "polar-test-public-files"]
+  bucket_names      = [local.files_bucket_name, local.files_public_bucket_name]
   source_account_id = "975049931254"
   queue_arn         = module.lambda_worker[0].queue_arn
   queue_url         = module.lambda_worker[0].queue_url

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -217,7 +217,7 @@ module "test" {
     region                        = "us-east-2"
     signature_version             = "v4"
     files_presign_ttl             = "600"
-    files_public_bucket_name      = "polar-test-public-files"
+    files_public_bucket_name      = local.files_public_bucket_name
     customer_invoices_bucket_name = "polar-test-customer-invoices"
     customer_receipts_bucket_name = "polar-test-customer-receipts"
     payout_invoices_bucket_name   = "polar-test-payout-invoices"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure Lambda workers use the correct S3 bucket names across production, sandbox, and test by wiring names through locals and environment variables. This removes hard-coded strings and prevents misrouted file operations.

- **Bug Fixes**
  - Added `POLAR_S3_FILES_BUCKET_NAME` and `POLAR_S3_FILES_PUBLIC_BUCKET_NAME` to Lambda envs, sourced from new `locals`.
  - Replaced hard-coded GuardDuty `bucket_names` with `local.files_bucket_name` and `local.files_public_bucket_name`.
  - Updated Render modules to use `local.files_public_bucket_name` for `files_public_bucket_name`.

<sup>Written for commit 5c334e6ad78bf47b99ea0f5eee8a477a865091c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

