### PR TITLE
fix(dispute): tolerate concurrent dispute transaction creation

### DIFF
--- a/server/polar/dispute/service.py
+++ b/server/polar/dispute/service.py
@@ -29,6 +29,9 @@ from polar.subscription.repository import SubscriptionRepository
 from polar.subscription.service import SubscriptionUpdateContext
 from polar.subscription.service import subscription as subscription_service
 from polar.transaction.service.dispute import (
+    DisputeTransactionAlreadyExistsError,
+)
+from polar.transaction.service.dispute import (
     dispute_transaction as dispute_transaction_service,
 )
 
@@ -233,10 +236,15 @@ class DisputeService:
             dispute.status = new_status
             # If won or lost, record the transactions
             if dispute.resolved:
-                await dispute_transaction_service.create_dispute(
-                    session, dispute=dispute
-                )
-                await self._revoke(session, dispute)
+                try:
+                    await dispute_transaction_service.create_dispute(
+                        session, dispute=dispute
+                    )
+                    await self._revoke(session, dispute)
+                except DisputeTransactionAlreadyExistsError:
+                    # A concurrent writer already recorded the transactions and
+                    # revoked; the idempotent updates below still apply.
+                    pass
 
         dispute = await repository.update(dispute)
         await self._sync_support_case(session, dispute, previous_status=previous_status)

--- a/server/polar/transaction/service/dispute.py
+++ b/server/polar/transaction/service/dispute.py
@@ -2,6 +2,7 @@ import math
 
 import structlog
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
 
 from polar.enums import PaymentProcessor
@@ -131,6 +132,15 @@ class DisputeTransactionService(BaseTransactionService):
             incurred_transactions=[],
         )
         session.add(dispute_transaction)
+        # Flush in a savepoint so a concurrent writer on the same dispute
+        # surfaces as the domain error instead of a double insert, while keeping
+        # the outer transaction usable for the caller.
+        try:
+            async with session.begin_nested():
+                await session.flush()
+        except IntegrityError as e:
+            raise DisputeTransactionAlreadyExistsError(dispute) from e
+
         dispute_fees = await processor_fee_transaction_service.create_dispute_fees(
             session,
             dispute=dispute,

--- a/server/polar/transaction/service/dispute.py
+++ b/server/polar/transaction/service/dispute.py
@@ -131,15 +131,17 @@ class DisputeTransactionService(BaseTransactionService):
             order_id=payment_transaction.order_id,
             incurred_transactions=[],
         )
-        session.add(dispute_transaction)
         # Flush in a savepoint so a concurrent writer on the same dispute
         # surfaces as the domain error instead of a double insert, while keeping
         # the outer transaction usable for the caller.
         try:
             async with session.begin_nested():
+                session.add(dispute_transaction)
                 await session.flush()
         except IntegrityError as e:
-            raise DisputeTransactionAlreadyExistsError(dispute) from e
+            if await repository.get_by_dispute_id(dispute.id) is not None:
+                raise DisputeTransactionAlreadyExistsError(dispute) from e
+            raise
 
         dispute_fees = await processor_fee_transaction_service.create_dispute_fees(
             session,

--- a/server/tests/dispute/test_service.py
+++ b/server/tests/dispute/test_service.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime
 from typing import Literal
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pytest_mock import MockerFixture
@@ -21,7 +21,10 @@ from polar.postgres import AsyncSession
 from polar.refund.service import RefundService
 from polar.support_case.repository import SupportCaseMessageRepository
 from polar.tax.calculation.base import AlreadyRevertedError
-from polar.transaction.service.dispute import DisputeTransactionService
+from polar.transaction.service.dispute import (
+    DisputeTransactionAlreadyExistsError,
+    DisputeTransactionService,
+)
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_active_subscription,
@@ -225,6 +228,53 @@ class TestUpsertFromStripe:
         dispute_transaction_service_mock.create_dispute.assert_awaited_once_with(
             session, dispute=updated_dispute
         )
+
+    async def test_update_from_dispute_id_concurrent_transaction_noop(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        organization: Organization,
+        dispute_transaction_service_mock: MagicMock,
+        mocker: MockerFixture,
+    ) -> None:
+        order = await create_order(save_fixture, customer=customer)
+        charge_id = "STRIPE_CHARGE_ID"
+        payment = await create_payment(
+            save_fixture, organization, order=order, processor_id=charge_id
+        )
+        dispute = await create_dispute(save_fixture, order, payment)
+        assert dispute.payment_processor_id is not None
+
+        # The other writer already recorded the transactions, so this one hits
+        # the uniqueness guard and must no-op instead of raising.
+        dispute_transaction_service_mock.create_dispute.side_effect = (
+            DisputeTransactionAlreadyExistsError(dispute)
+        )
+        revoke_mock = mocker.patch.object(
+            dispute_service, "_revoke", new_callable=AsyncMock
+        )
+
+        stripe_dispute = build_stripe_dispute(
+            status="lost",
+            id=dispute.payment_processor_id,
+            charge_id=charge_id,
+            amount=order.subtotal_amount + order.tax_amount,
+            balance_transactions=[
+                build_stripe_balance_transaction(
+                    amount=-dispute.amount, reporting_category="dispute", fee=1500
+                )
+            ],
+        )
+
+        updated_dispute = await dispute_service.upsert_from_stripe(
+            session, stripe_dispute
+        )
+
+        assert updated_dispute.id == dispute.id
+        assert updated_dispute.status == DisputeStatus.lost
+        dispute_transaction_service_mock.create_dispute.assert_awaited_once()
+        revoke_mock.assert_not_awaited()
 
     async def test_update_from_matching_payment(
         self,

--- a/server/tests/transaction/service/test_dispute.py
+++ b/server/tests/transaction/service/test_dispute.py
@@ -162,20 +162,23 @@ class TestCreateDispute:
 
         # Pre-check ran before the racing insert was visible, so the unique
         # index must turn it into the domain error, not a leaking IntegrityError.
-        await create_transaction(
+        existing_transaction = await create_transaction(
             save_fixture, type=TransactionType.dispute, dispute=dispute
         )
         mocker.patch.object(
             DisputeTransactionRepository,
             "get_by_dispute_id",
             new_callable=AsyncMock,
-            return_value=None,
+            side_effect=[None, existing_transaction],
         )
 
         with pytest.raises(DisputeTransactionAlreadyExistsError):
             await dispute_transaction_service.create_dispute(session, dispute=dispute)
 
         create_dispute_fees_mock.assert_not_awaited()
+
+        # The savepoint must keep the outer transaction usable for the caller.
+        await session.flush()
 
     async def test_valid_lost(
         self,

--- a/server/tests/transaction/service/test_dispute.py
+++ b/server/tests/transaction/service/test_dispute.py
@@ -17,6 +17,7 @@ from polar.models import (
 from polar.models.dispute import DisputeStatus
 from polar.models.transaction import Processor, TransactionType
 from polar.postgres import AsyncSession
+from polar.transaction.repository import DisputeTransactionRepository
 from polar.transaction.service.balance import BalanceTransactionService
 from polar.transaction.service.balance import (
     balance_transaction as balance_transaction_service,
@@ -122,6 +123,59 @@ class TestCreateDispute:
 
         with pytest.raises(DisputeTransactionAlreadyExistsError):
             await dispute_transaction_service.create_dispute(session, dispute=dispute)
+
+    async def test_transaction_already_exists_concurrent_flush(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        order: Order,
+        payment: Payment,
+        create_dispute_fees_mock: AsyncMock,
+        stripe_service_mock: MagicMock,
+    ) -> None:
+        charge = build_stripe_charge(id=payment.processor_id)
+        dispute = await create_dispute(
+            save_fixture, order, payment, status=DisputeStatus.lost, amount=1000
+        )
+        stripe_service_mock.get_dispute.return_value = build_stripe_dispute(
+            status="lost",
+            amount=1000,
+            charge_id=charge.id,
+            balance_transactions=[
+                build_stripe_balance_transaction(
+                    reporting_category="dispute", amount=-1000
+                ),
+            ],
+        )
+        payment_transaction = Transaction(
+            type=TransactionType.payment,
+            processor=Processor.stripe,
+            currency=charge.currency,
+            amount=charge.amount,
+            account_currency=charge.currency,
+            account_amount=charge.amount,
+            tax_amount=0,
+            charge_id=charge.id,
+        )
+        await save_fixture(payment_transaction)
+
+        # Pre-check ran before the racing insert was visible, so the unique
+        # index must turn it into the domain error, not a leaking IntegrityError.
+        await create_transaction(
+            save_fixture, type=TransactionType.dispute, dispute=dispute
+        )
+        mocker.patch.object(
+            DisputeTransactionRepository,
+            "get_by_dispute_id",
+            new_callable=AsyncMock,
+            return_value=None,
+        )
+
+        with pytest.raises(DisputeTransactionAlreadyExistsError):
+            await dispute_transaction_service.create_dispute(session, dispute=dispute)
+
+        create_dispute_fees_mock.assert_not_awaited()
 
     async def test_valid_lost(
         self,


### PR DESCRIPTION
## Summary
**Fixes**: #13110

## What
Makes `create_dispute` conflict-tolerant: it flushes the dispute transaction in a savepoint and converts the unique-index violation into `DisputeTransactionAlreadyExistsError`. `upsert_from_stripe` catches it so the losing writer no-ops.

## Why
`POST /disputes/{id}/accept` closes the dispute, which fires Stripe's own `charge.dispute.closed` webhook running the *same* `upsert_from_stripe` concurrently.
Both carry the final status, so both entered the resolved branch and called `create_dispute` — raising `DisputeTransactionAlreadyExistsError` (Sentry) or, in the truly-concurrent window, double-inserting the dispute transaction. Builds on the unique index from #13178.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

