### PR TITLE
feat: merchant-migration review listing and classification

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -23117,6 +23117,11 @@ export interface components {
     }
     /** MerchantMigrationRecordItem */
     MerchantMigrationRecordItem: {
+      /**
+       * Record Id
+       * @description The ledger record id, used to select this row for import. Null for price rows, which are imported together with their product.
+       */
+      record_id: string | null
       /** @description The source entity type. */
       entity: components['schemas']['PrecheckEntity']
       /**
@@ -23131,22 +23136,48 @@ export interface components {
       title: string
       /**
        * Subtitle
-       * @description Secondary detail (interval, amount, country, status).
+       * @description Secondary detail (lifecycle status, country).
        */
       subtitle: string | null
+      /**
+       * Amount
+       * @description Recurring price in minor units (cents), for priced rows.
+       */
+      amount: number | null
+      /**
+       * Currency
+       * @description ISO currency for `amount`.
+       */
+      currency: string | null
+      /**
+       * Recurring Interval
+       * @description Billing interval for `amount` (e.g. `month`, `year`).
+       */
+      recurring_interval: string | null
       /** @description Whether this record will be imported or stays on the source. */
       status: components['schemas']['PrecheckRecordStatus']
+      /** @description The ledger status of this record: `pending` (not imported yet), `imported`, `skipped` or `failed`. Null for price rows, which import with their product. */
+      import_status:
+        | components['schemas']['MerchantMigrationRecordStatus']
+        | null
       /**
        * Reason
-       * @description Why the record is skipped, if it is.
+       * @description Why the record is skipped, or what to know about it if it isn't.
        */
       reason: string | null
       /**
        * Reason Code
-       * @description Stable code for the skip reason, if any.
+       * @description Stable code for `reason`, if any.
        */
       reason_code: string | null
+      /** @description How urgent `reason` is: `action_required` when the merchant has to fix something, `info` when there is nothing to fix. Null without a reason. */
+      reason_level: components['schemas']['PrecheckReasonLevel'] | null
     }
+    /**
+     * MerchantMigrationRecordStatus
+     * @enum {string}
+     */
+    MerchantMigrationRecordStatus: 'pending' | 'imported' | 'skipped' | 'failed'
     /**
      * MerchantMigrationSourcePlatform
      * @enum {string}
@@ -29344,6 +29375,11 @@ export interface components {
      * @enum {string}
      */
     PrecheckIssueLevel: 'blocker' | 'warning'
+    /**
+     * PrecheckReasonLevel
+     * @enum {string}
+     */
+    PrecheckReasonLevel: 'action_required' | 'info'
     /**
      * PrecheckRecordStatus
      * @enum {string}
@@ -51268,9 +51304,10 @@ export interface operations {
   }
   'merchant-migrations:records': {
     parameters: {
-      query: {
-        entity: components['schemas']['PrecheckEntity']
+      query?: {
+        entity?: components['schemas']['PrecheckEntity'] | null
         status?: components['schemas']['PrecheckRecordStatus'] | null
+        reason_level?: components['schemas']['PrecheckReasonLevel'] | null
         /** @description Page number, defaults to 1. */
         page?: number
         /** @description Size of a page, defaults to 10. Maximum is 100. */
@@ -63955,6 +63992,9 @@ export const memberRoleValues: ReadonlyArray<
 export const memberSortPropertyValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['MemberSortProperty']
 > = ['created_at', '-created_at']
+export const merchantMigrationRecordStatusValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['MerchantMigrationRecordStatus']
+> = ['pending', 'imported', 'skipped', 'failed']
 export const merchantMigrationSourcePlatformValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['MerchantMigrationSourcePlatform']
 > = ['stripe', 'lemon_squeezy', 'paddle']
@@ -65578,6 +65618,9 @@ export const precheckEntityValues: ReadonlyArray<
 export const precheckIssueLevelValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['PrecheckIssueLevel']
 > = ['blocker', 'warning']
+export const precheckReasonLevelValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['PrecheckReasonLevel']
+> = ['action_required', 'info']
 export const precheckRecordStatusValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['PrecheckRecordStatus']
 > = ['importable', 'skipped']

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -23141,7 +23141,7 @@ export interface components {
       subtitle: string | null
       /**
        * Amount
-       * @description Recurring price in minor units (cents), for priced rows.
+       * @description Recurring price in the currency's smallest unit (cents for USD), for priced rows.
        */
       amount: number | null
       /**

--- a/server/polar/merchant_migration/adapters/stripe.py
+++ b/server/polar/merchant_migration/adapters/stripe.py
@@ -224,6 +224,8 @@ class StripeAdapter:
             line_item_count=len(items),
             quantity=first_item.get("quantity") or 1,
             payment_method=self._resolve_payment_method(subscription),
+            has_discount=bool(subscription.get("discounts"))
+            or subscription.get("discount") is not None,
         )
 
     def _map_customer(self, customer: stripe_lib.Customer) -> CanonicalCustomer:

--- a/server/polar/merchant_migration/canonical.py
+++ b/server/polar/merchant_migration/canonical.py
@@ -106,6 +106,9 @@ class CanonicalSubscription:
     line_item_count: int
     quantity: int
     payment_method: CanonicalPaymentMethod | None
+    # A discount/coupon on the source. Its amount isn't migrated yet, so importing
+    # at list price would overcharge; such subscriptions are skipped for now.
+    has_discount: bool = False
 
     type = MerchantMigrationRecordType.subscription
 
@@ -182,6 +185,7 @@ def deserialize(
                 )
                 if payment_method is not None
                 else None,
+                has_discount=data.get("has_discount", False),
             )
         case _:
             raise ValueError(f"Cannot deserialize record of type {type}")

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -165,8 +165,9 @@ async def records(
     id: UUID4,
     auth_subject: MerchantMigrationWrite,
     pagination: PaginationParamsQuery,
-    entity: Annotated[PrecheckEntity, Query()],
+    entity: Annotated[PrecheckEntity | None, Query()] = None,
     status: Annotated[PrecheckRecordStatus | None, Query()] = None,
+    needs_attention: Annotated[bool, Query()] = False,
     session: AsyncSession = Depends(get_db_session),
 ) -> ListResource[MerchantMigrationRecordItem]:
     items, count = await merchant_migration_service.list_records(
@@ -175,6 +176,7 @@ async def records(
         id,
         entity=entity,
         status=status,
+        needs_attention=needs_attention,
         pagination=pagination,
     )
     return ListResource.from_paginated_results(items, count, pagination)

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -18,6 +18,7 @@ from .schemas import (
     MerchantMigrationCreate,
     MerchantMigrationRecordItem,
     PrecheckEntity,
+    PrecheckReasonLevel,
     PrecheckRecordStatus,
     PrecheckReport,
 )
@@ -167,7 +168,7 @@ async def records(
     pagination: PaginationParamsQuery,
     entity: Annotated[PrecheckEntity | None, Query()] = None,
     status: Annotated[PrecheckRecordStatus | None, Query()] = None,
-    needs_attention: Annotated[bool, Query()] = False,
+    reason_level: Annotated[PrecheckReasonLevel | None, Query()] = None,
     session: AsyncSession = Depends(get_db_session),
 ) -> ListResource[MerchantMigrationRecordItem]:
     items, count = await merchant_migration_service.list_records(
@@ -176,7 +177,7 @@ async def records(
         id,
         entity=entity,
         status=status,
-        needs_attention=needs_attention,
+        reason_level=reason_level,
         pagination=pagination,
     )
     return ListResource.from_paginated_results(items, count, pagination)

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -50,9 +50,8 @@ NON_IMPORTABLE_STATUSES = {
     CanonicalSubscriptionStatus.paused,
 }
 
-# Warning codes that mean a record won't be imported (it stays on the source),
-# grouped by the entity they apply to. Kept in sync with the `_check_*` methods
-# so the per-record classification below matches the report's warnings.
+# Codes whose warning means a record won't import, by entity. Keep in sync with
+# the `_check_*` methods so classification matches the report.
 PRODUCT_DROP_CODES = {"one_time_product", "unsupported_recurring_interval"}
 PRICE_DROP_CODES = {
     "unsupported_pricing_scheme",
@@ -292,9 +291,8 @@ class PrecheckEngine:
         products_by_name: dict[str, set[str]],
         existing_product_names: set[str],
     ) -> Iterable[PrecheckIssue]:
-        # Warn (don't block): the source product still imports, but as a new Polar
-        # product alongside the existing one. Mapping onto the existing product is
-        # a separate, merchant-driven step.
+        # Warn, don't block: the product still imports, as a new Polar product next
+        # to the existing one. Mapping onto it is a later, merchant-driven step.
         for name in products_by_name:
             if name.lower() in existing_product_names:
                 yield PrecheckIssue(
@@ -553,8 +551,7 @@ def _duplicate_customer_source_ids(
 def _product_items(
     products: Sequence[CanonicalProduct],
 ) -> list[MerchantMigrationRecordItem]:
-    # Classify with the importer's own plan so the report never promises a product
-    # the importer will later skip (e.g. one with no importable price).
+    # Use the importer's plan, so the report can't promise a product it will skip.
     plans = plan_product_imports(products)
     items: list[MerchantMigrationRecordItem] = []
     for product in products:
@@ -616,8 +613,7 @@ def _price_items(
 def _customer_items(
     customers: Sequence[CanonicalCustomer],
 ) -> list[MerchantMigrationRecordItem]:
-    # Classify with the importer's own plan so the report never promises a customer
-    # the importer will later skip (e.g. one with no email).
+    # Use the importer's plan, so the report can't promise a customer it will skip.
     plans = plan_customer_imports(customers)
     items: list[MerchantMigrationRecordItem] = []
     for customer in customers:
@@ -644,8 +640,7 @@ def _subscription_items(
     products: Sequence[CanonicalProduct],
     customers: Sequence[CanonicalCustomer],
 ) -> list[MerchantMigrationRecordItem]:
-    # Classify with the importer's own plan so the report matches the import;
-    # layer the display-only trialing warning on top.
+    # Use the importer's plan; add the display-only trialing warning on top.
     plans = plan_subscription_imports(subscriptions, products, customers)
     email_by_source = {c.source_id: c.email for c in customers if c.email}
     price_info = _price_info(products)

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -8,6 +8,7 @@ report, so a record's importable/skipped status always matches the summary.
 
 from collections import Counter
 from collections.abc import AsyncIterable, Iterable, Sequence
+from dataclasses import dataclass
 
 from polar.enums import SubscriptionRecurringInterval
 from polar.kit.currency import (
@@ -65,12 +66,16 @@ SUBSCRIPTION_DROP_CODES = {
     "send_invoice_collection",
     "subscription_not_importable",
     "subscription_paused_collection",
+    "subscription_has_discount",
 }
 _DUPLICATE_PRODUCT_NAME_REASON = (
     "Another product already uses this name; the duplicate stays on the source."
 )
 _DUPLICATE_CUSTOMER_EMAIL_REASON = (
     "Another customer already uses this email; the duplicate stays on the source."
+)
+_MISSING_EMAIL_REASON = (
+    "The source customer has no email, so it can't be imported into Polar."
 )
 _SUBSCRIPTION_PRODUCT_REASON = (
     "The product or price for this subscription won't be imported, so it stays "
@@ -79,6 +84,17 @@ _SUBSCRIPTION_PRODUCT_REASON = (
 _SUBSCRIPTION_CUSTOMER_REASON = (
     "The customer for this subscription won't be imported, so it stays on the source."
 )
+_NO_IMPORTABLE_PRICE_REASON = (
+    "None of this product's prices can be imported, so the product is skipped."
+)
+_MISSING_COUNTRY_REASON = (
+    "No billing country. Confirm it before the first renewal so tax is correct."
+)
+_TRIALING_REASON = "On trial. Billing resumes on Polar when the trial ends."
+
+
+def _humanize_subscription_status(status: CanonicalSubscriptionStatus) -> str:
+    return status.value.replace("_", " ").capitalize()
 
 
 def _is_supported_currency(currency: str) -> bool:
@@ -95,6 +111,7 @@ class PrecheckEngine:
         records: AsyncIterable[CanonicalRecord],
         organization: Organization,
         source_account: CanonicalAccount,
+        existing_product_names: set[str] | None = None,
     ) -> PrecheckReport:
         record_list = [record async for record in records]
 
@@ -120,6 +137,11 @@ class PrecheckEngine:
                 issues.extend(self._check_subscription(record))
 
         issues.extend(self._check_duplicate_names(products_by_name))
+        issues.extend(
+            self._check_existing_products(
+                products_by_name, existing_product_names or set()
+            )
+        )
         issues.extend(self._check_duplicate_emails(email_counts))
         issues.extend(self._check_missing_country(customers_without_country))
 
@@ -175,8 +197,8 @@ class PrecheckEngine:
                 level=PrecheckIssueLevel.warning,
                 code="one_time_product",
                 message=(
-                    f"Product '{product.name}' is one-time; it and its "
-                    "subscriptions won't be imported."
+                    "This one-time product can't be imported as a subscription, "
+                    "so it stays on the source."
                 ),
                 source_id=product.source_id,
             )
@@ -265,6 +287,26 @@ class PrecheckEngine:
                     source_id=None,
                 )
 
+    def _check_existing_products(
+        self,
+        products_by_name: dict[str, set[str]],
+        existing_product_names: set[str],
+    ) -> Iterable[PrecheckIssue]:
+        # Warn (don't block): the source product still imports, but as a new Polar
+        # product alongside the existing one. Mapping onto the existing product is
+        # a separate, merchant-driven step.
+        for name in products_by_name:
+            if name.lower() in existing_product_names:
+                yield PrecheckIssue(
+                    level=PrecheckIssueLevel.warning,
+                    code="product_exists_in_polar",
+                    message=(
+                        f"A Polar product named '{name}' already exists; importing "
+                        "will create a duplicate."
+                    ),
+                    source_id=None,
+                )
+
     def _check_duplicate_emails(
         self, email_counts: Counter[str]
     ) -> Iterable[PrecheckIssue]:
@@ -317,6 +359,16 @@ class PrecheckEngine:
                 ),
                 source_id=source_id,
             )
+        if subscription.has_discount:
+            yield PrecheckIssue(
+                level=PrecheckIssueLevel.warning,
+                code="subscription_has_discount",
+                message=(
+                    "Subscription has a discount, which isn't migrated yet; it "
+                    "won't be imported so the customer isn't overcharged."
+                ),
+                source_id=source_id,
+            )
         if subscription.collection_method == CanonicalCollectionMethod.send_invoice:
             yield PrecheckIssue(
                 level=PrecheckIssueLevel.warning,
@@ -332,8 +384,9 @@ class PrecheckEngine:
                 level=PrecheckIssueLevel.warning,
                 code="subscription_not_importable",
                 message=(
-                    f"Subscription is {subscription.status.value}; it won't be "
-                    "imported and stays on the current provider."
+                    f"This {_humanize_subscription_status(subscription.status).lower()} "
+                    "subscription can't be imported yet; it stays with the "
+                    "current provider."
                 ),
                 source_id=source_id,
             )
@@ -396,12 +449,22 @@ def _item(
     *,
     reason_code: str | None,
     reason: str | None,
+    amount: int | None = None,
+    currency: str | None = None,
+    recurring_interval: str | None = None,
 ) -> MerchantMigrationRecordItem:
     return MerchantMigrationRecordItem(
+        # record_id and import_status come from the ledger via
+        # `_attach_record_ids`; the classifier itself has none.
+        record_id=None,
+        import_status=None,
         entity=entity,
         source_id=source_id,
         title=title,
         subtitle=subtitle,
+        amount=amount,
+        currency=currency,
+        recurring_interval=recurring_interval,
         status=(
             PrecheckRecordStatus.skipped
             if reason_code
@@ -410,6 +473,31 @@ def _item(
         reason=reason,
         reason_code=reason_code,
     )
+
+
+# The price shown on a priced row: (amount, currency, interval). A product is
+# represented by its first price; a subscription by the price it runs on.
+def _price_info(
+    products: Sequence[CanonicalProduct],
+) -> dict[str, tuple[int | None, str, str | None]]:
+    info: dict[str, tuple[int | None, str, str | None]] = {}
+    for product in products:
+        for price in product.prices:
+            info[price.source_id] = (
+                price.amount,
+                price.currency,
+                product.recurring_interval,
+            )
+    return info
+
+
+def _representative_price(
+    product: CanonicalProduct,
+) -> tuple[int | None, str | None, str | None]:
+    if not product.prices:
+        return None, None, None
+    price = product.prices[0]
+    return price.amount, price.currency, product.recurring_interval
 
 
 def _duplicate_product_names(
@@ -462,46 +550,27 @@ def _duplicate_customer_source_ids(
     return duplicates
 
 
-def _importable_price_source_ids(
-    products: Sequence[CanonicalProduct],
-    first_source_id_by_name: dict[str, str],
-    duplicate_names: set[str],
-) -> set[str]:
-    """Prices that will import: their product imports and the price passes its
-    own checks. A subscription whose price is *not* in this set can't import
-    either — whether the price was dropped or never extracted at all (e.g. the
-    subscription runs on an archived price the source no longer lists)."""
-    importable: set[str] = set()
-    for product in products:
-        product_code, _ = _product_drop(
-            product, first_source_id_by_name, duplicate_names
-        )
-        if product_code is not None:
-            continue
-        for price in product.prices:
-            price_code, _ = _drop_reason(
-                precheck_engine._check_price(product, price), PRICE_DROP_CODES
-            )
-            if price_code is None:
-                importable.add(price.source_id)
-    return importable
-
-
 def _product_items(
     products: Sequence[CanonicalProduct],
 ) -> list[MerchantMigrationRecordItem]:
-    first_source_id_by_name, duplicate_names = _duplicate_product_names(products)
+    # Classify with the importer's own plan so the report never promises a product
+    # the importer will later skip (e.g. one with no importable price).
+    plans = plan_product_imports(products)
     items: list[MerchantMigrationRecordItem] = []
     for product in products:
-        code, reason = _product_drop(product, first_source_id_by_name, duplicate_names)
+        plan = plans[product.source_id]
+        amount, currency, interval = _representative_price(product)
         items.append(
             _item(
                 PrecheckEntity.products,
                 product.product_source_id,
                 product.name,
                 _interval_label(product),
-                reason_code=code,
-                reason=reason,
+                reason_code=plan.skip_code,
+                reason=plan.skip_reason,
+                amount=amount,
+                currency=currency,
+                recurring_interval=interval,
             )
         )
     return items
@@ -547,14 +616,16 @@ def _price_items(
 def _customer_items(
     customers: Sequence[CanonicalCustomer],
 ) -> list[MerchantMigrationRecordItem]:
-    duplicates = _duplicate_customer_source_ids(customers)
+    # Classify with the importer's own plan so the report never promises a customer
+    # the importer will later skip (e.g. one with no email).
+    plans = plan_customer_imports(customers)
     items: list[MerchantMigrationRecordItem] = []
     for customer in customers:
-        if customer.source_id in duplicates:
-            code: str | None = "duplicate_customer_email"
-            reason: str | None = _DUPLICATE_CUSTOMER_EMAIL_REASON
-        else:
-            code, reason = None, None
+        code, reason = plans[customer.source_id]
+        if code is None and not customer.country:
+            # A warning, not a skip: it still imports, but a missing country means
+            # tax can't be computed until the merchant confirms it.
+            reason = _MISSING_COUNTRY_REASON
         items.append(
             _item(
                 PrecheckEntity.customers,
@@ -573,36 +644,25 @@ def _subscription_items(
     products: Sequence[CanonicalProduct],
     customers: Sequence[CanonicalCustomer],
 ) -> list[MerchantMigrationRecordItem]:
-    first_source_id_by_name, duplicate_names = _duplicate_product_names(products)
-    importable_prices = _importable_price_source_ids(
-        products, first_source_id_by_name, duplicate_names
-    )
-    skipped_customers = _duplicate_customer_source_ids(customers)
+    # Classify with the importer's own plan so the report matches the import;
+    # layer the display-only trialing warning on top.
+    plans = plan_subscription_imports(subscriptions, products, customers)
     email_by_source = {c.source_id: c.email for c in customers if c.email}
+    price_info = _price_info(products)
     items: list[MerchantMigrationRecordItem] = []
     for subscription in subscriptions:
-        code, reason = _drop_reason(
-            precheck_engine._check_subscription(subscription), SUBSCRIPTION_DROP_CODES
-        )
-        # A subscription can't import if the records it depends on won't either.
-        # `not in importable_prices` also catches prices never extracted (e.g.
-        # the subscription runs on an archived price).
-        if code is None and subscription.price_source_id not in importable_prices:
-            code, reason = (
-                "subscription_product_not_importable",
-                _SUBSCRIPTION_PRODUCT_REASON,
-            )
-        elif code is None and subscription.customer_source_id in skipped_customers:
-            code, reason = (
-                "subscription_customer_not_importable",
-                _SUBSCRIPTION_CUSTOMER_REASON,
-            )
+        code, reason = plans[subscription.source_id]
+        if code is None and subscription.trialing:
+            # A warning, not a skip: the trial carries over, but it's worth the
+            # merchant's eye since billing resumes when it ends.
+            reason = _TRIALING_REASON
         title = email_by_source.get(
             subscription.customer_source_id, subscription.customer_source_id
         )
-        subtitle = subscription.status.value
-        if subscription.trialing:
-            subtitle = f"{subtitle} · trial"
+        subtitle = _humanize_subscription_status(subscription.status)
+        amount, currency, interval = price_info.get(
+            subscription.price_source_id, (None, None, None)
+        )
         items.append(
             _item(
                 PrecheckEntity.subscriptions,
@@ -611,6 +671,9 @@ def _subscription_items(
                 subtitle,
                 reason_code=code,
                 reason=reason,
+                amount=amount,
+                currency=currency,
+                recurring_interval=interval,
             )
         )
     return items
@@ -649,6 +712,115 @@ def classify_records(
     if entity == PrecheckEntity.customers:
         return _customer_items(customers)
     return _subscription_items(subscriptions, products, customers)
+
+
+@dataclass
+class ProductImportPlan:
+    """The importer's decision for one canonical product (keyed by its
+    ``source_id``, the ``(product, interval)`` composite). Either a skip with a
+    reason, or the set of price ``source_id``s to create under the Polar product.
+    """
+
+    skip_code: str | None
+    skip_reason: str | None
+    importable_price_ids: set[str]
+
+    @property
+    def importable(self) -> bool:
+        return self.skip_code is None
+
+
+def plan_product_imports(
+    products: Sequence[CanonicalProduct],
+) -> dict[str, ProductImportPlan]:
+    """What the catalog importer should do with each canonical product, using the
+    exact same predicates as the precheck report so imported == report-importable.
+
+    A product is skipped when its own checks fail (one-time, unsupported interval,
+    duplicate name) or when none of its prices can be imported (a product with no
+    price is unsellable). Otherwise it imports with the prices that pass.
+    """
+    first_source_id_by_name, duplicate_names = _duplicate_product_names(products)
+    plans: dict[str, ProductImportPlan] = {}
+    for product in products:
+        code, reason = _product_drop(product, first_source_id_by_name, duplicate_names)
+        if code is not None:
+            plans[product.source_id] = ProductImportPlan(code, reason, set())
+            continue
+        price_ids = {
+            price.source_id
+            for price in product.prices
+            if _drop_reason(
+                precheck_engine._check_price(product, price), PRICE_DROP_CODES
+            )[0]
+            is None
+        }
+        if not price_ids:
+            plans[product.source_id] = ProductImportPlan(
+                "no_importable_price", _NO_IMPORTABLE_PRICE_REASON, set()
+            )
+        else:
+            plans[product.source_id] = ProductImportPlan(None, None, price_ids)
+    return plans
+
+
+def plan_customer_imports(
+    customers: Sequence[CanonicalCustomer],
+) -> dict[str, tuple[str | None, str | None]]:
+    """Per customer ``source_id``, the skip ``(code, reason)`` or ``(None, None)``
+    when importable. Duplicate emails are reused, not re-imported (design
+    Appendix A), so only the later duplicate is skipped; a customer with no email
+    can't be imported at all."""
+    duplicates = _duplicate_customer_source_ids(customers)
+    plans: dict[str, tuple[str | None, str | None]] = {}
+    for customer in customers:
+        if customer.source_id in duplicates:
+            plans[customer.source_id] = (
+                "duplicate_customer_email",
+                _DUPLICATE_CUSTOMER_EMAIL_REASON,
+            )
+        elif not customer.email:
+            plans[customer.source_id] = (
+                "customer_missing_email",
+                _MISSING_EMAIL_REASON,
+            )
+        else:
+            plans[customer.source_id] = (None, None)
+    return plans
+
+
+def plan_subscription_imports(
+    subscriptions: Sequence[CanonicalSubscription],
+    products: Sequence[CanonicalProduct],
+    customers: Sequence[CanonicalCustomer],
+) -> dict[str, tuple[str | None, str | None]]:
+    """Per subscription ``source_id``, the skip ``(code, reason)`` or
+    ``(None, None)`` when importable. Mirrors the review drawer's per-subscription
+    classification: a subscription can't import if its own checks fail or the
+    product/price or customer it depends on won't import."""
+    importable_prices = {
+        price_id
+        for plan in plan_product_imports(products).values()
+        for price_id in plan.importable_price_ids
+    }
+    skipped_customers = _duplicate_customer_source_ids(customers)
+    plans: dict[str, tuple[str | None, str | None]] = {}
+    for subscription in subscriptions:
+        code, reason = _drop_reason(
+            precheck_engine._check_subscription(subscription), SUBSCRIPTION_DROP_CODES
+        )
+        if code is None and subscription.price_source_id not in importable_prices:
+            code, reason = (
+                "subscription_product_not_importable",
+                _SUBSCRIPTION_PRODUCT_REASON,
+            )
+        elif code is None and subscription.customer_source_id in skipped_customers:
+            code, reason = (
+                "subscription_customer_not_importable",
+                _SUBSCRIPTION_CUSTOMER_REASON,
+            )
+        plans[subscription.source_id] = (code, reason)
+    return plans
 
 
 def summarize_records(

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -4,6 +4,8 @@ records for the review drawer.
 
 The per-record classification reuses the same `_check_*` predicates as the
 report, so a record's importable/skipped status always matches the summary.
+Each reason also carries a level: `action_required` when the merchant has to fix
+something, `info` when there is nothing to fix.
 """
 
 from collections import Counter
@@ -37,6 +39,7 @@ from .schemas import (
     PrecheckEntitySummary,
     PrecheckIssue,
     PrecheckIssueLevel,
+    PrecheckReasonLevel,
     PrecheckRecordStatus,
     PrecheckReport,
 )
@@ -67,11 +70,24 @@ SUBSCRIPTION_DROP_CODES = {
     "subscription_paused_collection",
     "subscription_has_discount",
 }
+# Reasons the merchant has to act on. Every other code is informational: the
+# record either imports as-is, or Polar can't take it and there is nothing to do.
+ACTION_REQUIRED_CODES = {
+    "customer_missing_country",
+    "customer_missing_email",
+    "duplicate_customer_email",
+    "subscription_has_discount",
+    "send_invoice_collection",
+}
 _DUPLICATE_PRODUCT_NAME_REASON = (
-    "Another product already uses this name; the duplicate stays on the source."
+    "Another source product uses this name. Both import and share it in Polar."
+)
+_EXISTING_PRODUCT_NAME_REASON = (
+    "A Polar product already uses this name. Importing adds a second one."
 )
 _DUPLICATE_CUSTOMER_EMAIL_REASON = (
-    "Another customer already uses this email; the duplicate stays on the source."
+    "Another source customer uses this email, and a Polar customer can only carry "
+    "one source id. Merge them at the source, then run the pre-check again."
 )
 _MISSING_EMAIL_REASON = (
     "The source customer has no email, so it can't be imported into Polar."
@@ -90,6 +106,10 @@ _MISSING_COUNTRY_REASON = (
     "No billing country. Confirm it before the first renewal so tax is correct."
 )
 _TRIALING_REASON = "On trial. Billing resumes on Polar when the trial ends."
+_PAYMENT_REENTRY_REASON = (
+    "The payment method can't be copied. Ask the customer to re-enter their "
+    "billing details."
+)
 
 
 def _humanize_subscription_status(status: CanonicalSubscriptionStatus) -> str:
@@ -280,8 +300,8 @@ class PrecheckEngine:
                     level=PrecheckIssueLevel.warning,
                     code="duplicate_product_name",
                     message=(
-                        f"Multiple products share the name '{name}'; the duplicates "
-                        "won't be imported."
+                        f"Multiple products share the name '{name}'; they all "
+                        "import and keep the shared name."
                     ),
                     source_id=None,
                 )
@@ -439,18 +459,33 @@ def _drop_reason(
     return None, None
 
 
+Reason = tuple[str, str]
+
+
+def _pick_note(*notes: Reason | None) -> Reason | None:
+    """The one note to show on an importable row, worth-acting-on first."""
+    present = [note for note in notes if note is not None]
+    for note in present:
+        if note[0] in ACTION_REQUIRED_CODES:
+            return note
+    return present[0] if present else None
+
+
 def _item(
     entity: PrecheckEntity,
     source_id: str,
     title: str,
     subtitle: str | None,
     *,
-    reason_code: str | None,
-    reason: str | None,
+    skip: Reason | None,
+    note: Reason | None = None,
     amount: int | None = None,
     currency: str | None = None,
     recurring_interval: str | None = None,
 ) -> MerchantMigrationRecordItem:
+    """One review row. ``skip`` means it won't import; ``note`` only annotates a
+    row that will."""
+    code, reason = skip or note or (None, None)
     return MerchantMigrationRecordItem(
         # record_id and import_status come from the ledger via
         # `_attach_record_ids`; the classifier itself has none.
@@ -464,13 +499,20 @@ def _item(
         currency=currency,
         recurring_interval=recurring_interval,
         status=(
-            PrecheckRecordStatus.skipped
-            if reason_code
-            else PrecheckRecordStatus.importable
+            PrecheckRecordStatus.skipped if skip else PrecheckRecordStatus.importable
         ),
         reason=reason,
-        reason_code=reason_code,
+        reason_code=code,
+        reason_level=_reason_level(code),
     )
+
+
+def _reason_level(code: str | None) -> PrecheckReasonLevel | None:
+    if code is None:
+        return None
+    if code in ACTION_REQUIRED_CODES:
+        return PrecheckReasonLevel.action_required
+    return PrecheckReasonLevel.info
 
 
 # The price shown on a priced row: (amount, currency, interval). A product is
@@ -498,39 +540,24 @@ def _representative_price(
     return price.amount, price.currency, product.recurring_interval
 
 
-def _duplicate_product_names(
-    products: Sequence[CanonicalProduct],
-) -> tuple[dict[str, str], set[str]]:
+def _duplicate_product_names(products: Sequence[CanonicalProduct]) -> set[str]:
     """A name is a duplicate only when two *distinct* source products share it;
     one product split into several interval rows keeps the same source id and is
     not a duplicate.
     """
-    first_source_id_by_name: dict[str, str] = {}
-    duplicate_names: set[str] = set()
+    source_ids_by_name: dict[str, set[str]] = {}
     for product in products:
-        first = first_source_id_by_name.setdefault(
-            product.name, product.product_source_id
+        source_ids_by_name.setdefault(product.name, set()).add(
+            product.product_source_id
         )
-        if first != product.product_source_id:
-            duplicate_names.add(product.name)
-    return first_source_id_by_name, duplicate_names
+    return {name for name, ids in source_ids_by_name.items() if len(ids) > 1}
 
 
-def _product_drop(
-    product: CanonicalProduct,
-    first_source_id_by_name: dict[str, str],
-    duplicate_names: set[str],
-) -> tuple[str | None, str | None]:
+def _product_drop(product: CanonicalProduct) -> Reason | None:
     code, reason = _drop_reason(
         precheck_engine._check_product(product), PRODUCT_DROP_CODES
     )
-    if (
-        code is None
-        and product.name in duplicate_names
-        and product.product_source_id != first_source_id_by_name[product.name]
-    ):
-        return "duplicate_product_name", _DUPLICATE_PRODUCT_NAME_REASON
-    return code, reason
+    return (code, reason) if code is not None and reason is not None else None
 
 
 def _duplicate_customer_source_ids(
@@ -550,21 +577,32 @@ def _duplicate_customer_source_ids(
 
 def _product_items(
     products: Sequence[CanonicalProduct],
+    existing_product_names: set[str],
 ) -> list[MerchantMigrationRecordItem]:
     # Use the importer's plan, so the report can't promise a product it will skip.
     plans = plan_product_imports(products)
+    duplicate_names = _duplicate_product_names(products)
     items: list[MerchantMigrationRecordItem] = []
     for product in products:
         plan = plans[product.source_id]
         amount, currency, interval = _representative_price(product)
+        # Sharing a name is allowed in Polar, so it only earns a note.
+        note = _pick_note(
+            ("duplicate_product_name", _DUPLICATE_PRODUCT_NAME_REASON)
+            if product.name in duplicate_names
+            else None,
+            ("product_exists_in_polar", _EXISTING_PRODUCT_NAME_REASON)
+            if product.name.lower() in existing_product_names
+            else None,
+        )
         items.append(
             _item(
                 PrecheckEntity.products,
                 product.product_source_id,
                 product.name,
                 _interval_label(product),
-                reason_code=plan.skip_code,
-                reason=plan.skip_reason,
+                skip=plan.skip,
+                note=note,
                 amount=amount,
                 currency=currency,
                 recurring_interval=interval,
@@ -576,22 +614,17 @@ def _product_items(
 def _price_items(
     products: Sequence[CanonicalProduct],
 ) -> list[MerchantMigrationRecordItem]:
-    first_source_id_by_name, duplicate_names = _duplicate_product_names(products)
     items: list[MerchantMigrationRecordItem] = []
     for product in products:
         # A price under a product that won't import can't import either.
-        product_code, product_reason = _product_drop(
-            product, first_source_id_by_name, duplicate_names
-        )
+        product_skip = _product_drop(product)
         for price in product.prices:
-            code: str | None
-            reason: str | None
-            if product_code is not None:
-                code, reason = product_code, product_reason
-            else:
+            skip = product_skip
+            if skip is None:
                 code, reason = _drop_reason(
                     precheck_engine._check_price(product, price), PRICE_DROP_CODES
                 )
+                skip = (code, reason) if code and reason else None
             subtitle = (
                 "No amount"
                 if price.amount is None
@@ -603,8 +636,7 @@ def _price_items(
                     price.source_id,
                     product.name,
                     subtitle,
-                    reason_code=code,
-                    reason=reason,
+                    skip=skip,
                 )
             )
     return items
@@ -617,19 +649,20 @@ def _customer_items(
     plans = plan_customer_imports(customers)
     items: list[MerchantMigrationRecordItem] = []
     for customer in customers:
-        code, reason = plans[customer.source_id]
-        if code is None and not customer.country:
-            # A warning, not a skip: it still imports, but a missing country means
-            # tax can't be computed until the merchant confirms it.
-            reason = _MISSING_COUNTRY_REASON
+        # It imports either way, but without a country tax can't be computed.
+        note = (
+            ("customer_missing_country", _MISSING_COUNTRY_REASON)
+            if not customer.country
+            else None
+        )
         items.append(
             _item(
                 PrecheckEntity.customers,
                 customer.source_id,
                 customer.email or customer.name or customer.source_id,
                 customer.country or "No billing country",
-                reason_code=code,
-                reason=reason,
+                skip=plans[customer.source_id],
+                note=note,
             )
         )
     return items
@@ -640,17 +673,21 @@ def _subscription_items(
     products: Sequence[CanonicalProduct],
     customers: Sequence[CanonicalCustomer],
 ) -> list[MerchantMigrationRecordItem]:
-    # Use the importer's plan; add the display-only trialing warning on top.
+    # Use the importer's plan; the notes on top are display-only.
     plans = plan_subscription_imports(subscriptions, products, customers)
     email_by_source = {c.source_id: c.email for c in customers if c.email}
     price_info = _price_info(products)
     items: list[MerchantMigrationRecordItem] = []
     for subscription in subscriptions:
-        code, reason = plans[subscription.source_id]
-        if code is None and subscription.trialing:
-            # A warning, not a skip: the trial carries over, but it's worth the
-            # merchant's eye since billing resumes when it ends.
-            reason = _TRIALING_REASON
+        payment_method = subscription.payment_method
+        note = _pick_note(
+            ("payment_method_requires_reentry", _PAYMENT_REENTRY_REASON)
+            if payment_method is not None and payment_method.type.requires_reentry
+            else None,
+            ("subscription_trialing", _TRIALING_REASON)
+            if subscription.trialing
+            else None,
+        )
         title = email_by_source.get(
             subscription.customer_source_id, subscription.customer_source_id
         )
@@ -664,8 +701,8 @@ def _subscription_items(
                 subscription.source_id,
                 title,
                 subtitle,
-                reason_code=code,
-                reason=reason,
+                skip=plans[subscription.source_id],
+                note=note,
                 amount=amount,
                 currency=currency,
                 recurring_interval=interval,
@@ -695,13 +732,15 @@ def _split_records(
 
 
 def classify_records(
-    records: Sequence[CanonicalRecord], entity: PrecheckEntity
+    records: Sequence[CanonicalRecord],
+    entity: PrecheckEntity,
+    existing_product_names: set[str] | None = None,
 ) -> list[MerchantMigrationRecordItem]:
     """Classify the source catalog into per-record rows of one entity type,
     each marked importable or skipped with a reason."""
     products, customers, subscriptions = _split_records(records)
     if entity == PrecheckEntity.products:
-        return _product_items(products)
+        return _product_items(products, existing_product_names or set())
     if entity == PrecheckEntity.prices:
         return _price_items(products)
     if entity == PrecheckEntity.customers:
@@ -716,13 +755,12 @@ class ProductImportPlan:
     reason, or the set of price ``source_id``s to create under the Polar product.
     """
 
-    skip_code: str | None
-    skip_reason: str | None
+    skip: Reason | None
     importable_price_ids: set[str]
 
     @property
     def importable(self) -> bool:
-        return self.skip_code is None
+        return self.skip is None
 
 
 def plan_product_imports(
@@ -731,16 +769,16 @@ def plan_product_imports(
     """What the catalog importer should do with each canonical product, using the
     exact same predicates as the precheck report so imported == report-importable.
 
-    A product is skipped when its own checks fail (one-time, unsupported interval,
-    duplicate name) or when none of its prices can be imported (a product with no
-    price is unsellable). Otherwise it imports with the prices that pass.
+    A product is skipped when its own checks fail (one-time, unsupported interval)
+    or when none of its prices can be imported (a product with no price is
+    unsellable). Otherwise it imports with the prices that pass. Sharing a name
+    with another product is fine: Polar doesn't require unique names.
     """
-    first_source_id_by_name, duplicate_names = _duplicate_product_names(products)
     plans: dict[str, ProductImportPlan] = {}
     for product in products:
-        code, reason = _product_drop(product, first_source_id_by_name, duplicate_names)
-        if code is not None:
-            plans[product.source_id] = ProductImportPlan(code, reason, set())
+        skip = _product_drop(product)
+        if skip is not None:
+            plans[product.source_id] = ProductImportPlan(skip, set())
             continue
         price_ids = {
             price.source_id
@@ -752,22 +790,22 @@ def plan_product_imports(
         }
         if not price_ids:
             plans[product.source_id] = ProductImportPlan(
-                "no_importable_price", _NO_IMPORTABLE_PRICE_REASON, set()
+                ("no_importable_price", _NO_IMPORTABLE_PRICE_REASON), set()
             )
         else:
-            plans[product.source_id] = ProductImportPlan(None, None, price_ids)
+            plans[product.source_id] = ProductImportPlan(None, price_ids)
     return plans
 
 
 def plan_customer_imports(
     customers: Sequence[CanonicalCustomer],
-) -> dict[str, tuple[str | None, str | None]]:
-    """Per customer ``source_id``, the skip ``(code, reason)`` or ``(None, None)``
-    when importable. Duplicate emails are reused, not re-imported (design
-    Appendix A), so only the later duplicate is skipped; a customer with no email
-    can't be imported at all."""
+) -> dict[str, Reason | None]:
+    """Per customer ``source_id``, the skip reason or ``None`` when importable.
+    A Polar customer is unique by email and carries a single source id, so of
+    several customers sharing an email only the first can be imported; a customer
+    with no email can't be imported at all."""
     duplicates = _duplicate_customer_source_ids(customers)
-    plans: dict[str, tuple[str | None, str | None]] = {}
+    plans: dict[str, Reason | None] = {}
     for customer in customers:
         if customer.source_id in duplicates:
             plans[customer.source_id] = (
@@ -780,7 +818,7 @@ def plan_customer_imports(
                 _MISSING_EMAIL_REASON,
             )
         else:
-            plans[customer.source_id] = (None, None)
+            plans[customer.source_id] = None
     return plans
 
 
@@ -788,33 +826,31 @@ def plan_subscription_imports(
     subscriptions: Sequence[CanonicalSubscription],
     products: Sequence[CanonicalProduct],
     customers: Sequence[CanonicalCustomer],
-) -> dict[str, tuple[str | None, str | None]]:
-    """Per subscription ``source_id``, the skip ``(code, reason)`` or
-    ``(None, None)`` when importable. Mirrors the review drawer's per-subscription
-    classification: a subscription can't import if its own checks fail or the
-    product/price or customer it depends on won't import."""
+) -> dict[str, Reason | None]:
+    """Per subscription ``source_id``, the skip reason or ``None`` when
+    importable. Mirrors the review drawer's per-subscription classification: a
+    subscription can't import if its own checks fail or the product/price or
+    customer it depends on won't import."""
     importable_prices = {
         price_id
         for plan in plan_product_imports(products).values()
         for price_id in plan.importable_price_ids
     }
-    skipped_customers = _duplicate_customer_source_ids(customers)
-    plans: dict[str, tuple[str | None, str | None]] = {}
+    customer_plans = plan_customer_imports(customers)
+    plans: dict[str, Reason | None] = {}
     for subscription in subscriptions:
         code, reason = _drop_reason(
             precheck_engine._check_subscription(subscription), SUBSCRIPTION_DROP_CODES
         )
-        if code is None and subscription.price_source_id not in importable_prices:
-            code, reason = (
-                "subscription_product_not_importable",
-                _SUBSCRIPTION_PRODUCT_REASON,
-            )
-        elif code is None and subscription.customer_source_id in skipped_customers:
-            code, reason = (
+        skip: Reason | None = (code, reason) if code and reason else None
+        if skip is None and subscription.price_source_id not in importable_prices:
+            skip = ("subscription_product_not_importable", _SUBSCRIPTION_PRODUCT_REASON)
+        elif skip is None and customer_plans.get(subscription.customer_source_id):
+            skip = (
                 "subscription_customer_not_importable",
                 _SUBSCRIPTION_CUSTOMER_REASON,
             )
-        plans[subscription.source_id] = (code, reason)
+        plans[subscription.source_id] = skip
     return plans
 
 

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -140,6 +140,7 @@ class PrecheckEngine:
         products_by_name: dict[str, set[str]] = {}
         email_counts: Counter[str] = Counter()
         customers_without_country = 0
+        customers_without_email = 0
 
         for record in record_list:
             if isinstance(record, CanonicalProduct):
@@ -150,6 +151,8 @@ class PrecheckEngine:
             elif isinstance(record, CanonicalCustomer):
                 if record.email:
                     email_counts[record.email.lower()] += 1
+                else:
+                    customers_without_email += 1
                 if not record.country:
                     customers_without_country += 1
             elif isinstance(record, CanonicalSubscription):
@@ -162,6 +165,7 @@ class PrecheckEngine:
             )
         )
         issues.extend(self._check_duplicate_emails(email_counts))
+        issues.extend(self._check_missing_email(customers_without_email))
         issues.extend(self._check_missing_country(customers_without_country))
 
         return PrecheckReport(
@@ -339,6 +343,18 @@ class PrecheckEngine:
                     ),
                     source_id=None,
                 )
+
+    def _check_missing_email(self, count: int) -> Iterable[PrecheckIssue]:
+        if count > 0:
+            yield PrecheckIssue(
+                level=PrecheckIssueLevel.warning,
+                code="customer_missing_email",
+                message=(
+                    f"{count} customers have no email; they and their subscriptions "
+                    "won't be imported."
+                ),
+                source_id=None,
+            )
 
     def _check_missing_country(self, count: int) -> Iterable[PrecheckIssue]:
         if count > 0:
@@ -532,11 +548,16 @@ def _price_info(
 
 
 def _representative_price(
-    product: CanonicalProduct,
+    product: CanonicalProduct, importable_price_ids: set[str]
 ) -> tuple[int | None, str | None, str | None]:
-    if not product.prices:
+    """The price to show on a product row: one that will actually be imported,
+    falling back to the first when the product is skipped."""
+    price = next(
+        (price for price in product.prices if price.source_id in importable_price_ids),
+        product.prices[0] if product.prices else None,
+    )
+    if price is None:
         return None, None, None
-    price = product.prices[0]
     return price.amount, price.currency, product.recurring_interval
 
 
@@ -585,7 +606,9 @@ def _product_items(
     items: list[MerchantMigrationRecordItem] = []
     for product in products:
         plan = plans[product.source_id]
-        amount, currency, interval = _representative_price(product)
+        amount, currency, interval = _representative_price(
+            product, plan.importable_price_ids
+        )
         # Sharing a name is allowed in Polar, so it only earns a note.
         note = _pick_note(
             ("duplicate_product_name", _DUPLICATE_PRODUCT_NAME_REASON)
@@ -637,6 +660,9 @@ def _price_items(
                     product.name,
                     subtitle,
                     skip=skip,
+                    amount=price.amount,
+                    currency=price.currency,
+                    recurring_interval=product.recurring_interval,
                 )
             )
     return items
@@ -836,7 +862,11 @@ def plan_subscription_imports(
         for plan in plan_product_imports(products).values()
         for price_id in plan.importable_price_ids
     }
-    customer_plans = plan_customer_imports(customers)
+    importable_customers = {
+        source_id
+        for source_id, skip in plan_customer_imports(customers).items()
+        if skip is None
+    }
     plans: dict[str, Reason | None] = {}
     for subscription in subscriptions:
         code, reason = _drop_reason(
@@ -845,7 +875,9 @@ def plan_subscription_imports(
         skip: Reason | None = (code, reason) if code and reason else None
         if skip is None and subscription.price_source_id not in importable_prices:
             skip = ("subscription_product_not_importable", _SUBSCRIPTION_PRODUCT_REASON)
-        elif skip is None and customer_plans.get(subscription.customer_source_id):
+        elif (
+            skip is None and subscription.customer_source_id not in importable_customers
+        ):
             skip = (
                 "subscription_customer_not_importable",
                 _SUBSCRIPTION_CUSTOMER_REASON,

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -67,8 +67,15 @@ class MerchantMigrationRecordRepository(
     async def list_by_migration(
         self, migration_id: UUID
     ) -> Sequence[MerchantMigrationRecord]:
-        statement = self.get_base_statement().where(
-            MerchantMigrationRecord.merchant_migration_id == migration_id
+        # Stable order so in-memory pagination stays consistent as import updates
+        # record statuses (which would otherwise reshuffle the scan order).
+        statement = (
+            self.get_base_statement()
+            .where(MerchantMigrationRecord.merchant_migration_id == migration_id)
+            .order_by(
+                MerchantMigrationRecord.created_at,
+                MerchantMigrationRecord.id,
+            )
         )
         return await self.get_all(statement)
 

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -8,6 +8,7 @@ from polar.models.merchant_migration import (
     MerchantMigrationSourcePlatform,
     MerchantMigrationStep,
 )
+from polar.models.merchant_migration_record import MerchantMigrationRecordStatus
 
 
 class MerchantMigrationCreate(Schema):
@@ -70,14 +71,34 @@ class PrecheckReport(Schema):
 
 
 class MerchantMigrationRecordItem(Schema):
+    record_id: UUID4 | None = Field(
+        description=(
+            "The ledger record id, used to select this row for import. Null for "
+            "price rows, which are imported together with their product."
+        ),
+    )
     entity: PrecheckEntity = Field(description="The source entity type.")
     source_id: str = Field(description="The source identifier (e.g. Stripe `sub_…`).")
     title: str = Field(description="Primary label (name, email or product).")
     subtitle: str | None = Field(
-        description="Secondary detail (interval, amount, country, status)."
+        description="Secondary detail (lifecycle status, country)."
+    )
+    amount: int | None = Field(
+        description="Recurring price in minor units (cents), for priced rows.",
+    )
+    currency: str | None = Field(description="ISO currency for `amount`.")
+    recurring_interval: str | None = Field(
+        description="Billing interval for `amount` (e.g. `month`, `year`).",
     )
     status: PrecheckRecordStatus = Field(
         description="Whether this record will be imported or stays on the source."
+    )
+    import_status: MerchantMigrationRecordStatus | None = Field(
+        description=(
+            "The ledger status of this record: `pending` (not imported yet), "
+            "`imported`, `skipped` or `failed`. Null for price rows, which import "
+            "with their product."
+        ),
     )
     reason: str | None = Field(description="Why the record is skipped, if it is.")
     reason_code: str | None = Field(

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -53,6 +53,11 @@ class PrecheckRecordStatus(StrEnum):
     skipped = "skipped"
 
 
+class PrecheckReasonLevel(StrEnum):
+    action_required = "action_required"
+    info = "info"
+
+
 class PrecheckEntitySummary(Schema):
     entity: PrecheckEntity = Field(description="The source entity type.")
     total: int = Field(description="How many were read from the source.")
@@ -100,9 +105,16 @@ class MerchantMigrationRecordItem(Schema):
             "with their product."
         ),
     )
-    reason: str | None = Field(description="Why the record is skipped, if it is.")
-    reason_code: str | None = Field(
-        description="Stable code for the skip reason, if any."
+    reason: str | None = Field(
+        description="Why the record is skipped, or what to know about it if it isn't."
+    )
+    reason_code: str | None = Field(description="Stable code for `reason`, if any.")
+    reason_level: PrecheckReasonLevel | None = Field(
+        description=(
+            "How urgent `reason` is: `action_required` when the merchant has to "
+            "fix something, `info` when there is nothing to fix. Null without a "
+            "reason."
+        )
     )
 
 

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -89,7 +89,10 @@ class MerchantMigrationRecordItem(Schema):
         description="Secondary detail (lifecycle status, country)."
     )
     amount: int | None = Field(
-        description="Recurring price in minor units (cents), for priced rows.",
+        description=(
+            "Recurring price in the currency's smallest unit (cents for USD), for "
+            "priced rows."
+        ),
     )
     currency: str | None = Field(description="ISO currency for `amount`.")
     recurring_interval: str | None = Field(

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -12,13 +12,15 @@ from polar.exceptions import PolarError
 from polar.kit.db.postgres import AsyncSession
 from polar.kit.encryption import EncryptedString
 from polar.kit.pagination import PaginationParams
-from polar.models import MerchantMigration
+from polar.models import MerchantMigration, MerchantMigrationRecord
 from polar.models.merchant_migration import (
     MerchantMigrationSourcePlatform,
     MerchantMigrationStep,
 )
+from polar.models.merchant_migration_record import MerchantMigrationRecordType
 from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncReadSession
+from polar.product.repository import ProductRepository
 
 from .adapters import SourceAdapter, StripeAdapter
 from .canonical import CanonicalRecord, deserialize
@@ -34,6 +36,14 @@ from .schemas import (
     PrecheckRecordStatus,
     PrecheckReport,
 )
+
+# Entities whose records map 1:1 to a ledger row, so a listing item can carry its
+# record id for selection. Prices live inside a product record and are excluded.
+_ENTITY_RECORD_TYPE = {
+    PrecheckEntity.products: MerchantMigrationRecordType.product,
+    PrecheckEntity.customers: MerchantMigrationRecordType.customer,
+    PrecheckEntity.subscriptions: MerchantMigrationRecordType.subscription,
+}
 
 SOURCE_CREDENTIALS_ENCRYPTION_CONTEXT = {
     "table": "merchant_migrations",
@@ -224,6 +234,9 @@ class MerchantMigrationService:
 
         adapter = await self._build_adapter(migration)
         source_account = await adapter.get_source_account()
+        existing_product_names = await ProductRepository.from_session(
+            session
+        ).get_active_names_by_organization(organization.id)
         record_repository = MerchantMigrationRecordRepository.from_session(session)
         report = await precheck_engine.run(
             self._stage_records(
@@ -231,6 +244,7 @@ class MerchantMigrationService:
             ),
             organization,
             source_account,
+            existing_product_names,
         )
 
         repository = MerchantMigrationRepository.from_session(session)
@@ -266,24 +280,61 @@ class MerchantMigrationService:
         auth_subject: AuthSubject[User | Organization],
         migration_id: UUID,
         *,
-        entity: PrecheckEntity,
+        entity: PrecheckEntity | None,
         status: PrecheckRecordStatus | None,
+        needs_attention: bool = False,
         pagination: PaginationParams,
     ) -> tuple[Sequence[MerchantMigrationRecordItem], int]:
-        """Return the records of one entity type from the staged ledger,
-        classified importable/skipped and paginated in memory. Reads what
-        ``run_precheck`` persisted, so it never re-reads the source."""
+        """Return staged records classified importable/skipped and paginated in
+        memory. ``entity`` scopes to one type; ``None`` returns products, customers
+        and subscriptions together. ``status`` filters to importable or skipped;
+        ``needs_attention`` filters to importable rows carrying a warning. Reads
+        what ``run_precheck`` persisted."""
         migration = await self._get_manageable(session, auth_subject, migration_id)
 
         record_repository = MerchantMigrationRecordRepository.from_session(session)
         staged = await record_repository.list_by_migration(migration.id)
         records = [deserialize(record.type, record.canonical) for record in staged]
-        items = classify_records(records, entity)
+
+        entities = [entity] if entity is not None else list(_ENTITY_RECORD_TYPE)
+        items: list[MerchantMigrationRecordItem] = []
+        for entity_type in entities:
+            entity_items = classify_records(records, entity_type)
+            self._attach_record_ids(entity_items, staged, entity_type)
+            items.extend(entity_items)
+
         if status is not None:
             items = [item for item in items if item.status == status]
+        if needs_attention:
+            items = [
+                item
+                for item in items
+                if item.status == PrecheckRecordStatus.importable and item.reason
+            ]
 
         start = (pagination.page - 1) * pagination.limit
         return items[start : start + pagination.limit], len(items)
+
+    def _attach_record_ids(
+        self,
+        items: Sequence[MerchantMigrationRecordItem],
+        staged: Sequence[MerchantMigrationRecord],
+        entity: PrecheckEntity,
+    ) -> None:
+        """Give each item its ledger record id, so a row can be selected for
+        import. The 1:1 entities (products/customers/subscriptions) map to their
+        staged records in order — both derive from the same `staged` fetch. Prices
+        aren't their own record (they live in a product), so they keep a null id.
+        """
+        record_type = _ENTITY_RECORD_TYPE.get(entity)
+        if record_type is None:
+            return
+        staged_of_type = [record for record in staged if record.type == record_type]
+        if len(staged_of_type) != len(items):
+            return
+        for item, record in zip(items, staged_of_type, strict=True):
+            item.record_id = record.id
+            item.import_status = record.status
 
     async def _stage_records(
         self,

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -33,6 +33,7 @@ from .schemas import (
     MerchantMigrationCreate,
     MerchantMigrationRecordItem,
     PrecheckEntity,
+    PrecheckReasonLevel,
     PrecheckRecordStatus,
     PrecheckReport,
 )
@@ -282,35 +283,37 @@ class MerchantMigrationService:
         *,
         entity: PrecheckEntity | None,
         status: PrecheckRecordStatus | None,
-        needs_attention: bool = False,
+        reason_level: PrecheckReasonLevel | None = None,
         pagination: PaginationParams,
     ) -> tuple[Sequence[MerchantMigrationRecordItem], int]:
         """Return staged records classified importable/skipped and paginated in
         memory. ``entity`` scopes to one type; ``None`` returns products, customers
         and subscriptions together. ``status`` filters to importable or skipped;
-        ``needs_attention`` filters to importable rows carrying a warning. Reads
-        what ``run_precheck`` persisted."""
+        ``reason_level`` filters to rows the merchant has to act on
+        (`action_required`) or only needs to know about (`info`). Reads what
+        ``run_precheck`` persisted."""
         migration = await self._get_manageable(session, auth_subject, migration_id)
 
         record_repository = MerchantMigrationRecordRepository.from_session(session)
         staged = await record_repository.list_by_migration(migration.id)
         records = [deserialize(record.type, record.canonical) for record in staged]
+        existing_product_names = await ProductRepository.from_session(
+            session
+        ).get_active_names_by_organization(migration.organization_id)
 
         entities = [entity] if entity is not None else list(_ENTITY_RECORD_TYPE)
         items: list[MerchantMigrationRecordItem] = []
         for entity_type in entities:
-            entity_items = classify_records(records, entity_type)
+            entity_items = classify_records(
+                records, entity_type, existing_product_names
+            )
             self._attach_record_ids(entity_items, staged, entity_type)
             items.extend(entity_items)
 
         if status is not None:
             items = [item for item in items if item.status == status]
-        if needs_attention:
-            items = [
-                item
-                for item in items
-                if item.status == PrecheckRecordStatus.importable and item.reason
-            ]
+        if reason_level is not None:
+            items = [item for item in items if item.reason_level == reason_level]
 
         start = (pagination.page - 1) * pagination.limit
         return items[start : start + pagination.limit], len(items)

--- a/server/polar/product/repository.py
+++ b/server/polar/product/repository.py
@@ -65,6 +65,17 @@ class ProductRepository(
         result = await self.session.execute(statement)
         return {row[0].lower() for row in result.all()}
 
+    async def get_active_names_by_organization(self, organization_id: UUID) -> set[str]:
+        """Lower-cased names of the org's active products, used to warn when a
+        migration source product would duplicate one that already exists."""
+        statement = select(func.lower(Product.name)).where(
+            Product.organization_id == organization_id,
+            Product.is_archived.is_(False),
+            Product.deleted_at.is_(None),
+        )
+        result = await self.session.execute(statement)
+        return {row[0] for row in result.all()}
+
     async def get_all_by_organization(
         self,
         organization_id: UUID,

--- a/server/tests/merchant_migration/test_precheck.py
+++ b/server/tests/merchant_migration/test_precheck.py
@@ -18,6 +18,8 @@ from polar.merchant_migration.canonical import (
 )
 from polar.merchant_migration.precheck import (
     classify_records,
+    plan_customer_imports,
+    plan_product_imports,
     precheck_engine,
     summarize_records,
 )
@@ -81,13 +83,19 @@ def build_price(
 
 def build_product(
     *,
-    source_id: str = "prod_1:month:1",
+    source_id: str | None = None,
     product_source_id: str = "prod_1",
     name: str = "Pro",
     recurring_interval: str | None = "month",
     recurring_interval_count: int = 1,
     prices: list[CanonicalPrice] | None = None,
 ) -> CanonicalProduct:
+    # A canonical product is keyed per (product, interval); default to a source_id
+    # unique to that pair so distinct products don't collide.
+    if source_id is None:
+        source_id = (
+            f"{product_source_id}:{recurring_interval}:{recurring_interval_count}"
+        )
     return CanonicalProduct(
         source_id=source_id,
         product_source_id=product_source_id,
@@ -110,6 +118,7 @@ def build_subscription(
     line_item_count: int = 1,
     quantity: int = 1,
     payment_method: CanonicalPaymentMethod | None = None,
+    has_discount: bool = False,
 ) -> CanonicalSubscription:
     return CanonicalSubscription(
         source_id=source_id,
@@ -124,6 +133,7 @@ def build_subscription(
         line_item_count=line_item_count,
         quantity=quantity,
         payment_method=payment_method,
+        has_discount=has_discount,
     )
 
 
@@ -136,11 +146,13 @@ async def run(
     *,
     organization: Organization | None = None,
     account: CanonicalAccount | None = None,
+    existing_product_names: set[str] | None = None,
 ) -> PrecheckReport:
     return await precheck_engine.run(
         aiter_records(records),
         organization or build_organization(),
         account or build_account(),
+        existing_product_names,
     )
 
 
@@ -231,6 +243,25 @@ class TestPrecheckEngine:
         )
         assert "duplicate_product_name" in codes(report, PrecheckIssueLevel.warning)
         assert report.can_start is True
+
+    async def test_existing_polar_product_warns_without_blocking(self) -> None:
+        report = await run(
+            [build_product(name="Pro")],
+            existing_product_names={"pro"},
+        )
+        assert "product_exists_in_polar" in codes(report, PrecheckIssueLevel.warning)
+        assert report.can_start is True
+        # the collision is a warning only: the product still imports.
+        products = next(
+            e for e in report.entities if e.entity == PrecheckEntity.products
+        )
+        assert products.importable == 1
+
+    async def test_no_existing_products_no_warning(self) -> None:
+        report = await run([build_product(name="Pro")])
+        assert "product_exists_in_polar" not in codes(
+            report, PrecheckIssueLevel.warning
+        )
 
     async def test_same_product_different_intervals_is_not_a_duplicate(self) -> None:
         report = await run(
@@ -331,6 +362,37 @@ class TestClassifyRecords:
         assert by_id["prod_2"].status == PrecheckRecordStatus.skipped
         assert by_id["prod_2"].reason_code == "one_time_product"
 
+    def test_product_without_importable_price_skipped(self) -> None:
+        # The classifier must agree with the importer: a product whose only price
+        # can't be imported is skipped, not promised as importable.
+        records: list[CanonicalRecord] = [
+            build_product(
+                product_source_id="prod_1",
+                prices=[
+                    build_price(pricing_scheme=CanonicalPricingScheme.tiered),
+                ],
+            ),
+        ]
+
+        items = classify_records(records, PrecheckEntity.products)
+
+        assert items[0].status == PrecheckRecordStatus.skipped
+        assert items[0].reason_code == "no_importable_price"
+
+    def test_subscription_with_discount_skipped(self) -> None:
+        records: list[CanonicalRecord] = [
+            build_product(
+                product_source_id="prod_1", prices=[build_price(source_id="price_1")]
+            ),
+            build_customer(source_id="cus_1", email="a@example.com"),
+            build_subscription(source_id="sub_1", has_discount=True),
+        ]
+
+        items = classify_records(records, PrecheckEntity.subscriptions)
+
+        assert items[0].status == PrecheckRecordStatus.skipped
+        assert items[0].reason_code == "subscription_has_discount"
+
     def test_prices_drop_unsupported_scheme(self) -> None:
         records: list[CanonicalRecord] = [
             build_product(
@@ -368,6 +430,16 @@ class TestClassifyRecords:
         assert by_id["cus_1"].status == PrecheckRecordStatus.importable
         assert by_id["cus_2"].status == PrecheckRecordStatus.skipped
         assert by_id["cus_2"].reason_code == "duplicate_customer_email"
+
+    def test_customer_without_email_skipped(self) -> None:
+        # The classifier must agree with the importer: a customer with no email
+        # is skipped, not promised as importable.
+        records: list[CanonicalRecord] = [build_customer(source_id="cus_1", email="")]
+
+        items = classify_records(records, PrecheckEntity.customers)
+
+        assert items[0].status == PrecheckRecordStatus.skipped
+        assert items[0].reason_code == "customer_missing_email"
 
     def test_subscription_status_drop(self) -> None:
         records: list[CanonicalRecord] = [
@@ -524,3 +596,78 @@ class TestClassifyCascade:
 
         assert items[0].status == PrecheckRecordStatus.skipped
         assert items[0].reason_code == "subscription_product_not_importable"
+
+
+class TestPlanProductImports:
+    def test_importable_product_lists_its_prices(self) -> None:
+        product = build_product(prices=[build_price(source_id="price_1")])
+
+        plans = plan_product_imports([product])
+
+        plan = plans[product.source_id]
+        assert plan.importable is True
+        assert plan.importable_price_ids == {"price_1"}
+
+    def test_one_time_product_is_skipped(self) -> None:
+        product = build_product(source_id="prod_1:one_time", recurring_interval=None)
+
+        plan = plan_product_imports([product])[product.source_id]
+
+        assert plan.importable is False
+        assert plan.skip_code == "one_time_product"
+
+    def test_drops_unsupported_prices_but_keeps_the_rest(self) -> None:
+        product = build_product(
+            prices=[
+                build_price(source_id="price_ok"),
+                build_price(
+                    source_id="price_bad",
+                    pricing_scheme=CanonicalPricingScheme.tiered,
+                ),
+            ]
+        )
+
+        plan = plan_product_imports([product])[product.source_id]
+
+        assert plan.importable is True
+        assert plan.importable_price_ids == {"price_ok"}
+
+    def test_product_with_no_importable_price_is_skipped(self) -> None:
+        product = build_product(
+            prices=[
+                build_price(
+                    source_id="price_bad",
+                    pricing_scheme=CanonicalPricingScheme.metered,
+                )
+            ]
+        )
+
+        plan = plan_product_imports([product])[product.source_id]
+
+        assert plan.importable is False
+        assert plan.skip_code == "no_importable_price"
+
+    def test_duplicate_name_skips_the_later_product(self) -> None:
+        first = build_product(source_id="prod_1:month:1", product_source_id="prod_1")
+        second = build_product(source_id="prod_2:month:1", product_source_id="prod_2")
+
+        plans = plan_product_imports([first, second])
+
+        assert plans[first.source_id].importable is True
+        assert plans[second.source_id].skip_code == "duplicate_product_name"
+
+
+class TestPlanCustomerImports:
+    def test_unique_customers_are_importable(self) -> None:
+        customer = build_customer(source_id="cus_1", email="a@example.com")
+
+        assert plan_customer_imports([customer])[customer.source_id] == (None, None)
+
+    def test_duplicate_email_skips_the_later_customer(self) -> None:
+        first = build_customer(source_id="cus_1", email="a@example.com")
+        second = build_customer(source_id="cus_2", email="a@example.com")
+
+        plans = plan_customer_imports([first, second])
+
+        assert plans["cus_1"] == (None, None)
+        assert plans["cus_2"][0] == "duplicate_customer_email"

--- a/server/tests/merchant_migration/test_precheck.py
+++ b/server/tests/merchant_migration/test_precheck.py
@@ -26,6 +26,7 @@ from polar.merchant_migration.precheck import (
 from polar.merchant_migration.schemas import (
     PrecheckEntity,
     PrecheckIssueLevel,
+    PrecheckReasonLevel,
     PrecheckRecordStatus,
     PrecheckReport,
 )
@@ -418,6 +419,77 @@ class TestClassifyRecords:
         assert by_id["price_metered"].status == PrecheckRecordStatus.skipped
         assert by_id["price_metered"].reason_code == "unsupported_pricing_scheme"
 
+    def test_missing_country_is_importable_and_action_required(self) -> None:
+        records: list[CanonicalRecord] = [
+            build_customer(source_id="cus_1", email="a@example.com", country=None)
+        ]
+
+        items = classify_records(records, PrecheckEntity.customers)
+
+        assert items[0].status == PrecheckRecordStatus.importable
+        assert items[0].reason_code == "customer_missing_country"
+        assert items[0].reason_level == PrecheckReasonLevel.action_required
+
+    def test_trialing_subscription_is_importable_with_info(self) -> None:
+        records: list[CanonicalRecord] = [
+            build_product(
+                product_source_id="prod_1", prices=[build_price(source_id="price_1")]
+            ),
+            build_customer(source_id="cus_1", email="a@example.com"),
+            build_subscription(source_id="sub_1", trialing=True),
+        ]
+
+        items = classify_records(records, PrecheckEntity.subscriptions)
+
+        assert items[0].status == PrecheckRecordStatus.importable
+        assert items[0].reason_code == "subscription_trialing"
+        assert items[0].reason_level == PrecheckReasonLevel.info
+
+    def test_payment_method_reentry_is_importable_with_info(self) -> None:
+        records: list[CanonicalRecord] = [
+            build_product(
+                product_source_id="prod_1", prices=[build_price(source_id="price_1")]
+            ),
+            build_customer(source_id="cus_1", email="a@example.com"),
+            build_subscription(
+                source_id="sub_1",
+                payment_method=CanonicalPaymentMethod(
+                    source_id="pm_1", type=CanonicalPaymentMethodType.link
+                ),
+            ),
+        ]
+
+        items = classify_records(records, PrecheckEntity.subscriptions)
+
+        assert items[0].status == PrecheckRecordStatus.importable
+        assert items[0].reason_code == "payment_method_requires_reentry"
+        assert items[0].reason_level == PrecheckReasonLevel.info
+
+    def test_skipped_record_carries_its_level(self) -> None:
+        records: list[CanonicalRecord] = [
+            build_product(
+                product_source_id="prod_1", prices=[build_price(source_id="price_1")]
+            ),
+            build_customer(source_id="cus_1", email="a@example.com"),
+            build_subscription(source_id="sub_1", has_discount=True),
+        ]
+
+        items = classify_records(records, PrecheckEntity.subscriptions)
+
+        assert items[0].status == PrecheckRecordStatus.skipped
+        assert items[0].reason_level == PrecheckReasonLevel.action_required
+
+    def test_product_matching_an_existing_polar_name_gets_a_note(self) -> None:
+        records: list[CanonicalRecord] = [
+            build_product(product_source_id="prod_1", name="Pro")
+        ]
+
+        items = classify_records(records, PrecheckEntity.products, {"pro"})
+
+        assert items[0].status == PrecheckRecordStatus.importable
+        assert items[0].reason_code == "product_exists_in_polar"
+        assert items[0].reason_level == PrecheckReasonLevel.info
+
     def test_duplicate_customer_email_skipped(self) -> None:
         records: list[CanonicalRecord] = [
             build_customer(source_id="cus_1", email="same@example.com"),
@@ -430,6 +502,7 @@ class TestClassifyRecords:
         assert by_id["cus_1"].status == PrecheckRecordStatus.importable
         assert by_id["cus_2"].status == PrecheckRecordStatus.skipped
         assert by_id["cus_2"].reason_code == "duplicate_customer_email"
+        assert by_id["cus_2"].reason_level == PrecheckReasonLevel.action_required
 
     def test_customer_without_email_skipped(self) -> None:
         # The classifier must agree with the importer: a customer with no email
@@ -514,7 +587,7 @@ class TestClassifyCascade:
         assert len(items) == 2
         assert all(i.status == PrecheckRecordStatus.importable for i in items)
 
-    def test_distinct_products_same_name_duplicate(self) -> None:
+    def test_distinct_products_same_name_both_import(self) -> None:
         records: list[CanonicalRecord] = [
             build_product(product_source_id="prod_1", name="Pro"),
             build_product(product_source_id="prod_2", name="Pro"),
@@ -523,9 +596,10 @@ class TestClassifyCascade:
         items = classify_records(records, PrecheckEntity.products)
 
         by_id = {item.source_id: item for item in items}
-        assert by_id["prod_1"].status == PrecheckRecordStatus.importable
-        assert by_id["prod_2"].status == PrecheckRecordStatus.skipped
-        assert by_id["prod_2"].reason_code == "duplicate_product_name"
+        for source_id in ("prod_1", "prod_2"):
+            assert by_id[source_id].status == PrecheckRecordStatus.importable
+            assert by_id[source_id].reason_code == "duplicate_product_name"
+            assert by_id[source_id].reason_level == PrecheckReasonLevel.info
 
     def test_price_skipped_when_parent_product_skipped(self) -> None:
         records: list[CanonicalRecord] = [
@@ -577,6 +651,31 @@ class TestClassifyCascade:
         assert items[0].status == PrecheckRecordStatus.skipped
         assert items[0].reason_code == "subscription_customer_not_importable"
 
+    def test_subscription_imports_when_its_product_shares_a_name(self) -> None:
+        subscription = replace(
+            build_subscription(source_id="sub_2"), price_source_id="price_2"
+        )
+        records: list[CanonicalRecord] = [
+            build_product(
+                source_id="prod_1:month:1",
+                product_source_id="prod_1",
+                name="Pro",
+                prices=[build_price(source_id="price_1")],
+            ),
+            build_product(
+                source_id="prod_2:month:1",
+                product_source_id="prod_2",
+                name="Pro",
+                prices=[build_price(source_id="price_2")],
+            ),
+            build_customer(source_id="cus_1", email="a@example.com"),
+            subscription,
+        ]
+
+        items = classify_records(records, PrecheckEntity.subscriptions)
+
+        assert items[0].status == PrecheckRecordStatus.importable
+
     def test_subscription_skipped_when_price_not_extracted(self) -> None:
         # The subscription runs on a price the source no longer lists (archived),
         # so no product carrying that price id was extracted.
@@ -614,7 +713,8 @@ class TestPlanProductImports:
         plan = plan_product_imports([product])[product.source_id]
 
         assert plan.importable is False
-        assert plan.skip_code == "one_time_product"
+        assert plan.skip is not None
+        assert plan.skip[0] == "one_time_product"
 
     def test_drops_unsupported_prices_but_keeps_the_rest(self) -> None:
         product = build_product(
@@ -645,29 +745,40 @@ class TestPlanProductImports:
         plan = plan_product_imports([product])[product.source_id]
 
         assert plan.importable is False
-        assert plan.skip_code == "no_importable_price"
+        assert plan.skip is not None
+        assert plan.skip[0] == "no_importable_price"
 
-    def test_duplicate_name_skips_the_later_product(self) -> None:
+    def test_products_sharing_a_name_both_import(self) -> None:
         first = build_product(source_id="prod_1:month:1", product_source_id="prod_1")
         second = build_product(source_id="prod_2:month:1", product_source_id="prod_2")
 
         plans = plan_product_imports([first, second])
 
         assert plans[first.source_id].importable is True
-        assert plans[second.source_id].skip_code == "duplicate_product_name"
+        assert plans[second.source_id].importable is True
 
 
 class TestPlanCustomerImports:
     def test_unique_customers_are_importable(self) -> None:
         customer = build_customer(source_id="cus_1", email="a@example.com")
 
-        assert plan_customer_imports([customer])[customer.source_id] == (None, None)
+        assert plan_customer_imports([customer])[customer.source_id] is None
 
     def test_duplicate_email_skips_the_later_customer(self) -> None:
         first = build_customer(source_id="cus_1", email="a@example.com")
         second = build_customer(source_id="cus_2", email="a@example.com")
 
         plans = plan_customer_imports([first, second])
+        skip = plans["cus_2"]
 
-        assert plans["cus_1"] == (None, None)
-        assert plans["cus_2"][0] == "duplicate_customer_email"
+        assert plans["cus_1"] is None
+        assert skip is not None
+        assert skip[0] == "duplicate_customer_email"
+
+    def test_customer_without_email_is_skipped(self) -> None:
+        customer = build_customer(source_id="cus_1", email="")
+
+        skip = plan_customer_imports([customer])["cus_1"]
+
+        assert skip is not None
+        assert skip[0] == "customer_missing_email"

--- a/server/tests/merchant_migration/test_precheck.py
+++ b/server/tests/merchant_migration/test_precheck.py
@@ -299,6 +299,15 @@ class TestPrecheckEngine:
         )
         assert "customer_missing_country" in codes(report, PrecheckIssueLevel.warning)
 
+    async def test_missing_email_warns(self) -> None:
+        report = await run(
+            [
+                build_customer(source_id="cus_1", email=""),
+                build_customer(source_id="cus_2", email="a@example.com"),
+            ]
+        )
+        assert "customer_missing_email" in codes(report, PrecheckIssueLevel.warning)
+
     async def test_subscription_warnings_do_not_block(self) -> None:
         report = await run(
             [
@@ -478,6 +487,42 @@ class TestClassifyRecords:
 
         assert items[0].status == PrecheckRecordStatus.skipped
         assert items[0].reason_level == PrecheckReasonLevel.action_required
+
+    def test_product_row_shows_a_price_that_will_import(self) -> None:
+        records: list[CanonicalRecord] = [
+            build_product(
+                product_source_id="prod_1",
+                prices=[
+                    build_price(
+                        source_id="price_tiered",
+                        amount=99,
+                        pricing_scheme=CanonicalPricingScheme.tiered,
+                    ),
+                    build_price(source_id="price_ok", amount=1000),
+                ],
+            )
+        ]
+
+        items = classify_records(records, PrecheckEntity.products)
+
+        assert items[0].status == PrecheckRecordStatus.importable
+        assert items[0].amount == 1000
+
+    def test_subscription_skipped_when_its_customer_was_not_extracted(self) -> None:
+        subscription = replace(
+            build_subscription(source_id="sub_1"), customer_source_id="cus_gone"
+        )
+        records: list[CanonicalRecord] = [
+            build_product(
+                product_source_id="prod_1", prices=[build_price(source_id="price_1")]
+            ),
+            subscription,
+        ]
+
+        items = classify_records(records, PrecheckEntity.subscriptions)
+
+        assert items[0].status == PrecheckRecordStatus.skipped
+        assert items[0].reason_code == "subscription_customer_not_importable"
 
     def test_product_matching_an_existing_polar_name_gets_a_note(self) -> None:
         records: list[CanonicalRecord] = [

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -11,6 +11,7 @@ from polar.kit.encryption import LocalKeyProvider
 from polar.kit.pagination import PaginationParams
 from polar.merchant_migration.canonical import (
     CanonicalAccount,
+    CanonicalCustomer,
     CanonicalPrice,
     CanonicalPricingScheme,
     CanonicalProduct,
@@ -37,6 +38,7 @@ from polar.merchant_migration.service import merchant_migration as service
 from polar.models import (
     MerchantMigration,
     Organization,
+    Product,
     User,
     UserOrganization,
 )
@@ -44,6 +46,11 @@ from polar.models.merchant_migration import (
     MerchantMigrationSourcePlatform,
     MerchantMigrationStep,
 )
+from polar.models.merchant_migration_record import (
+    MerchantMigrationRecordStatus,
+    MerchantMigrationRecordType,
+)
+from polar.models.product_price import ProductPriceFixed
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
 from tests.merchant_migration._helpers import build_connected_migration
@@ -331,6 +338,40 @@ class TestRunPrecheck:
         assert records[0].canonical["name"] == "Pro"
 
     @pytest.mark.auth
+    async def test_warns_when_a_polar_product_already_exists(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        existing = Product(
+            organization=organization,
+            name="Pro",
+            recurring_interval="month",
+            recurring_interval_count=1,
+            prices=[ProductPriceFixed(price_amount=1000, price_currency="usd")],
+            all_prices=[ProductPriceFixed(price_amount=1000, price_currency="usd")],
+            product_benefits=[],
+            product_medias=[],
+            attached_custom_fields=[],
+        )
+        await save_fixture(existing)
+
+        migration = await build_connected_migration(save_fixture, organization)
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter",
+            return_value=_FakeAdapter(_catalog()),
+        )
+
+        report = await service.run_precheck(session, auth_subject, migration.id)
+
+        codes = {issue.code for issue in report.issues}
+        assert "product_exists_in_polar" in codes
+
+    @pytest.mark.auth
     async def test_source_not_connected(
         self,
         session: AsyncSession,
@@ -464,3 +505,75 @@ class TestListRecords:
         assert count == 1
         assert items[0].source_id == "prod_2"
         assert items[0].reason_code == "one_time_product"
+
+    @pytest.mark.auth
+    async def test_items_carry_ledger_record_id(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter",
+            return_value=_FakeAdapter(_catalog()),
+        )
+
+        await service.run_precheck(session, auth_subject, migration.id)
+        items, _ = await service.list_records(
+            session,
+            auth_subject,
+            migration.id,
+            entity=PrecheckEntity.products,
+            status=None,
+            pagination=PaginationParams(page=1, limit=20),
+        )
+
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        # every product row exposes the ledger id + status of its staged record
+        for item in items:
+            assert item.record_id is not None
+            assert item.import_status == MerchantMigrationRecordStatus.pending
+        prod_1 = await record_repository.get_by_source(
+            organization_id=organization.id,
+            type=MerchantMigrationRecordType.product,
+            source_id="prod_1:month:1",
+        )
+        assert prod_1 is not None
+        assert prod_1.id in {item.record_id for item in items}
+
+
+def _importable_catalog() -> list[CanonicalRecord]:
+    """An importable recurring product, a one-time product that's skipped, and
+    a customer."""
+    return [
+        *_catalog(),
+        CanonicalCustomer(
+            source_id="cus_1",
+            email="alice@example.com",
+            name="Alice",
+            country="US",
+        ),
+    ]
+
+
+async def _staged_migration(
+    mocker: MockerFixture,
+    session: AsyncSession,
+    save_fixture: SaveFixture,
+    auth_subject: AuthSubject[User],
+    organization: Organization,
+    records: list[CanonicalRecord] | None = None,
+) -> MerchantMigration:
+    migration = await build_connected_migration(save_fixture, organization)
+    mocker.patch(
+        "polar.merchant_migration.service.StripeAdapter",
+        return_value=_FakeAdapter(
+            records if records is not None else _importable_catalog()
+        ),
+    )
+    await service.run_precheck(session, auth_subject, migration.id)
+    return migration


### PR DESCRIPTION
## Summary

The read side of merchant migration: it classifies a merchant's staged Stripe catalog and serves the data the review dashboard shows before anything is imported. 

## What

- Classifies each staged record as **importable** or **skipped**, each with a reason and price detail (amount, currency, interval).
- `/records` gains an **"all"** view across products, customers and subscriptions, a **"needs attention"** filter (importable rows that carry a warning), and per-record warnings: no billing country, on trial, and one-time or discounted items that won't import.
- Warns when a source product name already matches an existing Polar product.
- Stable record ordering so paginated listing stays consistent.

## Why

Merchants need to see exactly what will and won't come over, and why, before they run the import. Getting the classification right up front avoids surprises during import.

## How

There is one classification plan per entity, shared by the report and (in the follow-up PR) the importer, so the review can never promise something the importer would skip.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

