### PR TITLE
sdk/python: set exclude-newer to 1 week

### DIFF
--- a/sdk/generator/python/template/pyproject.toml
+++ b/sdk/generator/python/template/pyproject.toml
@@ -41,3 +41,4 @@ extend-select = ["I", "UP"]
 
 [tool.uv]
 default-groups = ["dev"]
+exclude-newer = "1 week"


### PR DESCRIPTION
Fix #13180


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set `uv`'s `exclude-newer` to "1 week" in the Python SDK template `pyproject.toml` to ignore very recent releases and make dependency resolution more deterministic. Supports Linear POL-13180 by stabilizing generated SDK builds.

<sup>Written for commit 04b9652959ad7012a9c40c56068fe0fb687508bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

