### PR TITLE
payout: lock payout row FOR UPDATE in trigger_payout to prevent cancel race

### DIFF
--- a/server/polar/payout/tasks.py
+++ b/server/polar/payout/tasks.py
@@ -71,10 +71,6 @@ async def trigger_payout(
 ) -> None:
     async with AsyncSessionMaker() as session:
         repository = PayoutRepository(session)
-        # Lock the payout row up front: a queued trigger can race a cancel
-        # (deny/block/backoffice) and would otherwise pay out a payout the ledger
-        # already reversed. FOR UPDATE serializes with cancel(), which locks the
-        # same row.
         payout = await repository.get_by_id(
             payout_id, options=repository.get_eager_options(), for_update=True
         )

--- a/server/polar/payout/tasks.py
+++ b/server/polar/payout/tasks.py
@@ -71,8 +71,12 @@ async def trigger_payout(
 ) -> None:
     async with AsyncSessionMaker() as session:
         repository = PayoutRepository(session)
+        # Lock the payout row up front: a queued trigger can race a cancel
+        # (deny/block/backoffice) and would otherwise pay out a payout the ledger
+        # already reversed. FOR UPDATE serializes with cancel(), which locks the
+        # same row.
         payout = await repository.get_by_id(
-            payout_id, options=repository.get_eager_options()
+            payout_id, options=repository.get_eager_options(), for_update=True
         )
         if payout is None:
             raise PayoutDoesNotExist(payout_id)


### PR DESCRIPTION
## Summary

The `trigger_payout` task in `server/polar/payout/tasks.py` loads the payout row **without** a `FOR UPDATE` lock, so it can race a concurrent `cancel()` and trigger a real Stripe payout for a payout whose DB row is already `canceled` and whose ledger has been reversed — an unrecoverable financial discrepancy.

## What

Add `for_update=True` when loading the payout in `trigger_payout`, so the task acquires a row lock before reading status and creating the Stripe payout.

```diff
 payout = await repository.get_by_id(
-    payout_id, options=repository.get_eager_options()
+    payout_id, options=repository.get_eager_options(), for_update=True
 )
```

## Why

Dramatiq workers run in separate SQLAlchemy sessions. Without `FOR UPDATE`, once `trigger_payout` has loaded the ORM object, a concurrent `cancel()` that commits afterward does **not** refresh it. The status gate in `trigger_stripe_payout` (`if payout.status == PayoutStatus.canceled: raise PayoutCanceled(...)`) then reads a stale `pending` value and proceeds, creating a Stripe payout for a payout the ledger already reversed.

The sibling `payout_transfer` task locks the same row for exactly this reason, and `cancel()` locks it via `session.refresh(..., with_for_update=True)`. `trigger_payout` was the one path left unprotected. This race was introduced in #12097.

## How

`FOR UPDATE` serializes `trigger_payout` with `cancel()` (which locks the same row). When a cancel commits first, the trigger blocks until the lock is released and then reads the fresh `canceled` status, correctly raising `PayoutCanceled` instead of paying out. The change mirrors the existing `payout_transfer` implementation, comment included.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests — no behavioral surface to unit-test beyond the existing `PayoutRepository` `for_update` coverage (`tests/payout/test_repository.py::test_for_update`); this matches how the sibling `payout_transfer` lock was landed
- [ ] Linting and type checking pass — could not run in this environment (Python 3.14 interpreter unavailable); the change is a one-line argument addition mirroring existing working code
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MssKfDue8xVqZPEKzJJsBU

---
_Generated by [Claude Code](https://claude.ai/code/session_01MssKfDue8xVqZPEKzJJsBU)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

