### PR TITLE
payout: Add CRC minimum payout threshold for Costa Rica

### DIFF
--- a/docs/features/finance/payouts.mdx
+++ b/docs/features/finance/payouts.mdx
@@ -31,6 +31,7 @@ The minimum balance required to issue a payout varies based on the payout curren
 | BOB      | $40.00              |
 | BTN      | $40.00              |
 | CLP      | $40.00              |
+| CRC      | $40.00              |
 | GMD      | $40.00              |
 | GYD      | $40.00              |
 | KHR      | $40.00              |

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -441,6 +441,7 @@ class Settings(BaseSettings):
         "chf": 1500,
         "clp": 4000,
         "cop": 5000,
+        "crc": 4000,
         "eur": 1300,
         "gbp": 1500,
         "gmd": 4000,

--- a/server/tests/payout/test_service.py
+++ b/server/tests/payout/test_service.py
@@ -90,6 +90,9 @@ class TestCreate:
             # Country-specific minimum (Panama: $50 USD) dominates the
             # currency-based USD default ($10).
             ("usd", "PA", settings.get_minimum_payout("usd", "PA") - 1),
+            # Costa Rica settles in CRC, whose currency minimum ($40) holds the
+            # payout until the converted amount clears Stripe's ₡300 floor.
+            ("crc", "CR", settings.get_minimum_payout("crc", "CR") - 1),
         ],
     )
     async def test_insufficient_balance(


### PR DESCRIPTION
## Summary

**Related Issue**: polarsource/feedback#251

Small payouts to Costa Rica fail at Stripe with `Amount must be no less than ₡300.00` because Polar had no CRC-specific payout minimum and fell back to the `$10` default. This adds a `crc` entry to the payout-minimum table so a CRC balance is held until it clears Stripe's local-currency minimum with FX/fee headroom, instead of being sent and rejected.

## What

- Add `"crc": 4000` (`$40`) to `ACCOUNT_PAYOUT_MINIMUM_BALANCE_PER_PAYOUT_CURRENCY` in `server/polar/config.py`.
- Document CRC in the minimum-payout table in `docs/features/finance/payouts.mdx`.
- Add a parametrized `("crc", "CR", …)` case to `TestCreate.test_insufficient_balance`.

## Why

Costa Rican Stripe accounts settle in CRC. With no `crc` entry, `get_minimum_payout("crc", "CR")` returned the `$10` default. A payout clearing that gross check would be created and transferred, then rejected at Stripe's payout step once converted to CRC (`Amount must be no less than ₡300.00`), leaving a **failed payout attempt** rather than holding the balance until it is payable.

Raising the threshold makes small CRC balances raise `InsufficientBalance` — which already surfaces the minimum amount to the merchant through both `/payouts/estimate` and payout creation — so merchants see a clear "insufficient balance, minimum is $40.00" message instead of a silently failing Stripe attempt. No new state was introduced (`PayoutStatus.held` already denotes review-holds, an unrelated concept).

## How

- `$40` matches the sibling Latin-American / emerging-market currencies already in the table (`clp`/`bob` at `$40`, `cop` at `$50`) that were added for the same cross-border reason, and sits comfortably above Stripe's `₡300` (~`$0.60`) floor to absorb FX conversion and payout fees.
- Because CR accounts settle in CRC, the per-currency entry is the correct lever: `get_minimum_payout` returns `max(currency_min, country_min)`, which now yields `$40` for every Costa Rican account. A `CR` entry in `ACCOUNT_PAYOUT_MINIMUM_BALANCE_PER_PAYOUT_COUNTRY` would be redundant with the currency entry and contradicts that table's documented purpose (USD-denominated countries the per-currency table can't cover), so it was intentionally left out.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`) — could not run in the sandbox (backend requires Python 3.14.6, unavailable here). The change is a config-literal + docs + test-param addition; `config.py` and `test_service.py` were validated by parsing the module and exercising `get_minimum_payout` for the new and neighboring cases.
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VyMLmkUnSCEZQL47NmM2m

---
_Generated by [Claude Code](https://claude.ai/code/session_019VyMLmkUnSCEZQL47NmM2m)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

