### PR TITLE
fix(dev): set pnpm store dir via env var to avoid dirtying tracked file

### DIFF
--- a/dev/docker/scripts/startup.sh
+++ b/dev/docker/scripts/startup.sh
@@ -29,8 +29,9 @@ if [[ "${1:-api}" == "api" ]] && [[ ! -f "$EMAIL_MARKER" ]]; then
     # Clean previous builds (may be from different architecture)
     rm -rf dist
     rm -f bin/react-email-pkg bin/.built-* 2>/dev/null || true
-    # Configure pnpm to use the mounted store volume for faster installs
-    pnpm config set store-dir /root/.local/share/pnpm/store --location project
+    # Point pnpm at the mounted store volume for faster installs via env var,
+    # so we don't mutate the bind-mounted (and git-tracked) pnpm-workspace.yaml.
+    export npm_config_store_dir=/root/.local/share/pnpm/store
     # Install dependencies (uses shared pnpm store for speed)
     pnpm install --frozen-lockfile
     # Build: tsup compiles TypeScript, pkg creates standalone binary


### PR DESCRIPTION
## Summary

The dev container startup script wrote a container-only path into a git-tracked file on every first boot. This fixes that.

## Why

`server/emails` is bind-mounted from the host. The old command wrote `storeDir: /root/.local/share/pnpm/store` into the tracked file `server/emails/pnpm-workspace.yaml`. So every first container boot dirtied the git tree. It also risked committing a container-only path by accident.

## How

The env var `npm_config_store_dir` sets the same pnpm store dir. It touches no file. The store volume is still used, so installs stay fast.

Verified locally:
- Old command appends `storeDir: ...` to `pnpm-workspace.yaml`.
- With the env var, `pnpm store path` resolves to `/root/.local/share/pnpm/store/v10` and `pnpm-workspace.yaml` stays unchanged.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

