### PR TITLE
fix(subscription): re-land auto-resume scheduler with descriptor-binding fix

### DIFF
--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -412,24 +412,6 @@ class SubscriptionRepository(
         )
         return await self.get_all(statement)
 
-    async def get_subscriptions_to_resume(
-        self,
-        now: datetime,
-        *,
-        options: Options = (),
-    ) -> Sequence[Subscription]:
-        """Find paused subscriptions whose scheduled resume time has passed."""
-        statement = (
-            self.get_base_statement()
-            .where(
-                Subscription.status == SubscriptionStatus.paused,
-                Subscription.resumes_at.isnot(None),
-                Subscription.resumes_at <= now,
-            )
-            .options(*options)
-        )
-        return await self.get_all(statement)
-
     async def get_subscriptions_needing_trial_conversion_reminder(
         self,
         now: datetime,

--- a/server/polar/subscription/scheduler.py
+++ b/server/polar/subscription/scheduler.py
@@ -89,6 +89,7 @@ class _SubscriptionScheduleJobStore(BaseJobStore):
         log.debug("All jobs", count=len(jobs), store=self.job_id_prefix)
         return jobs
 
+    @_report_failures
     def remove_job(self, job_id: str) -> None:
         # Conditional UPDATE dedupes concurrent schedulers: losers see 0 rows.
         subscription_id = job_id.split(":")[-1]

--- a/server/polar/subscription/scheduler.py
+++ b/server/polar/subscription/scheduler.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session
 from polar.kit.utils import utc_now
 from polar.logging import Logger
 from polar.models import Customer, Organization, Subscription
+from polar.models.subscription import SubscriptionStatus
 from polar.postgres import create_sync_engine
 
 log: Logger = structlog.get_logger()
@@ -180,4 +181,34 @@ class SubscriptionJobStore(_SubscriptionScheduleJobStore):
                 Subscription.current_period_end.is_not(None),
             )
             .order_by(Subscription.current_period_end.asc())
+        )
+
+
+class SubscriptionResumeJobStore(_SubscriptionScheduleJobStore):
+    """Triggers ``subscription.resume`` at each paused subscription's ``resumes_at``."""
+
+    job_id_prefix = "subscriptions:resume"
+    actor_name = "subscription.resume"
+
+    @property
+    def trigger_column(self) -> ColumnElement[datetime.datetime | None]:
+        return cast(ColumnElement[datetime.datetime | None], Subscription.resumes_at)
+
+    @staticmethod
+    def scheduling_statement() -> Select[tuple[Subscription]]:
+        """Paused subscriptions eligible for auto-resume. Excludes renewals-disabled
+        orgs — resuming charges immediately (the API path guards separately)."""
+        return (
+            select(Subscription)
+            .join(Customer, onclause=Customer.id == Subscription.customer_id)
+            .join(Organization, onclause=Organization.id == Customer.organization_id)
+            .where(
+                Customer.is_deleted.is_(False),
+                Organization.is_deleted.is_(False),
+                Organization.can_renew_subscriptions.is_(True),
+                Subscription.scheduler_locked_at.is_(None),
+                Subscription.status == SubscriptionStatus.paused,
+                Subscription.resumes_at.is_not(None),
+            )
+            .order_by(Subscription.resumes_at.asc())
         )

--- a/server/polar/subscription/scheduler.py
+++ b/server/polar/subscription/scheduler.py
@@ -1,6 +1,7 @@
 import datetime
 import functools
 from collections.abc import Callable
+from typing import ClassVar, cast
 
 import dramatiq
 import sentry_sdk
@@ -8,7 +9,7 @@ import structlog
 from apscheduler.job import Job
 from apscheduler.jobstores.base import BaseJobStore
 from apscheduler.triggers.date import DateTrigger
-from sqlalchemy import Select, select, update
+from sqlalchemy import ColumnElement, Select, select, update
 from sqlalchemy.orm import Session
 
 from polar.kit.utils import utc_now
@@ -38,11 +39,13 @@ def _report_failures[**P, R](method: Callable[P, R]) -> Callable[P, R]:
     return wrapper
 
 
-class SubscriptionJobStore(BaseJobStore):
-    """
-    A custom job store for APScheduler that uses our subscription data to trigger
-    cycle jobs based on subscription dates
-    """
+class _SubscriptionScheduleJobStore(BaseJobStore):
+    """APScheduler job store that turns subscription rows into date-triggered jobs,
+    dispatched under an atomic ``scheduler_locked_at`` claim."""
+
+    trigger_column: ClassVar[ColumnElement[datetime.datetime | None]]
+    job_id_prefix: ClassVar[str]
+    actor_name: ClassVar[str]
 
     def __init__(self, executor: str = "default") -> None:
         self.engine = create_sync_engine("scheduler")
@@ -57,31 +60,29 @@ class SubscriptionJobStore(BaseJobStore):
 
     @_report_failures
     def get_due_jobs(self, now: datetime.datetime) -> list[Job]:
-        statement = self.scheduling_statement().where(
-            Subscription.current_period_end <= now,
-        )
+        statement = self.scheduling_statement().where(self.trigger_column <= now)
         jobs = self._list_jobs_from_statement(statement)
-        log.debug("Due jobs", count=len(jobs))
+        log.debug("Due jobs", count=len(jobs), store=self.job_id_prefix)
         return jobs
 
     @_report_failures
     def get_next_run_time(self) -> datetime.datetime | None:
         statement = (
-            self.scheduling_statement()
-            .with_only_columns(Subscription.current_period_end)
-            .limit(1)
+            self.scheduling_statement().with_only_columns(self.trigger_column).limit(1)
         )
         with self.engine.connect() as connection:
             result = connection.execute(statement)
             next_run_time = result.scalar_one_or_none()
-            log.debug("Next run time", next_run_time=next_run_time)
+            log.debug(
+                "Next run time", next_run_time=next_run_time, store=self.job_id_prefix
+            )
             return next_run_time
 
     @_report_failures
     def get_all_jobs(self) -> list[Job]:
         statement = self.scheduling_statement()
         jobs = self._list_jobs_from_statement(statement)
-        log.debug("All jobs", count=len(jobs))
+        log.debug("All jobs", count=len(jobs), store=self.job_id_prefix)
         return jobs
 
     def remove_job(self, job_id: str) -> None:
@@ -98,7 +99,7 @@ class SubscriptionJobStore(BaseJobStore):
         with self.engine.begin() as connection:
             if connection.execute(statement).rowcount == 0:
                 return
-        actor = dramatiq.get_broker().get_actor("subscription.cycle")
+        actor = dramatiq.get_broker().get_actor(self.actor_name)
         actor.send(subscription_id=subscription_id)
 
     def add_job(self, job: Job) -> None:
@@ -117,12 +118,12 @@ class SubscriptionJobStore(BaseJobStore):
         with Session(self.engine) as session:
             results = session.execute(
                 statement.with_only_columns(
-                    Subscription.id, Subscription.current_period_end
+                    Subscription.id, self.trigger_column
                 ).execution_options(stream_results=True, max_row_buffer=250)
             )
             for result in results.yield_per(250):
-                subscription_id, current_period_end = result._tuple()
-                trigger = DateTrigger(current_period_end, datetime.UTC)
+                subscription_id, run_date = result._tuple()
+                trigger = DateTrigger(run_date, datetime.UTC)
                 job_kwargs = {
                     **(self._scheduler._job_defaults if self._scheduler else {}),
                     "trigger": trigger,
@@ -130,7 +131,7 @@ class SubscriptionJobStore(BaseJobStore):
                     "func": lambda: None,
                     "args": (),
                     "kwargs": {},
-                    "id": f"subscriptions:cycle:{subscription_id}",
+                    "id": f"{self.job_id_prefix}:{subscription_id}",
                     "name": None,
                     "next_run_time": trigger.run_date,
                     "misfire_grace_time": None,
@@ -140,7 +141,21 @@ class SubscriptionJobStore(BaseJobStore):
 
     @staticmethod
     def scheduling_statement() -> Select[tuple[Subscription]]:
-        """Base query for subscriptions eligible for scheduler processing.
+        raise NotImplementedError
+
+
+class SubscriptionJobStore(_SubscriptionScheduleJobStore):
+    """Triggers ``subscription.cycle`` at each active subscription's period end."""
+
+    trigger_column = cast(
+        ColumnElement[datetime.datetime | None], Subscription.current_period_end
+    )
+    job_id_prefix = "subscriptions:cycle"
+    actor_name = "subscription.cycle"
+
+    @staticmethod
+    def scheduling_statement() -> Select[tuple[Subscription]]:
+        """Base query for subscriptions eligible for cycle scheduling.
 
         Returns an engine-agnostic ``Select`` — safe to execute via either
         a sync ``Session`` (production APScheduler) or an async ``AsyncSession``

--- a/server/polar/subscription/scheduler.py
+++ b/server/polar/subscription/scheduler.py
@@ -1,6 +1,9 @@
 import datetime
+import functools
+from collections.abc import Callable
 
 import dramatiq
+import sentry_sdk
 import structlog
 from apscheduler.job import Job
 from apscheduler.jobstores.base import BaseJobStore
@@ -14,6 +17,25 @@ from polar.models import Customer, Organization, Subscription
 from polar.postgres import create_sync_engine
 
 log: Logger = structlog.get_logger()
+
+
+def _report_failures[**P, R](method: Callable[P, R]) -> Callable[P, R]:
+    """Report job store query failures to Sentry, then re-raise.
+
+    APScheduler swallows job store exceptions into a warning and retries, so
+    without this a broken store degrades silently.
+    """
+
+    @functools.wraps(method)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        try:
+            return method(*args, **kwargs)
+        except Exception as e:
+            log.error("subscription.scheduler.job_store_failure", exc_info=True)
+            sentry_sdk.capture_exception(e)
+            raise
+
+    return wrapper
 
 
 class SubscriptionJobStore(BaseJobStore):
@@ -33,6 +55,7 @@ class SubscriptionJobStore(BaseJobStore):
     def lookup_job(self, job_id: str) -> Job | None:
         return None
 
+    @_report_failures
     def get_due_jobs(self, now: datetime.datetime) -> list[Job]:
         statement = self.scheduling_statement().where(
             Subscription.current_period_end <= now,
@@ -41,6 +64,7 @@ class SubscriptionJobStore(BaseJobStore):
         log.debug("Due jobs", count=len(jobs))
         return jobs
 
+    @_report_failures
     def get_next_run_time(self) -> datetime.datetime | None:
         statement = (
             self.scheduling_statement()
@@ -53,6 +77,7 @@ class SubscriptionJobStore(BaseJobStore):
             log.debug("Next run time", next_run_time=next_run_time)
             return next_run_time
 
+    @_report_failures
     def get_all_jobs(self) -> list[Job]:
         statement = self.scheduling_statement()
         jobs = self._list_jobs_from_statement(statement)

--- a/server/polar/subscription/scheduler.py
+++ b/server/polar/subscription/scheduler.py
@@ -43,9 +43,12 @@ class _SubscriptionScheduleJobStore(BaseJobStore):
     """APScheduler job store that turns subscription rows into date-triggered jobs,
     dispatched under an atomic ``scheduler_locked_at`` claim."""
 
-    trigger_column: ClassVar[ColumnElement[datetime.datetime | None]]
     job_id_prefix: ClassVar[str]
     actor_name: ClassVar[str]
+
+    @property
+    def trigger_column(self) -> ColumnElement[datetime.datetime | None]:
+        raise NotImplementedError
 
     def __init__(self, executor: str = "default") -> None:
         self.engine = create_sync_engine("scheduler")
@@ -147,11 +150,14 @@ class _SubscriptionScheduleJobStore(BaseJobStore):
 class SubscriptionJobStore(_SubscriptionScheduleJobStore):
     """Triggers ``subscription.cycle`` at each active subscription's period end."""
 
-    trigger_column = cast(
-        ColumnElement[datetime.datetime | None], Subscription.current_period_end
-    )
     job_id_prefix = "subscriptions:cycle"
     actor_name = "subscription.cycle"
+
+    @property
+    def trigger_column(self) -> ColumnElement[datetime.datetime | None]:
+        return cast(
+            ColumnElement[datetime.datetime | None], Subscription.current_period_end
+        )
 
     @staticmethod
     def scheduling_statement() -> Select[tuple[Subscription]]:

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1976,6 +1976,7 @@ class SubscriptionService:
         subscription.status = SubscriptionStatus.active
         subscription.paused_at = None
         subscription.resumes_at = None
+        subscription.scheduler_locked_at = None
 
         # Start a fresh billing period from now and charge immediately.
         subscription.current_period_start = now

--- a/server/polar/subscription/tasks.py
+++ b/server/polar/subscription/tasks.py
@@ -149,24 +149,10 @@ async def subscription_cancel_customer(customer_id: uuid.UUID) -> None:
         await subscription_service.cancel_customer(session, customer_id)
 
 
-@actor(
-    actor_name="subscription.scan_paused_resumptions",
-    cron_trigger=CronTrigger.from_crontab("15 * * * *"),
-    priority=TaskPriority.LOW,
-)
-async def scan_paused_resumptions() -> None:
-    """Scan for paused subscriptions due to resume and fan out."""
-    now = utc_now()
-    async with AsyncSessionMaker() as session:
-        repository = SubscriptionRepository.from_session(session)
-        subscriptions = await repository.get_subscriptions_to_resume(now)
-
-    for sub in subscriptions:
-        enqueue_job("subscription.resume", sub.id)
-
-
 @actor(actor_name="subscription.resume", priority=TaskPriority.MEDIUM)
 async def subscription_resume(subscription_id: uuid.UUID) -> None:
+    """Resume a paused subscription. Enqueued by the resume scheduler once its
+    ``resumes_at`` is reached (see ``SubscriptionResumeJobStore``)."""
     async with AsyncSessionMaker() as session:
         repository = SubscriptionRepository.from_session(session)
         subscription = await repository.get_by_id(
@@ -177,10 +163,19 @@ async def subscription_resume(subscription_id: uuid.UUID) -> None:
         if subscription is None:
             raise SubscriptionDoesNotExist(subscription_id)
 
-        if not subscription.can_resume():
+        now = utc_now()
+        is_due = (
+            subscription.can_resume()
+            and subscription.resumes_at is not None
+            and subscription.resumes_at <= now
+        )
+        if not is_due:
             log.info(
-                "Subscription is no longer paused, skipping resume",
+                "Subscription is not due for resume, skipping",
                 subscription_id=subscription_id,
+            )
+            await repository.update(
+                subscription, update_dict={"scheduler_locked_at": None}
             )
             return
 

--- a/server/polar/worker/scheduler.py
+++ b/server/polar/worker/scheduler.py
@@ -10,7 +10,10 @@ from polar import tasks
 from polar.logfire import configure_logfire
 from polar.logging import configure as configure_logging
 from polar.sentry import configure_sentry
-from polar.subscription.scheduler import SubscriptionJobStore
+from polar.subscription.scheduler import (
+    SubscriptionJobStore,
+    SubscriptionResumeJobStore,
+)
 
 from ._broker import scheduler_middleware
 from ._health import _run_exposition_server, set_heartbeat_checker
@@ -50,6 +53,7 @@ def start() -> None:
 
     scheduler.add_jobstore(MemoryJobStore(), "memory")
     scheduler.add_jobstore(SubscriptionJobStore(), "subscription")
+    scheduler.add_jobstore(SubscriptionResumeJobStore(), "subscription_resume")
 
     for func, cron_trigger in scheduler_middleware.cron_triggers:
         scheduler.add_job(func, cron_trigger, jobstore="memory")

--- a/server/tests/subscription/test_scheduler.py
+++ b/server/tests/subscription/test_scheduler.py
@@ -2,19 +2,27 @@ import pytest
 from pytest_mock import MockerFixture
 
 from polar.kit.utils import utc_now
-from polar.subscription.scheduler import SubscriptionJobStore
+from polar.subscription.scheduler import (
+    SubscriptionJobStore,
+    SubscriptionResumeJobStore,
+    _SubscriptionScheduleJobStore,
+)
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "store_class", [SubscriptionJobStore, SubscriptionResumeJobStore]
+)
 async def test_get_due_jobs_does_not_raise(
+    store_class: type[_SubscriptionScheduleJobStore],
     mocker: MockerFixture,
 ) -> None:
     """``get_due_jobs`` must build and run its query without raising.
 
-    Guards the job store's instance query path — previously uncovered, since
+    Guards each store's instance query path — previously uncovered, since
     tests only exercised the class-level ``scheduling_statement()``.
     """
-    store = SubscriptionJobStore()
+    store = store_class()
     mocker.patch.object(store, "_list_jobs_from_statement", return_value=[])
 
     jobs = store.get_due_jobs(utc_now())

--- a/server/tests/subscription/test_scheduler.py
+++ b/server/tests/subscription/test_scheduler.py
@@ -20,3 +20,22 @@ async def test_get_due_jobs_does_not_raise(
     jobs = store.get_due_jobs(utc_now())
 
     assert jobs == []
+
+
+@pytest.mark.asyncio
+async def test_get_due_jobs_reports_failures_to_sentry(
+    mocker: MockerFixture,
+) -> None:
+    """A failing query is captured to Sentry and re-raised, so a broken store
+    can't degrade silently behind APScheduler's warn-and-retry."""
+    store = SubscriptionJobStore()
+    error = RuntimeError("query failed")
+    mocker.patch.object(store, "scheduling_statement", side_effect=error)
+    capture_exception = mocker.patch(
+        "polar.subscription.scheduler.sentry_sdk.capture_exception"
+    )
+
+    with pytest.raises(RuntimeError):
+        store.get_due_jobs(utc_now())
+
+    capture_exception.assert_called_once_with(error)

--- a/server/tests/subscription/test_scheduler.py
+++ b/server/tests/subscription/test_scheduler.py
@@ -1,0 +1,22 @@
+import pytest
+from pytest_mock import MockerFixture
+
+from polar.kit.utils import utc_now
+from polar.subscription.scheduler import SubscriptionJobStore
+
+
+@pytest.mark.asyncio
+async def test_get_due_jobs_does_not_raise(
+    mocker: MockerFixture,
+) -> None:
+    """``get_due_jobs`` must build and run its query without raising.
+
+    Guards the job store's instance query path — previously uncovered, since
+    tests only exercised the class-level ``scheduling_statement()``.
+    """
+    store = SubscriptionJobStore()
+    mocker.patch.object(store, "_list_jobs_from_statement", return_value=[])
+
+    jobs = store.get_due_jobs(utc_now())
+
+    assert jobs == []

--- a/server/tests/subscription/test_tasks.py
+++ b/server/tests/subscription/test_tasks.py
@@ -13,7 +13,6 @@ from polar.subscription.service import SubscriptionService
 from polar.subscription.tasks import (  # type: ignore[attr-defined]
     SubscriptionDoesNotExist,
     SubscriptionTierDoesNotExist,
-    scan_paused_resumptions,
     subscription_cancel_for_organization,
     subscription_enqueue_benefits_grants,
     subscription_resume,
@@ -153,51 +152,6 @@ class TestSubscriptionEnqueueBenefitsGrants:
 
 
 @pytest.mark.asyncio
-class TestScanPausedResumptions:
-    async def test_enqueues_only_due_subscriptions(
-        self,
-        mocker: MockerFixture,
-        save_fixture: SaveFixture,
-        session: AsyncSession,
-        product: Product,
-        customer: Customer,
-    ) -> None:
-        now = utc_now()
-        due = await create_subscription(
-            save_fixture,
-            product=product,
-            customer=customer,
-            status=SubscriptionStatus.paused,
-        )
-        due.resumes_at = now - timedelta(hours=1)
-        await save_fixture(due)
-
-        not_yet_due = await create_subscription(
-            save_fixture,
-            product=product,
-            customer=customer,
-            status=SubscriptionStatus.paused,
-        )
-        not_yet_due.resumes_at = now + timedelta(days=1)
-        await save_fixture(not_yet_due)
-
-        # Paused indefinitely (no resumes_at) — never auto-resumed.
-        await create_subscription(
-            save_fixture,
-            product=product,
-            customer=customer,
-            status=SubscriptionStatus.paused,
-        )
-
-        enqueue_job_mock = mocker.patch("polar.subscription.tasks.enqueue_job")
-        session.expunge_all()
-
-        await scan_paused_resumptions()
-
-        enqueue_job_mock.assert_called_once_with("subscription.resume", due.id)
-
-
-@pytest.mark.asyncio
 class TestSubscriptionResume:
     async def test_not_existing_subscription(self, session: AsyncSession) -> None:
         session.expunge_all()
@@ -205,7 +159,7 @@ class TestSubscriptionResume:
         with pytest.raises(SubscriptionDoesNotExist):
             await subscription_resume(uuid.uuid4())
 
-    async def test_paused_subscription_is_resumed(
+    async def test_due_paused_subscription_is_resumed(
         self,
         mocker: MockerFixture,
         save_fixture: SaveFixture,
@@ -219,6 +173,8 @@ class TestSubscriptionResume:
             customer=customer,
             status=SubscriptionStatus.paused,
         )
+        subscription.resumes_at = utc_now() - timedelta(hours=1)
+        await save_fixture(subscription)
         resume_mock = mocker.patch.object(
             subscription_service, "resume", spec=SubscriptionService.resume
         )
@@ -239,6 +195,55 @@ class TestSubscriptionResume:
         subscription = await create_active_subscription(
             save_fixture, product=product, customer=customer
         )
+        resume_mock = mocker.patch.object(
+            subscription_service, "resume", spec=SubscriptionService.resume
+        )
+        session.expunge_all()
+
+        await subscription_resume(subscription.id)
+
+        resume_mock.assert_not_called()
+
+    async def test_indefinite_pause_is_skipped(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+        resume_mock = mocker.patch.object(
+            subscription_service, "resume", spec=SubscriptionService.resume
+        )
+        session.expunge_all()
+
+        await subscription_resume(subscription.id)
+
+        resume_mock.assert_not_called()
+
+    async def test_postponed_resume_is_skipped(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+            scheduler_locked_at=utc_now(),
+        )
+        subscription.resumes_at = utc_now() + timedelta(days=1)
+        await save_fixture(subscription)
         resume_mock = mocker.patch.object(
             subscription_service, "resume", spec=SubscriptionService.resume
         )


### PR DESCRIPTION
## Summary

Re-lands #12997 (reverted in #13072) with the production bug fixed and a safety net so this class of failure can't fail silently again.

### The bug, in plain terms
The scheduler stashed a database column (`current_period_end` / `resumes_at`) on the job-store object and read it back via `self.trigger_column`. A SQLAlchemy column is a descriptor, so reading it off self made SQLAlchemy think the job store was a database row and crash (`'NoneType' … supports_population`). APScheduler caught that, logged one warning, and kept retrying — so the scheduler stayed "up" while quietly no longer scheduling any subscription renewals. The fix exposes the column through a `@property`, so the lookup happens on the model class (correct) instead of the instance.

### Green → red → green (commit by commit)
A regression test written against the working code (green), then the refactor reintroduced to reproduce the exact crash (red), then the property fix (green) — so the history proves the bug and the fix rather than just asserting them.

### Making the scheduler noisier
Job-store query failures are now captured to Sentry and re-raised, so a broken store pages us instead of disappearing into an APScheduler warning-and-retry loop.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included
