### PR TITLE
refactor(order): extract shared order amount computation

### DIFF
--- a/server/polar/order/amounts.py
+++ b/server/polar/order/amounts.py
@@ -1,0 +1,178 @@
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import structlog
+
+from polar.enums import TaxBehavior, TaxBehaviorOption, TaxProcessor
+from polar.logging import Logger
+from polar.models import Customer, OrderItem, Product, Subscription
+from polar.tax.calculation import (
+    TaxBreakdownItem,
+    TaxCalculation,
+    TaxCalculationLogicalError,
+)
+from polar.tax.calculation import tax_calculation as tax_calculation_service
+
+log: Logger = structlog.get_logger()
+
+
+@dataclass(frozen=True)
+class OrderAmounts:
+    """Monetary breakdown of an order: allocates no invoice number, touches no balance."""
+
+    subtotal_amount: int
+    discount_amount: int
+    tax_amount: int
+    net_amount: int
+    total_amount: int
+    tax_processor: TaxProcessor | None
+    tax_behavior: TaxBehavior | None
+    tax_calculation_processor_id: str | None
+    tax_breakdown: Sequence[TaxBreakdownItem]
+
+
+async def calculate_tax(
+    *,
+    reference: str,
+    taxable_amount: int,
+    tax_behavior_option: TaxBehaviorOption,
+    currency: str,
+    customer: Customer,
+    product: Product,
+    tax_exempted: bool,
+    allow_silent_failure: bool = True,
+) -> tuple[
+    TaxProcessor | None,
+    TaxBehavior | None,
+    str | None,
+    int,
+    Sequence[TaxBreakdownItem],
+]:
+    billing_address = customer.billing_address
+    tax_id = customer.tax_id
+
+    tax_processor: TaxProcessor | None = None
+    tax_behavior: TaxBehavior | None = None
+    tax_calculation: TaxCalculation | None = None
+    tax_amount = 0
+    tax_breakdown: list[TaxBreakdownItem] = []
+    tax_calculation_processor_id: str | None = None
+
+    if (
+        taxable_amount != 0
+        and product.is_tax_applicable
+        and billing_address is not None
+    ):
+        try:
+            (
+                tax_calculation,
+                tax_processor,
+            ) = await tax_calculation_service.calculate(
+                reference,
+                currency,
+                # Stripe doesn't support calculating negative tax amounts
+                taxable_amount if taxable_amount >= 0 else -taxable_amount,
+                tax_behavior_option,
+                product.tax_code,
+                billing_address,
+                [tax_id] if tax_id is not None else [],
+                tax_exempted,
+            )
+        except TaxCalculationLogicalError:
+            # The subscription flow tolerates an uncomputable tax (the
+            # address is fixed up over the lifecycle). Off-session draft
+            # orders persist this result and never recompute it, so a silent
+            # zero would charge tax-free — the caller must surface it instead.
+            if not allow_silent_failure:
+                raise
+            log.warning(
+                "Failed to calculate tax for subscription order due to invalid or incomplete address",
+                reference=reference,
+                customer_id=customer.id,
+            )
+            tax_amount = 0
+            tax_calculation_processor_id = None
+        else:
+            if taxable_amount >= 0:
+                tax_calculation_processor_id = tax_calculation["processor_id"]
+                tax_amount = tax_calculation["amount"]
+            else:
+                # When the taxable amount is negative it's usually due to a credit proration
+                # this means we "owe" the customer money -- but we don't pay it back at this
+                # point. This also means that there's no money transaction going on, and we
+                # don't have to record the tax transaction either.
+                tax_calculation_processor_id = None
+                tax_amount = -tax_calculation["amount"]
+
+        if tax_calculation is not None:
+            tax_behavior = tax_calculation["tax_behavior"]
+            tax_breakdown = tax_calculation["tax_breakdown"]
+
+    return (
+        tax_processor,
+        tax_behavior,
+        tax_calculation_processor_id,
+        tax_amount,
+        tax_breakdown,
+    )
+
+
+async def compute_order_amounts(
+    subscription: Subscription,
+    items: Sequence[OrderItem],
+    *,
+    reference: str,
+) -> OrderAmounts:
+    customer = subscription.customer
+
+    subtotal_amount = sum(item.amount for item in items)
+
+    discount = subscription.discount
+    discount_amount = 0
+    if discount is not None:
+        # Discount only applies to cycle and meter items, as prorations
+        # use "last month's" discount and so this month's discount
+        # shouldn't apply to those.
+        discountable_amount = sum(item.amount for item in items if item.discountable)
+        discount_amount = discount.get_discount_amount(
+            discountable_amount, subscription.currency
+        )
+
+    tax_behavior_option = (
+        subscription.tax_behavior.to_option()
+        if subscription.tax_behavior is not None
+        else customer.organization.default_tax_behavior
+    )
+    (
+        tax_processor,
+        tax_behavior,
+        tax_calculation_processor_id,
+        tax_amount,
+        tax_breakdown,
+    ) = await calculate_tax(
+        reference=reference,
+        taxable_amount=subtotal_amount - discount_amount,
+        tax_behavior_option=tax_behavior_option,
+        currency=subscription.currency,
+        customer=customer,
+        product=subscription.product,
+        tax_exempted=subscription.tax_exempted,
+    )
+
+    net_amount = (
+        subtotal_amount
+        - discount_amount
+        - (tax_amount if tax_behavior == TaxBehavior.inclusive else 0)
+    )
+
+    return OrderAmounts(
+        subtotal_amount=subtotal_amount,
+        discount_amount=discount_amount,
+        tax_amount=tax_amount,
+        net_amount=net_amount,
+        total_amount=net_amount + tax_amount,
+        tax_processor=tax_processor,
+        tax_behavior=tax_behavior,
+        tax_calculation_processor_id=tax_calculation_processor_id,
+        tax_breakdown=tax_breakdown,
+    )

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -31,7 +31,6 @@ from polar.enums import (
     PaymentMode,
     PaymentProcessor,
     TaxBehavior,
-    TaxBehaviorOption,
     TaxProcessor,
 )
 from polar.event.repository import EventRepository
@@ -112,8 +111,6 @@ from polar.subscription.service import SubscriptionUpdateContext
 from polar.subscription.service import subscription as subscription_service
 from polar.tax.calculation import (
     CalculationExpiredError,
-    TaxBreakdownItem,
-    TaxCalculation,
     TaxCalculationLogicalError,
     TaxCode,
 )
@@ -130,6 +127,7 @@ from polar.wallet.service import wallet as wallet_service
 from polar.webhook.service import webhook as webhook_service
 from polar.worker import enqueue_job, make_bulk_job_delay_calculator
 
+from .amounts import calculate_tax, compute_order_amounts
 from .repository import OrderRepository
 from .schemas import OrderCreate, OrderInvoice, OrderReceipt, OrderUpdate
 from .sorting import OrderSortProperty
@@ -1043,7 +1041,7 @@ class OrderService:
                 tax_calculation_processor_id,
                 tax_amount,
                 tax_breakdown,
-            ) = await self._calculate_tax(
+            ) = await calculate_tax(
                 reference=str(order_id),
                 taxable_amount=subtotal_amount - discount_amount,
                 tax_behavior_option=organization.default_tax_behavior,
@@ -1337,57 +1335,15 @@ class OrderService:
         order_id = uuid.uuid4()
         customer = subscription.customer
 
-        subtotal_amount = sum(item.amount for item in items)
-
-        discount = subscription.discount
-        discount_amount = 0
-        if discount is not None:
-            # Discount only applies to cycle and meter items, as prorations
-            # use "last month's" discount and so this month's discount
-            # shouldn't apply to those.
-            discountable_amount = sum(
-                item.amount for item in items if item.discountable
-            )
-            discount_amount = discount.get_discount_amount(
-                discountable_amount, subscription.currency
-            )
-
-        billing_address = customer.billing_address
-        tax_id = customer.tax_id
-        product = subscription.product
-
-        tax_behavior_option = (
-            subscription.tax_behavior.to_option()
-            if subscription.tax_behavior is not None
-            else customer.organization.default_tax_behavior
+        amounts = await compute_order_amounts(
+            subscription, items, reference=str(order_id)
         )
-        # Calculate tax
-        (
-            tax_processor,
-            tax_behavior,
-            tax_calculation_processor_id,
-            tax_amount,
-            tax_breakdown,
-        ) = await self._calculate_tax(
-            reference=str(order_id),
-            taxable_amount=subtotal_amount - discount_amount,
-            tax_behavior_option=tax_behavior_option,
-            currency=subscription.currency,
-            customer=customer,
-            product=product,
-            tax_exempted=subscription.tax_exempted,
-        )
+        total_amount = amounts.total_amount
 
         invoice_number = await organization_service.get_next_invoice_number(
             session, subscription.organization, customer
         )
 
-        net_amount = (
-            subtotal_amount
-            - discount_amount
-            - (tax_amount if tax_behavior == TaxBehavior.inclusive else 0)
-        )
-        total_amount = net_amount + tax_amount
         customer_balance = await wallet_service.get_billing_wallet_balance(
             session, customer, subscription.currency, for_update=True
         )
@@ -1411,25 +1367,25 @@ class OrderService:
             Order(
                 id=order_id,
                 status=OrderStatus.pending,
-                subtotal_amount=subtotal_amount,
-                discount_amount=discount_amount,
-                tax_amount=tax_amount,
-                net_amount=net_amount,
+                subtotal_amount=amounts.subtotal_amount,
+                discount_amount=amounts.discount_amount,
+                tax_amount=amounts.tax_amount,
+                net_amount=amounts.net_amount,
                 applied_balance_amount=applied_balance_amount,
                 currency=subscription.currency,
                 billing_reason=billing_reason,
                 billing_name=customer.billing_name,
-                billing_address=billing_address,
-                tax_behavior=tax_behavior,
-                tax_id=tax_id,
-                tax_breakdown=tax_breakdown or None,
-                tax_processor=tax_processor,
-                tax_calculation_processor_id=tax_calculation_processor_id,
+                billing_address=customer.billing_address,
+                tax_behavior=amounts.tax_behavior,
+                tax_id=customer.tax_id,
+                tax_breakdown=amounts.tax_breakdown or None,
+                tax_processor=amounts.tax_processor,
+                tax_calculation_processor_id=amounts.tax_calculation_processor_id,
                 invoice_number=invoice_number,
                 organization=subscription.organization,
                 customer=customer,
                 product=subscription.product,
-                discount=discount,
+                discount=subscription.discount,
                 subscription=subscription,
                 checkout=None,
                 items=items,
@@ -2154,7 +2110,7 @@ class OrderService:
                     tax_calculation_processor_id,
                     tax_amount,
                     tax_breakdown,
-                ) = await self._calculate_tax(
+                ) = await calculate_tax(
                     reference=str(order.id),
                     taxable_amount=order.net_amount,
                     currency=order.currency,
@@ -2981,92 +2937,6 @@ class OrderService:
             await subscription_service.enqueue_benefits_grants(session, subscription)
 
         return order
-
-    async def _calculate_tax(
-        self,
-        *,
-        reference: str,
-        taxable_amount: int,
-        tax_behavior_option: TaxBehaviorOption,
-        currency: str,
-        customer: Customer,
-        product: Product,
-        tax_exempted: bool,
-        allow_silent_failure: bool = True,
-    ) -> tuple[
-        TaxProcessor | None,
-        TaxBehavior | None,
-        str | None,
-        int,
-        Sequence[TaxBreakdownItem],
-    ]:
-        billing_address = customer.billing_address
-        tax_id = customer.tax_id
-
-        tax_processor: TaxProcessor | None = None
-        tax_behavior: TaxBehavior | None = None
-        tax_calculation: TaxCalculation | None = None
-        tax_amount = 0
-        tax_breakdown: list[TaxBreakdownItem] = []
-        tax_calculation_processor_id: str | None = None
-
-        if (
-            taxable_amount != 0
-            and product.is_tax_applicable
-            and billing_address is not None
-        ):
-            try:
-                (
-                    tax_calculation,
-                    tax_processor,
-                ) = await tax_calculation_service.calculate(
-                    reference,
-                    currency,
-                    # Stripe doesn't support calculating negative tax amounts
-                    taxable_amount if taxable_amount >= 0 else -taxable_amount,
-                    tax_behavior_option,
-                    product.tax_code,
-                    billing_address,
-                    [tax_id] if tax_id is not None else [],
-                    tax_exempted,
-                )
-            except TaxCalculationLogicalError:
-                # The subscription flow tolerates an uncomputable tax (the
-                # address is fixed up over the lifecycle). Off-session draft
-                # orders persist this result and never recompute it, so a silent
-                # zero would charge tax-free — the caller must surface it instead.
-                if not allow_silent_failure:
-                    raise
-                log.warning(
-                    "Failed to calculate tax for subscription order due to invalid or incomplete address",
-                    reference=reference,
-                    customer_id=customer.id,
-                )
-                tax_amount = 0
-                tax_calculation_processor_id = None
-            else:
-                if taxable_amount >= 0:
-                    tax_calculation_processor_id = tax_calculation["processor_id"]
-                    tax_amount = tax_calculation["amount"]
-                else:
-                    # When the taxable amount is negative it's usually due to a credit proration
-                    # this means we "owe" the customer money -- but we don't pay it back at this
-                    # point. This also means that there's no money transaction going on, and we
-                    # don't have to record the tax transaction either.
-                    tax_calculation_processor_id = None
-                    tax_amount = -tax_calculation["amount"]
-
-            if tax_calculation is not None:
-                tax_behavior = tax_calculation["tax_behavior"]
-                tax_breakdown = tax_calculation["tax_breakdown"]
-
-        return (
-            tax_processor,
-            tax_behavior,
-            tax_calculation_processor_id,
-            tax_amount,
-            tax_breakdown,
-        )
 
     async def schedule_retry_for_past_due_orders(
         self,

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -2184,6 +2184,15 @@ class SubscriptionService:
         Returns:
             SubscriptionChargePreview with breakdown of charges
         """
+        nested = await session.begin_nested()
+        try:
+            return await self._compute_charge_preview(session, subscription)
+        finally:
+            await nested.rollback()
+
+    async def _compute_charge_preview(
+        self, session: AsyncSession, subscription: Subscription
+    ) -> SubscriptionChargePreview:
         # Apply any pending subscription update (product change, seats change)
         pending_update = subscription.pending_update
         if pending_update is not None:
@@ -2296,9 +2305,6 @@ class SubscriptionService:
                     net_amount -= tax_amount
 
         total = net_amount + tax_amount
-
-        # Make sure nothing is saved to DB
-        await session.rollback()
 
         return SubscriptionChargePreview(
             base_amount=base_price,

--- a/server/tests/e2e/infra/external_mocks.py
+++ b/server/tests/e2e/infra/external_mocks.py
@@ -93,6 +93,7 @@ def mock_tax_calculation(mocker: MockerFixture) -> MagicMock:
     mock = MagicMock(spec=TaxCalculationService)
     mocker.patch("polar.checkout.service.tax_calculation_service", new=mock)
     mocker.patch("polar.order.service.tax_calculation_service", new=mock)
+    mocker.patch("polar.order.amounts.tax_calculation_service", new=mock)
     mock.calculate.return_value = (
         {
             "processor_id": "TAX_E2E_TEST",

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -198,6 +198,7 @@ def tax_service_mock(mocker: MockerFixture) -> MagicMock:
     mock = mocker.patch(
         "polar.order.service.tax_calculation_service", spec=TaxCalculationService
     )
+    mocker.patch("polar.order.amounts.tax_calculation_service", new=mock)
     mock.record.return_value = ("TAX_TRANSACTION_ID", TaxProcessor.numeral)
     return mock
 

--- a/server/tests/subscription/test_service_charge_preview.py
+++ b/server/tests/subscription/test_service_charge_preview.py
@@ -4,15 +4,22 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pytest_mock import MockerFixture
+from sqlalchemy import func, select
 
-from polar.enums import TaxBehavior, TaxProcessor
+from polar.enums import (
+    SubscriptionProrationBehavior,
+    SubscriptionRecurringInterval,
+    TaxBehavior,
+    TaxProcessor,
+)
 from polar.kit.address import Address
-from polar.models import Customer, Organization, Product
+from polar.models import BillingEntry, Customer, Organization, Product, Subscription
 from polar.models.billing_entry import BillingEntryDirection, BillingEntryType
 from polar.models.discount import DiscountDuration, DiscountType
 from polar.models.product_price import ProductPriceFixed
 from polar.models.subscription_meter import SubscriptionMeter
 from polar.postgres import AsyncSession
+from polar.subscription.service import SubscriptionUpdateContext
 from polar.subscription.service import subscription as subscription_service
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
@@ -21,6 +28,7 @@ from tests.fixtures.random_objects import (
     create_customer,
     create_discount,
     create_meter,
+    create_product,
 )
 
 
@@ -255,3 +263,93 @@ class TestCalculateChargePreview:
         assert preview.discount_amount == 250
         assert preview.net_amount == 3250 - 250
         assert preview.total_amount == 3000
+
+
+@pytest.mark.asyncio
+class TestCalculateChargePreviewPersistsNothing:
+    async def test_pending_update_is_previewed_but_not_persisted(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        """The preview applies the pending update in memory to price the next charge.
+
+        None of that may reach the database, and the surrounding transaction must
+        survive — the guard is a savepoint, not a bare `session.rollback()`.
+        """
+        new_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(5000, "usd")],
+        )
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        subscription_id = subscription.id
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_product(
+                session,
+                ctx,
+                subscription,
+                product_id=new_product.id,
+                proration_behavior=SubscriptionProrationBehavior.next_period,
+            )
+        await session.flush()
+
+        entries_before = await session.scalar(
+            select(func.count()).select_from(BillingEntry)
+        )
+
+        preview = await subscription_service.calculate_charge_preview(
+            session, subscription
+        )
+
+        # The pending update is reflected in the preview...
+        assert preview.base_amount == 5000
+
+        # ...but a later flush (as at request end) must not persist it.
+        await session.flush()
+
+        assert (
+            await session.scalar(
+                select(Subscription.product_id).where(
+                    Subscription.id == subscription_id
+                )
+            )
+            == product.id
+        )
+        assert (
+            await session.scalar(select(func.count()).select_from(BillingEntry))
+            == entries_before
+        )
+
+    async def test_surrounding_transaction_survives(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        """A bare `session.rollback()` guard would discard the caller's own work."""
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        subscription_id = subscription.id
+
+        await subscription_service.calculate_charge_preview(session, subscription)
+
+        assert (
+            await session.scalar(
+                select(func.count())
+                .select_from(Subscription)
+                .where(Subscription.id == subscription_id)
+            )
+            == 1
+        )

--- a/server/tests/subscription/test_service_charge_preview.py
+++ b/server/tests/subscription/test_service_charge_preview.py
@@ -1,0 +1,257 @@
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from polar.enums import TaxBehavior, TaxProcessor
+from polar.kit.address import Address
+from polar.models import Customer, Organization, Product
+from polar.models.billing_entry import BillingEntryDirection, BillingEntryType
+from polar.models.discount import DiscountDuration, DiscountType
+from polar.models.product_price import ProductPriceFixed
+from polar.models.subscription_meter import SubscriptionMeter
+from polar.postgres import AsyncSession
+from polar.subscription.service import subscription as subscription_service
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import (
+    create_active_subscription,
+    create_billing_entry,
+    create_customer,
+    create_discount,
+    create_meter,
+)
+
+
+@pytest.fixture
+def tax_mock(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch("polar.subscription.service.tax_calculation_service")
+
+
+def set_tax(tax_mock: MagicMock, amount: int) -> None:
+    async def calculate(
+        *args: Any, **kwargs: Any
+    ) -> tuple[dict[str, Any], TaxProcessor]:
+        return {"amount": amount}, TaxProcessor.stripe
+
+    tax_mock.calculate = AsyncMock(side_effect=calculate)
+
+
+@pytest.mark.asyncio
+class TestCalculateChargePreview:
+    async def test_fixed_price_only(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        preview = await subscription_service.calculate_charge_preview(
+            session, subscription
+        )
+
+        assert preview.base_amount == 1000
+        assert preview.metered_amount == 0
+        assert preview.proration_amount == 0
+        assert preview.prorations == []
+        assert preview.subtotal_amount == 1000
+        assert preview.discount_amount == 0
+        assert preview.net_amount == 1000
+        assert preview.tax_amount == 0
+        assert preview.total_amount == 1000
+
+    async def test_cancel_at_period_end_zeroes_base(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer, cancel_at_period_end=True
+        )
+
+        preview = await subscription_service.calculate_charge_preview(
+            session, subscription
+        )
+
+        assert preview.base_amount == 0
+        assert preview.subtotal_amount == 0
+        assert preview.total_amount == 0
+
+    async def test_percentage_discount_applies_to_recurring(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.percentage,
+            basis_points=2500,
+            duration=DiscountDuration.forever,
+            organization=organization,
+        )
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer, discount=discount
+        )
+
+        preview = await subscription_service.calculate_charge_preview(
+            session, subscription
+        )
+
+        assert preview.base_amount == 1000
+        assert preview.discount_amount == 250
+        assert preview.net_amount == 750
+        assert preview.total_amount == 750
+
+    async def test_exclusive_tax_added_on_top(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        tax_mock: MagicMock,
+    ) -> None:
+        set_tax(tax_mock, 200)
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            billing_address=Address(country="FR"),  # type: ignore[arg-type]
+        )
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            tax_behavior=TaxBehavior.exclusive,
+        )
+
+        preview = await subscription_service.calculate_charge_preview(
+            session, subscription
+        )
+
+        assert preview.net_amount == 1000
+        assert preview.tax_amount == 200
+        assert preview.total_amount == 1200
+
+    async def test_inclusive_tax_carved_out_of_net(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        tax_mock: MagicMock,
+    ) -> None:
+        set_tax(tax_mock, 200)
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            billing_address=Address(country="FR"),  # type: ignore[arg-type]
+        )
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            tax_behavior=TaxBehavior.inclusive,
+        )
+
+        preview = await subscription_service.calculate_charge_preview(
+            session, subscription
+        )
+
+        assert preview.net_amount == 800
+        assert preview.tax_amount == 200
+        assert preview.total_amount == 1000
+
+    async def test_metered_amount_included_in_subtotal(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        meter = await create_meter(save_fixture, organization=organization)
+        await save_fixture(
+            SubscriptionMeter(subscription=subscription, meter=meter, amount=500)
+        )
+
+        preview = await subscription_service.calculate_charge_preview(
+            session, subscription
+        )
+
+        assert preview.base_amount == 1000
+        assert preview.metered_amount == 500
+        assert preview.subtotal_amount == 1500
+        assert preview.total_amount == 1500
+
+    async def test_prorations_surfaced_and_excluded_from_discount(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.percentage,
+            basis_points=2500,
+            duration=DiscountDuration.forever,
+            organization=organization,
+        )
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer, discount=discount
+        )
+        price = subscription.product.prices[0]
+        assert isinstance(price, ProductPriceFixed)
+
+        await create_billing_entry(
+            save_fixture,
+            type=BillingEntryType.proration,
+            direction=BillingEntryDirection.debit,
+            customer=customer,
+            product_price=price,
+            subscription=subscription,
+            amount=3375,
+            discount_amount=1125,
+            currency="usd",
+            start_timestamp=datetime(2025, 9, 16, tzinfo=UTC),
+            end_timestamp=datetime(2025, 10, 1, tzinfo=UTC),
+        )
+        await create_billing_entry(
+            save_fixture,
+            type=BillingEntryType.proration,
+            direction=BillingEntryDirection.credit,
+            customer=customer,
+            product_price=price,
+            subscription=subscription,
+            amount=1125,
+            discount_amount=375,
+            currency="usd",
+            start_timestamp=datetime(2025, 9, 16, tzinfo=UTC),
+            end_timestamp=datetime(2025, 10, 1, tzinfo=UTC),
+        )
+
+        preview = await subscription_service.calculate_charge_preview(
+            session, subscription
+        )
+
+        assert preview.base_amount == 1000
+        assert preview.proration_amount == 3375 - 1125
+        assert len(preview.prorations) == 2
+        assert preview.subtotal_amount == 1000 + 2250
+        # 25% of the recurring amount (1000) only — NOT of the 2250 proration.
+        assert preview.discount_amount == 250
+        assert preview.net_amount == 3250 - 250
+        assert preview.total_amount == 3000


### PR DESCRIPTION
## Summary

Groundwork for the subscription change-preview endpoint (polarsource/feedback#58), which asks for an endpoint to preview proration amounts before confirming a subscription change — today customers have to estimate it client-side and their numbers drift from what we charge.

The subtotal → discount → tax → net → total arithmetic is implemented twice: 
- once in `OrderService._create_order`, 
- once inline in `SubscriptionService.calculate_charge_preview`. 

Adding a preview endpoint that recomputes totals a third way is how a previewed amount ends up disagreeing with
the invoiced one. 

This gives that math a single home so the new endpoint can reuse it rather than reimplement it.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

