### PR TITLE
mobile dashboard overflow quickfixes

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/CheckoutsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/CheckoutsPage.tsx
@@ -244,12 +244,14 @@ const ClientPage: React.FC<ClientPageProps> = ({
     <DashboardBody wide>
       <div className="flex flex-col gap-8">
         <div className="flex w-full flex-row items-center justify-between gap-2">
-          <div className="grid grid-cols-3 gap-4">
-            <Input
-              type="text"
-              placeholder="Filter by email"
-              onChange={(e) => setQuery(e.target.value)}
-            />
+          <div className="grid w-full grid-cols-2 gap-4 sm:w-auto sm:grid-cols-3">
+            <div className="col-span-2 sm:col-span-1">
+              <Input
+                type="text"
+                placeholder="Filter by email"
+                onChange={(e) => setQuery(e.target.value)}
+              />
+            </div>
             <CheckoutStatusSelect value={status || ''} onChange={setStatus} />
             <ProductSelect
               organization={organization}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/webhooks/endpoints/[id]/EndpointsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/webhooks/endpoints/[id]/EndpointsPage.tsx
@@ -187,13 +187,13 @@ export default function ClientPage({
           <div className="flex min-w-0 flex-col gap-1">
             {endpoint.name && endpoint.name.length > 0 ? (
               <>
-                <h3 className="break-words text-lg">{endpoint.name}</h3>
-                <p className="dark:text-polar-400 break-all font-mono text-sm text-gray-500">
+                <h3 className="text-lg break-words">{endpoint.name}</h3>
+                <p className="dark:text-polar-400 font-mono text-sm break-all text-gray-500">
                   {endpoint.url}
                 </p>
               </>
             ) : (
-              <h3 className="break-words text-lg">{endpoint.url}</h3>
+              <h3 className="text-lg break-words">{endpoint.url}</h3>
             )}
           </div>
           <div className="flex shrink-0 items-center gap-2">

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/webhooks/endpoints/[id]/EndpointsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/webhooks/endpoints/[id]/EndpointsPage.tsx
@@ -183,17 +183,17 @@ export default function ClientPage({
       wide
     >
       <div className="flex flex-col gap-4">
-        <div className="flex items-center justify-between gap-4">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="flex min-w-0 flex-col gap-1">
             {endpoint.name && endpoint.name.length > 0 ? (
               <>
-                <h3 className="text-lg">{endpoint.name}</h3>
-                <p className="dark:text-polar-400 truncate font-mono text-sm text-gray-500">
+                <h3 className="break-words text-lg">{endpoint.name}</h3>
+                <p className="dark:text-polar-400 break-all font-mono text-sm text-gray-500">
                   {endpoint.url}
                 </p>
               </>
             ) : (
-              <h3 className="text-lg">{endpoint.url}</h3>
+              <h3 className="break-words text-lg">{endpoint.url}</h3>
             )}
           </div>
           <div className="flex shrink-0 items-center gap-2">

--- a/clients/apps/web/src/components/Customer/CustomerPage.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerPage.tsx
@@ -549,7 +549,7 @@ export const CustomerPage: React.FC<CustomerPageProps> = ({
         <ShadowBox className="flex flex-col gap-8">
           <div className="flex flex-col gap-4">
             <h2 className="text-lg">Customer Details</h2>
-            <div className="flex flex-col">
+            <div className="flex flex-col gap-y-3 md:gap-y-0.5">
               <DetailRow label="ID" value={customer.id} />
               <DetailRow label="External ID" value={customer.external_id} />
               <DetailRow label="Email" value={customer.email ?? '—'} />
@@ -572,7 +572,7 @@ export const CustomerPage: React.FC<CustomerPageProps> = ({
           </div>
           <div className="flex flex-col gap-4">
             <h4 className="text-lg">Billing Information</h4>
-            <div className="flex flex-col">
+            <div className="flex flex-col gap-y-3 md:gap-y-0.5">
               <DetailRow label="Billing Name" value={customer.billing_name} />
               <DetailRow
                 label="Tax ID"
@@ -623,7 +623,7 @@ export const CustomerPage: React.FC<CustomerPageProps> = ({
               <div className="flex flex-row items-center justify-between gap-2">
                 <h3 className="text-lg">Metadata</h3>
               </div>
-              <div className="flex flex-col">
+              <div className="flex flex-col gap-y-3 md:gap-y-0.5">
                 {Object.entries(customer.metadata).map(([key, value]) => (
                   <DetailRow key={key} label={key} value={value} />
                 ))}

--- a/clients/apps/web/src/components/DashboardOverview/MetricSelectorModal.tsx
+++ b/clients/apps/web/src/components/DashboardOverview/MetricSelectorModal.tsx
@@ -197,9 +197,9 @@ export const MetricDashboardEditorContent = ({
           </div>
         )}
 
-        <div className="dark:divide-polar-700 grid grid-cols-2 divide-x divide-gray-100 p-6">
+        <div className="dark:divide-polar-700 grid grid-cols-1 gap-y-6 divide-gray-100 p-6 md:grid-cols-2 md:gap-y-0 md:divide-x">
           {/* Left panel — selected metrics */}
-          <div className="flex flex-col gap-y-4 pr-6">
+          <div className="flex flex-col gap-y-4 md:pr-6">
             <div className="flex items-center justify-between">
               <h3 className="text-sm font-medium text-gray-900 dark:text-white">
                 Selected
@@ -227,7 +227,7 @@ export const MetricDashboardEditorContent = ({
                 items={selected.map((m) => m.id)}
                 strategy={verticalListSortingStrategy}
               >
-                <div className="flex max-h-96 flex-col gap-y-2 overflow-y-auto">
+                <div className="flex max-h-64 flex-col gap-y-2 overflow-y-auto md:max-h-96">
                   {selected.map((item) => (
                     <SortableMetricRow
                       key={item.id}
@@ -261,11 +261,11 @@ export const MetricDashboardEditorContent = ({
           </div>
 
           {/* Right panel — available metrics */}
-          <div className="flex flex-col gap-y-4 pl-6">
+          <div className="flex flex-col gap-y-4 md:pl-6">
             <h3 className="text-sm font-medium text-gray-900 dark:text-white">
               Metrics
             </h3>
-            <div className="flex h-96 flex-col gap-y-2 overflow-y-auto">
+            <div className="flex max-h-64 flex-col gap-y-2 overflow-y-auto md:h-96 md:max-h-none">
               {groupedAvailable.map(({ category, metrics }) => (
                 <details key={category} className="group">
                   <summary className="dark:bg-polar-800 flex cursor-pointer list-none items-center justify-between rounded-lg bg-gray-100 px-4 py-2 text-sm font-medium select-none">

--- a/clients/apps/web/src/components/Metrics/dashboards/CancellationsContent.tsx
+++ b/clients/apps/web/src/components/Metrics/dashboards/CancellationsContent.tsx
@@ -28,7 +28,7 @@ export function CancellationsContent({
     <div className="flex flex-col gap-y-6">
       <div className="dark:border-polar-700 flex flex-col overflow-hidden rounded-2xl border border-gray-200">
         <div className="grid grid-cols-1 flex-col [clip-path:inset(1px_1px_1px_1px)] lg:grid-cols-2 2xl:grid-cols-3">
-          <div className="dark:border-polar-700 lg:col-span-2 border-t-0 border-r border-b border-l-0 border-gray-200 p-4">
+          <div className="dark:border-polar-700 border-t-0 border-r border-b border-l-0 border-gray-200 p-4 lg:col-span-2">
             <CancellationsStackedChart
               data={data}
               interval={interval}

--- a/clients/apps/web/src/components/Metrics/dashboards/CancellationsContent.tsx
+++ b/clients/apps/web/src/components/Metrics/dashboards/CancellationsContent.tsx
@@ -28,7 +28,7 @@ export function CancellationsContent({
     <div className="flex flex-col gap-y-6">
       <div className="dark:border-polar-700 flex flex-col overflow-hidden rounded-2xl border border-gray-200">
         <div className="grid grid-cols-1 flex-col [clip-path:inset(1px_1px_1px_1px)] lg:grid-cols-2 2xl:grid-cols-3">
-          <div className="dark:border-polar-700 col-span-2 border-t-0 border-r border-b border-l-0 border-gray-200 p-4">
+          <div className="dark:border-polar-700 lg:col-span-2 border-t-0 border-r border-b border-l-0 border-gray-200 p-4">
             <CancellationsStackedChart
               data={data}
               interval={interval}

--- a/clients/apps/web/src/components/Products/ProductSelect.tsx
+++ b/clients/apps/web/src/components/Products/ProductSelect.tsx
@@ -222,7 +222,7 @@ const ProductSelect: React.FC<ProductSelectProps> = ({
             'ring-offset-background placeholder:text-muted-foreground focus:ring-ring dark:bg-polar-800 font-medium dark:hover:bg-polar-700 dark:border-polar-700 dark:hover:border-polar-700 flex h-10 w-full! flex-row items-center justify-between gap-x-2 rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm font-sans shadow-xs transition-colors hover:border-gray-300 hover:bg-white focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
             className,
           )}
-          wrapperClassNames="justify-between w-full min-w-[200px]"
+          wrapperClassNames="justify-between w-full min-w-0 sm:min-w-[200px]"
         >
           <div className="overflow-hidden text-ellipsis whitespace-nowrap">
             {buttonLabel}


### PR DESCRIPTION
Mobile responsiveness fixes for some UI bugs in dashboard

1. In _Metrics Page_, under _Cancelations_ there was a bug were columns stacked on top of one another on mobile.
2. In _Checkout Page_, the filter dropdowns was buggy and moved the whole screen weirdly
3. Add spacing to Customer Deatils on mobile for better readability
4. Fixed customize overview dialog causing weird visual issues on mobile
5. Webhook page overflow title issue





| Before | After |
|---|---|
| <img width="447" height="857" alt="Screenshot 2026-07-14 at 00 11 16" src="https://github.com/user-attachments/assets/6ca22885-ed17-4905-a2b4-6c116e45ed98" /> | <img width="457"  alt="Screenshot 2026-07-14 at 00 11 31" src="https://github.com/user-attachments/assets/f2f18009-9f94-4c51-b6b6-2e52b2955322" /> |
| <img width="450" alt="image" src="https://github.com/user-attachments/assets/bb89c972-f510-4813-84fe-9eec4152b28e" /> | <img width="597"  alt="Screenshot 2026-07-14 at 00 39 16" src="https://github.com/user-attachments/assets/acfdc57f-6c3a-4dd4-9db6-979bc011f950" /> |
| <img width="494" height="503" alt="Screenshot 2026-07-13 at 23 52 39" src="https://github.com/user-attachments/assets/918c9bf8-b6f3-47cd-9281-eb6a3ad8f4d9" /> | <img width="453" height="616" alt="Screenshot 2026-07-13 at 23 52 36" src="https://github.com/user-attachments/assets/84d7d4c9-bb35-4091-bc54-8f86c6f8f8c4" /> | 
| <img width="463" height="643" alt="Screenshot 2026-07-13 at 23 58 37" src="https://github.com/user-attachments/assets/3660826e-1746-4e86-aa29-0364346382ed" /> | <img width="474" height="764" alt="Screenshot 2026-07-13 at 23 58 13" src="https://github.com/user-attachments/assets/bb266308-ec6a-4242-b67e-c13a4b97db1d" /> |
| <img width="500" alt="image" src="https://github.com/user-attachments/assets/b2aa8437-d58a-412b-93f6-6e95f6422609" /> | <img width="458" alt="Screenshot 2026-07-14 at 00 25 58" src="https://github.com/user-attachments/assets/173528e0-e041-469b-9e6e-e9931c9e8516" /> |



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

