### PR TITLE
fix(dispute): reuse payment join with contains_eager to avoid duplicate joins

### DIFF
--- a/server/polar/dispute/repository.py
+++ b/server/polar/dispute/repository.py
@@ -2,7 +2,7 @@ from uuid import UUID
 
 from sqlalchemy import Select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import contains_eager, joinedload
 
 from polar.authz.types import AccessibleOrganizationID
 from polar.enums import PaymentProcessor
@@ -97,7 +97,7 @@ class DisputeRepository(
                 Payment.processor == processor,
                 Payment.processor_id == processor_payment_id,
             )
-            .options(*options)
+            .options(contains_eager(Dispute.payment), *options)
             .order_by(Dispute.created_at.asc())
             .limit(1)
         )
@@ -126,6 +126,7 @@ class DisputeRepository(
         return (
             self.get_base_statement()
             .join(Dispute.payment)
+            .options(contains_eager(Dispute.payment))
             .where(Payment.organization_id.in_(org_ids))
         )
 

--- a/server/tests/dispute/test_service.py
+++ b/server/tests/dispute/test_service.py
@@ -263,6 +263,7 @@ class TestUpsertFromStripe:
         assert updated_dispute.status == DisputeStatus.won
         assert updated_dispute.payment_processor == PaymentProcessor.stripe
         assert updated_dispute.payment_processor_id == stripe_dispute.id
+        assert updated_dispute.payment == payment
 
         dispute_transaction_service_mock.create_dispute.assert_awaited_once_with(
             session, dispute=updated_dispute


### PR DESCRIPTION
Fixes [https://github.com/polarsource/feedback/issues/221](https://github.com/polarsource/feedback/issues/221#issue-4765977574)

## Summary

**Related Issue**: polarsource/feedback#221

`Dispute` has no direct `organization_id`, so `get_statement_by_org_ids` and `get_matching_by_dispute_alert` `JOIN payments` to filter on `Payment.organization_id`. They did so with a bare `.join(Dispute.payment)` that left the relationship unhydrated. When an eager `joinedload(Dispute.payment)` was applied on top, SQLAlchemy could not reuse the explicit join and emitted a **second, redundant** join to `payments` — an `INNER JOIN` from `.join()` plus a `LEFT OUTER JOIN payments AS payments_1` from the `joinedload`.

## What

- `get_statement_by_org_ids` and `get_matching_by_dispute_alert` now use `contains_eager(Dispute.payment)` to load the payment relationship from the join they already perform.
- Added a regression assertion in `test_update_from_matching_payment` verifying the payment is hydrated on the dispute-alert matching path (would raise `lazy="raise"` without the fix).

## Why

A `.join()` used only for filtering can't be reused by a `joinedload(Dispute.payment)`, so the two coexist as duplicate joins to `payments`. Every dispute list/get, webhook processing, and dispute-alert lookup paid for the redundant join. This is the exact regression that appeared when the original `contains_eager` was dropped from `get_statement_by_org_ids`.

## How

- Reuse the existing join with `contains_eager(Dispute.payment)` — the same pattern the `wallet` repository already uses for its org-scoped statement.
- This hydrates `payment` consistently across every dispute lookup, and turns any re-introduced `joinedload(Dispute.payment)` into an immediate loader-strategy conflict (caught by tests) rather than a silent duplicate join.

Verified against the project's pinned SQLAlchemy 2.0.51 by compiling the statements: the duplicate (`payments` + `payments_1`) collapses back to a single `JOIN payments`.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

> Note: `ruff` (lint + format) passes locally; `lint_types` (mypy) could not run in this sandbox because Python 3.14 couldn't be fetched (egress policy blocks the download host) — it will be validated by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CChUDyQkDNzSTFedAHy1pK)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

