### PR TITLE
fix organization profile section alignment issue

### DIFF
--- a/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
@@ -242,8 +242,8 @@ const OrganizationDetailsForm: React.FC<OrganizationDetailsFormProps> = ({
     <div className="space-y-8">
       {/* Basic Info - Always Visible */}
       <div className="space-y-6">
-        <div className="grid grid-cols-1 gap-6 sm:grid-cols-12">
-          <div className="sm:col-span-2">
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-[auto_1fr] sm:gap-x-5">
+          <div>
             <label className="mb-2 block text-sm font-medium">Logo</label>
             <FormField
               control={control}
@@ -279,7 +279,7 @@ const OrganizationDetailsForm: React.FC<OrganizationDetailsFormProps> = ({
             />
           </div>
 
-          <div className="space-y-4 sm:col-span-10">
+          <div className="space-y-4">
             <div>
               <label className="mb-2 block text-sm font-medium">
                 Organization Name *
@@ -535,7 +535,6 @@ const OrganizationProfileSettings: React.FC<
         onSubmit={(e) => {
           e.preventDefault()
         }}
-        className="mx-auto max-w-2xl"
       >
         <SettingsGroup>
           <SettingsGroupItem


### PR DESCRIPTION
Fixes alignment issue on the org profile section in settings.

| Before | After |
|---|---|
| <img width="1440" height="900" alt="dashboard-admin-org-settings_desktop_before" src="https://github.com/user-attachments/assets/c89309e5-7a57-4521-b02f-8f237831932d" /> | <img width="1440" height="900" alt="dashboard-admin-org-settings_desktop_after" src="https://github.com/user-attachments/assets/0b275b4d-dbed-4f95-8020-500d32af8ca5" /> |

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

