### PR TITLE
sdk: setup LICENSE

### DIFF
--- a/sdk/generator/python/emitter.py
+++ b/sdk/generator/python/emitter.py
@@ -90,6 +90,7 @@ class PythonEmitter(EmitterBase):
             ("tests", "test_base.py"),
             (".python-version",),
             ("justfile",),
+            ("LICENSE",),
             ("pyproject.toml",),
             ("README.md",),
         }:

--- a/sdk/generator/python/template/LICENSE
+++ b/sdk/generator/python/template/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Polar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdk/generator/python/template/pyproject.toml
+++ b/sdk/generator/python/template/pyproject.toml
@@ -1,6 +1,8 @@
 [project]
 name = "polar-sdk"
 authors = [{ name = "Polar", email = "contact@polar.sh" }]
+license = "MIT"
+license-files = ["LICENSE"]
 description = "Polar SDK — A billing platform for the intelligence era"
 readme = "README.md"
 dynamic = ["version"]

--- a/sdk/generator/typescript/emitter.py
+++ b/sdk/generator/typescript/emitter.py
@@ -49,6 +49,7 @@ class TypeScriptEmitter(EmitterBase):
         )
         self.copy_file(self.templates_dir / "justfile", root_directory / "justfile")
         self.copy_file(self.templates_dir / "README.md", root_directory / "README.md")
+        self.copy_file(self.templates_dir / "LICENSE", root_directory / "LICENSE")
 
         self.render_file(
             "package.json",

--- a/sdk/generator/typescript/template/LICENSE
+++ b/sdk/generator/typescript/template/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Polar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/sdk/generator/typescript/template/package.json
+++ b/sdk/generator/typescript/template/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "sideEffects": false,
   "files": [
-    "dist", "README.md"
+    "dist", "README.md", "LICENSE"
   ],
   "engines": { "node": ">=18" },
   "main": "dist/index.cjs",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add an MIT LICENSE to the generated Python and TypeScript SDKs and update the generators to include it. This ensures published packages include the license and correct metadata.

- **New Features**
  - Added MIT `LICENSE` to both SDK templates and emitters now copy it into outputs.
  - Python: set `license = "MIT"` and `license-files = ["LICENSE"]` in `pyproject.toml`.
  - TypeScript: added `LICENSE` to the `files` array in `package.json`.

<sup>Written for commit 53b930fffdd0af60844f758eab8a6350b54eab00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

