### PR TITLE
Add tax calc error logging

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -988,6 +988,17 @@ class CheckoutService:
         try:
             checkout = await self._update_checkout_tax(session, checkout)
         except TaxCalculationLogicalError as e:
+            billing_address = checkout.customer_billing_address
+            log.warning(
+                "Checkout confirmation blocked by tax calculation error",
+                error_type=type(e).__name__,
+                error_message=e.message,
+                checkout_id=str(checkout.id),
+                organization_id=str(checkout.organization_id),
+                product_id=str(checkout.product_id) if checkout.product_id else None,
+                billing_country=billing_address.country if billing_address else None,
+                billing_state=billing_address.state if billing_address else None,
+            )
             errors.append(
                 {
                     "type": "value_error",


### PR DESCRIPTION
## Summary

We have received a bug report regarding a user seeing a `Required tax location information is missing` error in our checkout. However reproducing this is very tricky and requires fiddling with the network to be able to block some requests.

To see how big of an issue this is I've added some error logging so we can properly triage the issue.

<img width="485" height="381" alt="Screenshot 2026-07-13 at 13 19 56" src="https://github.com/user-attachments/assets/00150c9b-bf5e-49e8-8a5d-7cfcbf915e84" />


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

