### PR TITLE
feat: merchant-migration catalog import

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -51408,6 +51408,17 @@ export interface operations {
           'application/json': components['schemas']['MerchantMigrationImportReport']
         }
       }
+      /** @description The source is not connected or isn't supported. */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json':
+            | components['schemas']['SourceNotConnected']
+            | components['schemas']['UnsupportedMigrationSource']
+        }
+      }
       /** @description Not allowed to manage this organization. */
       403: {
         headers: {

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -11926,6 +11926,17 @@ export interface components {
       /** Detail */
       detail: string
     }
+    /** CatalogImportBlocked */
+    CatalogImportBlocked: {
+      /**
+       * Error
+       * @example CatalogImportBlocked
+       * @constant
+       */
+      error: 'CatalogImportBlocked'
+      /** Detail */
+      detail: string
+    }
     /** CatalogImportNotReady */
     CatalogImportNotReady: {
       /**
@@ -51415,13 +51426,15 @@ export interface operations {
           'application/json': components['schemas']['MerchantMigrationNotFound']
         }
       }
-      /** @description The pre-check hasn't run yet. */
+      /** @description The pre-check hasn't run yet, or it reports a blocker. */
       409: {
         headers: {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['CatalogImportNotReady']
+          'application/json':
+            | components['schemas']['CatalogImportNotReady']
+            | components['schemas']['CatalogImportBlocked']
         }
       }
       /** @description Validation Error */

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -5148,6 +5148,26 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/merchant-migrations/{id}/import': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Import Merchant Migration Catalog
+     * @description **Scopes**: `organizations:write`
+     */
+    post: operations['merchant-migrations:import_catalog']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/merchant-migrations/{id}/records': {
     parameters: {
       query?: never
@@ -11903,6 +11923,17 @@ export interface components {
        * @constant
        */
       error: 'CaseRepliesNotSupportedError'
+      /** Detail */
+      detail: string
+    }
+    /** CatalogImportNotReady */
+    CatalogImportNotReady: {
+      /**
+       * Error
+       * @example CatalogImportNotReady
+       * @constant
+       */
+      error: 'CatalogImportNotReady'
       /** Detail */
       detail: string
     }
@@ -23092,6 +23123,44 @@ export interface components {
        * @description A Stripe API key for the source account (a restricted `rk_...` key is recommended). It is validated for all required permissions before the migration is saved.
        */
       api_key: string
+    }
+    /** MerchantMigrationImportReport */
+    MerchantMigrationImportReport: {
+      /** @description The migration step after the import. */
+      step: components['schemas']['MerchantMigrationStep']
+      /**
+       * Results
+       * @description Per-entity counts of what was imported vs skipped.
+       */
+      results: components['schemas']['MerchantMigrationImportResult'][]
+    }
+    /** MerchantMigrationImportRequest */
+    MerchantMigrationImportRequest: {
+      /**
+       * Record Ids
+       * @description The ledger record ids to import (from the records listing). When omitted, every importable record is imported (subject to `exclude_record_ids`). Records not selected stay pending.
+       */
+      record_ids?: string[] | null
+      /**
+       * Exclude Record Ids
+       * @description Import every importable record except these — the opt-out selection for large catalogs. Ignored when `record_ids` is set.
+       */
+      exclude_record_ids?: string[] | null
+    }
+    /** MerchantMigrationImportResult */
+    MerchantMigrationImportResult: {
+      /** @description The source entity type. */
+      entity: components['schemas']['PrecheckEntity']
+      /**
+       * Imported
+       * @description How many were created or reused in Polar.
+       */
+      imported: number
+      /**
+       * Skipped
+       * @description How many were left on the source (not importable).
+       */
+      skipped: number
     }
     /** MerchantMigrationNotEnabled */
     MerchantMigrationNotEnabled: {
@@ -51289,6 +51358,70 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['MerchantMigrationNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'merchant-migrations:import_catalog': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: {
+      content: {
+        'application/json':
+          | components['schemas']['MerchantMigrationImportRequest']
+          | null
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationImportReport']
+        }
+      }
+      /** @description Not allowed to manage this organization. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['NotPermitted']
+        }
+      }
+      /** @description Merchant migration not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationNotFound']
+        }
+      }
+      /** @description The pre-check hasn't run yet. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['CatalogImportNotReady']
         }
       }
       /** @description Validation Error */

--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -279,6 +279,7 @@ class CustomerService:
         email: str,
         name: str | None = None,
         billing_address: Address | None = None,
+        stripe_customer_id: str | None = None,
         send_webhooks: bool = False,
     ) -> Customer:
         """Create a customer for a known organization (internal flows)."""
@@ -300,6 +301,7 @@ class CustomerService:
             email=email,
             name=name,
             billing_address=billing_address,
+            stripe_customer_id=stripe_customer_id,
             organization=organization,
         )
 

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -16,12 +16,15 @@ from .auth import MerchantMigrationRead, MerchantMigrationWrite
 from .schemas import MerchantMigration as MerchantMigrationSchema
 from .schemas import (
     MerchantMigrationCreate,
+    MerchantMigrationImportReport,
+    MerchantMigrationImportRequest,
     MerchantMigrationRecordItem,
     PrecheckEntity,
     PrecheckRecordStatus,
     PrecheckReport,
 )
 from .service import (
+    CatalogImportNotReady,
     InvalidSourceCredentials,
     MerchantMigrationNotEnabled,
     MerchantMigrationNotFound,
@@ -140,6 +143,40 @@ async def precheck(
     session: AsyncSession = Depends(get_db_session),
 ) -> PrecheckReport:
     return await merchant_migration_service.run_precheck(session, auth_subject, id)
+
+
+@router.post(
+    "/{id}/import",
+    response_model=MerchantMigrationImportReport,
+    summary="Import Merchant Migration Catalog",
+    responses={
+        403: {
+            "description": "Not allowed to manage this organization.",
+            "model": NotPermitted.schema(),
+        },
+        404: {
+            "description": "Merchant migration not found.",
+            "model": MerchantMigrationNotFound.schema(),
+        },
+        409: {
+            "description": "The pre-check hasn't run yet.",
+            "model": CatalogImportNotReady.schema(),
+        },
+    },
+)
+async def import_catalog(
+    id: UUID4,
+    auth_subject: MerchantMigrationWrite,
+    body: MerchantMigrationImportRequest | None = None,
+    session: AsyncSession = Depends(get_db_session),
+) -> MerchantMigrationImportReport:
+    return await merchant_migration_service.import_catalog(
+        session,
+        auth_subject,
+        id,
+        record_ids=body.record_ids if body is not None else None,
+        exclude_record_ids=body.exclude_record_ids if body is not None else None,
+    )
 
 
 @router.get(

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -152,6 +152,10 @@ async def precheck(
     response_model=MerchantMigrationImportReport,
     summary="Import Merchant Migration Catalog",
     responses={
+        400: {
+            "description": "The source is not connected or isn't supported.",
+            "model": SourceNotConnected.schema() | UnsupportedMigrationSource.schema(),
+        },
         403: {
             "description": "Not allowed to manage this organization.",
             "model": NotPermitted.schema(),

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -16,6 +16,8 @@ from .auth import MerchantMigrationRead, MerchantMigrationWrite
 from .schemas import MerchantMigration as MerchantMigrationSchema
 from .schemas import (
     MerchantMigrationCreate,
+    MerchantMigrationImportReport,
+    MerchantMigrationImportRequest,
     MerchantMigrationRecordItem,
     PrecheckEntity,
     PrecheckReasonLevel,
@@ -23,6 +25,7 @@ from .schemas import (
     PrecheckReport,
 )
 from .service import (
+    CatalogImportNotReady,
     InvalidSourceCredentials,
     MerchantMigrationNotEnabled,
     MerchantMigrationNotFound,
@@ -141,6 +144,40 @@ async def precheck(
     session: AsyncSession = Depends(get_db_session),
 ) -> PrecheckReport:
     return await merchant_migration_service.run_precheck(session, auth_subject, id)
+
+
+@router.post(
+    "/{id}/import",
+    response_model=MerchantMigrationImportReport,
+    summary="Import Merchant Migration Catalog",
+    responses={
+        403: {
+            "description": "Not allowed to manage this organization.",
+            "model": NotPermitted.schema(),
+        },
+        404: {
+            "description": "Merchant migration not found.",
+            "model": MerchantMigrationNotFound.schema(),
+        },
+        409: {
+            "description": "The pre-check hasn't run yet.",
+            "model": CatalogImportNotReady.schema(),
+        },
+    },
+)
+async def import_catalog(
+    id: UUID4,
+    auth_subject: MerchantMigrationWrite,
+    body: MerchantMigrationImportRequest | None = None,
+    session: AsyncSession = Depends(get_db_session),
+) -> MerchantMigrationImportReport:
+    return await merchant_migration_service.import_catalog(
+        session,
+        auth_subject,
+        id,
+        record_ids=body.record_ids if body is not None else None,
+        exclude_record_ids=body.exclude_record_ids if body is not None else None,
+    )
 
 
 @router.get(

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -25,6 +25,7 @@ from .schemas import (
     PrecheckReport,
 )
 from .service import (
+    CatalogImportBlocked,
     CatalogImportNotReady,
     InvalidSourceCredentials,
     MerchantMigrationNotEnabled,
@@ -160,8 +161,8 @@ async def precheck(
             "model": MerchantMigrationNotFound.schema(),
         },
         409: {
-            "description": "The pre-check hasn't run yet.",
-            "model": CatalogImportNotReady.schema(),
+            "description": "The pre-check hasn't run yet, or it reports a blocker.",
+            "model": CatalogImportNotReady.schema() | CatalogImportBlocked.schema(),
         },
     },
 )

--- a/server/polar/merchant_migration/importer.py
+++ b/server/polar/merchant_migration/importer.py
@@ -1,0 +1,506 @@
+"""Imports the staged catalog into Polar (the `create_catalog` step).
+Idempotent; migrated subscriptions arrive paused so nothing bills until cutover.
+"""
+
+from collections.abc import Sequence
+from typing import TypeVar
+from uuid import UUID
+
+from sqlalchemy.orm import selectinload
+
+from polar.customer.repository import CustomerRepository
+from polar.customer.service import customer as customer_service
+from polar.enums import SubscriptionRecurringInterval
+from polar.kit.address import Address, CountryAlpha2
+from polar.kit.db.postgres import AsyncSession
+from polar.kit.utils import utc_now
+from polar.models import (
+    Customer,
+    MerchantMigration,
+    MerchantMigrationRecord,
+    Organization,
+    Product,
+    Subscription,
+    SubscriptionProductPrice,
+)
+from polar.models.merchant_migration import MerchantMigrationSourcePlatform
+from polar.models.merchant_migration_record import (
+    MerchantMigrationRecordStatus,
+    MerchantMigrationRecordType,
+)
+from polar.models.product_price import ProductPriceFixed
+from polar.models.subscription import SubscriptionStatus
+from polar.product.repository import ProductRepository
+from polar.subscription.repository import SubscriptionRepository
+
+from .canonical import (
+    CanonicalCustomer,
+    CanonicalProduct,
+    CanonicalSubscription,
+    deserialize,
+)
+from .precheck import (
+    ProductImportPlan,
+    plan_customer_imports,
+    plan_product_imports,
+    plan_subscription_imports,
+)
+from .repository import MerchantMigrationRecordRepository
+from .schemas import (
+    MerchantMigrationImportReport,
+    MerchantMigrationImportResult,
+    PrecheckEntity,
+)
+
+_CanonicalT = TypeVar("_CanonicalT")
+
+_CUSTOMER_NOT_IMPORTED_REASON = (
+    "Its customer wasn't imported, so this subscription stays on the source."
+)
+_PRODUCT_NOT_IMPORTED_REASON = (
+    "Its product wasn't imported, so this subscription stays on the source."
+)
+_CUSTOMER_ALREADY_SUBSCRIBED_REASON = (
+    "This customer already has a live subscription to the product on Polar, so a "
+    "duplicate isn't created. It stays on the source."
+)
+_CUSTOMER_STRIPE_ID_CONFLICT_REASON = (
+    "A Polar customer with this email already has a different Stripe id. Reconcile "
+    "them manually; this customer stays on the source."
+)
+
+
+class CatalogImporter:
+    def __init__(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        organization: Organization,
+        *,
+        record_ids: set[UUID] | None = None,
+        exclude_record_ids: set[UUID] | None = None,
+    ) -> None:
+        self.session = session
+        self.migration = migration
+        self.organization = organization
+        # Selection: include only `record_ids`, or exclude `exclude_record_ids`
+        # (the opt-out default for large catalogs), or neither to import all.
+        self.record_ids = record_ids
+        self.exclude_record_ids = exclude_record_ids
+        self.record_repository = MerchantMigrationRecordRepository.from_session(session)
+        self.product_repository = ProductRepository.from_session(session)
+        self.customer_repository = CustomerRepository.from_session(session)
+        self.subscription_repository = SubscriptionRepository.from_session(session)
+        self._product_cache: dict[UUID, Product] = {}
+
+    async def run(self) -> MerchantMigrationImportReport:
+        records = await self.record_repository.list_by_migration(self.migration.id)
+        product_records = self._records_of(records, MerchantMigrationRecordType.product)
+        customer_records = self._records_of(
+            records, MerchantMigrationRecordType.customer
+        )
+        subscription_records = self._records_of(
+            records, MerchantMigrationRecordType.subscription
+        )
+
+        # Products and customers first: a subscription resolves its Polar product,
+        # price and customer from their imported ledger rows.
+        product_result = await self._import_products(product_records)
+        customer_result = await self._import_customers(customer_records)
+        subscription_result = await self._import_subscriptions(
+            subscription_records, product_records, customer_records
+        )
+
+        return MerchantMigrationImportReport(
+            step=self.migration.step,
+            results=[product_result, customer_result, subscription_result],
+        )
+
+    def _records_of(
+        self,
+        records: Sequence[MerchantMigrationRecord],
+        type: MerchantMigrationRecordType,
+    ) -> list[MerchantMigrationRecord]:
+        return [record for record in records if record.type == type]
+
+    def _is_selected(self, record: MerchantMigrationRecord) -> bool:
+        if self.record_ids is not None:
+            return record.id in self.record_ids
+        if self.exclude_record_ids is not None:
+            return record.id not in self.exclude_record_ids
+        return True
+
+    async def _import_products(
+        self, records: Sequence[MerchantMigrationRecord]
+    ) -> MerchantMigrationImportResult:
+        products = [
+            self._as(deserialize(record.type, record.canonical), CanonicalProduct)
+            for record in records
+        ]
+        plans = plan_product_imports(products)
+
+        imported = skipped = 0
+        for record, product in zip(records, products, strict=True):
+            if not self._is_selected(record):
+                continue
+            if record.status == MerchantMigrationRecordStatus.imported:
+                imported += 1
+                continue
+            plan = plans[product.source_id]
+            if not plan.importable:
+                await self._mark_skipped(record, plan.skip_code, plan.skip_reason)
+                skipped += 1
+                continue
+            polar_product = await self._create_product(product, plan)
+            await self._mark_imported(record, polar_product.id)
+            imported += 1
+
+        return MerchantMigrationImportResult(
+            entity=PrecheckEntity.products, imported=imported, skipped=skipped
+        )
+
+    async def _import_customers(
+        self, records: Sequence[MerchantMigrationRecord]
+    ) -> MerchantMigrationImportResult:
+        customers = [
+            self._as(deserialize(record.type, record.canonical), CanonicalCustomer)
+            for record in records
+        ]
+        plans = plan_customer_imports(customers)
+
+        imported = skipped = 0
+        for record, customer in zip(records, customers, strict=True):
+            if not self._is_selected(record):
+                continue
+            if record.status == MerchantMigrationRecordStatus.imported:
+                imported += 1
+                continue
+            skip_code, skip_reason = plans[customer.source_id]
+            if skip_code is not None:
+                await self._mark_skipped(record, skip_code, skip_reason)
+                skipped += 1
+                continue
+            polar_customer, conflict_reason = await self._create_or_reuse_customer(
+                customer
+            )
+            if conflict_reason is not None:
+                await self._mark_skipped(
+                    record, "customer_stripe_id_conflict", conflict_reason
+                )
+                skipped += 1
+                continue
+            assert polar_customer is not None
+            await self._mark_imported(record, polar_customer.id)
+            imported += 1
+
+        return MerchantMigrationImportResult(
+            entity=PrecheckEntity.customers, imported=imported, skipped=skipped
+        )
+
+    async def _create_product(
+        self, product: CanonicalProduct, plan: ProductImportPlan
+    ) -> Product:
+        assert product.recurring_interval is not None
+        prices: list[ProductPriceFixed] = []
+        for price in product.prices:
+            if price.source_id not in plan.importable_price_ids:
+                continue
+            assert price.amount is not None
+            prices.append(
+                ProductPriceFixed(
+                    price_amount=price.amount,
+                    price_currency=price.currency.lower(),
+                )
+            )
+        # Repository, not ProductService.create: a bulk import must not fire a
+        # product_created webhook or re-run org review for every product.
+        return await self.product_repository.create(
+            Product(
+                organization=self.organization,
+                name=product.name,
+                recurring_interval=SubscriptionRecurringInterval(
+                    product.recurring_interval
+                ),
+                recurring_interval_count=product.recurring_interval_count,
+                prices=prices,
+                all_prices=list(prices),
+                product_benefits=[],
+                product_medias=[],
+                attached_custom_fields=[],
+            ),
+            flush=True,
+        )
+
+    async def _create_or_reuse_customer(
+        self, customer: CanonicalCustomer
+    ) -> tuple[Customer | None, str | None]:
+        stripe_customer_id = self._stripe_customer_id(customer)
+        existing = await self.customer_repository.get_by_email_and_organization(
+            customer.email, self.organization.id
+        )
+        if existing is not None:
+            # The email matches an existing Polar customer that already carries a
+            # different Stripe id: reusing it would attach this subscription and a
+            # PAN-copied card to the wrong record, so skip for manual reconciliation.
+            if (
+                stripe_customer_id is not None
+                and existing.stripe_customer_id is not None
+                and existing.stripe_customer_id != stripe_customer_id
+            ):
+                return None, _CUSTOMER_STRIPE_ID_CONFLICT_REASON
+            # Reuse the existing customer (design Appendix A). Reconcile the source
+            # id so the PAN-copied card lands on the same customer, but never
+            # overwrite an id that's already set.
+            if stripe_customer_id and existing.stripe_customer_id is None:
+                await self.customer_repository.update(
+                    existing, update_dict={"stripe_customer_id": stripe_customer_id}
+                )
+            return existing, None
+        polar_customer = await customer_service.create_for_organization(
+            self.session,
+            self.organization,
+            email=customer.email,
+            name=customer.name,
+            billing_address=self._billing_address(customer),
+            stripe_customer_id=stripe_customer_id,
+        )
+        return polar_customer, None
+
+    def _stripe_customer_id(self, customer: CanonicalCustomer) -> str | None:
+        # PAN copy preserves the Stripe `cus_…` id, which the canonical record
+        # carries as its source id; other providers have no such concept.
+        if self.migration.source_platform == MerchantMigrationSourcePlatform.stripe:
+            return customer.source_id
+        return None
+
+    def _billing_address(self, customer: CanonicalCustomer) -> Address | None:
+        if not customer.country:
+            return None
+        try:
+            country = CountryAlpha2(customer.country.upper())
+        except ValueError:
+            return None
+        return Address(country=country)
+
+    async def _import_subscriptions(
+        self,
+        records: Sequence[MerchantMigrationRecord],
+        product_records: Sequence[MerchantMigrationRecord],
+        customer_records: Sequence[MerchantMigrationRecord],
+    ) -> MerchantMigrationImportResult:
+        subscriptions = [
+            self._as(deserialize(record.type, record.canonical), CanonicalSubscription)
+            for record in records
+        ]
+        products = [
+            self._as(deserialize(record.type, record.canonical), CanonicalProduct)
+            for record in product_records
+        ]
+        customers = [
+            self._as(deserialize(record.type, record.canonical), CanonicalCustomer)
+            for record in customer_records
+        ]
+        plans = plan_subscription_imports(subscriptions, products, customers)
+        product_by_price = {
+            price.source_id: product for product in products for price in product.prices
+        }
+        # Products and customers were imported earlier in this run, so their ledger
+        # rows already carry target ids in-session: resolve dependencies from these
+        # maps instead of a per-subscription query.
+        customer_target_by_source = self._imported_targets(customer_records)
+        product_target_by_source = self._imported_targets(product_records)
+
+        imported = skipped = 0
+        for record, subscription in zip(records, subscriptions, strict=True):
+            if not self._is_selected(record):
+                continue
+            if record.status == MerchantMigrationRecordStatus.imported:
+                imported += 1
+                continue
+            code, reason = plans[subscription.source_id]
+            if code is not None:
+                await self._mark_skipped(record, code, reason)
+                skipped += 1
+                continue
+            polar_subscription, skip_reason = await self._create_subscription(
+                subscription,
+                product_by_price,
+                customer_target_by_source,
+                product_target_by_source,
+            )
+            # Product and customer import first, so a missing one means it was
+            # skipped or deselected: skip the subscription rather than leave it pending.
+            if skip_reason is not None:
+                await self._mark_skipped(
+                    record, "subscription_dependency_not_imported", skip_reason
+                )
+                skipped += 1
+                continue
+            if polar_subscription is None:
+                continue
+            await self._mark_imported(record, polar_subscription.id)
+            imported += 1
+
+        return MerchantMigrationImportResult(
+            entity=PrecheckEntity.subscriptions, imported=imported, skipped=skipped
+        )
+
+    async def _create_subscription(
+        self,
+        subscription: CanonicalSubscription,
+        product_by_price: dict[str, CanonicalProduct],
+        customer_target_by_source: dict[str, UUID],
+        product_target_by_source: dict[str, UUID],
+    ) -> tuple[Subscription | None, str | None]:
+        # (subscription, skip_reason): a reason means skip; both None means an
+        # unexpected miss, left pending.
+        customer_target = customer_target_by_source.get(subscription.customer_source_id)
+        if customer_target is None:
+            return None, _CUSTOMER_NOT_IMPORTED_REASON
+        canonical_product = product_by_price.get(subscription.price_source_id)
+        if canonical_product is None:
+            return None, _PRODUCT_NOT_IMPORTED_REASON
+        product_target = product_target_by_source.get(canonical_product.source_id)
+        if product_target is None:
+            return None, _PRODUCT_NOT_IMPORTED_REASON
+
+        polar_product = await self._load_product(product_target)
+        customer = await self.customer_repository.get_by_id(customer_target)
+        if polar_product is None or customer is None:
+            return None, None
+
+        # Never create a second live subscription to the same product for a
+        # customer — at cutover it would double-bill them.
+        if await self.subscription_repository.exists_live_by_customer_and_product(
+            customer.id, polar_product.id
+        ):
+            return None, _CUSTOMER_ALREADY_SUBSCRIBED_REASON
+
+        price = self._find_price(
+            polar_product, canonical_product, subscription.price_source_id
+        )
+        if price is None:
+            return None, None
+
+        subscription_target = await self._persist_subscription(
+            subscription, polar_product, price, customer
+        )
+        return subscription_target, None
+
+    async def _persist_subscription(
+        self,
+        subscription: CanonicalSubscription,
+        product: Product,
+        price: ProductPriceFixed,
+        customer: Customer,
+    ) -> Subscription:
+        assert product.recurring_interval is not None
+        interval = product.recurring_interval
+        count = product.recurring_interval_count or 1
+        start = subscription.current_period_start or utc_now()
+        end = subscription.current_period_end or interval.get_next_period(
+            start, start.day, count
+        )
+        polar_subscription = Subscription(
+            # Paused isn't active or billable, so the renewal scheduler skips it
+            # and the customer isn't charged until cutover resumes it.
+            status=SubscriptionStatus.paused,
+            paused_at=utc_now(),
+            started_at=start,
+            anchor_day=start.day,
+            current_period_start=start,
+            current_period_end=end,
+            cancel_at_period_end=False,
+            recurring_interval=interval,
+            recurring_interval_count=count,
+            meter_interval=product.meter_interval,
+            meter_interval_count=product.meter_interval_count,
+            organization=self.organization,
+            product=product,
+            customer=customer,
+            subscription_product_prices=[SubscriptionProductPrice.from_price(price)],
+            currency=price.price_currency,
+            user_metadata={"stripe_subscription_id": subscription.source_id},
+            pending_update=None,
+        )
+        polar_subscription.initialize_meter_period(start)
+        return await self.subscription_repository.create(polar_subscription, flush=True)
+
+    def _imported_targets(
+        self, records: Sequence[MerchantMigrationRecord]
+    ) -> dict[str, UUID]:
+        return {
+            record.source_id: record.target_id
+            for record in records
+            if record.status == MerchantMigrationRecordStatus.imported
+            and record.target_id is not None
+        }
+
+    async def _load_product(self, product_id: UUID) -> Product | None:
+        cached = self._product_cache.get(product_id)
+        if cached is not None:
+            return cached
+        # None only if an imported product row vanished (data corruption); the
+        # caller leaves the subscription pending rather than crashing.
+        product = await self.product_repository.get_by_id_and_organization(
+            product_id,
+            self.organization.id,
+            options=(selectinload(Product.prices),),
+        )
+        if product is not None:
+            self._product_cache[product_id] = product
+        return product
+
+    def _find_price(
+        self,
+        product: Product,
+        canonical_product: CanonicalProduct,
+        price_source_id: str,
+    ) -> ProductPriceFixed | None:
+        # Prices carry no durable source id, so match the source price to a Polar
+        # one by the currency and amount the product importer created it with.
+        canonical_price = next(
+            (p for p in canonical_product.prices if p.source_id == price_source_id),
+            None,
+        )
+        if canonical_price is None or canonical_price.amount is None:
+            return None
+        currency = canonical_price.currency.lower()
+        for price in product.prices:
+            if (
+                isinstance(price, ProductPriceFixed)
+                and price.price_currency == currency
+                and price.price_amount == canonical_price.amount
+            ):
+                return price
+        return None
+
+    async def _mark_imported(
+        self, record: MerchantMigrationRecord, target_id: UUID
+    ) -> None:
+        await self.record_repository.update(
+            record,
+            update_dict={
+                "status": MerchantMigrationRecordStatus.imported,
+                "target_id": target_id,
+                "error": None,
+            },
+        )
+
+    async def _mark_skipped(
+        self,
+        record: MerchantMigrationRecord,
+        code: str | None,
+        reason: str | None,
+    ) -> None:
+        await self.record_repository.update(
+            record,
+            update_dict={
+                "status": MerchantMigrationRecordStatus.skipped,
+                "error": reason or code,
+            },
+        )
+
+    def _as(self, record: object, expected: type[_CanonicalT]) -> _CanonicalT:
+        assert isinstance(record, expected)
+        return record

--- a/server/polar/merchant_migration/importer.py
+++ b/server/polar/merchant_migration/importer.py
@@ -84,6 +84,19 @@ _CUSTOMER_STRIPE_ID_CONFLICT = Reason(
 )
 
 
+@dataclass
+class ImportCounts:
+    imported: int = 0
+    skipped: int = 0
+
+    def settle(self, status: MerchantMigrationRecordStatus) -> None:
+        """Carry over a row a previous run already decided."""
+        if status == MerchantMigrationRecordStatus.imported:
+            self.imported += 1
+        else:
+            self.skipped += 1
+
+
 @dataclass(frozen=True)
 class ImportedCustomer:
     """The Polar customer to use, or why the record is skipped."""
@@ -125,6 +138,7 @@ class CatalogImporter:
         self.customer_repository = CustomerRepository.from_session(session)
         self.subscription_repository = SubscriptionRepository.from_session(session)
         self._product_cache: dict[UUID, Product] = {}
+        self._customer_cache: dict[UUID, Customer] = {}
 
     async def run(self) -> MerchantMigrationImportReport:
         records = await self.record_repository.list_by_migration(self.migration.id)
@@ -172,24 +186,26 @@ class CatalogImporter:
         ]
         plans = plan_product_imports(products)
 
-        imported = skipped = 0
+        counts = ImportCounts()
         for record, product in zip(records, products, strict=True):
             if not self._is_selected(record):
                 continue
-            if record.status == MerchantMigrationRecordStatus.imported:
-                imported += 1
+            if record.status != MerchantMigrationRecordStatus.pending:
+                counts.settle(record.status)
                 continue
             plan = plans[product.source_id]
             if plan.skip is not None:
                 await self._mark_skipped(record, plan.skip)
-                skipped += 1
+                counts.skipped += 1
                 continue
             polar_product = await self._create_product(product, plan)
             await self._mark_imported(record, polar_product.id)
-            imported += 1
+            counts.imported += 1
 
         return MerchantMigrationImportResult(
-            entity=PrecheckEntity.products, imported=imported, skipped=skipped
+            entity=PrecheckEntity.products,
+            imported=counts.imported,
+            skipped=counts.skipped,
         )
 
     async def _import_customers(
@@ -201,29 +217,31 @@ class CatalogImporter:
         ]
         plans = plan_customer_imports(customers)
 
-        imported = skipped = 0
+        counts = ImportCounts()
         for record, customer in zip(records, customers, strict=True):
             if not self._is_selected(record):
                 continue
-            if record.status == MerchantMigrationRecordStatus.imported:
-                imported += 1
+            if record.status != MerchantMigrationRecordStatus.pending:
+                counts.settle(record.status)
                 continue
             skip = plans[customer.source_id]
             if skip is not None:
                 await self._mark_skipped(record, skip)
-                skipped += 1
+                counts.skipped += 1
                 continue
             result = await self._create_or_reuse_customer(customer)
             if result.skip is not None:
                 await self._mark_skipped(record, result.skip)
-                skipped += 1
+                counts.skipped += 1
                 continue
             assert result.customer is not None
             await self._mark_imported(record, result.customer.id)
-            imported += 1
+            counts.imported += 1
 
         return MerchantMigrationImportResult(
-            entity=PrecheckEntity.customers, imported=imported, skipped=skipped
+            entity=PrecheckEntity.customers,
+            imported=counts.imported,
+            skipped=counts.skipped,
         )
 
     async def _create_product(
@@ -334,17 +352,17 @@ class CatalogImporter:
         customer_target_by_source = self._imported_targets(customer_records)
         product_target_by_source = self._imported_targets(product_records)
 
-        imported = skipped = 0
+        counts = ImportCounts()
         for record, subscription in zip(records, subscriptions, strict=True):
             if not self._is_selected(record):
                 continue
-            if record.status == MerchantMigrationRecordStatus.imported:
-                imported += 1
+            if record.status != MerchantMigrationRecordStatus.pending:
+                counts.settle(record.status)
                 continue
             skip = plans[subscription.source_id]
             if skip is not None:
                 await self._mark_skipped(record, skip)
-                skipped += 1
+                counts.skipped += 1
                 continue
             result = await self._create_subscription(
                 subscription,
@@ -356,15 +374,17 @@ class CatalogImporter:
             # the subscription rather than leave it pending.
             if result.skip is not None:
                 await self._mark_skipped(record, result.skip)
-                skipped += 1
+                counts.skipped += 1
                 continue
             if result.subscription is None:
                 continue
             await self._mark_imported(record, result.subscription.id)
-            imported += 1
+            counts.imported += 1
 
         return MerchantMigrationImportResult(
-            entity=PrecheckEntity.subscriptions, imported=imported, skipped=skipped
+            entity=PrecheckEntity.subscriptions,
+            imported=counts.imported,
+            skipped=counts.skipped,
         )
 
     async def _create_subscription(
@@ -385,7 +405,7 @@ class CatalogImporter:
             return ImportedSubscription(skip=_PRODUCT_NOT_IMPORTED)
 
         polar_product = await self._load_product(product_target)
-        customer = await self.customer_repository.get_by_id(customer_target)
+        customer = await self._load_customer(customer_target)
         if polar_product is None or customer is None:
             return ImportedSubscription()
 
@@ -434,6 +454,15 @@ class CatalogImporter:
             if record.status == MerchantMigrationRecordStatus.imported
             and record.target_id is not None
         }
+
+    async def _load_customer(self, customer_id: UUID) -> Customer | None:
+        # Several subscriptions often share one customer.
+        if customer_id not in self._customer_cache:
+            customer = await self.customer_repository.get_by_id(customer_id)
+            if customer is None:
+                return None
+            self._customer_cache[customer_id] = customer
+        return self._customer_cache[customer_id]
 
     async def _load_product(self, product_id: UUID) -> Product | None:
         cached = self._product_cache.get(product_id)

--- a/server/polar/merchant_migration/importer.py
+++ b/server/polar/merchant_migration/importer.py
@@ -6,14 +6,15 @@ from collections.abc import Sequence
 from typing import TypeVar
 from uuid import UUID
 
-from sqlalchemy.orm import selectinload
+from sqlalchemy.orm import joinedload, selectinload
 
+from polar.auth.models import AuthSubject
 from polar.customer.repository import CustomerRepository
 from polar.customer.service import customer as customer_service
 from polar.enums import SubscriptionRecurringInterval
 from polar.kit.address import Address, CountryAlpha2
+from polar.kit.currency import PresentmentCurrency
 from polar.kit.db.postgres import AsyncSession
-from polar.kit.utils import utc_now
 from polar.models import (
     Customer,
     MerchantMigration,
@@ -21,17 +22,23 @@ from polar.models import (
     Organization,
     Product,
     Subscription,
-    SubscriptionProductPrice,
+    User,
 )
 from polar.models.merchant_migration import MerchantMigrationSourcePlatform
 from polar.models.merchant_migration_record import (
     MerchantMigrationRecordStatus,
     MerchantMigrationRecordType,
 )
-from polar.models.product_price import ProductPriceFixed
-from polar.models.subscription import SubscriptionStatus
+from polar.models.product_price import ProductPriceAmountType, ProductPriceFixed
 from polar.product.repository import ProductRepository
+from polar.product.schemas import (
+    ProductCreateRecurring,
+    ProductPriceCreate,
+    ProductPriceFixedCreate,
+)
+from polar.product.service import product as product_service
 from polar.subscription.repository import SubscriptionRepository
+from polar.subscription.service import subscription as subscription_service
 
 from .canonical import (
     CanonicalCustomer,
@@ -76,6 +83,7 @@ class CatalogImporter:
         session: AsyncSession,
         migration: MerchantMigration,
         organization: Organization,
+        auth_subject: AuthSubject[User | Organization],
         *,
         record_ids: set[UUID] | None = None,
         exclude_record_ids: set[UUID] | None = None,
@@ -83,6 +91,7 @@ class CatalogImporter:
         self.session = session
         self.migration = migration
         self.organization = organization
+        self.auth_subject = auth_subject
         # Selection: include only `record_ids`, or exclude `exclude_record_ids`
         # (the opt-out default for large catalogs), or neither to import all.
         self.record_ids = record_ids
@@ -201,34 +210,33 @@ class CatalogImporter:
         self, product: CanonicalProduct, plan: ProductImportPlan
     ) -> Product:
         assert product.recurring_interval is not None
-        prices: list[ProductPriceFixed] = []
+        prices: list[ProductPriceCreate] = []
         for price in product.prices:
             if price.source_id not in plan.importable_price_ids:
                 continue
             assert price.amount is not None
             prices.append(
-                ProductPriceFixed(
+                ProductPriceFixedCreate(
+                    amount_type=ProductPriceAmountType.fixed,
                     price_amount=price.amount,
-                    price_currency=price.currency.lower(),
+                    price_currency=PresentmentCurrency(price.currency.lower()),
                 )
             )
-        # Repository, not ProductService.create: a bulk import must not fire a
-        # product_created webhook or re-run org review for every product.
-        return await self.product_repository.create(
-            Product(
-                organization=self.organization,
+        # `notify=False`: a bulk import must not fire a product_created webhook or
+        # re-run the organization review for every product.
+        return await product_service.create(
+            self.session,
+            ProductCreateRecurring(
                 name=product.name,
+                organization_id=self.organization.id,
                 recurring_interval=SubscriptionRecurringInterval(
                     product.recurring_interval
                 ),
                 recurring_interval_count=product.recurring_interval_count,
                 prices=prices,
-                all_prices=list(prices),
-                product_benefits=[],
-                product_medias=[],
-                attached_custom_fields=[],
             ),
-            flush=True,
+            self.auth_subject,
+            notify=False,
         )
 
     async def _create_or_reuse_customer(
@@ -394,37 +402,15 @@ class CatalogImporter:
         price: ProductPriceFixed,
         customer: Customer,
     ) -> Subscription:
-        assert product.recurring_interval is not None
-        interval = product.recurring_interval
-        count = product.recurring_interval_count or 1
-        start = subscription.current_period_start or utc_now()
-        end = subscription.current_period_end or interval.get_next_period(
-            start, start.day, count
-        )
-        polar_subscription = Subscription(
-            # Paused isn't active or billable, so the renewal scheduler skips it
-            # and the customer isn't charged until cutover resumes it.
-            status=SubscriptionStatus.paused,
-            paused_at=utc_now(),
-            started_at=start,
-            anchor_day=start.day,
-            current_period_start=start,
-            current_period_end=end,
-            cancel_at_period_end=False,
-            recurring_interval=interval,
-            recurring_interval_count=count,
-            meter_interval=product.meter_interval,
-            meter_interval_count=product.meter_interval_count,
-            organization=self.organization,
+        return await subscription_service.create_imported(
+            self.session,
             product=product,
+            price=price,
             customer=customer,
-            subscription_product_prices=[SubscriptionProductPrice.from_price(price)],
-            currency=price.price_currency,
+            current_period_start=subscription.current_period_start,
+            current_period_end=subscription.current_period_end,
             user_metadata={"stripe_subscription_id": subscription.source_id},
-            pending_update=None,
         )
-        polar_subscription.initialize_meter_period(start)
-        return await self.subscription_repository.create(polar_subscription, flush=True)
 
     def _imported_targets(
         self, records: Sequence[MerchantMigrationRecord]
@@ -445,7 +431,10 @@ class CatalogImporter:
         product = await self.product_repository.get_by_id_and_organization(
             product_id,
             self.organization.id,
-            options=(selectinload(Product.prices),),
+            options=(
+                selectinload(Product.prices),
+                joinedload(Product.organization),
+            ),
         )
         if product is not None:
             self._product_cache[product_id] = product
@@ -457,23 +446,24 @@ class CatalogImporter:
         canonical_product: CanonicalProduct,
         price_source_id: str,
     ) -> ProductPriceFixed | None:
-        # Prices carry no durable source id, so match the source price to a Polar
-        # one by the currency and amount the product importer created it with.
+        # Prices carry no durable source id, so match on currency. A product that
+        # got this far holds one fixed price per currency, so that's unambiguous.
         canonical_price = next(
             (p for p in canonical_product.prices if p.source_id == price_source_id),
             None,
         )
-        if canonical_price is None or canonical_price.amount is None:
+        if canonical_price is None:
             return None
         currency = canonical_price.currency.lower()
-        for price in product.prices:
-            if (
-                isinstance(price, ProductPriceFixed)
+        return next(
+            (
+                price
+                for price in product.prices
+                if isinstance(price, ProductPriceFixed)
                 and price.price_currency == currency
-                and price.price_amount == canonical_price.amount
-            ):
-                return price
-        return None
+            ),
+            None,
+        )
 
     async def _mark_imported(
         self, record: MerchantMigrationRecord, target_id: UUID

--- a/server/polar/merchant_migration/importer.py
+++ b/server/polar/merchant_migration/importer.py
@@ -1,0 +1,506 @@
+"""Imports the staged catalog into Polar (the `create_catalog` step).
+Idempotent; migrated subscriptions arrive paused so nothing bills until cutover.
+"""
+
+from collections.abc import Sequence
+from typing import TypeVar
+from uuid import UUID
+
+from sqlalchemy.orm import selectinload
+
+from polar.customer.repository import CustomerRepository
+from polar.customer.service import customer as customer_service
+from polar.enums import SubscriptionRecurringInterval
+from polar.kit.address import Address, CountryAlpha2
+from polar.kit.db.postgres import AsyncSession
+from polar.kit.utils import utc_now
+from polar.models import (
+    Customer,
+    MerchantMigration,
+    MerchantMigrationRecord,
+    Organization,
+    Product,
+    Subscription,
+    SubscriptionProductPrice,
+)
+from polar.models.merchant_migration import MerchantMigrationSourcePlatform
+from polar.models.merchant_migration_record import (
+    MerchantMigrationRecordStatus,
+    MerchantMigrationRecordType,
+)
+from polar.models.product_price import ProductPriceFixed
+from polar.models.subscription import SubscriptionStatus
+from polar.product.repository import ProductRepository
+from polar.subscription.repository import SubscriptionRepository
+
+from .canonical import (
+    CanonicalCustomer,
+    CanonicalProduct,
+    CanonicalSubscription,
+    deserialize,
+)
+from .precheck import (
+    ProductImportPlan,
+    plan_customer_imports,
+    plan_product_imports,
+    plan_subscription_imports,
+)
+from .repository import MerchantMigrationRecordRepository
+from .schemas import (
+    MerchantMigrationImportReport,
+    MerchantMigrationImportResult,
+    PrecheckEntity,
+)
+
+_CanonicalT = TypeVar("_CanonicalT")
+
+_CUSTOMER_NOT_IMPORTED_REASON = (
+    "Its customer wasn't imported, so this subscription stays on the source."
+)
+_PRODUCT_NOT_IMPORTED_REASON = (
+    "Its product wasn't imported, so this subscription stays on the source."
+)
+_CUSTOMER_ALREADY_SUBSCRIBED_REASON = (
+    "This customer already has a live subscription to the product on Polar, so a "
+    "duplicate isn't created. It stays on the source."
+)
+_CUSTOMER_STRIPE_ID_CONFLICT_REASON = (
+    "A Polar customer with this email already has a different Stripe id. Reconcile "
+    "them manually; this customer stays on the source."
+)
+
+
+class CatalogImporter:
+    def __init__(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        organization: Organization,
+        *,
+        record_ids: set[UUID] | None = None,
+        exclude_record_ids: set[UUID] | None = None,
+    ) -> None:
+        self.session = session
+        self.migration = migration
+        self.organization = organization
+        # Selection: include only `record_ids`, or exclude `exclude_record_ids`
+        # (the opt-out default for large catalogs), or neither to import all.
+        self.record_ids = record_ids
+        self.exclude_record_ids = exclude_record_ids
+        self.record_repository = MerchantMigrationRecordRepository.from_session(session)
+        self.product_repository = ProductRepository.from_session(session)
+        self.customer_repository = CustomerRepository.from_session(session)
+        self.subscription_repository = SubscriptionRepository.from_session(session)
+        self._product_cache: dict[UUID, Product] = {}
+
+    async def run(self) -> MerchantMigrationImportReport:
+        records = await self.record_repository.list_by_migration(self.migration.id)
+        product_records = self._records_of(records, MerchantMigrationRecordType.product)
+        customer_records = self._records_of(
+            records, MerchantMigrationRecordType.customer
+        )
+        subscription_records = self._records_of(
+            records, MerchantMigrationRecordType.subscription
+        )
+
+        # Products and customers first: a subscription resolves its Polar product,
+        # price and customer from their imported ledger rows.
+        product_result = await self._import_products(product_records)
+        customer_result = await self._import_customers(customer_records)
+        subscription_result = await self._import_subscriptions(
+            subscription_records, product_records, customer_records
+        )
+
+        return MerchantMigrationImportReport(
+            step=self.migration.step,
+            results=[product_result, customer_result, subscription_result],
+        )
+
+    def _records_of(
+        self,
+        records: Sequence[MerchantMigrationRecord],
+        type: MerchantMigrationRecordType,
+    ) -> list[MerchantMigrationRecord]:
+        return [record for record in records if record.type == type]
+
+    def _is_selected(self, record: MerchantMigrationRecord) -> bool:
+        if self.record_ids is not None:
+            return record.id in self.record_ids
+        if self.exclude_record_ids is not None:
+            return record.id not in self.exclude_record_ids
+        return True
+
+    async def _import_products(
+        self, records: Sequence[MerchantMigrationRecord]
+    ) -> MerchantMigrationImportResult:
+        products = [
+            self._as(deserialize(record.type, record.canonical), CanonicalProduct)
+            for record in records
+        ]
+        plans = plan_product_imports(products)
+
+        imported = skipped = 0
+        for record, product in zip(records, products, strict=True):
+            if not self._is_selected(record):
+                continue
+            if record.status == MerchantMigrationRecordStatus.imported:
+                imported += 1
+                continue
+            plan = plans[product.source_id]
+            if plan.skip is not None:
+                await self._mark_skipped(record, *plan.skip)
+                skipped += 1
+                continue
+            polar_product = await self._create_product(product, plan)
+            await self._mark_imported(record, polar_product.id)
+            imported += 1
+
+        return MerchantMigrationImportResult(
+            entity=PrecheckEntity.products, imported=imported, skipped=skipped
+        )
+
+    async def _import_customers(
+        self, records: Sequence[MerchantMigrationRecord]
+    ) -> MerchantMigrationImportResult:
+        customers = [
+            self._as(deserialize(record.type, record.canonical), CanonicalCustomer)
+            for record in records
+        ]
+        plans = plan_customer_imports(customers)
+
+        imported = skipped = 0
+        for record, customer in zip(records, customers, strict=True):
+            if not self._is_selected(record):
+                continue
+            if record.status == MerchantMigrationRecordStatus.imported:
+                imported += 1
+                continue
+            skip = plans[customer.source_id]
+            if skip is not None:
+                await self._mark_skipped(record, *skip)
+                skipped += 1
+                continue
+            polar_customer, conflict_reason = await self._create_or_reuse_customer(
+                customer
+            )
+            if conflict_reason is not None:
+                await self._mark_skipped(
+                    record, "customer_stripe_id_conflict", conflict_reason
+                )
+                skipped += 1
+                continue
+            assert polar_customer is not None
+            await self._mark_imported(record, polar_customer.id)
+            imported += 1
+
+        return MerchantMigrationImportResult(
+            entity=PrecheckEntity.customers, imported=imported, skipped=skipped
+        )
+
+    async def _create_product(
+        self, product: CanonicalProduct, plan: ProductImportPlan
+    ) -> Product:
+        assert product.recurring_interval is not None
+        prices: list[ProductPriceFixed] = []
+        for price in product.prices:
+            if price.source_id not in plan.importable_price_ids:
+                continue
+            assert price.amount is not None
+            prices.append(
+                ProductPriceFixed(
+                    price_amount=price.amount,
+                    price_currency=price.currency.lower(),
+                )
+            )
+        # Repository, not ProductService.create: a bulk import must not fire a
+        # product_created webhook or re-run org review for every product.
+        return await self.product_repository.create(
+            Product(
+                organization=self.organization,
+                name=product.name,
+                recurring_interval=SubscriptionRecurringInterval(
+                    product.recurring_interval
+                ),
+                recurring_interval_count=product.recurring_interval_count,
+                prices=prices,
+                all_prices=list(prices),
+                product_benefits=[],
+                product_medias=[],
+                attached_custom_fields=[],
+            ),
+            flush=True,
+        )
+
+    async def _create_or_reuse_customer(
+        self, customer: CanonicalCustomer
+    ) -> tuple[Customer | None, str | None]:
+        stripe_customer_id = self._stripe_customer_id(customer)
+        existing = await self.customer_repository.get_by_email_and_organization(
+            customer.email, self.organization.id
+        )
+        if existing is not None:
+            # The email matches an existing Polar customer that already carries a
+            # different Stripe id: reusing it would attach this subscription and a
+            # PAN-copied card to the wrong record, so skip for manual reconciliation.
+            if (
+                stripe_customer_id is not None
+                and existing.stripe_customer_id is not None
+                and existing.stripe_customer_id != stripe_customer_id
+            ):
+                return None, _CUSTOMER_STRIPE_ID_CONFLICT_REASON
+            # Reuse the existing customer (design Appendix A). Reconcile the source
+            # id so the PAN-copied card lands on the same customer, but never
+            # overwrite an id that's already set.
+            if stripe_customer_id and existing.stripe_customer_id is None:
+                await self.customer_repository.update(
+                    existing, update_dict={"stripe_customer_id": stripe_customer_id}
+                )
+            return existing, None
+        polar_customer = await customer_service.create_for_organization(
+            self.session,
+            self.organization,
+            email=customer.email,
+            name=customer.name,
+            billing_address=self._billing_address(customer),
+            stripe_customer_id=stripe_customer_id,
+        )
+        return polar_customer, None
+
+    def _stripe_customer_id(self, customer: CanonicalCustomer) -> str | None:
+        # PAN copy preserves the Stripe `cus_…` id, which the canonical record
+        # carries as its source id; other providers have no such concept.
+        if self.migration.source_platform == MerchantMigrationSourcePlatform.stripe:
+            return customer.source_id
+        return None
+
+    def _billing_address(self, customer: CanonicalCustomer) -> Address | None:
+        if not customer.country:
+            return None
+        try:
+            country = CountryAlpha2(customer.country.upper())
+        except ValueError:
+            return None
+        return Address(country=country)
+
+    async def _import_subscriptions(
+        self,
+        records: Sequence[MerchantMigrationRecord],
+        product_records: Sequence[MerchantMigrationRecord],
+        customer_records: Sequence[MerchantMigrationRecord],
+    ) -> MerchantMigrationImportResult:
+        subscriptions = [
+            self._as(deserialize(record.type, record.canonical), CanonicalSubscription)
+            for record in records
+        ]
+        products = [
+            self._as(deserialize(record.type, record.canonical), CanonicalProduct)
+            for record in product_records
+        ]
+        customers = [
+            self._as(deserialize(record.type, record.canonical), CanonicalCustomer)
+            for record in customer_records
+        ]
+        plans = plan_subscription_imports(subscriptions, products, customers)
+        product_by_price = {
+            price.source_id: product for product in products for price in product.prices
+        }
+        # Products and customers were imported earlier in this run, so their ledger
+        # rows already carry target ids in-session: resolve dependencies from these
+        # maps instead of a per-subscription query.
+        customer_target_by_source = self._imported_targets(customer_records)
+        product_target_by_source = self._imported_targets(product_records)
+
+        imported = skipped = 0
+        for record, subscription in zip(records, subscriptions, strict=True):
+            if not self._is_selected(record):
+                continue
+            if record.status == MerchantMigrationRecordStatus.imported:
+                imported += 1
+                continue
+            skip = plans[subscription.source_id]
+            if skip is not None:
+                await self._mark_skipped(record, *skip)
+                skipped += 1
+                continue
+            polar_subscription, skip_reason = await self._create_subscription(
+                subscription,
+                product_by_price,
+                customer_target_by_source,
+                product_target_by_source,
+            )
+            # Product and customer import first, so a missing one means it was
+            # skipped or deselected: skip the subscription rather than leave it pending.
+            if skip_reason is not None:
+                await self._mark_skipped(
+                    record, "subscription_dependency_not_imported", skip_reason
+                )
+                skipped += 1
+                continue
+            if polar_subscription is None:
+                continue
+            await self._mark_imported(record, polar_subscription.id)
+            imported += 1
+
+        return MerchantMigrationImportResult(
+            entity=PrecheckEntity.subscriptions, imported=imported, skipped=skipped
+        )
+
+    async def _create_subscription(
+        self,
+        subscription: CanonicalSubscription,
+        product_by_price: dict[str, CanonicalProduct],
+        customer_target_by_source: dict[str, UUID],
+        product_target_by_source: dict[str, UUID],
+    ) -> tuple[Subscription | None, str | None]:
+        # (subscription, skip_reason): a reason means skip; both None means an
+        # unexpected miss, left pending.
+        customer_target = customer_target_by_source.get(subscription.customer_source_id)
+        if customer_target is None:
+            return None, _CUSTOMER_NOT_IMPORTED_REASON
+        canonical_product = product_by_price.get(subscription.price_source_id)
+        if canonical_product is None:
+            return None, _PRODUCT_NOT_IMPORTED_REASON
+        product_target = product_target_by_source.get(canonical_product.source_id)
+        if product_target is None:
+            return None, _PRODUCT_NOT_IMPORTED_REASON
+
+        polar_product = await self._load_product(product_target)
+        customer = await self.customer_repository.get_by_id(customer_target)
+        if polar_product is None or customer is None:
+            return None, None
+
+        # Never create a second live subscription to the same product for a
+        # customer — at cutover it would double-bill them.
+        if await self.subscription_repository.exists_live_by_customer_and_product(
+            customer.id, polar_product.id
+        ):
+            return None, _CUSTOMER_ALREADY_SUBSCRIBED_REASON
+
+        price = self._find_price(
+            polar_product, canonical_product, subscription.price_source_id
+        )
+        if price is None:
+            return None, None
+
+        subscription_target = await self._persist_subscription(
+            subscription, polar_product, price, customer
+        )
+        return subscription_target, None
+
+    async def _persist_subscription(
+        self,
+        subscription: CanonicalSubscription,
+        product: Product,
+        price: ProductPriceFixed,
+        customer: Customer,
+    ) -> Subscription:
+        assert product.recurring_interval is not None
+        interval = product.recurring_interval
+        count = product.recurring_interval_count or 1
+        start = subscription.current_period_start or utc_now()
+        end = subscription.current_period_end or interval.get_next_period(
+            start, start.day, count
+        )
+        polar_subscription = Subscription(
+            # Paused isn't active or billable, so the renewal scheduler skips it
+            # and the customer isn't charged until cutover resumes it.
+            status=SubscriptionStatus.paused,
+            paused_at=utc_now(),
+            started_at=start,
+            anchor_day=start.day,
+            current_period_start=start,
+            current_period_end=end,
+            cancel_at_period_end=False,
+            recurring_interval=interval,
+            recurring_interval_count=count,
+            meter_interval=product.meter_interval,
+            meter_interval_count=product.meter_interval_count,
+            organization=self.organization,
+            product=product,
+            customer=customer,
+            subscription_product_prices=[SubscriptionProductPrice.from_price(price)],
+            currency=price.price_currency,
+            user_metadata={"stripe_subscription_id": subscription.source_id},
+            pending_update=None,
+        )
+        polar_subscription.initialize_meter_period(start)
+        return await self.subscription_repository.create(polar_subscription, flush=True)
+
+    def _imported_targets(
+        self, records: Sequence[MerchantMigrationRecord]
+    ) -> dict[str, UUID]:
+        return {
+            record.source_id: record.target_id
+            for record in records
+            if record.status == MerchantMigrationRecordStatus.imported
+            and record.target_id is not None
+        }
+
+    async def _load_product(self, product_id: UUID) -> Product | None:
+        cached = self._product_cache.get(product_id)
+        if cached is not None:
+            return cached
+        # None only if an imported product row vanished (data corruption); the
+        # caller leaves the subscription pending rather than crashing.
+        product = await self.product_repository.get_by_id_and_organization(
+            product_id,
+            self.organization.id,
+            options=(selectinload(Product.prices),),
+        )
+        if product is not None:
+            self._product_cache[product_id] = product
+        return product
+
+    def _find_price(
+        self,
+        product: Product,
+        canonical_product: CanonicalProduct,
+        price_source_id: str,
+    ) -> ProductPriceFixed | None:
+        # Prices carry no durable source id, so match the source price to a Polar
+        # one by the currency and amount the product importer created it with.
+        canonical_price = next(
+            (p for p in canonical_product.prices if p.source_id == price_source_id),
+            None,
+        )
+        if canonical_price is None or canonical_price.amount is None:
+            return None
+        currency = canonical_price.currency.lower()
+        for price in product.prices:
+            if (
+                isinstance(price, ProductPriceFixed)
+                and price.price_currency == currency
+                and price.price_amount == canonical_price.amount
+            ):
+                return price
+        return None
+
+    async def _mark_imported(
+        self, record: MerchantMigrationRecord, target_id: UUID
+    ) -> None:
+        await self.record_repository.update(
+            record,
+            update_dict={
+                "status": MerchantMigrationRecordStatus.imported,
+                "target_id": target_id,
+                "error": None,
+            },
+        )
+
+    async def _mark_skipped(
+        self,
+        record: MerchantMigrationRecord,
+        code: str,
+        reason: str,
+    ) -> None:
+        await self.record_repository.update(
+            record,
+            update_dict={
+                "status": MerchantMigrationRecordStatus.skipped,
+                "error": reason or code,
+            },
+        )
+
+    def _as(self, record: object, expected: type[_CanonicalT]) -> _CanonicalT:
+        assert isinstance(record, expected)
+        return record

--- a/server/polar/merchant_migration/importer.py
+++ b/server/polar/merchant_migration/importer.py
@@ -3,6 +3,7 @@ Idempotent; migrated subscriptions arrive paused so nothing bills until cutover.
 """
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 from typing import TypeVar
 from uuid import UUID
 
@@ -48,6 +49,7 @@ from .canonical import (
 )
 from .precheck import (
     ProductImportPlan,
+    Reason,
     plan_customer_imports,
     plan_product_imports,
     plan_subscription_imports,
@@ -61,20 +63,42 @@ from .schemas import (
 
 _CanonicalT = TypeVar("_CanonicalT")
 
-_CUSTOMER_NOT_IMPORTED_REASON = (
-    "Its customer wasn't imported, so this subscription stays on the source."
+_DEPENDENCY_CODE = "subscription_dependency_not_imported"
+_CUSTOMER_NOT_IMPORTED = Reason(
+    _DEPENDENCY_CODE,
+    "Its customer wasn't imported, so this subscription stays on the source.",
 )
-_PRODUCT_NOT_IMPORTED_REASON = (
-    "Its product wasn't imported, so this subscription stays on the source."
+_PRODUCT_NOT_IMPORTED = Reason(
+    _DEPENDENCY_CODE,
+    "Its product wasn't imported, so this subscription stays on the source.",
 )
-_CUSTOMER_ALREADY_SUBSCRIBED_REASON = (
+_CUSTOMER_ALREADY_SUBSCRIBED = Reason(
+    _DEPENDENCY_CODE,
     "This customer already has a live subscription to the product on Polar, so a "
-    "duplicate isn't created. It stays on the source."
+    "duplicate isn't created. It stays on the source.",
 )
-_CUSTOMER_STRIPE_ID_CONFLICT_REASON = (
+_CUSTOMER_STRIPE_ID_CONFLICT = Reason(
+    "customer_stripe_id_conflict",
     "A Polar customer with this email already has a different Stripe id. Reconcile "
-    "them manually; this customer stays on the source."
+    "them manually; this customer stays on the source.",
 )
+
+
+@dataclass(frozen=True)
+class ImportedCustomer:
+    """The Polar customer to use, or why the record is skipped."""
+
+    customer: Customer | None = None
+    skip: Reason | None = None
+
+
+@dataclass(frozen=True)
+class ImportedSubscription:
+    """The created subscription, or why the record is skipped. Both unset means
+    an unexpected miss, which leaves the record pending."""
+
+    subscription: Subscription | None = None
+    skip: Reason | None = None
 
 
 class CatalogImporter:
@@ -157,7 +181,7 @@ class CatalogImporter:
                 continue
             plan = plans[product.source_id]
             if plan.skip is not None:
-                await self._mark_skipped(record, *plan.skip)
+                await self._mark_skipped(record, plan.skip)
                 skipped += 1
                 continue
             polar_product = await self._create_product(product, plan)
@@ -186,20 +210,16 @@ class CatalogImporter:
                 continue
             skip = plans[customer.source_id]
             if skip is not None:
-                await self._mark_skipped(record, *skip)
+                await self._mark_skipped(record, skip)
                 skipped += 1
                 continue
-            polar_customer, conflict_reason = await self._create_or_reuse_customer(
-                customer
-            )
-            if conflict_reason is not None:
-                await self._mark_skipped(
-                    record, "customer_stripe_id_conflict", conflict_reason
-                )
+            result = await self._create_or_reuse_customer(customer)
+            if result.skip is not None:
+                await self._mark_skipped(record, result.skip)
                 skipped += 1
                 continue
-            assert polar_customer is not None
-            await self._mark_imported(record, polar_customer.id)
+            assert result.customer is not None
+            await self._mark_imported(record, result.customer.id)
             imported += 1
 
         return MerchantMigrationImportResult(
@@ -240,7 +260,7 @@ class CatalogImporter:
 
     async def _create_or_reuse_customer(
         self, customer: CanonicalCustomer
-    ) -> tuple[Customer | None, str | None]:
+    ) -> ImportedCustomer:
         stripe_customer_id = self._stripe_customer_id(customer)
         existing = await self.customer_repository.get_by_email_and_organization(
             customer.email, self.organization.id
@@ -253,14 +273,14 @@ class CatalogImporter:
                 and existing.stripe_customer_id is not None
                 and existing.stripe_customer_id != stripe_customer_id
             ):
-                return None, _CUSTOMER_STRIPE_ID_CONFLICT_REASON
+                return ImportedCustomer(skip=_CUSTOMER_STRIPE_ID_CONFLICT)
             # Reconcile the source id so the PAN-copied card lands on the same
             # customer, but never overwrite one that's already set.
             if stripe_customer_id and existing.stripe_customer_id is None:
                 await self.customer_repository.update(
                     existing, update_dict={"stripe_customer_id": stripe_customer_id}
                 )
-            return existing, None
+            return ImportedCustomer(customer=existing)
         polar_customer = await customer_service.create_for_organization(
             self.session,
             self.organization,
@@ -269,7 +289,7 @@ class CatalogImporter:
             billing_address=self._billing_address(customer),
             stripe_customer_id=stripe_customer_id,
         )
-        return polar_customer, None
+        return ImportedCustomer(customer=polar_customer)
 
     def _stripe_customer_id(self, customer: CanonicalCustomer) -> str | None:
         # PAN copy preserves the Stripe `cus_…` id; other providers have no
@@ -323,10 +343,10 @@ class CatalogImporter:
                 continue
             skip = plans[subscription.source_id]
             if skip is not None:
-                await self._mark_skipped(record, *skip)
+                await self._mark_skipped(record, skip)
                 skipped += 1
                 continue
-            polar_subscription, skip_reason = await self._create_subscription(
+            result = await self._create_subscription(
                 subscription,
                 product_by_price,
                 customer_target_by_source,
@@ -334,15 +354,13 @@ class CatalogImporter:
             )
             # A missing dependency means it was skipped or deselected, so skip
             # the subscription rather than leave it pending.
-            if skip_reason is not None:
-                await self._mark_skipped(
-                    record, "subscription_dependency_not_imported", skip_reason
-                )
+            if result.skip is not None:
+                await self._mark_skipped(record, result.skip)
                 skipped += 1
                 continue
-            if polar_subscription is None:
+            if result.subscription is None:
                 continue
-            await self._mark_imported(record, polar_subscription.id)
+            await self._mark_imported(record, result.subscription.id)
             imported += 1
 
         return MerchantMigrationImportResult(
@@ -355,40 +373,40 @@ class CatalogImporter:
         product_by_price: dict[str, CanonicalProduct],
         customer_target_by_source: dict[str, UUID],
         product_target_by_source: dict[str, UUID],
-    ) -> tuple[Subscription | None, str | None]:
-        # A reason means skip; both None means an unexpected miss, left pending.
+    ) -> ImportedSubscription:
         customer_target = customer_target_by_source.get(subscription.customer_source_id)
         if customer_target is None:
-            return None, _CUSTOMER_NOT_IMPORTED_REASON
+            return ImportedSubscription(skip=_CUSTOMER_NOT_IMPORTED)
         canonical_product = product_by_price.get(subscription.price_source_id)
         if canonical_product is None:
-            return None, _PRODUCT_NOT_IMPORTED_REASON
+            return ImportedSubscription(skip=_PRODUCT_NOT_IMPORTED)
         product_target = product_target_by_source.get(canonical_product.source_id)
         if product_target is None:
-            return None, _PRODUCT_NOT_IMPORTED_REASON
+            return ImportedSubscription(skip=_PRODUCT_NOT_IMPORTED)
 
         polar_product = await self._load_product(product_target)
         customer = await self.customer_repository.get_by_id(customer_target)
         if polar_product is None or customer is None:
-            return None, None
+            return ImportedSubscription()
 
         # Never create a second live subscription to the same product for a
         # customer — at cutover it would double-bill them.
         if await self.subscription_repository.exists_live_by_customer_and_product(
             customer.id, polar_product.id
         ):
-            return None, _CUSTOMER_ALREADY_SUBSCRIBED_REASON
+            return ImportedSubscription(skip=_CUSTOMER_ALREADY_SUBSCRIBED)
 
         price = self._find_price(
             polar_product, canonical_product, subscription.price_source_id
         )
         if price is None:
-            return None, None
+            return ImportedSubscription()
 
-        subscription_target = await self._persist_subscription(
-            subscription, polar_product, price, customer
+        return ImportedSubscription(
+            subscription=await self._persist_subscription(
+                subscription, polar_product, price, customer
+            )
         )
-        return subscription_target, None
 
     async def _persist_subscription(
         self,
@@ -473,16 +491,13 @@ class CatalogImporter:
         )
 
     async def _mark_skipped(
-        self,
-        record: MerchantMigrationRecord,
-        code: str,
-        reason: str,
+        self, record: MerchantMigrationRecord, reason: Reason
     ) -> None:
         await self.record_repository.update(
             record,
             update_dict={
                 "status": MerchantMigrationRecordStatus.skipped,
-                "error": reason or code,
+                "error": reason.message,
             },
         )
 

--- a/server/polar/merchant_migration/importer.py
+++ b/server/polar/merchant_migration/importer.py
@@ -92,8 +92,8 @@ class CatalogImporter:
         self.migration = migration
         self.organization = organization
         self.auth_subject = auth_subject
-        # Selection: include only `record_ids`, or exclude `exclude_record_ids`
-        # (the opt-out default for large catalogs), or neither to import all.
+        # Neither set imports everything; excluding is the opt-out default for
+        # large catalogs.
         self.record_ids = record_ids
         self.exclude_record_ids = exclude_record_ids
         self.record_repository = MerchantMigrationRecordRepository.from_session(session)
@@ -112,8 +112,8 @@ class CatalogImporter:
             records, MerchantMigrationRecordType.subscription
         )
 
-        # Products and customers first: a subscription resolves its Polar product,
-        # price and customer from their imported ledger rows.
+        # Products and customers first: a subscription resolves both from their
+        # imported ledger rows.
         product_result = await self._import_products(product_records)
         customer_result = await self._import_customers(customer_records)
         subscription_result = await self._import_subscriptions(
@@ -222,8 +222,7 @@ class CatalogImporter:
                     price_currency=PresentmentCurrency(price.currency.lower()),
                 )
             )
-        # `notify=False`: a bulk import must not fire a product_created webhook or
-        # re-run the organization review for every product.
+        # A bulk import must not webhook or re-review the org for every product.
         return await product_service.create(
             self.session,
             ProductCreateRecurring(
@@ -247,18 +246,16 @@ class CatalogImporter:
             customer.email, self.organization.id
         )
         if existing is not None:
-            # The email matches an existing Polar customer that already carries a
-            # different Stripe id: reusing it would attach this subscription and a
-            # PAN-copied card to the wrong record, so skip for manual reconciliation.
+            # Reusing a customer bound to another Stripe id would attach the
+            # PAN-copied card to the wrong record.
             if (
                 stripe_customer_id is not None
                 and existing.stripe_customer_id is not None
                 and existing.stripe_customer_id != stripe_customer_id
             ):
                 return None, _CUSTOMER_STRIPE_ID_CONFLICT_REASON
-            # Reuse the existing customer (design Appendix A). Reconcile the source
-            # id so the PAN-copied card lands on the same customer, but never
-            # overwrite an id that's already set.
+            # Reconcile the source id so the PAN-copied card lands on the same
+            # customer, but never overwrite one that's already set.
             if stripe_customer_id and existing.stripe_customer_id is None:
                 await self.customer_repository.update(
                     existing, update_dict={"stripe_customer_id": stripe_customer_id}
@@ -275,8 +272,8 @@ class CatalogImporter:
         return polar_customer, None
 
     def _stripe_customer_id(self, customer: CanonicalCustomer) -> str | None:
-        # PAN copy preserves the Stripe `cus_…` id, which the canonical record
-        # carries as its source id; other providers have no such concept.
+        # PAN copy preserves the Stripe `cus_…` id; other providers have no
+        # such concept.
         if self.migration.source_platform == MerchantMigrationSourcePlatform.stripe:
             return customer.source_id
         return None
@@ -312,9 +309,8 @@ class CatalogImporter:
         product_by_price = {
             price.source_id: product for product in products for price in product.prices
         }
-        # Products and customers were imported earlier in this run, so their ledger
-        # rows already carry target ids in-session: resolve dependencies from these
-        # maps instead of a per-subscription query.
+        # Their ledger rows already carry target ids in-session, so resolve from
+        # these maps instead of a query per subscription.
         customer_target_by_source = self._imported_targets(customer_records)
         product_target_by_source = self._imported_targets(product_records)
 
@@ -336,8 +332,8 @@ class CatalogImporter:
                 customer_target_by_source,
                 product_target_by_source,
             )
-            # Product and customer import first, so a missing one means it was
-            # skipped or deselected: skip the subscription rather than leave it pending.
+            # A missing dependency means it was skipped or deselected, so skip
+            # the subscription rather than leave it pending.
             if skip_reason is not None:
                 await self._mark_skipped(
                     record, "subscription_dependency_not_imported", skip_reason
@@ -360,8 +356,7 @@ class CatalogImporter:
         customer_target_by_source: dict[str, UUID],
         product_target_by_source: dict[str, UUID],
     ) -> tuple[Subscription | None, str | None]:
-        # (subscription, skip_reason): a reason means skip; both None means an
-        # unexpected miss, left pending.
+        # A reason means skip; both None means an unexpected miss, left pending.
         customer_target = customer_target_by_source.get(subscription.customer_source_id)
         if customer_target is None:
             return None, _CUSTOMER_NOT_IMPORTED_REASON
@@ -426,8 +421,8 @@ class CatalogImporter:
         cached = self._product_cache.get(product_id)
         if cached is not None:
             return cached
-        # None only if an imported product row vanished (data corruption); the
-        # caller leaves the subscription pending rather than crashing.
+        # None only if an imported product row vanished; the caller leaves the
+        # subscription pending rather than crashing.
         product = await self.product_repository.get_by_id_and_organization(
             product_id,
             self.organization.id,
@@ -446,8 +441,8 @@ class CatalogImporter:
         canonical_product: CanonicalProduct,
         price_source_id: str,
     ) -> ProductPriceFixed | None:
-        # Prices carry no durable source id, so match on currency. A product that
-        # got this far holds one fixed price per currency, so that's unambiguous.
+        # Prices carry no durable source id, and an imported product holds one
+        # fixed price per currency, so the currency identifies it.
         canonical_price = next(
             (p for p in canonical_product.prices if p.source_id == price_source_id),
             None,

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -50,9 +50,8 @@ NON_IMPORTABLE_STATUSES = {
     CanonicalSubscriptionStatus.paused,
 }
 
-# Warning codes that mean a record won't be imported (it stays on the source),
-# grouped by the entity they apply to. Kept in sync with the `_check_*` methods
-# so the per-record classification below matches the report's warnings.
+# Codes whose warning means a record won't import, by entity. Keep in sync with
+# the `_check_*` methods so classification matches the report.
 PRODUCT_DROP_CODES = {"one_time_product", "unsupported_recurring_interval"}
 PRICE_DROP_CODES = {
     "unsupported_pricing_scheme",
@@ -292,9 +291,8 @@ class PrecheckEngine:
         products_by_name: dict[str, set[str]],
         existing_product_names: set[str],
     ) -> Iterable[PrecheckIssue]:
-        # Warn (don't block): the source product still imports, but as a new Polar
-        # product alongside the existing one. Mapping onto the existing product is
-        # a separate, merchant-driven step.
+        # Warn, don't block: the product still imports, as a new Polar product next
+        # to the existing one. Mapping onto it is a later, merchant-driven step.
         for name in products_by_name:
             if name.lower() in existing_product_names:
                 yield PrecheckIssue(
@@ -553,8 +551,7 @@ def _duplicate_customer_source_ids(
 def _product_items(
     products: Sequence[CanonicalProduct],
 ) -> list[MerchantMigrationRecordItem]:
-    # Classify with the importer's own plan so the report never promises a product
-    # the importer will later skip (e.g. one with no importable price).
+    # Use the importer's plan, so the report can't promise a product it will skip.
     plans = plan_product_imports(products)
     items: list[MerchantMigrationRecordItem] = []
     for product in products:
@@ -616,8 +613,7 @@ def _price_items(
 def _customer_items(
     customers: Sequence[CanonicalCustomer],
 ) -> list[MerchantMigrationRecordItem]:
-    # Classify with the importer's own plan so the report never promises a customer
-    # the importer will later skip (e.g. one with no email).
+    # Use the importer's plan, so the report can't promise a customer it will skip.
     plans = plan_customer_imports(customers)
     items: list[MerchantMigrationRecordItem] = []
     for customer in customers:
@@ -644,8 +640,7 @@ def _subscription_items(
     products: Sequence[CanonicalProduct],
     customers: Sequence[CanonicalCustomer],
 ) -> list[MerchantMigrationRecordItem]:
-    # Classify with the importer's own plan so the report matches the import;
-    # layer the display-only trialing warning on top.
+    # Use the importer's plan; add the display-only trialing warning on top.
     plans = plan_subscription_imports(subscriptions, products, customers)
     email_by_source = {c.source_id: c.email for c in customers if c.email}
     price_info = _price_info(products)

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -220,6 +220,7 @@ class PrecheckEngine:
     def _check_product(self, product: CanonicalProduct) -> Iterable[PrecheckIssue]:
         # A product Polar can't represent is skipped along with its subscriptions,
         # rather than blocking the whole migration.
+        dropped = False
         if product.recurring_interval is None:
             yield PrecheckIssue(
                 level=PrecheckIssueLevel.warning,
@@ -230,6 +231,7 @@ class PrecheckEngine:
                 ),
                 source_id=product.source_id,
             )
+            dropped = True
         elif (
             product.recurring_interval not in SUPPORTED_INTERVALS
             or not 1 <= product.recurring_interval_count <= MAX_INTERVAL_COUNT
@@ -245,12 +247,16 @@ class PrecheckEngine:
                 ),
                 source_id=product.source_id,
             )
+            dropped = True
         importable_currencies: Counter[str] = Counter()
         for price in product.prices:
             price_issues = list(self._check_price(product, price))
             yield from price_issues
             if not any(issue.code in PRICE_DROP_CODES for issue in price_issues):
                 importable_currencies[price.currency.lower()] += 1
+        # Only worth reporting on a product that would otherwise import.
+        if dropped:
+            return
         for currency, count in importable_currencies.items():
             if count > 1:
                 yield PrecheckIssue(
@@ -761,6 +767,18 @@ class SplitRecords:
             elif isinstance(record, CanonicalSubscription):
                 split.subscriptions.append(record)
         return split
+
+
+def import_blockers(
+    organization: Organization, source_account: CanonicalAccount
+) -> list[PrecheckIssue]:
+    """Blockers that don't depend on the catalog, so the import can re-check them
+    without re-reading the whole source."""
+    issues = [
+        *precheck_engine._check_organization(organization),
+        *precheck_engine._check_account(source_account),
+    ]
+    return [issue for issue in issues if issue.level == PrecheckIssueLevel.blocker]
 
 
 def classify_records(

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -55,7 +55,11 @@ NON_IMPORTABLE_STATUSES = {
 
 # Codes whose warning means a record won't import, by entity. Keep in sync with
 # the `_check_*` methods so classification matches the report.
-PRODUCT_DROP_CODES = {"one_time_product", "unsupported_recurring_interval"}
+PRODUCT_DROP_CODES = {
+    "one_time_product",
+    "unsupported_recurring_interval",
+    "multiple_prices_same_currency",
+}
 PRICE_DROP_CODES = {
     "unsupported_pricing_scheme",
     "unsupported_price_amount",
@@ -76,6 +80,7 @@ ACTION_REQUIRED_CODES = {
     "customer_missing_country",
     "customer_missing_email",
     "duplicate_customer_email",
+    "multiple_prices_same_currency",
     "subscription_has_discount",
     "send_invoice_collection",
 }
@@ -240,8 +245,24 @@ class PrecheckEngine:
                 ),
                 source_id=product.source_id,
             )
+        importable_currencies: Counter[str] = Counter()
         for price in product.prices:
-            yield from self._check_price(product, price)
+            price_issues = list(self._check_price(product, price))
+            yield from price_issues
+            if not any(issue.code in PRICE_DROP_CODES for issue in price_issues):
+                importable_currencies[price.currency.lower()] += 1
+        for currency, count in importable_currencies.items():
+            if count > 1:
+                yield PrecheckIssue(
+                    level=PrecheckIssueLevel.warning,
+                    code="multiple_prices_same_currency",
+                    message=(
+                        f"Product '{product.name}' has {count} prices in "
+                        f"{currency.upper()}; Polar allows one per currency, so it "
+                        "and its subscriptions won't be imported."
+                    ),
+                    source_id=product.source_id,
+                )
 
     def _check_price(
         self, product: CanonicalProduct, price: CanonicalPrice

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -487,23 +487,45 @@ def _interval_label(product: CanonicalProduct) -> str:
     return f"Every {count} {product.recurring_interval}s"
 
 
-def _drop_reason(
-    issues: Iterable[PrecheckIssue], codes: set[str]
-) -> tuple[str | None, str | None]:
+@dataclass(frozen=True)
+class Reason:
+    """Why a record is skipped, or what to know about one that isn't."""
+
+    code: str
+    message: str
+
+    @property
+    def level(self) -> PrecheckReasonLevel:
+        if self.code in ACTION_REQUIRED_CODES:
+            return PrecheckReasonLevel.action_required
+        return PrecheckReasonLevel.info
+
+
+@dataclass(frozen=True)
+class PriceDisplay:
+    """The price shown on a priced review row."""
+
+    amount: int | None = None
+    currency: str | None = None
+    recurring_interval: str | None = None
+
+    @classmethod
+    def of(cls, product: CanonicalProduct, price: CanonicalPrice) -> "PriceDisplay":
+        return cls(price.amount, price.currency, product.recurring_interval)
+
+
+def _drop_reason(issues: Iterable[PrecheckIssue], codes: set[str]) -> Reason | None:
     for issue in issues:
         if issue.code in codes:
-            return issue.code, issue.message
-    return None, None
-
-
-Reason = tuple[str, str]
+            return Reason(issue.code, issue.message)
+    return None
 
 
 def _pick_note(*notes: Reason | None) -> Reason | None:
     """The one note to show on an importable row, worth-acting-on first."""
     present = [note for note in notes if note is not None]
     for note in present:
-        if note[0] in ACTION_REQUIRED_CODES:
+        if note.level == PrecheckReasonLevel.action_required:
             return note
     return present[0] if present else None
 
@@ -516,13 +538,12 @@ def _item(
     *,
     skip: Reason | None,
     note: Reason | None = None,
-    amount: int | None = None,
-    currency: str | None = None,
-    recurring_interval: str | None = None,
+    price: PriceDisplay | None = None,
 ) -> MerchantMigrationRecordItem:
     """One review row. ``skip`` means it won't import; ``note`` only annotates a
     row that will."""
-    code, reason = skip or note or (None, None)
+    reason = skip or note
+    price = price or PriceDisplay()
     return MerchantMigrationRecordItem(
         # record_id and import_status come from the ledger via
         # `_attach_record_ids`; the classifier itself has none.
@@ -532,54 +553,38 @@ def _item(
         source_id=source_id,
         title=title,
         subtitle=subtitle,
-        amount=amount,
-        currency=currency,
-        recurring_interval=recurring_interval,
+        amount=price.amount,
+        currency=price.currency,
+        recurring_interval=price.recurring_interval,
         status=(
             PrecheckRecordStatus.skipped if skip else PrecheckRecordStatus.importable
         ),
-        reason=reason,
-        reason_code=code,
-        reason_level=_reason_level(code),
+        reason=reason.message if reason else None,
+        reason_code=reason.code if reason else None,
+        reason_level=reason.level if reason else None,
     )
 
 
-def _reason_level(code: str | None) -> PrecheckReasonLevel | None:
-    if code is None:
-        return None
-    if code in ACTION_REQUIRED_CODES:
-        return PrecheckReasonLevel.action_required
-    return PrecheckReasonLevel.info
-
-
-# The price shown on a priced row: (amount, currency, interval). A product is
-# represented by its first price; a subscription by the price it runs on.
-def _price_info(
+def _price_display_by_source_id(
     products: Sequence[CanonicalProduct],
-) -> dict[str, tuple[int | None, str, str | None]]:
-    info: dict[str, tuple[int | None, str, str | None]] = {}
-    for product in products:
-        for price in product.prices:
-            info[price.source_id] = (
-                price.amount,
-                price.currency,
-                product.recurring_interval,
-            )
-    return info
+) -> dict[str, PriceDisplay]:
+    return {
+        price.source_id: PriceDisplay.of(product, price)
+        for product in products
+        for price in product.prices
+    }
 
 
 def _representative_price(
     product: CanonicalProduct, importable_price_ids: set[str]
-) -> tuple[int | None, str | None, str | None]:
+) -> PriceDisplay:
     """The price to show on a product row: one that will actually be imported,
     falling back to the first when the product is skipped."""
     price = next(
         (price for price in product.prices if price.source_id in importable_price_ids),
         product.prices[0] if product.prices else None,
     )
-    if price is None:
-        return None, None, None
-    return price.amount, price.currency, product.recurring_interval
+    return PriceDisplay.of(product, price) if price else PriceDisplay()
 
 
 def _duplicate_product_names(products: Sequence[CanonicalProduct]) -> set[str]:
@@ -593,13 +598,6 @@ def _duplicate_product_names(products: Sequence[CanonicalProduct]) -> set[str]:
             product.product_source_id
         )
     return {name for name, ids in source_ids_by_name.items() if len(ids) > 1}
-
-
-def _product_drop(product: CanonicalProduct) -> Reason | None:
-    code, reason = _drop_reason(
-        precheck_engine._check_product(product), PRODUCT_DROP_CODES
-    )
-    return (code, reason) if code is not None and reason is not None else None
 
 
 def _duplicate_customer_source_ids(
@@ -627,15 +625,12 @@ def _product_items(
     items: list[MerchantMigrationRecordItem] = []
     for product in products:
         plan = plans[product.source_id]
-        amount, currency, interval = _representative_price(
-            product, plan.importable_price_ids
-        )
         # Sharing a name is allowed in Polar, so it only earns a note.
         note = _pick_note(
-            ("duplicate_product_name", _DUPLICATE_PRODUCT_NAME_REASON)
+            Reason("duplicate_product_name", _DUPLICATE_PRODUCT_NAME_REASON)
             if product.name in duplicate_names
             else None,
-            ("product_exists_in_polar", _EXISTING_PRODUCT_NAME_REASON)
+            Reason("product_exists_in_polar", _EXISTING_PRODUCT_NAME_REASON)
             if product.name.lower() in existing_product_names
             else None,
         )
@@ -647,9 +642,7 @@ def _product_items(
                 _interval_label(product),
                 skip=plan.skip,
                 note=note,
-                amount=amount,
-                currency=currency,
-                recurring_interval=interval,
+                price=_representative_price(product, plan.importable_price_ids),
             )
         )
     return items
@@ -661,14 +654,13 @@ def _price_items(
     items: list[MerchantMigrationRecordItem] = []
     for product in products:
         # A price under a product that won't import can't import either.
-        product_skip = _product_drop(product)
+        product_skip = _drop_reason(
+            precheck_engine._check_product(product), PRODUCT_DROP_CODES
+        )
         for price in product.prices:
-            skip = product_skip
-            if skip is None:
-                code, reason = _drop_reason(
-                    precheck_engine._check_price(product, price), PRICE_DROP_CODES
-                )
-                skip = (code, reason) if code and reason else None
+            skip = product_skip or _drop_reason(
+                precheck_engine._check_price(product, price), PRICE_DROP_CODES
+            )
             subtitle = (
                 "No amount"
                 if price.amount is None
@@ -681,9 +673,7 @@ def _price_items(
                     product.name,
                     subtitle,
                     skip=skip,
-                    amount=price.amount,
-                    currency=price.currency,
-                    recurring_interval=product.recurring_interval,
+                    price=PriceDisplay.of(product, price),
                 )
             )
     return items
@@ -698,7 +688,7 @@ def _customer_items(
     for customer in customers:
         # It imports either way, but without a country tax can't be computed.
         note = (
-            ("customer_missing_country", _MISSING_COUNTRY_REASON)
+            Reason("customer_missing_country", _MISSING_COUNTRY_REASON)
             if not customer.country
             else None
         )
@@ -723,59 +713,54 @@ def _subscription_items(
     # Use the importer's plan; the notes on top are display-only.
     plans = plan_subscription_imports(subscriptions, products, customers)
     email_by_source = {c.source_id: c.email for c in customers if c.email}
-    price_info = _price_info(products)
+    price_by_source = _price_display_by_source_id(products)
     items: list[MerchantMigrationRecordItem] = []
     for subscription in subscriptions:
         payment_method = subscription.payment_method
         note = _pick_note(
-            ("payment_method_requires_reentry", _PAYMENT_REENTRY_REASON)
+            Reason("payment_method_requires_reentry", _PAYMENT_REENTRY_REASON)
             if payment_method is not None and payment_method.type.requires_reentry
             else None,
-            ("subscription_trialing", _TRIALING_REASON)
+            Reason("subscription_trialing", _TRIALING_REASON)
             if subscription.trialing
             else None,
         )
         title = email_by_source.get(
             subscription.customer_source_id, subscription.customer_source_id
         )
-        subtitle = _humanize_subscription_status(subscription.status)
-        amount, currency, interval = price_info.get(
-            subscription.price_source_id, (None, None, None)
-        )
         items.append(
             _item(
                 PrecheckEntity.subscriptions,
                 subscription.source_id,
                 title,
-                subtitle,
+                _humanize_subscription_status(subscription.status),
                 skip=plans[subscription.source_id],
                 note=note,
-                amount=amount,
-                currency=currency,
-                recurring_interval=interval,
+                price=price_by_source.get(subscription.price_source_id),
             )
         )
     return items
 
 
-def _split_records(
-    records: Sequence[CanonicalRecord],
-) -> tuple[
-    list[CanonicalProduct],
-    list[CanonicalCustomer],
-    list[CanonicalSubscription],
-]:
-    products: list[CanonicalProduct] = []
-    customers: list[CanonicalCustomer] = []
-    subscriptions: list[CanonicalSubscription] = []
-    for record in records:
-        if isinstance(record, CanonicalProduct):
-            products.append(record)
-        elif isinstance(record, CanonicalCustomer):
-            customers.append(record)
-        elif isinstance(record, CanonicalSubscription):
-            subscriptions.append(record)
-    return products, customers, subscriptions
+@dataclass(frozen=True)
+class SplitRecords:
+    """The staged catalog grouped by entity."""
+
+    products: list[CanonicalProduct]
+    customers: list[CanonicalCustomer]
+    subscriptions: list[CanonicalSubscription]
+
+    @classmethod
+    def of(cls, records: Sequence[CanonicalRecord]) -> "SplitRecords":
+        split = cls([], [], [])
+        for record in records:
+            if isinstance(record, CanonicalProduct):
+                split.products.append(record)
+            elif isinstance(record, CanonicalCustomer):
+                split.customers.append(record)
+            elif isinstance(record, CanonicalSubscription):
+                split.subscriptions.append(record)
+        return split
 
 
 def classify_records(
@@ -785,14 +770,14 @@ def classify_records(
 ) -> list[MerchantMigrationRecordItem]:
     """Classify the source catalog into per-record rows of one entity type,
     each marked importable or skipped with a reason."""
-    products, customers, subscriptions = _split_records(records)
+    split = SplitRecords.of(records)
     if entity == PrecheckEntity.products:
-        return _product_items(products, existing_product_names or set())
+        return _product_items(split.products, existing_product_names or set())
     if entity == PrecheckEntity.prices:
-        return _price_items(products)
+        return _price_items(split.products)
     if entity == PrecheckEntity.customers:
-        return _customer_items(customers)
-    return _subscription_items(subscriptions, products, customers)
+        return _customer_items(split.customers)
+    return _subscription_items(split.subscriptions, split.products, split.customers)
 
 
 @dataclass
@@ -823,7 +808,7 @@ def plan_product_imports(
     """
     plans: dict[str, ProductImportPlan] = {}
     for product in products:
-        skip = _product_drop(product)
+        skip = _drop_reason(precheck_engine._check_product(product), PRODUCT_DROP_CODES)
         if skip is not None:
             plans[product.source_id] = ProductImportPlan(skip, set())
             continue
@@ -832,12 +817,12 @@ def plan_product_imports(
             for price in product.prices
             if _drop_reason(
                 precheck_engine._check_price(product, price), PRICE_DROP_CODES
-            )[0]
+            )
             is None
         }
         if not price_ids:
             plans[product.source_id] = ProductImportPlan(
-                ("no_importable_price", _NO_IMPORTABLE_PRICE_REASON), set()
+                Reason("no_importable_price", _NO_IMPORTABLE_PRICE_REASON), set()
             )
         else:
             plans[product.source_id] = ProductImportPlan(None, price_ids)
@@ -855,14 +840,12 @@ def plan_customer_imports(
     plans: dict[str, Reason | None] = {}
     for customer in customers:
         if customer.source_id in duplicates:
-            plans[customer.source_id] = (
-                "duplicate_customer_email",
-                _DUPLICATE_CUSTOMER_EMAIL_REASON,
+            plans[customer.source_id] = Reason(
+                "duplicate_customer_email", _DUPLICATE_CUSTOMER_EMAIL_REASON
             )
         elif not customer.email:
-            plans[customer.source_id] = (
-                "customer_missing_email",
-                _MISSING_EMAIL_REASON,
+            plans[customer.source_id] = Reason(
+                "customer_missing_email", _MISSING_EMAIL_REASON
             )
         else:
             plans[customer.source_id] = None
@@ -890,18 +873,18 @@ def plan_subscription_imports(
     }
     plans: dict[str, Reason | None] = {}
     for subscription in subscriptions:
-        code, reason = _drop_reason(
+        skip = _drop_reason(
             precheck_engine._check_subscription(subscription), SUBSCRIPTION_DROP_CODES
         )
-        skip: Reason | None = (code, reason) if code and reason else None
         if skip is None and subscription.price_source_id not in importable_prices:
-            skip = ("subscription_product_not_importable", _SUBSCRIPTION_PRODUCT_REASON)
+            skip = Reason(
+                "subscription_product_not_importable", _SUBSCRIPTION_PRODUCT_REASON
+            )
         elif (
             skip is None and subscription.customer_source_id not in importable_customers
         ):
-            skip = (
-                "subscription_customer_not_importable",
-                _SUBSCRIPTION_CUSTOMER_REASON,
+            skip = Reason(
+                "subscription_customer_not_importable", _SUBSCRIPTION_CUSTOMER_REASON
             )
         plans[subscription.source_id] = skip
     return plans

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -106,6 +106,41 @@ class MerchantMigrationRecordItem(Schema):
     )
 
 
+class MerchantMigrationImportRequest(Schema):
+    record_ids: list[UUID4] | None = Field(
+        default=None,
+        description=(
+            "The ledger record ids to import (from the records listing). When "
+            "omitted, every importable record is imported (subject to "
+            "`exclude_record_ids`). Records not selected stay pending."
+        ),
+    )
+    exclude_record_ids: list[UUID4] | None = Field(
+        default=None,
+        description=(
+            "Import every importable record except these — the opt-out selection "
+            "for large catalogs. Ignored when `record_ids` is set."
+        ),
+    )
+
+
+class MerchantMigrationImportResult(Schema):
+    entity: PrecheckEntity = Field(description="The source entity type.")
+    imported: int = Field(description="How many were created or reused in Polar.")
+    skipped: int = Field(
+        description="How many were left on the source (not importable)."
+    )
+
+
+class MerchantMigrationImportReport(Schema):
+    step: MerchantMigrationStep = Field(
+        description="The migration step after the import."
+    )
+    results: list[MerchantMigrationImportResult] = Field(
+        description="Per-entity counts of what was imported vs skipped."
+    )
+
+
 class MerchantMigration(IDSchema, TimestampedSchema):
     organization_id: UUID4
     source_platform: MerchantMigrationSourcePlatform = Field(

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -121,6 +121,41 @@ class MerchantMigrationRecordItem(Schema):
     )
 
 
+class MerchantMigrationImportRequest(Schema):
+    record_ids: list[UUID4] | None = Field(
+        default=None,
+        description=(
+            "The ledger record ids to import (from the records listing). When "
+            "omitted, every importable record is imported (subject to "
+            "`exclude_record_ids`). Records not selected stay pending."
+        ),
+    )
+    exclude_record_ids: list[UUID4] | None = Field(
+        default=None,
+        description=(
+            "Import every importable record except these — the opt-out selection "
+            "for large catalogs. Ignored when `record_ids` is set."
+        ),
+    )
+
+
+class MerchantMigrationImportResult(Schema):
+    entity: PrecheckEntity = Field(description="The source entity type.")
+    imported: int = Field(description="How many were created or reused in Polar.")
+    skipped: int = Field(
+        description="How many were left on the source (not importable)."
+    )
+
+
+class MerchantMigrationImportReport(Schema):
+    step: MerchantMigrationStep = Field(
+        description="The migration step after the import."
+    )
+    results: list[MerchantMigrationImportResult] = Field(
+        description="Per-entity counts of what was imported vs skipped."
+    )
+
+
 class MerchantMigration(IDSchema, TimestampedSchema):
     organization_id: UUID4
     source_platform: MerchantMigrationSourcePlatform = Field(

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -24,6 +24,7 @@ from polar.product.repository import ProductRepository
 
 from .adapters import SourceAdapter, StripeAdapter
 from .canonical import CanonicalRecord, deserialize
+from .importer import CatalogImporter
 from .precheck import classify_records, precheck_engine
 from .repository import (
     MerchantMigrationRecordRepository,
@@ -31,11 +32,17 @@ from .repository import (
 )
 from .schemas import (
     MerchantMigrationCreate,
+    MerchantMigrationImportReport,
     MerchantMigrationRecordItem,
     PrecheckEntity,
     PrecheckRecordStatus,
     PrecheckReport,
 )
+
+IMPORTABLE_STEPS = {
+    MerchantMigrationStep.pre_check,
+    MerchantMigrationStep.create_catalog,
+}
 
 # Entities whose records map 1:1 to a ledger row, so a listing item can carry its
 # record id for selection. Prices live inside a product record and are excluded.
@@ -113,6 +120,14 @@ class SourceVerificationUnavailable(MerchantMigrationError):
         super().__init__(
             "We couldn't verify the Stripe key right now. Please try again.",
             502,
+        )
+
+
+class CatalogImportNotReady(MerchantMigrationError):
+    def __init__(self) -> None:
+        super().__init__(
+            "Run the pre-check before importing the catalog.",
+            409,
         )
 
 
@@ -224,7 +239,9 @@ class MerchantMigrationService:
         """Read the connected source, normalize it, and report whether it can be
         imported. Advances the migration from source setup to the precheck step.
         """
-        migration = await self._get_manageable(session, auth_subject, migration_id)
+        migration = await self._get_manageable(
+            session, auth_subject, migration_id, for_update=True
+        )
 
         organization = await OrganizationRepository.from_session(session).get_by_id(
             migration.organization_id
@@ -247,10 +264,57 @@ class MerchantMigrationService:
             existing_product_names,
         )
 
+        # Only advance from source setup: re-running precheck later (to refresh the
+        # ledger) must not regress a migration that has already moved on.
+        if migration.step == MerchantMigrationStep.source_setup:
+            repository = MerchantMigrationRepository.from_session(session)
+            await repository.update(
+                migration, update_dict={"step": MerchantMigrationStep.pre_check}
+            )
+        return report
+
+    async def import_catalog(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        migration_id: UUID,
+        *,
+        record_ids: Sequence[UUID] | None = None,
+        exclude_record_ids: Sequence[UUID] | None = None,
+    ) -> MerchantMigrationImportReport:
+        """Create the Polar catalog from the staged importable records, then
+        advance the migration to the create-catalog step. Import a subset via
+        ``record_ids`` (only those), or everything except ``exclude_record_ids``
+        (the opt-out default); otherwise everything importable. Idempotent:
+        re-running only imports records still pending in the ledger.
+        """
+        migration = await self._get_manageable(
+            session, auth_subject, migration_id, for_update=True
+        )
+        if migration.step not in IMPORTABLE_STEPS:
+            raise CatalogImportNotReady()
+
+        organization = await OrganizationRepository.from_session(session).get_by_id(
+            migration.organization_id
+        )
+        if organization is None:
+            raise MerchantMigrationNotFound()
+
+        report = await CatalogImporter(
+            session,
+            migration,
+            organization,
+            record_ids=set(record_ids) if record_ids is not None else None,
+            exclude_record_ids=(
+                set(exclude_record_ids) if exclude_record_ids is not None else None
+            ),
+        ).run()
+
         repository = MerchantMigrationRepository.from_session(session)
         await repository.update(
-            migration, update_dict={"step": MerchantMigrationStep.pre_check}
+            migration, update_dict={"step": MerchantMigrationStep.create_catalog}
         )
+        report.step = MerchantMigrationStep.create_catalog
         return report
 
     async def _get_manageable(
@@ -258,11 +322,17 @@ class MerchantMigrationService:
         session: AsyncSession,
         auth_subject: AuthSubject[User | Organization],
         migration_id: UUID,
+        *,
+        for_update: bool = False,
     ) -> MerchantMigration:
         repository = MerchantMigrationRepository.from_session(session)
         statement = repository.get_readable_statement(auth_subject).where(
             MerchantMigration.id == migration_id
         )
+        if for_update:
+            # Serialize concurrent precheck/import for the same migration so a
+            # double-click or retry can't create duplicate Polar objects.
+            statement = statement.with_for_update(of=MerchantMigration)
         migration = await repository.get_one_or_none(statement)
         if migration is None:
             raise MerchantMigrationNotFound()

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -25,7 +25,7 @@ from polar.product.repository import ProductRepository
 from .adapters import SourceAdapter, StripeAdapter
 from .canonical import CanonicalRecord, deserialize
 from .importer import CatalogImporter
-from .precheck import classify_records, precheck_engine
+from .precheck import classify_records, import_blockers, precheck_engine
 from .repository import (
     MerchantMigrationRecordRepository,
     MerchantMigrationRepository,
@@ -35,6 +35,7 @@ from .schemas import (
     MerchantMigrationImportReport,
     MerchantMigrationRecordItem,
     PrecheckEntity,
+    PrecheckIssue,
     PrecheckReasonLevel,
     PrecheckRecordStatus,
     PrecheckReport,
@@ -128,6 +129,15 @@ class CatalogImportNotReady(MerchantMigrationError):
     def __init__(self) -> None:
         super().__init__(
             "Run the pre-check before importing the catalog.",
+            409,
+        )
+
+
+class CatalogImportBlocked(MerchantMigrationError):
+    def __init__(self, blockers: list[PrecheckIssue]) -> None:
+        self.blockers = [issue.code for issue in blockers]
+        super().__init__(
+            "The migration can't be imported: " + " ".join(i.message for i in blockers),
             409,
         )
 
@@ -297,6 +307,13 @@ class MerchantMigrationService:
         )
         if organization is None:
             raise MerchantMigrationNotFound()
+
+        # The pre-check reports blockers but doesn't stop the import, and both the
+        # org and the source account can change after it ran.
+        adapter = await self._build_adapter(migration)
+        blockers = import_blockers(organization, await adapter.get_source_account())
+        if blockers:
+            raise CatalogImportBlocked(blockers)
 
         report = await CatalogImporter(
             session,

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -305,6 +305,7 @@ class MerchantMigrationService:
             session,
             migration,
             organization,
+            auth_subject,
             record_ids=set(record_ids) if record_ids is not None else None,
             exclude_record_ids=(
                 set(exclude_record_ids) if exclude_record_ids is not None else None

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -24,6 +24,7 @@ from polar.product.repository import ProductRepository
 
 from .adapters import SourceAdapter, StripeAdapter
 from .canonical import CanonicalRecord, deserialize
+from .importer import CatalogImporter
 from .precheck import classify_records, precheck_engine
 from .repository import (
     MerchantMigrationRecordRepository,
@@ -31,12 +32,18 @@ from .repository import (
 )
 from .schemas import (
     MerchantMigrationCreate,
+    MerchantMigrationImportReport,
     MerchantMigrationRecordItem,
     PrecheckEntity,
     PrecheckReasonLevel,
     PrecheckRecordStatus,
     PrecheckReport,
 )
+
+IMPORTABLE_STEPS = {
+    MerchantMigrationStep.pre_check,
+    MerchantMigrationStep.create_catalog,
+}
 
 # Entities whose records map 1:1 to a ledger row, so a listing item can carry its
 # record id for selection. Prices live inside a product record and are excluded.
@@ -114,6 +121,14 @@ class SourceVerificationUnavailable(MerchantMigrationError):
         super().__init__(
             "We couldn't verify the Stripe key right now. Please try again.",
             502,
+        )
+
+
+class CatalogImportNotReady(MerchantMigrationError):
+    def __init__(self) -> None:
+        super().__init__(
+            "Run the pre-check before importing the catalog.",
+            409,
         )
 
 
@@ -225,7 +240,9 @@ class MerchantMigrationService:
         """Read the connected source, normalize it, and report whether it can be
         imported. Advances the migration from source setup to the precheck step.
         """
-        migration = await self._get_manageable(session, auth_subject, migration_id)
+        migration = await self._get_manageable(
+            session, auth_subject, migration_id, for_update=True
+        )
 
         organization = await OrganizationRepository.from_session(session).get_by_id(
             migration.organization_id
@@ -248,10 +265,57 @@ class MerchantMigrationService:
             existing_product_names,
         )
 
+        # Only advance from source setup: re-running precheck later (to refresh the
+        # ledger) must not regress a migration that has already moved on.
+        if migration.step == MerchantMigrationStep.source_setup:
+            repository = MerchantMigrationRepository.from_session(session)
+            await repository.update(
+                migration, update_dict={"step": MerchantMigrationStep.pre_check}
+            )
+        return report
+
+    async def import_catalog(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        migration_id: UUID,
+        *,
+        record_ids: Sequence[UUID] | None = None,
+        exclude_record_ids: Sequence[UUID] | None = None,
+    ) -> MerchantMigrationImportReport:
+        """Create the Polar catalog from the staged importable records, then
+        advance the migration to the create-catalog step. Import a subset via
+        ``record_ids`` (only those), or everything except ``exclude_record_ids``
+        (the opt-out default); otherwise everything importable. Idempotent:
+        re-running only imports records still pending in the ledger.
+        """
+        migration = await self._get_manageable(
+            session, auth_subject, migration_id, for_update=True
+        )
+        if migration.step not in IMPORTABLE_STEPS:
+            raise CatalogImportNotReady()
+
+        organization = await OrganizationRepository.from_session(session).get_by_id(
+            migration.organization_id
+        )
+        if organization is None:
+            raise MerchantMigrationNotFound()
+
+        report = await CatalogImporter(
+            session,
+            migration,
+            organization,
+            record_ids=set(record_ids) if record_ids is not None else None,
+            exclude_record_ids=(
+                set(exclude_record_ids) if exclude_record_ids is not None else None
+            ),
+        ).run()
+
         repository = MerchantMigrationRepository.from_session(session)
         await repository.update(
-            migration, update_dict={"step": MerchantMigrationStep.pre_check}
+            migration, update_dict={"step": MerchantMigrationStep.create_catalog}
         )
+        report.step = MerchantMigrationStep.create_catalog
         return report
 
     async def _get_manageable(
@@ -259,11 +323,17 @@ class MerchantMigrationService:
         session: AsyncSession,
         auth_subject: AuthSubject[User | Organization],
         migration_id: UUID,
+        *,
+        for_update: bool = False,
     ) -> MerchantMigration:
         repository = MerchantMigrationRepository.from_session(session)
         statement = repository.get_readable_statement(auth_subject).where(
             MerchantMigration.id == migration_id
         )
+        if for_update:
+            # Serialize concurrent precheck/import for the same migration so a
+            # double-click or retry can't create duplicate Polar objects.
+            statement = statement.with_for_update(of=MerchantMigration)
         migration = await repository.get_one_or_none(statement)
         if migration is None:
             raise MerchantMigrationNotFound()

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -265,8 +265,8 @@ class MerchantMigrationService:
             existing_product_names,
         )
 
-        # Only advance from source setup: re-running precheck later (to refresh the
-        # ledger) must not regress a migration that has already moved on.
+        # Re-running the precheck to refresh the ledger must not regress a
+        # migration that has already moved on.
         if migration.step == MerchantMigrationStep.source_setup:
             repository = MerchantMigrationRepository.from_session(session)
             await repository.update(
@@ -284,11 +284,8 @@ class MerchantMigrationService:
         exclude_record_ids: Sequence[UUID] | None = None,
     ) -> MerchantMigrationImportReport:
         """Create the Polar catalog from the staged importable records, then
-        advance the migration to the create-catalog step. Import a subset via
-        ``record_ids`` (only those), or everything except ``exclude_record_ids``
-        (the opt-out default); otherwise everything importable. Idempotent:
-        re-running only imports records still pending in the ledger.
-        """
+        advance the migration to the create-catalog step. Idempotent: re-running
+        only imports records still pending in the ledger."""
         migration = await self._get_manageable(
             session, auth_subject, migration_id, for_update=True
         )
@@ -332,8 +329,7 @@ class MerchantMigrationService:
             MerchantMigration.id == migration_id
         )
         if for_update:
-            # Serialize concurrent precheck/import for the same migration so a
-            # double-click or retry can't create duplicate Polar objects.
+            # Serialized so a double-click or retry can't create duplicates.
             statement = statement.with_for_update(of=MerchantMigration)
         migration = await repository.get_one_or_none(statement)
         if migration is None:

--- a/server/polar/product/service.py
+++ b/server/polar/product/service.py
@@ -171,7 +171,12 @@ class ProductService:
         session: AsyncSession,
         create_schema: ProductCreate,
         auth_subject: AuthSubject[User | Organization],
+        *,
+        notify: bool = True,
     ) -> Product:
+        """Create a product. ``notify=False`` skips the webhook and the
+        organization re-review, for bulk internal writes such as a catalog
+        import."""
         repository = ProductRepository.from_session(session)
         organization = await get_payload_organization(
             session, auth_subject, create_schema
@@ -262,7 +267,8 @@ class ProductService:
 
         await session.flush()
 
-        await self._after_product_created(session, auth_subject, product)
+        if notify:
+            await self._after_product_created(session, auth_subject, product)
 
         return product
 

--- a/server/polar/product/service.py
+++ b/server/polar/product/service.py
@@ -174,9 +174,8 @@ class ProductService:
         *,
         notify: bool = True,
     ) -> Product:
-        """Create a product. ``notify=False`` skips the webhook and the
-        organization re-review, for bulk internal writes such as a catalog
-        import."""
+        """``notify=False`` skips the webhook and the organization re-review, for
+        bulk internal writes such as a catalog import."""
         repository = ProductRepository.from_session(session)
         organization = await get_payload_organization(
             session, auth_subject, create_schema

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -137,6 +137,29 @@ class SubscriptionRepository(
         result = await self.session.execute(statement)
         return result.scalars().all()
 
+    async def exists_live_by_customer_and_product(
+        self, customer_id: UUID, product_id: UUID
+    ) -> bool:
+        # "Live" = could still bill: not canceled/unpaid/incomplete, not ended.
+        # Used to avoid importing a duplicate subscription.
+        dead_statuses = (
+            SubscriptionStatus.revoked_statuses()
+            | SubscriptionStatus.incomplete_statuses()
+        )
+        statement = (
+            select(Subscription.id)
+            .where(
+                Subscription.customer_id == customer_id,
+                Subscription.product_id == product_id,
+                Subscription.status.not_in(dead_statuses),
+                Subscription.ended_at.is_(None),
+                Subscription.is_deleted.is_(False),
+            )
+            .limit(1)
+        )
+        result = await self.session.execute(statement)
+        return result.first() is not None
+
     async def get_churn_breakdown(
         self,
         organization_id: UUID,

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -156,7 +156,6 @@ class SubscriptionRepository(
         self, customer_id: UUID, product_id: UUID
     ) -> bool:
         # "Live" = could still bill: not canceled/unpaid/incomplete, not ended.
-        # Used to avoid importing a duplicate subscription.
         dead_statuses = (
             SubscriptionStatus.revoked_statuses()
             | SubscriptionStatus.incomplete_statuses()

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -152,6 +152,29 @@ class SubscriptionRepository(
         result = await self.session.execute(statement)
         return result.scalars().all()
 
+    async def exists_live_by_customer_and_product(
+        self, customer_id: UUID, product_id: UUID
+    ) -> bool:
+        # "Live" = could still bill: not canceled/unpaid/incomplete, not ended.
+        # Used to avoid importing a duplicate subscription.
+        dead_statuses = (
+            SubscriptionStatus.revoked_statuses()
+            | SubscriptionStatus.incomplete_statuses()
+        )
+        statement = (
+            select(Subscription.id)
+            .where(
+                Subscription.customer_id == customer_id,
+                Subscription.product_id == product_id,
+                Subscription.status.not_in(dead_statuses),
+                Subscription.ended_at.is_(None),
+                Subscription.is_deleted.is_(False),
+            )
+            .limit(1)
+        )
+        result = await self.session.execute(statement)
+        return result.first() is not None
+
     async def get_churn_breakdown(
         self,
         organization_id: UUID,

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -673,13 +673,8 @@ class SubscriptionService:
         current_period_end: datetime | None,
         user_metadata: dict[str, Any],
     ) -> Subscription:
-        """Create a subscription migrated from another provider.
-
-        It starts paused so the renewal scheduler skips it and the customer isn't
-        charged until the merchant cuts over. No benefits are granted and no
-        webhook fires: the subscription already exists for the customer, it is
-        only moving to Polar.
-        """
+        """Create a subscription migrated from another provider. It starts paused
+        so nothing bills until the merchant cuts over, and grants no benefits."""
         assert product.recurring_interval is not None
         recurring_interval = product.recurring_interval
         recurring_interval_count = product.recurring_interval_count or 1

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -89,7 +89,11 @@ from polar.models import (
 )
 from polar.models.billing_entry import BillingEntryDirection, BillingEntryType
 from polar.models.order import OrderBillingReasonInternal
-from polar.models.product_price import ProductPrice, ProductPriceSeatUnit
+from polar.models.product_price import (
+    ProductPrice,
+    ProductPriceFixed,
+    ProductPriceSeatUnit,
+)
 from polar.models.subscription import CustomerCancellationReason, SubscriptionStatus
 from polar.models.webhook_endpoint import WebhookEventType
 from polar.notifications.notification import (
@@ -657,6 +661,57 @@ class SubscriptionService:
         await self.enqueue_benefits_grants(session, subscription)
 
         return subscription
+
+    async def create_imported(
+        self,
+        session: AsyncSession,
+        *,
+        product: Product,
+        price: ProductPriceFixed,
+        customer: Customer,
+        current_period_start: datetime | None,
+        current_period_end: datetime | None,
+        user_metadata: dict[str, Any],
+    ) -> Subscription:
+        """Create a subscription migrated from another provider.
+
+        It starts paused so the renewal scheduler skips it and the customer isn't
+        charged until the merchant cuts over. No benefits are granted and no
+        webhook fires: the subscription already exists for the customer, it is
+        only moving to Polar.
+        """
+        assert product.recurring_interval is not None
+        recurring_interval = product.recurring_interval
+        recurring_interval_count = product.recurring_interval_count or 1
+        start = current_period_start or utc_now()
+        end = current_period_end or recurring_interval.get_next_period(
+            start, start.day, recurring_interval_count
+        )
+
+        subscription = Subscription(
+            status=SubscriptionStatus.paused,
+            paused_at=utc_now(),
+            started_at=start,
+            anchor_day=start.day,
+            current_period_start=start,
+            current_period_end=end,
+            cancel_at_period_end=False,
+            recurring_interval=recurring_interval,
+            recurring_interval_count=recurring_interval_count,
+            meter_interval=product.meter_interval,
+            meter_interval_count=product.meter_interval_count,
+            organization=product.organization,
+            product=product,
+            customer=customer,
+            subscription_product_prices=[SubscriptionProductPrice.from_price(price)],
+            currency=price.price_currency,
+            user_metadata=user_metadata,
+            pending_update=None,
+        )
+        subscription.initialize_meter_period(start)
+
+        repository = SubscriptionRepository.from_session(session)
+        return await repository.create(subscription, flush=True)
 
     async def create_or_update_from_checkout(
         self,

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -679,8 +679,15 @@ class SubscriptionService:
         recurring_interval = product.recurring_interval
         recurring_interval_count = product.recurring_interval_count or 1
         start = current_period_start or utc_now()
-        end = current_period_end or recurring_interval.get_next_period(
+        next_period = recurring_interval.get_next_period(
             start, start.day, recurring_interval_count
+        )
+        # A source end that predates the start would invert the period, which
+        # would then feed the renewal maths at cutover.
+        end = (
+            current_period_end
+            if current_period_end and current_period_end > start
+            else next_period
         )
 
         subscription = Subscription(

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -8,6 +8,7 @@ from pytest_mock import MockerFixture
 from polar.auth.scope import Scope
 from polar.merchant_migration.canonical import (
     CanonicalAccount,
+    CanonicalCustomer,
     CanonicalPrice,
     CanonicalPricingScheme,
     CanonicalProduct,
@@ -357,6 +358,110 @@ class TestRecords:
         assert json_body["pagination"]["total_count"] == 1
         assert json_body["items"][0]["source_id"] == "prod_1"
         assert json_body["items"][0]["status"] == "importable"
+
+
+async def _catalog_with_customer_extract() -> AsyncIterator[CanonicalRecord]:
+    async for record in _catalog_extract():
+        yield record
+    yield CanonicalCustomer(
+        source_id="cus_1",
+        email="alice@example.com",
+        name="Alice",
+        country="US",
+    )
+
+
+@pytest.mark.asyncio
+class TestImport:
+    async def test_anonymous(
+        self, client: AsyncClient, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        migration = await _create_migration(save_fixture, organization)
+        response = await client.post(f"/v1/merchant-migrations/{migration.id}/import")
+        assert response.status_code == 401
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_precheck_required_returns_409(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        response = await client.post(f"/v1/merchant-migrations/{migration.id}/import")
+        assert response.status_code == 409
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_imports_catalog(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        adapter = mocker.MagicMock()
+        adapter.extract.return_value = _catalog_with_customer_extract()
+        adapter.get_source_account = mocker.AsyncMock(
+            return_value=CanonicalAccount(country="US", is_connect_platform=False)
+        )
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
+        )
+
+        precheck = await client.post(f"/v1/merchant-migrations/{migration.id}/precheck")
+        assert precheck.status_code == 200
+
+        response = await client.post(f"/v1/merchant-migrations/{migration.id}/import")
+        assert response.status_code == 200
+        json_body = response.json()
+        assert json_body["step"] == "create_catalog"
+        results = {result["entity"]: result for result in json_body["results"]}
+        assert results["products"]["imported"] == 1
+        assert results["customers"]["imported"] == 1
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_imports_only_selected_records(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        adapter = mocker.MagicMock()
+        adapter.extract.return_value = _catalog_with_customer_extract()
+        adapter.get_source_account = mocker.AsyncMock(
+            return_value=CanonicalAccount(country="US", is_connect_platform=False)
+        )
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
+        )
+
+        assert (
+            await client.post(f"/v1/merchant-migrations/{migration.id}/precheck")
+        ).status_code == 200
+
+        # pick the customer row's ledger id from the records listing
+        records = await client.get(
+            f"/v1/merchant-migrations/{migration.id}/records",
+            params={"entity": "customers"},
+        )
+        customer_record_id = records.json()["items"][0]["record_id"]
+        assert customer_record_id is not None
+
+        response = await client.post(
+            f"/v1/merchant-migrations/{migration.id}/import",
+            json={"record_ids": [customer_record_id]},
+        )
+        assert response.status_code == 200
+        results = {r["entity"]: r for r in response.json()["results"]}
+        # only the customer was selected; the product stays pending
+        assert results["customers"]["imported"] == 1
+        assert results["products"]["imported"] == 0
 
 
 async def _create_migration(

--- a/server/tests/merchant_migration/test_precheck.py
+++ b/server/tests/merchant_migration/test_precheck.py
@@ -488,6 +488,57 @@ class TestClassifyRecords:
         assert items[0].status == PrecheckRecordStatus.skipped
         assert items[0].reason_level == PrecheckReasonLevel.action_required
 
+    def test_two_prices_in_one_currency_skip_the_product(self) -> None:
+        records: list[CanonicalRecord] = [
+            build_product(
+                product_source_id="prod_1",
+                prices=[
+                    build_price(source_id="price_old", amount=1000),
+                    build_price(source_id="price_new", amount=1200),
+                ],
+            )
+        ]
+
+        items = classify_records(records, PrecheckEntity.products)
+
+        assert items[0].status == PrecheckRecordStatus.skipped
+        assert items[0].reason_code == "multiple_prices_same_currency"
+        assert items[0].reason_level == PrecheckReasonLevel.action_required
+
+    def test_one_price_per_currency_imports(self) -> None:
+        records: list[CanonicalRecord] = [
+            build_product(
+                product_source_id="prod_1",
+                prices=[
+                    build_price(source_id="price_usd", currency="usd"),
+                    build_price(source_id="price_eur", currency="eur"),
+                ],
+            )
+        ]
+
+        items = classify_records(records, PrecheckEntity.products)
+
+        assert items[0].status == PrecheckRecordStatus.importable
+
+    def test_a_dropped_price_does_not_count_as_a_collision(self) -> None:
+        records: list[CanonicalRecord] = [
+            build_product(
+                product_source_id="prod_1",
+                prices=[
+                    build_price(source_id="price_ok", amount=1000),
+                    build_price(
+                        source_id="price_tiered",
+                        amount=1200,
+                        pricing_scheme=CanonicalPricingScheme.tiered,
+                    ),
+                ],
+            )
+        ]
+
+        items = classify_records(records, PrecheckEntity.products)
+
+        assert items[0].status == PrecheckRecordStatus.importable
+
     def test_product_row_shows_a_price_that_will_import(self) -> None:
         records: list[CanonicalRecord] = [
             build_product(

--- a/server/tests/merchant_migration/test_precheck.py
+++ b/server/tests/merchant_migration/test_precheck.py
@@ -810,7 +810,7 @@ class TestPlanProductImports:
 
         assert plan.importable is False
         assert plan.skip is not None
-        assert plan.skip[0] == "one_time_product"
+        assert plan.skip.code == "one_time_product"
 
     def test_drops_unsupported_prices_but_keeps_the_rest(self) -> None:
         product = build_product(
@@ -842,7 +842,7 @@ class TestPlanProductImports:
 
         assert plan.importable is False
         assert plan.skip is not None
-        assert plan.skip[0] == "no_importable_price"
+        assert plan.skip.code == "no_importable_price"
 
     def test_products_sharing_a_name_both_import(self) -> None:
         first = build_product(source_id="prod_1:month:1", product_source_id="prod_1")
@@ -869,7 +869,7 @@ class TestPlanCustomerImports:
 
         assert plans["cus_1"] is None
         assert skip is not None
-        assert skip[0] == "duplicate_customer_email"
+        assert skip.code == "duplicate_customer_email"
 
     def test_customer_without_email_is_skipped(self) -> None:
         customer = build_customer(source_id="cus_1", email="")
@@ -877,4 +877,4 @@ class TestPlanCustomerImports:
         skip = plan_customer_imports([customer])["cus_1"]
 
         assert skip is not None
-        assert skip[0] == "customer_missing_email"
+        assert skip.code == "customer_missing_email"

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -3,19 +3,26 @@ from collections.abc import AsyncIterator
 import pytest
 import stripe as stripe_lib
 from pytest_mock import MockerFixture
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
 
 from polar.auth.models import AuthSubject
 from polar.config import settings
+from polar.customer.repository import CustomerRepository
+from polar.customer.service import customer as customer_service
 from polar.kit import encryption
 from polar.kit.encryption import LocalKeyProvider
 from polar.kit.pagination import PaginationParams
 from polar.merchant_migration.canonical import (
     CanonicalAccount,
+    CanonicalCollectionMethod,
     CanonicalCustomer,
     CanonicalPrice,
     CanonicalPricingScheme,
     CanonicalProduct,
     CanonicalRecord,
+    CanonicalSubscription,
+    CanonicalSubscriptionStatus,
 )
 from polar.merchant_migration.repository import (
     MerchantMigrationRecordRepository,
@@ -27,6 +34,7 @@ from polar.merchant_migration.schemas import (
     PrecheckRecordStatus,
 )
 from polar.merchant_migration.service import (
+    CatalogImportNotReady,
     InvalidSourceCredentials,
     MissingStripeScopes,
     SourceKeyModeMismatch,
@@ -36,9 +44,11 @@ from polar.merchant_migration.service import (
 )
 from polar.merchant_migration.service import merchant_migration as service
 from polar.models import (
+    Customer,
     MerchantMigration,
     Organization,
     Product,
+    Subscription,
     User,
     UserOrganization,
 )
@@ -51,6 +61,7 @@ from polar.models.merchant_migration_record import (
     MerchantMigrationRecordType,
 )
 from polar.models.product_price import ProductPriceFixed
+from polar.models.subscription import SubscriptionStatus
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
 from tests.merchant_migration._helpers import build_connected_migration
@@ -577,3 +588,538 @@ async def _staged_migration(
     )
     await service.run_precheck(session, auth_subject, migration.id)
     return migration
+
+
+def _catalog_with_subscription() -> list[CanonicalRecord]:
+    """The importable catalog plus an active subscription on the Pro price."""
+    return [
+        *_importable_catalog(),
+        CanonicalSubscription(
+            source_id="sub_1",
+            customer_source_id="cus_1",
+            price_source_id="price_1",
+            status=CanonicalSubscriptionStatus.active,
+            collection_method=CanonicalCollectionMethod.charge_automatically,
+            current_period_start=None,
+            current_period_end=None,
+            trialing=False,
+            paused_collection=False,
+            line_item_count=1,
+            quantity=1,
+            payment_method=None,
+        ),
+    ]
+
+
+async def _products(session: AsyncSession, organization: Organization) -> list[Product]:
+    result = await session.execute(
+        select(Product)
+        .where(Product.organization_id == organization.id)
+        .options(selectinload(Product.prices))
+    )
+    return list(result.scalars().unique().all())
+
+
+@pytest.mark.asyncio
+class TestImportCatalog:
+    @pytest.mark.auth
+    async def test_imports_catalog_and_advances_step(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+
+        report = await service.import_catalog(session, auth_subject, migration.id)
+
+        assert report.step == MerchantMigrationStep.create_catalog
+        results = {result.entity: result for result in report.results}
+        assert results[PrecheckEntity.products].imported == 1
+        assert results[PrecheckEntity.products].skipped == 1
+        assert results[PrecheckEntity.customers].imported == 1
+        assert results[PrecheckEntity.customers].skipped == 0
+
+        products = await _products(session, organization)
+        assert len(products) == 1
+        product = products[0]
+        assert product.name == "Pro"
+        assert product.recurring_interval == "month"
+        assert len(product.prices) == 1
+        price = product.prices[0]
+        assert isinstance(price, ProductPriceFixed)
+        assert price.price_amount == 1000
+        assert price.price_currency == "usd"
+
+        customer_repository = CustomerRepository.from_session(session)
+        customer = await customer_repository.get_by_email_and_organization(
+            "alice@example.com", organization.id
+        )
+        assert customer is not None
+        assert customer.stripe_customer_id == "cus_1"
+        assert customer.billing_address is not None
+        assert customer.billing_address.country == "US"
+
+        migration_repository = MerchantMigrationRepository.from_session(session)
+        updated = await migration_repository.get_by_id(migration.id)
+        assert updated is not None
+        assert updated.step == MerchantMigrationStep.create_catalog
+
+    @pytest.mark.auth
+    async def test_listing_reflects_import_status_after_import(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+        await service.import_catalog(session, auth_subject, migration.id)
+
+        items, _ = await service.list_records(
+            session,
+            auth_subject,
+            migration.id,
+            entity=PrecheckEntity.products,
+            status=None,
+            pagination=PaginationParams(page=1, limit=20),
+        )
+        by_source = {item.source_id: item for item in items}
+        # the imported product now reads as imported; the skipped one as skipped
+        assert by_source["prod_1"].import_status == (
+            MerchantMigrationRecordStatus.imported
+        )
+        assert by_source["prod_2"].import_status == (
+            MerchantMigrationRecordStatus.skipped
+        )
+
+    @pytest.mark.auth
+    async def test_imports_subscription_as_paused(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker,
+            session,
+            save_fixture,
+            auth_subject,
+            organization,
+            records=_catalog_with_subscription(),
+        )
+
+        report = await service.import_catalog(session, auth_subject, migration.id)
+
+        results = {result.entity: result for result in report.results}
+        assert results[PrecheckEntity.subscriptions].imported == 1
+
+        result = await session.execute(
+            select(Subscription)
+            .where(Subscription.organization_id == organization.id)
+            .options(selectinload(Subscription.customer))
+        )
+        subscription = result.scalars().unique().one()
+        # held from billing: paused is neither active nor billable, so the
+        # renewal scheduler skips it until cutover
+        assert subscription.status == SubscriptionStatus.paused
+        assert subscription.active is False
+        assert subscription.paused_at is not None
+        assert subscription.amount == 1000
+        assert subscription.currency == "usd"
+        assert subscription.customer.email == "alice@example.com"
+        assert subscription.user_metadata["stripe_subscription_id"] == "sub_1"
+
+    @pytest.mark.auth
+    async def test_subscription_skipped_when_its_product_is_excluded(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker,
+            session,
+            save_fixture,
+            auth_subject,
+            organization,
+            records=_catalog_with_subscription(),
+        )
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        product_record = await record_repository.get_by_source(
+            organization_id=organization.id,
+            type=MerchantMigrationRecordType.product,
+            source_id="prod_1:month:1",
+        )
+        assert product_record is not None
+
+        report = await service.import_catalog(
+            session,
+            auth_subject,
+            migration.id,
+            exclude_record_ids=[product_record.id],
+        )
+
+        results = {result.entity: result for result in report.results}
+        assert results[PrecheckEntity.subscriptions].imported == 0
+        assert results[PrecheckEntity.subscriptions].skipped == 1
+
+        # The subscription is skipped with a reason, not silently left pending.
+        subscription_record = await record_repository.get_by_source(
+            organization_id=organization.id,
+            type=MerchantMigrationRecordType.subscription,
+            source_id="sub_1",
+        )
+        assert subscription_record is not None
+        assert subscription_record.status == MerchantMigrationRecordStatus.skipped
+        assert subscription_record.error is not None
+        assert subscription_record.target_id is None
+
+    @pytest.mark.auth
+    async def test_second_subscription_to_same_product_is_skipped(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        # Two source subscriptions for the same customer on the same product must
+        # not become two Polar subscriptions, or cutover would double-bill.
+        catalog = _catalog_with_subscription()
+        catalog.append(
+            CanonicalSubscription(
+                source_id="sub_2",
+                customer_source_id="cus_1",
+                price_source_id="price_1",
+                status=CanonicalSubscriptionStatus.active,
+                collection_method=CanonicalCollectionMethod.charge_automatically,
+                current_period_start=None,
+                current_period_end=None,
+                trialing=False,
+                paused_collection=False,
+                line_item_count=1,
+                quantity=1,
+                payment_method=None,
+            )
+        )
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization, records=catalog
+        )
+
+        report = await service.import_catalog(session, auth_subject, migration.id)
+
+        results = {result.entity: result for result in report.results}
+        assert results[PrecheckEntity.subscriptions].imported == 1
+        assert results[PrecheckEntity.subscriptions].skipped == 1
+        result = await session.execute(
+            select(Subscription).where(Subscription.organization_id == organization.id)
+        )
+        assert len(result.scalars().unique().all()) == 1
+
+    @pytest.mark.auth
+    async def test_customer_skipped_on_stripe_id_conflict(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        # An existing Polar customer sharing the email but carrying a different
+        # Stripe id must not be reused, or the card would land on the wrong record.
+        await customer_service.create_for_organization(
+            session,
+            organization,
+            email="alice@example.com",
+            name="Alice",
+            billing_address=None,
+            stripe_customer_id="cus_existing",
+        )
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+
+        report = await service.import_catalog(session, auth_subject, migration.id)
+
+        results = {result.entity: result for result in report.results}
+        assert results[PrecheckEntity.customers].imported == 0
+        assert results[PrecheckEntity.customers].skipped == 1
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        customer_record = await record_repository.get_by_source(
+            organization_id=organization.id,
+            type=MerchantMigrationRecordType.customer,
+            source_id="cus_1",
+        )
+        assert customer_record is not None
+        assert customer_record.status == MerchantMigrationRecordStatus.skipped
+        assert customer_record.error is not None
+
+    @pytest.mark.auth
+    async def test_rerunning_precheck_does_not_regress_step(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+        await service.import_catalog(session, auth_subject, migration.id)
+
+        # Re-running precheck after import must not push the step back to pre_check.
+        await service.run_precheck(session, auth_subject, migration.id)
+
+        migration_repository = MerchantMigrationRepository.from_session(session)
+        updated = await migration_repository.get_by_id(migration.id)
+        assert updated is not None
+        assert updated.step == MerchantMigrationStep.create_catalog
+
+    @pytest.mark.auth
+    async def test_marks_records_in_the_ledger(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+
+        await service.import_catalog(session, auth_subject, migration.id)
+
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        imported = await record_repository.get_by_source(
+            organization_id=organization.id,
+            type=MerchantMigrationRecordType.product,
+            source_id="prod_1:month:1",
+        )
+        assert imported is not None
+        assert imported.status == MerchantMigrationRecordStatus.imported
+        assert imported.target_id is not None
+
+        skipped = await record_repository.get_by_source(
+            organization_id=organization.id,
+            type=MerchantMigrationRecordType.product,
+            source_id="prod_2:one_time",
+        )
+        assert skipped is not None
+        assert skipped.status == MerchantMigrationRecordStatus.skipped
+        assert skipped.error is not None
+        assert skipped.target_id is None
+
+    @pytest.mark.auth
+    async def test_reuses_existing_customer_by_email(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        existing = Customer(
+            email="alice@example.com",
+            name="Existing Alice",
+            organization=organization,
+        )
+        await save_fixture(existing)
+
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+        await service.import_catalog(session, auth_subject, migration.id)
+
+        customer_repository = CustomerRepository.from_session(session)
+        matches = await session.execute(
+            select(Customer).where(
+                Customer.organization_id == organization.id,
+                Customer.email == "alice@example.com",
+            )
+        )
+        customers = list(matches.scalars().all())
+        assert len(customers) == 1
+        # the existing customer is reused, with the source id reconciled onto it
+        reused = customers[0]
+        assert reused.id == existing.id
+        assert reused.stripe_customer_id == "cus_1"
+
+    @pytest.mark.auth
+    async def test_is_idempotent_on_rerun(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+
+        first = await service.import_catalog(session, auth_subject, migration.id)
+        second = await service.import_catalog(session, auth_subject, migration.id)
+
+        # the second run reports the same counts but creates nothing new
+        assert second.results == first.results
+        assert len(await _products(session, organization)) == 1
+        matches = await session.execute(
+            select(Customer).where(
+                Customer.organization_id == organization.id,
+                Customer.email == "alice@example.com",
+            )
+        )
+        assert len(list(matches.scalars().all())) == 1
+
+    @pytest.mark.auth
+    async def test_imports_only_selected_records(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        product_record = await record_repository.get_by_source(
+            organization_id=organization.id,
+            type=MerchantMigrationRecordType.product,
+            source_id="prod_1:month:1",
+        )
+        assert product_record is not None
+
+        report = await service.import_catalog(
+            session, auth_subject, migration.id, record_ids=[product_record.id]
+        )
+
+        results = {result.entity: result for result in report.results}
+        # only the selected product is acted on
+        assert results[PrecheckEntity.products].imported == 1
+        assert results[PrecheckEntity.customers].imported == 0
+
+        assert len(await _products(session, organization)) == 1
+        # the unselected customer stays pending, available to import later
+        customer_record = await record_repository.get_by_source(
+            organization_id=organization.id,
+            type=MerchantMigrationRecordType.customer,
+            source_id="cus_1",
+        )
+        assert customer_record is not None
+        assert customer_record.status == MerchantMigrationRecordStatus.pending
+
+    @pytest.mark.auth
+    async def test_imports_everything_except_excluded(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        product_record = await record_repository.get_by_source(
+            organization_id=organization.id,
+            type=MerchantMigrationRecordType.product,
+            source_id="prod_1:month:1",
+        )
+        assert product_record is not None
+
+        report = await service.import_catalog(
+            session,
+            auth_subject,
+            migration.id,
+            exclude_record_ids=[product_record.id],
+        )
+
+        results = {result.entity: result for result in report.results}
+        # everything importable imports except the excluded product
+        assert results[PrecheckEntity.products].imported == 0
+        assert results[PrecheckEntity.customers].imported == 1
+        excluded = await record_repository.get_by_source(
+            organization_id=organization.id,
+            type=MerchantMigrationRecordType.product,
+            source_id="prod_1:month:1",
+        )
+        assert excluded is not None
+        assert excluded.status == MerchantMigrationRecordStatus.pending
+
+    @pytest.mark.auth
+    async def test_unselected_records_import_on_a_later_pass(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        product_record = await record_repository.get_by_source(
+            organization_id=organization.id,
+            type=MerchantMigrationRecordType.product,
+            source_id="prod_1:month:1",
+        )
+        assert product_record is not None
+
+        await service.import_catalog(
+            session, auth_subject, migration.id, record_ids=[product_record.id]
+        )
+        # a second pass with no selection imports what's still pending
+        report = await service.import_catalog(session, auth_subject, migration.id)
+
+        results = {result.entity: result for result in report.results}
+        assert results[PrecheckEntity.customers].imported == 1
+        customer_repository = CustomerRepository.from_session(session)
+        customer = await customer_repository.get_by_email_and_organization(
+            "alice@example.com", organization.id
+        )
+        assert customer is not None
+
+    @pytest.mark.auth
+    async def test_requires_precheck_first(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+
+        with pytest.raises(CatalogImportNotReady):
+            await service.import_catalog(session, auth_subject, migration.id)

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -63,6 +63,7 @@ from polar.models.merchant_migration_record import (
 from polar.models.product_price import ProductPriceFixed
 from polar.models.subscription import SubscriptionStatus
 from polar.postgres import AsyncSession
+from polar.product.service import product as product_service
 from tests.fixtures.database import SaveFixture
 from tests.merchant_migration._helpers import build_connected_migration
 
@@ -669,6 +670,25 @@ class TestImportCatalog:
         updated = await migration_repository.get_by_id(migration.id)
         assert updated is not None
         assert updated.step == MerchantMigrationStep.create_catalog
+
+    @pytest.mark.auth
+    async def test_import_does_not_notify_for_each_product(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+        after_created = mocker.spy(product_service, "_after_product_created")
+
+        await service.import_catalog(session, auth_subject, migration.id)
+
+        after_created.assert_not_called()
 
     @pytest.mark.auth
     async def test_listing_reflects_import_status_after_import(

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -34,6 +34,7 @@ from polar.merchant_migration.schemas import (
     PrecheckRecordStatus,
 )
 from polar.merchant_migration.service import (
+    CatalogImportBlocked,
     CatalogImportNotReady,
     InvalidSourceCredentials,
     MissingStripeScopes,
@@ -60,6 +61,7 @@ from polar.models.merchant_migration_record import (
     MerchantMigrationRecordStatus,
     MerchantMigrationRecordType,
 )
+from polar.models.organization import OrganizationStatus
 from polar.models.product_price import ProductPriceFixed
 from polar.models.subscription import SubscriptionStatus
 from polar.postgres import AsyncSession
@@ -670,6 +672,55 @@ class TestImportCatalog:
         updated = await migration_repository.get_by_id(migration.id)
         assert updated is not None
         assert updated.step == MerchantMigrationStep.create_catalog
+
+    @pytest.mark.auth
+    async def test_blocked_organization_cannot_import(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+        organization.status = OrganizationStatus.CREATED
+        await save_fixture(organization)
+
+        with pytest.raises(CatalogImportBlocked):
+            await service.import_catalog(session, auth_subject, migration.id)
+
+        assert await _products(session, organization) == []
+
+    @pytest.mark.auth
+    async def test_settled_records_are_not_reimported(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        records = await record_repository.list_by_migration(migration.id)
+        for record in records:
+            if record.type == MerchantMigrationRecordType.product:
+                await record_repository.update(
+                    record,
+                    update_dict={"status": MerchantMigrationRecordStatus.skipped},
+                )
+
+        report = await service.import_catalog(session, auth_subject, migration.id)
+
+        results = {result.entity: result for result in report.results}
+        assert results[PrecheckEntity.products].imported == 0
+        assert await _products(session, organization) == []
 
     @pytest.mark.auth
     async def test_import_does_not_notify_for_each_product(


### PR DESCRIPTION
> **Stacked on #13189** (review listing). Review and merge that one first — this PR only shows the import delta on top of it.

## Summary

The write side of merchant migration: it turns the staged, classified Stripe catalog into real Polar products, customers and subscriptions (the `create_catalog` step).

## What

- `CatalogImporter` creates a Polar Product, Customer or Subscription for each importable ledger record and writes the source→target mapping back. Idempotent: a re-run only picks up records still pending. Subscriptions are created **paused**, so nothing is billed until cutover.
- Selective import: import a chosen set (`record_ids`) or everything except a set (`exclude_record_ids`, the opt-out default that scales to large catalogs).

## Why

Merchants moving from Stripe need their catalog recreated in Polar correctly. Money mistakes here mean double charges or overcharges, so the import is conservative by default.

## How

Safety guards, added after an adversarial review:

- `FOR UPDATE` lock on the migration during precheck/import, so a double-click can't create duplicate objects; the precheck step advance is monotonic.
- Never create a second live subscription to a product for a customer.
- Skip customer reuse when an existing customer has a conflicting Stripe id.
- Skip a subscription with a reason when its product or customer isn't imported, instead of leaving it silently pending.

No `session.commit()` in the service; DB-generated ids come from `flush=True` within the request transaction.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)