### PR TITLE
fix(benefit): revoke external access per granted account, not grant count

### DIFF
--- a/server/polar/benefit/grant/service.py
+++ b/server/polar/benefit/grant/service.py
@@ -323,12 +323,27 @@ class BenefitGrantService(ResourceServiceReader[BenefitGrant]):
         benefit_strategy = get_benefit_strategy(benefit.type, session, redis)
         # Call the revoke logic in two cases:
         # * If the service requires grants to be revoked individually
-        # * If there is only one grant remaining for this benefit,
-        #   so the benefit remains if other grants exist via other purchases
+        # * If no other active grant retains access through the same external
+        #   account (e.g. Discord ID, GitHub username). Member-specific grants
+        #   can map to different external accounts, so a remaining grant for a
+        #   different account must not skip the external revoke.
+        # Grants not tied to an external account share the same `None` identity,
+        # preserving the behavior where the benefit remains if the customer
+        # holds it through other purchases.
         other_grants = await repository.list_granted_by_benefit_and_customer(
             benefit, customer
         )
-        if benefit_strategy.should_revoke_individually or len(other_grants) < 2:
+        granted_account_id = grant.properties.get("granted_account_id")
+        other_granted_account_ids = {
+            other_grant.properties.get("granted_account_id")
+            for other_grant in other_grants
+            if other_grant.id != grant.id
+        }
+        should_revoke_externally = (
+            benefit_strategy.should_revoke_individually
+            or granted_account_id not in other_granted_account_ids
+        )
+        if should_revoke_externally:
             try:
                 properties = await benefit_strategy.revoke(
                     benefit,

--- a/server/tests/benefit/grant/test_service.py
+++ b/server/tests/benefit/grant/test_service.py
@@ -1655,3 +1655,178 @@ class TestRevokeBenefitWithMember:
 
         # Member2's grant should still be granted
         assert grant2.is_granted
+
+    async def test_revoke_member_with_different_account_calls_revoke(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        subscription: Subscription,
+        benefit_organization: Benefit,
+        organization: Organization,
+        benefit_strategy_mock: MagicMock,
+    ) -> None:
+        """The external revoke must run when the only remaining grant is for a
+        different external account (e.g. another member's Discord ID)."""
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+
+        member1 = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="member1@example.com",
+            name="Member 1",
+            role=MemberRole.member,
+        )
+        await save_fixture(member1)
+
+        member2 = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="member2@example.com",
+            name="Member 2",
+            role=MemberRole.member,
+        )
+        await save_fixture(member2)
+
+        grant1 = BenefitGrant(
+            subscription=subscription,
+            customer=customer,
+            benefit=benefit_organization,
+            member_id=member1.id,
+            properties={"granted_account_id": "discord_AAA"},
+        )
+        grant1.set_granted()
+        await save_fixture(grant1)
+
+        grant2 = BenefitGrant(
+            subscription=subscription,
+            customer=customer,
+            benefit=benefit_organization,
+            member_id=member2.id,
+            properties={"granted_account_id": "discord_BBB"},
+        )
+        grant2.set_granted()
+        await save_fixture(grant2)
+
+        await benefit_grant_service.revoke_benefit(
+            session,
+            redis,
+            customer,
+            benefit_organization,
+            member=member1,
+            subscription=subscription,
+        )
+
+        benefit_strategy_mock.revoke.assert_called_once()
+
+    async def test_revoke_member_alone_calls_revoke(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        subscription: Subscription,
+        benefit_organization: Benefit,
+        organization: Organization,
+        benefit_strategy_mock: MagicMock,
+    ) -> None:
+        """The external revoke must run when the member's grant is the only one."""
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+
+        member = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="member@example.com",
+            name="Member",
+            role=MemberRole.member,
+        )
+        await save_fixture(member)
+
+        grant = BenefitGrant(
+            subscription=subscription,
+            customer=customer,
+            benefit=benefit_organization,
+            member_id=member.id,
+            properties={"granted_account_id": "discord_AAA"},
+        )
+        grant.set_granted()
+        await save_fixture(grant)
+
+        await benefit_grant_service.revoke_benefit(
+            session,
+            redis,
+            customer,
+            benefit_organization,
+            member=member,
+            subscription=subscription,
+        )
+
+        benefit_strategy_mock.revoke.assert_called_once()
+
+    async def test_revoke_member_with_same_account_skips_revoke(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        subscription: Subscription,
+        benefit_organization: Benefit,
+        organization: Organization,
+        benefit_strategy_mock: MagicMock,
+    ) -> None:
+        """The external revoke is skipped when another active grant retains
+        access through the same external account."""
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+
+        member1 = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="member1@example.com",
+            name="Member 1",
+            role=MemberRole.member,
+        )
+        await save_fixture(member1)
+
+        member2 = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="member2@example.com",
+            name="Member 2",
+            role=MemberRole.member,
+        )
+        await save_fixture(member2)
+
+        grant1 = BenefitGrant(
+            subscription=subscription,
+            customer=customer,
+            benefit=benefit_organization,
+            member_id=member1.id,
+            properties={"granted_account_id": "discord_AAA"},
+        )
+        grant1.set_granted()
+        await save_fixture(grant1)
+
+        grant2 = BenefitGrant(
+            subscription=subscription,
+            customer=customer,
+            benefit=benefit_organization,
+            member_id=member2.id,
+            properties={"granted_account_id": "discord_AAA"},
+        )
+        grant2.set_granted()
+        await save_fixture(grant2)
+
+        await benefit_grant_service.revoke_benefit(
+            session,
+            redis,
+            customer,
+            benefit_organization,
+            member=member1,
+            subscription=subscription,
+        )
+
+        benefit_strategy_mock.revoke.assert_not_called()


### PR DESCRIPTION
## Summary

Revoking a member-specific benefit grant could leave a member's external access (Discord role, GitHub collaborator) in place, because the external `revoke()` was skipped based on the *count* of remaining grants rather than on whether the same external account still had access.

## What

In `revoke_benefit` (`server/polar/benefit/grant/service.py`), replace the count-based skip condition:

```python
if benefit_strategy.should_revoke_individually or len(other_grants) < 2:
```

with an identity-based one that only skips the external revoke when another active grant retains access through the **same** `granted_account_id`:

```python
granted_account_id = grant.properties.get("granted_account_id")
other_granted_account_ids = {
    other_grant.properties.get("granted_account_id")
    for other_grant in other_grants
    if other_grant.id != grant.id
}
should_revoke_externally = (
    benefit_strategy.should_revoke_individually
    or granted_account_id not in other_granted_account_ids
)
```

Adds regression tests to `TestRevokeBenefitWithMember` in `server/tests/benefit/grant/test_service.py`.

## Why

The `len(other_grants) < 2` optimization was introduced when grants were subscription-level, where multiple grants for the same benefit/customer always mapped to the same external identity. With member-based grants (introduced in `419edea9`), different members can map to different external accounts (`granted_account_id`, e.g. `discord_AAA` vs `discord_BBB`).

Under the old logic, revoking member A's grant while member B still held a grant was skipped purely because two grants existed — even though they targeted different Discord IDs / GitHub usernames — so member A kept their external access.

## How

- Skip the external `revoke()` only when another active grant carries the **same** `granted_account_id`.
- Grants not tied to an external account (no `granted_account_id`, e.g. custom/downloadable/feature-flag benefits) all share the same `None` identity, so the original subscription-dedup behavior is preserved: revoke is still skipped when the customer holds the benefit through another purchase. This is what keeps `test_several_benefit_grants` green and avoids regressing e.g. downloadables, whose `revoke_for_benefit` would otherwise strip access still held via a second subscription.
- The current grant is excluded from the comparison by id so it never matches itself.

New tests:
- `test_revoke_member_with_different_account_calls_revoke` — two member grants with different `granted_account_id`; revoking one **calls** `revoke()`. (Fails on `main`, passes here.)
- `test_revoke_member_alone_calls_revoke` — a single member grant; revoking **calls** `revoke()`.
- `test_revoke_member_with_same_account_skips_revoke` — two member grants sharing a `granted_account_id`; revoking one **skips** `revoke()`.

Verified locally: all `TestRevokeBenefit` and `TestRevokeBenefitWithMember` tests pass (11 passed); `ruff format`, `ruff check`, and `mypy` are clean.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012hKsDf17QvVo21cGv3Rp4X)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

