### PR TITLE
server/transaction: make sure to mark payout_reversal transactions as paid when creating a new payout transaction

### DIFF
--- a/server/polar/transaction/repository.py
+++ b/server/polar/transaction/repository.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 from uuid import UUID
 
-from sqlalchemy import Select, func, or_, update
+from sqlalchemy import Select, and_, func, or_, update
 from sqlalchemy.orm import selectinload
 
 from polar.kit.repository import (
@@ -20,6 +20,39 @@ class TransactionRepository(
     RepositoryBase[Transaction],
 ):
     model = Transaction
+
+    async def get_all_unpaid_by_account(self, account: UUID) -> Sequence[Transaction]:
+        statement = (
+            self.get_base_statement()
+            .join(Account, Account.id == Transaction.account_id)
+            .where(
+                Transaction.account_id == account,
+                Transaction.payout_transaction_id.is_(None),
+                or_(
+                    # Balance transactions that are either :
+                    # * Ready to be paid out (after the payout delay)
+                    # * Payout fees we just incurred (we need to pay them out immediately)
+                    and_(
+                        Transaction.type == TransactionType.balance,
+                        or_(
+                            Transaction.created_at + Account.payout_transaction_delay
+                            <= func.now(),
+                            Transaction.platform_fee_type.in_(
+                                PlatformFeeType.payout_fee_types()
+                            ),
+                        ),
+                    ),
+                    # Payout reversal transactions should always be included
+                    Transaction.type == TransactionType.payout_reversal,
+                ),
+            )
+            .options(
+                selectinload(Transaction.balance_reversal_transaction),
+                selectinload(Transaction.balance_reversal_transactions),
+                selectinload(Transaction.payment_transaction),
+            )
+        )
+        return await self.get_all(statement)
 
     async def get_all_paid_transactions_by_payout(
         self, payout_transaction_id: UUID
@@ -68,30 +101,6 @@ class PaymentTransactionRepository(TransactionRepository):
 
 
 class BalanceTransactionRepository(TransactionRepository):
-    async def get_all_unpaid_by_account(self, account: UUID) -> Sequence[Transaction]:
-        statement = (
-            self.get_base_statement()
-            .join(Account, Account.id == Transaction.account_id)
-            .where(
-                Transaction.type == TransactionType.balance,
-                Transaction.account_id == account,
-                Transaction.payout_transaction_id.is_(None),
-                or_(
-                    Transaction.created_at + Account.payout_transaction_delay
-                    <= func.now(),
-                    Transaction.platform_fee_type.in_(
-                        PlatformFeeType.payout_fee_types()
-                    ),
-                ),
-            )
-            .options(
-                selectinload(Transaction.balance_reversal_transaction),
-                selectinload(Transaction.balance_reversal_transactions),
-                selectinload(Transaction.payment_transaction),
-            )
-        )
-        return await self.get_all(statement)
-
     async def reset_payout_transaction_id(self, payout_transaction_id: UUID) -> None:
         statement = (
             update(Transaction)

--- a/server/polar/transaction/service/payout.py
+++ b/server/polar/transaction/service/payout.py
@@ -10,6 +10,7 @@ from ..repository import (
     BalanceTransactionRepository,
     PayoutReversalTransactionRepository,
     PayoutTransactionRepository,
+    TransactionRepository,
 )
 from .base import BaseTransactionService
 
@@ -41,11 +42,9 @@ class PayoutTransactionService(BaseTransactionService):
             payout=payout,
         )
 
-        balance_transaction_repository = BalanceTransactionRepository.from_session(
-            session
-        )
+        transaction_repository = TransactionRepository.from_session(session)
         unpaid_balance_transactions = (
-            await balance_transaction_repository.get_all_unpaid_by_account(account.id)
+            await transaction_repository.get_all_unpaid_by_account(account.id)
         )
 
         if payout.processor == PayoutAccountType.stripe:

--- a/server/tests/transaction/service/test_payout.py
+++ b/server/tests/transaction/service/test_payout.py
@@ -26,6 +26,7 @@ from tests.fixtures import random_objects as ro
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_account, create_payout_account
 from tests.fixtures.random_objects import create_payout as _create_payout
+from tests.transaction.conftest import create_transaction
 
 ten_days_ago = utc_now() - timedelta(days=10)
 create_payment_transaction = partial(
@@ -99,6 +100,16 @@ class TestCreate:
             save_fixture, account=account, payment_transaction=payment_transaction_2
         )
 
+        # Payout reversal transaction always available for payouts
+        payout_reversal_transaction = await create_transaction(
+            save_fixture,
+            account=account,
+            type=TransactionType.payout_reversal,
+        )
+        assert payout_reversal_transaction.id is not None
+        assert payout_reversal_transaction.account == account
+        assert payout_reversal_transaction.type == TransactionType.payout_reversal
+
         # Transactions not available for payouts
         payment_transaction_3 = await create_payment_transaction(
             save_fixture, created_at=utc_now(), charge_id="CHARGE_3"
@@ -125,12 +136,13 @@ class TestCreate:
         assert transaction.account_amount < 0
         assert transaction.transfer_id is None
 
-        assert len(transaction.paid_transactions) == 2 + len(
+        assert len(transaction.paid_transactions) == 3 + len(
             transaction.account_incurred_transactions
         )
         paid_transaction_ids = {t.id for t in transaction.paid_transactions}
         assert balance_transaction_1.id in paid_transaction_ids
         assert balance_transaction_2.id in paid_transaction_ids
+        assert payout_reversal_transaction.id in paid_transaction_ids
 
         assert len(transaction.incurred_transactions) > 0
         assert (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Include `payout_reversal` transactions in payout creation and mark them as paid. Fixes unpaid reversals and keeps balances correct.

- **Bug Fixes**
  - Include `payout_reversal` in the unpaid-by-account query and mark them as paid during payout creation.
  - Added tests to assert `payout_reversal` transactions are included in paid transactions.

- **Refactors**
  - Moved the unpaid-by-account query to `TransactionRepository` and expanded it to include delay-ready balance and payout-fee types, and to always include `payout_reversal`.
  - Payout service now fetches unpaid transactions via `TransactionRepository`.

<sup>Written for commit 5ce66a4c3d1628ee7e74ed9746bbab7f6a338d77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

