### PR TITLE
Revert "feat(subscription): cycle-style auto-resume scheduler (#12997)"

### DIFF
--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -409,6 +409,24 @@ class SubscriptionRepository(
         )
         return await self.get_all(statement)
 
+    async def get_subscriptions_to_resume(
+        self,
+        now: datetime,
+        *,
+        options: Options = (),
+    ) -> Sequence[Subscription]:
+        """Find paused subscriptions whose scheduled resume time has passed."""
+        statement = (
+            self.get_base_statement()
+            .where(
+                Subscription.status == SubscriptionStatus.paused,
+                Subscription.resumes_at.isnot(None),
+                Subscription.resumes_at <= now,
+            )
+            .options(*options)
+        )
+        return await self.get_all(statement)
+
     async def get_subscriptions_needing_trial_conversion_reminder(
         self,
         now: datetime,

--- a/server/polar/subscription/scheduler.py
+++ b/server/polar/subscription/scheduler.py
@@ -1,30 +1,26 @@
 import datetime
-from typing import ClassVar, cast
 
 import dramatiq
 import structlog
 from apscheduler.job import Job
 from apscheduler.jobstores.base import BaseJobStore
 from apscheduler.triggers.date import DateTrigger
-from sqlalchemy import ColumnElement, Select, select, update
+from sqlalchemy import Select, select, update
 from sqlalchemy.orm import Session
 
 from polar.kit.utils import utc_now
 from polar.logging import Logger
 from polar.models import Customer, Organization, Subscription
-from polar.models.subscription import SubscriptionStatus
 from polar.postgres import create_sync_engine
 
 log: Logger = structlog.get_logger()
 
 
-class _SubscriptionScheduleJobStore(BaseJobStore):
-    """APScheduler job store that turns subscription rows into date-triggered jobs,
-    dispatched under an atomic ``scheduler_locked_at`` claim."""
-
-    trigger_column: ClassVar[ColumnElement[datetime.datetime | None]]
-    job_id_prefix: ClassVar[str]
-    actor_name: ClassVar[str]
+class SubscriptionJobStore(BaseJobStore):
+    """
+    A custom job store for APScheduler that uses our subscription data to trigger
+    cycle jobs based on subscription dates
+    """
 
     def __init__(self, executor: str = "default") -> None:
         self.engine = create_sync_engine("scheduler")
@@ -38,27 +34,29 @@ class _SubscriptionScheduleJobStore(BaseJobStore):
         return None
 
     def get_due_jobs(self, now: datetime.datetime) -> list[Job]:
-        statement = self.scheduling_statement().where(self.trigger_column <= now)
+        statement = self.scheduling_statement().where(
+            Subscription.current_period_end <= now,
+        )
         jobs = self._list_jobs_from_statement(statement)
-        log.debug("Due jobs", count=len(jobs), store=self.job_id_prefix)
+        log.debug("Due jobs", count=len(jobs))
         return jobs
 
     def get_next_run_time(self) -> datetime.datetime | None:
         statement = (
-            self.scheduling_statement().with_only_columns(self.trigger_column).limit(1)
+            self.scheduling_statement()
+            .with_only_columns(Subscription.current_period_end)
+            .limit(1)
         )
         with self.engine.connect() as connection:
             result = connection.execute(statement)
             next_run_time = result.scalar_one_or_none()
-            log.debug(
-                "Next run time", next_run_time=next_run_time, store=self.job_id_prefix
-            )
+            log.debug("Next run time", next_run_time=next_run_time)
             return next_run_time
 
     def get_all_jobs(self) -> list[Job]:
         statement = self.scheduling_statement()
         jobs = self._list_jobs_from_statement(statement)
-        log.debug("All jobs", count=len(jobs), store=self.job_id_prefix)
+        log.debug("All jobs", count=len(jobs))
         return jobs
 
     def remove_job(self, job_id: str) -> None:
@@ -75,7 +73,7 @@ class _SubscriptionScheduleJobStore(BaseJobStore):
         with self.engine.begin() as connection:
             if connection.execute(statement).rowcount == 0:
                 return
-        actor = dramatiq.get_broker().get_actor(self.actor_name)
+        actor = dramatiq.get_broker().get_actor("subscription.cycle")
         actor.send(subscription_id=subscription_id)
 
     def add_job(self, job: Job) -> None:
@@ -94,12 +92,12 @@ class _SubscriptionScheduleJobStore(BaseJobStore):
         with Session(self.engine) as session:
             results = session.execute(
                 statement.with_only_columns(
-                    Subscription.id, self.trigger_column
+                    Subscription.id, Subscription.current_period_end
                 ).execution_options(stream_results=True, max_row_buffer=250)
             )
             for result in results.yield_per(250):
-                subscription_id, run_date = result._tuple()
-                trigger = DateTrigger(run_date, datetime.UTC)
+                subscription_id, current_period_end = result._tuple()
+                trigger = DateTrigger(current_period_end, datetime.UTC)
                 job_kwargs = {
                     **(self._scheduler._job_defaults if self._scheduler else {}),
                     "trigger": trigger,
@@ -107,7 +105,7 @@ class _SubscriptionScheduleJobStore(BaseJobStore):
                     "func": lambda: None,
                     "args": (),
                     "kwargs": {},
-                    "id": f"{self.job_id_prefix}:{subscription_id}",
+                    "id": f"subscriptions:cycle:{subscription_id}",
                     "name": None,
                     "next_run_time": trigger.run_date,
                     "misfire_grace_time": None,
@@ -117,21 +115,7 @@ class _SubscriptionScheduleJobStore(BaseJobStore):
 
     @staticmethod
     def scheduling_statement() -> Select[tuple[Subscription]]:
-        raise NotImplementedError
-
-
-class SubscriptionJobStore(_SubscriptionScheduleJobStore):
-    """Triggers ``subscription.cycle`` at each active subscription's period end."""
-
-    trigger_column = cast(
-        ColumnElement[datetime.datetime | None], Subscription.current_period_end
-    )
-    job_id_prefix = "subscriptions:cycle"
-    actor_name = "subscription.cycle"
-
-    @staticmethod
-    def scheduling_statement() -> Select[tuple[Subscription]]:
-        """Base query for subscriptions eligible for cycle scheduling.
+        """Base query for subscriptions eligible for scheduler processing.
 
         Returns an engine-agnostic ``Select`` — safe to execute via either
         a sync ``Session`` (production APScheduler) or an async ``AsyncSession``
@@ -150,33 +134,4 @@ class SubscriptionJobStore(_SubscriptionScheduleJobStore):
                 Subscription.current_period_end.is_not(None),
             )
             .order_by(Subscription.current_period_end.asc())
-        )
-
-
-class SubscriptionResumeJobStore(_SubscriptionScheduleJobStore):
-    """Triggers ``subscription.resume`` at each paused subscription's ``resumes_at``."""
-
-    trigger_column = cast(
-        ColumnElement[datetime.datetime | None], Subscription.resumes_at
-    )
-    job_id_prefix = "subscriptions:resume"
-    actor_name = "subscription.resume"
-
-    @staticmethod
-    def scheduling_statement() -> Select[tuple[Subscription]]:
-        """Paused subscriptions eligible for auto-resume. Excludes renewals-disabled
-        orgs — resuming charges immediately (the API path guards separately)."""
-        return (
-            select(Subscription)
-            .join(Customer, onclause=Customer.id == Subscription.customer_id)
-            .join(Organization, onclause=Organization.id == Customer.organization_id)
-            .where(
-                Customer.is_deleted.is_(False),
-                Organization.is_deleted.is_(False),
-                Organization.can_renew_subscriptions.is_(True),
-                Subscription.scheduler_locked_at.is_(None),
-                Subscription.status == SubscriptionStatus.paused,
-                Subscription.resumes_at.is_not(None),
-            )
-            .order_by(Subscription.resumes_at.asc())
         )

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1976,7 +1976,6 @@ class SubscriptionService:
         subscription.status = SubscriptionStatus.active
         subscription.paused_at = None
         subscription.resumes_at = None
-        subscription.scheduler_locked_at = None
 
         # Start a fresh billing period from now and charge immediately.
         subscription.current_period_start = now

--- a/server/polar/subscription/tasks.py
+++ b/server/polar/subscription/tasks.py
@@ -149,10 +149,24 @@ async def subscription_cancel_customer(customer_id: uuid.UUID) -> None:
         await subscription_service.cancel_customer(session, customer_id)
 
 
+@actor(
+    actor_name="subscription.scan_paused_resumptions",
+    cron_trigger=CronTrigger.from_crontab("15 * * * *"),
+    priority=TaskPriority.LOW,
+)
+async def scan_paused_resumptions() -> None:
+    """Scan for paused subscriptions due to resume and fan out."""
+    now = utc_now()
+    async with AsyncSessionMaker() as session:
+        repository = SubscriptionRepository.from_session(session)
+        subscriptions = await repository.get_subscriptions_to_resume(now)
+
+    for sub in subscriptions:
+        enqueue_job("subscription.resume", sub.id)
+
+
 @actor(actor_name="subscription.resume", priority=TaskPriority.MEDIUM)
 async def subscription_resume(subscription_id: uuid.UUID) -> None:
-    """Resume a paused subscription. Enqueued by the resume scheduler once its
-    ``resumes_at`` is reached (see ``SubscriptionResumeJobStore``)."""
     async with AsyncSessionMaker() as session:
         repository = SubscriptionRepository.from_session(session)
         subscription = await repository.get_by_id(
@@ -163,19 +177,10 @@ async def subscription_resume(subscription_id: uuid.UUID) -> None:
         if subscription is None:
             raise SubscriptionDoesNotExist(subscription_id)
 
-        now = utc_now()
-        is_due = (
-            subscription.can_resume()
-            and subscription.resumes_at is not None
-            and subscription.resumes_at <= now
-        )
-        if not is_due:
+        if not subscription.can_resume():
             log.info(
-                "Subscription is not due for resume, skipping",
+                "Subscription is no longer paused, skipping resume",
                 subscription_id=subscription_id,
-            )
-            await repository.update(
-                subscription, update_dict={"scheduler_locked_at": None}
             )
             return
 

--- a/server/polar/worker/scheduler.py
+++ b/server/polar/worker/scheduler.py
@@ -12,6 +12,7 @@ from polar.logging import configure as configure_logging
 from polar.sentry import configure_sentry
 from polar.subscription.scheduler import (
     SubscriptionJobStore,
+    SubscriptionResumeJobStore,
 )
 
 from ._broker import scheduler_middleware
@@ -52,7 +53,7 @@ def start() -> None:
 
     scheduler.add_jobstore(MemoryJobStore(), "memory")
     scheduler.add_jobstore(SubscriptionJobStore(), "subscription")
-    # scheduler.add_jobstore(SubscriptionResumeJobStore(), "subscription_resume")
+    scheduler.add_jobstore(SubscriptionResumeJobStore(), "subscription_resume")
 
     for func, cron_trigger in scheduler_middleware.cron_triggers:
         scheduler.add_job(func, cron_trigger, jobstore="memory")

--- a/server/polar/worker/scheduler.py
+++ b/server/polar/worker/scheduler.py
@@ -10,10 +10,7 @@ from polar import tasks
 from polar.logfire import configure_logfire
 from polar.logging import configure as configure_logging
 from polar.sentry import configure_sentry
-from polar.subscription.scheduler import (
-    SubscriptionJobStore,
-    SubscriptionResumeJobStore,
-)
+from polar.subscription.scheduler import SubscriptionJobStore
 
 from ._broker import scheduler_middleware
 from ._health import _run_exposition_server, set_heartbeat_checker
@@ -53,7 +50,6 @@ def start() -> None:
 
     scheduler.add_jobstore(MemoryJobStore(), "memory")
     scheduler.add_jobstore(SubscriptionJobStore(), "subscription")
-    scheduler.add_jobstore(SubscriptionResumeJobStore(), "subscription_resume")
 
     for func, cron_trigger in scheduler_middleware.cron_triggers:
         scheduler.add_job(func, cron_trigger, jobstore="memory")

--- a/server/tests/subscription/test_tasks.py
+++ b/server/tests/subscription/test_tasks.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import pytest
 from pytest_mock import MockerFixture
@@ -9,11 +9,11 @@ from polar.models import Customer, Organization, Product, Subscription
 from polar.models.organization import OrganizationStatus
 from polar.models.subscription import SubscriptionStatus
 from polar.postgres import AsyncSession
-from polar.subscription.scheduler import SubscriptionResumeJobStore
 from polar.subscription.service import SubscriptionService
 from polar.subscription.tasks import (  # type: ignore[attr-defined]
     SubscriptionDoesNotExist,
     SubscriptionTierDoesNotExist,
+    scan_paused_resumptions,
     subscription_cancel_for_organization,
     subscription_enqueue_benefits_grants,
     subscription_resume,
@@ -153,25 +153,16 @@ class TestSubscriptionEnqueueBenefitsGrants:
 
 
 @pytest.mark.asyncio
-class TestSubscriptionResumeJobStore:
-    async def _due_ids(self, session: AsyncSession, now: datetime) -> set[uuid.UUID]:
-        statement = (
-            SubscriptionResumeJobStore.scheduling_statement()
-            .where(Subscription.resumes_at <= now)
-            .with_only_columns(Subscription.id)
-        )
-        result = await session.execute(statement)
-        return set(result.scalars().all())
-
-    async def test_selects_only_due_paused_subscriptions(
+class TestScanPausedResumptions:
+    async def test_enqueues_only_due_subscriptions(
         self,
+        mocker: MockerFixture,
         save_fixture: SaveFixture,
         session: AsyncSession,
         product: Product,
         customer: Customer,
     ) -> None:
         now = utc_now()
-
         due = await create_subscription(
             save_fixture,
             product=product,
@@ -198,39 +189,12 @@ class TestSubscriptionResumeJobStore:
             status=SubscriptionStatus.paused,
         )
 
-        # Active — not a resume candidate.
-        await create_active_subscription(
-            save_fixture, product=product, customer=customer
-        )
+        enqueue_job_mock = mocker.patch("polar.subscription.tasks.enqueue_job")
+        session.expunge_all()
 
-        assert await self._due_ids(session, now) == {due.id}
+        await scan_paused_resumptions()
 
-    async def test_excludes_renewals_disabled_organization(
-        self,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        organization: Organization,
-        product: Product,
-        customer: Customer,
-    ) -> None:
-        organization.capabilities = {
-            **organization.capabilities,
-            "subscription_renewals": False,
-        }
-        await save_fixture(organization)
-
-        now = utc_now()
-        due = await create_subscription(
-            save_fixture,
-            product=product,
-            customer=customer,
-            status=SubscriptionStatus.paused,
-        )
-        due.resumes_at = now - timedelta(hours=1)
-        await save_fixture(due)
-
-        # Renewals disabled → the org's paused sub is never auto-resumed.
-        assert await self._due_ids(session, now) == set()
+        enqueue_job_mock.assert_called_once_with("subscription.resume", due.id)
 
 
 @pytest.mark.asyncio
@@ -241,7 +205,7 @@ class TestSubscriptionResume:
         with pytest.raises(SubscriptionDoesNotExist):
             await subscription_resume(uuid.uuid4())
 
-    async def test_due_paused_subscription_is_resumed(
+    async def test_paused_subscription_is_resumed(
         self,
         mocker: MockerFixture,
         save_fixture: SaveFixture,
@@ -255,8 +219,6 @@ class TestSubscriptionResume:
             customer=customer,
             status=SubscriptionStatus.paused,
         )
-        subscription.resumes_at = utc_now() - timedelta(hours=1)
-        await save_fixture(subscription)
         resume_mock = mocker.patch.object(
             subscription_service, "resume", spec=SubscriptionService.resume
         )
@@ -277,55 +239,6 @@ class TestSubscriptionResume:
         subscription = await create_active_subscription(
             save_fixture, product=product, customer=customer
         )
-        resume_mock = mocker.patch.object(
-            subscription_service, "resume", spec=SubscriptionService.resume
-        )
-        session.expunge_all()
-
-        await subscription_resume(subscription.id)
-
-        resume_mock.assert_not_called()
-
-    async def test_indefinite_pause_is_skipped(
-        self,
-        mocker: MockerFixture,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        product: Product,
-        customer: Customer,
-    ) -> None:
-        subscription = await create_subscription(
-            save_fixture,
-            product=product,
-            customer=customer,
-            status=SubscriptionStatus.paused,
-        )
-        resume_mock = mocker.patch.object(
-            subscription_service, "resume", spec=SubscriptionService.resume
-        )
-        session.expunge_all()
-
-        await subscription_resume(subscription.id)
-
-        resume_mock.assert_not_called()
-
-    async def test_postponed_resume_is_skipped(
-        self,
-        mocker: MockerFixture,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        product: Product,
-        customer: Customer,
-    ) -> None:
-        subscription = await create_subscription(
-            save_fixture,
-            product=product,
-            customer=customer,
-            status=SubscriptionStatus.paused,
-            scheduler_locked_at=utc_now(),
-        )
-        subscription.resumes_at = utc_now() + timedelta(days=1)
-        await save_fixture(subscription)
         resume_mock = mocker.patch.object(
             subscription_service, "resume", spec=SubscriptionService.resume
         )


### PR DESCRIPTION
- Revert "feat(subscription): cycle-style auto-resume scheduler (#12997)"
- Revert "server: disable subscription_resume scheduler temporarily (#13071)"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the cycle-style auto-resume scheduler and restores an hourly scan for paused subscriptions that are due to resume. Removes the resume job store and simplifies scheduling to use `subscription.cycle` only.

- **Refactors**
  - Replace the APScheduler resume job store with a `scan_paused_resumptions` cron actor (runs at 15 past the hour) that enqueues `subscription.resume` for due subscriptions.
  - Add `SubscriptionRepository.get_subscriptions_to_resume(now)` and make `subscription_resume` rely on `can_resume()` only.
  - Simplify `SubscriptionJobStore`; remove resume-specific logic and `scheduler_locked_at` handling; update worker wiring and tests.

<sup>Written for commit 9b083b55c332accf1531521d0cac750880f8744b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

