### PR TITLE
test(merchant_mig): stop production key test depending on cache order

### DIFF
--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -6,6 +6,8 @@ from pytest_mock import MockerFixture
 
 from polar.auth.models import AuthSubject
 from polar.config import settings
+from polar.kit import encryption
+from polar.kit.encryption import LocalKeyProvider
 from polar.kit.pagination import PaginationParams
 from polar.merchant_migration.canonical import (
     CanonicalAccount,
@@ -242,6 +244,13 @@ class TestCreate:
     ) -> None:
         await _enable_feature(save_fixture, organization)
         mocker.patch.object(settings, "is_production", return_value=True)
+        # `get_key_provider` is cached, so faking production would otherwise reach
+        # for KMS whenever this test happens to be the first caller in the process.
+        mocker.patch.object(
+            encryption,
+            "get_key_provider",
+            return_value=LocalKeyProvider(settings.ENCRYPTION_LOCAL_KEY),
+        )
 
         # A test-mode key is rejected in production...
         with pytest.raises(SourceKeyModeMismatch):


### PR DESCRIPTION

get_key_provider is functools.cached, so faking production reached for KMS whenever this test was the first caller in the process — passing only when an earlier test had warmed the cache. Pin the local key provider instead.



## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

