### PR TITLE
sdk: fix CI

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -37,15 +37,6 @@ jobs:
           echo "Extracted version: $version"
           echo "version=$version" >> $GITHUB_OUTPUT
 
-      - name: Verify version format
-        if: steps.check.outputs.release == 'true'
-        run: |
-          version="${{ steps.extract.outputs.version }}"
-          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
-            echo "Invalid version format: $version"
-            exit 1
-          fi
-
   tag:
     needs: detect-release
     if: needs.detect-release.outputs.version != ''


### PR DESCRIPTION
- sdk: fix CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the version format verification step from the SDK release workflow to stop false failures and restore CI. Tagging now proceeds whenever a version is detected.

<sup>Written for commit 07f31366e0f5ee6ba59a36058d865a2f6e9236a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

