### PR TITLE
Improve mobile responsiveness of Events, Meter & filter UIs

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/events/[eventId]/EventsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/events/[eventId]/EventsPage.tsx
@@ -158,9 +158,9 @@ export default function EventDetailPage({
           </div>
           {children.length > 0 && (
             <div className="flex flex-col gap-y-8">
-              <div className="flex flex-row justify-between">
-                <h3 className="text-2xl">Child Events</h3>
-                <h3 className="dark:text-polar-500 text-2xl text-gray-400">
+              <div className="flex flex-row items-baseline justify-between">
+                <h3 className="text-xl sm:text-2xl">Child Events</h3>
+                <h3 className="dark:text-polar-500 text-xl text-gray-400 sm:text-2xl">
                   {children.length} {children.length === 1 ? 'Event' : 'Events'}
                 </h3>
               </div>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/events/[eventId]/EventsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/events/[eventId]/EventsPage.tsx
@@ -134,7 +134,7 @@ export default function EventDetailPage({
         {/* Left column — event rows */}
         <div className="flex flex-col gap-y-8">
           <div className="flex flex-row items-baseline justify-between gap-x-4">
-            <h3 className="min-w-0 break-words text-2xl sm:text-4xl">
+            <h3 className="min-w-0 text-2xl break-words sm:text-4xl">
               {event.label}
             </h3>
             {'_cost' in event.metadata && event.metadata._cost && (

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/events/[eventId]/EventsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/events/[eventId]/EventsPage.tsx
@@ -133,10 +133,12 @@ export default function EventDetailPage({
       <div className="grid grid-cols-1 items-start gap-12 md:grid-cols-[1fr_300px]">
         {/* Left column — event rows */}
         <div className="flex flex-col gap-y-8">
-          <div className="flex flex-row items-center justify-between gap-x-4">
-            <h3 className="text-4xl">{event.label}</h3>
+          <div className="flex flex-row items-baseline justify-between gap-x-4">
+            <h3 className="min-w-0 break-words text-2xl sm:text-4xl">
+              {event.label}
+            </h3>
             {'_cost' in event.metadata && event.metadata._cost && (
-              <h3 className="dark:text-polar-500 font-mono text-4xl text-gray-400">
+              <h3 className="dark:text-polar-500 shrink-0 font-mono text-2xl whitespace-nowrap text-gray-400 sm:text-4xl">
                 {formatCurrency('subcent')(
                   Number(event.metadata._cost?.amount ?? 0),
                   event.metadata._cost?.currency ?? 'usd',

--- a/clients/apps/web/src/components/Events/EventCard/LLMInferenceEventCard.tsx
+++ b/clients/apps/web/src/components/Events/EventCard/LLMInferenceEventCard.tsx
@@ -10,11 +10,13 @@ const DataRow = ({
   value: string | number
 }) => {
   return (
-    <div className="flex flex-row items-center gap-x-4">
-      <div className="flex w-48 flex-row items-center gap-x-4">
+    <div className="flex flex-row items-start gap-x-4">
+      <div className="flex w-32 shrink-0 flex-row items-center gap-x-4 sm:w-48">
         <span>{label}</span>
       </div>
-      <span className="dark:text-polar-500 text-gray-500">{value}</span>
+      <span className="dark:text-polar-500 min-w-0 break-all text-gray-500">
+        {value}
+      </span>
     </div>
   )
 }

--- a/clients/apps/web/src/components/Events/EventCostBadge.tsx
+++ b/clients/apps/web/src/components/Events/EventCostBadge.tsx
@@ -73,7 +73,7 @@ export type EventCostBadgeProps =
 export const EventCostBadge = (props: EventCostBadgeProps) => {
   if ('nonCostEvent' in props && props.nonCostEvent) {
     return (
-      <div className="flex flex-row items-center gap-x-4 font-mono">
+      <div className="flex flex-row items-center gap-x-2 font-mono sm:gap-x-4">
         <EventCostIndicator type="neutral" />
       </div>
     )
@@ -83,7 +83,7 @@ export const EventCostBadge = (props: EventCostBadgeProps) => {
   const parsedNumber = Number(cost)
 
   return (
-    <div className="flex flex-row items-center gap-x-4 font-mono">
+    <div className="flex flex-row items-center gap-x-2 font-mono sm:gap-x-4">
       {formatCurrency('subcent')(parsedNumber, currency)}
       <EventCostIndicator type={cost === 0 ? 'neutral' : type} />
     </div>

--- a/clients/apps/web/src/components/Events/EventCustomer.tsx
+++ b/clients/apps/web/src/components/Events/EventCustomer.tsx
@@ -75,17 +75,15 @@ export const EventCustomer = ({ event }: { event: schemas['Event'] }) => {
   if (isIdentifiedCustomerEvent(event)) {
     return (
       <Popover>
-        <PopoverTrigger className="group block">
-          <div className="flex flex-row items-center gap-x-2 font-sans">
-            <div className="flex flex-row items-center gap-x-2 font-sans">
-              <Avatar
-                className="size-6 shrink-0"
-                name={event.customer.name ?? event.customer.email ?? '—'}
-                avatar_url={event.customer.avatar_url ?? null}
-              />
-              <div className="dark:text-polar-200 flex flex-row items-baseline gap-x-2 text-sm whitespace-nowrap text-gray-700">
-                {event.customer.name ?? event.customer.email ?? '—'}
-              </div>
+        <PopoverTrigger className="group block min-w-0 max-w-full">
+          <div className="flex min-w-0 flex-row items-center gap-x-2 font-sans">
+            <Avatar
+              className="size-6 shrink-0"
+              name={event.customer.name ?? event.customer.email ?? '—'}
+              avatar_url={event.customer.avatar_url ?? null}
+            />
+            <div className="dark:text-polar-200 min-w-0 truncate text-left text-sm text-gray-700">
+              {event.customer.name ?? event.customer.email ?? '—'}
             </div>
           </div>
         </PopoverTrigger>

--- a/clients/apps/web/src/components/Events/EventCustomer.tsx
+++ b/clients/apps/web/src/components/Events/EventCustomer.tsx
@@ -75,7 +75,7 @@ export const EventCustomer = ({ event }: { event: schemas['Event'] }) => {
   if (isIdentifiedCustomerEvent(event)) {
     return (
       <Popover>
-        <PopoverTrigger className="group block min-w-0 max-w-full">
+        <PopoverTrigger className="group block max-w-full min-w-0">
           <div className="flex min-w-0 flex-row items-center gap-x-2 font-sans">
             <Avatar
               className="size-6 shrink-0"

--- a/clients/apps/web/src/components/Events/EventRow.tsx
+++ b/clients/apps/web/src/components/Events/EventRow.tsx
@@ -121,10 +121,10 @@ export const EventRow = ({
           depth === 0 && 'rounded-t-xl!',
         )}
       >
-        <div className="flex flex-row items-center justify-between p-3 select-none">
-          <div className="flex flex-row items-center gap-x-4">
+        <div className="flex flex-row items-center justify-between gap-x-2 p-3 select-none">
+          <div className="flex min-w-0 flex-row items-center gap-x-2 sm:gap-x-4">
             {depth === 0 ? (
-              <div className="dark:bg-polar-700 dark:hover:bg-polar-600 flex flex-row items-center justify-center rounded-sm border border-gray-200 bg-gray-100 p-1 transition-colors duration-150 hover:bg-gray-200 dark:border-white/5">
+              <div className="dark:bg-polar-700 dark:hover:bg-polar-600 flex shrink-0 flex-row items-center justify-center rounded-sm border border-gray-200 bg-gray-100 p-1 transition-colors duration-150 hover:bg-gray-200 dark:border-white/5">
                 {isExpanded ? (
                   <KeyboardArrowDownOutlined fontSize="inherit" />
                 ) : (
@@ -132,25 +132,25 @@ export const EventRow = ({
                 )}
               </div>
             ) : (
-              <div className="flex w-6 flex-col items-center justify-center">
+              <div className="flex w-6 shrink-0 flex-col items-center justify-center">
                 <div className="dark:bg-polar-500 size-1.5 rounded-full bg-gray-300" />
               </div>
             )}
-            <div className="flex flex-row items-center gap-x-4">
-              <span className="text-xs">{event.label}</span>
+            <div className="flex min-w-0 flex-row flex-wrap items-center gap-x-2 gap-y-1 sm:gap-x-4">
+              <span className="truncate text-xs">{event.label}</span>
               <EventSourceBadge source={event.source} />
               {event.child_count > 0 && (
-                <span className="dark:text-polar-500 dark:bg-polar-700 text-xxs rounded-md bg-gray-100 px-2 py-1 text-gray-500 capitalize">
+                <span className="dark:text-polar-500 dark:bg-polar-700 text-xxs shrink-0 rounded-md bg-gray-100 px-2 py-1 text-gray-500 capitalize">
                   {event.child_count}{' '}
                   {event.child_count === 1 ? 'child' : 'children'}
                 </span>
               )}
+              <span className="dark:text-polar-500 w-full text-xs whitespace-nowrap text-gray-500 capitalize sm:w-auto">
+                {formattedTimestamp}
+              </span>
             </div>
-            <span className="dark:text-polar-500 text-xs text-gray-500 capitalize">
-              {formattedTimestamp}
-            </span>
           </div>
-          <div className="flex flex-row items-center gap-x-6">
+          <div className="flex shrink-0 flex-row items-center gap-x-2 sm:gap-x-6">
             {isExpanded
               ? null
               : costBadge !== undefined
@@ -243,9 +243,11 @@ export const EventRow = ({
         </div>
         {isExpanded ? eventCard : null}
         {isExpanded ? (
-          <div className="flex flex-row items-center justify-between gap-x-2 px-3 py-2">
+          <div className="flex min-w-0 flex-row items-center justify-between gap-x-2 px-3 py-2">
             <EventCustomer event={event} />
-            {costBadge !== undefined ? costBadge : eventCostBadge}
+            <div className="shrink-0">
+              {costBadge !== undefined ? costBadge : eventCostBadge}
+            </div>
           </div>
         ) : null}
       </div>

--- a/clients/apps/web/src/components/Events/EventRow.tsx
+++ b/clients/apps/web/src/components/Events/EventRow.tsx
@@ -121,8 +121,8 @@ export const EventRow = ({
           depth === 0 && 'rounded-t-xl!',
         )}
       >
-        <div className="flex flex-row items-center justify-between gap-x-2 p-3 select-none">
-          <div className="flex min-w-0 flex-row items-center gap-x-2 sm:gap-x-4">
+        <div className="flex flex-row items-start justify-between gap-x-2 p-3 select-none sm:items-center">
+          <div className="flex min-w-0 flex-row items-start gap-x-2 sm:items-center sm:gap-x-4">
             {depth === 0 ? (
               <div className="dark:bg-polar-700 dark:hover:bg-polar-600 flex shrink-0 flex-row items-center justify-center rounded-sm border border-gray-200 bg-gray-100 p-1 transition-colors duration-150 hover:bg-gray-200 dark:border-white/5">
                 {isExpanded ? (
@@ -136,18 +136,22 @@ export const EventRow = ({
                 <div className="dark:bg-polar-500 size-1.5 rounded-full bg-gray-300" />
               </div>
             )}
-            <div className="flex min-w-0 flex-row flex-wrap items-center gap-x-2 gap-y-1 sm:gap-x-4">
-              <span className="truncate text-xs">{event.label}</span>
-              <EventSourceBadge source={event.source} />
-              {event.child_count > 0 && (
-                <span className="dark:text-polar-500 dark:bg-polar-700 text-xxs shrink-0 rounded-md bg-gray-100 px-2 py-1 text-gray-500 capitalize">
-                  {event.child_count}{' '}
-                  {event.child_count === 1 ? 'child' : 'children'}
+            <div className="flex min-w-0 flex-col gap-y-1 sm:flex-row sm:flex-wrap sm:items-center sm:gap-x-4">
+              <div className="flex min-w-0 flex-row items-center gap-x-2 sm:contents">
+                <span className="truncate text-xs">{event.label}</span>
+                <EventSourceBadge source={event.source} />
+              </div>
+              <div className="flex flex-row flex-wrap items-center gap-x-2 gap-y-1 sm:contents">
+                {event.child_count > 0 && (
+                  <span className="dark:text-polar-500 dark:bg-polar-700 text-xxs shrink-0 rounded-md bg-gray-100 px-2 py-1 text-gray-500 capitalize">
+                    {event.child_count}{' '}
+                    {event.child_count === 1 ? 'child' : 'children'}
+                  </span>
+                )}
+                <span className="dark:text-polar-500 text-xs whitespace-nowrap text-gray-500 capitalize">
+                  {formattedTimestamp}
                 </span>
-              )}
-              <span className="dark:text-polar-500 w-full text-xs whitespace-nowrap text-gray-500 capitalize sm:w-auto">
-                {formattedTimestamp}
-              </span>
+              </div>
             </div>
           </div>
           <div className="flex shrink-0 flex-row items-center gap-x-2 sm:gap-x-6">

--- a/clients/apps/web/src/components/Meter/MeterFilterInput.tsx
+++ b/clients/apps/web/src/components/Meter/MeterFilterInput.tsx
@@ -63,9 +63,9 @@ const MeterFilterInput = ({
     <div className="flex flex-col gap-4">
       {/* To make the UI more digest, we don't allow to add single clause at the root level */}
       {prefix !== 'filter' && (
-        <div className="flex items-center justify-between gap-2">
+        <div className="flex flex-wrap items-center justify-between gap-2">
           <h3>Condition group</h3>
-          <div className="flex flex-row items-center gap-x-2">
+          <div className="flex flex-row flex-wrap items-center gap-2">
             <Button
               type="button"
               variant="secondary"
@@ -108,7 +108,7 @@ const MeterFilterInput = ({
                 >
                   {index === 0 ? '|' : conjunction}
                 </div>
-                <div className="grid grow grid-cols-[1fr_1fr_1fr_auto] items-start gap-x-2">
+                <div className="grid grow grid-cols-1 gap-2 sm:grid-cols-[1fr_1fr_1fr_auto] sm:items-start sm:gap-y-0">
                   <FormField
                     control={control}
                     name={`${prefix}.clauses.${index}.property`}
@@ -185,7 +185,12 @@ const MeterFilterInput = ({
                       )
                     }}
                   />
-                  <div className="flex h-10 items-center">
+                  <div
+                    className={twMerge(
+                      'h-10 items-center',
+                      index === 0 ? 'hidden sm:flex' : 'flex',
+                    )}
+                  >
                     <Button
                       type="button"
                       variant="secondary"

--- a/clients/apps/web/src/components/Meter/MeterPage.tsx
+++ b/clients/apps/web/src/components/Meter/MeterPage.tsx
@@ -219,10 +219,7 @@ const MeterActivityCards = ({ meter }: { meter: schemas['Meter'] }) => {
   })
 
   return (
-    <Grid
-      templateColumns={{ base: '1fr', md: 'repeat(3, 1fr)' }}
-      gap="2xl"
-    >
+    <Grid templateColumns={{ base: '1fr', md: 'repeat(3, 1fr)' }} gap="2xl">
       {[
         {
           title: 'Current Month',

--- a/clients/apps/web/src/components/Meter/MeterPage.tsx
+++ b/clients/apps/web/src/components/Meter/MeterPage.tsx
@@ -2,7 +2,7 @@
 
 import { Events } from '@/components/Events/Events'
 import MeterEventsTab from '@/components/Meter/MeterEventsTab'
-import { Spinner } from '@polar-sh/orbit'
+import { Grid, Spinner } from '@polar-sh/orbit'
 import { useEvents } from '@/hooks/queries/events'
 import { useMeterQuantities } from '@/hooks/queries/meters'
 import { ParsedMetricPeriod } from '@/hooks/queries/metrics'
@@ -219,7 +219,10 @@ const MeterActivityCards = ({ meter }: { meter: schemas['Meter'] }) => {
   })
 
   return (
-    <div className="flex flex-row gap-x-8">
+    <Grid
+      templateColumns={{ base: '1fr', md: 'repeat(3, 1fr)' }}
+      gap="2xl"
+    >
       {[
         {
           title: 'Current Month',
@@ -243,7 +246,7 @@ const MeterActivityCards = ({ meter }: { meter: schemas['Meter'] }) => {
           endDate: dates.allTimeEnd,
         },
       ].map((card, i) => (
-        <Card key={i} className="flex-1 rounded-3xl">
+        <Card key={i} className="rounded-3xl">
           <CardHeader className="flex flex-col gap-y-0">
             <h3 className="text-lg">{card.title}</h3>
             <span className="dark:text-polar-500 text-gray-500">
@@ -272,6 +275,6 @@ const MeterActivityCards = ({ meter }: { meter: schemas['Meter'] }) => {
           </CardContent>
         </Card>
       ))}
-    </div>
+    </Grid>
   )
 }


### PR DESCRIPTION
Fixes several dashboard layouts that clipped or crammed content on mobile. All changes are sm:/md:-gated, so desktop is unchanged.

- Event rows: deterministic two-tier mobile layout (title/badge + cost on line one, timestamp below); overflow guards so long labels/names/costs truncate instead of clipping.
- Event detail page: title/amount scaled down on mobile; "Child Events" heading reduced for hierarchy.
- Meter page: Activity cards use Orbit Grid — stacks on mobile, 3 columns on desktop.
- Create Meter filters: condition rows stack vertically on mobile instead of overflowing.

| Before | After | 
|---|---|
| <img width="634" height="685" alt="Screenshot 2026-07-15 at 10 14 30" src="https://github.com/user-attachments/assets/6dc1be4a-12cc-45e1-83c4-4aa163227d09" /> | <img width="563" height="697" alt="Screenshot 2026-07-15 at 10 14 52" src="https://github.com/user-attachments/assets/db9e4716-e102-4e97-ac70-7834a43c9464" /> |
| <img width="566" height="525" alt="Screenshot 2026-07-15 at 10 19 48" src="https://github.com/user-attachments/assets/f424a4b0-ebbe-48f8-bff5-19605c07b23a" /> | <img width="513" height="633" alt="Screenshot 2026-07-15 at 10 20 27" src="https://github.com/user-attachments/assets/b57dc373-2e52-4cbf-b250-8af679e1436b" /> |


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

