### PR TITLE
Add SubscriptionsFuturePeriodStartInvariant and SubscriptionsLockedInvariant invariants

### DIFF
--- a/server/polar/observability/invariants/rules/__init__.py
+++ b/server/polar/observability/invariants/rules/__init__.py
@@ -3,10 +3,12 @@ from .subscriptions_canceled_deleted_customer import (
     SubscriptionsCanceledDeletedCustomerInvariant,
 )
 from .subscriptions_current_period_end import SubscriptionsCurrentPeriodEndInvariant
+from .subscriptions_locked_invariant import SubscriptionsLockedInvariant
 
 INVARIANTS: set[type[Invariant]] = {
     SubscriptionsCanceledDeletedCustomerInvariant,
     SubscriptionsCurrentPeriodEndInvariant,
+    SubscriptionsLockedInvariant,
 }
 
 __all__ = ["INVARIANTS", "Invariant", "InvariantError"]

--- a/server/polar/observability/invariants/rules/__init__.py
+++ b/server/polar/observability/invariants/rules/__init__.py
@@ -3,11 +3,13 @@ from .subscriptions_canceled_deleted_customer import (
     SubscriptionsCanceledDeletedCustomerInvariant,
 )
 from .subscriptions_current_period_end import SubscriptionsCurrentPeriodEndInvariant
+from .subscriptions_future_period_start import SubscriptionsFuturePeriodStartInvariant
 from .subscriptions_locked_invariant import SubscriptionsLockedInvariant
 
 INVARIANTS: set[type[Invariant]] = {
     SubscriptionsCanceledDeletedCustomerInvariant,
     SubscriptionsCurrentPeriodEndInvariant,
+    SubscriptionsFuturePeriodStartInvariant,
     SubscriptionsLockedInvariant,
 }
 

--- a/server/polar/observability/invariants/rules/subscriptions_future_period_start.py
+++ b/server/polar/observability/invariants/rules/subscriptions_future_period_start.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import timedelta
 
 from sqlalchemy import func, over, select
 
@@ -34,14 +35,13 @@ class SubscriptionsFuturePeriodStartInvariant(Invariant):
     Failure of this invariant indicate there is an issue with the subscription cycle process.
     """
 
+    LEEWAY = timedelta(minutes=5)
     LIMIT = 10
 
     async def check(self) -> None:
         statement = (
             select(Subscription.id, over(func.count()))
-            .where(
-                Subscription.current_period_start > func.now(),
-            )
+            .where(Subscription.current_period_start > (func.now() + self.LEEWAY))
             .limit(self.LIMIT)
             .order_by(Subscription.current_period_start.asc(), Subscription.id.asc())
         )

--- a/server/polar/observability/invariants/rules/subscriptions_future_period_start.py
+++ b/server/polar/observability/invariants/rules/subscriptions_future_period_start.py
@@ -1,0 +1,58 @@
+import uuid
+
+from sqlalchemy import func, over, select
+
+from polar.models import Subscription
+
+from .base import Invariant, InvariantError
+
+
+class SubscriptionsFuturePeriodStartInvariantError(InvariantError):
+    """Exception raised when the SubscriptionsFuturePeriodStartInvariant check fails."""
+
+    def __init__(self, count: int, subscriptions: list[uuid.UUID]) -> None:
+        message = (
+            f"Found {count} subscriptions with current_period_start in the future."
+        )
+        super().__init__(
+            SubscriptionsFuturePeriodStartInvariant,
+            message,
+            {
+                "count": count,
+                "subscriptions": {
+                    "ids": subscriptions,
+                    "has_more": count > len(subscriptions),
+                },
+            },
+        )
+
+
+class SubscriptionsFuturePeriodStartInvariant(Invariant):
+    """
+    Invariant that checks if there are any subscriptions with a current_period_start in the future.
+
+    Failure of this invariant indicate there is an issue with the subscription cycle process.
+    """
+
+    LIMIT = 10
+
+    async def check(self) -> None:
+        statement = (
+            select(Subscription.id, over(func.count()))
+            .where(
+                Subscription.current_period_start > func.now(),
+            )
+            .limit(self.LIMIT)
+            .order_by(Subscription.current_period_start.asc(), Subscription.id.asc())
+        )
+
+        result = await self.session.execute(statement)
+        results = result.fetchall()
+        if len(results) > 0:
+            count = results[0][1]
+        else:
+            count = 0
+
+        if count > 0:
+            subscriptions = [row[0] for row in results]
+            raise SubscriptionsFuturePeriodStartInvariantError(count, subscriptions)

--- a/server/polar/observability/invariants/rules/subscriptions_locked_invariant.py
+++ b/server/polar/observability/invariants/rules/subscriptions_locked_invariant.py
@@ -1,0 +1,59 @@
+import uuid
+from datetime import timedelta
+
+from sqlalchemy import func, over, select
+
+from polar.models import Subscription
+
+from .base import Invariant, InvariantError
+
+
+class SubscriptionsLockedInvariantError(InvariantError):
+    """Exception raised when the SubscriptionsCurrentPeriodEndInvariant check fails."""
+
+    def __init__(self, count: int, subscriptions: list[uuid.UUID]) -> None:
+        message = f"Found {count} subscriptions with too old scheduler_locked_at."
+        super().__init__(
+            SubscriptionsLockedInvariant,
+            message,
+            {
+                "count": count,
+                "subscriptions": {
+                    "ids": subscriptions,
+                    "has_more": count > len(subscriptions),
+                },
+            },
+        )
+
+
+class SubscriptionsLockedInvariant(Invariant):
+    """
+    Invariant that checks if there are any subscriptions that are locked for more than a certain period of time.
+
+    Failure of this invariant indicate there is an issue with the subscription cycle process.
+    """
+
+    LEEWAY = timedelta(minutes=5)
+    LIMIT = 10
+
+    async def check(self) -> None:
+        statement = (
+            select(Subscription.id, over(func.count()))
+            .where(
+                Subscription.scheduler_locked_at.isnot(None),
+                Subscription.scheduler_locked_at < (func.now() - self.LEEWAY),
+            )
+            .limit(self.LIMIT)
+            .order_by(Subscription.scheduler_locked_at.asc(), Subscription.id.asc())
+        )
+
+        result = await self.session.execute(statement)
+        results = result.fetchall()
+        if len(results) > 0:
+            count = results[0][1]
+        else:
+            count = 0
+
+        if count > 0:
+            subscriptions = [row[0] for row in results]
+            raise SubscriptionsLockedInvariantError(count, subscriptions)

--- a/server/polar/observability/invariants/rules/subscriptions_locked_invariant.py
+++ b/server/polar/observability/invariants/rules/subscriptions_locked_invariant.py
@@ -9,7 +9,7 @@ from .base import Invariant, InvariantError
 
 
 class SubscriptionsLockedInvariantError(InvariantError):
-    """Exception raised when the SubscriptionsCurrentPeriodEndInvariant check fails."""
+    """Exception raised when the SubscriptionsLockedInvariant check fails."""
 
     def __init__(self, count: int, subscriptions: list[uuid.UUID]) -> None:
         message = f"Found {count} subscriptions with too old scheduler_locked_at."

--- a/server/tests/observability/invariants/rules/test_subscriptions_future_period_start.py
+++ b/server/tests/observability/invariants/rules/test_subscriptions_future_period_start.py
@@ -1,0 +1,91 @@
+from datetime import timedelta
+
+import pytest
+import pytest_asyncio
+
+from polar.kit.utils import utc_now
+from polar.models import Customer, Product
+from polar.models.subscription import SubscriptionStatus
+from polar.observability.invariants.rules.subscriptions_future_period_start import (
+    SubscriptionsFuturePeriodStartInvariant,
+    SubscriptionsFuturePeriodStartInvariantError,
+)
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_subscription
+
+
+@pytest_asyncio.fixture
+async def invariant(session: AsyncSession) -> SubscriptionsFuturePeriodStartInvariant:
+    return SubscriptionsFuturePeriodStartInvariant(session)
+
+
+@pytest.mark.asyncio
+async def test_failure(
+    invariant: SubscriptionsFuturePeriodStartInvariant,
+    save_fixture: SaveFixture,
+    product: Product,
+    customer: Customer,
+) -> None:
+    subscription = await create_subscription(
+        save_fixture,
+        status=SubscriptionStatus.active,
+        product=product,
+        customer=customer,
+        current_period_start=utc_now() + timedelta(days=1),
+    )
+
+    with pytest.raises(SubscriptionsFuturePeriodStartInvariantError) as exc_info:
+        await invariant.check()
+    assert exc_info.value.context == {
+        "count": 1,
+        "subscriptions": {"ids": [subscription.id], "has_more": False},
+    }
+
+
+@pytest.mark.asyncio
+async def test_failure_over_limit(
+    invariant: SubscriptionsFuturePeriodStartInvariant,
+    save_fixture: SaveFixture,
+    product: Product,
+    customer: Customer,
+) -> None:
+    for _ in range(15):
+        await create_subscription(
+            save_fixture,
+            status=SubscriptionStatus.active,
+            product=product,
+            customer=customer,
+            current_period_start=utc_now() + timedelta(days=1),
+        )
+
+    with pytest.raises(SubscriptionsFuturePeriodStartInvariantError) as exc_info:
+        await invariant.check()
+    assert exc_info.value.context["count"] == 15
+    assert len(exc_info.value.context["subscriptions"]["ids"]) == 10
+    assert exc_info.value.context["subscriptions"]["has_more"] is True
+
+
+@pytest.mark.asyncio
+async def test_success(
+    invariant: SubscriptionsFuturePeriodStartInvariant,
+    save_fixture: SaveFixture,
+    product: Product,
+    customer: Customer,
+) -> None:
+    await create_subscription(
+        save_fixture,
+        status=SubscriptionStatus.active,
+        product=product,
+        customer=customer,
+        current_period_start=utc_now() - timedelta(minutes=1),
+    )
+    await create_subscription(
+        save_fixture,
+        status=SubscriptionStatus.active,
+        product=product,
+        customer=customer,
+        current_period_start=utc_now() - timedelta(minutes=2),
+    )
+
+    await invariant.check()

--- a/server/tests/observability/invariants/rules/test_subscriptions_locked_invariant.py
+++ b/server/tests/observability/invariants/rules/test_subscriptions_locked_invariant.py
@@ -1,0 +1,91 @@
+from datetime import timedelta
+
+import pytest
+import pytest_asyncio
+
+from polar.kit.utils import utc_now
+from polar.models import Customer, Product
+from polar.models.subscription import SubscriptionStatus
+from polar.observability.invariants.rules.subscriptions_locked_invariant import (
+    SubscriptionsLockedInvariant,
+    SubscriptionsLockedInvariantError,
+)
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_subscription
+
+
+@pytest_asyncio.fixture
+async def invariant(session: AsyncSession) -> SubscriptionsLockedInvariant:
+    return SubscriptionsLockedInvariant(session)
+
+
+@pytest.mark.asyncio
+async def test_failure(
+    invariant: SubscriptionsLockedInvariant,
+    save_fixture: SaveFixture,
+    product: Product,
+    customer: Customer,
+) -> None:
+    subscription = await create_subscription(
+        save_fixture,
+        status=SubscriptionStatus.active,
+        product=product,
+        customer=customer,
+        scheduler_locked_at=utc_now() - timedelta(minutes=10),
+    )
+
+    with pytest.raises(SubscriptionsLockedInvariantError) as exc_info:
+        await invariant.check()
+    assert exc_info.value.context == {
+        "count": 1,
+        "subscriptions": {"ids": [subscription.id], "has_more": False},
+    }
+
+
+@pytest.mark.asyncio
+async def test_failure_over_limit(
+    invariant: SubscriptionsLockedInvariant,
+    save_fixture: SaveFixture,
+    product: Product,
+    customer: Customer,
+) -> None:
+    for _ in range(15):
+        await create_subscription(
+            save_fixture,
+            status=SubscriptionStatus.active,
+            product=product,
+            customer=customer,
+            scheduler_locked_at=utc_now() - timedelta(minutes=10),
+        )
+
+    with pytest.raises(SubscriptionsLockedInvariantError) as exc_info:
+        await invariant.check()
+    assert exc_info.value.context["count"] == 15
+    assert len(exc_info.value.context["subscriptions"]["ids"]) == 10
+    assert exc_info.value.context["subscriptions"]["has_more"] is True
+
+
+@pytest.mark.asyncio
+async def test_success(
+    invariant: SubscriptionsLockedInvariant,
+    save_fixture: SaveFixture,
+    product: Product,
+    customer: Customer,
+) -> None:
+    await create_subscription(
+        save_fixture,
+        status=SubscriptionStatus.active,
+        product=product,
+        customer=customer,
+    )
+    # Past scheduler_locked_at, but below the threshold
+    await create_subscription(
+        save_fixture,
+        status=SubscriptionStatus.active,
+        product=product,
+        customer=customer,
+        scheduler_locked_at=utc_now() - timedelta(minutes=1),
+    )
+
+    await invariant.check()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added two subscription health invariants to catch bad states early and provide clear error context. Flags future period starts and stale scheduler locks; includes tests.

- **New Features**
  - SubscriptionsFuturePeriodStartInvariant: flags subscriptions with current_period_start more than 5 minutes in the future.
  - SubscriptionsLockedInvariant: flags subscriptions with scheduler_locked_at older than 5 minutes.
  - Both raise errors with the total count and up to 10 IDs in context (with has_more).

<sup>Written for commit d874bf69acb4f56a1997f4877b891f21b790e76e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

