### PR TITLE
fix(backoffice): compute org support cases unread per viewer

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -1027,7 +1027,10 @@ async def get_organization_detail(
             elif section == "support_case":
                 case_rows = (
                     await session.execute(
-                        cases_statement(organization_id=organization.id)
+                        cases_statement(
+                            organization_id=organization.id,
+                            viewer_user_id=user_session.user_id,
+                        )
                     )
                 ).all()
                 support_cases_section = SupportCasesListSection(

--- a/server/polar/backoffice/organizations_v2/views/sections/support_cases_list_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/support_cases_list_section.py
@@ -55,7 +55,7 @@ class SupportCasesListSection:
                         is_open,
                         assignee_email,
                         awaiting_platform,
-                        _unread,
+                        unread,
                         dispute_status,
                     ) in self.rows:
                         case_url = case_detail_url(
@@ -66,7 +66,10 @@ class SupportCasesListSection:
                             _=f"on click set window.location to '{case_url}'",
                         ):
                             with tag.td():
-                                with tag.a(href=case_url, classes="link"):
+                                link_classes = "link"
+                                if unread:
+                                    link_classes += " font-semibold"
+                                with tag.a(href=case_url, classes=link_classes):
                                     text(TYPE_LABELS.get(case.type, case.type.value))
                             with tag.td():
                                 with tag.div(classes="flex items-center gap-2"):


### PR DESCRIPTION
Fixes https://github.com/polarsource/feedback/issues/222

## Summary

**Related Issue**: https://github.com/polarsource/feedback/issues/222

The organization detail's **Support Cases** tab did not reflect the current viewer's read state for support cases. This turned out to have two parts: the query wasn't computing unread per viewer, and the tab wasn't rendering the unread signal at all.

## What

1. Pass `viewer_user_id=user_session.user_id` to `cases_statement()` in the organization detail endpoint's `support_case` section (`server/polar/backoffice/organizations_v2/endpoints.py`), so unread is computed against the viewer's saved read state.
2. Render that unread state on the tab: bold the case link when unread in `SupportCasesListSection` (`server/polar/backoffice/organizations_v2/views/sections/support_cases_list_section.py`).

## Why

`cases_statement()` gained a `viewer_user_id` parameter in #12609 to compute unread per viewer (against `SupportCaseParticipant.last_read_at`). The global support cases list caller and the query tests were updated to pass it, but the organization detail endpoint was missed — so on an org's Support Cases tab, unread was computed without the viewer and was effectively always `True` whenever a case had activity, even after it had been marked read (e.g. the org → case detail → back to org flow).

While fixing that I found the org tab's `SupportCasesListSection` received the `unread` value but discarded it (`_unread`), so it was never displayed. Passing `viewer_user_id` alone would have corrected the computed value but produced no visible change. Both parts are needed for the tab to actually show correct, per-viewer unread state.

## How

- The endpoint already receives `user_session: UserSession = Depends(get_admin)`, so it forwards `user_session.user_id`, mirroring the global list caller in `server/polar/backoffice/support_cases/endpoints.py`.
- The section bolds the first-column link when unread, mirroring the global list's first-column treatment. The existing "Awaiting reply" warning dot is a separate, case-level signal and is left as-is (using bold for the per-viewer unread signal avoids two visually identical dots).

## Checklist

- [x] This PR addresses a single concern (org support cases unread per viewer)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests — per-viewer unread is already covered at the query level (`server/tests/backoffice/support_cases/test_queries.py::TestCasesStatement::test_unread_per_viewer`, which asserts organization-scoped `viewer_user_id`). This PR wires that tested behavior into the org detail endpoint and renders it. I could not add/run an endpoint-level render test in this environment (see below).
- [ ] Linting and type checking pass — could not be executed in this environment (no Python 3.14 interpreter and no database available). Changes are small and mirror existing typed call sites: `user_session.user_id` is `Mapped[UUID]` (matches `viewer_user_id: UUID | None`), and the bold treatment mirrors the global list's `link_classes` pattern.
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWF3diopcFDMYVqGRzSEZm