### PR TITLE
feat: add edit button to backoffice org profile card

### DIFF
--- a/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
@@ -21,7 +21,7 @@ from polar.organization_review.thresholds import (
     thresholds_for_prompt,
 )
 
-from ....components import card
+from ....components import button, card
 from ....components._metric_card import Variant
 from ._shared import (
     RISK_LEVEL_BADGE,
@@ -577,11 +577,25 @@ class OverviewSection(ChecklistMixin):
     # ------------------------------------------------------------------
 
     @contextlib.contextmanager
-    def organization_profile_card(self) -> Generator[None]:
-        """Read-only org profile: website, details, social links."""
+    def organization_profile_card(self, request: Request) -> Generator[None]:
+        """Org profile: website, details, social links."""
         with card(bordered=True):
-            with tag.h2(classes="text-lg font-bold mb-4"):
-                text("Organization Profile")
+            with tag.div(classes="flex items-center justify-between mb-4"):
+                with tag.h2(classes="text-lg font-bold"):
+                    text("Organization Profile")
+                with button(
+                    variant="secondary",
+                    size="sm",
+                    ghost=True,
+                    hx_get=str(
+                        request.url_for(
+                            "organizations:edit_details",
+                            organization_id=self.org.id,
+                        )
+                    ),
+                    hx_target="#modal",
+                ):
+                    text("Edit")
 
             has_content = False
 
@@ -760,7 +774,7 @@ class OverviewSection(ChecklistMixin):
                 with self.setup_checklist_card(setup_data):
                     pass
 
-                with self.organization_profile_card():
+                with self.organization_profile_card(request):
                     pass
 
             yield


### PR DESCRIPTION
## Summary

Add an "Edit" button to the "Organization Profile" card in the backoffice organization detail view.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13153?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

