### PR TITLE
Clarify income and payouts

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/(wide)/income/IncomePage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/(wide)/income/IncomePage.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import AccessRestricted from '@/components/Finance/AccessRestricted'
-import AccountBalance from '@/components/Payouts/AccountBalance'
 import TransactionsList from '@/components/Transactions/TransactionsList'
 import { useHasPermission } from '@/hooks/permissions'
 import { useOrganizationAccount, useSearchTransactions } from '@/hooks/queries'
@@ -86,15 +85,6 @@ export default function ClientPage({
 
   return (
     <div className="flex flex-col gap-y-8">
-      {account && (
-        <AccountBalance
-          account={account}
-          organization={organization}
-          onWithdrawSuccess={() =>
-            router.push(`/dashboard/${organization.slug}/finance/payouts`)
-          }
-        />
-      )}
       <TransactionsList
         transactions={balances}
         rowCount={rowCount}

--- a/clients/apps/web/src/components/Payouts/AccountBalance.tsx
+++ b/clients/apps/web/src/components/Payouts/AccountBalance.tsx
@@ -10,6 +10,7 @@ import React, { useCallback } from 'react'
 import { useModal } from '../Modal/useModal'
 import { Well, WellContent, WellFooter, WellHeader } from '../Shared/Well'
 import { FeeCreditGrantsModal } from './FeeCreditGrantsModal'
+import { HeldBalanceSummary } from './HeldBalanceSummary'
 import WithdrawModal from './WithdrawModal'
 
 interface AccountBalanceProps {
@@ -86,16 +87,7 @@ const AccountBalance: React.FC<AccountBalanceProps> = ({
           </Text>
         </WellContent>
         <WellFooter>
-          {summary &&
-          summary.available_balance.amount !== summary.balance.amount ? (
-            <Text color="muted">
-              Held balance:{' '}
-              {formatCurrency('accounting')(
-                summary.balance.amount - summary.available_balance.amount,
-                summary.balance.currency,
-              )}
-            </Text>
-          ) : null}
+          <HeldBalanceSummary heldBalance={summary?.held_balance} />
         </WellFooter>
       </Well>
       <Well className="flex-1 justify-start rounded-2xl bg-gray-50 p-6">

--- a/clients/apps/web/src/components/Payouts/HeldBalanceSummary.tsx
+++ b/clients/apps/web/src/components/Payouts/HeldBalanceSummary.tsx
@@ -1,0 +1,81 @@
+import { schemas } from '@polar-sh/client'
+import { formatCurrency } from '@polar-sh/currency'
+import { Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+
+const formatReleaseDate = (datetime: string) =>
+  new Date(datetime).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  })
+
+const HeldBalanceNote = ({
+  label,
+  amount,
+  currency,
+  caption,
+}: {
+  label: string
+  amount: number
+  currency: string
+  caption?: string
+}) => (
+  <Box flexDirection="column" rowGap="xs">
+    <Text color="muted">
+      {label}: {formatCurrency('accounting')(amount, currency)}
+    </Text>
+    {caption ? (
+      <Text variant="caption" color="muted">
+        {caption}
+      </Text>
+    ) : null}
+  </Box>
+)
+
+export const HeldBalanceSummary = ({
+  heldBalance,
+}: {
+  heldBalance: schemas['TransactionsHeldBalance'] | undefined
+}) => {
+  if (!heldBalance || heldBalance.amount === 0) {
+    return null
+  }
+
+  if (heldBalance.amount < 0) {
+    return (
+      <HeldBalanceNote
+        label="Pending refunds"
+        amount={-heldBalance.amount}
+        currency={heldBalance.currency}
+        caption={
+          heldBalance.fully_available_at
+            ? `Settles by ${formatReleaseDate(heldBalance.fully_available_at)}, reducing your available balance`
+            : 'Reduces your available balance as refunds settle'
+        }
+      />
+    )
+  }
+
+  const nextRelease =
+    heldBalance.next_release_at && heldBalance.next_release_amount > 0
+      ? `${formatCurrency('accounting')(
+          heldBalance.next_release_amount,
+          heldBalance.currency,
+        )} releases ${formatReleaseDate(heldBalance.next_release_at)}`
+      : null
+  const fullyAvailable =
+    heldBalance.fully_available_at &&
+    heldBalance.fully_available_at !== heldBalance.next_release_at
+      ? `Fully available by ${formatReleaseDate(heldBalance.fully_available_at)}`
+      : null
+  const caption = [nextRelease, fullyAvailable].filter(Boolean).join('. ')
+
+  return (
+    <HeldBalanceNote
+      label="Pending"
+      amount={heldBalance.amount}
+      currency={heldBalance.currency}
+      caption={caption || undefined}
+    />
+  )
+}

--- a/clients/apps/web/src/components/Payouts/PayoutStatus.tsx
+++ b/clients/apps/web/src/components/Payouts/PayoutStatus.tsx
@@ -5,7 +5,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@polar-sh/orbit'
 const PayoutStatusDisplayTitle: Record<schemas['PayoutStatus'], string> = {
   succeeded: 'Succeeded',
   pending: 'Pending',
-  held: 'Held',
+  held: 'Held for review',
   failed: 'Failed',
   in_transit: 'In Transit',
   canceled: 'Canceled',

--- a/clients/apps/web/src/components/Transactions/TransactionAvailabilityStatus.tsx
+++ b/clients/apps/web/src/components/Transactions/TransactionAvailabilityStatus.tsx
@@ -18,7 +18,7 @@ const TransactionAvailabilityStatusTitle: Record<
   'on_hold' | 'available' | 'paid_out',
   string
 > = {
-  on_hold: 'On hold',
+  on_hold: 'Pending',
   available: 'Available',
   paid_out: 'Paid out',
 }
@@ -73,21 +73,30 @@ export const TransactionAvailabilityStatus = ({
     const isWithin48Hours =
       availableAt.getTime() - mountedAt <= 48 * 60 * 60 * 1000
 
+    const badge = (
+      <Status
+        status={`${TransactionAvailabilityStatusTitle[status]} until ${availableAt.toLocaleDateString(
+          'en-US',
+          { month: 'short', day: 'numeric' },
+        )}`}
+        color={TransactionAvailabilityStatusColor[status]}
+      />
+    )
+
+    if (!isWithin48Hours) {
+      return badge
+    }
+
     return (
       <Tooltip>
-        <TooltipTrigger>
-          <Status
-            status={TransactionAvailabilityStatusTitle[status]}
-            color={TransactionAvailabilityStatusColor[status]}
-          />
-        </TooltipTrigger>
+        <TooltipTrigger>{badge}</TooltipTrigger>
         <TooltipContent>
           <p>
             Available on{' '}
             <FormattedDateTime
               datetime={availableAt}
               dateStyle="medium"
-              resolution={isWithin48Hours ? 'time' : 'day'}
+              resolution="time"
             />
           </p>
         </TooltipContent>

--- a/clients/apps/web/src/components/Transactions/TransactionsList.tsx
+++ b/clients/apps/web/src/components/Transactions/TransactionsList.tsx
@@ -52,6 +52,14 @@ const TransactionsList = ({
       ),
       cell: (props) => {
         const datetime = props.getValue() as string
+        const parentCreatedAt = props.row.getParentRow()?.original.created_at
+        const isSameDayAsParent =
+          parentCreatedAt !== undefined &&
+          new Date(parentCreatedAt).toDateString() ===
+            new Date(datetime).toDateString()
+        if (isSameDayAsParent) {
+          return null
+        }
         return (
           <Tooltip>
             <TooltipTrigger asChild>
@@ -80,7 +88,7 @@ const TransactionsList = ({
           return <TransactionMeta transaction={transaction} />
         } else if (transaction.platform_fee_type) {
           return (
-            <div className="flex gap-x-4">
+            <div className="flex gap-x-4 pl-6">
               <div className="flex flex-row items-center gap-x-2">
                 <span className="text-sm">→</span>
                 <h3 className="text-sm">
@@ -287,6 +295,7 @@ const TransactionsList = ({
     {
       id: 'status',
       enableSorting: false,
+      size: 190,
       header: ({ column }) => (
         <DataTableColumnHeader
           column={column}
@@ -295,11 +304,14 @@ const TransactionsList = ({
         />
       ),
       cell: (props) => {
-        const transaction = props.row.original
+        const { row } = props
+        if (row.depth > 0) {
+          return null
+        }
         return (
-          <div className="flex justify-end">
+          <div className="flex justify-end whitespace-nowrap">
             <TransactionAvailabilityStatus
-              transaction={transaction}
+              transaction={row.original}
               delay={payoutTransactionDelay}
             />
           </div>

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -34046,10 +34046,42 @@ export interface components {
       /** Account Amount */
       account_amount: number
     }
+    /** TransactionsHeldBalance */
+    TransactionsHeldBalance: {
+      /** Currency */
+      currency: string
+      /** Amount */
+      amount: number
+      /** Account Currency */
+      account_currency: string
+      /** Account Amount */
+      account_amount: number
+      /**
+       * Next Release At
+       * @description When the next chunk of the held balance becomes available for payout.
+       */
+      next_release_at: string | null
+      /**
+       * Next Release Amount
+       * @description Amount becoming available for payout at `next_release_at`.
+       */
+      next_release_amount: number
+      /**
+       * Next Release Account Amount
+       * @description Amount becoming available for payout at `next_release_at`, in the account's currency.
+       */
+      next_release_account_amount: number
+      /**
+       * Fully Available At
+       * @description When the whole held balance has become available for payout.
+       */
+      fully_available_at: string | null
+    }
     /** TransactionsSummary */
     TransactionsSummary: {
       balance: components['schemas']['TransactionsBalance']
       available_balance: components['schemas']['TransactionsBalance']
+      held_balance: components['schemas']['TransactionsHeldBalance']
       payout: components['schemas']['TransactionsBalance']
     }
     /** TrialAlreadyRedeemed */

--- a/server/polar/transaction/schemas.py
+++ b/server/polar/transaction/schemas.py
@@ -1,4 +1,6 @@
-from pydantic import UUID4
+from datetime import datetime
+
+from pydantic import UUID4, Field
 
 from polar.enums import SubscriptionRecurringInterval
 from polar.kit.schemas import IDSchema, Schema, TimestampedSchema
@@ -84,7 +86,26 @@ class TransactionsBalance(Schema):
     account_amount: int
 
 
+class TransactionsHeldBalance(TransactionsBalance):
+    next_release_at: datetime | None = Field(
+        description="When the next chunk of the held balance becomes available for payout."
+    )
+    next_release_amount: int = Field(
+        description="Amount becoming available for payout at `next_release_at`."
+    )
+    next_release_account_amount: int = Field(
+        description=(
+            "Amount becoming available for payout at `next_release_at`, "
+            "in the account's currency."
+        )
+    )
+    fully_available_at: datetime | None = Field(
+        description="When the whole held balance has become available for payout."
+    )
+
+
 class TransactionsSummary(Schema):
     balance: TransactionsBalance
     available_balance: TransactionsBalance
+    held_balance: TransactionsHeldBalance
     payout: TransactionsBalance

--- a/server/polar/transaction/service/transaction.py
+++ b/server/polar/transaction/service/transaction.py
@@ -1,5 +1,6 @@
 import uuid
 from collections.abc import Sequence
+from datetime import datetime
 from enum import StrEnum
 from typing import Any, cast
 
@@ -26,6 +27,7 @@ from polar.postgres import AsyncReadSession, AsyncSession
 
 from ..schemas import (
     TransactionsBalance,
+    TransactionsHeldBalance,
     TransactionsSummary,
 )
 from .base import BaseTransactionService
@@ -248,6 +250,45 @@ class TransactionService(BaseTransactionService):
             available_amount = 0
             available_account_amount = 0
 
+        released_at = Transaction.created_at + Account.payout_transaction_delay
+        release_day = func.date_trunc("day", released_at)
+        held_statement = (
+            select(
+                cast(type[datetime], func.max(released_at)),
+                cast(type[int], func.sum(Transaction.amount)),
+                cast(type[int], func.sum(Transaction.account_amount)),
+            )
+            .join(Account, Account.id == Transaction.account_id)
+            .where(
+                Transaction.account_id == account.id,
+                Transaction.type.not_in(
+                    (TransactionType.payout, TransactionType.payout_reversal)
+                ),
+                or_(
+                    Transaction.platform_fee_type.is_(None),
+                    Transaction.platform_fee_type.not_in(
+                        PlatformFeeType.payout_fee_types()
+                    ),
+                ),
+                released_at > func.now(),
+            )
+            .group_by(release_day)
+            .order_by(release_day)
+        )
+
+        held_result = await session.execute(held_statement)
+        held_releases = held_result.tuples().all()
+
+        held_amount = sum(amount for _, amount, _ in held_releases)
+        held_account_amount = sum(
+            account_amount for _, _, account_amount in held_releases
+        )
+        fully_available_at = held_releases[-1][0] if held_releases else None
+        next_release_at, next_release_amount, next_release_account_amount = next(
+            (release for release in held_releases if release[1] > 0),
+            (None, 0, 0),
+        )
+
         return TransactionsSummary(
             balance=TransactionsBalance(
                 currency=currency,
@@ -260,6 +301,16 @@ class TransactionService(BaseTransactionService):
                 amount=available_amount,
                 account_currency=account_currency,
                 account_amount=available_account_amount,
+            ),
+            held_balance=TransactionsHeldBalance(
+                currency=currency,
+                amount=held_amount,
+                account_currency=account_currency,
+                account_amount=held_account_amount,
+                next_release_at=next_release_at,
+                next_release_amount=next_release_amount,
+                next_release_account_amount=next_release_account_amount,
+                fully_available_at=fully_available_at,
             ),
             payout=TransactionsBalance(
                 currency=currency,

--- a/server/tests/transaction/service/test_transaction.py
+++ b/server/tests/transaction/service/test_transaction.py
@@ -190,6 +190,12 @@ class TestGetSummary:
         assert summary.payout.amount == 0
         assert summary.payout.account_amount == 0
 
+        assert summary.held_balance.amount == 0
+        assert summary.held_balance.account_amount == 0
+        assert summary.held_balance.next_release_at is None
+        assert summary.held_balance.next_release_amount == 0
+        assert summary.held_balance.fully_available_at is None
+
     async def test_valid(
         self, session: AsyncSession, save_fixture: SaveFixture, account: Account
     ) -> None:
@@ -256,6 +262,100 @@ class TestGetSummary:
         # Payout balance should include all payouts
         assert summary.payout.amount == -2000
         assert summary.payout.account_amount == -2000
+
+        assert summary.held_balance.amount == 500
+        assert summary.held_balance.account_amount == 500
+        assert summary.held_balance.next_release_amount == 500
+        assert summary.held_balance.next_release_at == now + timedelta(days=5)
+        assert summary.held_balance.fully_available_at == now + timedelta(days=5)
+
+    async def test_held_release_schedule(
+        self, session: AsyncSession, save_fixture: SaveFixture, account: Account
+    ) -> None:
+        now = utc_now()
+
+        await create_transaction(
+            save_fixture,
+            type=TransactionType.balance,
+            account=account,
+            amount=1000,
+            account_currency="usd",
+            created_at=now - timedelta(days=10),
+        )
+        for amount in (300, 200):
+            await create_transaction(
+                save_fixture,
+                type=TransactionType.balance,
+                account=account,
+                amount=amount,
+                account_currency="usd",
+                created_at=now - timedelta(days=5),
+            )
+        await create_transaction(
+            save_fixture,
+            type=TransactionType.balance,
+            account=account,
+            amount=-100,
+            account_currency="usd",
+            created_at=now - timedelta(days=3),
+        )
+
+        summary = await transaction_service.get_summary(session, account)
+
+        assert summary.held_balance.amount == 400
+        assert summary.held_balance.next_release_amount == 500
+        assert summary.held_balance.next_release_at == now + timedelta(days=2)
+        assert summary.held_balance.fully_available_at == now + timedelta(days=4)
+
+    async def test_held_negative_release_skipped(
+        self, session: AsyncSession, save_fixture: SaveFixture, account: Account
+    ) -> None:
+        now = utc_now()
+
+        await create_transaction(
+            save_fixture,
+            type=TransactionType.balance,
+            account=account,
+            amount=-100,
+            account_currency="usd",
+            created_at=now - timedelta(days=6),
+        )
+        await create_transaction(
+            save_fixture,
+            type=TransactionType.balance,
+            account=account,
+            amount=500,
+            account_currency="usd",
+            created_at=now - timedelta(days=2),
+        )
+
+        summary = await transaction_service.get_summary(session, account)
+
+        assert summary.held_balance.amount == 400
+        assert summary.held_balance.next_release_amount == 500
+        assert summary.held_balance.next_release_at == now + timedelta(days=5)
+        assert summary.held_balance.fully_available_at == now + timedelta(days=5)
+
+    async def test_held_negative_only(
+        self, session: AsyncSession, save_fixture: SaveFixture, account: Account
+    ) -> None:
+        now = utc_now()
+
+        await create_transaction(
+            save_fixture,
+            type=TransactionType.balance,
+            account=account,
+            amount=-100,
+            account_currency="usd",
+            created_at=now - timedelta(days=2),
+        )
+
+        summary = await transaction_service.get_summary(session, account)
+
+        assert summary.held_balance.amount == -100
+        assert summary.held_balance.next_release_at is None
+        assert summary.held_balance.next_release_amount == 0
+        assert summary.held_balance.fully_available_at == now + timedelta(days=5)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

* Remove header from the Income page
* Switch copy from `On hold` to `Pending until X`
* Switch copy from `Held balance: $X` to `Pending: $X. $Y releases on <date1>. Fully available <date2>`
* Some table UI fixes when you expand a payout row


## Screenshots

| Income | Payouts  |
|--------|--------|
| <img width="1840" height="1133" alt="Screenshot 2026-07-13 at 13 02 08" src="https://github.com/user-attachments/assets/4384f015-e264-4b1d-bb96-0038b3604945" /> | <img width="1840" height="1133" alt="Screenshot 2026-07-13 at 13 02 05" src="https://github.com/user-attachments/assets/6597347d-eaf4-496e-b981-c628a257095d" /> |





