### PR TITLE
fix(subscription): validate discount currency on subscription update

### DIFF
--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1539,6 +1539,7 @@ class SubscriptionService:
             discount,
             subscription.organization,
             products=[product],
+            currency=subscription.currency,
         )
         if resolved_discount is None:
             raise PolarRequestValidationError(

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -4895,6 +4895,34 @@ class TestUpdateDiscount:
         assert event.customer_id == customer.id
         assert event.organization_id == customer.organization_id
 
+    async def test_fixed_discount_incompatible_currency(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"eur": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+        )
+
+        with pytest.raises(PolarRequestValidationError):
+            async with SubscriptionUpdateContext(
+                session, subscription, subscription_service
+            ) as ctx:
+                await subscription_service.update_discount(
+                    session, ctx, subscription, discount=discount.id
+                )
+
 
 @pytest.mark.asyncio
 class TestUpdateTrial:


### PR DESCRIPTION
Fixes https://github.com/polarsource/feedback/issues/171

## Summary

A fixed discount that only supports certain currencies could be applied to a subscription with a different currency, causing an immediate `KeyError` crash (500) instead of being rejected during validation.

`SubscriptionService.resolve_discount` called `discount_service.get_by_id_and_organization` without passing `currency`, so the existing currency-compatibility check for `DiscountFixed` was skipped. The discount was returned as "resolved" and assigned to the subscription, and later the SQLAlchemy setter path called `discount.get_discount_amount(amount, self.currency)`, which indexes `self.amounts[currency]` and raised `KeyError` for an unsupported currency (e.g. `'eur'`).

The checkout flow already passes `currency=currency` in the identical call; this brings subscription updates in line with it.

## Changes

- `server/polar/subscription/service.py`: pass `currency=subscription.currency` in `resolve_discount` so an incompatible fixed discount resolves to `None` and raises the existing `PolarRequestValidationError` (422) instead of crashing.
- `server/tests/subscription/test_service.py`: add `TestUpdateDiscount.test_fixed_discount_incompatible_currency` covering a USD subscription with a EUR-only fixed discount.

## Context

Introduced in #12209 (commit 3d57c7638), which added `resolve_discount()` with product validation (`products=[product]`) but omitted `currency=subscription.currency`. Reachable via `PATCH /v1/subscriptions/{id}`; the dashboard lets any org discount be selected.

> [!NOTE]
> The E2E test could not be run in this environment — the Docker registry CDN and the Python 3.14 interpreter download are both blocked by the outbound proxy, so PostgreSQL couldn't be brought up. Both edited files byte-compile cleanly and the test reuses established fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dHUe528Kh27f2kcm73P9n

---
_Generated by [Claude Code](https://claude.ai/code/session_013dHUe528Kh27f2kcm73P9n)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

