### PR TITLE
fix(benefit): clear error when revoking a benefit grant

### DIFF
--- a/server/polar/models/benefit_grant.py
+++ b/server/polar/models/benefit_grant.py
@@ -210,6 +210,7 @@ class BenefitGrant(RecordModel):
     def set_revoked(self) -> None:
         self.granted_at = None
         self.revoked_at = datetime.now(UTC)
+        self.error = None
 
     def set_grant_failed(self, error: Exception) -> None:
         self.granted_at = None

--- a/server/tests/benefit/grant/test_service.py
+++ b/server/tests/benefit/grant/test_service.py
@@ -500,6 +500,40 @@ class TestEnqueueBenefitsGrants:
         assert benefits[0].id not in grant_benefit_ids
         assert set(grant_benefit_ids) == {b.id for b in benefits[1:]}
 
+    async def test_grant_reenqueues_revoked_previously_errored_benefits(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        benefits: list[Benefit],
+        customer: Customer,
+        subscription: Subscription,
+    ) -> None:
+        """Revoked grants clear their error, so a benefit that previously failed
+        with BenefitActionRequiredError is re-enqueued after revocation."""
+        enqueue_job_mock = mocker.patch("polar.benefit.grant.service.enqueue_job")
+
+        grant = BenefitGrant(
+            subscription=subscription, customer=customer, benefit=benefits[0]
+        )
+        grant.set_grant_failed(BenefitActionRequiredError("Connect GitHub"))
+        grant.set_revoked()
+        await save_fixture(grant)
+
+        product = await set_product_benefits(
+            save_fixture, product=product, benefits=benefits
+        )
+
+        await benefit_grant_service.enqueue_benefits_grants(
+            session, "grant", customer, product, subscription=subscription
+        )
+
+        call_args = enqueue_job_mock.call_args
+        assert call_args[0][0] == "benefit.enqueue_grants"
+        grant_benefit_ids = call_args[1]["grant_benefit_ids"]
+        assert set(grant_benefit_ids) == {b.id for b in benefits}
+
     async def test_revoke_only_granted_benefits(
         self,
         mocker: MockerFixture,


### PR DESCRIPTION
## Summary

`BenefitGrant.set_revoked()` never clears the `error` field, leaving stale error state on revoked grants. This permanently blocks re-granting of benefits that previously failed with `BenefitActionRequiredError` when a subscription transitions `past_due → active`.

Reported via Detail. Introduced in #5705 (commit `23509d910`).

## What

Add `self.error = None` to `BenefitGrant.set_revoked()`, so revoking a grant resets its error state — mirroring what `set_granted()` already does.

```python
def set_revoked(self) -> None:
    self.granted_at = None
    self.revoked_at = datetime.now(UTC)
    self.error = None  # <-- added
```

## Why

`enqueue_benefits_grants(task="grant")` computes `errored_benefit_ids` by scanning **all** existing grants (via `list_by_customer_and_scope`, which includes revoked grants) for `error.type == "BenefitActionRequiredError"` and excludes those benefit IDs from being enqueued for granting:

```python
errored_benefit_ids = {
    g.benefit_id
    for g in existing_grants
    if g.error and g.error.get("type") == BenefitActionRequiredError.__name__
}
```

In the flow `subscribe → grant fails (action required) → subscription past_due → revoke → subscription active → grant`, revocation should reset the grant so reactivation enqueues a fresh grant. Because `set_revoked()` left `error` set, the benefit stayed blocked indefinitely.

The stale state is also invisible to the customer and to recovery paths: the customer portal listing and the OAuth recovery query both filter out revoked grants (`is_revoked.is_(False)`), so nothing else clears or retries the error. When `set_granted()` was added it correctly cleared `error`; `set_revoked()` was simply missed — the error is irrelevant to a revoked grant.

## How

- `server/polar/models/benefit_grant.py`: clear `error` in `set_revoked()`.
- `server/tests/benefit/grant/test_service.py`: add `test_grant_reenqueues_revoked_previously_errored_benefits` under `TestEnqueueBenefitsGrants`, asserting that a grant which failed with `BenefitActionRequiredError` and was then revoked is re-enqueued for granting (mirrors the existing `test_grant_skips_errored_benefits`, which stays valid for non-revoked errored grants).

> [!NOTE]
> I couldn't run the backend test suite or `lint`/`lint_types` in this environment: the pinned Python 3.14.6 toolchain download is blocked by the sandbox egress policy and the Docker daemon (Postgres/Redis/Minio) isn't available. Both files pass a `py_compile` syntax check, and I manually audited every `set_revoked()` usage in the tests to confirm none rely on `error` persisting after a revoke. Relying on CI for the full run.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`) — could not run locally (see note above)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqCm9hqML8NMMKwk6nYrSA)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13136?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

