### PR TITLE
docs: remove false claim about cost insights in docs

### DIFF
--- a/docs/features/cost-insights/introduction.mdx
+++ b/docs/features/cost-insights/introduction.mdx
@@ -4,21 +4,10 @@ sidebarTitle: Introduction
 description: Track costs, profits, and customer lifetime value with event-based cost tracking
 ---
 
-<img
-  className="block dark:hidden"
-  src="/assets/features/cost/ingestion.light.png"
-/>
-<img
-  className="hidden dark:block"
-  src="/assets/features/cost/ingestion.dark.png"
-/>
+<img className="block dark:hidden" src="/assets/features/cost/ingestion.light.png" />
+<img className="hidden dark:block" src="/assets/features/cost/ingestion.dark.png" />
 
 Cost Insights is a powerful feature that enables you to calculate business-centric metrics like Costs, Profits, and Customer Lifetime Value (LTV) by annotating your events with cost data.
-
-<Note>
-  Cost Insights is currently in beta. You may enable it in your organization
-  settings.
-</Note>
 
 ## Overview
 
@@ -61,13 +50,8 @@ Cost Insights works in three simple steps:
 ## Documentation
 
 <CardGroup cols={2}>
-  <Card
-    title="Cost Events"
-    icon="chart-line"
-    href="/features/cost-insights/cost-events"
-  >
-    Learn how to track costs by adding the `_cost` property to your events
-    metadata
+  <Card title="Cost Events" icon="chart-line" href="/features/cost-insights/cost-events">
+    Learn how to track costs by adding the `_cost` property to your events metadata
   </Card>
   <Card title="Cost Metrics" icon="chart-bar" href="/features/analytics">
     Query and analyze costs, profits, and customer lifetime value


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed an incorrect note that said Cost Insights is in beta and can be enabled in organization settings. Also cleaned up MDX formatting for the images and the Cost Events card.

<sup>Written for commit d734fe8d3cbc29720ccaca7050ecb4da6d4859fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

