### PR TITLE
sdk[release]: 1.0.0-alpha.7

### DIFF
--- a/sdk/python/polar/__init__.py
+++ b/sdk/python/polar/__init__.py
@@ -1,6 +1,6 @@
 from polar.base import PolarClientError, PolarError, PolarNetworkError, PolarServerError
 
-__version__ = "1.0.0a6"
+__version__ = "1.0.0a7"
 __all__ = [
     "PolarError",
     "PolarNetworkError",

--- a/sdk/python/polar/v2026_04/literals.py
+++ b/sdk/python/polar/v2026_04/literals.py
@@ -786,7 +786,6 @@ PaymentTrigger: typing.TypeAlias = typing.Literal[
 Permission: typing.TypeAlias = typing.Literal[
     "pull", "triage", "push", "maintain", "admin"
 ]
-"""The permission level to grant. Read more about roles and their permissions on [GitHub documentation](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role)."""
 PresentmentCurrency: typing.TypeAlias = typing.Literal[
     "aed",
     "all",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polar-sh/sdk",
-  "version": "1.0.0-alpha.6",
+  "version": "1.0.0-alpha.7",
   "description": "Polar SDK — A billing platform for the intelligence era",
   "keywords": [
     "api",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Release 1.0.0-alpha.7 of the SDK. Bumps Python `polar` to 1.0.0a7 and TypeScript `@polar-sh/sdk` to 1.0.0-alpha.7, and removes an outdated docstring in the Python literals module.

<sup>Written for commit c78b9b130493e1ec41555d5d76339ab5a4ac85fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

