### PR TITLE
Fix opaque background in embedded checkouts in dark mode

### DIFF
--- a/clients/apps/web/src/styles/globals.css
+++ b/clients/apps/web/src/styles/globals.css
@@ -262,7 +262,7 @@
     @apply text-gray-200;
   }
 
-  #polar-embed-layout {
+  html:has(#polar-embed-layout) {
     color-scheme: normal;
   }
 

--- a/clients/packages/checkout/src/checkout.ts
+++ b/clients/packages/checkout/src/checkout.ts
@@ -168,7 +168,7 @@ class EmbedCheckout {
     iframe.style.border = 'none'
     iframe.style.zIndex = '2147483647'
     iframe.style.backgroundColor = 'rgba(0, 0, 0, 0.5)'
-    iframe.style.colorScheme = 'auto'
+    iframe.style.colorScheme = 'normal'
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore

--- a/clients/packages/checkout/src/payment-method.ts
+++ b/clients/packages/checkout/src/payment-method.ts
@@ -318,7 +318,7 @@ class EmbedPaymentMethod {
     iframe.style.border = 'none'
     iframe.style.zIndex = '2147483647'
     iframe.style.backgroundColor = 'rgba(0, 0, 0, 0.5)'
-    iframe.style.colorScheme = 'auto'
+    iframe.style.colorScheme = 'normal'
 
     iframe.allow = buildIframeAllow()
 
@@ -365,7 +365,7 @@ class EmbedPaymentMethod {
     iframe.style.width = '100%'
     iframe.style.height = '0'
     iframe.style.border = 'none'
-    iframe.style.colorScheme = 'auto'
+    iframe.style.colorScheme = 'normal'
     iframe.allow = buildIframeAllow()
 
     element.replaceChildren(iframe)


### PR DESCRIPTION
This one's for you @pieterbeulque.

Fixes: https://github.com/polarsource/feedback/issues/238

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an opaque background in embedded checkout modals in dark mode by forcing a consistent color scheme. The overlay and iframe remain semi-transparent across themes.

- **Bug Fixes**
  - Set iframe `colorScheme` to `normal` in checkout and payment method embeds.
  - Apply `color-scheme: normal` on `html:has(#polar-embed-layout)` to avoid dark-mode overrides inside the embed.

<sup>Written for commit f9d0f894dd333ae27d4fae11666596971e0e9671. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

