### PR TITLE
feat(migration): import catalog — products, customers and paused subscriptions

### DIFF
--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -279,6 +279,7 @@ class CustomerService:
         email: str,
         name: str | None = None,
         billing_address: Address | None = None,
+        stripe_customer_id: str | None = None,
         send_webhooks: bool = False,
     ) -> Customer:
         """Create a customer for a known organization (internal flows)."""
@@ -300,6 +301,7 @@ class CustomerService:
             email=email,
             name=name,
             billing_address=billing_address,
+            stripe_customer_id=stripe_customer_id,
             organization=organization,
         )
 

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -16,12 +16,15 @@ from .auth import MerchantMigrationRead, MerchantMigrationWrite
 from .schemas import MerchantMigration as MerchantMigrationSchema
 from .schemas import (
     MerchantMigrationCreate,
+    MerchantMigrationImportReport,
+    MerchantMigrationImportRequest,
     MerchantMigrationRecordItem,
     PrecheckEntity,
     PrecheckRecordStatus,
     PrecheckReport,
 )
 from .service import (
+    CatalogImportNotReady,
     InvalidSourceCredentials,
     MerchantMigrationNotEnabled,
     MerchantMigrationNotFound,
@@ -140,6 +143,39 @@ async def precheck(
     session: AsyncSession = Depends(get_db_session),
 ) -> PrecheckReport:
     return await merchant_migration_service.run_precheck(session, auth_subject, id)
+
+
+@router.post(
+    "/{id}/import",
+    response_model=MerchantMigrationImportReport,
+    summary="Import Merchant Migration Catalog",
+    responses={
+        403: {
+            "description": "Not allowed to manage this organization.",
+            "model": NotPermitted.schema(),
+        },
+        404: {
+            "description": "Merchant migration not found.",
+            "model": MerchantMigrationNotFound.schema(),
+        },
+        409: {
+            "description": "The pre-check hasn't run yet.",
+            "model": CatalogImportNotReady.schema(),
+        },
+    },
+)
+async def import_catalog(
+    id: UUID4,
+    auth_subject: MerchantMigrationWrite,
+    body: MerchantMigrationImportRequest | None = None,
+    session: AsyncSession = Depends(get_db_session),
+) -> MerchantMigrationImportReport:
+    return await merchant_migration_service.import_catalog(
+        session,
+        auth_subject,
+        id,
+        record_ids=body.record_ids if body is not None else None,
+    )
 
 
 @router.get(

--- a/server/polar/merchant_migration/importer.py
+++ b/server/polar/merchant_migration/importer.py
@@ -1,0 +1,461 @@
+"""Imports the staged catalog (products, customers and subscriptions) into
+Polar: the `create_catalog` step.
+
+Reads the ledger the precheck populated, creates a Polar `Product` (with its
+fixed prices), `Customer` and `Subscription` for every importable record, and
+writes the source→target mapping and any skip reason back onto each
+`MerchantMigrationRecord`. It is idempotent through that ledger: a record already
+`imported` is left as-is, so a re-run only picks up what's still pending.
+
+Migrated subscriptions are created **paused**: `paused` isn't an active or
+billable status, so the renewal scheduler skips them and the customer isn't
+charged until cutover resumes them. This reuses Polar's existing pause mechanism
+rather than a bespoke flag.
+"""
+
+from collections.abc import Sequence
+from uuid import UUID
+
+from sqlalchemy.orm import selectinload
+
+from polar.customer.repository import CustomerRepository
+from polar.customer.service import customer as customer_service
+from polar.enums import SubscriptionRecurringInterval
+from polar.kit.address import Address, CountryAlpha2
+from polar.kit.db.postgres import AsyncSession
+from polar.kit.utils import utc_now
+from polar.models import (
+    Customer,
+    MerchantMigration,
+    MerchantMigrationRecord,
+    Organization,
+    Product,
+    Subscription,
+    SubscriptionProductPrice,
+)
+from polar.models.merchant_migration import MerchantMigrationSourcePlatform
+from polar.models.merchant_migration_record import (
+    MerchantMigrationRecordStatus,
+    MerchantMigrationRecordType,
+)
+from polar.models.product_price import ProductPriceFixed
+from polar.models.subscription import SubscriptionStatus
+from polar.product.repository import ProductRepository
+from polar.subscription.repository import SubscriptionRepository
+
+from .canonical import (
+    CanonicalCustomer,
+    CanonicalProduct,
+    CanonicalSubscription,
+    deserialize,
+)
+from .precheck import (
+    ProductImportPlan,
+    plan_customer_imports,
+    plan_product_imports,
+    plan_subscription_imports,
+)
+from .repository import MerchantMigrationRecordRepository
+from .schemas import (
+    MerchantMigrationImportReport,
+    MerchantMigrationImportResult,
+    PrecheckEntity,
+)
+
+_MISSING_EMAIL_REASON = (
+    "The source customer has no email, so it can't be imported into Polar."
+)
+
+
+class CatalogImporter:
+    def __init__(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        organization: Organization,
+        *,
+        record_ids: set[UUID] | None = None,
+    ) -> None:
+        self.session = session
+        self.migration = migration
+        self.organization = organization
+        # None means import everything importable; a set restricts the run to the
+        # merchant's selected ledger records (the rest stay pending).
+        self.record_ids = record_ids
+        self.record_repository = MerchantMigrationRecordRepository.from_session(session)
+        self.product_repository = ProductRepository.from_session(session)
+        self.customer_repository = CustomerRepository.from_session(session)
+        self.subscription_repository = SubscriptionRepository.from_session(session)
+        self._product_cache: dict[UUID, Product] = {}
+
+    async def run(self) -> MerchantMigrationImportReport:
+        records = await self.record_repository.list_by_migration(self.migration.id)
+        product_records = self._records_of(records, MerchantMigrationRecordType.product)
+        customer_records = self._records_of(
+            records, MerchantMigrationRecordType.customer
+        )
+        subscription_records = self._records_of(
+            records, MerchantMigrationRecordType.subscription
+        )
+
+        # Products and customers first: a subscription resolves its Polar product,
+        # price and customer from their imported ledger rows.
+        product_result = await self._import_products(product_records)
+        customer_result = await self._import_customers(customer_records)
+        subscription_result = await self._import_subscriptions(
+            subscription_records, product_records, customer_records
+        )
+
+        return MerchantMigrationImportReport(
+            step=self.migration.step,
+            results=[product_result, customer_result, subscription_result],
+        )
+
+    def _records_of(
+        self,
+        records: Sequence[MerchantMigrationRecord],
+        type: MerchantMigrationRecordType,
+    ) -> list[MerchantMigrationRecord]:
+        return [record for record in records if record.type == type]
+
+    def _is_selected(self, record: MerchantMigrationRecord) -> bool:
+        return self.record_ids is None or record.id in self.record_ids
+
+    async def _import_products(
+        self, records: Sequence[MerchantMigrationRecord]
+    ) -> MerchantMigrationImportResult:
+        products = [
+            self._as_product(deserialize(record.type, record.canonical))
+            for record in records
+        ]
+        plans = plan_product_imports(products)
+
+        imported = skipped = 0
+        for record, product in zip(records, products, strict=True):
+            if not self._is_selected(record):
+                continue
+            if record.status == MerchantMigrationRecordStatus.imported:
+                imported += 1
+                continue
+            plan = plans[product.source_id]
+            if not plan.importable:
+                await self._mark_skipped(record, plan.skip_code, plan.skip_reason)
+                skipped += 1
+                continue
+            polar_product = await self._create_product(product, plan)
+            await self._mark_imported(record, polar_product.id)
+            imported += 1
+
+        return MerchantMigrationImportResult(
+            entity=PrecheckEntity.products, imported=imported, skipped=skipped
+        )
+
+    async def _import_customers(
+        self, records: Sequence[MerchantMigrationRecord]
+    ) -> MerchantMigrationImportResult:
+        customers = [
+            self._as_customer(deserialize(record.type, record.canonical))
+            for record in records
+        ]
+        plans = plan_customer_imports(customers)
+
+        imported = skipped = 0
+        for record, customer in zip(records, customers, strict=True):
+            if not self._is_selected(record):
+                continue
+            if record.status == MerchantMigrationRecordStatus.imported:
+                imported += 1
+                continue
+            skip_code, skip_reason = plans[customer.source_id]
+            if skip_code is None and not customer.email:
+                skip_code, skip_reason = "customer_missing_email", _MISSING_EMAIL_REASON
+            if skip_code is not None:
+                await self._mark_skipped(record, skip_code, skip_reason)
+                skipped += 1
+                continue
+            polar_customer = await self._create_or_reuse_customer(customer)
+            await self._mark_imported(record, polar_customer.id)
+            imported += 1
+
+        return MerchantMigrationImportResult(
+            entity=PrecheckEntity.customers, imported=imported, skipped=skipped
+        )
+
+    async def _create_product(
+        self, product: CanonicalProduct, plan: ProductImportPlan
+    ) -> Product:
+        assert product.recurring_interval is not None
+        prices: list[ProductPriceFixed] = []
+        for price in product.prices:
+            if price.source_id not in plan.importable_price_ids:
+                continue
+            assert price.amount is not None
+            prices.append(
+                ProductPriceFixed(
+                    price_amount=price.amount,
+                    price_currency=price.currency.lower(),
+                )
+            )
+        return await self.product_repository.create(
+            Product(
+                organization=self.organization,
+                name=product.name,
+                recurring_interval=SubscriptionRecurringInterval(
+                    product.recurring_interval
+                ),
+                recurring_interval_count=product.recurring_interval_count,
+                prices=prices,
+                all_prices=list(prices),
+                product_benefits=[],
+                product_medias=[],
+                attached_custom_fields=[],
+            ),
+            flush=True,
+        )
+
+    async def _create_or_reuse_customer(self, customer: CanonicalCustomer) -> Customer:
+        stripe_customer_id = self._stripe_customer_id(customer)
+        existing = await self.customer_repository.get_by_email_and_organization(
+            customer.email, self.organization.id
+        )
+        if existing is not None:
+            # Reuse the existing customer (design Appendix A). Reconcile the source
+            # id so the PAN-copied card lands on the same customer, but never
+            # overwrite an id that's already set.
+            if stripe_customer_id and existing.stripe_customer_id is None:
+                await self.customer_repository.update(
+                    existing, update_dict={"stripe_customer_id": stripe_customer_id}
+                )
+            return existing
+        return await customer_service.create_for_organization(
+            self.session,
+            self.organization,
+            email=customer.email,
+            name=customer.name,
+            billing_address=self._billing_address(customer),
+            stripe_customer_id=stripe_customer_id,
+        )
+
+    def _stripe_customer_id(self, customer: CanonicalCustomer) -> str | None:
+        # PAN copy preserves the Stripe `cus_…` id, which the canonical record
+        # carries as its source id; other providers have no such concept.
+        if self.migration.source_platform == MerchantMigrationSourcePlatform.stripe:
+            return customer.source_id
+        return None
+
+    def _billing_address(self, customer: CanonicalCustomer) -> Address | None:
+        if not customer.country:
+            return None
+        try:
+            country = CountryAlpha2(customer.country.upper())
+        except ValueError:
+            return None
+        return Address(country=country)
+
+    async def _import_subscriptions(
+        self,
+        records: Sequence[MerchantMigrationRecord],
+        product_records: Sequence[MerchantMigrationRecord],
+        customer_records: Sequence[MerchantMigrationRecord],
+    ) -> MerchantMigrationImportResult:
+        subscriptions = [
+            self._as_subscription(deserialize(record.type, record.canonical))
+            for record in records
+        ]
+        products = [
+            self._as_product(deserialize(record.type, record.canonical))
+            for record in product_records
+        ]
+        customers = [
+            self._as_customer(deserialize(record.type, record.canonical))
+            for record in customer_records
+        ]
+        plans = plan_subscription_imports(subscriptions, products, customers)
+        product_by_price = {
+            price.source_id: product for product in products for price in product.prices
+        }
+
+        imported = skipped = 0
+        for record, subscription in zip(records, subscriptions, strict=True):
+            if not self._is_selected(record):
+                continue
+            if record.status == MerchantMigrationRecordStatus.imported:
+                imported += 1
+                continue
+            code, reason = plans[subscription.source_id]
+            if code is not None:
+                await self._mark_skipped(record, code, reason)
+                skipped += 1
+                continue
+            polar_subscription = await self._create_subscription(
+                subscription, product_by_price
+            )
+            # None means the product or customer it depends on isn't imported yet;
+            # leave it pending so a later pass can pick it up.
+            if polar_subscription is None:
+                continue
+            await self._mark_imported(record, polar_subscription.id)
+            imported += 1
+
+        return MerchantMigrationImportResult(
+            entity=PrecheckEntity.subscriptions, imported=imported, skipped=skipped
+        )
+
+    async def _create_subscription(
+        self,
+        subscription: CanonicalSubscription,
+        product_by_price: dict[str, CanonicalProduct],
+    ) -> Subscription | None:
+        customer_target = await self._imported_target(
+            MerchantMigrationRecordType.customer, subscription.customer_source_id
+        )
+        if customer_target is None:
+            return None
+        canonical_product = product_by_price.get(subscription.price_source_id)
+        if canonical_product is None:
+            return None
+        product_target = await self._imported_target(
+            MerchantMigrationRecordType.product, canonical_product.source_id
+        )
+        if product_target is None:
+            return None
+
+        polar_product = await self._load_product(product_target)
+        price = self._find_price(
+            polar_product, canonical_product, subscription.price_source_id
+        )
+        customer = await self.customer_repository.get_by_id(customer_target)
+        if price is None or customer is None:
+            return None
+
+        return await self._persist_subscription(
+            subscription, polar_product, price, customer
+        )
+
+    async def _persist_subscription(
+        self,
+        subscription: CanonicalSubscription,
+        product: Product,
+        price: ProductPriceFixed,
+        customer: Customer,
+    ) -> Subscription:
+        assert product.recurring_interval is not None
+        interval = product.recurring_interval
+        count = product.recurring_interval_count or 1
+        start = subscription.current_period_start or utc_now()
+        end = subscription.current_period_end or interval.get_next_period(
+            start, start.day, count
+        )
+        polar_subscription = Subscription(
+            # Paused isn't active or billable, so the renewal scheduler skips it
+            # and the customer isn't charged until cutover resumes it.
+            status=SubscriptionStatus.paused,
+            paused_at=utc_now(),
+            started_at=start,
+            anchor_day=start.day,
+            current_period_start=start,
+            current_period_end=end,
+            cancel_at_period_end=False,
+            recurring_interval=interval,
+            recurring_interval_count=count,
+            meter_interval=product.meter_interval,
+            meter_interval_count=product.meter_interval_count,
+            organization=self.organization,
+            product=product,
+            customer=customer,
+            subscription_product_prices=[SubscriptionProductPrice.from_price(price)],
+            currency=price.price_currency,
+            user_metadata={"stripe_subscription_id": subscription.source_id},
+            pending_update=None,
+        )
+        polar_subscription.initialize_meter_period(start)
+        return await self.subscription_repository.create(polar_subscription, flush=True)
+
+    async def _imported_target(
+        self, type: MerchantMigrationRecordType, source_id: str
+    ) -> UUID | None:
+        record = await self.record_repository.get_by_source(
+            organization_id=self.organization.id, type=type, source_id=source_id
+        )
+        if (
+            record is None
+            or record.status != MerchantMigrationRecordStatus.imported
+            or record.target_id is None
+        ):
+            return None
+        return record.target_id
+
+    async def _load_product(self, product_id: UUID) -> Product:
+        cached = self._product_cache.get(product_id)
+        if cached is not None:
+            return cached
+        product = await self.product_repository.get_by_id_and_organization(
+            product_id,
+            self.organization.id,
+            options=(selectinload(Product.prices),),
+        )
+        assert product is not None
+        self._product_cache[product_id] = product
+        return product
+
+    def _find_price(
+        self,
+        product: Product,
+        canonical_product: CanonicalProduct,
+        price_source_id: str,
+    ) -> ProductPriceFixed | None:
+        # Prices carry no durable source id, so match the source price to a Polar
+        # one by the currency and amount the product importer created it with.
+        canonical_price = next(
+            (p for p in canonical_product.prices if p.source_id == price_source_id),
+            None,
+        )
+        if canonical_price is None or canonical_price.amount is None:
+            return None
+        currency = canonical_price.currency.lower()
+        for price in product.prices:
+            if (
+                isinstance(price, ProductPriceFixed)
+                and price.price_currency == currency
+                and price.price_amount == canonical_price.amount
+            ):
+                return price
+        return None
+
+    async def _mark_imported(
+        self, record: MerchantMigrationRecord, target_id: UUID
+    ) -> None:
+        await self.record_repository.update(
+            record,
+            update_dict={
+                "status": MerchantMigrationRecordStatus.imported,
+                "target_id": target_id,
+                "error": None,
+            },
+        )
+
+    async def _mark_skipped(
+        self,
+        record: MerchantMigrationRecord,
+        code: str | None,
+        reason: str | None,
+    ) -> None:
+        await self.record_repository.update(
+            record,
+            update_dict={
+                "status": MerchantMigrationRecordStatus.skipped,
+                "error": reason or code,
+            },
+        )
+
+    def _as_product(self, record: object) -> CanonicalProduct:
+        assert isinstance(record, CanonicalProduct)
+        return record
+
+    def _as_customer(self, record: object) -> CanonicalCustomer:
+        assert isinstance(record, CanonicalCustomer)
+        return record
+
+    def _as_subscription(self, record: object) -> CanonicalSubscription:
+        assert isinstance(record, CanonicalSubscription)
+        return record

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -8,6 +8,7 @@ report, so a record's importable/skipped status always matches the summary.
 
 from collections import Counter
 from collections.abc import AsyncIterable, Iterable, Sequence
+from dataclasses import dataclass
 
 from polar.enums import SubscriptionRecurringInterval
 from polar.kit.currency import (
@@ -79,6 +80,13 @@ _SUBSCRIPTION_PRODUCT_REASON = (
 _SUBSCRIPTION_CUSTOMER_REASON = (
     "The customer for this subscription won't be imported, so it stays on the source."
 )
+_NO_IMPORTABLE_PRICE_REASON = (
+    "None of this product's prices can be imported, so the product is skipped."
+)
+
+
+def _humanize_subscription_status(status: CanonicalSubscriptionStatus) -> str:
+    return status.value.replace("_", " ").capitalize()
 
 
 def _is_supported_currency(currency: str) -> bool:
@@ -95,6 +103,7 @@ class PrecheckEngine:
         records: AsyncIterable[CanonicalRecord],
         organization: Organization,
         source_account: CanonicalAccount,
+        existing_product_names: set[str] | None = None,
     ) -> PrecheckReport:
         record_list = [record async for record in records]
 
@@ -120,6 +129,11 @@ class PrecheckEngine:
                 issues.extend(self._check_subscription(record))
 
         issues.extend(self._check_duplicate_names(products_by_name))
+        issues.extend(
+            self._check_existing_products(
+                products_by_name, existing_product_names or set()
+            )
+        )
         issues.extend(self._check_duplicate_emails(email_counts))
         issues.extend(self._check_missing_country(customers_without_country))
 
@@ -175,8 +189,8 @@ class PrecheckEngine:
                 level=PrecheckIssueLevel.warning,
                 code="one_time_product",
                 message=(
-                    f"Product '{product.name}' is one-time; it and its "
-                    "subscriptions won't be imported."
+                    "This one-time product can't be imported as a subscription, "
+                    "so it stays on the source."
                 ),
                 source_id=product.source_id,
             )
@@ -265,6 +279,26 @@ class PrecheckEngine:
                     source_id=None,
                 )
 
+    def _check_existing_products(
+        self,
+        products_by_name: dict[str, set[str]],
+        existing_product_names: set[str],
+    ) -> Iterable[PrecheckIssue]:
+        # Warn (don't block): the source product still imports, but as a new Polar
+        # product alongside the existing one. Mapping onto the existing product is
+        # a separate, merchant-driven step.
+        for name in products_by_name:
+            if name.lower() in existing_product_names:
+                yield PrecheckIssue(
+                    level=PrecheckIssueLevel.warning,
+                    code="product_exists_in_polar",
+                    message=(
+                        f"A Polar product named '{name}' already exists; importing "
+                        "will create a duplicate."
+                    ),
+                    source_id=None,
+                )
+
     def _check_duplicate_emails(
         self, email_counts: Counter[str]
     ) -> Iterable[PrecheckIssue]:
@@ -332,8 +366,9 @@ class PrecheckEngine:
                 level=PrecheckIssueLevel.warning,
                 code="subscription_not_importable",
                 message=(
-                    f"Subscription is {subscription.status.value}; it won't be "
-                    "imported and stays on the current provider."
+                    f"This {_humanize_subscription_status(subscription.status).lower()} "
+                    "subscription can't be imported yet; it stays with the "
+                    "current provider."
                 ),
                 source_id=source_id,
             )
@@ -600,9 +635,7 @@ def _subscription_items(
         title = email_by_source.get(
             subscription.customer_source_id, subscription.customer_source_id
         )
-        subtitle = subscription.status.value
-        if subscription.trialing:
-            subtitle = f"{subtitle} · trial"
+        subtitle = _humanize_subscription_status(subscription.status)
         items.append(
             _item(
                 PrecheckEntity.subscriptions,
@@ -649,6 +682,106 @@ def classify_records(
     if entity == PrecheckEntity.customers:
         return _customer_items(customers)
     return _subscription_items(subscriptions, products, customers)
+
+
+@dataclass
+class ProductImportPlan:
+    """The importer's decision for one canonical product (keyed by its
+    ``source_id``, the ``(product, interval)`` composite). Either a skip with a
+    reason, or the set of price ``source_id``s to create under the Polar product.
+    """
+
+    skip_code: str | None
+    skip_reason: str | None
+    importable_price_ids: set[str]
+
+    @property
+    def importable(self) -> bool:
+        return self.skip_code is None
+
+
+def plan_product_imports(
+    products: Sequence[CanonicalProduct],
+) -> dict[str, ProductImportPlan]:
+    """What the catalog importer should do with each canonical product, using the
+    exact same predicates as the precheck report so imported == report-importable.
+
+    A product is skipped when its own checks fail (one-time, unsupported interval,
+    duplicate name) or when none of its prices can be imported (a product with no
+    price is unsellable). Otherwise it imports with the prices that pass.
+    """
+    first_source_id_by_name, duplicate_names = _duplicate_product_names(products)
+    plans: dict[str, ProductImportPlan] = {}
+    for product in products:
+        code, reason = _product_drop(product, first_source_id_by_name, duplicate_names)
+        if code is not None:
+            plans[product.source_id] = ProductImportPlan(code, reason, set())
+            continue
+        price_ids = {
+            price.source_id
+            for price in product.prices
+            if _drop_reason(
+                precheck_engine._check_price(product, price), PRICE_DROP_CODES
+            )[0]
+            is None
+        }
+        if not price_ids:
+            plans[product.source_id] = ProductImportPlan(
+                "no_importable_price", _NO_IMPORTABLE_PRICE_REASON, set()
+            )
+        else:
+            plans[product.source_id] = ProductImportPlan(None, None, price_ids)
+    return plans
+
+
+def plan_customer_imports(
+    customers: Sequence[CanonicalCustomer],
+) -> dict[str, tuple[str | None, str | None]]:
+    """Per customer ``source_id``, the skip ``(code, reason)`` or ``(None, None)``
+    when importable. Duplicate emails are reused, not re-imported (design
+    Appendix A), so only the later duplicate is skipped."""
+    duplicates = _duplicate_customer_source_ids(customers)
+    return {
+        customer.source_id: (
+            ("duplicate_customer_email", _DUPLICATE_CUSTOMER_EMAIL_REASON)
+            if customer.source_id in duplicates
+            else (None, None)
+        )
+        for customer in customers
+    }
+
+
+def plan_subscription_imports(
+    subscriptions: Sequence[CanonicalSubscription],
+    products: Sequence[CanonicalProduct],
+    customers: Sequence[CanonicalCustomer],
+) -> dict[str, tuple[str | None, str | None]]:
+    """Per subscription ``source_id``, the skip ``(code, reason)`` or
+    ``(None, None)`` when importable. Mirrors the review drawer's per-subscription
+    classification: a subscription can't import if its own checks fail or the
+    product/price or customer it depends on won't import."""
+    first_source_id_by_name, duplicate_names = _duplicate_product_names(products)
+    importable_prices = _importable_price_source_ids(
+        products, first_source_id_by_name, duplicate_names
+    )
+    skipped_customers = _duplicate_customer_source_ids(customers)
+    plans: dict[str, tuple[str | None, str | None]] = {}
+    for subscription in subscriptions:
+        code, reason = _drop_reason(
+            precheck_engine._check_subscription(subscription), SUBSCRIPTION_DROP_CODES
+        )
+        if code is None and subscription.price_source_id not in importable_prices:
+            code, reason = (
+                "subscription_product_not_importable",
+                _SUBSCRIPTION_PRODUCT_REASON,
+            )
+        elif code is None and subscription.customer_source_id in skipped_customers:
+            code, reason = (
+                "subscription_customer_not_importable",
+                _SUBSCRIPTION_CUSTOMER_REASON,
+            )
+        plans[subscription.source_id] = (code, reason)
+    return plans
 
 
 def summarize_records(

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -8,6 +8,7 @@ from polar.models.merchant_migration import (
     MerchantMigrationSourcePlatform,
     MerchantMigrationStep,
 )
+from polar.models.merchant_migration_record import MerchantMigrationRecordStatus
 
 
 class MerchantMigrationCreate(Schema):
@@ -70,6 +71,13 @@ class PrecheckReport(Schema):
 
 
 class MerchantMigrationRecordItem(Schema):
+    record_id: UUID4 | None = Field(
+        default=None,
+        description=(
+            "The ledger record id, used to select this row for import. Null for "
+            "price rows, which are imported together with their product."
+        ),
+    )
     entity: PrecheckEntity = Field(description="The source entity type.")
     source_id: str = Field(description="The source identifier (e.g. Stripe `sub_…`).")
     title: str = Field(description="Primary label (name, email or product).")
@@ -79,9 +87,45 @@ class MerchantMigrationRecordItem(Schema):
     status: PrecheckRecordStatus = Field(
         description="Whether this record will be imported or stays on the source."
     )
+    import_status: MerchantMigrationRecordStatus | None = Field(
+        default=None,
+        description=(
+            "The ledger status of this record: `pending` (not imported yet), "
+            "`imported`, `skipped` or `failed`. Null for price rows, which import "
+            "with their product."
+        ),
+    )
     reason: str | None = Field(description="Why the record is skipped, if it is.")
     reason_code: str | None = Field(
         description="Stable code for the skip reason, if any."
+    )
+
+
+class MerchantMigrationImportRequest(Schema):
+    record_ids: list[UUID4] | None = Field(
+        default=None,
+        description=(
+            "The ledger record ids to import (from the records listing). When "
+            "omitted, every importable record is imported. Records not selected "
+            "stay pending and can be imported later."
+        ),
+    )
+
+
+class MerchantMigrationImportResult(Schema):
+    entity: PrecheckEntity = Field(description="The source entity type.")
+    imported: int = Field(description="How many were created or reused in Polar.")
+    skipped: int = Field(
+        description="How many were left on the source (not importable)."
+    )
+
+
+class MerchantMigrationImportReport(Schema):
+    step: MerchantMigrationStep = Field(
+        description="The migration step after the import."
+    )
+    results: list[MerchantMigrationImportResult] = Field(
+        description="Per-entity counts of what was imported vs skipped."
     )
 
 

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -12,16 +12,19 @@ from polar.exceptions import PolarError
 from polar.kit.db.postgres import AsyncSession
 from polar.kit.encryption import EncryptedString
 from polar.kit.pagination import PaginationParams
-from polar.models import MerchantMigration
+from polar.models import MerchantMigration, MerchantMigrationRecord
 from polar.models.merchant_migration import (
     MerchantMigrationSourcePlatform,
     MerchantMigrationStep,
 )
+from polar.models.merchant_migration_record import MerchantMigrationRecordType
 from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncReadSession
+from polar.product.repository import ProductRepository
 
 from .adapters import SourceAdapter, StripeAdapter
 from .canonical import CanonicalRecord, deserialize
+from .importer import CatalogImporter
 from .precheck import classify_records, precheck_engine
 from .repository import (
     MerchantMigrationRecordRepository,
@@ -29,11 +32,25 @@ from .repository import (
 )
 from .schemas import (
     MerchantMigrationCreate,
+    MerchantMigrationImportReport,
     MerchantMigrationRecordItem,
     PrecheckEntity,
     PrecheckRecordStatus,
     PrecheckReport,
 )
+
+IMPORTABLE_STEPS = {
+    MerchantMigrationStep.pre_check,
+    MerchantMigrationStep.create_catalog,
+}
+
+# Entities whose records map 1:1 to a ledger row, so a listing item can carry its
+# record id for selection. Prices live inside a product record and are excluded.
+_ENTITY_RECORD_TYPE = {
+    PrecheckEntity.products: MerchantMigrationRecordType.product,
+    PrecheckEntity.customers: MerchantMigrationRecordType.customer,
+    PrecheckEntity.subscriptions: MerchantMigrationRecordType.subscription,
+}
 
 SOURCE_CREDENTIALS_ENCRYPTION_CONTEXT = {
     "table": "merchant_migrations",
@@ -103,6 +120,14 @@ class SourceVerificationUnavailable(MerchantMigrationError):
         super().__init__(
             "We couldn't verify the Stripe key right now. Please try again.",
             502,
+        )
+
+
+class CatalogImportNotReady(MerchantMigrationError):
+    def __init__(self) -> None:
+        super().__init__(
+            "Run the pre-check before importing the catalog.",
+            409,
         )
 
 
@@ -224,6 +249,9 @@ class MerchantMigrationService:
 
         adapter = await self._build_adapter(migration)
         source_account = await adapter.get_source_account()
+        existing_product_names = await ProductRepository.from_session(
+            session
+        ).get_active_names_by_organization(organization.id)
         record_repository = MerchantMigrationRecordRepository.from_session(session)
         report = await precheck_engine.run(
             self._stage_records(
@@ -231,12 +259,49 @@ class MerchantMigrationService:
             ),
             organization,
             source_account,
+            existing_product_names,
         )
 
         repository = MerchantMigrationRepository.from_session(session)
         await repository.update(
             migration, update_dict={"step": MerchantMigrationStep.pre_check}
         )
+        return report
+
+    async def import_catalog(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        migration_id: UUID,
+        *,
+        record_ids: Sequence[UUID] | None = None,
+    ) -> MerchantMigrationImportReport:
+        """Create the Polar catalog (products and customers) from the staged
+        importable records, then advance the migration to the create-catalog step.
+        When ``record_ids`` is given, only those records are imported (the rest
+        stay pending); otherwise every importable record is. Idempotent: re-running
+        only imports records still pending in the ledger.
+        """
+        migration = await self._get_manageable(session, auth_subject, migration_id)
+        if migration.step not in IMPORTABLE_STEPS:
+            raise CatalogImportNotReady()
+
+        organization = await OrganizationRepository.from_session(session).get_by_id(
+            migration.organization_id
+        )
+        if organization is None:
+            raise MerchantMigrationNotFound()
+
+        selected = set(record_ids) if record_ids is not None else None
+        report = await CatalogImporter(
+            session, migration, organization, record_ids=selected
+        ).run()
+
+        repository = MerchantMigrationRepository.from_session(session)
+        await repository.update(
+            migration, update_dict={"step": MerchantMigrationStep.create_catalog}
+        )
+        report.step = MerchantMigrationStep.create_catalog
         return report
 
     async def _get_manageable(
@@ -279,11 +344,33 @@ class MerchantMigrationService:
         staged = await record_repository.list_by_migration(migration.id)
         records = [deserialize(record.type, record.canonical) for record in staged]
         items = classify_records(records, entity)
+        self._attach_record_ids(items, staged, entity)
         if status is not None:
             items = [item for item in items if item.status == status]
 
         start = (pagination.page - 1) * pagination.limit
         return items[start : start + pagination.limit], len(items)
+
+    def _attach_record_ids(
+        self,
+        items: Sequence[MerchantMigrationRecordItem],
+        staged: Sequence[MerchantMigrationRecord],
+        entity: PrecheckEntity,
+    ) -> None:
+        """Give each item its ledger record id, so a row can be selected for
+        import. The 1:1 entities (products/customers/subscriptions) map to their
+        staged records in order — both derive from the same `staged` fetch. Prices
+        aren't their own record (they live in a product), so they keep a null id.
+        """
+        record_type = _ENTITY_RECORD_TYPE.get(entity)
+        if record_type is None:
+            return
+        staged_of_type = [record for record in staged if record.type == record_type]
+        if len(staged_of_type) != len(items):
+            return
+        for item, record in zip(items, staged_of_type, strict=True):
+            item.record_id = record.id
+            item.import_status = record.status
 
     async def _stage_records(
         self,

--- a/server/polar/product/repository.py
+++ b/server/polar/product/repository.py
@@ -65,6 +65,17 @@ class ProductRepository(
         result = await self.session.execute(statement)
         return {row[0].lower() for row in result.all()}
 
+    async def get_active_names_by_organization(self, organization_id: UUID) -> set[str]:
+        """Lower-cased names of the org's active products, used to warn when a
+        migration source product would duplicate one that already exists."""
+        statement = select(func.lower(Product.name)).where(
+            Product.organization_id == organization_id,
+            Product.is_archived.is_(False),
+            Product.deleted_at.is_(None),
+        )
+        result = await self.session.execute(statement)
+        return {row[0] for row in result.all()}
+
     async def get_all_by_organization(
         self,
         organization_id: UUID,

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -8,6 +8,7 @@ from pytest_mock import MockerFixture
 from polar.auth.scope import Scope
 from polar.merchant_migration.canonical import (
     CanonicalAccount,
+    CanonicalCustomer,
     CanonicalPrice,
     CanonicalPricingScheme,
     CanonicalProduct,
@@ -357,6 +358,110 @@ class TestRecords:
         assert json_body["pagination"]["total_count"] == 1
         assert json_body["items"][0]["source_id"] == "prod_1"
         assert json_body["items"][0]["status"] == "importable"
+
+
+async def _catalog_with_customer_extract() -> AsyncIterator[CanonicalRecord]:
+    async for record in _catalog_extract():
+        yield record
+    yield CanonicalCustomer(
+        source_id="cus_1",
+        email="alice@example.com",
+        name="Alice",
+        country="US",
+    )
+
+
+@pytest.mark.asyncio
+class TestImport:
+    async def test_anonymous(
+        self, client: AsyncClient, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        migration = await _create_migration(save_fixture, organization)
+        response = await client.post(f"/v1/merchant-migrations/{migration.id}/import")
+        assert response.status_code == 401
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_precheck_required_returns_409(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        response = await client.post(f"/v1/merchant-migrations/{migration.id}/import")
+        assert response.status_code == 409
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_imports_catalog(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        adapter = mocker.MagicMock()
+        adapter.extract.return_value = _catalog_with_customer_extract()
+        adapter.get_source_account = mocker.AsyncMock(
+            return_value=CanonicalAccount(country="US", is_connect_platform=False)
+        )
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
+        )
+
+        precheck = await client.post(f"/v1/merchant-migrations/{migration.id}/precheck")
+        assert precheck.status_code == 200
+
+        response = await client.post(f"/v1/merchant-migrations/{migration.id}/import")
+        assert response.status_code == 200
+        json_body = response.json()
+        assert json_body["step"] == "create_catalog"
+        results = {result["entity"]: result for result in json_body["results"]}
+        assert results["products"]["imported"] == 1
+        assert results["customers"]["imported"] == 1
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_imports_only_selected_records(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        adapter = mocker.MagicMock()
+        adapter.extract.return_value = _catalog_with_customer_extract()
+        adapter.get_source_account = mocker.AsyncMock(
+            return_value=CanonicalAccount(country="US", is_connect_platform=False)
+        )
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
+        )
+
+        assert (
+            await client.post(f"/v1/merchant-migrations/{migration.id}/precheck")
+        ).status_code == 200
+
+        # pick the customer row's ledger id from the records listing
+        records = await client.get(
+            f"/v1/merchant-migrations/{migration.id}/records",
+            params={"entity": "customers"},
+        )
+        customer_record_id = records.json()["items"][0]["record_id"]
+        assert customer_record_id is not None
+
+        response = await client.post(
+            f"/v1/merchant-migrations/{migration.id}/import",
+            json={"record_ids": [customer_record_id]},
+        )
+        assert response.status_code == 200
+        results = {r["entity"]: r for r in response.json()["results"]}
+        # only the customer was selected; the product stays pending
+        assert results["customers"]["imported"] == 1
+        assert results["products"]["imported"] == 0
 
 
 async def _create_migration(

--- a/server/tests/merchant_migration/test_precheck.py
+++ b/server/tests/merchant_migration/test_precheck.py
@@ -18,6 +18,8 @@ from polar.merchant_migration.canonical import (
 )
 from polar.merchant_migration.precheck import (
     classify_records,
+    plan_customer_imports,
+    plan_product_imports,
     precheck_engine,
     summarize_records,
 )
@@ -136,11 +138,13 @@ async def run(
     *,
     organization: Organization | None = None,
     account: CanonicalAccount | None = None,
+    existing_product_names: set[str] | None = None,
 ) -> PrecheckReport:
     return await precheck_engine.run(
         aiter_records(records),
         organization or build_organization(),
         account or build_account(),
+        existing_product_names,
     )
 
 
@@ -231,6 +235,25 @@ class TestPrecheckEngine:
         )
         assert "duplicate_product_name" in codes(report, PrecheckIssueLevel.warning)
         assert report.can_start is True
+
+    async def test_existing_polar_product_warns_without_blocking(self) -> None:
+        report = await run(
+            [build_product(name="Pro")],
+            existing_product_names={"pro"},
+        )
+        assert "product_exists_in_polar" in codes(report, PrecheckIssueLevel.warning)
+        assert report.can_start is True
+        # the collision is a warning only: the product still imports.
+        products = next(
+            e for e in report.entities if e.entity == PrecheckEntity.products
+        )
+        assert products.importable == 1
+
+    async def test_no_existing_products_no_warning(self) -> None:
+        report = await run([build_product(name="Pro")])
+        assert "product_exists_in_polar" not in codes(
+            report, PrecheckIssueLevel.warning
+        )
 
     async def test_same_product_different_intervals_is_not_a_duplicate(self) -> None:
         report = await run(
@@ -524,3 +547,78 @@ class TestClassifyCascade:
 
         assert items[0].status == PrecheckRecordStatus.skipped
         assert items[0].reason_code == "subscription_product_not_importable"
+
+
+class TestPlanProductImports:
+    def test_importable_product_lists_its_prices(self) -> None:
+        product = build_product(prices=[build_price(source_id="price_1")])
+
+        plans = plan_product_imports([product])
+
+        plan = plans[product.source_id]
+        assert plan.importable is True
+        assert plan.importable_price_ids == {"price_1"}
+
+    def test_one_time_product_is_skipped(self) -> None:
+        product = build_product(source_id="prod_1:one_time", recurring_interval=None)
+
+        plan = plan_product_imports([product])[product.source_id]
+
+        assert plan.importable is False
+        assert plan.skip_code == "one_time_product"
+
+    def test_drops_unsupported_prices_but_keeps_the_rest(self) -> None:
+        product = build_product(
+            prices=[
+                build_price(source_id="price_ok"),
+                build_price(
+                    source_id="price_bad",
+                    pricing_scheme=CanonicalPricingScheme.tiered,
+                ),
+            ]
+        )
+
+        plan = plan_product_imports([product])[product.source_id]
+
+        assert plan.importable is True
+        assert plan.importable_price_ids == {"price_ok"}
+
+    def test_product_with_no_importable_price_is_skipped(self) -> None:
+        product = build_product(
+            prices=[
+                build_price(
+                    source_id="price_bad",
+                    pricing_scheme=CanonicalPricingScheme.metered,
+                )
+            ]
+        )
+
+        plan = plan_product_imports([product])[product.source_id]
+
+        assert plan.importable is False
+        assert plan.skip_code == "no_importable_price"
+
+    def test_duplicate_name_skips_the_later_product(self) -> None:
+        first = build_product(source_id="prod_1:month:1", product_source_id="prod_1")
+        second = build_product(source_id="prod_2:month:1", product_source_id="prod_2")
+
+        plans = plan_product_imports([first, second])
+
+        assert plans[first.source_id].importable is True
+        assert plans[second.source_id].skip_code == "duplicate_product_name"
+
+
+class TestPlanCustomerImports:
+    def test_unique_customers_are_importable(self) -> None:
+        customer = build_customer(source_id="cus_1", email="a@example.com")
+
+        assert plan_customer_imports([customer])[customer.source_id] == (None, None)
+
+    def test_duplicate_email_skips_the_later_customer(self) -> None:
+        first = build_customer(source_id="cus_1", email="a@example.com")
+        second = build_customer(source_id="cus_2", email="a@example.com")
+
+        plans = plan_customer_imports([first, second])
+
+        assert plans["cus_1"] == (None, None)
+        assert plans["cus_2"][0] == "duplicate_customer_email"

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -3,16 +3,23 @@ from collections.abc import AsyncIterator
 import pytest
 import stripe as stripe_lib
 from pytest_mock import MockerFixture
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
 
 from polar.auth.models import AuthSubject
 from polar.config import settings
+from polar.customer.repository import CustomerRepository
 from polar.kit.pagination import PaginationParams
 from polar.merchant_migration.canonical import (
     CanonicalAccount,
+    CanonicalCollectionMethod,
+    CanonicalCustomer,
     CanonicalPrice,
     CanonicalPricingScheme,
     CanonicalProduct,
     CanonicalRecord,
+    CanonicalSubscription,
+    CanonicalSubscriptionStatus,
 )
 from polar.merchant_migration.repository import (
     MerchantMigrationRecordRepository,
@@ -24,6 +31,7 @@ from polar.merchant_migration.schemas import (
     PrecheckRecordStatus,
 )
 from polar.merchant_migration.service import (
+    CatalogImportNotReady,
     InvalidSourceCredentials,
     MissingStripeScopes,
     SourceKeyModeMismatch,
@@ -33,8 +41,11 @@ from polar.merchant_migration.service import (
 )
 from polar.merchant_migration.service import merchant_migration as service
 from polar.models import (
+    Customer,
     MerchantMigration,
     Organization,
+    Product,
+    Subscription,
     User,
     UserOrganization,
 )
@@ -42,6 +53,12 @@ from polar.models.merchant_migration import (
     MerchantMigrationSourcePlatform,
     MerchantMigrationStep,
 )
+from polar.models.merchant_migration_record import (
+    MerchantMigrationRecordStatus,
+    MerchantMigrationRecordType,
+)
+from polar.models.product_price import ProductPriceFixed
+from polar.models.subscription import SubscriptionStatus
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
 from tests.merchant_migration._helpers import build_connected_migration
@@ -322,6 +339,40 @@ class TestRunPrecheck:
         assert records[0].canonical["name"] == "Pro"
 
     @pytest.mark.auth
+    async def test_warns_when_a_polar_product_already_exists(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        existing = Product(
+            organization=organization,
+            name="Pro",
+            recurring_interval="month",
+            recurring_interval_count=1,
+            prices=[ProductPriceFixed(price_amount=1000, price_currency="usd")],
+            all_prices=[ProductPriceFixed(price_amount=1000, price_currency="usd")],
+            product_benefits=[],
+            product_medias=[],
+            attached_custom_fields=[],
+        )
+        await save_fixture(existing)
+
+        migration = await build_connected_migration(save_fixture, organization)
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter",
+            return_value=_FakeAdapter(_catalog()),
+        )
+
+        report = await service.run_precheck(session, auth_subject, migration.id)
+
+        codes = {issue.code for issue in report.issues}
+        assert "product_exists_in_polar" in codes
+
+    @pytest.mark.auth
     async def test_source_not_connected(
         self,
         session: AsyncSession,
@@ -455,3 +506,417 @@ class TestListRecords:
         assert count == 1
         assert items[0].source_id == "prod_2"
         assert items[0].reason_code == "one_time_product"
+
+    @pytest.mark.auth
+    async def test_items_carry_ledger_record_id(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter",
+            return_value=_FakeAdapter(_catalog()),
+        )
+
+        await service.run_precheck(session, auth_subject, migration.id)
+        items, _ = await service.list_records(
+            session,
+            auth_subject,
+            migration.id,
+            entity=PrecheckEntity.products,
+            status=None,
+            pagination=PaginationParams(page=1, limit=20),
+        )
+
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        # every product row exposes the ledger id + status of its staged record
+        for item in items:
+            assert item.record_id is not None
+            assert item.import_status == MerchantMigrationRecordStatus.pending
+        prod_1 = await record_repository.get_by_source(
+            organization_id=organization.id,
+            type=MerchantMigrationRecordType.product,
+            source_id="prod_1:month:1",
+        )
+        assert prod_1 is not None
+        assert prod_1.id in {item.record_id for item in items}
+
+
+def _importable_catalog() -> list[CanonicalRecord]:
+    """An importable recurring product, a one-time product that's skipped, and
+    a customer."""
+    return [
+        *_catalog(),
+        CanonicalCustomer(
+            source_id="cus_1",
+            email="alice@example.com",
+            name="Alice",
+            country="US",
+        ),
+    ]
+
+
+async def _staged_migration(
+    mocker: MockerFixture,
+    session: AsyncSession,
+    save_fixture: SaveFixture,
+    auth_subject: AuthSubject[User],
+    organization: Organization,
+    records: list[CanonicalRecord] | None = None,
+) -> MerchantMigration:
+    migration = await build_connected_migration(save_fixture, organization)
+    mocker.patch(
+        "polar.merchant_migration.service.StripeAdapter",
+        return_value=_FakeAdapter(
+            records if records is not None else _importable_catalog()
+        ),
+    )
+    await service.run_precheck(session, auth_subject, migration.id)
+    return migration
+
+
+def _catalog_with_subscription() -> list[CanonicalRecord]:
+    """The importable catalog plus an active subscription on the Pro price."""
+    return [
+        *_importable_catalog(),
+        CanonicalSubscription(
+            source_id="sub_1",
+            customer_source_id="cus_1",
+            price_source_id="price_1",
+            status=CanonicalSubscriptionStatus.active,
+            collection_method=CanonicalCollectionMethod.charge_automatically,
+            current_period_start=None,
+            current_period_end=None,
+            trialing=False,
+            paused_collection=False,
+            line_item_count=1,
+            quantity=1,
+            payment_method=None,
+        ),
+    ]
+
+
+async def _products(session: AsyncSession, organization: Organization) -> list[Product]:
+    result = await session.execute(
+        select(Product)
+        .where(Product.organization_id == organization.id)
+        .options(selectinload(Product.prices))
+    )
+    return list(result.scalars().unique().all())
+
+
+@pytest.mark.asyncio
+class TestImportCatalog:
+    @pytest.mark.auth
+    async def test_imports_catalog_and_advances_step(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+
+        report = await service.import_catalog(session, auth_subject, migration.id)
+
+        assert report.step == MerchantMigrationStep.create_catalog
+        results = {result.entity: result for result in report.results}
+        assert results[PrecheckEntity.products].imported == 1
+        assert results[PrecheckEntity.products].skipped == 1
+        assert results[PrecheckEntity.customers].imported == 1
+        assert results[PrecheckEntity.customers].skipped == 0
+
+        products = await _products(session, organization)
+        assert len(products) == 1
+        product = products[0]
+        assert product.name == "Pro"
+        assert product.recurring_interval == "month"
+        assert len(product.prices) == 1
+        price = product.prices[0]
+        assert isinstance(price, ProductPriceFixed)
+        assert price.price_amount == 1000
+        assert price.price_currency == "usd"
+
+        customer_repository = CustomerRepository.from_session(session)
+        customer = await customer_repository.get_by_email_and_organization(
+            "alice@example.com", organization.id
+        )
+        assert customer is not None
+        assert customer.stripe_customer_id == "cus_1"
+        assert customer.billing_address is not None
+        assert customer.billing_address.country == "US"
+
+        migration_repository = MerchantMigrationRepository.from_session(session)
+        updated = await migration_repository.get_by_id(migration.id)
+        assert updated is not None
+        assert updated.step == MerchantMigrationStep.create_catalog
+
+    @pytest.mark.auth
+    async def test_listing_reflects_import_status_after_import(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+        await service.import_catalog(session, auth_subject, migration.id)
+
+        items, _ = await service.list_records(
+            session,
+            auth_subject,
+            migration.id,
+            entity=PrecheckEntity.products,
+            status=None,
+            pagination=PaginationParams(page=1, limit=20),
+        )
+        by_source = {item.source_id: item for item in items}
+        # the imported product now reads as imported; the skipped one as skipped
+        assert by_source["prod_1"].import_status == (
+            MerchantMigrationRecordStatus.imported
+        )
+        assert by_source["prod_2"].import_status == (
+            MerchantMigrationRecordStatus.skipped
+        )
+
+    @pytest.mark.auth
+    async def test_imports_subscription_as_paused(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker,
+            session,
+            save_fixture,
+            auth_subject,
+            organization,
+            records=_catalog_with_subscription(),
+        )
+
+        report = await service.import_catalog(session, auth_subject, migration.id)
+
+        results = {result.entity: result for result in report.results}
+        assert results[PrecheckEntity.subscriptions].imported == 1
+
+        result = await session.execute(
+            select(Subscription)
+            .where(Subscription.organization_id == organization.id)
+            .options(selectinload(Subscription.customer))
+        )
+        subscription = result.scalars().unique().one()
+        # held from billing: paused is neither active nor billable, so the
+        # renewal scheduler skips it until cutover
+        assert subscription.status == SubscriptionStatus.paused
+        assert subscription.active is False
+        assert subscription.paused_at is not None
+        assert subscription.amount == 1000
+        assert subscription.currency == "usd"
+        assert subscription.customer.email == "alice@example.com"
+        assert subscription.user_metadata["stripe_subscription_id"] == "sub_1"
+
+    @pytest.mark.auth
+    async def test_marks_records_in_the_ledger(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+
+        await service.import_catalog(session, auth_subject, migration.id)
+
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        imported = await record_repository.get_by_source(
+            organization_id=organization.id,
+            type=MerchantMigrationRecordType.product,
+            source_id="prod_1:month:1",
+        )
+        assert imported is not None
+        assert imported.status == MerchantMigrationRecordStatus.imported
+        assert imported.target_id is not None
+
+        skipped = await record_repository.get_by_source(
+            organization_id=organization.id,
+            type=MerchantMigrationRecordType.product,
+            source_id="prod_2:one_time",
+        )
+        assert skipped is not None
+        assert skipped.status == MerchantMigrationRecordStatus.skipped
+        assert skipped.error is not None
+        assert skipped.target_id is None
+
+    @pytest.mark.auth
+    async def test_reuses_existing_customer_by_email(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        existing = Customer(
+            email="alice@example.com",
+            name="Existing Alice",
+            organization=organization,
+        )
+        await save_fixture(existing)
+
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+        await service.import_catalog(session, auth_subject, migration.id)
+
+        customer_repository = CustomerRepository.from_session(session)
+        matches = await session.execute(
+            select(Customer).where(
+                Customer.organization_id == organization.id,
+                Customer.email == "alice@example.com",
+            )
+        )
+        customers = list(matches.scalars().all())
+        assert len(customers) == 1
+        # the existing customer is reused, with the source id reconciled onto it
+        reused = customers[0]
+        assert reused.id == existing.id
+        assert reused.stripe_customer_id == "cus_1"
+
+    @pytest.mark.auth
+    async def test_is_idempotent_on_rerun(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+
+        first = await service.import_catalog(session, auth_subject, migration.id)
+        second = await service.import_catalog(session, auth_subject, migration.id)
+
+        # the second run reports the same counts but creates nothing new
+        assert second.results == first.results
+        assert len(await _products(session, organization)) == 1
+        matches = await session.execute(
+            select(Customer).where(
+                Customer.organization_id == organization.id,
+                Customer.email == "alice@example.com",
+            )
+        )
+        assert len(list(matches.scalars().all())) == 1
+
+    @pytest.mark.auth
+    async def test_imports_only_selected_records(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        product_record = await record_repository.get_by_source(
+            organization_id=organization.id,
+            type=MerchantMigrationRecordType.product,
+            source_id="prod_1:month:1",
+        )
+        assert product_record is not None
+
+        report = await service.import_catalog(
+            session, auth_subject, migration.id, record_ids=[product_record.id]
+        )
+
+        results = {result.entity: result for result in report.results}
+        # only the selected product is acted on
+        assert results[PrecheckEntity.products].imported == 1
+        assert results[PrecheckEntity.customers].imported == 0
+
+        assert len(await _products(session, organization)) == 1
+        # the unselected customer stays pending, available to import later
+        customer_record = await record_repository.get_by_source(
+            organization_id=organization.id,
+            type=MerchantMigrationRecordType.customer,
+            source_id="cus_1",
+        )
+        assert customer_record is not None
+        assert customer_record.status == MerchantMigrationRecordStatus.pending
+
+    @pytest.mark.auth
+    async def test_unselected_records_import_on_a_later_pass(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        product_record = await record_repository.get_by_source(
+            organization_id=organization.id,
+            type=MerchantMigrationRecordType.product,
+            source_id="prod_1:month:1",
+        )
+        assert product_record is not None
+
+        await service.import_catalog(
+            session, auth_subject, migration.id, record_ids=[product_record.id]
+        )
+        # a second pass with no selection imports what's still pending
+        report = await service.import_catalog(session, auth_subject, migration.id)
+
+        results = {result.entity: result for result in report.results}
+        assert results[PrecheckEntity.customers].imported == 1
+        customer_repository = CustomerRepository.from_session(session)
+        customer = await customer_repository.get_by_email_and_organization(
+            "alice@example.com", organization.id
+        )
+        assert customer is not None
+
+    @pytest.mark.auth
+    async def test_requires_precheck_first(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+
+        with pytest.raises(CatalogImportNotReady):
+            await service.import_catalog(session, auth_subject, migration.id)


### PR DESCRIPTION
## Summary

Adds the `create_catalog` step to the `merchant_migration` module: import the staged catalog (products, customers and subscriptions) from the source into Polar.

## What

- `CatalogImporter` reads the staged ledger and creates Polar products (with fixed prices), customers (reuse-by-email, carrying the source customer id) and subscriptions for the importable records. Idempotent via the ledger (`record_id` → target, status).
- `POST /merchant-migrations/{id}/import` with an optional `record_ids` body for selective import; unselected records stay pending.
- Records listing exposes `record_id` and `import_status` so the UI can select rows and reflect what is already imported.
- Pre-check warns when a source product name matches an existing Polar product.

## Why

Merchants moving billing to Polar need their catalog imported with minimal effort. Importing here (behind the existing feature flag) is the step that lets new checkouts run on Polar before cutover.

## How

- Subscriptions are created **paused**, which is neither active nor billable, so the renewal scheduler skips them and no one is charged until cutover resumes them — reusing the existing pause mechanism instead of a new flag.
- Importability decisions reuse the pre-check predicates, so imported == what the report marks importable.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

