### PR TITLE
feat(observability): add PayoutTransactionsAmountInvariant

### DIFF
--- a/server/polar/observability/invariants/rules/__init__.py
+++ b/server/polar/observability/invariants/rules/__init__.py
@@ -1,6 +1,7 @@
 from .base import Invariant, InvariantError
 from .no_recent_orders import NoRecentOrdersInvariant
 from .no_recent_subscriptions import NoRecentSubscriptionsInvariant
+from .payout_transactions_amount_invariant import PayoutTransactionsAmountInvariant
 from .subscriptions_canceled_deleted_customer import (
     SubscriptionsCanceledDeletedCustomerInvariant,
 )
@@ -11,6 +12,7 @@ from .subscriptions_locked_invariant import SubscriptionsLockedInvariant
 INVARIANTS: set[type[Invariant]] = {
     NoRecentOrdersInvariant,
     NoRecentSubscriptionsInvariant,
+    PayoutTransactionsAmountInvariant,
     SubscriptionsCanceledDeletedCustomerInvariant,
     SubscriptionsCurrentPeriodEndInvariant,
     SubscriptionsFuturePeriodStartInvariant,

--- a/server/polar/observability/invariants/rules/payout_transactions_amount_invariant.py
+++ b/server/polar/observability/invariants/rules/payout_transactions_amount_invariant.py
@@ -1,0 +1,106 @@
+import uuid
+from datetime import timedelta
+
+from sqlalchemy import func, over, select
+
+from polar.models import Transaction
+from polar.models.transaction import TransactionType
+
+from .base import Invariant, InvariantError
+
+
+class PayoutTransactionsAmountInvariantError(InvariantError):
+    """Exception raised when the PayoutTransactionsAmountInvariant check fails."""
+
+    def __init__(
+        self, count: int, payout_transactions: list[uuid.UUID], differences: list[int]
+    ) -> None:
+        message = (
+            f"Found {count} payout transactions with amount mismatch "
+            "between payout and sum of paid transactions."
+        )
+        super().__init__(
+            PayoutTransactionsAmountInvariant,
+            message,
+            {
+                "count": count,
+                "payout_transactions": {
+                    "ids": payout_transactions,
+                    "differences": differences,
+                    "has_more": count > len(payout_transactions),
+                },
+            },
+        )
+
+
+class PayoutTransactionsAmountInvariant(Invariant):
+    """
+    Invariant that checks if payout transaction amounts match the sum of
+    transactions that reference them via payout_transaction_id.
+
+    Reversed payouts are automatically excluded because when a payout is reversed,
+    the payout_transaction_id on the paid transactions is reset to NULL.
+
+    Failure indicates an issue with payout accounting.
+    """
+
+    LIMIT = 10
+    AGE_LIMIT = timedelta(days=30)
+
+    async def check(self) -> None:
+        # Payout transactions without reversal (same payout_id)
+        payout_subq = (
+            select(Transaction.id, Transaction.amount)
+            .where(
+                Transaction.created_at > (func.now() - self.AGE_LIMIT),
+                Transaction.type == TransactionType.payout,
+                ~Transaction.payout_id.in_(
+                    select(Transaction.payout_id).where(
+                        Transaction.type == TransactionType.payout_reversal,
+                        Transaction.payout_id.isnot(None),
+                    )
+                ),
+            )
+            .subquery()
+        )
+
+        # Sum of amounts per payout_transaction_id
+        paid_subq = (
+            select(
+                Transaction.payout_transaction_id,
+                func.coalesce(func.sum(Transaction.amount), 0).label("total_amount"),
+            )
+            .where(Transaction.payout_transaction_id.isnot(None))
+            .group_by(Transaction.payout_transaction_id)
+            .subquery()
+        )
+
+        # Find mismatches
+        diff_expr = func.abs(payout_subq.c.amount) - func.coalesce(
+            paid_subq.c.total_amount, 0
+        )
+        statement = (
+            select(
+                payout_subq.c.id,
+                diff_expr.label("diff"),
+                over(func.count()),
+            )
+            .select_from(
+                payout_subq.outerjoin(
+                    paid_subq, payout_subq.c.id == paid_subq.c.payout_transaction_id
+                )
+            )
+            .where(func.abs(diff_expr) > 0)
+            .limit(self.LIMIT)
+            .order_by(func.abs(diff_expr).desc(), payout_subq.c.id.asc())
+        )
+
+        result = await self.session.execute(statement)
+        results = result.fetchall()
+
+        count = results[0][2] if results else 0
+
+        if count > 0:
+            payout_ids = [row[0] for row in results]
+            differences = [row[1] for row in results]
+            raise PayoutTransactionsAmountInvariantError(count, payout_ids, differences)

--- a/server/tests/observability/invariants/rules/test_payout_transactions_amount_invariant.py
+++ b/server/tests/observability/invariants/rules/test_payout_transactions_amount_invariant.py
@@ -1,0 +1,379 @@
+import pytest
+import pytest_asyncio
+
+from polar.enums import PayoutAccountType
+from polar.models import Account, Organization, PayoutAccount, User
+from polar.models.transaction import TransactionType
+from polar.observability.invariants.rules.payout_transactions_amount_invariant import (
+    PayoutTransactionsAmountInvariant,
+    PayoutTransactionsAmountInvariantError,
+)
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_payout, create_payout_account
+from tests.transaction.conftest import create_transaction
+
+
+@pytest_asyncio.fixture
+async def payout_account_fixture(
+    save_fixture: SaveFixture,
+    organization: Organization,
+    user: User,
+) -> tuple[Account, PayoutAccount]:
+    """Create and return account, payout_account tuple for testing."""
+    account = organization.account
+    payout_account = await create_payout_account(
+        save_fixture,
+        organization=organization,
+        user=user,
+        type=PayoutAccountType.stripe,
+    )
+    return account, payout_account
+
+
+@pytest_asyncio.fixture
+async def invariant(session: AsyncSession) -> PayoutTransactionsAmountInvariant:
+    return PayoutTransactionsAmountInvariant(session)
+
+
+@pytest.mark.asyncio
+async def test_success_no_payouts(
+    invariant: PayoutTransactionsAmountInvariant,
+) -> None:
+    """No payout transactions exist - invariant should pass."""
+    await invariant.check()
+
+
+@pytest.mark.asyncio
+async def test_success_matching_amounts(
+    invariant: PayoutTransactionsAmountInvariant,
+    save_fixture: SaveFixture,
+    payout_account_fixture: tuple[Account, PayoutAccount],
+) -> None:
+    """Payout with transactions that sum correctly - invariant should pass."""
+    account, payout_account = payout_account_fixture
+
+    # Create payout transaction first
+    payout_transaction = await create_transaction(
+        save_fixture,
+        type=TransactionType.payout,
+        amount=-1000,  # -$10.00 from Polar's perspective
+        account=account,
+        account_currency="usd",
+        presentment_currency="usd",
+        presentment_amount=1000,
+    )
+
+    # Create payout with the transaction
+    payout = await create_payout(
+        save_fixture,
+        payout_account=payout_account,
+        account=account,
+        transaction=payout_transaction,
+        amount=-1000,
+        fees_amount=0,
+        account_amount=1000,
+    )
+
+    # Create two balance transactions that sum to 1000
+    await create_transaction(
+        save_fixture,
+        type=TransactionType.balance,
+        amount=300,
+        account=account,
+        account_currency="usd",
+        presentment_currency="usd",
+        presentment_amount=300,
+        payout_transaction=payout_transaction,
+    )
+
+    await create_transaction(
+        save_fixture,
+        type=TransactionType.balance,
+        amount=700,
+        account=account,
+        account_currency="usd",
+        presentment_currency="usd",
+        presentment_amount=700,
+        payout_transaction=payout_transaction,
+    )
+
+    # ABS(-1000) = 1000, sum = 300 + 700 = 1000, diff = 0
+    await invariant.check()
+
+
+@pytest.mark.asyncio
+async def test_success_zero_amount(
+    invariant: PayoutTransactionsAmountInvariant,
+    save_fixture: SaveFixture,
+    payout_account_fixture: tuple[Account, PayoutAccount],
+) -> None:
+    """Payout with amount=0 and no paid transactions - invariant should pass."""
+    account, payout_account = payout_account_fixture
+
+    # Create payout transaction first
+    payout_transaction = await create_transaction(
+        save_fixture,
+        type=TransactionType.payout,
+        amount=0,
+        account=account,
+        account_currency="usd",
+        presentment_currency="usd",
+        presentment_amount=0,
+    )
+
+    # Create payout with the transaction
+    payout = await create_payout(
+        save_fixture,
+        payout_account=payout_account,
+        account=account,
+        transaction=payout_transaction,
+        amount=0,
+        fees_amount=0,
+        account_amount=0,
+    )
+
+    # ABS(0) = 0, sum = 0, diff = 0
+    await invariant.check()
+
+
+@pytest.mark.asyncio
+async def test_failure_amount_mismatch(
+    invariant: PayoutTransactionsAmountInvariant,
+    save_fixture: SaveFixture,
+    payout_account_fixture: tuple[Account, PayoutAccount],
+) -> None:
+    """Payout with transactions that don't sum to payout amount - should fail."""
+    account, payout_account = payout_account_fixture
+
+    # Create payout transaction first
+    payout_transaction = await create_transaction(
+        save_fixture,
+        type=TransactionType.payout,
+        amount=-1000,  # -$10.00
+        account=account,
+        account_currency="usd",
+        presentment_currency="usd",
+        presentment_amount=1000,
+    )
+
+    # Create payout with the transaction
+    payout = await create_payout(
+        save_fixture,
+        payout_account=payout_account,
+        account=account,
+        transaction=payout_transaction,
+        amount=-1000,
+        fees_amount=0,
+        account_amount=1000,
+    )
+
+    # Create balance transaction with wrong amount
+    await create_transaction(
+        save_fixture,
+        type=TransactionType.balance,
+        amount=500,  # $5.00 instead of $10.00
+        account=account,
+        account_currency="usd",
+        presentment_currency="usd",
+        presentment_amount=500,
+        payout_transaction=payout_transaction,
+    )
+
+    # ABS(-1000) = 1000, sum = 500, diff = 500 > 0
+    with pytest.raises(PayoutTransactionsAmountInvariantError) as exc_info:
+        await invariant.check()
+
+    assert exc_info.value.context["count"] == 1
+    assert exc_info.value.context["payout_transactions"]["ids"] == [
+        payout_transaction.id
+    ]
+    assert exc_info.value.context["payout_transactions"]["differences"] == [500]
+    assert exc_info.value.context["payout_transactions"]["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_failure_missing_transactions(
+    invariant: PayoutTransactionsAmountInvariant,
+    save_fixture: SaveFixture,
+    payout_account_fixture: tuple[Account, PayoutAccount],
+) -> None:
+    """Payout with no transactions referencing it - should fail."""
+    account, payout_account = payout_account_fixture
+
+    # Create payout transaction first
+    payout_transaction = await create_transaction(
+        save_fixture,
+        type=TransactionType.payout,
+        amount=-1000,
+        account=account,
+        account_currency="usd",
+        presentment_currency="usd",
+        presentment_amount=1000,
+    )
+
+    # Create payout with the transaction
+    payout = await create_payout(
+        save_fixture,
+        payout_account=payout_account,
+        account=account,
+        transaction=payout_transaction,
+        amount=-1000,
+        fees_amount=0,
+        account_amount=1000,
+    )
+
+    # No balance transactions created
+    # ABS(-1000) = 1000, sum = 0, diff = 1000 > 0
+    with pytest.raises(PayoutTransactionsAmountInvariantError) as exc_info:
+        await invariant.check()
+
+    assert exc_info.value.context["count"] == 1
+    assert exc_info.value.context["payout_transactions"]["ids"] == [
+        payout_transaction.id
+    ]
+    assert exc_info.value.context["payout_transactions"]["differences"] == [1000]
+
+
+@pytest.mark.asyncio
+async def test_failure_sum_exceeds_payout(
+    invariant: PayoutTransactionsAmountInvariant,
+    save_fixture: SaveFixture,
+    payout_account_fixture: tuple[Account, PayoutAccount],
+) -> None:
+    """Sum of paid transactions exceeds payout amount - should fail (caught by abs)."""
+    account, payout_account = payout_account_fixture
+
+    # Create payout transaction first
+    payout_transaction = await create_transaction(
+        save_fixture,
+        type=TransactionType.payout,
+        amount=-500,  # -$5.00
+        account=account,
+        account_currency="usd",
+        presentment_currency="usd",
+        presentment_amount=500,
+    )
+
+    # Create payout with the transaction
+    payout = await create_payout(
+        save_fixture,
+        payout_account=payout_account,
+        account=account,
+        transaction=payout_transaction,
+        amount=-500,
+        fees_amount=0,
+        account_amount=500,
+    )
+
+    # Create balance transaction with amount > payout
+    await create_transaction(
+        save_fixture,
+        type=TransactionType.balance,
+        amount=1000,  # $10.00 > $5.00
+        account=account,
+        account_currency="usd",
+        presentment_currency="usd",
+        presentment_amount=1000,
+        payout_transaction=payout_transaction,
+    )
+
+    # ABS(-500) = 500, sum = 1000, diff = -500, ABS(diff) = 500 > 0
+    with pytest.raises(PayoutTransactionsAmountInvariantError) as exc_info:
+        await invariant.check()
+
+    assert exc_info.value.context["count"] == 1
+    assert exc_info.value.context["payout_transactions"]["ids"] == [
+        payout_transaction.id
+    ]
+    # diff = 500 - 1000 = -500
+    assert exc_info.value.context["payout_transactions"]["differences"] == [-500]
+
+
+@pytest.mark.asyncio
+async def test_failure_over_limit(
+    invariant: PayoutTransactionsAmountInvariant,
+    save_fixture: SaveFixture,
+    payout_account_fixture: tuple[Account, PayoutAccount],
+) -> None:
+    """More violations than LIMIT - verify has_more flag."""
+    account, payout_account = payout_account_fixture
+
+    # Create 15 payout transactions with mismatches (no paid transactions)
+    for i in range(15):
+        payout_transaction = await create_transaction(
+            save_fixture,
+            type=TransactionType.payout,
+            amount=-1000,
+            account=account,
+            account_currency="usd",
+            presentment_currency="usd",
+            presentment_amount=1000,
+        )
+
+        await create_payout(
+            save_fixture,
+            payout_account=payout_account,
+            account=account,
+            transaction=payout_transaction,
+            amount=-1000,
+            fees_amount=0,
+            account_amount=1000,
+            invoice_number=f"INV-{i:03d}",
+        )
+
+    with pytest.raises(PayoutTransactionsAmountInvariantError) as exc_info:
+        await invariant.check()
+
+    assert exc_info.value.context["count"] == 15
+    assert len(exc_info.value.context["payout_transactions"]["ids"]) == 10  # LIMIT
+    assert exc_info.value.context["payout_transactions"]["has_more"] is True
+
+
+@pytest.mark.asyncio
+async def test_excludes_reversed_payouts(
+    invariant: PayoutTransactionsAmountInvariant,
+    save_fixture: SaveFixture,
+    payout_account_fixture: tuple[Account, PayoutAccount],
+) -> None:
+    """Payout that has been reversed should be excluded from check."""
+    account, payout_account = payout_account_fixture
+
+    # Create payout transaction first
+    payout_transaction = await create_transaction(
+        save_fixture,
+        type=TransactionType.payout,
+        amount=-1000,
+        account=account,
+        account_currency="usd",
+        presentment_currency="usd",
+        presentment_amount=1000,
+    )
+
+    # Create payout with the transaction
+    payout = await create_payout(
+        save_fixture,
+        payout_account=payout_account,
+        account=account,
+        transaction=payout_transaction,
+        amount=-1000,
+        fees_amount=0,
+        account_amount=1000,
+        invoice_number="INV-REVERSED",
+    )
+
+    # Create a payout_reversal transaction (same payout_id)
+    await create_transaction(
+        save_fixture,
+        type=TransactionType.payout_reversal,
+        amount=1000,
+        account=account,
+        account_currency="usd",
+        presentment_currency="usd",
+        presentment_amount=1000,
+        payout=payout,  # Same payout_id
+    )
+
+    # The payout_transaction should be excluded because there's a payout_reversal
+    # with the same payout_id
+    await invariant.check()


### PR DESCRIPTION

Add new invariant rule that validates payout transaction amounts correspond
to the sum of transactions that reference them via payout_transaction_id.

- PayoutTransactionsAmountInvariant: checks if payout amounts match sum
  of paid transactions
- Excludes reversed payouts (by design, when reversed payout_transaction_id
  is reset to NULL on paid transactions)
- Uses abs(diff) > 0 to catch mismatches in both directions
- Follows existing invariant pattern with LIMIT=10 and has_more flag

Tests cover:

- Success cases (no payouts, matching amounts, zero amount)
- Failure cases (amount mismatch, missing transactions, sum exceeds payout,
  over limit)
- Edge case (reversed payouts excluded)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

