### PR TITLE
chore(transaction): add unique index on dispute transactions

### DIFF
--- a/server/migrations/versions/2026-07-15-1102_unique_index_on_dispute_transactions.py
+++ b/server/migrations/versions/2026-07-15-1102_unique_index_on_dispute_transactions.py
@@ -1,0 +1,50 @@
+"""unique index on dispute transactions
+
+Revision ID: 3955b27539d3
+Revises: cddb6a1cfd92
+Create Date: 2026-07-15 11:02:17.457273
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "3955b27539d3"
+down_revision = "cddb6a1cfd92"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+INDEX = "ix_dispute_transaction_dispute_id_uniqueness"
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        # Drop any INVALID leftover from an interrupted concurrent build first.
+        op.drop_index(
+            INDEX,
+            table_name="transactions",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            INDEX,
+            "transactions",
+            ["type", "dispute_id"],
+            unique=True,
+            postgresql_where="type = 'dispute'",
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            INDEX,
+            table_name="transactions",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )

--- a/server/polar/models/transaction.py
+++ b/server/polar/models/transaction.py
@@ -214,6 +214,13 @@ class Transaction(RecordModel):
             unique=True,
             postgresql_where="type = 'payment'",
         ),
+        Index(
+            "ix_dispute_transaction_dispute_id_uniqueness",
+            "type",
+            "dispute_id",
+            unique=True,
+            postgresql_where="type = 'dispute'",
+        ),
     )
 
     type: Mapped[TransactionType] = mapped_column(String, nullable=False, index=True)


### PR DESCRIPTION
## Summary

**Related Issue**: #13110

Adds a partial unique index `ix_dispute_transaction_dispute_id_uniqueness` on `transactions (type, dispute_id) WHERE type = 'dispute'`.

## Why

Groundwork for #13110: guarantees at most one dispute transaction per dispute, so a conflict-tolerant `create_dispute` (follow-up PR) can safely no-op on the accept-vs-webhook race instead of double-inserting.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

