### PR TITLE
sdk[release]: 1.0.0-alpha.6

### DIFF
--- a/sdk/python/polar/__init__.py
+++ b/sdk/python/polar/__init__.py
@@ -1,6 +1,6 @@
 from polar.base import PolarClientError, PolarError, PolarNetworkError, PolarServerError
 
-__version__ = "1.0.0a5"
+__version__ = "1.0.0a6"
 __all__ = [
     "PolarError",
     "PolarNetworkError",

--- a/sdk/python/polar/v2026_04/inputs.py
+++ b/sdk/python/polar/v2026_04/inputs.py
@@ -1710,9 +1710,6 @@ class CustomerSubscriptionUpdateSeats(typing.TypedDict):
     seats: int
     """Update the number of seats for this subscription."""
 
-    proration_behavior: typing.NotRequired[SubscriptionProrationBehavior | None]
-    """Determine how to handle the proration billing. If not provided, will use the default organization setting."""
-
 
 class CustomerTeamCreate(typing.TypedDict):
     metadata: typing.NotRequired[dict[str, str | int | float | bool]]

--- a/sdk/python/polar/v2026_04/literals.py
+++ b/sdk/python/polar/v2026_04/literals.py
@@ -786,6 +786,7 @@ PaymentTrigger: typing.TypeAlias = typing.Literal[
 Permission: typing.TypeAlias = typing.Literal[
     "pull", "triage", "push", "maintain", "admin"
 ]
+"""The permission level to grant. Read more about roles and their permissions on [GitHub documentation](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role)."""
 PresentmentCurrency: typing.TypeAlias = typing.Literal[
     "aed",
     "all",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polar-sh/sdk",
-  "version": "1.0.0-alpha.5",
+  "version": "1.0.0-alpha.6",
   "description": "Polar SDK — A billing platform for the intelligence era",
   "keywords": [
     "api",

--- a/sdk/typescript/pnpm-lock.yaml
+++ b/sdk/typescript/pnpm-lock.yaml
@@ -712,8 +712,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1392,7 +1392,7 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.16: {}
 
   obug@2.1.3: {}
 
@@ -1450,7 +1450,7 @@ snapshots:
 
   postcss@8.5.17:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/sdk/typescript/src/2026-04/models.ts
+++ b/sdk/typescript/src/2026-04/models.ts
@@ -10861,10 +10861,6 @@ export interface CustomerSubscriptionUpdateSeats {
    * Update the number of seats for this subscription.
    */
   seats: number;
-  /**
-   * Determine how to handle the proration billing. If not provided, will use the default organization setting.
-   */
-  proration_behavior?: SubscriptionProrationBehavior | null;
 }
 /**
  * A team customer in an organization.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Release 1.0.0-alpha.6 for the Python and TypeScript SDKs. Removes `proration_behavior` from `CustomerSubscriptionUpdateSeats`, adds a `Permission` docstring in Python, and updates the `nanoid` dependency.

- **Migration**
  - Remove `proration_behavior` when updating subscription seats; the org default proration behavior is used.

- **Dependencies**
  - Update `nanoid` to `3.3.16` in the TypeScript SDK.

<sup>Written for commit a1760642f9b10647710581b6b2e51a1bd8ab98f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

