### PR TITLE
sdk: fix CI again

### DIFF
--- a/.github/workflows/sdk-release.yml
+++ b/.github/workflows/sdk-release.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       version: ${{ steps.extract.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 
@@ -44,7 +44,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 
@@ -62,13 +62,13 @@ jobs:
     runs-on: ubuntu-latest
     environment: sdk-release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
         with:
           ref: "sdk/${{ needs.detect-release.outputs.version }}"
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v8.2.0
 
       - name: Build Python SDK
         working-directory: sdk/python
@@ -85,17 +85,17 @@ jobs:
     runs-on: ubuntu-latest
     environment: sdk-release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
         with:
           ref: "sdk/${{ needs.detect-release.outputs.version }}"
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6.0.9
 
-      - name: Setup Node.js (v22+ required for trusted publishing)
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
@@ -109,8 +109,7 @@ jobs:
 
       - name: Publish to npm (Trusted Publishing)
         working-directory: sdk/typescript
-        # npm automatically uses OIDC in GitHub Actions with id-token: write
-        run: npm publish --access public
+        run: npm publish
 
   create-github-release:
     needs: [detect-release, publish-python, publish-typescript]
@@ -119,7 +118,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the SDK release workflow by updating actions and Node to supported versions and simplifying the npm publish step for Trusted Publishing. This stabilizes Python and TypeScript releases and GitHub Release creation.

- **Bug Fixes**
  - Bumped GitHub Actions: `actions/checkout@v7.0.0`, `astral-sh/setup-uv@v8.2.0`, `pnpm/action-setup@v6.0.9`.
  - Use Node.js 24 for the TypeScript publish job via `actions/setup-node@v4`.
  - Simplified `npm publish` (removed `--access public`) for Trusted Publishing.

<sup>Written for commit 3cea4c3086b4b8a99ebfec2a9139c9aa6f2d1283. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

