### PR TITLE
sdk[release]: 1.0.0-alpha.10

### DIFF
--- a/sdk/python/polar/__init__.py
+++ b/sdk/python/polar/__init__.py
@@ -1,6 +1,6 @@
 from polar.base import PolarClientError, PolarError, PolarNetworkError, PolarServerError
 
-__version__ = "1.0.0a9"
+__version__ = "1.0.0a10"
 __all__ = [
     "PolarError",
     "PolarNetworkError",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polar-sh/sdk",
-  "version": "1.0.0-alpha.9",
+  "version": "1.0.0-alpha.10",
   "description": "Polar SDK — A billing platform for the intelligence era",
   "keywords": [
     "api",
@@ -12,7 +12,7 @@
   "author": "Polar",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/polar-sh/polar.git",
+    "url": "git+https://github.com/polarsource/polar.git",
     "directory": "sdk/typescript"
   },
   "files": [


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bump SDK version to 1.0.0-alpha.10 for Python and TypeScript. Also fixes the repository URL in `@polar-sh/sdk` package metadata (now github.com/polarsource/polar.git).

<sup>Written for commit 94ac94b15eae9f01442735795f99f4c9a733e809. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

