### PR TITLE
fix(member): sync seat emails when syncing owner email

### DIFF
--- a/server/polar/member/service.py
+++ b/server/polar/member/service.py
@@ -279,6 +279,10 @@ class MemberService:
 
         old_email = owner.email
         await repository.update(owner, update_dict={"email": customer.email})
+
+        seat_repository = CustomerSeatRepository.from_session(session)
+        await seat_repository.update_email_by_member_id(owner.id, customer.email)
+
         log.info(
             "member.sync_owner_email",
             customer_id=customer.id,

--- a/server/tests/member/test_service.py
+++ b/server/tests/member/test_service.py
@@ -1087,6 +1087,169 @@ class TestUpdateEmail:
 
 
 @pytest.mark.asyncio
+class TestSyncOwnerEmail:
+    async def test_syncs_owner_and_connected_seat_emails(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        """When an individual customer's email changes, both the owner member
+        and its connected seats mirror the new email."""
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="old@example.com",
+        )
+        customer.type = CustomerType.individual
+        await save_fixture(customer)
+        owner = await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            email="old@example.com",
+            role=MemberRole.owner,
+        )
+
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[("seat", 1000, "usd")],
+        )
+        subscription = await create_subscription_with_seats(
+            save_fixture, product=product, customer=customer, seats=5
+        )
+        pending_seat = CustomerSeat(
+            subscription_id=subscription.id,
+            customer_id=customer.id,
+            member_id=owner.id,
+            email="old@example.com",
+            status=SeatStatus.pending,
+        )
+        await save_fixture(pending_seat)
+        claimed_seat = CustomerSeat(
+            subscription_id=subscription.id,
+            customer_id=customer.id,
+            member_id=owner.id,
+            email="old@example.com",
+            status=SeatStatus.claimed,
+        )
+        await save_fixture(claimed_seat)
+
+        customer.email = "new@example.com"
+        await save_fixture(customer)
+
+        await member_service.sync_owner_email(session, customer)
+
+        await session.refresh(owner)
+        await session.refresh(pending_seat)
+        await session.refresh(claimed_seat)
+        assert owner.email == "new@example.com"
+        assert pending_seat.email == "new@example.com"
+        assert claimed_seat.email == "new@example.com"
+
+    async def test_leaves_seats_without_member_untouched(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        """A seat with no member connected (member_id NULL) is not touched when
+        the owner email is synced."""
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="old@example.com",
+        )
+        customer.type = CustomerType.individual
+        await save_fixture(customer)
+        owner = await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            email="old@example.com",
+            role=MemberRole.owner,
+        )
+
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[("seat", 1000, "usd")],
+        )
+        subscription = await create_subscription_with_seats(
+            save_fixture, product=product, customer=customer, seats=5
+        )
+        unconnected_seat = CustomerSeat(
+            subscription_id=subscription.id,
+            customer_id=customer.id,
+            member_id=None,
+            email="old@example.com",
+            status=SeatStatus.claimed,
+        )
+        await save_fixture(unconnected_seat)
+
+        customer.email = "new@example.com"
+        await save_fixture(customer)
+
+        await member_service.sync_owner_email(session, customer)
+
+        await session.refresh(owner)
+        await session.refresh(unconnected_seat)
+        assert owner.email == "new@example.com"
+        assert unconnected_seat.email == "old@example.com"
+
+    async def test_skips_team_customer(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        """Team customers legitimately have members with distinct emails, so
+        neither the owner nor its seats are synced."""
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="new@example.com",
+        )
+        customer.type = CustomerType.team
+        await save_fixture(customer)
+        owner = await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            email="old@example.com",
+            role=MemberRole.owner,
+        )
+
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[("seat", 1000, "usd")],
+        )
+        subscription = await create_subscription_with_seats(
+            save_fixture, product=product, customer=customer, seats=5
+        )
+        seat = CustomerSeat(
+            subscription_id=subscription.id,
+            customer_id=customer.id,
+            member_id=owner.id,
+            email="old@example.com",
+            status=SeatStatus.claimed,
+        )
+        await save_fixture(seat)
+
+        await member_service.sync_owner_email(session, customer)
+
+        await session.refresh(owner)
+        await session.refresh(seat)
+        assert owner.email == "old@example.com"
+        assert seat.email == "old@example.com"
+
+
+@pytest.mark.asyncio
 class TestDelete:
     async def test_delete_member_enqueues_seat_revocation_job(
         self,


### PR DESCRIPTION
## Summary

**Related Issue**: Fixes https://github.com/polarsource/feedback/issues/183

`MemberService.sync_owner_email` mirrors an individual customer's email onto their owner `Member` when the customer's email changes, but it did not update the denormalized `CustomerSeat.email` snapshot on the seats connected to that member. This left seat emails stale.

## What

After updating the owner member's email in `sync_owner_email`, also propagate the new email to the owner's active seats via `CustomerSeatRepository.update_email_by_member_id(owner.id, customer.email)` — the same seat-email sync that `MemberService.update()` already performs when a member's email changes.

Added `TestSyncOwnerEmail` covering:
- owner member and its connected (pending + claimed) seats both mirror the new email;
- seats with no member connected (`member_id` NULL) are left untouched;
- team customers are skipped (existing behavior — no owner/seat sync).

## Why

`CustomerSeat.email` is a denormalized copy read with **higher precedence** than `seat.member.email` (e.g. seat invitation resend and API schemas prioritize `seat.email`). When only `Member.email` was updated, connected seats kept the old address, causing incorrect seat lookups and invitation emails sent to the wrong recipient.

Individual customers can end up with seats (e.g. one-time seat-based products create seats before a customer is upgraded to `team`), so this path is reachable in practice.

## How

The seat-sync logic already exists and is exercised in `MemberService.update()`; this change applies the identical pattern to `sync_owner_email`. `CustomerSeatRepository` is already imported in the module, so the fix is a two-line addition mirroring the established convention.

The bug was introduced in #12430, which added seat-email sync to `update()` but not to `sync_owner_email`.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] No unrelated changes or drive-by fixes are included

> Note: the sandbox's egress policy blocks the Docker image registry, so the Postgres-backed integration tests could not be run here. `ruff check` and `ruff format --check` pass on the changed files. The added tests mirror the existing, passing seat-email-sync tests for `MemberService.update()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdRVGaNCDhZPnHMRdKUTBQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01EdRVGaNCDhZPnHMRdKUTBQ)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

