### PR TITLE
sdk: add preset server URLs

### DIFF
--- a/sdk/generator/generator/ir.py
+++ b/sdk/generator/generator/ir.py
@@ -265,6 +265,14 @@ class Service(BaseModel):
     methods: list["Method"]
 
 
+class Server(BaseModel):
+    """A named API server extracted from the OpenAPI specification."""
+
+    environment: str
+    url: str
+    description: str | None = None
+
+
 class APIVersion(BaseModel):
     """
     A single version of an API, with its services and models.
@@ -280,6 +288,7 @@ class APIVersion(BaseModel):
     """
 
     version: str
+    servers: list[Server]
     services: list[Service]
     input_models: list[Model]
     output_models: list[Model]
@@ -357,6 +366,8 @@ def _default_model_name_normalizer(input: str) -> str:
 
 
 type ServiceNameNormalizer = typing.Callable[[str], str]
+
+ENVIRONMENT = "x-polar-environment"
 
 
 def _default_service_name_normalizer(input: str) -> str:
@@ -943,6 +954,16 @@ def _generate_ir_version(
     """
     Generate an intermediate representation of a single OpenAPI spec version.
     """
+    servers = [
+        Server(
+            environment=server.model_extra[ENVIRONMENT],
+            url=server.url,
+            description=server.description or None,
+        )
+        for server in spec.servers or []
+        if server.model_extra is not None and ENVIRONMENT in server.model_extra
+    ]
+
     services: list[Service] = []
 
     component_schemas: dict[str, op.Schema] = {}
@@ -1217,6 +1238,7 @@ def _generate_ir_version(
 
     return APIVersion(
         version=spec.info.version,
+        servers=servers,
         services=services,
         input_models=sorted(
             [m for name, m in models_dict.items() if name in input_names],

--- a/sdk/generator/python/template/polar/base.py
+++ b/sdk/generator/python/template/polar/base.py
@@ -1,9 +1,12 @@
 import builtins
+import collections.abc
 import types
 import typing
 
 import adaptix
 import httpx
+
+_EnvironmentT = typing.TypeVar("_EnvironmentT", bound=str)
 
 
 class PolarError(Exception):
@@ -41,6 +44,22 @@ class PolarRateLimitError(PolarClientError):
     def __init__(self, status_code: typing.Literal[429], retry_after: int | None = None):
         super().__init__(status_code, "Rate limit exceeded")
         self.retry_after = retry_after
+
+
+def resolve_base_url(
+    servers: collections.abc.Mapping[_EnvironmentT, str],
+    environment: _EnvironmentT,
+    base_url: str | None,
+) -> str:
+    if base_url is not None:
+        return base_url
+    try:
+        return servers[environment]
+    except KeyError as e:
+        environments = ", ".join(sorted(servers))
+        raise ValueError(
+            f"Invalid environment {environment!r}. Expected one of: {environments}."
+        ) from e
 
 
 class BuildRequestMixin:

--- a/sdk/generator/python/template/polar/version/__init__.py
+++ b/sdk/generator/python/template/polar/version/__init__.py
@@ -1,3 +1,3 @@
-from polar.{{ version }}.client import Polar, PolarAsync
+from polar.{{ version }}.client import Environment, Polar, PolarAsync
 
-__all__ = ["Polar", "PolarAsync"]
+__all__ = ["Environment", "Polar", "PolarAsync"]

--- a/sdk/generator/python/template/polar/version/client.py
+++ b/sdk/generator/python/template/polar/version/client.py
@@ -1,18 +1,33 @@
 import types
 import typing
 
-from polar.base import AsyncClientBase, SyncClientBase
+from polar.base import AsyncClientBase, SyncClientBase, resolve_base_url
 
 {% for service in api.services %}
 from polar.{{ version }}.{{ service.name | snake }} import {{ service.name }}Async
 from polar.{{ version }}.{{ service.name | snake }} import {{ service.name }}Sync
 {% endfor %}
 
+Environment = typing.Literal[{% for server in api.servers %}"{{ server.environment }}"{% if not loop.last %}, {% endif %}{% endfor %}]
+SERVERS: typing.Final[dict[Environment, str]] = {
+{% for server in api.servers %}
+    "{{ server.environment }}": "{{ server.url }}",
+{% endfor %}
+}
+
+
 class Polar:
     version: str = "{{ api.version }}"
 
-    def __init__(self, base_url: str, access_token: str) -> None:
-        self._client = SyncClientBase(base_url, self.version, access_token)
+    def __init__(
+        self,
+        access_token: str,
+        *,
+        environment: Environment = "production",
+        base_url: str | None = None,
+    ) -> None:
+        resolved_base_url = resolve_base_url(SERVERS, environment, base_url)
+        self._client = SyncClientBase(resolved_base_url, self.version, access_token)
 {% for service in api.services %}
         self.{{ service.name | snake }} = {{ service.name }}Sync(self._client)
 {% endfor %}
@@ -33,8 +48,15 @@ class Polar:
 class PolarAsync:
     version: str = "{{ api.version }}"
 
-    def __init__(self, base_url: str, access_token: str) -> None:
-        self._client = AsyncClientBase(base_url, self.version, access_token)
+    def __init__(
+        self,
+        access_token: str,
+        *,
+        environment: Environment = "production",
+        base_url: str | None = None,
+    ) -> None:
+        resolved_base_url = resolve_base_url(SERVERS, environment, base_url)
+        self._client = AsyncClientBase(resolved_base_url, self.version, access_token)
 {% for service in api.services %}
         self.{{ service.name | snake }} = {{ service.name }}Async(self._client)
 {% endfor %}
@@ -52,4 +74,4 @@ class PolarAsync:
         await self._client.__aexit__(exc_type, exc_val, exc_tb)
 
 
-__all__ = ["Polar", "PolarAsync"]
+__all__ = ["Environment", "Polar", "PolarAsync"]

--- a/sdk/generator/python/template/tests/test_base.py
+++ b/sdk/generator/python/template/tests/test_base.py
@@ -2,7 +2,31 @@ import typing
 
 import pytest
 
-from polar.base import SyncClientBase, AsyncClientBase
+from polar.base import AsyncClientBase, SyncClientBase, resolve_base_url
+
+SERVERS = {
+    "production": "https://api.polar.sh",
+    "sandbox": "https://sandbox-api.polar.sh",
+}
+
+
+@pytest.mark.parametrize(
+    ("environment", "base_url", "expected"),
+    [
+        ("production", None, "https://api.polar.sh"),
+        ("sandbox", None, "https://sandbox-api.polar.sh"),
+        ("invalid", "http://localhost:8000", "http://localhost:8000"),
+    ],
+)
+def test_resolve_base_url(
+    environment: str, base_url: str | None, expected: str
+) -> None:
+    assert resolve_base_url(SERVERS, environment, base_url) == expected
+
+
+def test_resolve_base_url_invalid_environment() -> None:
+    with pytest.raises(ValueError, match="Invalid environment 'invalid'"):
+        resolve_base_url(SERVERS, "invalid", None)
 
 
 @pytest.fixture(params=[SyncClientBase, AsyncClientBase])

--- a/sdk/generator/tests/test_ir.py
+++ b/sdk/generator/tests/test_ir.py
@@ -84,6 +84,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                 "versions": [
                     {
                         "version": "1.0.0",
+                        "servers": [],
                         "services": [
                             {
                                 "name": "Products",
@@ -216,6 +217,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                 "versions": [
                     {
                         "version": "1.0.0",
+                        "servers": [],
                         "services": [
                             {
                                 "name": "Users",
@@ -312,6 +314,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                 "versions": [
                     {
                         "version": "1.0.0",
+                        "servers": [],
                         "services": [],
                         "input_models": [],
                         "output_models": [],
@@ -402,6 +405,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                 "versions": [
                     {
                         "version": "1.0.0",
+                        "servers": [],
                         "services": [
                             {
                                 "name": "Products",
@@ -538,6 +542,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                 "versions": [
                     {
                         "version": "1.0.0",
+                        "servers": [],
                         "services": [
                             {
                                 "name": "Orders",
@@ -672,6 +677,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                 "versions": [
                     {
                         "version": "1.0.0",
+                        "servers": [],
                         "services": [
                             {
                                 "name": "Products",
@@ -799,6 +805,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                 "versions": [
                     {
                         "version": "1.0.0",
+                        "servers": [],
                         "services": [
                             {
                                 "name": "Accounts",
@@ -911,6 +918,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                 "versions": [
                     {
                         "version": "1.0.0",
+                        "servers": [],
                         "services": [
                             {
                                 "name": "Events",
@@ -1034,6 +1042,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                 "versions": [
                     {
                         "version": "1.0.0",
+                        "servers": [],
                         "services": [
                             {
                                 "name": "Payments",
@@ -1134,6 +1143,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                 "versions": [
                     {
                         "version": "1.0.0",
+                        "servers": [],
                         "services": [
                             {
                                 "name": "Metadata",
@@ -1253,6 +1263,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                 "versions": [
                     {
                         "version": "1.0.0",
+                        "servers": [],
                         "services": [
                             {
                                 "name": "Products",
@@ -1449,6 +1460,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                 "versions": [
                     {
                         "version": "1.0.0",
+                        "servers": [],
                         "services": [
                             {
                                 "name": "Items",
@@ -1587,6 +1599,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                 "versions": [
                     {
                         "version": "1.0.0",
+                        "servers": [],
                         "services": [
                             {
                                 "name": "Items",
@@ -1696,6 +1709,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                 "versions": [
                     {
                         "version": "1.0.0",
+                        "servers": [],
                         "services": [
                             {
                                 "name": "Checkout",
@@ -1837,6 +1851,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                 "versions": [
                     {
                         "version": "1.0.0",
+                        "servers": [],
                         "services": [
                             {
                                 "name": "Payment",
@@ -1970,6 +1985,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                 "versions": [
                     {
                         "version": "1.0.0",
+                        "servers": [],
                         "services": [
                             {
                                 "name": "Files",
@@ -2102,6 +2118,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                 "versions": [
                     {
                         "version": "1.0.0",
+                        "servers": [],
                         "services": [
                             {
                                 "name": "Export",
@@ -2177,6 +2194,53 @@ _STRING = {"kind": "primitive", "type": "string"}
                 {
                     "openapi": "3.1.0",
                     "info": {"title": "Test API", "version": "1.0.0"},
+                    "servers": [
+                        {
+                            "url": "https://api.example.com",
+                            "description": "Production environment",
+                            "x-polar-environment": "production",
+                        },
+                        {
+                            "url": "https://sandbox-api.example.com",
+                            "description": "Sandbox environment",
+                            "x-polar-environment": "sandbox",
+                        },
+                    ],
+                    "paths": {},
+                }
+            ],
+            {
+                "versions": [
+                    {
+                        "version": "1.0.0",
+                        "servers": [
+                            {
+                                "environment": "production",
+                                "url": "https://api.example.com",
+                                "description": "Production environment",
+                            },
+                            {
+                                "environment": "sandbox",
+                                "url": "https://sandbox-api.example.com",
+                                "description": "Sandbox environment",
+                            },
+                        ],
+                        "services": [],
+                        "input_models": [],
+                        "output_models": [],
+                        "enums": [],
+                        "input_unions": [],
+                        "output_unions": [],
+                    }
+                ]
+            },
+            id="Servers use the Polar environment extension",
+        ),
+        pytest.param(
+            [
+                {
+                    "openapi": "3.1.0",
+                    "info": {"title": "Test API", "version": "1.0.0"},
                     "paths": {},
                 },
                 {
@@ -2189,6 +2253,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                 "versions": [
                     {
                         "version": "1.0.0",
+                        "servers": [],
                         "services": [],
                         "input_models": [],
                         "output_models": [],
@@ -2198,6 +2263,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                     },
                     {
                         "version": "2.0.0",
+                        "servers": [],
                         "services": [],
                         "input_models": [],
                         "output_models": [],

--- a/sdk/generator/typescript/template/src/base.test.ts
+++ b/sdk/generator/typescript/template/src/base.test.ts
@@ -1,5 +1,29 @@
 import { describe, expect, test } from "vitest";
-import { ClientBase } from "./base";
+import { ClientBase, resolveBaseUrl } from "./base";
+
+const servers = {
+  production: "https://api.polar.sh",
+  sandbox: "https://sandbox-api.polar.sh",
+};
+
+describe("resolveBaseUrl", () => {
+  test.each([
+    ["production", undefined, "https://api.polar.sh"],
+    ["sandbox", undefined, "https://sandbox-api.polar.sh"],
+    ["invalid", "http://localhost:8000", "http://localhost:8000"],
+  ])(
+    "resolves %s with override %s",
+    (environment, baseUrl, expected) => {
+      expect(resolveBaseUrl(servers, environment, baseUrl)).toBe(expected);
+    },
+  );
+
+  test("rejects invalid environments", () => {
+    expect(() => resolveBaseUrl(servers, "invalid")).toThrow(
+      'Invalid environment "invalid"',
+    );
+  });
+});
 
 const client = new ClientBase({
   baseUrl: "https://api.polar.sh",

--- a/sdk/generator/typescript/template/src/base.ts
+++ b/sdk/generator/typescript/template/src/base.ts
@@ -103,6 +103,23 @@ export interface ClientOptions {
   accessToken: string;
 }
 
+export const resolveBaseUrl = (
+  servers: Record<string, string>,
+  environment: string,
+  baseUrl?: string,
+): string => {
+  if (baseUrl !== undefined) {
+    return baseUrl;
+  }
+  const serverUrl = servers[environment];
+  if (serverUrl === undefined) {
+    throw new Error(
+      `Invalid environment ${JSON.stringify(environment)}. Expected one of: ${Object.keys(servers).sort().join(", ")}.`,
+    );
+  }
+  return serverUrl;
+};
+
 export class ClientBase {
   protected readonly options: ClientOptions;
 

--- a/sdk/generator/typescript/template/src/version/client.ts
+++ b/sdk/generator/typescript/template/src/version/client.ts
@@ -1,15 +1,32 @@
-import { ClientBase, ClientOptions } from "../base";
+import { ClientBase, ClientOptions, resolveBaseUrl } from "../base";
 {% for service in api.services %}
 import { create{{ service.name }}Service } from "./services/{{ service.name | snake }}";
 {% endfor %}
 
-export interface PolarOptions extends Omit<ClientOptions, "version"> {
+export type Environment = {% for server in api.servers %}"{{ server.environment }}"{% if not loop.last %} | {% endif %}{% endfor %};
+
+const SERVERS: Record<Environment, string> = {
+  {% for server in api.servers %}
+  "{{ server.environment }}": "{{ server.url }}",{% if not loop.last %}
+  {% endif %}
+  {% endfor %}
+};
+
+export interface PolarOptions
+  extends Omit<ClientOptions, "baseUrl" | "version"> {
   version?: string;
+  environment?: Environment;
+  baseUrl?: string;
 }
 
 export function createPolar(options: PolarOptions) {
   const client = new ClientBase({
     ...options,
+    baseUrl: resolveBaseUrl(
+      SERVERS,
+      options.environment ?? "production",
+      options.baseUrl,
+    ),
     version: options.version ?? "{{ api.version }}",
   });
 

--- a/sdk/generator/typescript/template/src/version/index.ts
+++ b/sdk/generator/typescript/template/src/version/index.ts
@@ -1,4 +1,4 @@
 export { createPolar } from "./client";
-export type { Polar } from "./client";
+export type { Environment, Polar, PolarOptions } from "./client";
 export * as models from "./models";
 export * as errors from "./errors";

--- a/sdk/python/polar/base.py
+++ b/sdk/python/polar/base.py
@@ -1,9 +1,12 @@
 import builtins
+import collections.abc
 import types
 import typing
 
 import adaptix
 import httpx
+
+_EnvironmentT = typing.TypeVar("_EnvironmentT", bound=str)
 
 
 class PolarError(Exception):
@@ -43,6 +46,22 @@ class PolarRateLimitError(PolarClientError):
     ):
         super().__init__(status_code, "Rate limit exceeded")
         self.retry_after = retry_after
+
+
+def resolve_base_url(
+    servers: collections.abc.Mapping[_EnvironmentT, str],
+    environment: _EnvironmentT,
+    base_url: str | None,
+) -> str:
+    if base_url is not None:
+        return base_url
+    try:
+        return servers[environment]
+    except KeyError as e:
+        environments = ", ".join(sorted(servers))
+        raise ValueError(
+            f"Invalid environment {environment!r}. Expected one of: {environments}."
+        ) from e
 
 
 class BuildRequestMixin:

--- a/sdk/python/polar/v2026_04/__init__.py
+++ b/sdk/python/polar/v2026_04/__init__.py
@@ -1,3 +1,3 @@
-from polar.v2026_04.client import Polar, PolarAsync
+from polar.v2026_04.client import Environment, Polar, PolarAsync
 
-__all__ = ["Polar", "PolarAsync"]
+__all__ = ["Environment", "Polar", "PolarAsync"]

--- a/sdk/python/polar/v2026_04/client.py
+++ b/sdk/python/polar/v2026_04/client.py
@@ -1,7 +1,7 @@
 import types
 import typing
 
-from polar.base import AsyncClientBase, SyncClientBase
+from polar.base import AsyncClientBase, SyncClientBase, resolve_base_url
 from polar.v2026_04.benefit_grants import BenefitGrantsAsync, BenefitGrantsSync
 from polar.v2026_04.benefits import BenefitsAsync, BenefitsSync
 from polar.v2026_04.checkout_links import CheckoutLinksAsync, CheckoutLinksSync
@@ -30,12 +30,25 @@ from polar.v2026_04.refunds import RefundsAsync, RefundsSync
 from polar.v2026_04.subscriptions import SubscriptionsAsync, SubscriptionsSync
 from polar.v2026_04.webhooks import WebhooksAsync, WebhooksSync
 
+Environment = typing.Literal["production", "sandbox"]
+SERVERS: typing.Final[dict[Environment, str]] = {
+    "production": "https://api.polar.sh",
+    "sandbox": "https://sandbox-api.polar.sh",
+}
+
 
 class Polar:
     version: str = "2026-04"
 
-    def __init__(self, base_url: str, access_token: str) -> None:
-        self._client = SyncClientBase(base_url, self.version, access_token)
+    def __init__(
+        self,
+        access_token: str,
+        *,
+        environment: Environment = "production",
+        base_url: str | None = None,
+    ) -> None:
+        resolved_base_url = resolve_base_url(SERVERS, environment, base_url)
+        self._client = SyncClientBase(resolved_base_url, self.version, access_token)
         self.organizations = OrganizationsSync(self._client)
         self.subscriptions = SubscriptionsSync(self._client)
         self.oauth2 = Oauth2Sync(self._client)
@@ -80,8 +93,15 @@ class Polar:
 class PolarAsync:
     version: str = "2026-04"
 
-    def __init__(self, base_url: str, access_token: str) -> None:
-        self._client = AsyncClientBase(base_url, self.version, access_token)
+    def __init__(
+        self,
+        access_token: str,
+        *,
+        environment: Environment = "production",
+        base_url: str | None = None,
+    ) -> None:
+        resolved_base_url = resolve_base_url(SERVERS, environment, base_url)
+        self._client = AsyncClientBase(resolved_base_url, self.version, access_token)
         self.organizations = OrganizationsAsync(self._client)
         self.subscriptions = SubscriptionsAsync(self._client)
         self.oauth2 = Oauth2Async(self._client)
@@ -123,4 +143,4 @@ class PolarAsync:
         await self._client.__aexit__(exc_type, exc_val, exc_tb)
 
 
-__all__ = ["Polar", "PolarAsync"]
+__all__ = ["Environment", "Polar", "PolarAsync"]

--- a/sdk/python/tests/test_base.py
+++ b/sdk/python/tests/test_base.py
@@ -2,7 +2,31 @@ import typing
 
 import pytest
 
-from polar.base import AsyncClientBase, SyncClientBase
+from polar.base import AsyncClientBase, SyncClientBase, resolve_base_url
+
+SERVERS = {
+    "production": "https://api.polar.sh",
+    "sandbox": "https://sandbox-api.polar.sh",
+}
+
+
+@pytest.mark.parametrize(
+    ("environment", "base_url", "expected"),
+    [
+        ("production", None, "https://api.polar.sh"),
+        ("sandbox", None, "https://sandbox-api.polar.sh"),
+        ("invalid", "http://localhost:8000", "http://localhost:8000"),
+    ],
+)
+def test_resolve_base_url(
+    environment: str, base_url: str | None, expected: str
+) -> None:
+    assert resolve_base_url(SERVERS, environment, base_url) == expected
+
+
+def test_resolve_base_url_invalid_environment() -> None:
+    with pytest.raises(ValueError, match="Invalid environment 'invalid'"):
+        resolve_base_url(SERVERS, "invalid", None)
 
 
 @pytest.fixture(params=[SyncClientBase, AsyncClientBase])

--- a/sdk/typescript/src/2026-04/client.ts
+++ b/sdk/typescript/src/2026-04/client.ts
@@ -1,4 +1,4 @@
-import { ClientBase, ClientOptions } from "../base";
+import { ClientBase, ClientOptions, resolveBaseUrl } from "../base";
 import { createBenefitGrantsService } from "./services/benefit_grants";
 import { createBenefitsService } from "./services/benefits";
 import { createCheckoutLinksService } from "./services/checkout_links";
@@ -27,13 +27,23 @@ import { createRefundsService } from "./services/refunds";
 import { createSubscriptionsService } from "./services/subscriptions";
 import { createWebhooksService } from "./services/webhooks";
 
-export interface PolarOptions extends Omit<ClientOptions, "version"> {
+export type Environment = "production" | "sandbox";
+
+const SERVERS: Record<Environment, string> = {
+  production: "https://api.polar.sh",
+  sandbox: "https://sandbox-api.polar.sh",
+};
+
+export interface PolarOptions extends Omit<ClientOptions, "baseUrl" | "version"> {
   version?: string;
+  environment?: Environment;
+  baseUrl?: string;
 }
 
 export function createPolar(options: PolarOptions) {
   const client = new ClientBase({
     ...options,
+    baseUrl: resolveBaseUrl(SERVERS, options.environment ?? "production", options.baseUrl),
     version: options.version ?? "2026-04",
   });
 

--- a/sdk/typescript/src/2026-04/index.ts
+++ b/sdk/typescript/src/2026-04/index.ts
@@ -1,4 +1,4 @@
 export { createPolar } from "./client";
-export type { Polar } from "./client";
+export type { Environment, Polar, PolarOptions } from "./client";
 export * as models from "./models";
 export * as errors from "./errors";

--- a/sdk/typescript/src/base.test.ts
+++ b/sdk/typescript/src/base.test.ts
@@ -1,6 +1,25 @@
 import { describe, expect, test } from "vitest";
 
-import { ClientBase } from "./base";
+import { ClientBase, resolveBaseUrl } from "./base";
+
+const servers = {
+  production: "https://api.polar.sh",
+  sandbox: "https://sandbox-api.polar.sh",
+};
+
+describe("resolveBaseUrl", () => {
+  test.each([
+    ["production", undefined, "https://api.polar.sh"],
+    ["sandbox", undefined, "https://sandbox-api.polar.sh"],
+    ["invalid", "http://localhost:8000", "http://localhost:8000"],
+  ])("resolves %s with override %s", (environment, baseUrl, expected) => {
+    expect(resolveBaseUrl(servers, environment, baseUrl)).toBe(expected);
+  });
+
+  test("rejects invalid environments", () => {
+    expect(() => resolveBaseUrl(servers, "invalid")).toThrow('Invalid environment "invalid"');
+  });
+});
 
 const client = new ClientBase({
   baseUrl: "https://api.polar.sh",

--- a/sdk/typescript/src/base.ts
+++ b/sdk/typescript/src/base.ts
@@ -94,6 +94,23 @@ export interface ClientOptions {
   accessToken: string;
 }
 
+export const resolveBaseUrl = (
+  servers: Record<string, string>,
+  environment: string,
+  baseUrl?: string,
+): string => {
+  if (baseUrl !== undefined) {
+    return baseUrl;
+  }
+  const serverUrl = servers[environment];
+  if (serverUrl === undefined) {
+    throw new Error(
+      `Invalid environment ${JSON.stringify(environment)}. Expected one of: ${Object.keys(servers).sort().join(", ")}.`,
+    );
+  }
+  return serverUrl;
+};
+
 export class ClientBase {
   protected readonly options: ClientOptions;
 


### PR DESCRIPTION
## Summary

**Related Issue**: #13184

Adds schema-driven preset server URLs to the generated Python and TypeScript SDKs, defaulting clients to production while supporting sandbox selection and explicit URL overrides.

## What

- Parse named environments and URLs from the OpenAPI servers extension into the generator IR.
- Generate typed production and sandbox environment configuration for both SDKs.
- Keep explicit base URL overrides available for local development and proxy setups.
- Cover server extraction, URL resolution, override precedence, and invalid environment handling with tests.

## Why

SDK consumers currently have to provide the Polar API base URL for every client. The OpenAPI specification already declares the production and sandbox servers, so generated clients can provide safe defaults and a simpler initialization API.

## How

The generator reads x-polar-environment from each declared OpenAPI server and stores the resulting server list per API version. Language templates generate environment types and server maps, then resolve the final URL before constructing the existing HTTP client. Explicit base URLs take precedence over named environments.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (using the SDK generator and generated-package checks)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

