### PR TITLE
i18n: Clarify German "Subscribe Now" CTA text

### DIFF
--- a/clients/packages/i18n/src/locales/de.ts
+++ b/clients/packages/i18n/src/locales/de.ts
@@ -220,7 +220,7 @@ export default {
     },
     cta: {
       startTrial: 'Testphase starten',
-      subscribeNow: 'Jetzt abonnieren',
+      subscribeNow: 'Jetzt kostenpflichtig abonnieren',
       payNow: 'Jetzt bezahlen',
       getFree: 'Kostenlos erhalten',
       paymentsUnavailable: 'Zahlungen sind derzeit nicht verfügbar',


### PR DESCRIPTION
## Summary

👮‍♂️ § 312j Abs. 3 BGB 👮‍♂️ 

Update the German translation for the "Subscribe Now" call-to-action button to be more explicit about the paid nature of the subscription.

## What

Changed the German translation of the `subscribeNow` CTA from "Jetzt abonnieren" to "Jetzt kostenpflichtig abonnieren" in the German locale file (`de.ts`).

## Why

The updated text clarifies that subscribing involves a cost, making it more transparent to German-speaking users and reducing potential confusion about whether the subscription is free or paid.

## How

Updated the single translation string in the German locale configuration file.

## Checklist

- [x] This PR addresses a single concern (one translation clarification)
- [x] The diff is reasonably sized and easy to review
- [x] No testing needed (translation string update)
- [x] No linting or type checking issues introduced
- [x] No unrelated changes included

https://claude.ai/code/session_01HuMmaAiv1uXshkYf3Jh31B

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

