### PR TITLE
feat: disable Stripe account on organization deny or block

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -37,6 +37,7 @@ from polar.integrations.plain.service import (
     plain_thread_url,
 )
 from polar.integrations.plain.service import plain as plain_service
+from polar.integrations.stripe.service import StripeAccountRejectReason
 from polar.integrations.stripe.service import stripe as stripe_service
 from polar.kit.pagination import count_subquery
 from polar.kit.sorting import Sorting
@@ -151,10 +152,6 @@ router = APIRouter(prefix="/organizations", tags=["organizations"])
 
 logger = structlog.getLogger(__name__)
 
-_AUP_SECTION_OPTIONS = [
-    (label, member.value) for member, label in AUP_SECTION_LABELS.items()
-]
-
 
 def _parse_violated_aup_section(
     form_data: FormData, *, required_error: str
@@ -168,20 +165,138 @@ def _parse_violated_aup_section(
         return raw_section, None, "Invalid AUP section."
 
 
-def _render_violated_aup_section_field(selected_section: str | None) -> None:
-    with tag.div(classes="form-control"):
+# AUP sections whose violation is inherently deceptive, infringing, or harmful
+# (scams, counterfeits, piracy, malware, IP/data theft). These map to Stripe's
+# "fraud" reject reason; every other prohibited category maps to
+# "terms_of_service". "other" (risk of delinquency) is a payment-risk reason and
+# is never implied by an AUP section.
+_FRAUD_AUP_SECTIONS: set[AUPSection] = {
+    AUPSection.INTELLECTUAL_PROPERTY_INFRINGEMENT,
+    AUPSection.UNAUTHORIZED_DATA_ACCESS,
+    AUPSection.RESELLING_CUSTOMER_DATA,
+    AUPSection.LOW_QUALITY_COUNTERFEIT,
+    AUPSection.FAKE_TESTIMONIALS_REVIEWS,
+    AUPSection.RESELLING_SOFTWARE_LICENSES,
+    AUPSection.CIRCUMVENTION,
+    AUPSection.GET_RICH_SCHEMES,
+    AUPSection.CHEATING,
+    AUPSection.IPTV,
+    AUPSection.VIRUSES_SPYWARE,
+    AUPSection.API_IP_CLOAKING,
+    AUPSection.TRADEMARK_REMOVAL,
+    AUPSection.CONTENT_DOWNLOADERS,
+    AUPSection.CONTENT_GENERATION_INFRINGING,
+    AUPSection.TEST_PREP_PLATFORMS,
+}
+
+
+def _stripe_reject_reason_for_aup(section: AUPSection) -> StripeAccountRejectReason:
+    return "fraud" if section in _FRAUD_AUP_SECTIONS else "terms_of_service"
+
+
+def _render_violated_aup_section_field(
+    selected_section: str | None, *, link_stripe_reason: bool = False
+) -> None:
+    with tag.div(classes="form-control min-w-0 overflow-hidden"):
         with tag.label(classes="label"):
             with tag.span(classes="label-text"):
                 text("Violated AUP section (required)")
-        with input.select(
-            _AUP_SECTION_OPTIONS,
-            selected_section,
-            name="violated_aup_section",
-            placeholder="Select the violated AUP section…",
-            classes="select-bordered w-full",
-            required=True,
-        ):
-            pass
+        select_attrs: dict[str, Any] = {
+            "name": "violated_aup_section",
+            "classes": "select select-bordered w-full min-w-0",
+            "required": True,
+        }
+        if link_stripe_reason:
+            # Picking a section suggests the matching Stripe reject reason,
+            # carried on each option as data-stripe-reason.
+            select_attrs["_"] = (
+                "on change "
+                "set the value of <select[name='stripe_reject_reason']/> "
+                "to my.selectedOptions[0].dataset.stripeReason"
+            )
+        with tag.select(**select_attrs):
+            with tag.option(value="", selected=not selected_section):
+                text("Select the violated AUP section…")
+            for member, label in AUP_SECTION_LABELS.items():
+                option_attrs: dict[str, Any] = {
+                    "value": member.value,
+                    "selected": member.value == selected_section,
+                }
+                if link_stripe_reason:
+                    option_attrs["data-stripe-reason"] = _stripe_reject_reason_for_aup(
+                        member
+                    )
+                with tag.option(**option_attrs):
+                    text(label)
+
+
+def _prefill_aup_section(report: ReviewAgentReport | None) -> str | None:
+    """Pick the first AI-flagged section that maps to a known AUP section, so the
+    deny dialog can default the select without a reviewer having to re-pick it."""
+    if report is None:
+        return None
+    valid = {section.value for section in AUPSection}
+    for candidate in report.violated_sections:
+        if candidate in valid:
+            return candidate
+    return None
+
+
+# Labels map to Stripe's own reject-dialog buckets; the values are the only ones
+# the Account.reject API accepts (fraud, terms_of_service, other). "Risk of
+# delinquency" has no dedicated API value, so it maps to "other".
+_STRIPE_REJECT_REASON_OPTIONS: list[tuple[str, str]] = [
+    ("Violates Stripe AUP / ToS", "terms_of_service"),
+    ("Fraudulent", "fraud"),
+    ("Risk of delinquency", "other"),
+]
+_STRIPE_REJECT_REASONS = {value for _, value in _STRIPE_REJECT_REASON_OPTIONS}
+
+
+def _parse_stripe_reject_reason(
+    form_data: FormData,
+) -> tuple[bool, str | None, StripeAccountRejectReason | None, str | None]:
+    """Parse the opt-in "disable Stripe account" control.
+
+    Returns ``(checked, selected_value, reason, error)``. ``reason`` is only set
+    when the reviewer ticked the box and picked a valid Stripe reject reason.
+    """
+    checked = bool(form_data.get("disable_stripe_account"))
+    selected_value = str(form_data.get("stripe_reject_reason", "")).strip() or None
+    if not checked:
+        return False, selected_value, None, None
+    if selected_value in _STRIPE_REJECT_REASONS:
+        return (
+            True,
+            selected_value,
+            cast(StripeAccountRejectReason, selected_value),
+            None,
+        )
+    return True, selected_value, None, "Select a valid Stripe reject reason."
+
+
+def _render_stripe_reject_field(*, checked: bool, selected_reason: str | None) -> None:
+    with tag.div(classes="border-t border-base-200 pt-4"):
+        with tag.div(classes="flex items-center gap-2"):
+            with tag.label(classes="flex items-center gap-2 cursor-pointer"):
+                with tag.input(
+                    type="checkbox",
+                    name="disable_stripe_account",
+                    classes="checkbox checkbox-sm",
+                    checked=checked,
+                ):
+                    pass
+                with tag.span(classes="text-sm font-medium"):
+                    text("Disable Stripe account")
+            with input.select(
+                _STRIPE_REJECT_REASON_OPTIONS,
+                selected_reason or "terms_of_service",
+                name="stripe_reject_reason",
+                classes="select-bordered select-sm ml-auto w-52",
+            ):
+                pass
+        with tag.p(classes="text-xs text-base-content/60 mt-1.5"):
+            text("Permanent. Reactivation later needs a fresh Stripe onboarding.")
 
 
 REVIEW_TICKET_TITLE_PREFIX = "Ongoing organization review"
@@ -1292,20 +1407,35 @@ async def deny_dialog(
     review_report = _get_review_report(agent_review)
 
     error_message: str | None = None
-    selected_section: str | None = None
+    selected_section: str | None = _prefill_aup_section(review_report)
+    override_reason: str | None = None
+    stripe_checked = False
+    stripe_selected_reason: str | None = None
 
     if request.method == "POST":
         form_data = await request.form()
         override_reason = str(form_data.get("override_reason", "")).strip() or None
 
-        selected_section, violated_aup_section, error_message = (
-            _parse_violated_aup_section(
-                form_data,
-                required_error="An AUP section is required when denying an organization.",
-            )
+        selected_section, violated_aup_section, aup_error = _parse_violated_aup_section(
+            form_data,
+            required_error="An AUP section is required when denying an organization.",
         )
-        if not override_reason:
-            error_message = "A reason is required when denying an organization."
+        stripe_checked, stripe_selected_reason, stripe_reject_reason, stripe_error = (
+            _parse_stripe_reject_reason(form_data)
+        )
+
+        errors = [
+            message
+            for message in (
+                aup_error,
+                None
+                if override_reason
+                else "A reason is required when denying an organization.",
+                stripe_error,
+            )
+            if message
+        ]
+        error_message = " ".join(errors) if errors else None
 
         if error_message is None:
             # Record review decision before denying
@@ -1318,7 +1448,9 @@ async def deny_dialog(
             )
 
             # Deny the organization
-            await organization_service.deny_organization(session, organization)
+            await organization_service.deny_organization(
+                session, organization, stripe_reject_reason=stripe_reject_reason
+            )
 
             return HXRedirectResponse(
                 request,
@@ -1334,7 +1466,7 @@ async def deny_dialog(
         "name": "override_reason",
         "classes": "textarea textarea-bordered w-full",
         "placeholder": "Why are you denying this organization?",
-        "rows": "3",
+        "rows": "2",
         "required": True,
     }
 
@@ -1353,27 +1485,50 @@ async def deny_dialog(
                 with tag.div(classes="alert alert-error"):
                     text(error_message)
 
-            with tag.p(classes="font-semibold text-error"):
-                text("⚠️ Warning: Payments will be blocked")
+            with tag.p(classes="text-sm text-base-content/70"):
+                text("Blocks payments. Reversible after another review.")
 
             if review_report:
-                _render_ai_review_summary(review_report)
+                risk_level = review_report.overall_risk_level.value
+                if review_report.verdict.value == ReviewVerdict.APPROVE.value:
+                    with tag.p(classes="text-sm text-error"):
+                        text(
+                            f"⚠️ Overriding AI recommendation "
+                            f"(APPROVE · {risk_level} risk)"
+                        )
+                else:
+                    with tag.p(classes="text-sm text-base-content/60"):
+                        text(
+                            f"AI recommendation: {review_report.verdict.value} "
+                            f"· {risk_level} risk"
+                        )
 
-            with tag.div(classes="bg-base-200 p-4 rounded-lg"):
-                with tag.p(classes="mb-2"):
-                    text(
-                        "Denying this organization will prevent them from receiving payments. "
-                        "This action can be reversed, but the organization will need to be reviewed again."
-                    )
-
-            _render_violated_aup_section_field(selected_section)
+            _render_violated_aup_section_field(
+                selected_section, link_stripe_reason=True
+            )
 
             with tag.div(classes="form-control"):
                 with tag.label(classes="label"):
                     with tag.span(classes="label-text"):
                         text("Reason for denial (required)")
                 with tag.textarea(**textarea_attrs):
+                    if override_reason:
+                        text(override_reason)
+
+            # Match the Stripe reason to the initially-selected AUP section so the
+            # field agrees with the section before the reviewer changes anything.
+            initial_stripe_reason = stripe_selected_reason
+            if initial_stripe_reason is None and selected_section is not None:
+                try:
+                    initial_stripe_reason = _stripe_reject_reason_for_aup(
+                        AUPSection(selected_section)
+                    )
+                except ValueError:
                     pass
+
+            _render_stripe_reject_field(
+                checked=stripe_checked, selected_reason=initial_stripe_reason
+            )
 
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
                 with tag.form(method="dialog"):
@@ -2104,54 +2259,62 @@ async def block_dialog(
     if not organization:
         raise HTTPException(status_code=404, detail="Organization not found")
 
-    if request.method == "POST":
-        await organization_service.block_organization(session, organization)
+    error_message: str | None = None
+    stripe_checked = False
+    stripe_selected_reason: str | None = None
 
-        return HXRedirectResponse(
-            request,
-            str(
-                request.url_for("organizations:detail", organization_id=organization_id)
-            ),
-            303,
+    if request.method == "POST":
+        form_data = await request.form()
+        stripe_checked, stripe_selected_reason, stripe_reject_reason, error_message = (
+            _parse_stripe_reject_reason(form_data)
         )
 
-    with modal("Block Organization", open=True):
-        with tag.div(classes="flex flex-col gap-4"):
-            with tag.p(classes="font-semibold text-error"):
-                text("⚠️ Critical Warning: Complete Organization Block")
+        if error_message is None:
+            await organization_service.block_organization(
+                session, organization, stripe_reject_reason=stripe_reject_reason
+            )
 
-            with tag.div(classes="bg-error/10 border border-error/20 p-4 rounded-lg"):
-                with tag.p(classes="font-semibold mb-2 text-error"):
-                    text("Blocking this organization will:")
-                with tag.ul(classes="list-disc list-inside space-y-1 text-sm"):
-                    with tag.li():
-                        text("Prevent all access to the organization")
-                    with tag.li():
-                        text("Block all payments and transactions")
-                    with tag.li():
-                        text("Disable API access")
-                    with tag.li():
-                        text("Prevent any organization operations")
-
-                with tag.p(classes="mt-3 text-sm font-semibold"):
-                    text(
-                        "This is a severe action typically used for fraud or ToS violations."
+            return HXRedirectResponse(
+                request,
+                str(
+                    request.url_for(
+                        "organizations:detail", organization_id=organization_id
                     )
+                ),
+                303,
+            )
+
+    with modal("Block Organization", open=True):
+        with tag.form(
+            hx_post=str(
+                request.url_for(
+                    "organizations:block_dialog",
+                    organization_id=organization_id,
+                )
+            ),
+            hx_target="#modal",
+            classes="flex flex-col gap-4",
+        ):
+            if error_message:
+                with tag.div(classes="alert alert-error"):
+                    text(error_message)
+
+            with tag.p(classes="text-sm text-base-content/70"):
+                text(
+                    "Blocks all access, payments, and API. "
+                    "Typically used for fraud or ToS violations."
+                )
+
+            _render_stripe_reject_field(
+                checked=stripe_checked, selected_reason=stripe_selected_reason
+            )
 
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
                 with tag.form(method="dialog"):
                     with button(ghost=True):
                         text("Cancel")
-                with tag.form(
-                    hx_post=str(
-                        request.url_for(
-                            "organizations:block_dialog",
-                            organization_id=organization_id,
-                        )
-                    ),
-                ):
-                    with button(variant="error", type="submit"):
-                        text("Block Organization")
+                with button(variant="error", type="submit"):
+                    text("Block Organization")
 
     return None
 

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -165,11 +165,8 @@ def _parse_violated_aup_section(
         return raw_section, None, "Invalid AUP section."
 
 
-# AUP sections whose violation is inherently deceptive, infringing, or harmful
-# (scams, counterfeits, piracy, malware, IP/data theft). These map to Stripe's
-# "fraud" reject reason; every other prohibited category maps to
-# "terms_of_service". "other" (risk of delinquency) is a payment-risk reason and
-# is never implied by an AUP section.
+# Deceptive or infringing sections (scams, counterfeits, piracy, malware, theft)
+# map to Stripe's "fraud" reason. Every other section maps to "terms_of_service".
 _FRAUD_AUP_SECTIONS: set[AUPSection] = {
     AUPSection.INTELLECTUAL_PROPERTY_INFRINGEMENT,
     AUPSection.UNAUTHORIZED_DATA_ACCESS,
@@ -242,13 +239,11 @@ def _prefill_aup_section(report: ReviewAgentReport | None) -> str | None:
     return None
 
 
-# Labels map to Stripe's own reject-dialog buckets; the values are the only ones
-# the Account.reject API accepts (fraud, terms_of_service, other). "Risk of
-# delinquency" has no dedicated API value, so it maps to "other".
+# Values are the only ones Stripe's Account.reject API accepts.
 _STRIPE_REJECT_REASON_OPTIONS: list[tuple[str, str]] = [
     ("Violates Stripe AUP / ToS", "terms_of_service"),
     ("Fraudulent", "fraud"),
-    ("Risk of delinquency", "other"),
+    ("Other", "other"),
 ]
 _STRIPE_REJECT_REASONS = {value for _, value in _STRIPE_REJECT_REASON_OPTIONS}
 

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -1424,18 +1424,14 @@ async def deny_dialog(
             _parse_stripe_reject_reason(form_data)
         )
 
-        errors = [
-            message
-            for message in (
-                aup_error,
-                None
-                if override_reason
-                else "A reason is required when denying an organization.",
-                stripe_error,
-            )
-            if message
-        ]
-        error_message = " ".join(errors) if errors else None
+        errors = []
+        if aup_error:
+            errors.append(aup_error)
+        if not override_reason:
+            errors.append("A reason is required when denying an organization.")
+        if stripe_error:
+            errors.append(stripe_error)
+        error_message = " ".join(errors) or None
 
         if error_message is None:
             # Record review decision before denying
@@ -1490,7 +1486,7 @@ async def deny_dialog(
 
             if review_report:
                 risk_level = review_report.overall_risk_level.value
-                if review_report.verdict.value == ReviewVerdict.APPROVE.value:
+                if review_report.verdict == ReviewVerdict.APPROVE:
                     with tag.p(classes="text-sm text-error"):
                         text(
                             f"⚠️ Overriding AI recommendation "

--- a/server/polar/integrations/stripe/service.py
+++ b/server/polar/integrations/stripe/service.py
@@ -113,7 +113,8 @@ class StripeService:
         try:
             account = await stripe_lib.Account.retrieve_async(id)
             return bool(account)
-        except stripe_lib.PermissionError:
+        except (stripe_lib.PermissionError, stripe_lib.InvalidRequestError):
+            # No access, or the account was deleted / never existed.
             return False
 
     async def delete_account(self, id: str) -> stripe_lib.Account:

--- a/server/polar/integrations/stripe/service.py
+++ b/server/polar/integrations/stripe/service.py
@@ -67,6 +67,8 @@ StripeCancellationReasons = Literal[
     "unused",
 ]
 
+StripeAccountRejectReason = Literal["fraud", "terms_of_service", "other"]
+
 
 class StripeError(PolarError): ...
 
@@ -121,6 +123,16 @@ class StripeService:
             account_id=id,
         )
         return await stripe_lib.Account.delete_async(id)
+
+    async def reject_account(
+        self, id: str, reason: StripeAccountRejectReason
+    ) -> stripe_lib.Account:
+        log.info(
+            "stripe.account.reject",
+            account_id=id,
+            reason=reason,
+        )
+        return await stripe_lib.Account.reject_async(id, reason=reason)
 
     async def retrieve_balance(self, id: str) -> tuple[str, int]:
         # Return available balance in the account's default currency (we assume that

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -26,6 +26,7 @@ from polar.exceptions import (
 )
 from polar.integrations.polar.service import billing_member_role
 from polar.integrations.polar.service import polar_self as polar_self_service
+from polar.integrations.stripe.service import StripeAccountRejectReason
 from polar.kit.anonymization import anonymize_email_for_deletion, anonymize_for_deletion
 from polar.kit.currency import PresentmentCurrency
 from polar.kit.http import check_url_reachable
@@ -1038,15 +1039,31 @@ class OrganizationService:
                 account_id=organization.account_id,
             )
 
+    def _enqueue_reject_stripe_account(
+        self, organization: Organization, reason: StripeAccountRejectReason
+    ) -> None:
+        """Reject the org's Stripe connected account when a human reviewer opts
+        in from the backoffice. Rejection is permanent on Stripe's side."""
+        if organization.payout_account_id is not None:
+            enqueue_job(
+                "payout_account.reject_stripe_account",
+                payout_account_id=organization.payout_account_id,
+                reason=reason,
+            )
+
     async def block_organization(
         self,
         session: AsyncSession,
         organization: Organization,
+        *,
+        stripe_reject_reason: StripeAccountRejectReason | None = None,
     ) -> Organization:
         """Block an organization by setting status to BLOCKED."""
         organization.set_status(OrganizationStatus.BLOCKED)
         session.add(organization)
         self._enqueue_cancel_pending_payouts(organization)
+        if stripe_reject_reason is not None:
+            self._enqueue_reject_stripe_account(organization, stripe_reject_reason)
         return organization
 
     async def confirm_organization_reviewed(
@@ -1327,12 +1344,18 @@ class OrganizationService:
         return confirmed is not None
 
     async def deny_organization(
-        self, session: AsyncSession, organization: Organization
+        self,
+        session: AsyncSession,
+        organization: Organization,
+        *,
+        stripe_reject_reason: StripeAccountRejectReason | None = None,
     ) -> Organization:
         organization.set_status(OrganizationStatus.DENIED)
         session.add(organization)
 
         self._enqueue_cancel_pending_payouts(organization)
+        if stripe_reject_reason is not None:
+            self._enqueue_reject_stripe_account(organization, stripe_reject_reason)
 
         # If there's a pending appeal, mark it as rejected
         review_repository = OrganizationReviewRepository.from_session(session)

--- a/server/polar/payout_account/service.py
+++ b/server/polar/payout_account/service.py
@@ -192,7 +192,7 @@ class PayoutAccountService:
 
     async def reject_stripe_account(
         self,
-        session: AsyncSession,
+        session: AsyncReadSession,
         payout_account_id: uuid.UUID,
         reason: StripeAccountRejectReason,
     ) -> None:

--- a/server/polar/payout_account/service.py
+++ b/server/polar/payout_account/service.py
@@ -192,7 +192,7 @@ class PayoutAccountService:
 
     async def reject_stripe_account(
         self,
-        session: AsyncReadSession,
+        session: AsyncSession,
         payout_account_id: uuid.UUID,
         reason: StripeAccountRejectReason,
     ) -> None:

--- a/server/polar/payout_account/service.py
+++ b/server/polar/payout_account/service.py
@@ -9,7 +9,7 @@ from polar.auth.models import AuthSubject
 from polar.authz.service import get_accessible_org_ids
 from polar.enums import PayoutAccountType
 from polar.exceptions import PolarError
-from polar.integrations.stripe.service import stripe
+from polar.integrations.stripe.service import StripeAccountRejectReason, stripe
 from polar.kit.db.postgres import AsyncReadSession
 from polar.models import Organization, PayoutAccount, User
 from polar.organization.repository import OrganizationRepository
@@ -189,6 +189,30 @@ class PayoutAccountService:
 
         repository = PayoutAccountRepository.from_session(session)
         await repository.soft_delete(payout_account)
+
+    async def reject_stripe_account(
+        self,
+        session: AsyncSession,
+        payout_account_id: uuid.UUID,
+        reason: StripeAccountRejectReason,
+    ) -> None:
+        """Reject the Stripe connected account backing a payout account.
+
+        Enqueued when a human denies or blocks an organization and opts in to
+        disabling its Stripe account. A rejected account is permanently disabled
+        on Stripe's side; there is no un-reject.
+        """
+        repository = PayoutAccountRepository.from_session(session)
+        payout_account = await repository.get_by_id(payout_account_id)
+        if (
+            payout_account is None
+            or payout_account.type != PayoutAccountType.stripe
+            or payout_account.stripe_id is None
+        ):
+            return
+        if not await stripe.account_exists(payout_account.stripe_id):
+            return
+        await stripe.reject_account(payout_account.stripe_id, reason)
 
     async def update_account_from_stripe(
         self, session: AsyncSession, *, stripe_account: stripe_lib.Account

--- a/server/polar/payout_account/tasks.py
+++ b/server/polar/payout_account/tasks.py
@@ -1,7 +1,7 @@
 import uuid
 
 from polar.integrations.stripe.service import StripeAccountRejectReason
-from polar.worker import AsyncSessionMaker, TaskPriority, actor
+from polar.worker import AsyncReadSessionMaker, TaskPriority, actor
 
 from .service import payout_account as payout_account_service
 
@@ -15,7 +15,7 @@ async def reject_stripe_account(
     Enqueued by ``deny_organization``/``block_organization`` only when a human
     reviewer opts in from the backoffice. Rejection is permanent on Stripe.
     """
-    async with AsyncSessionMaker() as session:
+    async with AsyncReadSessionMaker() as session:
         await payout_account_service.reject_stripe_account(
             session, payout_account_id, reason
         )

--- a/server/polar/payout_account/tasks.py
+++ b/server/polar/payout_account/tasks.py
@@ -1,0 +1,21 @@
+import uuid
+
+from polar.integrations.stripe.service import StripeAccountRejectReason
+from polar.worker import AsyncSessionMaker, TaskPriority, actor
+
+from .service import payout_account as payout_account_service
+
+
+@actor(actor_name="payout_account.reject_stripe_account", priority=TaskPriority.LOW)
+async def reject_stripe_account(
+    payout_account_id: uuid.UUID, reason: StripeAccountRejectReason
+) -> None:
+    """Reject the Stripe connected account for a denied or blocked organization.
+
+    Enqueued by ``deny_organization``/``block_organization`` only when a human
+    reviewer opts in from the backoffice. Rejection is permanent on Stripe.
+    """
+    async with AsyncSessionMaker() as session:
+        await payout_account_service.reject_stripe_account(
+            session, payout_account_id, reason
+        )

--- a/server/polar/payout_account/tasks.py
+++ b/server/polar/payout_account/tasks.py
@@ -1,7 +1,7 @@
 import uuid
 
 from polar.integrations.stripe.service import StripeAccountRejectReason
-from polar.worker import AsyncReadSessionMaker, TaskPriority, actor
+from polar.worker import AsyncSessionMaker, TaskPriority, actor
 
 from .service import payout_account as payout_account_service
 
@@ -13,9 +13,10 @@ async def reject_stripe_account(
     """Reject the Stripe connected account for a denied or blocked organization.
 
     Enqueued by ``deny_organization``/``block_organization`` only when a human
-    reviewer opts in from the backoffice. Rejection is permanent on Stripe.
+    reviewer opts in from the backoffice. Rejection is permanent on Stripe, so
+    read from the primary session to avoid a replica-lag miss dropping it.
     """
-    async with AsyncReadSessionMaker() as session:
+    async with AsyncSessionMaker() as session:
         await payout_account_service.reject_stripe_account(
             session, payout_account_id, reason
         )

--- a/server/polar/tasks.py
+++ b/server/polar/tasks.py
@@ -30,6 +30,7 @@ from polar.organization import tasks as organization
 from polar.organization_access_token import tasks as organization_access_token
 from polar.organization_review import tasks as organization_review
 from polar.payout import tasks as payout
+from polar.payout_account import tasks as payout_account
 from polar.personal_access_token import tasks as personal_access_token
 from polar.processor_transaction import tasks as processor_transaction
 from polar.receipt import tasks as receipt
@@ -69,6 +70,7 @@ __all__ = [
     "organization_access_token",
     "organization_review",
     "payout",
+    "payout_account",
     "personal_access_token",
     "polar_self",
     "processor_transaction",

--- a/server/tests/backoffice/organizations_v2/test_endpoints.py
+++ b/server/tests/backoffice/organizations_v2/test_endpoints.py
@@ -10,7 +10,7 @@ from polar.backoffice import app as backoffice_app
 from polar.backoffice.dependencies import get_admin
 from polar.backoffice.organizations_v2.endpoints import _stripe_reject_reason_for_aup
 from polar.models import PayoutAccount
-from polar.models.organization import Organization
+from polar.models.organization import Organization, OrganizationStatus
 from polar.models.user import User
 from polar.models.user_session import UserSession
 from polar.organization_review.repository import OrganizationReviewRepository
@@ -165,6 +165,12 @@ class TestDenyDialog:
             reason="fraud",
         )
 
+        current = await OrganizationReviewRepository.from_session(
+            session
+        ).get_current_decision(organization.id)
+        assert current is not None
+        assert current.violated_aup_section == AUPSection.TRADING_FINANCIAL
+
     async def test_invalid_stripe_reject_reason_does_not_deny(
         self,
         backoffice_client: httpx.AsyncClient,
@@ -216,6 +222,8 @@ class TestBlockDialog:
             payout_account_id=stripe_payout_account.id,
             reason="terms_of_service",
         )
+
+        assert organization.status == OrganizationStatus.BLOCKED
 
     async def test_invalid_stripe_reject_reason_does_not_block(
         self,

--- a/server/tests/backoffice/organizations_v2/test_endpoints.py
+++ b/server/tests/backoffice/organizations_v2/test_endpoints.py
@@ -4,9 +4,11 @@ from datetime import UTC, datetime
 import httpx
 import pytest
 import pytest_asyncio
+from pytest_mock import MockerFixture
 
 from polar.backoffice import app as backoffice_app
 from polar.backoffice.dependencies import get_admin
+from polar.backoffice.organizations_v2.endpoints import _stripe_reject_reason_for_aup
 from polar.models import PayoutAccount
 from polar.models.organization import Organization
 from polar.models.user import User
@@ -33,6 +35,42 @@ async def backoffice_client(
     finally:
         backoffice_app.dependency_overrides.pop(get_db_session, None)
         backoffice_app.dependency_overrides.pop(get_admin, None)
+
+
+class TestStripeRejectReasonForAup:
+    @pytest.mark.parametrize(
+        "section",
+        [
+            AUPSection.VIRUSES_SPYWARE,
+            AUPSection.FAKE_TESTIMONIALS_REVIEWS,
+            AUPSection.INTELLECTUAL_PROPERTY_INFRINGEMENT,
+            AUPSection.GET_RICH_SCHEMES,
+            AUPSection.RESELLING_SOFTWARE_LICENSES,
+        ],
+    )
+    def test_fraud_sections(self, section: AUPSection) -> None:
+        assert _stripe_reject_reason_for_aup(section) == "fraud"
+
+    @pytest.mark.parametrize(
+        "section",
+        [
+            AUPSection.ADULT_CONTENT,
+            AUPSection.GAMBLING_BETTING,
+            AUPSection.MEDICAL_HEALTH_ADVICE,
+            AUPSection.PHYSICAL_PRODUCTS,
+            AUPSection.OTHER,
+        ],
+    )
+    def test_terms_of_service_sections(self, section: AUPSection) -> None:
+        assert _stripe_reject_reason_for_aup(section) == "terms_of_service"
+
+    def test_every_section_maps_to_fraud_or_terms_of_service(self) -> None:
+        # An AUP violation never implies "other" (risk of delinquency).
+        for section in AUPSection:
+            assert _stripe_reject_reason_for_aup(section) in {
+                "fraud",
+                "terms_of_service",
+            }
 
 
 @pytest.mark.asyncio
@@ -99,6 +137,105 @@ class TestDenyDialog:
             session
         ).get_current_decision(organization.id)
         assert current is None
+
+    async def test_disables_stripe_account_when_opted_in(
+        self,
+        mocker: MockerFixture,
+        backoffice_client: httpx.AsyncClient,
+        session: AsyncSession,
+        organization: Organization,
+        stripe_payout_account: PayoutAccount,
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        response = await backoffice_client.post(
+            f"/organizations/{organization.id}/deny-dialog",
+            data={
+                "override_reason": "Crypto trading bot",
+                "violated_aup_section": "trading_financial",
+                "disable_stripe_account": "on",
+                "stripe_reject_reason": "fraud",
+            },
+        )
+
+        assert response.status_code == 303
+        enqueue_job_mock.assert_any_call(
+            "payout_account.reject_stripe_account",
+            payout_account_id=stripe_payout_account.id,
+            reason="fraud",
+        )
+
+    async def test_invalid_stripe_reject_reason_does_not_deny(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        response = await backoffice_client.post(
+            f"/organizations/{organization.id}/deny-dialog",
+            data={
+                "override_reason": "Crypto trading bot",
+                "violated_aup_section": "trading_financial",
+                "disable_stripe_account": "on",
+                "stripe_reject_reason": "not_valid",
+            },
+        )
+
+        assert response.status_code == 200
+        assert "Select a valid Stripe reject reason." in response.text
+
+        current = await OrganizationReviewRepository.from_session(
+            session
+        ).get_current_decision(organization.id)
+        assert current is None
+
+
+@pytest.mark.asyncio
+class TestBlockDialog:
+    async def test_disables_stripe_account_when_opted_in(
+        self,
+        mocker: MockerFixture,
+        backoffice_client: httpx.AsyncClient,
+        session: AsyncSession,
+        organization: Organization,
+        stripe_payout_account: PayoutAccount,
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        response = await backoffice_client.post(
+            f"/organizations/{organization.id}/block-dialog",
+            data={
+                "disable_stripe_account": "on",
+                "stripe_reject_reason": "terms_of_service",
+            },
+        )
+
+        assert response.status_code == 303
+        enqueue_job_mock.assert_any_call(
+            "payout_account.reject_stripe_account",
+            payout_account_id=stripe_payout_account.id,
+            reason="terms_of_service",
+        )
+
+    async def test_invalid_stripe_reject_reason_does_not_block(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        previous_status = organization.status
+
+        response = await backoffice_client.post(
+            f"/organizations/{organization.id}/block-dialog",
+            data={
+                "disable_stripe_account": "on",
+                "stripe_reject_reason": "nope",
+            },
+        )
+
+        assert response.status_code == 200
+        assert "Select a valid Stripe reject reason." in response.text
+        assert organization.status == previous_status
 
 
 @pytest.mark.asyncio

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -21,6 +21,7 @@ from polar.kit.http import UrlReachability
 from polar.models import (
     Customer,
     Organization,
+    PayoutAccount,
     Product,
     User,
     UserOrganization,
@@ -1237,6 +1238,43 @@ class TestDenyOrganization:
             account_id=organization.account_id,
         )
 
+    async def test_enqueues_stripe_reject_when_reason_given(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+        stripe_payout_account: PayoutAccount,
+    ) -> None:
+        organization.status = OrganizationStatus.REVIEW
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        await organization_service.deny_organization(
+            session, organization, stripe_reject_reason="terms_of_service"
+        )
+
+        enqueue_job_mock.assert_any_call(
+            "payout_account.reject_stripe_account",
+            payout_account_id=stripe_payout_account.id,
+            reason="terms_of_service",
+        )
+
+    async def test_does_not_enqueue_stripe_reject_by_default(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+        stripe_payout_account: PayoutAccount,
+    ) -> None:
+        organization.status = OrganizationStatus.REVIEW
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        await organization_service.deny_organization(session, organization)
+
+        assert not any(
+            call.args and call.args[0] == "payout_account.reject_stripe_account"
+            for call in enqueue_job_mock.call_args_list
+        )
+
 
 @pytest.mark.asyncio
 class TestBlockOrganization:
@@ -1265,6 +1303,26 @@ class TestBlockOrganization:
         enqueue_job_mock.assert_any_call(
             "payout.cancel_account_payouts",
             account_id=organization.account_id,
+        )
+
+    async def test_enqueues_stripe_reject_when_reason_given(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+        stripe_payout_account: PayoutAccount,
+    ) -> None:
+        organization.status = OrganizationStatus.REVIEW
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
+
+        await organization_service.block_organization(
+            session, organization, stripe_reject_reason="fraud"
+        )
+
+        enqueue_job_mock.assert_any_call(
+            "payout_account.reject_stripe_account",
+            payout_account_id=stripe_payout_account.id,
+            reason="fraud",
         )
 
 

--- a/server/tests/payout_account/test_service.py
+++ b/server/tests/payout_account/test_service.py
@@ -192,3 +192,46 @@ class TestDelete:
         stripe_service_mock.delete_account.assert_called_once_with(  # type: ignore[attr-defined]
             payout_account.stripe_id
         )
+
+
+@pytest.mark.asyncio
+class TestRejectStripeAccount:
+    async def test_rejects_existing_stripe_account(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+        stripe_service_mock: StripeService,
+    ) -> None:
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        stripe_service_mock.account_exists.return_value = True  # type: ignore[attr-defined]
+
+        await payout_account_service.reject_stripe_account(
+            session, payout_account.id, "fraud"
+        )
+
+        stripe_service_mock.reject_account.assert_called_once_with(  # type: ignore[attr-defined]
+            payout_account.stripe_id, "fraud"
+        )
+
+    async def test_skips_when_stripe_account_missing(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+        stripe_service_mock: StripeService,
+    ) -> None:
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, type=PayoutAccountType.stripe
+        )
+        stripe_service_mock.account_exists.return_value = False  # type: ignore[attr-defined]
+
+        await payout_account_service.reject_stripe_account(
+            session, payout_account.id, "terms_of_service"
+        )
+
+        stripe_service_mock.reject_account.assert_not_called()  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

When a human reviewer denies or blocks an organization in the backoffice, they can now also disable that organization's Stripe connected account.

## What

- Add an opt-in "Disable Stripe account" checkbox plus a reason picker to the deny and block dialogs.
- Reject the Stripe connected account in the background when the reviewer opts in.
- Suggest the Stripe reject reason from the picked AUP section (fraud vs terms of service).
- Simplify the deny and block dialogs and fix a text overflow in the AUP section dropdown.

## Why

- A denied or blocked organization should not keep an active Stripe account.
- Only a human reviewer should trigger this. The AI auto-deny path never does.
- Rejecting on Stripe is permanent, so it stays opt-in and reviewer-driven.

## How

- New `reject_account` on the Stripe service. It maps to Stripe's only reject values: `fraud`, `terms_of_service`, `other`.
- `deny_organization` and `block_organization` take an optional reason and enqueue a background job when set.
- A new low-priority worker task rejects the account. It skips safely if the account is missing.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

