### PR TITLE
sdk: add Python and TypeScript READMEs

### DIFF
--- a/sdk/generator/python/template/README.md
+++ b/sdk/generator/python/template/README.md
@@ -1,1 +1,38 @@
 # Polar Python SDK
+
+The official Python client for the [Polar API](https://polar.sh/docs/api-reference).
+
+## Installation
+
+The SDK requires Python 3.11 or later.
+
+```bash
+uv add polar-sdk
+```
+
+or, with `pip`:
+
+```bash
+pip install polar-sdk
+```
+
+## Quick Start
+
+Create an [organization access token](https://polar.sh/docs/integrate/oat) and use the client for
+the current API version:
+
+```python
+from polar.v{{ ir.versions[0].version | replace("-", "_") | replace(".", "_") }} import Polar
+
+polar = Polar("polar_oat_xxx")
+
+customer_state = polar.customers.get_state_external("customer_external_id")
+print(customer_state)
+```
+
+The client uses the production environment by default. To use the sandbox, pass
+`environment="sandbox"` when creating the client. Sandbox and production access tokens are
+separate.
+
+Keep organization access tokens on the server and never expose them in browser or client-side
+code.

--- a/sdk/generator/typescript/emitter.py
+++ b/sdk/generator/typescript/emitter.py
@@ -48,7 +48,11 @@ class TypeScriptEmitter(EmitterBase):
             self.templates_dir / "oxfmt.config.ts", root_directory / "oxfmt.config.ts"
         )
         self.copy_file(self.templates_dir / "justfile", root_directory / "justfile")
-        self.copy_file(self.templates_dir / "README.md", root_directory / "README.md")
+        self.render_file(
+            "README.md",
+            root_directory / "README.md",
+            self.get_context(),
+        )
 
         self.render_file(
             "package.json",

--- a/sdk/generator/typescript/template/README.md
+++ b/sdk/generator/typescript/template/README.md
@@ -1,1 +1,37 @@
 # Polar TypeScript SDK
+
+The official TypeScript client for the [Polar API](https://polar.sh/docs/api-reference).
+
+## Installation
+
+```bash
+pnpm add @polar-sh/sdk
+```
+
+or, with `npm`:
+
+```bash
+npm install @polar-sh/sdk
+```
+
+## Quick Start
+
+Create an [organization access token](https://polar.sh/docs/integrate/oat) and use the client for
+the current API version:
+
+```typescript
+import { createPolar } from "@polar-sh/sdk/{{ ir.versions[0].version }}";
+
+const polar = createPolar({
+  accessToken: "polar_oat_xxx",
+});
+
+const customerState = await polar.customers.getStateExternal("customer_external_id");
+console.log(customerState);
+```
+
+The client uses the production environment by default. To use the sandbox, pass
+`environment: "sandbox"` to `createPolar`. Sandbox and production access tokens are separate.
+
+Keep organization access tokens on the server and never expose them in browser or client-side
+code.

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,1 +1,38 @@
 # Polar Python SDK
+
+The official Python client for the [Polar API](https://polar.sh/docs/api-reference).
+
+## Installation
+
+The SDK requires Python 3.11 or later.
+
+```bash
+uv add polar-sdk
+```
+
+or, with `pip`:
+
+```bash
+pip install polar-sdk
+```
+
+## Quick Start
+
+Create an [organization access token](https://polar.sh/docs/integrate/oat) and use the client for
+the current API version:
+
+```python
+from polar.v2026_04 import Polar
+
+polar = Polar("polar_oat_xxx")
+
+customer_state = polar.customers.get_state_external("customer_external_id")
+print(customer_state)
+```
+
+The client uses the production environment by default. To use the sandbox, pass
+`environment="sandbox"` when creating the client. Sandbox and production access tokens are
+separate.
+
+Keep organization access tokens on the server and never expose them in browser or client-side
+code.

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1,1 +1,37 @@
 # Polar TypeScript SDK
+
+The official TypeScript client for the [Polar API](https://polar.sh/docs/api-reference).
+
+## Installation
+
+```bash
+pnpm add @polar-sh/sdk
+```
+
+or, with `npm`:
+
+```bash
+npm install @polar-sh/sdk
+```
+
+## Quick Start
+
+Create an [organization access token](https://polar.sh/docs/integrate/oat) and use the client for
+the current API version:
+
+```typescript
+import { createPolar } from "@polar-sh/sdk/2026-04";
+
+const polar = createPolar({
+    accessToken: "polar_oat_xxx",
+});
+
+const customerState = await polar.customers.getStateExternal("customer_external_id");
+console.log(customerState);
+```
+
+The client uses the production environment by default. To use the sandbox, pass
+`environment: "sandbox"` to `createPolar`. Sandbox and production access tokens are separate.
+
+Keep organization access tokens on the server and never expose them in browser or client-side
+code.


### PR DESCRIPTION
## Summary

**Related Issue**: #13182

Adds useful installation and quick-start documentation to the generated Python and TypeScript SDKs.

## What

- Documented installation with `uv` and `pip` for Python.
- Documented installation with `pnpm` and `npm` for TypeScript.
- Added API-versioned quick-start examples that fetch customer state by external ID.
- Added sandbox and access-token safety guidance.
- Updated the generator templates so future SDK generations preserve the documentation.

## Why

The Python and TypeScript SDK READMEs previously contained only their titles, leaving package users without installation or usage guidance.

## How

The README content lives in each SDK generator template and is reflected in the generated SDK directories. The TypeScript emitter now renders its README template so it can include the current API version in the package import path.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

