### PR TITLE
fix(organization): link license keys & downloadables to member on member-model enablement

### DIFF
--- a/server/polar/organization/member_backfill.py
+++ b/server/polar/organization/member_backfill.py
@@ -1,0 +1,98 @@
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import (
+    ColumnElement,
+    ScalarSelect,
+    String,
+    Update,
+    bindparam,
+    select,
+    update,
+)
+
+from polar.models import Benefit, BenefitGrant, Downloadable, LicenseKey
+
+
+def _license_key_grant_member() -> ScalarSelect[Any]:
+    return (
+        select(BenefitGrant.member_id)
+        .where(
+            BenefitGrant.properties["license_key_id"].as_string()
+            == LicenseKey.id.cast(String),
+            BenefitGrant.member_id.is_not(None),
+            BenefitGrant.deleted_at.is_(None),
+        )
+        .order_by(BenefitGrant.granted_at.desc().nulls_last())
+        .limit(1)
+        .correlate(LicenseKey)
+        .scalar_subquery()
+    )
+
+
+def _downloadable_grant_member() -> ScalarSelect[Any]:
+    return (
+        select(BenefitGrant.member_id)
+        .where(
+            BenefitGrant.customer_id == Downloadable.customer_id,
+            BenefitGrant.benefit_id == Downloadable.benefit_id,
+            BenefitGrant.member_id.is_not(None),
+            BenefitGrant.deleted_at.is_(None),
+        )
+        .order_by(BenefitGrant.granted_at.desc().nulls_last())
+        .limit(1)
+        .correlate(Downloadable)
+        .scalar_subquery()
+    )
+
+
+def license_key_member_backfill_statement(
+    organization_id: UUID | None = None,
+    *,
+    batched: bool = False,
+) -> Update:
+    conditions: list[ColumnElement[bool]] = [
+        LicenseKey.member_id.is_(None),
+        LicenseKey.deleted_at.is_(None),
+        _license_key_grant_member().is_not(None),
+    ]
+    if organization_id is not None:
+        conditions.append(LicenseKey.organization_id == organization_id)
+
+    target = select(LicenseKey.id).where(*conditions).order_by(LicenseKey.id)
+    if batched:
+        target = target.limit(bindparam("limit"))
+
+    return (
+        update(LicenseKey)
+        .where(LicenseKey.id.in_(target.scalar_subquery()))
+        .values(member_id=_license_key_grant_member())
+    )
+
+
+def downloadable_member_backfill_statement(
+    organization_id: UUID | None = None,
+    *,
+    batched: bool = False,
+) -> Update:
+    conditions: list[ColumnElement[bool]] = [
+        Downloadable.member_id.is_(None),
+        Downloadable.deleted_at.is_(None),
+        _downloadable_grant_member().is_not(None),
+    ]
+    if organization_id is not None:
+        conditions.append(
+            Downloadable.benefit_id.in_(
+                select(Benefit.id).where(Benefit.organization_id == organization_id)
+            )
+        )
+
+    target = select(Downloadable.id).where(*conditions).order_by(Downloadable.id)
+    if batched:
+        target = target.limit(bindparam("limit"))
+
+    return (
+        update(Downloadable)
+        .where(Downloadable.id.in_(target.scalar_subquery()))
+        .values(member_id=_downloadable_grant_member())
+    )

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -1,7 +1,8 @@
 import uuid
+from typing import Any, cast
 
 import structlog
-from sqlalchemy import select
+from sqlalchemy import CursorResult, select
 from sqlalchemy.orm import joinedload
 
 from polar.customer.repository import CustomerRepository
@@ -32,6 +33,10 @@ from polar.worker import (
     enqueue_job,
 )
 
+from .member_backfill import (
+    downloadable_member_backfill_statement,
+    license_key_member_backfill_statement,
+)
 from .repository import OrganizationRepository
 from .service import organization as organization_service
 
@@ -288,6 +293,16 @@ async def backfill_members(organization_id: uuid.UUID) -> None:
             session, organization, orphaned_customer_ids
         )
 
+    # Step E: Link license keys and downloadables to their grant's member
+    async with AsyncSessionMaker() as session:
+        organization = await OrganizationRepository.from_session(session).get_by_id(
+            organization_id
+        )
+        assert organization is not None
+        license_keys_linked, downloadables_linked = await _backfill_benefit_records(
+            session, organization
+        )
+
     log.info(
         "organization.backfill_members.complete",
         organization_id=str(organization_id),
@@ -295,6 +310,8 @@ async def backfill_members(organization_id: uuid.UUID) -> None:
         seats_migrated=seats_migrated,
         grants_linked=grants_linked,
         customers_deleted=customers_deleted,
+        license_keys_linked=license_keys_linked,
+        downloadables_linked=downloadables_linked,
     )
 
 
@@ -823,6 +840,30 @@ async def _cleanup_orphaned_seat_customers(
         customers_deleted=count,
     )
     return count
+
+
+async def _backfill_benefit_records(
+    session: AsyncSession,
+    organization: Organization,
+) -> tuple[int, int]:
+    """Link license keys and downloadables to their grant's member (Step C only covers transfers)."""
+    lk_result = cast(
+        "CursorResult[Any]",
+        await session.execute(license_key_member_backfill_statement(organization.id)),
+    )
+    dl_result = cast(
+        "CursorResult[Any]",
+        await session.execute(downloadable_member_backfill_statement(organization.id)),
+    )
+    await session.flush()
+
+    log.info(
+        "organization.backfill_members.step_e_complete",
+        organization_id=str(organization.id),
+        license_keys_linked=lk_result.rowcount,
+        downloadables_linked=dl_result.rowcount,
+    )
+    return lk_result.rowcount, dl_result.rowcount
 
 
 # ---------------------------------------------------------------------------

--- a/server/scripts/migrate_organizations_members.py
+++ b/server/scripts/migrate_organizations_members.py
@@ -51,7 +51,7 @@ from typing import Any, cast
 
 import structlog
 import typer
-from sqlalchemy import String, func, or_, select, update
+from sqlalchemy import func, or_, select
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.orm import aliased, joinedload
 
@@ -59,6 +59,10 @@ from polar.kit.db.postgres import create_async_sessionmaker
 from polar.models import Organization
 from polar.models.benefit_grant import BenefitGrant
 from polar.models.organization import OrganizationStatus
+from polar.organization.member_backfill import (
+    downloadable_member_backfill_statement,
+    license_key_member_backfill_statement,
+)
 from polar.organization.repository import OrganizationRepository
 from polar.organization.tasks import (
     _backfill_benefit_grants,
@@ -69,6 +73,7 @@ from polar.organization.tasks import (
     _prepare_seats,
 )
 from polar.postgres import AsyncSession, create_async_engine
+from scripts.helper import run_batched_update
 
 cli = typer.Typer()
 
@@ -844,73 +849,19 @@ async def restore_oneoff_grants(
 
 
 async def _backfill_license_keys(session: AsyncSession) -> int:
-    """Backfill member_id on license keys using the grant's properties->>'license_key_id'."""
-    from polar.models.license_key import LicenseKey
-
-    lk_subq = (
-        select(
-            BenefitGrant.properties["license_key_id"].as_string().label("lk_id"),
-            BenefitGrant.member_id,
-        )
-        .where(
-            BenefitGrant.member_id.is_not(None),
-            BenefitGrant.is_deleted.is_(False),
-            BenefitGrant.properties["license_key_id"].is_not(None),
-        )
-        .subquery()
-    )
-
+    """Backfill member_id on license keys from their linked benefit grant."""
     result = cast(
         CursorResult[Any],
-        await session.execute(
-            update(LicenseKey)
-            .where(
-                LicenseKey.member_id.is_(None),
-                LicenseKey.id.cast(String) == lk_subq.c.lk_id,
-            )
-            .values(member_id=lk_subq.c.member_id)
-        ),
+        await session.execute(license_key_member_backfill_statement()),
     )
     return result.rowcount
 
 
 async def _backfill_downloadables(session: AsyncSession) -> int:
-    """Backfill member_id on downloadables via (customer_id, benefit_id).
-
-    Uses DISTINCT ON to pick the most recently granted grant.
-    """
-    from polar.models.downloadable import Downloadable
-
-    dl_subq = (
-        select(
-            BenefitGrant.customer_id,
-            BenefitGrant.benefit_id,
-            BenefitGrant.member_id,
-        )
-        .where(
-            BenefitGrant.member_id.is_not(None),
-            BenefitGrant.is_deleted.is_(False),
-        )
-        .distinct(BenefitGrant.customer_id, BenefitGrant.benefit_id)
-        .order_by(
-            BenefitGrant.customer_id,
-            BenefitGrant.benefit_id,
-            BenefitGrant.granted_at.desc().nulls_last(),
-        )
-        .subquery()
-    )
-
+    """Backfill member_id on downloadables from their linked benefit grant."""
     result = cast(
         CursorResult[Any],
-        await session.execute(
-            update(Downloadable)
-            .where(
-                Downloadable.member_id.is_(None),
-                Downloadable.customer_id == dl_subq.c.customer_id,
-                Downloadable.benefit_id == dl_subq.c.benefit_id,
-            )
-            .values(member_id=dl_subq.c.member_id)
-        ),
+        await session.execute(downloadable_member_backfill_statement()),
     )
     return result.rowcount
 
@@ -925,11 +876,12 @@ async def backfill_benefit_records(
     """One-time backfill of member_id on license_keys and downloadables.
 
     Uses benefit_grants (which already have member_id set by the migration)
-    to populate the missing member_id on the related benefit records.
+    to populate the missing member_id on the related benefit records. Runs in
+    batches to avoid long locks on large tables.
 
     License keys are matched 1:1 via the grant's properties->>'license_key_id'.
-    Downloadables are matched via (customer_id, benefit_id) with DISTINCT ON
-    to pick the most recently granted grant.
+    Downloadables are matched via (customer_id, benefit_id), taking the most
+    recently granted grant.
     """
     from polar.models.downloadable import Downloadable
     from polar.models.license_key import LicenseKey
@@ -957,14 +909,15 @@ async def backfill_benefit_records(
         typer.echo("DRY RUN - No changes will be made.")
         return
 
-    async with sessionmaker() as session:
-        lk_updated = await _backfill_license_keys(session)
-        typer.echo(f"License keys updated: {lk_updated}")
+    lk_updated = await run_batched_update(
+        license_key_member_backfill_statement(batched=True)
+    )
+    typer.echo(f"License keys updated: {lk_updated}")
 
-        dl_updated = await _backfill_downloadables(session)
-        typer.echo(f"Downloadables updated: {dl_updated}")
-
-        await session.commit()
+    dl_updated = await run_batched_update(
+        downloadable_member_backfill_statement(batched=True)
+    )
+    typer.echo(f"Downloadables updated: {dl_updated}")
 
     typer.echo()
     typer.echo("Backfill complete.")

--- a/server/tests/organization/test_backfill_members.py
+++ b/server/tests/organization/test_backfill_members.py
@@ -15,6 +15,8 @@ from polar.models.customer import (
     CustomerType,
 )
 from polar.models.customer_seat import SeatStatus
+from polar.models.downloadable import Downloadable, DownloadableStatus
+from polar.models.file import File, FileServiceTypes
 from polar.models.license_key import LicenseKey
 from polar.models.member import Member, MemberRole
 from polar.models.subscription import SubscriptionStatus
@@ -35,6 +37,22 @@ from tests.fixtures.random_objects import (
     create_subscription,
     create_subscription_with_seats,
 )
+
+
+async def _create_file(
+    save_fixture: SaveFixture,
+    organization_id: uuid.UUID,
+) -> File:
+    file = File(
+        organization_id=organization_id,
+        name="test-file.zip",
+        path=f"files/{uuid.uuid4()}.zip",
+        mime_type="application/zip",
+        size=1024,
+        service=FileServiceTypes.downloadable,
+    )
+    await save_fixture(file)
+    return file
 
 
 @pytest.mark.asyncio
@@ -1407,13 +1425,6 @@ class TestBackfillMembersB2C:
             type=BenefitType.license_keys,
             description="B2C license key",
         )
-        grant = await create_benefit_grant(
-            save_fixture,
-            customer=customer,
-            benefit=benefit,
-            granted=True,
-            subscription=subscription,
-        )
         license_key = LicenseKey(
             organization_id=organization.id,
             customer_id=customer.id,
@@ -1422,14 +1433,151 @@ class TestBackfillMembersB2C:
         )
         await save_fixture(license_key)
         lk_id = license_key.id
+        grant = await create_benefit_grant(
+            save_fixture,
+            customer=customer,
+            benefit=benefit,
+            granted=True,
+            properties={"license_key_id": str(lk_id)},
+            subscription=subscription,
+        )
 
         session.expunge_all()
         await backfill_members(organization.id)
 
-        # License key customer_id unchanged for B2C
+        # License key stays on the same customer but is linked to the owner member
         refreshed_lk = await session.get(LicenseKey, lk_id)
         assert refreshed_lk is not None
         assert refreshed_lk.customer_id == customer.id
+        refreshed_grant = await session.get(BenefitGrant, grant.id)
+        assert refreshed_grant is not None
+        assert refreshed_grant.member_id is not None
+        assert refreshed_lk.member_id == refreshed_grant.member_id
+
+    async def test_downloadables_linked_to_owner_member(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        account: Account,
+    ) -> None:
+        """B2C downloadables stay on the same customer but link to the owner member."""
+        organization = await create_organization(
+            save_fixture, account, feature_settings={"member_model_enabled": True}
+        )
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="b2c-dl@test.com",
+            stripe_customer_id="stripe_b2c_dl",
+        )
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+        )
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.active,
+            started_at=utc_now(),
+        )
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.downloadables,
+            properties={"archived": {}, "files": []},
+        )
+        grant = await create_benefit_grant(
+            save_fixture,
+            customer=customer,
+            benefit=benefit,
+            granted=True,
+            subscription=subscription,
+        )
+        file = await _create_file(save_fixture, organization.id)
+        downloadable = Downloadable(
+            customer_id=customer.id,
+            benefit_id=benefit.id,
+            file_id=file.id,
+            status=DownloadableStatus.granted,
+        )
+        await save_fixture(downloadable)
+        dl_id = downloadable.id
+
+        session.expunge_all()
+        await backfill_members(organization.id)
+
+        refreshed_dl = await session.get(Downloadable, dl_id)
+        assert refreshed_dl is not None
+        assert refreshed_dl.customer_id == customer.id
+        refreshed_grant = await session.get(BenefitGrant, grant.id)
+        assert refreshed_grant is not None
+        assert refreshed_grant.member_id is not None
+        assert refreshed_dl.member_id == refreshed_grant.member_id
+
+    async def test_benefit_records_backfill_is_idempotent(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        account: Account,
+    ) -> None:
+        """Re-running the backfill leaves an already-linked license key unchanged."""
+        organization = await create_organization(
+            save_fixture, account, feature_settings={"member_model_enabled": True}
+        )
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="b2c-idem@test.com",
+            stripe_customer_id="stripe_b2c_idem",
+        )
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+        )
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.active,
+            started_at=utc_now(),
+        )
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.license_keys,
+        )
+        license_key = LicenseKey(
+            organization_id=organization.id,
+            customer_id=customer.id,
+            benefit_id=benefit.id,
+            key="POLAR-B2C-IDEM-001",
+        )
+        await save_fixture(license_key)
+        lk_id = license_key.id
+        await create_benefit_grant(
+            save_fixture,
+            customer=customer,
+            benefit=benefit,
+            granted=True,
+            properties={"license_key_id": str(lk_id)},
+            subscription=subscription,
+        )
+
+        session.expunge_all()
+        await backfill_members(organization.id)
+        first = await session.get(LicenseKey, lk_id)
+        assert first is not None
+        first_member_id = first.member_id
+        assert first_member_id is not None
+
+        session.expunge_all()
+        await backfill_members(organization.id)
+        second = await session.get(LicenseKey, lk_id)
+        assert second is not None
+        assert second.member_id == first_member_id
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

`backfill_members` links a customer's benefit grants to their member but only moves the underlying `license_keys` / `downloadables` when a grant is transferred between customers. 

Grants already on the right customer leave those records with `member_id = NULL`. 

## Bug

The customer portal filters license keys and downloadables by `member_id` for member sessions, so the benefit grant appears but the license key / downloadable itself doesn't load.

Existing `license_keys` / `downloadables` with `member_id = NULL` across 6 orgs:

| Org | License keys | Downloadables |
|-----|-------------:|--------------:|
| A   |        2,283 |       566,914 |
| B   |          481 |             0 |
| C   |          109 |             0 |
| D   |          104 |             2 |
| E   |           81 |             0 |
| F   |            0 |             1 |
| **Total** | **3,058** | **566,917** |

## Fix

- Add a step to `backfill_members` that sets `member_id` on license keys and downloadables   from their grant.
- Route the `backfill-benefit-records` repair command through the same statements, batched.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

