### PR TITLE
server/observability/invariants: exclude soft deleted organizations from SubscriptionsCurrentPeriodEndInvariant

### DIFF
--- a/server/polar/observability/invariants/rules/subscriptions_current_period_end.py
+++ b/server/polar/observability/invariants/rules/subscriptions_current_period_end.py
@@ -42,6 +42,7 @@ class SubscriptionsCurrentPeriodEndInvariant(Invariant):
             .join(Subscription.organization)
             .where(
                 Subscription.active.is_(True),
+                Organization.deleted_at.is_(None),
                 Subscription.current_period_end < (func.now() - self.LEEWAY),
                 Organization.can_renew_subscriptions.is_(True),
             )


### PR DESCRIPTION
- server/observability/invariants: exclude soft deleted organizations from SubscriptionsCurrentPeriodEndInvariant

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

