### PR TITLE
ci: fetch mc from a pinned GitHub release

### DIFF
--- a/server/.minio/github.sh
+++ b/server/.minio/github.sh
@@ -1,6 +1,15 @@
 #!/bin/bash
+set -euo pipefail
 
-wget https://dl.min.io/client/mc/release/linux-amd64/mc
+# minio/minio was archived on 2026-04-25 and dl.min.io's TLS certificate expired
+# on 2026-07-10, so `mc` is fetched from a pinned GitHub release and verified.
+MC_RELEASE="RELEASE.2025-08-13T08-35-41Z"
+MC_BASE="https://github.com/minio/mc/releases/download/${MC_RELEASE}"
+
+curl -fsSL -o mc "${MC_BASE}/mc.linux-amd64.${MC_RELEASE}"
+curl -fsSL -o mc.sha256sum "${MC_BASE}/mc.linux-amd64.${MC_RELEASE}.sha256sum"
+echo "$(cut -d' ' -f1 mc.sha256sum)  mc" | sha256sum -c -
+
 chmod +x mc
 
 export CMD_MC=./mc


### PR DESCRIPTION

## Summary

minio/minio was archived on 2026-04-25 and dl.min.io's TLS certificate expired on 2026-07-10, breaking the MinIO setup step on every Server run. Pull mc from a pinned, checksum-verified GitHub release instead, and fail fast on download errors.

Unblocking the CI but we will need to find a better solution

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

