### PR TITLE
auth: include environment in TOTP issuer name

### DIFF
--- a/server/polar/auth/endpoints.py
+++ b/server/polar/auth/endpoints.py
@@ -29,6 +29,7 @@ from polar.auth.exceptions import (
 from polar.auth.oauth2.github import get_github_factor
 from polar.auth.oauth2.google import get_google_factor
 from polar.authz.dependencies import AuthorizeWebUserRead, AuthorizeWebUserWriteFresh
+from polar.config import settings
 from polar.exceptions import NotPermitted, ResourceNotFound
 from polar.models import UserSession as UserSession
 from polar.openapi import APITag
@@ -69,6 +70,10 @@ from .schemas import (
 )
 from .service import auth as auth_service
 from .sso.endpoints import router as sso_login_router
+
+TOTP_ISSUER = (
+    "Polar" if settings.is_production() else f"Polar {settings.ENV.value.capitalize()}"
+)
 
 router = APIRouter(prefix="/auth", tags=["auth", APITag.private])
 router.include_router(
@@ -272,7 +277,7 @@ async def totp_enroll(
         algorithm=enrollment.algorithm,
         digits=enrollment.code_length,
         period=enrollment.time_step,
-        provisioning_uri=enrollment.get_provisioning_uri(user.email, "Polar"),
+        provisioning_uri=enrollment.get_provisioning_uri(user.email, TOTP_ISSUER),
     )
 
 


### PR DESCRIPTION
## Summary

The TOTP issuer was hardcoded to `Polar`, so prod and sandbox enrollments were indistinguishable in authenticator apps. The issuer now includes the environment name outside production (e.g. `Polar Sandbox`).

Only affects new enrollments; existing entries keep their name until re-enrolled.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

