### PR TITLE
fix(disputes): invalidate supportCases query when accepting a dispute

### DIFF
--- a/clients/apps/web/src/hooks/queries/disputes.ts
+++ b/clients/apps/web/src/hooks/queries/disputes.ts
@@ -21,6 +21,7 @@ export const useAcceptDispute = () => {
       ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['disputes'] })
+      queryClient.invalidateQueries({ queryKey: ['supportCases'] })
     },
   })
 }


### PR DESCRIPTION
Fixes https://github.com/polarsource/feedback/issues/256

## Summary

Accepting a dispute did not refresh the disputes list or home banner, because the mutation invalidated the wrong query cache.

## What

`useAcceptDispute` now invalidates the `['supportCases']` query in addition to `['disputes']` on success.

## Why

`DisputesPage` and `DisputesBanner` were refactored in #12974 to fetch dispute listings via `useSupportCases` (query key `['supportCases']`), but `useAcceptDispute` still only invalidated the old `['disputes']` key. With React Query's `staleTime` of 60s, a user who accepted a dispute and navigated back to the disputes list or home page within 60 seconds saw stale data — outdated dispute counts and status — leading to confusion about whether the action succeeded.

The remaining `['disputes']` consumer is `OrderDisputesTable`, so both keys need to be invalidated.

## How

Added a second `queryClient.invalidateQueries({ queryKey: ['supportCases'] })` call in the mutation's `onSuccess` handler.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADoKfWgUpjrHyn3jPYavuX)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

