### PR TITLE
fix(org): scope member_id backfill to member-model orgs, drive from grants

### DIFF
--- a/server/polar/organization/member_backfill.py
+++ b/server/polar/organization/member_backfill.py
@@ -1,12 +1,13 @@
-from typing import Any
 from uuid import UUID
 
 from sqlalchemy import (
     ColumnElement,
-    ScalarSelect,
-    String,
+    Subquery,
     Update,
+    Uuid,
+    and_,
     bindparam,
+    cast,
     select,
     update,
 )
@@ -14,35 +15,41 @@ from sqlalchemy import (
 from polar.models import Benefit, BenefitGrant, Downloadable, LicenseKey
 
 
-def _license_key_grant_member() -> ScalarSelect[Any]:
+def _license_key_grants() -> Subquery:
+    key_id = BenefitGrant.properties["license_key_id"].as_string()
     return (
-        select(BenefitGrant.member_id)
+        select(
+            key_id.label("license_key_id"), BenefitGrant.member_id.label("member_id")
+        )
         .where(
-            BenefitGrant.properties["license_key_id"].as_string()
-            == LicenseKey.id.cast(String),
             BenefitGrant.member_id.is_not(None),
             BenefitGrant.deleted_at.is_(None),
+            BenefitGrant.properties["license_key_id"].is_not(None),
         )
-        .order_by(BenefitGrant.granted_at.desc().nulls_last())
-        .limit(1)
-        .correlate(LicenseKey)
-        .scalar_subquery()
+        .distinct(key_id)
+        .order_by(key_id, BenefitGrant.granted_at.desc().nulls_last())
+        .subquery()
     )
 
 
-def _downloadable_grant_member() -> ScalarSelect[Any]:
+def _downloadable_grants() -> Subquery:
     return (
-        select(BenefitGrant.member_id)
+        select(
+            BenefitGrant.customer_id,
+            BenefitGrant.benefit_id,
+            BenefitGrant.member_id,
+        )
         .where(
-            BenefitGrant.customer_id == Downloadable.customer_id,
-            BenefitGrant.benefit_id == Downloadable.benefit_id,
             BenefitGrant.member_id.is_not(None),
             BenefitGrant.deleted_at.is_(None),
         )
-        .order_by(BenefitGrant.granted_at.desc().nulls_last())
-        .limit(1)
-        .correlate(Downloadable)
-        .scalar_subquery()
+        .distinct(BenefitGrant.customer_id, BenefitGrant.benefit_id)
+        .order_by(
+            BenefitGrant.customer_id,
+            BenefitGrant.benefit_id,
+            BenefitGrant.granted_at.desc().nulls_last(),
+        )
+        .subquery()
     )
 
 
@@ -51,22 +58,36 @@ def license_key_member_backfill_statement(
     *,
     batched: bool = False,
 ) -> Update:
+    value_grants = _license_key_grants()
+    filter_grants = _license_key_grants()
+
     conditions: list[ColumnElement[bool]] = [
         LicenseKey.member_id.is_(None),
         LicenseKey.deleted_at.is_(None),
-        _license_key_grant_member().is_not(None),
     ]
     if organization_id is not None:
         conditions.append(LicenseKey.organization_id == organization_id)
 
-    target = select(LicenseKey.id).where(*conditions).order_by(LicenseKey.id)
+    target = (
+        select(LicenseKey.id)
+        .select_from(
+            filter_grants.join(
+                LicenseKey,
+                cast(filter_grants.c.license_key_id, Uuid) == LicenseKey.id,
+            )
+        )
+        .where(*conditions)
+    )
     if batched:
         target = target.limit(bindparam("limit"))
 
     return (
         update(LicenseKey)
-        .where(LicenseKey.id.in_(target.scalar_subquery()))
-        .values(member_id=_license_key_grant_member())
+        .values(member_id=value_grants.c.member_id)
+        .where(
+            cast(value_grants.c.license_key_id, Uuid) == LicenseKey.id,
+            LicenseKey.id.in_(target.scalar_subquery()),
+        )
     )
 
 
@@ -75,10 +96,12 @@ def downloadable_member_backfill_statement(
     *,
     batched: bool = False,
 ) -> Update:
+    value_grants = _downloadable_grants()
+    filter_grants = _downloadable_grants()
+
     conditions: list[ColumnElement[bool]] = [
         Downloadable.member_id.is_(None),
         Downloadable.deleted_at.is_(None),
-        _downloadable_grant_member().is_not(None),
     ]
     if organization_id is not None:
         conditions.append(
@@ -87,12 +110,28 @@ def downloadable_member_backfill_statement(
             )
         )
 
-    target = select(Downloadable.id).where(*conditions).order_by(Downloadable.id)
+    target = (
+        select(Downloadable.id)
+        .select_from(
+            filter_grants.join(
+                Downloadable,
+                and_(
+                    Downloadable.customer_id == filter_grants.c.customer_id,
+                    Downloadable.benefit_id == filter_grants.c.benefit_id,
+                ),
+            )
+        )
+        .where(*conditions)
+    )
     if batched:
         target = target.limit(bindparam("limit"))
 
     return (
         update(Downloadable)
-        .where(Downloadable.id.in_(target.scalar_subquery()))
-        .values(member_id=_downloadable_grant_member())
+        .values(member_id=value_grants.c.member_id)
+        .where(
+            Downloadable.customer_id == value_grants.c.customer_id,
+            Downloadable.benefit_id == value_grants.c.benefit_id,
+            Downloadable.id.in_(target.scalar_subquery()),
+        )
     )

--- a/server/polar/organization/member_backfill.py
+++ b/server/polar/organization/member_backfill.py
@@ -2,6 +2,7 @@ from uuid import UUID
 
 from sqlalchemy import (
     ColumnElement,
+    Select,
     Subquery,
     Update,
     Uuid,
@@ -12,7 +13,13 @@ from sqlalchemy import (
     update,
 )
 
-from polar.models import Benefit, BenefitGrant, Downloadable, LicenseKey
+from polar.models import Benefit, BenefitGrant, Downloadable, LicenseKey, Organization
+
+
+def _member_model_org_ids() -> Select[tuple[UUID]]:
+    return select(Organization.id).where(
+        Organization.feature_settings["member_model_enabled"].as_boolean().is_(True)
+    )
 
 
 def _license_key_grants() -> Subquery:
@@ -56,6 +63,7 @@ def _downloadable_grants() -> Subquery:
 def license_key_member_backfill_statement(
     organization_id: UUID | None = None,
     *,
+    member_model_only: bool = False,
     batched: bool = False,
 ) -> Update:
     value_grants = _license_key_grants()
@@ -67,6 +75,8 @@ def license_key_member_backfill_statement(
     ]
     if organization_id is not None:
         conditions.append(LicenseKey.organization_id == organization_id)
+    elif member_model_only:
+        conditions.append(LicenseKey.organization_id.in_(_member_model_org_ids()))
 
     target = (
         select(LicenseKey.id)
@@ -94,6 +104,7 @@ def license_key_member_backfill_statement(
 def downloadable_member_backfill_statement(
     organization_id: UUID | None = None,
     *,
+    member_model_only: bool = False,
     batched: bool = False,
 ) -> Update:
     value_grants = _downloadable_grants()
@@ -107,6 +118,14 @@ def downloadable_member_backfill_statement(
         conditions.append(
             Downloadable.benefit_id.in_(
                 select(Benefit.id).where(Benefit.organization_id == organization_id)
+            )
+        )
+    elif member_model_only:
+        conditions.append(
+            Downloadable.benefit_id.in_(
+                select(Benefit.id).where(
+                    Benefit.organization_id.in_(_member_model_org_ids())
+                )
             )
         )
 

--- a/server/scripts/migrate_organizations_members.py
+++ b/server/scripts/migrate_organizations_members.py
@@ -910,12 +910,12 @@ async def backfill_benefit_records(
         return
 
     lk_updated = await run_batched_update(
-        license_key_member_backfill_statement(batched=True)
+        license_key_member_backfill_statement(member_model_only=True, batched=True)
     )
     typer.echo(f"License keys updated: {lk_updated}")
 
     dl_updated = await run_batched_update(
-        downloadable_member_backfill_statement(batched=True)
+        downloadable_member_backfill_statement(member_model_only=True, batched=True)
     )
     typer.echo(f"Downloadables updated: {dl_updated}")
 

--- a/server/tests/organization/test_backfill_benefit_records.py
+++ b/server/tests/organization/test_backfill_benefit_records.py
@@ -12,6 +12,10 @@ from polar.models.file import File, FileServiceTypes
 from polar.models.license_key import LicenseKey
 from polar.models.member import MemberRole
 from polar.models.subscription import SubscriptionStatus
+from polar.organization.member_backfill import (
+    downloadable_member_backfill_statement,
+    license_key_member_backfill_statement,
+)
 from scripts.migrate_organizations_members import (
     _backfill_downloadables,
     _backfill_license_keys,
@@ -982,3 +986,123 @@ class TestBackfillDownloadables:
         refreshed2 = await session.get(Downloadable, dl2_id)
         assert refreshed2 is not None
         assert refreshed2.member_id is None
+
+
+@pytest.mark.asyncio
+class TestMemberModelOnlyScoping:
+    async def test_license_keys_skip_non_member_model_orgs(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        user: User,
+    ) -> None:
+        keys: dict[str, uuid.UUID] = {}
+        for label, feature_settings in (
+            ("off", {}),
+            ("on", {"member_model_enabled": True}),
+        ):
+            account = await create_account(save_fixture, user)
+            organization = await create_organization(
+                save_fixture, account, feature_settings=feature_settings
+            )
+            customer = await create_customer(
+                save_fixture, organization=organization, email=f"lk-{label}@test.com"
+            )
+            member = await create_member(
+                save_fixture,
+                customer=customer,
+                organization=organization,
+                role=MemberRole.owner,
+            )
+            benefit = await create_benefit(
+                save_fixture, organization=organization, type=BenefitType.license_keys
+            )
+            license_key = LicenseKey(
+                organization_id=organization.id,
+                customer_id=customer.id,
+                benefit_id=benefit.id,
+                key=f"POLAR-SCOPE-{label}",
+            )
+            await save_fixture(license_key)
+            keys[label] = license_key.id
+            await create_benefit_grant(
+                save_fixture,
+                customer=customer,
+                benefit=benefit,
+                granted=True,
+                member=member,
+                properties={"license_key_id": str(license_key.id)},
+            )
+
+        session.expunge_all()
+        await session.execute(
+            license_key_member_backfill_statement(member_model_only=True)
+        )
+        await session.flush()
+
+        off_key = await session.get(LicenseKey, keys["off"])
+        assert off_key is not None
+        assert off_key.member_id is None
+        on_key = await session.get(LicenseKey, keys["on"])
+        assert on_key is not None
+        assert on_key.member_id is not None
+
+    async def test_downloadables_skip_non_member_model_orgs(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        user: User,
+    ) -> None:
+        downloadables: dict[str, uuid.UUID] = {}
+        for label, feature_settings in (
+            ("off", {}),
+            ("on", {"member_model_enabled": True}),
+        ):
+            account = await create_account(save_fixture, user)
+            organization = await create_organization(
+                save_fixture, account, feature_settings=feature_settings
+            )
+            customer = await create_customer(
+                save_fixture, organization=organization, email=f"dl-{label}@test.com"
+            )
+            member = await create_member(
+                save_fixture,
+                customer=customer,
+                organization=organization,
+                role=MemberRole.owner,
+            )
+            benefit = await create_benefit(
+                save_fixture,
+                organization=organization,
+                type=BenefitType.downloadables,
+                properties={"archived": {}, "files": []},
+            )
+            file = await _create_file(save_fixture, organization.id)
+            downloadable = Downloadable(
+                customer_id=customer.id,
+                benefit_id=benefit.id,
+                file_id=file.id,
+                status=DownloadableStatus.granted,
+            )
+            await save_fixture(downloadable)
+            downloadables[label] = downloadable.id
+            await create_benefit_grant(
+                save_fixture,
+                customer=customer,
+                benefit=benefit,
+                granted=True,
+                member=member,
+            )
+
+        session.expunge_all()
+        await session.execute(
+            downloadable_member_backfill_statement(member_model_only=True)
+        )
+        await session.flush()
+
+        off_dl = await session.get(Downloadable, downloadables["off"])
+        assert off_dl is not None
+        assert off_dl.member_id is None
+        on_dl = await session.get(Downloadable, downloadables["on"])
+        assert on_dl is not None
+        assert on_dl.member_id is not None


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- issue number -->

The script timed out in production.

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->

## Why

<!-- Explain why this change is needed -->

## How

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scoped the `member_id` backfill to organizations with the member model and rewrote it to read from grants to avoid slow queries and timeouts. This speeds up backfills for `LicenseKey` and `Downloadable` records and avoids touching non-member-model orgs.

- **Bug Fixes**
  - Drive backfill from `BenefitGrant` subqueries (distinct latest grant) and join against targets, replacing correlated subqueries.
  - Added `member_model_only` flag to `license_key_member_backfill_statement` and `downloadable_member_backfill_statement`; `scripts/migrate_organizations_members.py` now sets it to `True`.
  - Apply updates only when a matching latest grant exists; batching is preserved.
  - Added tests to verify non-member-model orgs are skipped for both license keys and downloadables.

<sup>Written for commit 7798f55a8aaf463c23a885b06c2e21634d52d664. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

