### PR TITLE
cost analytics responsive layout & Orbit cleanup

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/CostsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/CostsPage.tsx
@@ -13,7 +13,8 @@ import { useMetrics } from '@/hooks/queries/metrics'
 import { fromISODate, toISODate } from '@/utils/metrics'
 import { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
-import { Avatar } from '@polar-sh/orbit'
+import { Avatar, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
 import { RankedList, RankedListItem } from './RankedListItem'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@polar-sh/orbit'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@polar-sh/orbit'
@@ -302,11 +303,6 @@ export default function ClientPage({
 
   const fmt = formatCurrency('accounting')
   const fmtSub = formatCurrency('subcent')
-  const fmtPct = (n: number) =>
-    Math.abs(n).toLocaleString(undefined, {
-      minimumFractionDigits: 1,
-      maximumFractionDigits: 1,
-    }) + '%'
 
   const content = (
     <Tabs defaultValue="overview">
@@ -351,9 +347,11 @@ export default function ClientPage({
                       share={s.share}
                       onSelect={() => router.push(spanHref(s))}
                       label={
-                        <span className="min-w-0 flex-1 truncate text-sm font-medium dark:text-white">
-                          {s.label}
-                        </span>
+                        <Box flex={1} minWidth={0}>
+                          <Text variant="title" truncate>
+                            {s.label}
+                          </Text>
+                        </Box>
                       }
                       stats={
                         <>
@@ -367,16 +365,30 @@ export default function ClientPage({
                               prevEnd={prevEnd}
                             />
                           )}
-                          <span className="dark:text-polar-400 text-xs text-gray-400 tabular-nums">
+                          <Text
+                            as="span"
+                            variant="caption"
+                            color="muted"
+                            tabularNums
+                          >
                             {s.occurrences.toLocaleString()} events
-                          </span>
-                          <span className="dark:text-polar-400 text-xs text-gray-400 tabular-nums">
+                          </Text>
+                          <Text
+                            as="span"
+                            variant="caption"
+                            color="muted"
+                            tabularNums
+                          >
                             Avg {fmtSub(s.avg, 'usd')}
-                          </span>
-                          <span className="w-24 text-right text-sm tabular-nums dark:text-white">
-                            {fmt(s.total, 'usd')}
-                          </span>
+                          </Text>
                         </>
+                      }
+                      value={
+                        <Box width={96} justifyContent="end">
+                          <Text as="span" variant="default" tabularNums>
+                            {fmt(s.total, 'usd')}
+                          </Text>
+                        </Box>
                       }
                     />
                   )
@@ -490,27 +502,34 @@ export default function ClientPage({
                               avatar_url={null}
                               className="h-9 w-9 shrink-0 text-xs"
                             />
-                            <div className="min-w-0 flex-1">
-                              <p className="truncate text-sm font-medium dark:text-white">
+                            <Box flexDirection="column" flex={1} minWidth={0}>
+                              <Text variant="title" truncate>
                                 {r.label}
-                              </p>
+                              </Text>
                               {r.email && r.email !== r.label && (
-                                <p className="dark:text-polar-400 truncate text-xs text-gray-400">
+                                <Text variant="caption" color="muted" truncate>
                                   {r.email}
-                                </p>
+                                </Text>
                               )}
-                            </div>
+                            </Box>
                           </>
                         }
                         stats={
-                          <>
-                            <span className="dark:text-polar-400 text-xs text-gray-400 tabular-nums">
-                              {r.occurrences.toLocaleString()} events
-                            </span>
-                            <span className="w-24 text-right text-sm tabular-nums dark:text-white">
+                          <Text
+                            as="span"
+                            variant="caption"
+                            color="muted"
+                            tabularNums
+                          >
+                            {r.occurrences.toLocaleString()} events
+                          </Text>
+                        }
+                        value={
+                          <Box width={96} justifyContent="end">
+                            <Text as="span" variant="default" tabularNums>
                               {fmt(r.total, 'usd')}
-                            </span>
-                          </>
+                            </Text>
+                          </Box>
                         }
                       />
                     )
@@ -629,9 +648,11 @@ export default function ClientPage({
                     rank={i + 1}
                     share={r.share}
                     label={
-                      <span className="min-w-0 flex-1 truncate text-sm font-medium dark:text-white">
-                        {r.value}
-                      </span>
+                      <Box flex={1} minWidth={0}>
+                        <Text variant="title" truncate>
+                          {r.value}
+                        </Text>
+                      </Box>
                     }
                     stats={
                       <>
@@ -645,16 +666,30 @@ export default function ClientPage({
                             prevEnd={prevEnd}
                           />
                         )}
-                        <span className="dark:text-polar-400 text-xs text-gray-400 tabular-nums">
+                        <Text
+                          as="span"
+                          variant="caption"
+                          color="muted"
+                          tabularNums
+                        >
                           {r.occurrences.toLocaleString()} events
-                        </span>
-                        <span className="dark:text-polar-400 text-xs text-gray-400 tabular-nums">
+                        </Text>
+                        <Text
+                          as="span"
+                          variant="caption"
+                          color="muted"
+                          tabularNums
+                        >
                           {r.customers.toLocaleString()} customers
-                        </span>
-                        <span className="w-24 text-right font-mono text-sm font-semibold tabular-nums dark:text-white">
-                          {fmtSub(r.total, 'usd')}
-                        </span>
+                        </Text>
                       </>
+                    }
+                    value={
+                      <Box width={96} justifyContent="end">
+                        <Text as="span" variant="title" monospace tabularNums>
+                          {fmtSub(r.total, 'usd')}
+                        </Text>
+                      </Box>
                     }
                   />
                 ))}
@@ -682,9 +717,11 @@ export default function ClientPage({
                     rank={i + 1}
                     share={r.share}
                     label={
-                      <span className="min-w-0 flex-1 truncate text-sm font-medium dark:text-white">
-                        {r.value}
-                      </span>
+                      <Box flex={1} minWidth={0}>
+                        <Text variant="title" truncate>
+                          {r.value}
+                        </Text>
+                      </Box>
                     }
                     stats={
                       <>
@@ -698,16 +735,30 @@ export default function ClientPage({
                             prevEnd={prevEnd}
                           />
                         )}
-                        <span className="dark:text-polar-400 text-xs text-gray-400 tabular-nums">
+                        <Text
+                          as="span"
+                          variant="caption"
+                          color="muted"
+                          tabularNums
+                        >
                           {r.occurrences.toLocaleString()} events
-                        </span>
-                        <span className="dark:text-polar-400 text-xs text-gray-400 tabular-nums">
+                        </Text>
+                        <Text
+                          as="span"
+                          variant="caption"
+                          color="muted"
+                          tabularNums
+                        >
                           {r.customers.toLocaleString()} customers
-                        </span>
-                        <span className="w-24 text-right font-mono text-sm font-semibold tabular-nums dark:text-white">
-                          {fmtSub(r.total, 'usd')}
-                        </span>
+                        </Text>
                       </>
+                    }
+                    value={
+                      <Box width={96} justifyContent="end">
+                        <Text as="span" variant="title" monospace tabularNums>
+                          {fmtSub(r.total, 'usd')}
+                        </Text>
+                      </Box>
                     }
                   />
                 ))}
@@ -752,27 +803,34 @@ export default function ClientPage({
                             avatar_url={null}
                             className="h-9 w-9 shrink-0 text-xs"
                           />
-                          <div className="min-w-0 flex-1">
-                            <p className="truncate text-sm font-medium dark:text-white">
+                          <Box flexDirection="column" flex={1} minWidth={0}>
+                            <Text variant="title" truncate>
                               {r.label}
-                            </p>
+                            </Text>
                             {r.email && r.email !== r.label && (
-                              <p className="dark:text-polar-400 truncate text-xs text-gray-400">
+                              <Text variant="caption" color="muted" truncate>
                                 {r.email}
-                              </p>
+                              </Text>
                             )}
-                          </div>
+                          </Box>
                         </>
                       }
                       stats={
-                        <>
-                          <span className="dark:text-polar-400 text-xs text-gray-400 tabular-nums">
-                            {r.occurrences.toLocaleString()} events
-                          </span>
-                          <span className="w-24 text-right font-mono text-sm font-semibold tabular-nums dark:text-white">
+                        <Text
+                          as="span"
+                          variant="caption"
+                          color="muted"
+                          tabularNums
+                        >
+                          {r.occurrences.toLocaleString()} events
+                        </Text>
+                      }
+                      value={
+                        <Box width={96} justifyContent="end">
+                          <Text as="span" variant="title" monospace tabularNums>
                             {fmt(r.total, 'usd')}
-                          </span>
-                        </>
+                          </Text>
+                        </Box>
                       }
                     />
                   ))}
@@ -814,6 +872,12 @@ const fmtDate = (d: Date) =>
     year: 'numeric',
   })
 
+const fmtPct = (n: number) =>
+  Math.abs(n).toLocaleString(undefined, {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  }) + '%'
+
 function TrendBadge({
   delta,
   pct,
@@ -834,14 +898,25 @@ function TrendBadge({
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span
-          className={`mt-1 flex w-fit cursor-default items-center gap-1 text-xs ${
+        <Box
+          as="span"
+          display="inline-flex"
+          width="fit-content"
+          alignItems="center"
+          columnGap="xs"
+          paddingHorizontal="s"
+          borderRadius="full"
+          cursor="default"
+          backgroundColor={
             isUp
-              ? 'text-red-500'
+              ? 'background-danger'
               : isDown
-                ? 'text-emerald-500'
-                : 'dark:text-polar-500 text-gray-400'
-          }`}
+                ? 'background-success'
+                : 'background-card'
+          }
+          color={
+            isUp ? 'text-danger' : isDown ? 'text-success' : 'text-tertiary'
+          }
         >
           {isUp ? (
             <ArrowUpRight className="size-3" />
@@ -850,20 +925,18 @@ function TrendBadge({
           ) : (
             <Minus className="size-3" />
           )}
-          {Math.abs(pct).toLocaleString(undefined, {
-            minimumFractionDigits: 1,
-            maximumFractionDigits: 1,
-          })}
-          %
-        </span>
+          <Text as="span" variant="label" color="inherit" tabularNums>
+            {fmtPct(pct)}
+          </Text>
+        </Box>
       </TooltipTrigger>
       <TooltipContent className="flex flex-col gap-1">
-        <span>
+        <Text as="span" variant="caption">
           {fmtDate(currentStart)} – {fmtDate(currentEnd)}
-        </span>
-        <span className="dark:text-polar-400 text-gray-400">
+        </Text>
+        <Text as="span" variant="caption" color="muted">
           vs {fmtDate(prevStart)} – {fmtDate(prevEnd)}
-        </span>
+        </Text>
       </TooltipContent>
     </Tooltip>
   )

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/CostsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/CostsPage.tsx
@@ -16,8 +16,8 @@ import { formatCurrency } from '@polar-sh/currency'
 import { Avatar, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { RankedList, RankedListItem } from './RankedListItem'
+import { TrendBadge } from './TrendBadge'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@polar-sh/orbit'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@polar-sh/orbit'
 import { endOfDay, subDays } from 'date-fns'
 import {
   AlertTriangle,
@@ -33,7 +33,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { parseAsArrayOf, parseAsString, useQueryState } from 'nuqs'
 import { useMemo } from 'react'
-import { getDefaultEndDate, getDefaultStartDate } from './utils'
+import { fmtPct, getDefaultEndDate, getDefaultStartDate } from './utils'
 import { getMetricsForType } from '@/components/Metrics/dashboards/metrics-config'
 import { MetricGroup } from '@/components/Metrics/dashboards/MetricGroup'
 
@@ -862,83 +862,6 @@ export default function ClientPage({
     >
       {content}
     </DashboardBody>
-  )
-}
-
-const fmtDate = (d: Date) =>
-  d.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  })
-
-const fmtPct = (n: number) =>
-  Math.abs(n).toLocaleString(undefined, {
-    minimumFractionDigits: 1,
-    maximumFractionDigits: 1,
-  }) + '%'
-
-function TrendBadge({
-  delta,
-  pct,
-  currentStart,
-  currentEnd,
-  prevStart,
-  prevEnd,
-}: {
-  delta: number
-  pct: number
-  currentStart: Date
-  currentEnd: Date
-  prevStart: Date
-  prevEnd: Date
-}) {
-  const isUp = delta > 0
-  const isDown = delta < 0
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Box
-          as="span"
-          display="inline-flex"
-          width="fit-content"
-          alignItems="center"
-          columnGap="xs"
-          paddingHorizontal="s"
-          borderRadius="full"
-          cursor="default"
-          backgroundColor={
-            isUp
-              ? 'background-danger'
-              : isDown
-                ? 'background-success'
-                : 'background-card'
-          }
-          color={
-            isUp ? 'text-danger' : isDown ? 'text-success' : 'text-tertiary'
-          }
-        >
-          {isUp ? (
-            <ArrowUpRight className="size-3" />
-          ) : isDown ? (
-            <ArrowDownRight className="size-3" />
-          ) : (
-            <Minus className="size-3" />
-          )}
-          <Text as="span" variant="label" color="inherit" tabularNums>
-            {fmtPct(pct)}
-          </Text>
-        </Box>
-      </TooltipTrigger>
-      <TooltipContent className="flex flex-col gap-1">
-        <Text as="span" variant="caption">
-          {fmtDate(currentStart)} – {fmtDate(currentEnd)}
-        </Text>
-        <Text as="span" variant="caption" color="muted">
-          vs {fmtDate(prevStart)} – {fmtDate(prevEnd)}
-        </Text>
-      </TooltipContent>
-    </Tooltip>
   )
 }
 

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/RankedListItem.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/RankedListItem.tsx
@@ -82,7 +82,6 @@ export const RankedListItem = ({
             width={`${sharePct}%`}
             borderRadius="full"
             backgroundColor="background-inverse"
-            transitionProperty="all"
             transitionDuration="base"
           />
         </Box>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/RankedListItem.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/RankedListItem.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { List, ListItem } from '@polar-sh/orbit'
+import { Grid, GridItem, List, ListItem, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
 import { ReactNode } from 'react'
 
 interface RankedListItemProps {
@@ -8,6 +9,7 @@ interface RankedListItemProps {
   rank: number
   label: ReactNode
   stats: ReactNode
+  value: ReactNode
   share: number
   onSelect?: () => void
 }
@@ -17,6 +19,7 @@ export const RankedListItem = ({
   rank,
   label,
   stats,
+  value,
   share,
   onSelect,
 }: RankedListItemProps) => {
@@ -27,24 +30,68 @@ export const RankedListItem = ({
       className="flex-col items-stretch gap-3 py-4"
       onSelect={onSelect}
     >
-      <div className="flex items-center gap-4">
-        <span className="dark:text-polar-500 shrink-0 text-xs text-gray-400 tabular-nums">
-          {rank}
-        </span>
-        {label}
-        <div className="flex shrink-0 items-center gap-3">{stats}</div>
-      </div>
-      <div className="flex items-center gap-3">
-        <div className="dark:bg-polar-700 relative h-1 flex-1 overflow-hidden rounded-full bg-gray-100">
-          <div
-            className="absolute inset-y-0 left-0 rounded-full bg-black transition-all dark:bg-white"
-            style={{ width: `${sharePct}%` }}
+      <Grid
+        templateAreas={{
+          base: '"rank label value" ". stats stats"',
+          sm: '"rank label stats value"',
+        }}
+        templateColumns={{
+          base: 'auto minmax(0, 1fr) auto',
+          sm: 'auto minmax(0, 1fr) auto auto',
+        }}
+        alignItems="center"
+        columnGap="l"
+        rowGap="s"
+      >
+        <GridItem area="rank">
+          <Text as="span" variant="caption" color="muted" tabularNums>
+            {rank}
+          </Text>
+        </GridItem>
+        <GridItem area="label" minWidth={0} alignItems="center" columnGap="m">
+          {label}
+        </GridItem>
+        <GridItem
+          area="stats"
+          alignItems="center"
+          flexWrap="wrap"
+          justifyContent={{ sm: 'end' }}
+          columnGap="m"
+          rowGap="xs"
+        >
+          {stats}
+        </GridItem>
+        <GridItem area="value" justifyContent="end">
+          {value}
+        </GridItem>
+      </Grid>
+      <Box alignItems="center" columnGap="m">
+        <Box
+          position="relative"
+          flex={1}
+          height={4}
+          overflow="hidden"
+          borderRadius="full"
+          backgroundColor="background-card"
+        >
+          <Box
+            position="absolute"
+            top={0}
+            bottom={0}
+            left={0}
+            width={`${sharePct}%`}
+            borderRadius="full"
+            backgroundColor="background-inverse"
+            transitionProperty="all"
+            transitionDuration="base"
           />
-        </div>
-        <span className="dark:text-polar-500 w-9 shrink-0 text-right text-xs text-gray-400 tabular-nums">
-          {sharePct}%
-        </span>
-      </div>
+        </Box>
+        <Box width={36} flexShrink={0} justifyContent="end">
+          <Text as="span" variant="caption" color="muted" tabularNums>
+            {sharePct}%
+          </Text>
+        </Box>
+      </Box>
     </ListItem>
   )
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/TrendBadge.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/TrendBadge.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@polar-sh/orbit'
+import FormattedInterval from '@polar-sh/ui/components/atoms/FormattedInterval'
+import { ArrowDownRight, ArrowUpRight, Minus } from 'lucide-react'
+import { fmtPct } from './utils'
+
+interface TrendBadgeProps {
+  delta: number
+  pct: number
+  currentStart: Date
+  currentEnd: Date
+  prevStart: Date
+  prevEnd: Date
+}
+
+export function TrendBadge({
+  delta,
+  pct,
+  currentStart,
+  currentEnd,
+  prevStart,
+  prevEnd,
+}: TrendBadgeProps) {
+  const isUp = delta > 0
+  const isDown = delta < 0
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Box
+          as="span"
+          display="inline-flex"
+          width="fit-content"
+          alignItems="center"
+          columnGap="xs"
+          paddingHorizontal="s"
+          borderRadius="full"
+          cursor="default"
+          backgroundColor={
+            isUp
+              ? 'background-danger'
+              : isDown
+                ? 'background-success'
+                : 'background-card'
+          }
+          color={
+            isUp ? 'text-danger' : isDown ? 'text-success' : 'text-tertiary'
+          }
+        >
+          {isUp ? (
+            <ArrowUpRight className="size-3" />
+          ) : isDown ? (
+            <ArrowDownRight className="size-3" />
+          ) : (
+            <Minus className="size-3" />
+          )}
+          <Text as="span" variant="label" color="inherit" tabularNums>
+            {fmtPct(pct)}
+          </Text>
+        </Box>
+      </TooltipTrigger>
+      <TooltipContent className="flex flex-col gap-1">
+        <Text as="span" variant="default">
+          <FormattedInterval
+            startDatetime={currentStart}
+            endDatetime={currentEnd}
+            hideCurrentYear={false}
+          />
+        </Text>
+        <Text as="span" variant="default" color="muted">
+          vs{' '}
+          <FormattedInterval
+            startDatetime={prevStart}
+            endDatetime={prevEnd}
+            hideCurrentYear={false}
+          />
+        </Text>
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/[spanId]/CostsSpanPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/[spanId]/CostsSpanPage.tsx
@@ -14,7 +14,7 @@ import {
 import { fromISODate, getTimestampFormatter } from '@/utils/metrics'
 import { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
-import { Button } from '@polar-sh/orbit'
+import { Button, Grid } from '@polar-sh/orbit'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@polar-sh/orbit'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@polar-sh/orbit'
 import { endOfDay, format, subDays, subMonths } from 'date-fns'
@@ -263,7 +263,13 @@ export default function SpanDetailPage({
 
         <TabsContent value="overview">
           <div className="flex flex-col gap-y-8">
-            <div className="grid grid-cols-4 gap-8">
+            <Grid
+              templateColumns={{
+                base: 'repeat(2, 1fr)',
+                lg: 'repeat(4, 1fr)',
+              }}
+              gap="2xl"
+            >
               <StatisticCard title="Occurrences" size="lg">
                 {costMetrics.totalOccurrences.toLocaleString()}
                 <Trend
@@ -308,7 +314,7 @@ export default function SpanDetailPage({
                   prevEnd={prevEnd}
                 />
               </StatisticCard>
-            </div>
+            </Grid>
 
             {chartData.length > 0 && (
               <div className="dark:border-polar-700 rounded-xl border border-gray-200 p-2">

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/utils.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/utils.ts
@@ -7,6 +7,12 @@ export const DEFAULT_INTERVAL: schemas['TimeInterval'] = 'day'
 export const getDefaultStartDate = () => toISODate(subMonths(endOfToday(), 1))
 export const getDefaultEndDate = () => toISODate(endOfToday())
 
+export const fmtPct = (n: number) =>
+  Math.abs(n).toLocaleString(undefined, {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  }) + '%'
+
 export const getCostsSearchParams = (
   startDate: string,
   endDate: string,


### PR DESCRIPTION
Costs analytics: responsive layout & Orbit cleanup

Fixes responsive layout issues in the cost analytics views and migrates the touched UI to the Orbit design system.

- Ranked lists: rebuilt with a responsive grid so stats reflow onto their own row on narrow screens instead of overflowing; migrated to Orbit Box/Text/Grid with design tokens.
- Event Span page: the stat cards no longer overflow on mobile — the fixed 4-column grid now collapses to 2 columns on small screens and 1 on mobile.
- Refactor: extracted TrendBadge into its own file and shared the percentage/date formatting helpers; date ranges now use the shared FormattedInterval component.

| Before | After | 
|---|---|
| <img width="574" height="439"  alt="Screenshot 2026-07-14 at 16 53 26" src="https://github.com/user-attachments/assets/35f79b6c-a29e-46a5-9273-b3bce08d48ec" /> | <img height="439"  alt="Screenshot 2026-07-14 at 16 52 34" src="https://github.com/user-attachments/assets/9fc8ce08-9e09-4833-83e8-56f198d8416a" /> |
| <img width="574" height="439" alt="Screenshot 2026-07-15 at 09 07 25" src="https://github.com/user-attachments/assets/55d505da-c8a7-449c-818a-4d759068fc7f" /> | <img height="439" alt="Screenshot 2026-07-15 at 09 07 45" src="https://github.com/user-attachments/assets/0037a8ef-5cf1-4400-add6-16dd571b4a1b" /> |



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13170?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

