### PR TITLE
Fix subscription webhook emission for unchanged seat updates

### DIFF
--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -285,6 +285,7 @@ class SubscriptionUpdateContext:
 
         self._billing_effect: Literal["invoice", "cycle"] | None = None
         self._event_metadata: SubscriptionUpdatedMetadataFields = {}
+        self._has_changes = True
 
     async def __aenter__(self) -> "SubscriptionUpdateContext":
         return self
@@ -321,13 +322,17 @@ class SubscriptionUpdateContext:
                 ),
             )
 
-        await self.service._after_subscription_updated(
-            self.session,
-            self.subscription,
-            previous_status=self._previous_status,
-            previous_is_canceled=self._previous_is_canceled,
-            notify_customer=self._notify_customer,
-        )
+        if self._has_changes:
+            await self.service._after_subscription_updated(
+                self.session,
+                self.subscription,
+                previous_status=self._previous_status,
+                previous_is_canceled=self._previous_is_canceled,
+                notify_customer=self._notify_customer,
+            )
+
+    def mark_unchanged(self) -> None:
+        self._has_changes = False
 
     def set_billing_effect(self, effect: Literal["invoice", "cycle"]) -> None:
         if effect == "cycle":
@@ -1712,6 +1717,11 @@ class SubscriptionService:
                 else:
                     pending.seats = None
                     await subscription_update_repository.update(pending)
+            else:
+                # Nothing changed: re-asserting the current seat count with no
+                # pending seat change to cancel is a true no-op, so don't emit
+                # a `subscription.updated` webhook.
+                ctx.mark_unchanged()
             return subscription
 
         event = await event_service.create_event(

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -5868,6 +5868,93 @@ class TestUpdateSeats:
         events = await get_all_by_name(session, SystemEvent.subscription_updated)
         assert len(events) == 0
 
+    async def test_unchanged_seats_no_pending_does_not_send_webhook(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        webhook_service_send_mock: AsyncMock,
+    ) -> None:
+        # Re-asserting the current seat count with no pending update to cancel
+        # is a true no-op and must not emit a `subscription.updated` webhook.
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[("seat", 1000, "usd")],
+        )
+        subscription = await create_subscription_with_seats(
+            save_fixture, product=product, customer=customer, seats=10
+        )
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=10,
+                proration_behavior=SubscriptionProrationBehavior.prorate,
+            )
+        await session.flush()
+
+        webhook_service_send_mock.assert_not_called()
+
+    async def test_unchanged_seats_clearing_pending_sends_webhook(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        webhook_service_send_mock: AsyncMock,
+    ) -> None:
+        # Re-asserting the current seat count cancels a scheduled seat change,
+        # which is a meaningful change and must emit a `subscription.updated`
+        # webhook.
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[("seat", 1000, "usd")],
+        )
+        subscription = await create_subscription_with_seats(
+            save_fixture, product=product, customer=customer, seats=10
+        )
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=15,
+                proration_behavior=SubscriptionProrationBehavior.next_period,
+            )
+        await session.flush()
+        webhook_service_send_mock.reset_mock()
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.update_seats(
+                session,
+                ctx,
+                subscription,
+                seats=10,
+                proration_behavior=SubscriptionProrationBehavior.next_period,
+            )
+        await session.flush()
+
+        assert_webhook_sent_once(
+            webhook_service_send_mock,
+            WebhookEventType.subscription_updated,
+            organization,
+            updated,
+        )
+
     @pytest.mark.parametrize(
         "proration_behavior",
         [


### PR DESCRIPTION
## Summary

Fixes https://github.com/polarsource/polar/issues/12231

Fixes an issue where updating subscription seats to the same value would incorrectly emit a `subscription.updated` webhook, even when no actual changes occurred.

## What

- Added a `_has_changes` flag to `SubscriptionUpdateContext` to track whether meaningful changes occurred during a subscription update
- Added `mark_unchanged()` method to allow operations to indicate no changes were made
- Modified `update_seats()` to call `mark_unchanged()` when re-asserting the current seat count with no pending changes to cancel
- Updated `SubscriptionUpdateContext.__aexit__()` to only emit webhooks and trigger post-update logic when `_has_changes` is True

## Why

When a user updates subscription seats to the same value as the current seats (with no pending seat change to cancel), this is a true no-op and should not trigger a `subscription.updated` webhook. Previously, the webhook was being sent regardless, causing unnecessary notifications and events.

## How

The solution introduces a change-tracking mechanism in the update context:
1. By default, `_has_changes` is True (preserving existing behavior for other update types)
2. Operations that determine no changes occurred can call `mark_unchanged()` to suppress webhook emission
3. The context's exit handler checks this flag before calling `_after_subscription_updated()`

This approach is minimal and non-invasive, allowing individual operations to opt-out of webhook emission when appropriate.

## Checklist

- [x] This PR addresses a single concern (fixing webhook emission for no-op seat updates)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests (two new test cases added)
- [x] No unrelated changes or drive-by fixes are included

https://claude.ai/code/session_0172Hsn4nPhKEsmZPZRHHity

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

