### PR TITLE
clean up product form on mobile

### DIFF
--- a/clients/apps/web/src/components/Layout/Section.tsx
+++ b/clients/apps/web/src/components/Layout/Section.tsx
@@ -20,7 +20,7 @@ export const Section = ({
     <div
       className={twMerge(
         'relative flex flex-col',
-        compact ? 'gap-6 p-8' : 'gap-8 p-12',
+        compact ? 'gap-6 p-6 md:p-8' : 'gap-8 p-6 md:p-12',
         className,
       )}
     >

--- a/clients/apps/web/src/components/Products/Benefits/components/BenefitRow.tsx
+++ b/clients/apps/web/src/components/Products/Benefits/components/BenefitRow.tsx
@@ -128,8 +128,13 @@ export const BenefitRow = ({
           >
             {resolveBenefitIcon(benefit.type, 'h-4 w-4')}
           </div>
-          <div className="flex flex-col">
-            <span className={twMerge('text-sm', selected ? 'font-medium' : '')}>
+          <div className="flex min-w-0 flex-col">
+            <span
+              className={twMerge(
+                'truncate text-sm',
+                selected ? 'font-medium' : '',
+              )}
+            >
               {benefit.description}
             </span>
             <div className="flex items-center gap-2">

--- a/clients/apps/web/src/components/Products/Benefits/components/BenefitRow.tsx
+++ b/clients/apps/web/src/components/Products/Benefits/components/BenefitRow.tsx
@@ -111,16 +111,16 @@ export const BenefitRow = ({
     <>
       <div
         className={twMerge(
-          'flex items-center justify-between px-4 py-3 transition-colors',
+          'flex items-center justify-between py-3 pl-4 pr-2 transition-colors',
           selected
             ? 'dark:bg-polar-800/50 bg-blue-50/50'
             : 'dark:hover:bg-polar-800/30 hover:bg-gray-50',
         )}
       >
-        <div className="flex items-center gap-3">
+        <div className="flex min-w-0 items-start gap-3">
           <div
             className={twMerge(
-              'flex h-8 w-8 items-center justify-center rounded-lg',
+              'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg',
               selected
                 ? 'bg-blue-100 text-blue-500 dark:bg-blue-950 dark:text-blue-400'
                 : 'dark:bg-polar-700 dark:text-polar-400 bg-gray-100 text-gray-500',

--- a/clients/apps/web/src/components/Products/ProductForm/ProductCheckoutSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductCheckoutSection.tsx
@@ -35,7 +35,7 @@ export const ProductCheckoutSection = ({
     <div className={twMerge('flex flex-col gap-12 p-6 md:p-12', className)}>
       <Accordion type="single" collapsible>
         <AccordionItem value="checkout-page" className="border-none px-0">
-          <AccordionTrigger className="cursor-pointer items-start hover:no-underline [&>svg]:mt-1">
+          <AccordionTrigger className="cursor-pointer items-start hover:no-underline md:items-center [&>svg]:mt-1 md:[&>svg]:mt-0">
             <div className="flex flex-col items-start gap-y-2 text-left">
               <h2 className="text-lg font-medium">Checkout Page</h2>
               <p className="dark:text-polar-500 text-sm leading-snug text-gray-500">

--- a/clients/apps/web/src/components/Products/ProductForm/ProductCheckoutSection.tsx
+++ b/clients/apps/web/src/components/Products/ProductForm/ProductCheckoutSection.tsx
@@ -32,10 +32,10 @@ export const ProductCheckoutSection = ({
   const { control } = useFormContext<ProductFormType>()
 
   return (
-    <div className={twMerge('flex flex-col gap-12 p-12', className)}>
+    <div className={twMerge('flex flex-col gap-12 p-6 md:p-12', className)}>
       <Accordion type="single" collapsible>
-        <AccordionItem value="checkout-page" className="border-none">
-          <AccordionTrigger className="cursor-pointer hover:no-underline">
+        <AccordionItem value="checkout-page" className="border-none px-0">
+          <AccordionTrigger className="cursor-pointer items-start hover:no-underline [&>svg]:mt-1">
             <div className="flex flex-col items-start gap-y-2 text-left">
               <h2 className="text-lg font-medium">Checkout Page</h2>
               <p className="dark:text-polar-500 text-sm leading-snug text-gray-500">

--- a/clients/apps/web/src/components/Products/ProductMediasField/index.tsx
+++ b/clients/apps/web/src/components/Products/ProductMediasField/index.tsx
@@ -82,7 +82,7 @@ const ProductMediasField = ({
   })
   return (
     <>
-      <div className="grid grid-cols-2 gap-3 [&>div>*]:aspect-video">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 [&>div>*]:aspect-video">
         <FileList files={files} setFiles={setFiles} removeFile={removeFile} />
         <div {...getRootProps()}>
           <DropzoneView isDragActive={isDragActive}>

--- a/clients/apps/web/src/components/Products/ProductMetadataForm.tsx
+++ b/clients/apps/web/src/components/Products/ProductMetadataForm.tsx
@@ -2,7 +2,8 @@ import { FormField } from '@polar-sh/ui/components/ui/form'
 
 import ClearOutlined from '@mui/icons-material/ClearOutlined'
 import { schemas } from '@polar-sh/client'
-import { Button } from '@polar-sh/orbit'
+import { Button, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
 import { Input } from '@polar-sh/orbit'
 import {
   Select,
@@ -55,7 +56,7 @@ const MetadataValueInput = ({
         value={value === true ? 'true' : 'false'}
         onValueChange={(v) => onChange(v === 'true')}
       >
-        <SelectTrigger className="flex-1 font-mono">
+        <SelectTrigger className="w-full min-w-0 flex-1 font-mono">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
@@ -76,7 +77,7 @@ const MetadataValueInput = ({
         type="number"
         value={value.toString()}
         placeholder="value"
-        className="font-mono"
+        className="w-full min-w-0 flex-1 font-mono"
         onChange={(e) => {
           const parsed = e.target.valueAsNumber
           onChange(Number.isNaN(parsed) ? 0 : parsed)
@@ -89,11 +90,26 @@ const MetadataValueInput = ({
     <Input
       value={value.toString()}
       placeholder="value"
-      className="font-mono"
+      className="w-full min-w-0 flex-1 font-mono"
       onChange={(e) => onChange(e.target.value)}
     />
   )
 }
+
+const RemoveMetadataButton = ({ onClick }: { onClick: () => void }) => (
+  <Button
+    className={
+      'self-center border-none bg-transparent text-[16px] opacity-50 transition-opacity hover:opacity-100 dark:bg-transparent'
+    }
+    size="icon"
+    variant="secondary"
+    type="button"
+    aria-label="Remove metadata"
+    onClick={onClick}
+  >
+    <ClearOutlined fontSize="inherit" />
+  </Button>
+)
 
 export const ProductMetadataForm = () => {
   const { control, trigger, getValues } = useFormContext<ProductFormType>()
@@ -128,17 +144,42 @@ export const ProductMetadataForm = () => {
   return (
     <FormItem className="flex flex-col gap-2">
       {fields.length > 0 && (
-        <div className="flex flex-col gap-2">
-          <div className="dark:text-polar-500 flex flex-row items-center gap-2 text-sm text-gray-500">
-            <div className="w-48">Key</div>
-            <div className="flex flex-1 flex-row gap-2">
-              <div className="w-32 shrink-0">Type</div>
-              <div className="flex-1">Value</div>
-            </div>
-            <div className="w-8 shrink-0" />
-          </div>
+        <Box flexDirection="column" gap="s">
+          <Box
+            display={{ base: 'none', sm: 'flex' }}
+            alignItems="center"
+            gap="s"
+          >
+            <Box width={192} flexShrink={0}>
+              <Text variant="caption" color="muted">
+                Key
+              </Text>
+            </Box>
+            <Box flex={1} gap="s">
+              <Box width={128} flexShrink={0}>
+                <Text variant="caption" color="muted">
+                  Type
+                </Text>
+              </Box>
+              <Box flex={1}>
+                <Text variant="caption" color="muted">
+                  Value
+                </Text>
+              </Box>
+            </Box>
+            <Box width={32} flexShrink={0} />
+          </Box>
           {fields.map((field, index) => (
-            <div key={field.id} className="flex flex-row items-start gap-2">
+            <Box
+              key={field.id}
+              flexDirection={{ base: 'column', sm: 'row' }}
+              alignItems="start"
+              gap="s"
+              borderTopWidth={index > 0 ? { base: 1, sm: 0 } : undefined}
+              borderStyle="solid"
+              borderColor="border-primary"
+              paddingTop={index > 0 ? { base: 'l', sm: 'none' } : undefined}
+            >
               <FormField
                 control={control}
                 name={`metadata.${index}.key`}
@@ -146,100 +187,132 @@ export const ProductMetadataForm = () => {
                   validate: (value: string) => validateUniqueKey(value, index),
                 }}
                 render={({ field }) => (
-                  <div className="flex w-48 flex-col gap-2">
-                    <FormControl>
-                      <Input
-                        {...field}
-                        className="font-mono"
-                        value={field.value || ''}
-                        placeholder="key"
-                        onChange={(e) => {
-                          field.onChange(e)
-                          revalidateAllKeys()
-                        }}
-                      />
-                    </FormControl>
+                  <Box
+                    flexDirection="column"
+                    gap="s"
+                    width={{ base: '100%', sm: 192 }}
+                    flexShrink={0}
+                  >
+                    <Box display={{ base: 'flex', sm: 'none' }}>
+                      <Text variant="caption" color="muted">
+                        Key
+                      </Text>
+                    </Box>
+                    <Box alignItems="center" gap="s">
+                      <FormControl>
+                        <Input
+                          {...field}
+                          className="w-full min-w-0 flex-1 font-mono"
+                          value={field.value || ''}
+                          placeholder="key"
+                          onChange={(e) => {
+                            field.onChange(e)
+                            revalidateAllKeys()
+                          }}
+                        />
+                      </FormControl>
+                      <Box
+                        display={{ base: 'flex', sm: 'none' }}
+                        flexShrink={0}
+                      >
+                        <RemoveMetadataButton onClick={() => remove(index)} />
+                      </Box>
+                    </Box>
                     <FormMessage />
-                  </div>
+                  </Box>
                 )}
               />
-              <FormField
-                control={control}
-                name={`metadata.${index}.value`}
-                render={({ field }) => {
-                  const type = getValueType(field.value)
-                  return (
-                    <div className="flex flex-1 flex-col gap-2">
-                      <div className="flex flex-row items-center gap-2">
-                        <Select
-                          value={type}
-                          onValueChange={(nextType) =>
-                            field.onChange(
-                              defaultValueForType(
-                                nextType as MetadataValueType,
-                              ),
-                            )
-                          }
-                        >
-                          <SelectTrigger className="w-32 shrink-0">
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="string">String</SelectItem>
-                            <SelectItem value="number">Number</SelectItem>
-                            <SelectItem value="boolean">Boolean</SelectItem>
-                          </SelectContent>
-                        </Select>
-                        <MetadataValueInput
-                          type={type}
-                          value={field.value}
-                          onChange={field.onChange}
-                        />
-                      </div>
-                      <FormMessage />
-                    </div>
-                  )
-                }}
-              />
-              <div className="flex h-10">
-                <Button
-                  className={
-                    'self-center border-none bg-transparent text-[16px] opacity-50 transition-opacity hover:opacity-100 dark:bg-transparent'
-                  }
-                  size="icon"
-                  variant="secondary"
-                  type="button"
-                  onClick={() => remove(index)}
+              <Box
+                width={{ base: '100%', sm: 'auto' }}
+                flex={1}
+                minWidth={0}
+                gap="s"
+              >
+                <FormField
+                  control={control}
+                  name={`metadata.${index}.value`}
+                  render={({ field }) => {
+                    const type = getValueType(field.value)
+                    return (
+                      <Box flexDirection="column" gap="s" flex={1} minWidth={0}>
+                        <Box display={{ base: 'flex', sm: 'none' }}>
+                          <Text variant="caption" color="muted">
+                            Value
+                          </Text>
+                        </Box>
+                        <Box alignItems="center" gap="s">
+                          <Select
+                            value={type}
+                            onValueChange={(nextType) =>
+                              field.onChange(
+                                defaultValueForType(
+                                  nextType as MetadataValueType,
+                                ),
+                              )
+                            }
+                          >
+                            <SelectTrigger className="w-32 shrink-0">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="string">String</SelectItem>
+                              <SelectItem value="number">Number</SelectItem>
+                              <SelectItem value="boolean">Boolean</SelectItem>
+                            </SelectContent>
+                          </Select>
+                          <MetadataValueInput
+                            type={type}
+                            value={field.value}
+                            onChange={field.onChange}
+                          />
+                        </Box>
+                        <FormMessage />
+                      </Box>
+                    )
+                  }}
+                />
+                <Box
+                  display={{ base: 'none', sm: 'flex' }}
+                  height={40}
+                  flexShrink={0}
                 >
-                  <ClearOutlined fontSize="inherit" />
-                </Button>
-              </div>
-            </div>
+                  <RemoveMetadataButton onClick={() => remove(index)} />
+                </Box>
+              </Box>
+            </Box>
           ))}
-        </div>
+        </Box>
       )}
 
       {fields.length === 0 && (
-        <p className="dark:text-polar-500 dark:border-polar-700 flex items-center justify-center rounded-2xl border border-gray-300 p-8 text-center text-sm text-gray-500">
-          No metadata added
-        </p>
+        <Box
+          alignItems="center"
+          justifyContent="center"
+          borderRadius="l"
+          borderWidth={1}
+          borderStyle="solid"
+          borderColor="border-primary"
+          padding="2xl"
+          textAlign="center"
+        >
+          <Text variant="caption" color="muted">
+            No metadata added
+          </Text>
+        </Box>
       )}
 
-      <div className="flex flex-row items-center justify-end">
-        <p className="dark:text-polar-500 text-sm text-gray-500">
-          <Button
-            size="sm"
-            variant="secondary"
-            className="self-start"
-            type="button"
-            onClick={() => {
-              append({ key: '', value: '' })
-            }}
-          >
-            Add Metadata
-          </Button>
-        </p>
-      </div>
+      <Box alignItems="center" justifyContent="end">
+        <Button
+          size="sm"
+          variant="secondary"
+          type="button"
+          onClick={() => {
+            append({ key: '', value: '' })
+          }}
+        >
+          Add Metadata
+        </Button>
+      </Box>
     </FormItem>
   )
 }


### PR DESCRIPTION
Cleans up the product create/edit page on mobile. 

- Metadata values were invisible — the value field was being squeezed to nothing by the fixed-width Key and Type controls, so you couldn't read or type your metadata values. Now sized correctly.
- Metadata rows now stack on mobile — Key gets its own row with Type and Value beneath, each entry labelled and separated by a divider so pairs read as pairs.
- Sections were too padded on mobile — reduced page and checkout section padding so content isn't crammed into a narrow strip.
- Long benefit names overflowed — they now truncate cleanly, and the icon no longer gets squashed.
- Product media grid — one image per row on mobile instead of two.


| Before | After |
|---|---|
| <img width="438" height="418" alt="Screenshot 2026-07-15 at 15 28 52" src="https://github.com/user-attachments/assets/a9ef2e13-b44f-43f8-84db-f7deed605ea4" /> | <img width="528" height="548" alt="Screenshot 2026-07-15 at 15 28 55" src="https://github.com/user-attachments/assets/79253954-21de-4eb7-8064-18045053165d" /> |
|  <img width="669" height="741" alt="Screenshot 2026-07-15 at 15 29 32" src="https://github.com/user-attachments/assets/0ffe69a9-8ac8-4d3a-9b1d-4b983eb5a114" /> | <img width="692" height="659" alt="Screenshot 2026-07-15 at 15 29 36" src="https://github.com/user-attachments/assets/4fd262c4-8523-4041-b275-d4158607c06b" /> |
| <img width="536" height="743" alt="Screenshot 2026-07-15 at 15 29 12" src="https://github.com/user-attachments/assets/ebc8a981-185d-45d3-9eb8-8a3fb14e449c" /> | <img width="530" height="761" alt="Screenshot 2026-07-15 at 15 29 21" src="https://github.com/user-attachments/assets/bdce6611-c27e-4c7c-aaf3-b6c39a89142b" /> |



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

