### PR TITLE
fix(chat): reset useFileDrop dragging state on document dragend

### DIFF
--- a/clients/apps/web/src/components/Chat/useFileDrop.ts
+++ b/clients/apps/web/src/components/Chat/useFileDrop.ts
@@ -1,4 +1,4 @@
-import { DragEvent, useRef, useState } from 'react'
+import { DragEvent, useEffect, useRef, useState } from 'react'
 
 interface FileDrop {
   isDragging: boolean
@@ -13,6 +13,15 @@ interface FileDrop {
 export const useFileDrop = (onFiles: (files: File[]) => void): FileDrop => {
   const [isDragging, setIsDragging] = useState(false)
   const dragCounter = useRef(0)
+
+  useEffect(() => {
+    const handleDragEnd = () => {
+      dragCounter.current = 0
+      setIsDragging(false)
+    }
+    document.addEventListener('dragend', handleDragEnd)
+    return () => document.removeEventListener('dragend', handleDragEnd)
+  }, [])
 
   const draggingFiles = (e: DragEvent) => e.dataTransfer.types.includes('Files')
 


### PR DESCRIPTION
## Summary

`useFileDrop` (the drag-and-drop hook powering the Chat composer) can get stuck with `isDragging === true` because its `dragCounter` never recovers from drag operations that end without a matching `dragleave`/`drop`.

## What

Add a document-level `dragend` listener in a `useEffect` that resets `dragCounter` to `0` and sets `isDragging` back to `false`, with proper cleanup on unmount.

## Why

The `dragCounter` pattern assumes every `dragenter` is balanced by a `dragleave`/`drop` on the same target. In real browsers a drag can end without one — Escape cancel, dropping outside the zone, tab switch, or dropped events during rapid interaction — leaving `dragCounter.current > 0` and `isDragging` stuck `true` indefinitely. `dragend` is the browser's definitive "drag finished" signal, so listening for it guarantees the state resets.

This mirrors the recovery pattern the repo already relies on via `react-dropzone`, which attaches a document-level `dragend` listener for exactly this reason.

Introduced in #12360.

## How

```ts
useEffect(() => {
  const handleDragEnd = () => {
    dragCounter.current = 0
    setIsDragging(false)
  }
  document.addEventListener('dragend', handleDragEnd)
  return () => document.removeEventListener('dragend', handleDragEnd)
}, [])
```

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests — scoped to the fix only per request; there is no existing unit-test harness for this hook
- [ ] Linting and type checking pass — frontend deps aren't installed in this environment; the change is a standard React effect
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjTaiJ7fCnDCbEydN3ai3i

---
_Generated by [Claude Code](https://claude.ai/code/session_01XjTaiJ7fCnDCbEydN3ai3i)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

