### PR TITLE
sdk: add prerelease versioning support

### DIFF
--- a/sdk/generator/cli.py
+++ b/sdk/generator/cli.py
@@ -5,6 +5,7 @@ import sys
 
 import openapi_pydantic as op
 
+from generator.emitter import Prerelease
 from generator.ir import generate_ir
 from generator.release import release_sdk
 from python.emitter import PythonEmitter
@@ -34,6 +35,12 @@ parser_generate.add_argument(
     help="Version of the SDK to emit (default: 0.0.0).",
 )
 parser_generate.add_argument(
+    "--prerelease",
+    type=str,
+    default=None,
+    help="Prerelease identifier in the form <label>.<number>, e.g. alpha.1, beta.2, rc.1.",
+)
+parser_generate.add_argument(
     "--clear",
     action="store_true",
     help="Clear the output directory before emitting the SDK (default: false).",
@@ -42,7 +49,13 @@ parser_generate.add_argument(
 # Release subcommand
 parser_release = subparsers.add_parser("release", help="Release a new SDK version")
 parser_release.add_argument(
-    "version", type=str, help="Version to release (e.g., 1.0.0-alpha.1)"
+    "version", type=str, help="Base version to release (e.g., 1.0.0)"
+)
+parser_release.add_argument(
+    "--prerelease",
+    type=str,
+    default=None,
+    help="Prerelease identifier in the form <label>.<number>, e.g. alpha.1, beta.2, rc.1.",
 )
 parser_release.add_argument(
     "--skip-openapi", action="store_true", help="Skip OpenAPI regeneration"
@@ -83,14 +96,22 @@ if args.command == "generate":
         if output_path.exists():
             shutil.rmtree(output_path)
 
+    prerelease: Prerelease | None = None
+    if args.prerelease is not None:
+        try:
+            prerelease = Prerelease.parse(args.prerelease)
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
     language = args.language
     match language:
         case "python":
-            emitter = PythonEmitter(ir, args.version)
+            emitter = PythonEmitter(ir, args.version, prerelease=prerelease)
         case "typescript":
             from typescript.emitter import TypeScriptEmitter
 
-            emitter = TypeScriptEmitter(ir, args.version)
+            emitter = TypeScriptEmitter(ir, args.version, prerelease=prerelease)
         case _:
             print(f"Error: Unsupported language {language}.", file=sys.stderr)
             sys.exit(1)
@@ -99,8 +120,17 @@ if args.command == "generate":
     emitter.run_post_actions(args.output)
 
 elif args.command == "release":
+    prerelease = None
+    if args.prerelease is not None:
+        try:
+            prerelease = Prerelease.parse(args.prerelease)
+        except ValueError as e:
+            print(f"Error: {e}", file=sys.stderr)
+            sys.exit(1)
+
     release_sdk(
         version=args.version,
+        prerelease=prerelease,
         skip_openapi=args.skip_openapi,
         skip_commit=args.skip_commit,
         dry_run=args.dry_run,

--- a/sdk/generator/generator/emitter.py
+++ b/sdk/generator/generator/emitter.py
@@ -1,8 +1,10 @@
 import abc
+import dataclasses
 import pathlib
 import re
 import subprocess
 import typing
+from typing import Literal
 
 from jinja2 import Environment, FileSystemLoader, Template
 
@@ -10,11 +12,42 @@ from generator.ir import APIIR, APIVersion
 
 _LOOP_DIRECTORY_PATTERN = re.compile(r"^\[\[([\w\.]+)\]\]$")
 
+PrereleaseLabel = Literal["alpha", "beta", "rc"]
+_PRERELEASE_PATTERN = re.compile(r"^(alpha|beta|rc)\.(\d+)$")
+
+
+@dataclasses.dataclass(frozen=True)
+class Prerelease:
+    label: PrereleaseLabel
+    number: int
+
+    @classmethod
+    def parse(cls, value: str) -> "Prerelease":
+        match = _PRERELEASE_PATTERN.match(value)
+        if not match:
+            raise ValueError(
+                f"Invalid prerelease '{value}'. "
+                "Expected <label>.<number> where label is one of: alpha, beta, rc."
+            )
+        label = typing.cast(PrereleaseLabel, match.group(1))
+        return cls(label=label, number=int(match.group(2)))
+
+    def __str__(self) -> str:
+        return f"{self.label}.{self.number}"
+
 
 class EmitterBase(abc.ABC):
-    def __init__(self, ir: APIIR, version: str, templates_dir: pathlib.Path | str):
+    def __init__(
+        self,
+        ir: APIIR,
+        version: str,
+        templates_dir: pathlib.Path | str,
+        *,
+        prerelease: Prerelease | None = None,
+    ):
         self.ir = ir
         self.version = version
+        self.prerelease = prerelease
         self.templates_dir = pathlib.Path(templates_dir)
         self.env = Environment(
             loader=FileSystemLoader(self.templates_dir),
@@ -28,6 +61,10 @@ class EmitterBase(abc.ABC):
 
     @abc.abstractmethod
     def get_version_string(self, api: APIVersion) -> str: ...
+
+    @abc.abstractmethod
+    def format_version(self) -> str:
+        """Return the full SDK version string formatted for the target language."""
 
     def setup_environment(self) -> None:
         """Setup the Jinja2 environment with default context and filters.
@@ -48,7 +85,7 @@ class EmitterBase(abc.ABC):
 
         Override this method in subclasses to add custom context variables.
         """
-        return {"ir": self.ir, "version": self.version}
+        return {"ir": self.ir, "version": self.format_version()}
 
     def get_version_context(self, api: APIVersion) -> dict[str, typing.Any]:
         """Get the context dictionary for template rendering for a specific API version.

--- a/sdk/generator/generator/release.py
+++ b/sdk/generator/generator/release.py
@@ -4,6 +4,8 @@ import re
 import subprocess
 import sys
 
+from generator.emitter import Prerelease
+
 GENERATOR_DIR = pathlib.Path(__file__).parent.parent
 ROOT = GENERATOR_DIR.parent.parent
 LANGUAGES = ["python", "typescript"]
@@ -11,7 +13,7 @@ GENERATED_SDK_PATHS = ["sdk/python", "sdk/typescript"]
 
 
 def validate_version(version: str) -> bool:
-    pattern = r"^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+    pattern = r"^\d+\.\d+\.\d+$"
     return bool(re.match(pattern, version))
 
 
@@ -29,7 +31,9 @@ def regenerate_openapi() -> None:
     (GENERATOR_DIR / "openapi.json").write_text(result.stdout)
 
 
-def generate_sdk(language: str, version: str) -> None:
+def generate_sdk(
+    language: str, version: str, prerelease: Prerelease | None = None
+) -> None:
     cmd = [
         sys.executable,
         "-m",
@@ -43,13 +47,15 @@ def generate_sdk(language: str, version: str) -> None:
         version,
         "--clear",
     ]
+    if prerelease is not None:
+        cmd += ["--prerelease", str(prerelease)]
     subprocess.run(cmd, cwd=GENERATOR_DIR, check=True)
 
 
-def generate_all_sdks(version: str) -> None:
+def generate_all_sdks(version: str, prerelease: Prerelease | None = None) -> None:
     with concurrent.futures.ThreadPoolExecutor() as executor:
         futures = {
-            executor.submit(generate_sdk, language, version): language
+            executor.submit(generate_sdk, language, version, prerelease): language
             for language in LANGUAGES
         }
         for future in concurrent.futures.as_completed(futures):
@@ -62,11 +68,12 @@ def generate_all_sdks(version: str) -> None:
                 raise
 
 
-def create_git_commit(version: str) -> None:
+def create_git_commit(version: str, prerelease: Prerelease | None = None) -> None:
+    release_label = f"{version}-{prerelease}" if prerelease else version
     for path in GENERATED_SDK_PATHS:
         subprocess.run(["git", "add", path], cwd=ROOT, check=True)
     subprocess.run(
-        ["git", "commit", "-m", f"sdk[release]: {version}"],
+        ["git", "commit", "-m", f"sdk[release]: {release_label}"],
         cwd=ROOT,
         check=True,
     )
@@ -74,16 +81,18 @@ def create_git_commit(version: str) -> None:
 
 def release_sdk(
     version: str,
+    prerelease: Prerelease | None = None,
     skip_openapi: bool = False,
     skip_commit: bool = False,
     dry_run: bool = False,
 ) -> None:
     if not validate_version(version):
         print(f"Error: Invalid version format: {version}", file=sys.stderr)
-        print("Expected format: X.Y.Z or X.Y.Z-pre-release", file=sys.stderr)
+        print("Expected format: X.Y.Z", file=sys.stderr)
         sys.exit(1)
 
-    print(f"Releasing SDK version: {version}")
+    release_label = f"{version}-{prerelease}" if prerelease else version
+    print(f"Releasing SDK version: {release_label}")
 
     if dry_run:
         print("[DRY RUN] Would perform:")
@@ -100,13 +109,13 @@ def release_sdk(
             print("Regenerating OpenAPI spec...")
             regenerate_openapi()
 
-        generate_all_sdks(version)
+        generate_all_sdks(version, prerelease)
 
         if not skip_commit:
             print("Creating git commit...")
-            create_git_commit(version)
+            create_git_commit(version, prerelease)
 
-        print(f"\nSuccessfully prepared SDK v{version} for release")
+        print(f"\nSuccessfully prepared SDK v{release_label} for release")
 
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/sdk/generator/justfile
+++ b/sdk/generator/justfile
@@ -29,5 +29,11 @@ generate-all:
 release version:
   uv run -m cli release {{version}}
 
+release-pre version prerelease:
+  uv run -m cli release {{version}} --prerelease {{prerelease}}
+
 release-dry version:
   uv run -m cli release --dry-run {{version}}
+
+release-pre-dry version prerelease:
+  uv run -m cli release --dry-run {{version}} --prerelease {{prerelease}}

--- a/sdk/generator/python/emitter.py
+++ b/sdk/generator/python/emitter.py
@@ -1,7 +1,7 @@
 import pathlib
 
 from generator.casing import to_snake_case
-from generator.emitter import EmitterBase
+from generator.emitter import EmitterBase, Prerelease
 from generator.ir import (
     APIIR,
     APIVersion,
@@ -64,8 +64,19 @@ def _collect_type_ref_names(
 
 
 class PythonEmitter(EmitterBase):
-    def __init__(self, ir: APIIR, version: str) -> None:
-        super().__init__(ir, version, EMITTER_DIRECTORY / "template")
+    def __init__(
+        self, ir: APIIR, version: str, *, prerelease: Prerelease | None = None
+    ) -> None:
+        super().__init__(
+            ir, version, EMITTER_DIRECTORY / "template", prerelease=prerelease
+        )
+
+    def format_version(self) -> str:
+        """Return the SDK version in PEP 440 notation (e.g. '1.2.3a1', '1.2.3b2', '1.2.3rc3')."""
+        if self.prerelease is None:
+            return self.version
+        _pep440: dict[str, str] = {"alpha": "a", "beta": "b", "rc": "rc"}
+        return f"{self.version}{_pep440[self.prerelease.label]}{self.prerelease.number}"
 
     def emit(self, root_directory: pathlib.Path | str) -> None:
         """Emit the Python SDK files to the specified root directory."""

--- a/sdk/generator/typescript/emitter.py
+++ b/sdk/generator/typescript/emitter.py
@@ -1,7 +1,7 @@
 import pathlib
 
 from generator.casing import to_camel_case, to_pascal_case, to_snake_case
-from generator.emitter import EmitterBase
+from generator.emitter import EmitterBase, Prerelease
 from generator.ir import (
     APIIR,
     APIVersion,
@@ -22,8 +22,12 @@ EMITTER_DIRECTORY = pathlib.Path(__file__).parent
 
 
 class TypeScriptEmitter(EmitterBase):
-    def __init__(self, ir: APIIR, version: str) -> None:
-        super().__init__(ir, version, EMITTER_DIRECTORY / "template")
+    def __init__(
+        self, ir: APIIR, version: str, *, prerelease: Prerelease | None = None
+    ) -> None:
+        super().__init__(
+            ir, version, EMITTER_DIRECTORY / "template", prerelease=prerelease
+        )
 
     def emit(self, root_directory: pathlib.Path | str) -> None:
         """Emit the TypeScript SDK files to the specified root directory."""
@@ -106,6 +110,12 @@ class TypeScriptEmitter(EmitterBase):
     def get_version_string(self, api: APIVersion) -> str:
         """Return the version string for a given API version."""
         return api.version
+
+    def format_version(self) -> str:
+        """Return the SDK version in semver notation (e.g. '1.2.3-alpha.1')."""
+        if self.prerelease is None:
+            return self.version
+        return f"{self.version}-{self.prerelease}"
 
     def setup_environment(self) -> None:
         """Add TypeScript-specific filters to the Jinja2 environment."""


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds prerelease versioning to the SDK generator and release flow. Supports alpha, beta, and rc builds with correct Python (PEP 440) and TypeScript (semver) formatting.

- **New Features**
  - CLI: `--prerelease <label>.<number>` for `generate` and `release` (e.g. alpha.1, beta.2, rc.1) with validation and clear errors.
  - Emitters: new `Prerelease` type and unified handling; templates now use `format_version()`; Python maps to `a`/`b`/`rc` (e.g. 1.2.3a1); TypeScript uses `-alpha.1`.
  - Release: accepts base `X.Y.Z` plus optional `--prerelease`; commit message and logs include the combined version.
  - Justfile: `release-pre` and `release-pre-dry` recipes.

- **Migration**
  - `release` now requires a base version `X.Y.Z`; pass prerelease via `--prerelease` instead of including it in the version string.
  - Version validation enforces `X.Y.Z` only for the `version` arg.

<sup>Written for commit a90734ccf72092f78b20de48895b6213dcc0eaf2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

