### PR TITLE
feat: add invariants alerting on stalled order and subscription creation

### DIFF
--- a/server/polar/observability/invariants/rules/__init__.py
+++ b/server/polar/observability/invariants/rules/__init__.py
@@ -1,4 +1,6 @@
 from .base import Invariant, InvariantError
+from .no_recent_orders import NoRecentOrdersInvariant
+from .no_recent_subscriptions import NoRecentSubscriptionsInvariant
 from .subscriptions_canceled_deleted_customer import (
     SubscriptionsCanceledDeletedCustomerInvariant,
 )
@@ -7,6 +9,8 @@ from .subscriptions_future_period_start import SubscriptionsFuturePeriodStartInv
 from .subscriptions_locked_invariant import SubscriptionsLockedInvariant
 
 INVARIANTS: set[type[Invariant]] = {
+    NoRecentOrdersInvariant,
+    NoRecentSubscriptionsInvariant,
     SubscriptionsCanceledDeletedCustomerInvariant,
     SubscriptionsCurrentPeriodEndInvariant,
     SubscriptionsFuturePeriodStartInvariant,

--- a/server/polar/observability/invariants/rules/base.py
+++ b/server/polar/observability/invariants/rules/base.py
@@ -1,6 +1,7 @@
 import abc
 import typing
 
+from polar.config import Environment
 from polar.postgres import AsyncReadSession
 
 
@@ -25,6 +26,9 @@ class Invariant(abc.ABC):
 
     Invariants are conditions that must always hold true for the system to be considered in a valid state.
     """
+
+    ENVIRONMENTS: typing.ClassVar[set[Environment] | None] = None
+    """Environments where this invariant runs. `None` means all environments."""
 
     def __init__(self, session: AsyncReadSession) -> None:
         self.session = session

--- a/server/polar/observability/invariants/rules/no_recent_orders.py
+++ b/server/polar/observability/invariants/rules/no_recent_orders.py
@@ -19,7 +19,10 @@ class NoRecentOrdersInvariantError(InvariantError):
         super().__init__(
             NoRecentOrdersInvariant,
             message,
-            {"threshold": str(threshold), "last_order_at": last_order_at},
+            {
+                "threshold": str(threshold),
+                "last_order_at": last_order_at.isoformat() if last_order_at else None,
+            },
         )
 
 

--- a/server/polar/observability/invariants/rules/no_recent_orders.py
+++ b/server/polar/observability/invariants/rules/no_recent_orders.py
@@ -1,0 +1,41 @@
+from datetime import datetime, timedelta
+
+from sqlalchemy import func, select
+
+from polar.kit.utils import utc_now
+from polar.models import Order
+
+from .base import Invariant, InvariantError
+
+
+class NoRecentOrdersInvariantError(InvariantError):
+    """Exception raised when the NoRecentOrdersInvariant check fails."""
+
+    def __init__(self, threshold: timedelta, last_order_at: datetime | None) -> None:
+        message = (
+            f"No new order created in the last {threshold}. "
+            "The checkout or payment pipeline may be stalled."
+        )
+        super().__init__(
+            NoRecentOrdersInvariant,
+            message,
+            {"threshold": str(threshold), "last_order_at": last_order_at},
+        )
+
+
+class NoRecentOrdersInvariant(Invariant):
+    """
+    Invariant that checks a new order has been created recently.
+
+    In production, orders are created continuously. A prolonged silence does not
+    happen under normal traffic and indicates the checkout or payment pipeline is
+    stalled.
+    """
+
+    THRESHOLD = timedelta(minutes=15)
+
+    async def check(self) -> None:
+        last_order_at = await self.session.scalar(select(func.max(Order.created_at)))
+
+        if last_order_at is None or last_order_at < utc_now() - self.THRESHOLD:
+            raise NoRecentOrdersInvariantError(self.THRESHOLD, last_order_at)

--- a/server/polar/observability/invariants/rules/no_recent_orders.py
+++ b/server/polar/observability/invariants/rules/no_recent_orders.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 
 from sqlalchemy import func, select
 
+from polar.config import Environment
 from polar.kit.utils import utc_now
 from polar.models import Order
 
@@ -32,9 +33,11 @@ class NoRecentOrdersInvariant(Invariant):
 
     In production, orders are created continuously. A prolonged silence does not
     happen under normal traffic and indicates the checkout or payment pipeline is
-    stalled.
+    stalled. Only runs in production, where traffic is continuous; other
+    environments have too little traffic for the absence of orders to be meaningful.
     """
 
+    ENVIRONMENTS = {Environment.production}
     THRESHOLD = timedelta(minutes=15)
 
     async def check(self) -> None:

--- a/server/polar/observability/invariants/rules/no_recent_subscriptions.py
+++ b/server/polar/observability/invariants/rules/no_recent_subscriptions.py
@@ -21,7 +21,12 @@ class NoRecentSubscriptionsInvariantError(InvariantError):
         super().__init__(
             NoRecentSubscriptionsInvariant,
             message,
-            {"threshold": str(threshold), "last_subscription_at": last_subscription_at},
+            {
+                "threshold": str(threshold),
+                "last_subscription_at": (
+                    last_subscription_at.isoformat() if last_subscription_at else None
+                ),
+            },
         )
 
 

--- a/server/polar/observability/invariants/rules/no_recent_subscriptions.py
+++ b/server/polar/observability/invariants/rules/no_recent_subscriptions.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 
 from sqlalchemy import func, select
 
+from polar.config import Environment
 from polar.kit.utils import utc_now
 from polar.models import Subscription
 
@@ -36,9 +37,12 @@ class NoRecentSubscriptionsInvariant(Invariant):
 
     In production, subscriptions are created continuously. A prolonged silence does
     not happen under normal traffic and indicates the checkout or subscription
-    pipeline is stalled.
+    pipeline is stalled. Only runs in production, where traffic is continuous; other
+    environments have too little traffic for the absence of subscriptions to be
+    meaningful.
     """
 
+    ENVIRONMENTS = {Environment.production}
     THRESHOLD = timedelta(minutes=45)
 
     async def check(self) -> None:

--- a/server/polar/observability/invariants/rules/no_recent_subscriptions.py
+++ b/server/polar/observability/invariants/rules/no_recent_subscriptions.py
@@ -1,0 +1,50 @@
+from datetime import datetime, timedelta
+
+from sqlalchemy import func, select
+
+from polar.kit.utils import utc_now
+from polar.models import Subscription
+
+from .base import Invariant, InvariantError
+
+
+class NoRecentSubscriptionsInvariantError(InvariantError):
+    """Exception raised when the NoRecentSubscriptionsInvariant check fails."""
+
+    def __init__(
+        self, threshold: timedelta, last_subscription_at: datetime | None
+    ) -> None:
+        message = (
+            f"No new subscription created in the last {threshold}. "
+            "The checkout or subscription pipeline may be stalled."
+        )
+        super().__init__(
+            NoRecentSubscriptionsInvariant,
+            message,
+            {"threshold": str(threshold), "last_subscription_at": last_subscription_at},
+        )
+
+
+class NoRecentSubscriptionsInvariant(Invariant):
+    """
+    Invariant that checks a new subscription has been created recently.
+
+    In production, subscriptions are created continuously. A prolonged silence does
+    not happen under normal traffic and indicates the checkout or subscription
+    pipeline is stalled.
+    """
+
+    THRESHOLD = timedelta(minutes=45)
+
+    async def check(self) -> None:
+        last_subscription_at = await self.session.scalar(
+            select(func.max(Subscription.created_at))
+        )
+
+        if (
+            last_subscription_at is None
+            or last_subscription_at < utc_now() - self.THRESHOLD
+        ):
+            raise NoRecentSubscriptionsInvariantError(
+                self.THRESHOLD, last_subscription_at
+            )

--- a/server/polar/observability/invariants/service.py
+++ b/server/polar/observability/invariants/service.py
@@ -71,6 +71,17 @@ class InvariantService:
     async def check(
         self, session: AsyncReadSession, invariant_cls: type[Invariant]
     ) -> None:
+        if (
+            invariant_cls.ENVIRONMENTS is not None
+            and settings.ENV not in invariant_cls.ENVIRONMENTS
+        ):
+            log.debug(
+                "Skipping invariant in this environment",
+                invariant=invariant_cls.__name__,
+                environment=settings.ENV,
+            )
+            return
+
         log.debug("Checking invariant", invariant=invariant_cls.__name__)
         invariant = invariant_cls(session)
         try:

--- a/server/tests/observability/invariants/rules/test_no_recent_orders.py
+++ b/server/tests/observability/invariants/rules/test_no_recent_orders.py
@@ -1,0 +1,57 @@
+from datetime import timedelta
+
+import pytest
+import pytest_asyncio
+
+from polar.kit.utils import utc_now
+from polar.models import Customer, Product
+from polar.observability.invariants.rules.no_recent_orders import (
+    NoRecentOrdersInvariant,
+    NoRecentOrdersInvariantError,
+)
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_order
+
+
+@pytest_asyncio.fixture
+async def invariant(session: AsyncSession) -> NoRecentOrdersInvariant:
+    return NoRecentOrdersInvariant(session)
+
+
+@pytest.mark.asyncio
+async def test_failure_no_orders(invariant: NoRecentOrdersInvariant) -> None:
+    with pytest.raises(NoRecentOrdersInvariantError) as exc_info:
+        await invariant.check()
+    assert exc_info.value.context["last_order_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_failure_stale_order(
+    invariant: NoRecentOrdersInvariant,
+    save_fixture: SaveFixture,
+    product: Product,
+    customer: Customer,
+) -> None:
+    await create_order(
+        save_fixture,
+        product=product,
+        customer=customer,
+        created_at=utc_now() - timedelta(hours=1),
+    )
+
+    with pytest.raises(NoRecentOrdersInvariantError) as exc_info:
+        await invariant.check()
+    assert exc_info.value.context["last_order_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_success_recent_order(
+    invariant: NoRecentOrdersInvariant,
+    save_fixture: SaveFixture,
+    product: Product,
+    customer: Customer,
+) -> None:
+    await create_order(save_fixture, product=product, customer=customer)
+
+    await invariant.check()

--- a/server/tests/observability/invariants/rules/test_no_recent_subscriptions.py
+++ b/server/tests/observability/invariants/rules/test_no_recent_subscriptions.py
@@ -1,0 +1,43 @@
+import pytest
+import pytest_asyncio
+
+from polar.models import Customer, Product
+from polar.models.subscription import SubscriptionStatus
+from polar.observability.invariants.rules.no_recent_subscriptions import (
+    NoRecentSubscriptionsInvariant,
+    NoRecentSubscriptionsInvariantError,
+)
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_subscription
+
+
+@pytest_asyncio.fixture
+async def invariant(session: AsyncSession) -> NoRecentSubscriptionsInvariant:
+    return NoRecentSubscriptionsInvariant(session)
+
+
+@pytest.mark.asyncio
+async def test_failure_no_subscriptions(
+    invariant: NoRecentSubscriptionsInvariant,
+) -> None:
+    with pytest.raises(NoRecentSubscriptionsInvariantError) as exc_info:
+        await invariant.check()
+    assert exc_info.value.context["last_subscription_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_success_recent_subscription(
+    invariant: NoRecentSubscriptionsInvariant,
+    save_fixture: SaveFixture,
+    product: Product,
+    customer: Customer,
+) -> None:
+    await create_subscription(
+        save_fixture,
+        status=SubscriptionStatus.active,
+        product=product,
+        customer=customer,
+    )
+
+    await invariant.check()

--- a/server/tests/observability/invariants/test_service.py
+++ b/server/tests/observability/invariants/test_service.py
@@ -1,0 +1,59 @@
+import pytest
+from pytest_mock import MockerFixture
+
+from polar.config import Environment, settings
+from polar.observability.invariants.rules.base import Invariant, InvariantError
+from polar.observability.invariants.service import invariant as invariant_service
+from polar.postgres import AsyncSession
+
+
+class _AllEnvironmentsInvariant(Invariant):
+    ENVIRONMENTS = None
+
+    async def check(self) -> None:
+        raise InvariantError(type(self), "always fails")
+
+
+class _ProductionOnlyInvariant(Invariant):
+    ENVIRONMENTS = {Environment.production}
+
+    async def check(self) -> None:
+        raise InvariantError(type(self), "always fails")
+
+
+@pytest.mark.asyncio
+async def test_skips_invariant_outside_its_environments(
+    session: AsyncSession, mocker: MockerFixture
+) -> None:
+    mocker.patch.object(settings, "ENV", Environment.sandbox)
+    check_spy = mocker.spy(_ProductionOnlyInvariant, "check")
+
+    await invariant_service.check(session, _ProductionOnlyInvariant)
+
+    check_spy.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_runs_invariant_within_its_environments(
+    session: AsyncSession, mocker: MockerFixture
+) -> None:
+    mocker.patch.object(settings, "ENV", Environment.production)
+    mocker.patch.object(invariant_service._slack, "chat_post_message")
+    check_spy = mocker.spy(_ProductionOnlyInvariant, "check")
+
+    await invariant_service.check(session, _ProductionOnlyInvariant)
+
+    check_spy.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_runs_invariant_with_no_environment_restriction(
+    session: AsyncSession, mocker: MockerFixture
+) -> None:
+    mocker.patch.object(settings, "ENV", Environment.sandbox)
+    mocker.patch.object(invariant_service._slack, "chat_post_message")
+    check_spy = mocker.spy(_AllEnvironmentsInvariant, "check")
+
+    await invariant_service.check(session, _AllEnvironmentsInvariant)
+
+    check_spy.assert_called_once()


### PR DESCRIPTION
## Summary

Add two observability invariants that alert when order or subscription creation stalls.

In production, orders and subscriptions are created all the time. If they stop, something in the checkout, payment, or subscription pipeline is broken. Today nothing tells us. These invariants catch it.

## What

- `NoRecentOrdersInvariant`: alerts if no new order in the last 15 minutes.
- `NoRecentSubscriptionsInvariant`: alerts if no new subscription in the last 45 minutes.

They run on the existing invariants cron (every 15 minutes) and post to Slack on failure, like the other invariants.

They run in production only. Sandbox, staging, and development have too little traffic for a quiet period to mean anything.

## Why

- Orders and subscriptions are a good health signal for the whole payment flow.
- A long silence is a strong sign of an outage.
- We want to know fast, not from a customer report.

## How

- Each invariant reads the most recent `created_at` from its table.
- If the newest one is older than the threshold, it raises and Slack is notified.
- The query uses the existing `created_at` btree index, so it reads a single row.
- A new `ENVIRONMENTS` attribute on the base `Invariant` gates where an invariant runs. `None` means all environments (the default). The service skips an invariant when the current environment is not in its set.

Thresholds are set above the largest natural gap seen in production, so normal quiet periods do not trigger a false alarm.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included
