### PR TITLE
sdk/typescript: fix repository URL and add minimum release age

### DIFF
--- a/sdk/generator/typescript/template/package.json
+++ b/sdk/generator/typescript/template/package.json
@@ -39,6 +39,7 @@
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   },
+  "packageManager": "pnpm@11.13.0",
   "keywords": [
     "polar",
     "sdk",
@@ -49,7 +50,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/polar-sh/polar",
+    "url": "git+https://github.com/polar-sh/polar.git",
     "directory": "sdk/typescript"
   }
 }

--- a/sdk/generator/typescript/template/pnpm-workspace.yaml
+++ b/sdk/generator/typescript/template/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 allowBuilds:
   '@biomejs/biome': true
   esbuild: true
+minimumReleaseAge: 10080


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes npm publishing metadata in the TypeScript SDK template and hardens dependency installs. Updates the repository URL and enforces a 7‑day minimum release age with `pnpm`.

- **Bug Fixes**
  - Set repository URL to git+https://github.com/polar-sh/polar.git in the template.

- **Dependencies**
  - Add `minimumReleaseAge: 10080` to the template `pnpm-workspace.yaml`.
  - Pin `packageManager` to `pnpm@11.13.0` in the template `package.json`.

<sup>Written for commit 1e168d88fb09ab6d45f0b42987a0e496934375b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

