### PR TITLE
server: disable subscription_resume scheduler temporarily

### DIFF
--- a/server/polar/worker/scheduler.py
+++ b/server/polar/worker/scheduler.py
@@ -12,7 +12,6 @@ from polar.logging import configure as configure_logging
 from polar.sentry import configure_sentry
 from polar.subscription.scheduler import (
     SubscriptionJobStore,
-    SubscriptionResumeJobStore,
 )
 
 from ._broker import scheduler_middleware
@@ -53,7 +52,7 @@ def start() -> None:
 
     scheduler.add_jobstore(MemoryJobStore(), "memory")
     scheduler.add_jobstore(SubscriptionJobStore(), "subscription")
-    scheduler.add_jobstore(SubscriptionResumeJobStore(), "subscription_resume")
+    # scheduler.add_jobstore(SubscriptionResumeJobStore(), "subscription_resume")
 
     for func, cron_trigger in scheduler_middleware.cron_triggers:
         scheduler.add_job(func, cron_trigger, jobstore="memory")


### PR DESCRIPTION
- server: disable subscription_resume scheduler temporarily

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily disables the `subscription_resume` scheduler by skipping registration of `SubscriptionResumeJobStore` in the worker scheduler. This stops resume jobs from being scheduled or executed.

<sup>Written for commit bbda1ad5e2953cc6f5bde8e0eda5b3f6768a1610. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

