### PR TITLE
adjust compass modal contents

### DIFF
--- a/clients/apps/web/src/components/Compass/CompassIntroModal.tsx
+++ b/clients/apps/web/src/components/Compass/CompassIntroModal.tsx
@@ -33,13 +33,9 @@ export const CompassIntroModal = ({
     markDismissed()
   }
 
-  const goToBilling = () => {
-    dismiss()
-    router.push(`/dashboard/${organization.slug}/products`)
-  }
-
   const explore = () => {
     dismiss()
+    router.push(`/dashboard/${organization.slug}/compass`)
   }
 
   return (
@@ -65,15 +61,15 @@ export const CompassIntroModal = ({
               Introducing Compass
             </Text>
             <Text color="muted" variant="body" wrap="pretty">
-              Your dashboard now has two surfaces. Billing that gets you paid.
-              Compass which shows you what every customer, feature, and model
-              actually costs to serve.
+              Ask anything about your revenue, costs, churn or customers and get
+              answers grounded in your data. Insights watch your metrics and
+              surface what needs attention.
             </Text>
           </Box>
           <Box flexDirection="column" gap="s" width="100%">
             <Button onClick={explore}>Explore Compass</Button>
-            <Button variant="ghost" onClick={goToBilling}>
-              Go to Billing
+            <Button variant="ghost" onClick={dismiss}>
+              Close
             </Button>
           </Box>
         </Box>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the Compass intro modal copy and simplified actions to focus on exploring Compass. “Explore” now routes to `/dashboard/{org}/compass`, and the secondary button is “Close” instead of “Go to Billing.”

<sup>Written for commit 12db062200b221d3f3e394afb6cf175f6d9f68b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

