### PR TITLE
fix(org): skip downloadable backfill rows that collide with member row

### DIFF
--- a/server/polar/organization/member_backfill.py
+++ b/server/polar/organization/member_backfill.py
@@ -9,9 +9,11 @@ from sqlalchemy import (
     and_,
     bindparam,
     cast,
+    not_,
     select,
     update,
 )
+from sqlalchemy.orm import aliased
 
 from polar.models import Benefit, BenefitGrant, Downloadable, LicenseKey, Organization
 
@@ -128,6 +130,23 @@ def downloadable_member_backfill_statement(
                 )
             )
         )
+
+    # Skip rows whose target member already holds this (customer, file, benefit),
+    # otherwise the update collides with ix_downloadables_scope_unique.
+    sibling = aliased(Downloadable)
+    conditions.append(
+        not_(
+            select(sibling.id)
+            .where(
+                sibling.customer_id == Downloadable.customer_id,
+                sibling.file_id == Downloadable.file_id,
+                sibling.benefit_id == Downloadable.benefit_id,
+                sibling.member_id == filter_grants.c.member_id,
+                sibling.deleted_at.is_(None),
+            )
+            .exists()
+        )
+    )
 
     target = (
         select(Downloadable.id)

--- a/server/tests/organization/test_backfill_benefit_records.py
+++ b/server/tests/organization/test_backfill_benefit_records.py
@@ -989,6 +989,72 @@ class TestBackfillDownloadables:
 
 
 @pytest.mark.asyncio
+class TestDownloadableConflict:
+    async def test_skips_row_when_member_already_holds_file(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        account: Account,
+    ) -> None:
+        """A customer-scoped row is skipped when the target member already holds
+        the same (customer, file, benefit) — otherwise the update would violate
+        ix_downloadables_scope_unique."""
+        organization = await create_organization(
+            save_fixture, account, feature_settings={"member_model_enabled": True}
+        )
+        customer = await create_customer(
+            save_fixture, organization=organization, email="conflict@test.com"
+        )
+        member = await create_member(
+            save_fixture,
+            customer=customer,
+            organization=organization,
+            role=MemberRole.owner,
+        )
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.downloadables,
+            properties={"archived": {}, "files": []},
+        )
+        file = await _create_file(save_fixture, organization.id)
+
+        existing = Downloadable(
+            customer_id=customer.id,
+            benefit_id=benefit.id,
+            file_id=file.id,
+            member_id=member.id,
+            status=DownloadableStatus.granted,
+        )
+        await save_fixture(existing)
+        leftover = Downloadable(
+            customer_id=customer.id,
+            benefit_id=benefit.id,
+            file_id=file.id,
+            member_id=None,
+            status=DownloadableStatus.granted,
+        )
+        await save_fixture(leftover)
+        leftover_id = leftover.id
+
+        await create_benefit_grant(
+            save_fixture,
+            customer=customer,
+            benefit=benefit,
+            granted=True,
+            member=member,
+        )
+
+        session.expunge_all()
+        await _backfill_downloadables(session)
+        await session.flush()
+
+        refreshed = await session.get(Downloadable, leftover_id)
+        assert refreshed is not None
+        assert refreshed.member_id is None
+
+
+@pytest.mark.asyncio
 class TestMemberModelOnlyScoping:
     async def test_license_keys_skip_non_member_model_orgs(
         self,


### PR DESCRIPTION
Setting member_id on a customer-scoped downloadable violates `ix_downloadables_scope_unique` when the target member already holds a row for the same (customer, file, benefit) — a leftover from the member-model migration plus a later re-grant. Guard the backfill with NOT EXISTS so those rows are skipped (the member already has the file via the existing row) instead of crashing.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

