### PR TITLE
Avoid focus lock when Stripe 3DS verification is shown

### DIFF
--- a/clients/packages/orbit/src/components/InlineModal.tsx
+++ b/clients/packages/orbit/src/components/InlineModal.tsx
@@ -20,6 +20,14 @@ export interface InlineModalProps {
   className?: string
 }
 
+// Let focus escape into iframes rendered outside the modal (e.g. Stripe's 3D
+// Secure challenge, which Stripe injects at the document root). Without this the
+// focus lock yanks focus back into the modal, making the challenge's inputs
+// uninteractable. Returning false tells the lock to ignore the element; every
+// other element stays trapped as usual.
+const allowFocusInIframes = (activeElement: HTMLElement) =>
+  activeElement.tagName !== 'IFRAME'
+
 export const InlineModal: FunctionComponent<InlineModalProps> = ({
   isShown,
   hide,
@@ -51,7 +59,7 @@ export const InlineModal: FunctionComponent<InlineModalProps> = ({
   }
 
   const modal = (
-    <FocusLock>
+    <FocusLock whiteList={allowFocusInIframes}>
       <div
         ref={ref}
         className="fixed inset-0 z-50 overflow-hidden focus-within:outline-none"

--- a/clients/packages/orbit/src/components/Modal.tsx
+++ b/clients/packages/orbit/src/components/Modal.tsx
@@ -22,6 +22,14 @@ export interface ModalProps {
   className?: string
 }
 
+// Let focus escape into iframes rendered outside the modal (e.g. Stripe's 3D
+// Secure challenge, which Stripe injects at the document root). Without this the
+// focus lock yanks focus back into the modal, making the challenge's inputs
+// uninteractable. Returning false tells the lock to ignore the element; every
+// other element stays trapped as usual.
+const allowFocusInIframes = (activeElement: HTMLElement) =>
+  activeElement.tagName !== 'IFRAME'
+
 export const Modal: FunctionComponent<ModalProps> = ({
   title,
   isShown,
@@ -55,7 +63,7 @@ export const Modal: FunctionComponent<ModalProps> = ({
   }
 
   const modal = (
-    <FocusLock>
+    <FocusLock whiteList={allowFocusInIframes}>
       <div
         ref={ref}
         className="fixed top-0 right-0 bottom-0 left-0 z-50 overflow-hidden focus-within:outline-none dark:text-white"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow focus to escape the modal for Stripe 3D Secure iframes so users can complete verification without the focus trap pulling focus back. This fixes blocked inputs during 3DS.

- **Bug Fixes**
  - Added a `whiteList` predicate to `FocusLock` in `Modal` and `InlineModal` to ignore `IFRAME` elements while keeping normal focus trapping for everything else.

<sup>Written for commit 129c14720f7722a87e5fc37462164e5ec338beac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

