### PR TITLE
sdk[release]: 1.0.0-alpha.4

### DIFF
--- a/sdk/python/polar/__init__.py
+++ b/sdk/python/polar/__init__.py
@@ -1,6 +1,6 @@
 from polar.base import PolarClientError, PolarError, PolarNetworkError, PolarServerError
 
-__version__ = "1.0.0a3"
+__version__ = "1.0.0a4"
 __all__ = [
     "PolarError",
     "PolarNetworkError",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polar-sh/sdk",
-  "version": "1.0.0-alpha.3",
+  "version": "1.0.0-alpha.4",
   "description": "Polar SDK — A billing platform for the intelligence era",
   "keywords": [
     "api",

--- a/sdk/typescript/src/2026-04/models.ts
+++ b/sdk/typescript/src/2026-04/models.ts
@@ -916,7 +916,7 @@ export type PaymentTrigger =
   | "retry_payment_method_update"
   | "retry_admin";
 /**
- * Permission
+ * The permission level to grant. Read more about roles and their permissions on [GitHub documentation](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role).
  */
 export type Permission = "pull" | "triage" | "push" | "maintain" | "admin";
 /**


### PR DESCRIPTION
- sdk[release]: 1.0.0-alpha.4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish SDK 1.0.0-alpha.4. Bumps the Python `__version__` and the `@polar-sh/sdk` package version, and clarifies the `Permission` type docs in TS models with a link to GitHub role permissions.

<sup>Written for commit ac90c7124f96a06b52b38778749247f164494321. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

