### PR TITLE
fix(sso): allow clearing the SSO connection name

### DIFF
--- a/server/polar/sso/schemas.py
+++ b/server/polar/sso/schemas.py
@@ -1,6 +1,12 @@
 from typing import Annotated, Literal
 
-from pydantic import UUID4, Discriminator, Field, StringConstraints
+from pydantic import (
+    UUID4,
+    BeforeValidator,
+    Discriminator,
+    Field,
+    StringConstraints,
+)
 
 from polar.kit.schemas import HttpsUrl, IDSchema, Schema, TimestampedSchema
 from polar.models.organization_sso_connection import (
@@ -9,6 +15,15 @@ from polar.models.organization_sso_connection import (
 )
 
 NonEmptyStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+def _blank_to_none(value: object) -> object:
+    if isinstance(value, str) and not value.strip():
+        return None
+    return value
+
+
+OptionalName = Annotated[NonEmptyStr | None, BeforeValidator(_blank_to_none)]
 
 
 class OIDCConfigurationBase(Schema):
@@ -66,7 +81,7 @@ class OrganizationSSOConnection(IDSchema, TimestampedSchema):
 
 
 class OrganizationSSOConnectionCreate(Schema):
-    name: NonEmptyStr | None = Field(
+    name: OptionalName = Field(
         default=None,
         description="Human-friendly label for the connection, shown on the login page.",
     )
@@ -83,7 +98,7 @@ class OrganizationSSOConnectionCreate(Schema):
 
 
 class OrganizationSSOConnectionUpdate(Schema):
-    name: NonEmptyStr | None = Field(
+    name: OptionalName = Field(
         default=None,
         description="Human-friendly label for the connection, shown on the login page.",
     )

--- a/server/polar/sso/schemas.py
+++ b/server/polar/sso/schemas.py
@@ -1,29 +1,20 @@
 from typing import Annotated, Literal
 
-from pydantic import (
-    UUID4,
-    BeforeValidator,
-    Discriminator,
-    Field,
-    StringConstraints,
-)
+from pydantic import UUID4, Discriminator, Field, StringConstraints
 
-from polar.kit.schemas import HttpsUrl, IDSchema, Schema, TimestampedSchema
+from polar.kit.schemas import (
+    EmptyStrToNone,
+    HttpsUrl,
+    IDSchema,
+    Schema,
+    TimestampedSchema,
+)
 from polar.models.organization_sso_connection import (
     OIDCAuthMethod,
     OrganizationSSOConnectionType,
 )
 
 NonEmptyStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
-
-
-def _blank_to_none(value: object) -> object:
-    if isinstance(value, str) and not value.strip():
-        return None
-    return value
-
-
-OptionalName = Annotated[NonEmptyStr | None, BeforeValidator(_blank_to_none)]
 
 
 class OIDCConfigurationBase(Schema):
@@ -81,7 +72,7 @@ class OrganizationSSOConnection(IDSchema, TimestampedSchema):
 
 
 class OrganizationSSOConnectionCreate(Schema):
-    name: OptionalName = Field(
+    name: EmptyStrToNone = Field(
         default=None,
         description="Human-friendly label for the connection, shown on the login page.",
     )
@@ -98,7 +89,7 @@ class OrganizationSSOConnectionCreate(Schema):
 
 
 class OrganizationSSOConnectionUpdate(Schema):
-    name: OptionalName = Field(
+    name: EmptyStrToNone = Field(
         default=None,
         description="Human-friendly label for the connection, shown on the login page.",
     )

--- a/server/polar/sso/service.py
+++ b/server/polar/sso/service.py
@@ -89,7 +89,7 @@ class OrganizationSSOConnectionService:
         ):
             raise LastSSOConnectionRequired()
         repository = OrganizationSSOConnectionRepository.from_session(session)
-        update_dict = update.model_dump(exclude_none=True)
+        update_dict = update.model_dump(exclude_unset=True)
         return await repository.update(connection, update_dict=update_dict)
 
     async def delete(

--- a/server/polar/sso/service.py
+++ b/server/polar/sso/service.py
@@ -89,7 +89,11 @@ class OrganizationSSOConnectionService:
         ):
             raise LastSSOConnectionRequired()
         repository = OrganizationSSOConnectionRepository.from_session(session)
-        update_dict = update.model_dump(exclude_unset=True)
+        update_dict = {
+            field: value
+            for field, value in update.model_dump(exclude_unset=True).items()
+            if value is not None or field == "name"
+        }
         return await repository.update(connection, update_dict=update_dict)
 
     async def delete(

--- a/server/tests/sso/test_endpoints.py
+++ b/server/tests/sso/test_endpoints.py
@@ -462,6 +462,40 @@ class TestUpdateSSOConnection:
         assert response.json()["name"] == "Acme SSO"
 
     @pytest.mark.auth
+    async def test_null_configuration_is_ignored(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        sso_enabled_organization: Organization,
+        user_organization: UserOrganization,
+        sso_connection: OrganizationSSOConnection,
+    ) -> None:
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}/sso-connections/{sso_connection.id}",
+            json={"name": "Acme SSO", "configuration": None},
+        )
+        assert response.status_code == 200
+        json = response.json()
+        assert json["name"] == "Acme SSO"
+        assert json["configuration"]["issuer"] == "https://idp.example.com"
+
+    @pytest.mark.auth
+    async def test_null_enabled_is_ignored(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        sso_enabled_organization: Organization,
+        user_organization: UserOrganization,
+        sso_connection: OrganizationSSOConnection,
+    ) -> None:
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}/sso-connections/{sso_connection.id}",
+            json={"enabled": None},
+        )
+        assert response.status_code == 200
+        assert response.json()["enabled"] is True
+
+    @pytest.mark.auth
     async def test_not_existing(
         self,
         client: AsyncClient,

--- a/server/tests/sso/test_endpoints.py
+++ b/server/tests/sso/test_endpoints.py
@@ -23,6 +23,7 @@ async def create_sso_connection(
     save_fixture: SaveFixture,
     organization: Organization,
     *,
+    name: str | None = None,
     auth_method: OIDCAuthMethod = OIDCAuthMethod.client_secret,
     client_secret: str | None = "secret",
     enabled: bool = True,
@@ -36,6 +37,7 @@ async def create_sso_connection(
         configuration["client_secret"] = client_secret
     connection = OrganizationSSOConnection(
         organization=organization,
+        name=name,
         type=OrganizationSSOConnectionType.oidc,
         configuration=configuration,
         enabled=enabled,
@@ -382,6 +384,82 @@ class TestUpdateSSOConnection:
             },
         )
         assert response.status_code == 422
+
+    @pytest.mark.auth
+    async def test_set_name(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        sso_enabled_organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        connection = await create_sso_connection(
+            save_fixture, organization, name="Acme SSO"
+        )
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}/sso-connections/{connection.id}",
+            json={"name": "New name"},
+        )
+        assert response.status_code == 200
+        assert response.json()["name"] == "New name"
+
+    @pytest.mark.auth
+    async def test_clear_name_with_null(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        sso_enabled_organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        connection = await create_sso_connection(
+            save_fixture, organization, name="Acme SSO"
+        )
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}/sso-connections/{connection.id}",
+            json={"name": None},
+        )
+        assert response.status_code == 200
+        assert response.json()["name"] is None
+
+    @pytest.mark.auth
+    async def test_clear_name_with_empty_string(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        sso_enabled_organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        connection = await create_sso_connection(
+            save_fixture, organization, name="Acme SSO"
+        )
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}/sso-connections/{connection.id}",
+            json={"name": ""},
+        )
+        assert response.status_code == 200
+        assert response.json()["name"] is None
+
+    @pytest.mark.auth
+    async def test_name_preserved_when_not_provided(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        sso_enabled_organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        connection = await create_sso_connection(
+            save_fixture, organization, name="Acme SSO"
+        )
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}/sso-connections/{connection.id}",
+            json={"enabled": False},
+        )
+        assert response.status_code == 200
+        assert response.json()["name"] == "Acme SSO"
 
     @pytest.mark.auth
     async def test_not_existing(


### PR DESCRIPTION
Fixes https://github.com/polarsource/feedback/issues/247

## Summary

**Related Issue**: polarsource/feedback#247

Users could not clear the human-friendly `name` of an SSO connection once it had been set. Both ways of clearing it were dropped by the backend, so the name was stuck at whatever it was first assigned.

## What

- `OrganizationSSOConnectionService.update` now dumps the patch with `exclude_unset=True` instead of `exclude_none=True`, so an explicit `name: null` is preserved and applied (clearing the column) instead of being silently discarded.
- The `name` field on the create/update schemas now normalizes a blank or whitespace-only string to `null` (via a `BeforeValidator`), so `name: ""` clears the label instead of failing validation with a 422.

## Why

The `name` column is nullable and is meant to be clearable — the dashboard already sends `name: values.name || null` when the field is emptied. Two independent issues prevented that from working:

1. `model_dump(exclude_none=True)` removed the explicit `null`, producing an empty update that changed nothing.
2. `NonEmptyStr` (`min_length=1`) rejected `""` with a `422`.

`exclude_unset=True` is also the PATCH convention already used by the other update services (account, customer, product), so this brings SSO in line with them.

## How

- Preserve explicitly-provided values (including `null`) by switching to `exclude_unset=True`; fields omitted from the request body are still left untouched.
- Add an `OptionalName` type that maps blank/whitespace input to `None` before validation, applied to both the create and update schemas. The generated OpenAPI schema is unchanged, so no client regeneration is required, and the dashboard needs no changes (it already sends `null`).
- Cover the update flow with tests: setting the name, clearing via `null`, clearing via `""`, and preserving the name when it is not part of the request.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`) — `ruff check`/`ruff format` verified on the changed files; the full suite / mypy will run in CI
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0138Kq5PDRGxhuwLCzbErXPE)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

