### PR TITLE
sdk/typescript: fix repository URL

### DIFF
--- a/sdk/generator/typescript/template/package.json
+++ b/sdk/generator/typescript/template/package.json
@@ -50,7 +50,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/polar-sh/polar.git",
+    "url": "git+https://github.com/polarsource/polar.git",
     "directory": "sdk/typescript"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the repository URL in the TypeScript SDK template `package.json` to point to `git+https://github.com/polarsource/polar.git`. This ensures npm `repository` links go to the correct repo.

<sup>Written for commit ca59f6d75c4d61a43ca8d7c052002dc08125bb1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

