### PR TITLE
fix minor visual mobile bugs on compass ui

### DIFF
--- a/clients/apps/web/src/components/Compass/AssistantBlocks.tsx
+++ b/clients/apps/web/src/components/Compass/AssistantBlocks.tsx
@@ -108,7 +108,7 @@ export const AssistantBlockView = ({
       return <MetricChartView block={block} />
     case 'insight_cards':
       return (
-        <Grid templateColumns="repeat(2, 1fr)" gap="m">
+        <Grid templateColumns={{ base: '1fr', sm: 'repeat(2, 1fr)' }} gap="m">
           {block.insights.map((insight) => (
             <GridItem key={insight.id}>
               <Box

--- a/clients/apps/web/src/components/Compass/CompassBox.tsx
+++ b/clients/apps/web/src/components/Compass/CompassBox.tsx
@@ -42,7 +42,7 @@ export const CompassBox = ({
       display="flex"
       justifyContent="center"
       alignItems="end"
-      paddingHorizontal="l"
+      paddingHorizontal={{ base: 'xs', md: 'l' }}
       paddingBottom="xl"
     >
       {/* Gradient fade — content scrolls under it toward the bottom. */}
@@ -54,8 +54,8 @@ export const CompassBox = ({
         paddingVertical="m"
         paddingHorizontal="l"
         top={-36}
-        left={12}
-        right={12}
+        left={{ base: 20, md: 12 }}
+        right={{ base: 20, md: 12 }}
         borderTopRightRadius="l"
         borderTopLeftRadius="l"
         backgroundColor="background-card"

--- a/clients/apps/web/src/components/Compass/CompassConversation.tsx
+++ b/clients/apps/web/src/components/Compass/CompassConversation.tsx
@@ -142,7 +142,7 @@ export const CompassConversation = ({
       >
         {empty ? (
           <Box display="flex" flexDirection="column" rowGap="xl">
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="grid grid-cols-1 gap-2.5 sm:gap-4 sm:grid-cols-2">
               {presets.map(({ question, Icon }) => (
                 <button
                   key={question}

--- a/clients/apps/web/src/components/Compass/CompassConversation.tsx
+++ b/clients/apps/web/src/components/Compass/CompassConversation.tsx
@@ -142,7 +142,7 @@ export const CompassConversation = ({
       >
         {empty ? (
           <Box display="flex" flexDirection="column" rowGap="xl">
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
               {presets.map(({ question, Icon }) => (
                 <button
                   key={question}
@@ -150,9 +150,9 @@ export const CompassConversation = ({
                   onClick={() => onAsk(question)}
                   className="dark:border-polar-700 dark:hover:border-polar-600 dark:hover:bg-polar-700 flex cursor-pointer flex-col gap-3 rounded-2xl border border-gray-200 p-4 text-left transition-colors hover:border-gray-300 hover:bg-gray-50"
                 >
-                  <Box columnGap="m" alignItems="start">
+                  <Box columnGap={{ base: 's', sm: 'm' }} alignItems="start">
                     <Icon
-                      className="dark:text-polar-500 text-gray-400"
+                      className="dark:text-polar-500 shrink-0 text-gray-400"
                       style={{ fontSize: '1rem', marginTop: '.2rem' }}
                     />
 

--- a/clients/apps/web/src/components/Compass/CompassConversation.tsx
+++ b/clients/apps/web/src/components/Compass/CompassConversation.tsx
@@ -142,7 +142,7 @@ export const CompassConversation = ({
       >
         {empty ? (
           <Box display="flex" flexDirection="column" rowGap="xl">
-            <div className="grid grid-cols-1 gap-2.5 sm:gap-4 sm:grid-cols-2">
+            <div className="grid grid-cols-1 gap-2.5 sm:grid-cols-2 sm:gap-4">
               {presets.map(({ question, Icon }) => (
                 <button
                   key={question}

--- a/clients/apps/web/src/components/Compass/CompassWidget.tsx
+++ b/clients/apps/web/src/components/Compass/CompassWidget.tsx
@@ -192,6 +192,7 @@ export const CompassWidget = ({
           alignItems="center"
           rowGap="m"
           paddingVertical="2xl"
+          paddingHorizontal={{ base: 'xl', sm: '2xl' }}
           borderRadius="l"
           borderWidth={1}
           borderStyle="solid"


### PR DESCRIPTION
Mobile responsiveness fixes for minor compass UI bugs.

1. The suggestion grid had overflow issues and had a cramped look. On mobile now is stacked instead of grid. Desktop unchanged.
2. The 'Introducing' banner on the CompassBox was misaligned on mobile.
3. Insights cards on mobile were cramped and hard to read. Didn't respect the `max-width: '85%'` styling that exists for the LLM chat responses.


| Before | After |
|---|---|
| <img width="500" alt="Screenshot 2026-07-13 at 18 38 32" src="https://github.com/user-attachments/assets/8084f238-85a3-4215-8d4d-cf0f0a0ebba8" /> | <img width="302" alt="Screenshot 2026-07-13 at 23 25 58" src="https://github.com/user-attachments/assets/437d26f8-8c58-4839-98a5-13f1b91ca3d4" /> |
| <img width="500" alt="Screenshot 2026-07-13 at 18 41 16" src="https://github.com/user-attachments/assets/2bb85f99-27cd-4a1d-9beb-2ab9bffb5c38" /> | <img width="500" alt="Screenshot 2026-07-13 at 18 39 34" src="https://github.com/user-attachments/assets/29a51074-4db9-470c-bfa9-f31062b39286" /> |
| <img width="370" height="751" alt="Screenshot 2026-07-13 at 23 00 33" src="https://github.com/user-attachments/assets/19bcd102-5895-4dee-979c-c28307dabf67" /> | <img width="373" height="754" alt="Screenshot 2026-07-13 at 22 59 44" src="https://github.com/user-attachments/assets/67af9207-d796-4cb6-97c6-4139c6c97fc6" /> |



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

