### PR TITLE
fix(subscription): re-evaluate benefits when scheduled product update applies at cycle

### DIFF
--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -876,6 +876,9 @@ class SubscriptionService:
                     await subscription_update_repository.soft_delete(pending_update)
                 else:
                     await subscription_update_repository.update(pending_update)
+                    if pending_update.product_id is not None:
+                        await session.flush()
+                        await self.enqueue_benefits_grants(session, subscription)
                 subscription.pending_update = None
 
             if update_cycle_dates and not pending_update_changed_interval:

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -1827,6 +1827,15 @@ class TestCycle:
             OrderBillingReasonInternal.subscription_cycle,
         )
 
+        enqueue_job_mock.assert_any_call(
+            "benefit.enqueue_benefits_grants",
+            task="grant",
+            customer_id=customer.id,
+            product_id=product_second.id,
+            subscription_id=subscription.id,
+            delay=None,
+        )
+
         assert updated_subscription.pending_update is None
 
         subscription_update_repository = SubscriptionUpdateRepository.from_session(
@@ -1905,6 +1914,11 @@ class TestCycle:
             "order.create_subscription_order",
             subscription.id,
             OrderBillingReasonInternal.subscription_cycle,
+        )
+
+        assert not any(
+            c.args and c.args[0] == "benefit.enqueue_benefits_grants"
+            for c in enqueue_job_mock.call_args_list
         )
 
         # The scheduled update is soft-deleted, not applied.


### PR DESCRIPTION
Applying a scheduled product update (`next_period` proration) at cycle swapped the product but never re-evaluated benefits, so the customer kept the previous product's grants and never received the new product's. `cycle()` now enqueues the benefit grants re-evaluation after applying a pending update that changes the product, matching the immediate update path.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

