### PR TITLE
fix: block member session auth for soft-deleted customers

### DIFF
--- a/server/polar/member_session/repository.py
+++ b/server/polar/member_session/repository.py
@@ -31,6 +31,7 @@ class MemberSessionRepository(
                 MemberSession.token == token_hash,
                 MemberSession.is_deleted.is_(False),
                 Member.is_deleted.is_(False),
+                Customer.can_authenticate.is_(True),
             )
             .options(
                 contains_eager(MemberSession.member)

--- a/server/tests/member_session/test_service.py
+++ b/server/tests/member_session/test_service.py
@@ -188,6 +188,31 @@ class TestGetByToken:
         result = await member_session.get_by_token(session, token)
         assert result is None
 
+    async def test_returns_none_for_deleted_customer(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture, organization=organization, email="test@example.com"
+        )
+        member = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email=customer.email,
+            name="Test Member",
+            role=MemberRole.owner,
+        )
+        await save_fixture(member)
+
+        token, _ = await member_session.create_member_session(session, member)
+        customer.deleted_at = utc_now()
+        await save_fixture(customer)
+
+        result = await member_session.get_by_token(session, token)
+        assert result is None
+
     async def test_eagerly_loads_member_and_customer(
         self,
         save_fixture: SaveFixture,


### PR DESCRIPTION
## Summary

**Related Issue**: Detail bug report [`bug_fc742fb6`](https://app.detail.dev/org_ecfbc7cf-6d21-4ce1-8c61-cda1d650ccf7/bugs/bug_fc742fb6-278f-4de2-a023-82d0a836bb2e) — introduced in #8917

`MemberSessionRepository.get_by_token_hash()` authenticated member-session tokens for customers that had been soft-deleted, because the query never required the joined `Customer` to be able to authenticate.

## What

Add `Customer.can_authenticate.is_(True)` to the `MemberSession` token lookup in `server/polar/member_session/repository.py`, and add a regression test asserting `get_by_token()` returns `None` when the associated customer has `deleted_at` set.

## Why

The token lookup filtered out deleted member sessions (`MemberSession.is_deleted.is_(False)`) and deleted members (`Member.is_deleted.is_(False)`), but not soft-deleted customers. This left an inconsistent state exploitable for authentication bypass:

1. A customer is transferred via `server/scripts/transfer_products_between_organizations.py`, which soft-deletes the source `Customer` (sets `deleted_at`) but leaves the related `Member` and `MemberSession` records active.
2. The customer portal continues to accept the existing `MemberSession` token, authenticating the user despite the customer being soft-deleted.

Customer-session authentication already guards against this with `Customer.can_authenticate.is_(True)` (`customer_session/service.py`); member-session authentication was missing the equivalent check.

## How

`Customer` is already imported and already joined in the query (`.join(Member.customer)`), so the fix is a single additional `where` clause. `Customer.can_authenticate` is the hybrid property whose SQL expression is `is_deleted.is_(False)`, so the filter excludes soft-deleted customers — semantically identical to the existing customer-session guard.

## Checklist

- [x] This PR addresses a single concern (one bug fix)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [ ] Linting and type checking pass — could not run in this environment (Python 3.14 toolchain unavailable; see note below)
- [x] No unrelated changes or drive-by fixes are included

> **Note on verification:** The backend test suite could not be run in the CI-less sandbox this change was authored in (the pinned Python 3.14.6 toolchain isn't provisionable here). The change was verified by inspection and syntax-compile; it mirrors the existing, tested `CustomerSession` auth guard exactly. Please rely on CI for the full run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQn1ykMtazr3kyj6UNYFam

---
_Generated by [Claude Code](https://claude.ai/code/session_01KQn1ykMtazr3kyj6UNYFam)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

