### PR TITLE
fix(sso): refresh server state after toggling SSO enforcement

### DIFF
--- a/clients/apps/web/src/components/Settings/SSO/SSOSettings.tsx
+++ b/clients/apps/web/src/components/Settings/SSO/SSOSettings.tsx
@@ -14,6 +14,7 @@ import { schemas } from '@polar-sh/client'
 import { Button, InlineModal, ListGroup, Status, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import CopyToClipboardInput from '@polar-sh/ui/components/atoms/CopyToClipboardInput'
+import { useRouter } from 'next/navigation'
 import { ConfirmModal } from '../../Modal/ConfirmModal'
 import { useModal } from '../../Modal/useModal'
 import EditSSOConnectionModal from './EditSSOConnectionModal'
@@ -27,6 +28,7 @@ const SSOSettings = ({ org }: { org: schemas['Organization'] }) => {
     hide: hideEnforceModal,
   } = useModal()
   const { currentUser } = useAuth()
+  const router = useRouter()
   const connections = useSSOConnections(org.id)
   const updateOrganization = useUpdateOrganization()
 
@@ -48,7 +50,10 @@ const SSOSettings = ({ org }: { org: schemas['Organization'] }) => {
         title: 'Update failed',
         description: extractApiErrorMessage(error),
       })
+      return
     }
+    // Refresh the router to get the updated organization data from the server
+    router.refresh()
   }
 
   return (


### PR DESCRIPTION
Fixes https://github.com/polarsource/feedback/issues/244

## Summary

Fixes a stale-UI bug in `SSOSettings.tsx`: after successfully toggling SSO enforcement, the Status badge and button label kept showing the old value until the user navigated away and back.

## What

Call `router.refresh()` after a successful `sso_enforced` toggle so the server component re-renders and the `org` prop is re-hydrated with the updated value.

## Why

`SSOSettings` is a client component that renders organization state from a server-provided `org` prop (via `OrganizationContextProvider`). The prop does not update on client-side mutations. `updateOrganization.mutateAsync()` updates the backend, but nothing in the render tree subscribes to the organization query key, so cache invalidation alone doesn't refresh the view. The result: after clicking "Enforce", the Status still showed "Not enforced" (gray) and the button still said "Enforce".

Reported bug (introduced in #12897): [detail.dev bug report](https://app.detail.dev/org_ecfbc7cf-6d21-4ce1-8c61-cda1d650ccf7/bugs/bug_694cd02a-fb03-4bd5-9406-8ec49f4d96f4).

## How

Added the `useRouter` hook and called `router.refresh()` on a successful toggle (early-returning on error). This matches the existing pattern already used in `OrganizationProfileSettings.tsx` and `SandboxPreviewAccessNotice.tsx`, which force a server re-render after mutating organization data.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkHeFWxm9ebTAdqBqR4cjT

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkHeFWxm9ebTAdqBqR4cjT)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

