### PR TITLE
fix(subscription): align charge preview tax with the invoice

### DIFF
--- a/server/polar/order/amounts.py
+++ b/server/polar/order/amounts.py
@@ -5,7 +5,7 @@ import structlog
 
 from polar.enums import TaxBehavior, TaxBehaviorOption, TaxProcessor
 from polar.logging import Logger
-from polar.models import Customer, OrderItem, Product, Subscription
+from polar.models import Customer, Discount, OrderItem, Product, Subscription
 from polar.tax.calculation import (
     TaxBreakdownItem,
     TaxCalculation,
@@ -122,12 +122,12 @@ async def compute_order_amounts(
     items: Sequence[OrderItem],
     *,
     reference: str,
+    discount: Discount | None,
 ) -> OrderAmounts:
     customer = subscription.customer
 
     subtotal_amount = sum(item.amount for item in items)
 
-    discount = subscription.discount
     discount_amount = 0
     if discount is not None:
         # Discount only applies to cycle and meter items, as prorations

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1336,7 +1336,7 @@ class OrderService:
         customer = subscription.customer
 
         amounts = await compute_order_amounts(
-            subscription, items, reference=str(order_id)
+            subscription, items, reference=str(order_id), discount=subscription.discount
         )
         total_amount = amounts.total_amount
 

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -33,7 +33,6 @@ from polar.enums import (
     PaymentMode,
     SubscriptionProrationBehavior,
     SubscriptionRecurringInterval,
-    TaxBehavior,
 )
 from polar.event.service import event as event_service
 from polar.event.system import (
@@ -72,6 +71,7 @@ from polar.models import (
     Customer,
     Discount,
     Order,
+    OrderItem,
     Organization,
     PaymentMethod,
     Product,
@@ -92,6 +92,7 @@ from polar.notifications.notification import (
 )
 from polar.notifications.service import PartialNotification
 from polar.notifications.service import notifications as notifications_service
+from polar.order.amounts import compute_order_amounts
 from polar.organization.repository import (
     SUBSCRIPTION_CANCELLATION_STATUSES,
     OrganizationRepository,
@@ -105,8 +106,6 @@ from polar.product.guard import (
 from polar.product.price_set import NoPricesForCurrencies, PriceSet
 from polar.product.repository import ProductRepository
 from polar.product.service import product as product_service
-from polar.tax.calculation import TaxCalculationLogicalError
-from polar.tax.calculation import tax_calculation as tax_calculation_service
 from polar.webhook.service import webhook as webhook_service
 from polar.worker import enqueue_job, make_bulk_job_delay_calculator
 
@@ -2223,6 +2222,23 @@ class SubscriptionService:
 
         metered_amount = sum(meter.amount for meter in subscription.meters)
 
+        items = [
+            OrderItem(
+                label="Subscription",
+                amount=base_price,
+                net_amount=base_price,
+                tax_amount=0,
+                proration=False,
+            ),
+            OrderItem(
+                label="Metered usage",
+                amount=metered_amount,
+                net_amount=metered_amount,
+                tax_amount=0,
+                proration=False,
+            ),
+        ]
+
         # Pending mid-period prorations (seat/product changes) already exist as
         # billing entries; surface them so the preview matches the next invoice.
         prorations: list[SubscriptionChargePreviewProration] = []
@@ -2241,14 +2257,17 @@ class SubscriptionService:
                 )
             )
             proration_amount += line_item.amount
-
-        recurring_amount = base_price + metered_amount
-        subtotal_amount = recurring_amount + proration_amount
-
-        discount_amount = 0
+            items.append(
+                OrderItem(
+                    label=line_item.label,
+                    amount=line_item.amount,
+                    net_amount=line_item.amount,
+                    tax_amount=0,
+                    proration=True,
+                )
+            )
 
         applicable_discount = None
-
         # Ensure the discount has not expired yet for the next charge (so at current_period_end)
         if subscription.discount is not None:
             # If discount hasn't been applied yet, it will be applied at the next cycle
@@ -2262,60 +2281,23 @@ class SubscriptionService:
             ):
                 applicable_discount = subscription.discount
 
-        if applicable_discount is not None:
-            # Discount applies to the recurring charge only; prorations are billed
-            # net of their own proration at entry-creation time.
-            discount_amount = applicable_discount.get_discount_amount(
-                recurring_amount, subscription.currency
-            )
-
-        net_amount = subtotal_amount - discount_amount
-        tax_amount = 0
-
-        if (
-            net_amount > 0
-            and subscription.product.is_tax_applicable
-            and subscription.tax_behavior
-            and subscription.customer.billing_address is not None
-        ):
-            tax_behavior = subscription.tax_behavior.to_option()
-            try:
-                tax, _ = await tax_calculation_service.calculate(
-                    subscription.id,
-                    subscription.currency,
-                    net_amount,
-                    tax_behavior,
-                    subscription.product.tax_code,
-                    subscription.customer.billing_address,
-                    [subscription.customer.tax_id]
-                    if subscription.customer.tax_id is not None
-                    else [],
-                    subscription.tax_exempted,
-                )
-            except TaxCalculationLogicalError:
-                log.warning(
-                    "Failed to calculate tax for subscription due to invalid or incomplete address",
-                    subscription_id=subscription.id,
-                    customer_id=subscription.customer_id,
-                )
-                tax_amount = 0
-            else:
-                tax_amount = tax["amount"]
-                if subscription.tax_behavior == TaxBehavior.inclusive:
-                    net_amount -= tax_amount
-
-        total = net_amount + tax_amount
+        amounts = await compute_order_amounts(
+            subscription,
+            items,
+            reference=str(subscription.id),
+            discount=applicable_discount,
+        )
 
         return SubscriptionChargePreview(
             base_amount=base_price,
             metered_amount=metered_amount,
             proration_amount=proration_amount,
             prorations=prorations,
-            subtotal_amount=subtotal_amount,
-            discount_amount=discount_amount,
-            net_amount=net_amount,
-            tax_amount=tax_amount,
-            total_amount=total,
+            subtotal_amount=amounts.subtotal_amount,
+            discount_amount=amounts.discount_amount,
+            net_amount=amounts.net_amount,
+            tax_amount=amounts.tax_amount,
+            total_amount=amounts.total_amount,
         )
 
     async def _after_subscription_updated(

--- a/server/tests/subscription/test_service_charge_preview.py
+++ b/server/tests/subscription/test_service_charge_preview.py
@@ -10,10 +10,18 @@ from polar.enums import (
     SubscriptionProrationBehavior,
     SubscriptionRecurringInterval,
     TaxBehavior,
+    TaxBehaviorOption,
     TaxProcessor,
 )
 from polar.kit.address import Address
-from polar.models import BillingEntry, Customer, Organization, Product, Subscription
+from polar.models import (
+    BillingEntry,
+    Customer,
+    OrderItem,
+    Organization,
+    Product,
+    Subscription,
+)
 from polar.models.billing_entry import BillingEntryDirection, BillingEntryType
 from polar.models.discount import DiscountDuration, DiscountType
 from polar.models.product_price import ProductPriceFixed
@@ -21,6 +29,7 @@ from polar.models.subscription_meter import SubscriptionMeter
 from polar.postgres import AsyncSession
 from polar.subscription.service import SubscriptionUpdateContext
 from polar.subscription.service import subscription as subscription_service
+from polar.tax.calculation import get_tax_behavior_from_option
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_active_subscription,
@@ -34,14 +43,32 @@ from tests.fixtures.random_objects import (
 
 @pytest.fixture
 def tax_mock(mocker: MockerFixture) -> MagicMock:
-    return mocker.patch("polar.subscription.service.tax_calculation_service")
+    return mocker.patch("polar.order.amounts.tax_calculation_service")
 
 
 def set_tax(tax_mock: MagicMock, amount: int) -> None:
     async def calculate(
-        *args: Any, **kwargs: Any
+        reference: str,
+        currency: str,
+        taxable_amount: int,
+        tax_behavior_option: TaxBehaviorOption,
+        tax_code: Any,
+        address: Address,
+        tax_ids: list[Any],
+        tax_exempted: bool,
     ) -> tuple[dict[str, Any], TaxProcessor]:
-        return {"amount": amount}, TaxProcessor.stripe
+        return (
+            {
+                "processor_id": "TAX_PROCESSOR_ID",
+                "amount": amount,
+                "currency": currency,
+                "tax_behavior": get_tax_behavior_from_option(
+                    tax_behavior_option, address
+                ),
+                "tax_breakdown": [],
+            },
+            TaxProcessor.stripe,
+        )
 
     tax_mock.calculate = AsyncMock(side_effect=calculate)
 
@@ -266,16 +293,12 @@ class TestCalculateChargePreview:
 
 
 @pytest.mark.asyncio
-class TestCalculateChargePreviewTaxDivergesFromOrder:
-    """The preview taxes strictly positive amounts and needs an explicit tax behavior.
-
-    `order.amounts.calculate_tax` taxes any non-zero amount — negating it for
-    credits — and falls back to the organization's default tax behavior. These pin
-    the preview's current, divergent rules so realigning it onto the shared
-    computation surfaces as failing assertions rather than a silent change.
+class TestCalculateChargePreviewTaxMatchesOrder:
+    """Any non-zero amount is taxed — negated for a credit — and an unset tax
+    behavior falls back to the organization's default, as `order.amounts` does.
     """
 
-    async def test_negative_net_is_not_taxed(
+    async def test_negative_net_is_taxed_as_a_credit(
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
@@ -316,12 +339,12 @@ class TestCalculateChargePreviewTaxDivergesFromOrder:
         assert preview.proration_amount == -1125
         assert preview.subtotal_amount == -1125
         assert preview.net_amount == -1125
-        # The invoice would record a negative tax here; the preview reports none.
-        assert preview.tax_amount == 0
-        assert preview.total_amount == -1125
-        tax_mock.calculate.assert_not_called()
+        # We owe the customer the tax on the credit too, as the invoice records it.
+        assert preview.tax_amount == -200
+        assert preview.total_amount == -1325
+        tax_mock.calculate.assert_called_once()
 
-    async def test_unset_tax_behavior_is_not_taxed(
+    async def test_unset_tax_behavior_falls_back_to_organization_default(
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
@@ -343,11 +366,12 @@ class TestCalculateChargePreviewTaxDivergesFromOrder:
             session, subscription
         )
 
-        # The invoice would fall back to `organization.default_tax_behavior`.
-        assert preview.net_amount == 1000
-        assert preview.tax_amount == 0
+        # `location` default + a non-tax-exclusive country resolves to inclusive,
+        # so the tax is carved out of the total rather than added on top.
+        assert preview.net_amount == 800
+        assert preview.tax_amount == 200
         assert preview.total_amount == 1000
-        tax_mock.calculate.assert_not_called()
+        tax_mock.calculate.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -360,10 +384,9 @@ class TestCalculateChargePreviewPersistsNothing:
         product: Product,
         customer: Customer,
     ) -> None:
-        """The preview applies the pending update in memory to price the next charge.
+        """The pending update is applied in memory to price the next charge.
 
-        None of that may reach the database, and the surrounding transaction must
-        survive — the guard is a savepoint, not a bare `session.rollback()`.
+        None of it may reach the database, and the surrounding transaction survives.
         """
         new_product = await create_product(
             save_fixture,
@@ -414,6 +437,8 @@ class TestCalculateChargePreviewPersistsNothing:
             await session.scalar(select(func.count()).select_from(BillingEntry))
             == entries_before
         )
+        # The preview builds `OrderItem`s to price the charge; none may be persisted.
+        assert await session.scalar(select(func.count()).select_from(OrderItem)) == 0
 
     async def test_surrounding_transaction_survives(
         self,
@@ -422,7 +447,7 @@ class TestCalculateChargePreviewPersistsNothing:
         product: Product,
         customer: Customer,
     ) -> None:
-        """A bare `session.rollback()` guard would discard the caller's own work."""
+        """The preview leaves the caller's own uncommitted work intact."""
         subscription = await create_active_subscription(
             save_fixture, product=product, customer=customer
         )

--- a/server/tests/subscription/test_service_charge_preview.py
+++ b/server/tests/subscription/test_service_charge_preview.py
@@ -266,6 +266,91 @@ class TestCalculateChargePreview:
 
 
 @pytest.mark.asyncio
+class TestCalculateChargePreviewTaxDivergesFromOrder:
+    """The preview taxes strictly positive amounts and needs an explicit tax behavior.
+
+    `order.amounts.calculate_tax` taxes any non-zero amount — negating it for
+    credits — and falls back to the organization's default tax behavior. These pin
+    the preview's current, divergent rules so realigning it onto the shared
+    computation surfaces as failing assertions rather than a silent change.
+    """
+
+    async def test_negative_net_is_not_taxed(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        tax_mock: MagicMock,
+    ) -> None:
+        set_tax(tax_mock, 200)
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            billing_address=Address(country="FR"),  # type: ignore[arg-type]
+        )
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer, cancel_at_period_end=True
+        )
+        price = subscription.product.prices[0]
+        assert isinstance(price, ProductPriceFixed)
+
+        await create_billing_entry(
+            save_fixture,
+            type=BillingEntryType.proration,
+            direction=BillingEntryDirection.credit,
+            customer=customer,
+            product_price=price,
+            subscription=subscription,
+            amount=1125,
+            currency="usd",
+            start_timestamp=datetime(2025, 9, 16, tzinfo=UTC),
+            end_timestamp=datetime(2025, 10, 1, tzinfo=UTC),
+        )
+
+        preview = await subscription_service.calculate_charge_preview(
+            session, subscription
+        )
+
+        assert preview.base_amount == 0
+        assert preview.proration_amount == -1125
+        assert preview.subtotal_amount == -1125
+        assert preview.net_amount == -1125
+        # The invoice would record a negative tax here; the preview reports none.
+        assert preview.tax_amount == 0
+        assert preview.total_amount == -1125
+        tax_mock.calculate.assert_not_called()
+
+    async def test_unset_tax_behavior_is_not_taxed(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        tax_mock: MagicMock,
+    ) -> None:
+        set_tax(tax_mock, 200)
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            billing_address=Address(country="FR"),  # type: ignore[arg-type]
+        )
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer, tax_behavior=None
+        )
+
+        preview = await subscription_service.calculate_charge_preview(
+            session, subscription
+        )
+
+        # The invoice would fall back to `organization.default_tax_behavior`.
+        assert preview.net_amount == 1000
+        assert preview.tax_amount == 0
+        assert preview.total_amount == 1000
+        tax_mock.calculate.assert_not_called()
+
+
+@pytest.mark.asyncio
 class TestCalculateChargePreviewPersistsNothing:
     async def test_pending_update_is_previewed_but_not_persisted(
         self,


### PR DESCRIPTION
## Summary

The charge preview taxed only strictly positive amounts and required an explicit `tax_behavior`. Two cases went untaxed and understated the amount:

- a downgrade credit of `-1125` previewed a total of `-1125`; the invoice credits  the tax on it too (`-1325`)
- a subscription with no `tax_behavior` previewed `net=1000 tax=0`; the invoice  resolves the organization default (for a FR customer, inclusive: `net=800 tax=200`)

Routes the preview through `compute_order_amounts` so it taxes exactly as the invoice does. 
The preview keeps its own repetition check on the discount, since it prices the next cycle rather than the current one.

> [!WARNING]
> **Behavior change.** Previewed totals computed by charge-preview endpoints move for both cases above.

Groundwork for polarsource/feedback#58.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

