### PR TITLE
sdk: add CI checks

### DIFF
--- a/.github/workflows/test_sdk.yaml
+++ b/.github/workflows/test_sdk.yaml
@@ -18,6 +18,9 @@ jobs:
   changes:
     name: "Detect changes"
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       sdk: ${{ steps.filter.outputs.sdk }}
     steps:

--- a/.github/workflows/test_sdk.yaml
+++ b/.github/workflows/test_sdk.yaml
@@ -1,0 +1,90 @@
+name: SDK
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    types: [opened, synchronize, edited]
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: "Detect changes"
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    outputs:
+      sdk: ${{ steps.filter.outputs.sdk }}
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - uses: dorny/paths-filter@v4.0.2
+        id: filter
+        with:
+          filters: |
+            sdk:
+              - 'sdk/**'
+              - '.github/workflows/test_sdk.yaml'
+
+  tests:
+    name: "SDK: Tests"
+    needs: changes
+    if: needs.changes.outputs.sdk == 'true'
+    timeout-minutes: 15
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      POLAR_EMAIL_RENDERER_BINARY_PATH: "/tmp/email-renderer"
+      POLAR_PYDANTIC_AI_GATEWAY_API_KEY: "POLAR_PYDANTIC_AI_GATEWAY_API_KEY"
+    steps:
+      - uses: actions/checkout@v7.0.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.3.2
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: "sdk/generator/pyproject.toml"
+
+      - uses: pnpm/action-setup@v6.0.9
+        with:
+          version: "11.13.0"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version: "24"
+
+      - name: Install just
+        uses: extractions/setup-just@v4
+
+      - name: Set up server
+        working-directory: ./server
+        run: |
+          touch /tmp/email-renderer
+          uv sync --frozen
+          uv run task generate_dev_jwks
+
+      - name: Install generator dependencies
+        working-directory: ./sdk/generator
+        run: uv sync --frozen
+
+      - name: Lint generator
+        working-directory: ./sdk/generator
+        run: just lint-check
+
+      - name: Test generator
+        working-directory: ./sdk/generator
+        run: just test
+
+      - name: Generate and test SDKs
+        working-directory: ./sdk/generator
+        run: |
+          just openapi
+          just generate-all

--- a/.github/workflows/test_sdk.yaml
+++ b/.github/workflows/test_sdk.yaml
@@ -52,14 +52,13 @@ jobs:
         with:
           python-version-file: "sdk/generator/pyproject.toml"
 
-      - uses: pnpm/action-setup@v6.0.9
-        with:
-          version: "11.13.0"
-
       - name: Set up Node.js
         uses: actions/setup-node@v6.4.0
         with:
           node-version: "24"
+
+      - name: Install pnpm
+        run: npm install --global pnpm@11.13.1
 
       - name: Install just
         uses: extractions/setup-just@v4

--- a/sdk/generator/typescript/template/package.json
+++ b/sdk/generator/typescript/template/package.json
@@ -39,7 +39,7 @@
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"
   },
-  "packageManager": "pnpm@11.13.0",
+  "packageManager": "pnpm@11.13.1",
   "keywords": [
     "polar",
     "sdk",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -64,5 +64,5 @@
   "engines": {
     "node": ">=18"
   },
-  "packageManager": "pnpm@11.13.0"
+  "packageManager": "pnpm@11.13.1"
 }


### PR DESCRIPTION
## Summary

- add an SDK-specific CI workflow for generator changes
- lint and test the SDK generator
- regenerate the Python and TypeScript SDKs from the server OpenAPI schema
- exercise generated SDK linting, type-checking, builds, and tests
- run the expensive SDK job only when `sdk/**` or its workflow changes

## Why

SDK generator and test failures were not covered by pull request or push CI. This adds an end-to-end check while keeping unrelated changes fast.

PNPM is pinned explicitly during bootstrap, and caching does not depend on the generated TypeScript SDK or its generated lockfile.

## Validation

- generator lint and type checks passed
- generator tests: 60 passed
- generated Python SDK tests: 12 passed
- generated TypeScript SDK tests: 9 passed
- generated TypeScript SDK type-check and build passed
- workflow YAML syntax validated
- ADR check: no violations

Closes #13204

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

