### PR TITLE
Make organization details fields optional

### DIFF
--- a/server/polar/backoffice/organizations_v2/forms.py
+++ b/server/polar/backoffice/organizations_v2/forms.py
@@ -11,7 +11,7 @@ from pydantic import (
 
 from polar.backoffice import forms
 from polar.enums import RateLimitGroup
-from polar.kit.schemas import HttpUrlToStr
+from polar.kit.schemas import EmptyStrToNone, HttpUrlToStr
 from polar.organization.schemas import NameInput, SlugInput
 
 
@@ -68,7 +68,7 @@ class UpdateRateLimitGroupForm(forms.BaseForm):
 
 class UpdateOrganizationDetailsDataForm(forms.BaseForm):
     about: Annotated[
-        str | None,
+        EmptyStrToNone,
         forms.TextAreaField(rows=4),
         Field(
             None,
@@ -77,7 +77,7 @@ class UpdateOrganizationDetailsDataForm(forms.BaseForm):
         ),
     ]
     product_description: Annotated[
-        str | None,
+        EmptyStrToNone,
         forms.TextAreaField(rows=4),
         Field(
             None,
@@ -86,7 +86,7 @@ class UpdateOrganizationDetailsDataForm(forms.BaseForm):
         ),
     ]
     intended_use: Annotated[
-        str | None,
+        EmptyStrToNone,
         forms.TextAreaField(rows=3),
         Field(
             None,

--- a/server/polar/backoffice/organizations_v2/forms.py
+++ b/server/polar/backoffice/organizations_v2/forms.py
@@ -68,19 +68,19 @@ class UpdateRateLimitGroupForm(forms.BaseForm):
 
 class UpdateOrganizationDetailsDataForm(forms.BaseForm):
     about: Annotated[
-        str,
+        str | None,
         forms.TextAreaField(rows=4),
         Field(
-            min_length=1,
+            None,
             title="About",
             description="Brief information about you and your business",
         ),
     ]
     product_description: Annotated[
-        str,
+        str | None,
         forms.TextAreaField(rows=4),
         Field(
-            min_length=1,
+            None,
             title="Product Description",
             description="Description of digital products being sold",
         ),


### PR DESCRIPTION
## Summary

Make the `about` and `product_description` fields optional in the organization details form by allowing `None` values and removing minimum length validation.

## What

Updated `UpdateOrganizationDetailsDataForm` to:
- Change `about` field type from `str` to `str | None`
- Change `product_description` field type from `str` to `str | None`
- Remove `min_length=1` constraint from both fields (replaced with `None`)

## Why

These fields should be optional to allow organizations to leave them blank during setup or updates, rather than requiring them to provide content.

## How

Modified the type annotations and Field constraints in the form definition to accept optional values and removed the minimum length validation that was enforcing non-empty strings.

## Checklist

- [x] This PR addresses a single concern (making form fields optional)
- [x] The diff is reasonably sized and easy to review
- [x] No testing needed (straightforward form field configuration change)
- [x] No unrelated changes included

https://claude.ai/code/session_01WL1pzN2Dm8vHgvsH8mxjgD

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

