### PR TITLE
fix: correct typo in LockerError message

### DIFF
--- a/server/polar/locker.py
+++ b/server/polar/locker.py
@@ -17,7 +17,7 @@ log: Logger = structlog.get_logger()
 class LockerError(PolarError):
     def __init__(
         self,
-        message: str = "A concurrency error occured. Try again later.",
+        message: str = "A concurrency error occurred. Try again later.",
         status_code: int = 500,
     ) -> None:
         super().__init__(message, status_code)


### PR DESCRIPTION
## Summary

Fix a spelling mistake in the default `LockerError` message. "occured" is now "occurred".

This message can reach API clients on lock contention, so the typo was user-facing.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

