### PR TITLE
fix(payouts): reliably download generated payout invoices

### DIFF
--- a/clients/apps/web/src/components/Payouts/DownloadInvoice.tsx
+++ b/clients/apps/web/src/components/Payouts/DownloadInvoice.tsx
@@ -303,7 +303,9 @@ const DownloadInvoice = ({
   }, [payout, handleDownloadInvoice, setSelectedPayout, openInvoiceModal])
 
   return (
-    <DropdownMenuItem onClick={onDownload}>Download invoice</DropdownMenuItem>
+    <DropdownMenuItem onClick={onDownload}>
+      {payout.is_invoice_generated ? 'Download invoice' : 'Generate invoice'}
+    </DropdownMenuItem>
   )
 }
 

--- a/clients/apps/web/src/components/Payouts/useInvoiceDownload.ts
+++ b/clients/apps/web/src/components/Payouts/useInvoiceDownload.ts
@@ -104,16 +104,22 @@ export const useInvoiceDownload = ({
         queryKey: ['organizations', 'account'],
       })
 
-      const { error: generateError } = await api.POST(
-        '/v1/payouts/{id}/invoice',
-        {
+      const { error: generateError, response: generateResponse } =
+        await api.POST('/v1/payouts/{id}/invoice', {
           params: { path: { id: payout.id } },
           body: {
             invoice_number: data.invoice_number,
           },
-        },
-      )
+        })
       if (generateError) {
+        // The invoice already exists (e.g. a stale list still shows it as not
+        // generated). Refresh the list and download the existing one instead
+        // of leaving the user stuck on a repeating generate error.
+        if (generateResponse.status === 409) {
+          await getQueryClient().invalidateQueries({ queryKey: ['payouts'] })
+          await downloadInvoice()
+          return
+        }
         if (isValidationError(generateError.detail)) {
           setValidationErrors(generateError.detail, setError)
         } else {
@@ -123,7 +129,7 @@ export const useInvoiceDownload = ({
         return
       }
     },
-    [payout, account, setError],
+    [payout, account, setError, downloadInvoice],
   )
 
   const eventEmitter = useOrganizationSSE(organization.id)
@@ -132,6 +138,7 @@ export const useInvoiceDownload = ({
 
     const callback = ({ payout_id }: { payout_id: string }) => {
       if (payout_id === payout.id) {
+        getQueryClient().invalidateQueries({ queryKey: ['payouts'] })
         onInvoiceGenerated()
         downloadInvoice()
       }


### PR DESCRIPTION
## Summary

Merchants could not download a payout invoice from the dashboard. After an invoice was generated, the payouts list did not refresh. The row action stayed on the generate flow, and trying again failed.

## What

- Refresh the payouts list when an invoice finishes generating, so it shows as generated.
- If the generate call returns 409 (invoice already exists), download the existing invoice instead of showing an error.
- The row action now reads "Generate invoice" when none exists yet, and "Download invoice" once it does.


## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

