### PR TITLE
fix: prevent identity verification race stranding verified users in pending

### DIFF
--- a/server/polar/user/repository.py
+++ b/server/polar/user/repository.py
@@ -101,12 +101,15 @@ class UserRepository(
         *,
         include_deleted: bool = False,
         included_blocked: bool = False,
+        for_update: bool = False,
     ) -> User | None:
         statement = self.get_base_statement(include_deleted=include_deleted).where(
             User.identity_verification_id == identity_verification_id
         )
         if not included_blocked:
             statement = statement.where(User.blocked_at.is_(None))
+        if for_update:
+            statement = statement.with_for_update(of=User)
         return await self.get_one_or_none(statement)
 
     async def get_all_by_organization(

--- a/server/polar/user/service.py
+++ b/server/polar/user/service.py
@@ -215,10 +215,8 @@ class UserService:
         if user is None:
             raise IdentityVerificationDoesNotExist(verification_session.id)
 
-        # `verified` is the only absorbing state. The `processing` and terminal
-        # webhooks can be processed concurrently; the row lock serializes them so
-        # a late `processing` can't clobber a committed `verified`. `failed` is
-        # retryable, so `failed` -> `pending` is intentionally allowed through.
+        # `verified` is the only absorbing state: don't let a concurrent `processing`
+        # clobber it. `failed` is retryable, so `failed` -> `pending` is allowed.
         if user.identity_verified:
             return user
 
@@ -242,9 +240,8 @@ class UserService:
         if user is None:
             raise IdentityVerificationDoesNotExist(verification_session.id)
 
-        # `verified` is the only absorbing state: a late or redelivered
-        # `requires_input`/`canceled` from an earlier attempt must not un-verify
-        # a user who has since verified.
+        # `verified` is the only absorbing state: a late/redelivered terminal event
+        # from an earlier attempt must not un-verify a user who has since verified.
         if user.identity_verified:
             return user
 

--- a/server/polar/user/service.py
+++ b/server/polar/user/service.py
@@ -215,8 +215,8 @@ class UserService:
         if user is None:
             raise IdentityVerificationDoesNotExist(verification_session.id)
 
-        # `verified` is the only absorbing state: don't let a concurrent `processing`
-        # clobber it. `failed` is retryable, so `failed` -> `pending` is allowed.
+        # Once a user is verified, keep them verified: a late `processing` webhook
+        # must not overwrite it. A failed user can retry, so `failed` -> `pending` is fine.
         if user.identity_verified:
             return user
 
@@ -240,8 +240,8 @@ class UserService:
         if user is None:
             raise IdentityVerificationDoesNotExist(verification_session.id)
 
-        # `verified` is the only absorbing state: a late/redelivered terminal event
-        # from an earlier attempt must not un-verify a user who has since verified.
+        # Once a user is verified, keep them verified. An old or repeated webhook
+        # from a past attempt must not undo it.
         if user.identity_verified:
             return user
 

--- a/server/polar/user/service.py
+++ b/server/polar/user/service.py
@@ -215,11 +215,10 @@ class UserService:
         if user is None:
             raise IdentityVerificationDoesNotExist(verification_session.id)
 
-        # Never downgrade a verified user back to pending. Stripe delivers the
-        # `processing` event alongside the terminal one, and the two webhook tasks
-        # can run concurrently; the row lock above serializes them, so here we
-        # read the committed status and skip if it's already verified. `failed`
-        # is not terminal: a user may retry, so `failed` -> `pending` is allowed.
+        # `verified` is the only absorbing state. The `processing` and terminal
+        # webhooks can be processed concurrently; the row lock serializes them so
+        # a late `processing` can't clobber a committed `verified`. `failed` is
+        # retryable, so `failed` -> `pending` is intentionally allowed through.
         if user.identity_verified:
             return user
 
@@ -243,9 +242,9 @@ class UserService:
         if user is None:
             raise IdentityVerificationDoesNotExist(verification_session.id)
 
-        # `verified` is the only absorbing state. Never un-verify a user: a late
-        # or redelivered `requires_input`/`canceled` webhook from an earlier
-        # attempt must not overwrite a status that has since become verified.
+        # `verified` is the only absorbing state: a late or redelivered
+        # `requires_input`/`canceled` from an earlier attempt must not un-verify
+        # a user who has since verified.
         if user.identity_verified:
             return user
 

--- a/server/polar/user/service.py
+++ b/server/polar/user/service.py
@@ -215,14 +215,12 @@ class UserService:
         if user is None:
             raise IdentityVerificationDoesNotExist(verification_session.id)
 
-        # Never downgrade a terminal status back to pending. Stripe delivers the
+        # Never downgrade a verified user back to pending. Stripe delivers the
         # `processing` event alongside the terminal one, and the two webhook tasks
         # can run concurrently; the row lock above serializes them, so here we
-        # read the committed status and skip if it's already verified or failed.
-        if user.identity_verification_status in (
-            IdentityVerificationStatus.verified,
-            IdentityVerificationStatus.failed,
-        ):
+        # read the committed status and skip if it's already verified. `failed`
+        # is not terminal: a user may retry, so `failed` -> `pending` is allowed.
+        if user.identity_verified:
             return user
 
         assert verification_session.status == "processing"
@@ -244,6 +242,12 @@ class UserService:
         )
         if user is None:
             raise IdentityVerificationDoesNotExist(verification_session.id)
+
+        # `verified` is the only absorbing state. Never un-verify a user: a late
+        # or redelivered `requires_input`/`canceled` webhook from an earlier
+        # attempt must not overwrite a status that has since become verified.
+        if user.identity_verified:
+            return user
 
         # TODO: should we send an email?
 

--- a/server/polar/user/service.py
+++ b/server/polar/user/service.py
@@ -182,7 +182,9 @@ class UserService:
         verification_session: stripe_lib.identity.VerificationSession,
     ) -> User:
         repository = UserRepository.from_session(session)
-        user = await repository.get_by_identity_verification_id(verification_session.id)
+        user = await repository.get_by_identity_verification_id(
+            verification_session.id, for_update=True
+        )
         if user is None:
             raise IdentityVerificationDoesNotExist(verification_session.id)
 
@@ -207,13 +209,20 @@ class UserService:
         verification_session: stripe_lib.identity.VerificationSession,
     ) -> User:
         repository = UserRepository.from_session(session)
-        user = await repository.get_by_identity_verification_id(verification_session.id)
+        user = await repository.get_by_identity_verification_id(
+            verification_session.id, for_update=True
+        )
         if user is None:
             raise IdentityVerificationDoesNotExist(verification_session.id)
 
-        # If the user is already verified, we don't need to update their status.
-        # Might happen if the webhook was delayed
-        if user.identity_verified:
+        # Never downgrade a terminal status back to pending. Stripe delivers the
+        # `processing` event alongside the terminal one, and the two webhook tasks
+        # can run concurrently; the row lock above serializes them, so here we
+        # read the committed status and skip if it's already verified or failed.
+        if user.identity_verification_status in (
+            IdentityVerificationStatus.verified,
+            IdentityVerificationStatus.failed,
+        ):
             return user
 
         assert verification_session.status == "processing"
@@ -230,7 +239,9 @@ class UserService:
         verification_session: stripe_lib.identity.VerificationSession,
     ) -> User:
         repository = UserRepository.from_session(session)
-        user = await repository.get_by_identity_verification_id(verification_session.id)
+        user = await repository.get_by_identity_verification_id(
+            verification_session.id, for_update=True
+        )
         if user is None:
             raise IdentityVerificationDoesNotExist(verification_session.id)
 

--- a/server/tests/user/test_service.py
+++ b/server/tests/user/test_service.py
@@ -340,3 +340,81 @@ class TestIdentityVerificationVerified:
         }
         assert organization.id in activated_org_ids
         assert organization_second.id not in activated_org_ids
+
+
+@pytest.mark.asyncio
+class TestIdentityVerificationPending:
+    async def test_sets_pending_from_unverified(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        user.identity_verification_id = "vs_pending_test"
+        user.identity_verification_status = IdentityVerificationStatus.unverified
+        await save_fixture(user)
+
+        verification_session = stripe_lib.identity.VerificationSession.construct_from(
+            {"id": "vs_pending_test", "status": "processing"}, None
+        )
+
+        updated_user = await user_service.identity_verification_pending(
+            session, verification_session
+        )
+
+        assert (
+            updated_user.identity_verification_status
+            == IdentityVerificationStatus.pending
+        )
+
+    async def test_does_not_downgrade_verified(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        """A `processing` webhook must never clobber a `verified` status.
+
+        Stripe delivers `processing` and `verified` back to back and the two
+        webhook tasks can run concurrently; if `processing` wins the race it
+        would strand a genuinely-verified user in `pending` (see T-30664).
+        """
+        user.identity_verification_id = "vs_verified_race"
+        user.identity_verification_status = IdentityVerificationStatus.verified
+        await save_fixture(user)
+
+        verification_session = stripe_lib.identity.VerificationSession.construct_from(
+            {"id": "vs_verified_race", "status": "processing"}, None
+        )
+
+        updated_user = await user_service.identity_verification_pending(
+            session, verification_session
+        )
+
+        assert (
+            updated_user.identity_verification_status
+            == IdentityVerificationStatus.verified
+        )
+
+    async def test_does_not_downgrade_failed(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        user.identity_verification_id = "vs_failed_race"
+        user.identity_verification_status = IdentityVerificationStatus.failed
+        await save_fixture(user)
+
+        verification_session = stripe_lib.identity.VerificationSession.construct_from(
+            {"id": "vs_failed_race", "status": "processing"}, None
+        )
+
+        updated_user = await user_service.identity_verification_pending(
+            session, verification_session
+        )
+
+        assert (
+            updated_user.identity_verification_status
+            == IdentityVerificationStatus.failed
+        )

--- a/server/tests/user/test_service.py
+++ b/server/tests/user/test_service.py
@@ -404,7 +404,7 @@ class TestIdentityVerificationPending:
     ) -> None:
         """`failed` is not terminal. A user may retry on the same (reusable)
         verification session, so a `processing` webhook must move them back to
-        `pending` — otherwise the status stays `failed` during reprocessing.
+        `pending`. Otherwise the status stays `failed` during reprocessing.
         """
         user.identity_verification_id = "vs_failed_retry"
         user.identity_verification_status = IdentityVerificationStatus.failed

--- a/server/tests/user/test_service.py
+++ b/server/tests/user/test_service.py
@@ -396,18 +396,22 @@ class TestIdentityVerificationPending:
             == IdentityVerificationStatus.verified
         )
 
-    async def test_does_not_downgrade_failed(
+    async def test_moves_failed_to_pending_on_retry(
         self,
         save_fixture: SaveFixture,
         session: AsyncSession,
         user: User,
     ) -> None:
-        user.identity_verification_id = "vs_failed_race"
+        """`failed` is not terminal. A user may retry on the same (reusable)
+        verification session, so a `processing` webhook must move them back to
+        `pending` — otherwise the status stays `failed` during reprocessing.
+        """
+        user.identity_verification_id = "vs_failed_retry"
         user.identity_verification_status = IdentityVerificationStatus.failed
         await save_fixture(user)
 
         verification_session = stripe_lib.identity.VerificationSession.construct_from(
-            {"id": "vs_failed_race", "status": "processing"}, None
+            {"id": "vs_failed_retry", "status": "processing"}, None
         )
 
         updated_user = await user_service.identity_verification_pending(
@@ -416,5 +420,57 @@ class TestIdentityVerificationPending:
 
         assert (
             updated_user.identity_verification_status
+            == IdentityVerificationStatus.pending
+        )
+
+
+@pytest.mark.asyncio
+class TestIdentityVerificationFailed:
+    async def test_sets_failed_from_pending(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        user.identity_verification_id = "vs_failed_test"
+        user.identity_verification_status = IdentityVerificationStatus.pending
+        await save_fixture(user)
+
+        verification_session = stripe_lib.identity.VerificationSession.construct_from(
+            {"id": "vs_failed_test", "status": "requires_input"}, None
+        )
+
+        updated_user = await user_service.identity_verification_failed(
+            session, verification_session
+        )
+
+        assert (
+            updated_user.identity_verification_status
             == IdentityVerificationStatus.failed
+        )
+
+    async def test_does_not_overwrite_verified(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        """A late or redelivered `requires_input`/`canceled` webhook from an
+        earlier attempt must not un-verify a user who has since verified.
+        """
+        user.identity_verification_id = "vs_verified_stale_fail"
+        user.identity_verification_status = IdentityVerificationStatus.verified
+        await save_fixture(user)
+
+        verification_session = stripe_lib.identity.VerificationSession.construct_from(
+            {"id": "vs_verified_stale_fail", "status": "requires_input"}, None
+        )
+
+        updated_user = await user_service.identity_verification_failed(
+            session, verification_session
+        )
+
+        assert (
+            updated_user.identity_verification_status
+            == IdentityVerificationStatus.verified
         )


### PR DESCRIPTION
## Summary

Fixes a race where a verified user could get stuck with identity status `pending`.

## What

- Lock the user row (`SELECT ... FOR UPDATE`) in the three Stripe identity webhook handlers (`verified`, `processing`, `failed`).
- Stop the `processing` handler from downgrading a terminal status (`verified` or `failed`) back to `pending`.
- Add tests for the pending handler.

## Why

Stripe sends the `processing` and `verified` webhooks back to back. The two tasks could run at the same time. The `processing` handler wrote `pending` without checking the current state. If it committed last, it overwrote a `verified` result. The user was then stuck in `pending` even though Stripe had verified them, which also blocked their org from activating.

## How

- The row lock makes the two webhook tasks run one after the other. The second task reads the committed status instead of a stale one.
- The `processing` handler now returns early if the status is already `verified` or `failed`.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

