### PR TITLE
fix: make local dev Minio uploads and downloads work in the browser

### DIFF
--- a/dev/docker/docker-compose.dev.yml
+++ b/dev/docker/docker-compose.dev.yml
@@ -35,7 +35,10 @@ x-common-backend-env: &common-backend-env
   POLAR_REDIS_PORT: "6379"
   POLAR_REDIS_DB: ${POLAR_REDIS_DB:-0}
   # S3/MinIO — shared instance; each app instance gets its own bucket pair.
+  # Server-side calls stay in-network (minio:9000); presigned URLs handed to
+  # the browser must point at the host-published port (localhost:9000).
   POLAR_S3_ENDPOINT_URL: http://minio:9000
+  POLAR_S3_PUBLIC_ENDPOINT_URL: http://localhost:9000
   POLAR_AWS_ACCESS_KEY_ID: ${POLAR_AWS_ACCESS_KEY_ID:-polar-development}
   POLAR_AWS_SECRET_ACCESS_KEY: ${POLAR_AWS_SECRET_ACCESS_KEY:-polar123456789}
   POLAR_S3_FILES_BUCKET_NAME: polar-s3-${POLAR_DOCKER_INSTANCE:-1}
@@ -46,6 +49,7 @@ x-common-backend-env: &common-backend-env
   # CORS and allowed hosts — configured for Docker networking
   POLAR_CORS_ORIGINS: '["http://localhost:${WEB_PORT:-3000}", "http://127.0.0.1:${WEB_PORT:-3000}", "http://web:3000"]'
   POLAR_ALLOWED_HOSTS: '["localhost:${WEB_PORT:-3000}", "127.0.0.1:${WEB_PORT:-3000}"]'
+  POLAR_BASE_URL: http://localhost:${API_PORT:-8000}
   POLAR_FRONTEND_BASE_URL: http://localhost:${WEB_PORT:-3000}
   POLAR_CHECKOUT_BASE_URL: http://localhost:${API_PORT:-8000}/v1/checkout-links/{client_secret}/redirect
   POLAR_USER_SESSION_COOKIE_DOMAIN: localhost
@@ -129,10 +133,10 @@ services:
       # must be set in server/.env (they're loaded via env_file)
       # POLAR_API_URL is for server-side requests (container-to-container)
       POLAR_API_URL: http://api:8000
-      # Browser-side MinIO uploads require a host-reachable MinIO. Shared
-      # infra doesn't publish a host port by default, so direct browser
-      # uploads won't work in this dev model — file features that round-trip
-      # through the API still work fine.
+      # Browser-side MinIO uploads require a host-reachable MinIO. Shared infra
+      # publishes MinIO on host port 9000, and the API generates presigned URLs
+      # against POLAR_S3_PUBLIC_ENDPOINT_URL (http://localhost:9000), so direct
+      # browser uploads/downloads work.
       S3_PUBLIC_IMAGES_BUCKET_PROTOCOL: http
       S3_PUBLIC_IMAGES_BUCKET_HOSTNAME: localhost
       S3_PUBLIC_IMAGES_BUCKET_PORT: "9000"

--- a/dev/docker/docker-compose.shared.yml
+++ b/dev/docker/docker-compose.shared.yml
@@ -51,6 +51,9 @@ services:
     expose:
       - "9000"
       - "9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
     volumes:
       - minio_data:/minio
     environment:

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -365,6 +365,15 @@ class Settings(BaseSettings):
     S3_FILES_DOWNLOAD_SALT: str = "saltysalty"
     # Override to http://127.0.0.1:9000 in .env during development
     S3_ENDPOINT_URL: str | None = None
+    # Endpoint used when generating presigned URLs handed to the browser.
+    # In local dev Minio must be reached as http://localhost:9000 from the host,
+    # while server-side calls use the in-network http://minio:9000. Defaults to
+    # S3_ENDPOINT_URL (production: same real AWS endpoint).
+    S3_PUBLIC_ENDPOINT_URL: str | None = None
+
+    @property
+    def s3_presign_endpoint_url(self) -> str | None:
+        return self.S3_PUBLIC_ENDPOINT_URL or self.S3_ENDPOINT_URL
 
     MINIO_USER: str = "polar"
     MINIO_PWD: str = "polarpolar"

--- a/server/polar/integrations/aws/s3/client.py
+++ b/server/polar/integrations/aws/s3/client.py
@@ -10,11 +10,13 @@ if TYPE_CHECKING:
 
 
 def get_client(
-    *, signature_version: str = settings.AWS_SIGNATURE_VERSION
+    *,
+    signature_version: str = settings.AWS_SIGNATURE_VERSION,
+    endpoint_url: str | None = settings.S3_ENDPOINT_URL,
 ) -> "S3Client":
     return boto3.client(
         "s3",
-        endpoint_url=settings.S3_ENDPOINT_URL,
+        endpoint_url=endpoint_url,
         aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
         aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
         config=Config(

--- a/server/polar/integrations/aws/s3/service.py
+++ b/server/polar/integrations/aws/s3/service.py
@@ -6,6 +6,7 @@ import botocore
 import structlog
 from botocore.client import ClientError
 
+from polar.config import settings
 from polar.kit.http import get_content_disposition
 from polar.kit.utils import generate_uuid, utc_now
 
@@ -38,7 +39,11 @@ class S3Service:
         self.bucket = bucket
         self.presign_ttl = presign_ttl
         self.client = client
-        self._unsigned_client = get_client(signature_version=botocore.UNSIGNED)
+        self._presign_client = get_client(endpoint_url=settings.s3_presign_endpoint_url)
+        self._unsigned_presign_client = get_client(
+            signature_version=botocore.UNSIGNED,
+            endpoint_url=settings.s3_presign_endpoint_url,
+        )
 
     def upload(
         self,
@@ -149,7 +154,7 @@ class S3Service:
         ret = []
         expires_in = self.presign_ttl
         for part in parts:
-            signed_post_url = self.client.generate_presigned_url(
+            signed_post_url = self._presign_client.generate_presigned_url(
                 "upload_part",
                 Params=dict(
                     UploadId=upload_id,
@@ -219,7 +224,7 @@ class S3Service:
     ) -> tuple[str, datetime]:
         expires_in = self.presign_ttl
         presign_from = utc_now()
-        signed_download_url = self.client.generate_presigned_url(
+        signed_download_url = self._presign_client.generate_presigned_url(
             "get_object",
             Params=dict(
                 Bucket=self.bucket,
@@ -237,7 +242,7 @@ class S3Service:
         # This is apparently the *only* way to get a public URL with boto3,
         # apart from building a URL manually 🙄
         # Ref: https://stackoverflow.com/a/48197923
-        return self._unsigned_client.generate_presigned_url(
+        return self._unsigned_presign_client.generate_presigned_url(
             "get_object", ExpiresIn=0, Params=dict(Bucket=self.bucket, Key=path)
         )
 


### PR DESCRIPTION
## Summary

Browser file uploads and downloads did not work against local Minio in the Docker dev setup. 
## Why

The backend used one S3 endpoint (`minio:9000`) for everything. That host only works inside the Docker network. The browser could not reach it, and the web CSP blocked it. Minio also did not publish a host port. So presigned upload/download URLs failed in the browser.

## What

- Add a separate public S3 endpoint used only for presigned URLs the browser uses. Server-side calls keep using the in-network endpoint.
- Publish the Minio host port in the shared dev compose so the host browser can reach it.
- Set the dev base URL to the instance API port so the customer download link points at the right host.

## How

- New `S3_PUBLIC_ENDPOINT_URL` setting with a `s3_presign_endpoint_url` resolver. It falls back to the existing `S3_ENDPOINT_URL` when unset, so production is unchanged.
- `get_client` takes an `endpoint_url` override. The S3 service uses the public endpoint for presigned upload, download, and public-image URLs, and the internal endpoint for direct server-side calls.
- Dev compose sets `POLAR_S3_PUBLIC_ENDPOINT_URL=http://localhost:9000` and `POLAR_BASE_URL=http://localhost:${API_PORT}`.

Verified end to end through the real dashboard UI: uploaded a file (presigned `PUT` to `localhost:9000` returned 200) and downloaded it via a customer checkout (presigned `GET` returned 200, bytes matched).

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

