### PR TITLE
sdk/typescript: export individual functions

### DIFF
--- a/sdk/generator/typescript/template/README.md
+++ b/sdk/generator/typescript/template/README.md
@@ -43,11 +43,12 @@ function:
 
 ```typescript
 import { createPolarCore } from "@polar-sh/sdk/{{ ir.versions[0].version }}";
-import { listProducts } from "@polar-sh/sdk/{{ ir.versions[0].version }}/services/products";
+import { getStateExternalCustomers } from "@polar-sh/sdk/{{ ir.versions[0].version }}/services/customers";
 
 const polar = createPolarCore({
   accessToken: "polar_oat_xxx",
 });
 
-const products = await listProducts(polar)({ limit: 10 });
+const customerState = await getStateExternalCustomers(polar)("customer_external_id");
+console.log(customerState);
 ```

--- a/sdk/generator/typescript/template/README.md
+++ b/sdk/generator/typescript/template/README.md
@@ -35,3 +35,19 @@ The client uses the production environment by default. To use the sandbox, pass
 
 Keep organization access tokens on the server and never expose them in browser or client-side
 code.
+
+## Individual API Functions
+
+To import individual API functions for tree-shaking, create a core client and pass it to the
+function:
+
+```typescript
+import { createPolarCore } from "@polar-sh/sdk/{{ ir.versions[0].version }}";
+import { listProducts } from "@polar-sh/sdk/{{ ir.versions[0].version }}/services/products";
+
+const polar = createPolarCore({
+  accessToken: "polar_oat_xxx",
+});
+
+const products = await listProducts(polar)({ limit: 10 });
+```

--- a/sdk/generator/typescript/template/package.json
+++ b/sdk/generator/typescript/template/package.json
@@ -20,7 +20,20 @@
     "./{{version.version}}": {
       "import": { "types": "./dist/{{version.version}}/index.d.mts", "default": "./dist/{{version.version}}/index.mjs" },
       "require": { "types": "./dist/{{version.version}}/index.d.cts", "default": "./dist/{{version.version}}/index.cjs" }
+    },
+    "./{{version.version}}/services/*": {
+      "import": { "types": "./dist/{{version.version}}/services/*.d.mts", "default": "./dist/{{version.version}}/services/*.mjs" },
+      "require": { "types": "./dist/{{version.version}}/services/*.d.cts", "default": "./dist/{{version.version}}/services/*.cjs" }
     }
+{% for service in version.services %}
+{% if service.services %}
+    ,
+    "./{{version.version}}/services/{{ service.name | snake }}": {
+      "import": { "types": "./dist/{{version.version}}/services/{{ service.name | snake }}/index.d.mts", "default": "./dist/{{version.version}}/services/{{ service.name | snake }}/index.mjs" },
+      "require": { "types": "./dist/{{version.version}}/services/{{ service.name | snake }}/index.d.cts", "default": "./dist/{{version.version}}/services/{{ service.name | snake }}/index.cjs" }
+    }
+{% endif %}
+{% endfor %}
 {% endfor %}
   },
   "scripts": {

--- a/sdk/generator/typescript/template/src/version/client.ts
+++ b/sdk/generator/typescript/template/src/version/client.ts
@@ -19,8 +19,8 @@ export interface PolarOptions
   baseUrl?: string;
 }
 
-export function createPolar(options: PolarOptions) {
-  const client = new ClientBase({
+export function createPolarCore(options: PolarOptions) {
+  return new ClientBase({
     ...options,
     baseUrl: resolveBaseUrl(
       SERVERS,
@@ -29,6 +29,12 @@ export function createPolar(options: PolarOptions) {
     ),
     version: options.version ?? "{{ api.version }}",
   });
+}
+
+export type PolarCore = ReturnType<typeof createPolarCore>;
+
+export function createPolar(options: PolarOptions) {
+  const client = createPolarCore(options);
 
   return {
     {% for service in api.services %}

--- a/sdk/generator/typescript/template/src/version/index.ts
+++ b/sdk/generator/typescript/template/src/version/index.ts
@@ -1,4 +1,4 @@
-export { createPolar } from "./client";
-export type { Environment, Polar, PolarOptions } from "./client";
+export { createPolar, createPolarCore } from "./client";
+export type { Environment, Polar, PolarCore, PolarOptions } from "./client";
 export * as models from "./models";
 export * as errors from "./errors";

--- a/sdk/generator/typescript/template/tsdown.config.ts
+++ b/sdk/generator/typescript/template/tsdown.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["src/index.ts"{% for version in ir.versions %}, "src/{{ version.version }}/index.ts"{% endfor %}],
+  entry: [
+    "src/index.ts",
+{% for version in ir.versions %}
+    "src/{{ version.version }}/index.ts",
+    "src/{{ version.version }}/services/**/*.ts",
+{% endfor %}
+  ],
   format: ["esm", "cjs"],
   dts: true,
   sourcemap: true,

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -35,3 +35,19 @@ The client uses the production environment by default. To use the sandbox, pass
 
 Keep organization access tokens on the server and never expose them in browser or client-side
 code.
+
+## Individual API Functions
+
+To import individual API functions for tree-shaking, create a core client and pass it to the
+function:
+
+```typescript
+import { createPolarCore } from "@polar-sh/sdk/2026-04";
+import { listProducts } from "@polar-sh/sdk/2026-04/services/products";
+
+const polar = createPolarCore({
+    accessToken: "polar_oat_xxx",
+});
+
+const products = await listProducts(polar)({ limit: 10 });
+```

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -43,11 +43,12 @@ function:
 
 ```typescript
 import { createPolarCore } from "@polar-sh/sdk/2026-04";
-import { listProducts } from "@polar-sh/sdk/2026-04/services/products";
+import { getStateExternalCustomers } from "@polar-sh/sdk/2026-04/services/customers";
 
 const polar = createPolarCore({
     accessToken: "polar_oat_xxx",
 });
 
-const products = await listProducts(polar)({ limit: 10 });
+const customerState = await getStateExternalCustomers(polar)("customer_external_id");
+console.log(customerState);
 ```

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -43,6 +43,46 @@
         "types": "./dist/2026-04/index.d.cts",
         "default": "./dist/2026-04/index.cjs"
       }
+    },
+    "./2026-04/services/*": {
+      "import": {
+        "types": "./dist/2026-04/services/*.d.mts",
+        "default": "./dist/2026-04/services/*.mjs"
+      },
+      "require": {
+        "types": "./dist/2026-04/services/*.d.cts",
+        "default": "./dist/2026-04/services/*.cjs"
+      }
+    },
+    "./2026-04/services/customer_portal": {
+      "import": {
+        "types": "./dist/2026-04/services/customer_portal/index.d.mts",
+        "default": "./dist/2026-04/services/customer_portal/index.mjs"
+      },
+      "require": {
+        "types": "./dist/2026-04/services/customer_portal/index.d.cts",
+        "default": "./dist/2026-04/services/customer_portal/index.cjs"
+      }
+    },
+    "./2026-04/services/customers": {
+      "import": {
+        "types": "./dist/2026-04/services/customers/index.d.mts",
+        "default": "./dist/2026-04/services/customers/index.mjs"
+      },
+      "require": {
+        "types": "./dist/2026-04/services/customers/index.d.cts",
+        "default": "./dist/2026-04/services/customers/index.cjs"
+      }
+    },
+    "./2026-04/services/oauth2": {
+      "import": {
+        "types": "./dist/2026-04/services/oauth2/index.d.mts",
+        "default": "./dist/2026-04/services/oauth2/index.mjs"
+      },
+      "require": {
+        "types": "./dist/2026-04/services/oauth2/index.d.cts",
+        "default": "./dist/2026-04/services/oauth2/index.cjs"
+      }
     }
   },
   "scripts": {

--- a/sdk/typescript/src/2026-04/client.ts
+++ b/sdk/typescript/src/2026-04/client.ts
@@ -40,12 +40,18 @@ export interface PolarOptions extends Omit<ClientOptions, "baseUrl" | "version">
   baseUrl?: string;
 }
 
-export function createPolar(options: PolarOptions) {
-  const client = new ClientBase({
+export function createPolarCore(options: PolarOptions) {
+  return new ClientBase({
     ...options,
     baseUrl: resolveBaseUrl(SERVERS, options.environment ?? "production", options.baseUrl),
     version: options.version ?? "2026-04",
   });
+}
+
+export type PolarCore = ReturnType<typeof createPolarCore>;
+
+export function createPolar(options: PolarOptions) {
+  const client = createPolarCore(options);
 
   return {
     organizations: createOrganizationsService(client),

--- a/sdk/typescript/src/2026-04/index.ts
+++ b/sdk/typescript/src/2026-04/index.ts
@@ -1,4 +1,4 @@
-export { createPolar } from "./client";
-export type { Environment, Polar, PolarOptions } from "./client";
+export { createPolar, createPolarCore } from "./client";
+export type { Environment, Polar, PolarCore, PolarOptions } from "./client";
 export * as models from "./models";
 export * as errors from "./errors";

--- a/sdk/typescript/tsdown.config.ts
+++ b/sdk/typescript/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["src/index.ts", "src/2026-04/index.ts"],
+  entry: ["src/index.ts", "src/2026-04/index.ts", "src/2026-04/services/**/*.ts"],
   format: ["esm", "cjs"],
   dts: true,
   sourcemap: true,


### PR DESCRIPTION
Closes #13181.

## What changed

- Build every generated TypeScript service module as an independent ESM and CommonJS entry point.
- Export versioned service subpaths, including explicit mappings for directory-backed services.
- Add `createPolarCore` as the configured low-level client for individual endpoint functions.
- Make `createPolar` delegate to `createPolarCore`.
- Document tree-shakable individual function usage in a dedicated README section.
- Apply the changes to both the generator templates and the generated TypeScript SDK.

## Why

The SDK generator already emitted individual endpoint functions, but the package build and export map only exposed the aggregate version entry. Consumers therefore could not import those functions or benefit from service-level tree-shaking. The functions also require a configured core client, so `createPolarCore` provides the API server preset, API version, and optional base URL override without exposing `ClientBase` directly.

## Validation

- TypeScript SDK formatting, linting, and typecheck
- TypeScript SDK tests: 9 passed
- Generator formatting, linting, and typecheck
- Generator tests: 60 passed
- ESM and CommonJS service import smoke tests
- TypeScript package export/declaration resolution smoke test
- npm package contents dry run

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

