### PR TITLE
sdk: fix CI

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -33,7 +33,7 @@ jobs:
         if: steps.check.outputs.release == 'true'
         id: extract
         run: |
-          version=$(git log --oneline -1 | grep -oP 'sdk\[release\]: \K.+')
+          version=$(git log --oneline -1 | grep -oP 'sdk\[release\]: \K\S+')
           echo "Extracted version: $version"
           echo "version=$version" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
- sdk: fix CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed the SDK release CI by tightening the commit regex to capture only the version token after "sdk[release]:". Prevents grabbing extra text and failing the release step.

<sup>Written for commit 957f850536cf66ad48710845bc12de1c838219b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

