### PR TITLE
embed resolved permission set on OrganizationWithRole

### DIFF
--- a/clients/apps/web/src/app/(main)/oauth2/authorize/components/CreateOrganizationForm.tsx
+++ b/clients/apps/web/src/app/(main)/oauth2/authorize/components/CreateOrganizationForm.tsx
@@ -97,7 +97,7 @@ const CreateOrganizationForm = ({
     await revalidate(`users:${currentUser?.id}:organizations`, { expire: 0 })
     setUserOrganizations((orgs) => [
       ...orgs,
-      { ...organization, role: 'owner' as const },
+      { ...organization, role: 'owner' as const, permissions: [] },
     ])
     onCreated(organization)
   }

--- a/clients/apps/web/src/components/Onboarding/ProductDetailsStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/ProductDetailsStep.tsx
@@ -185,7 +185,7 @@ export function ProductDetailsStep() {
 
     setUserOrganizations((previous) => [
       ...previous,
-      { ...organization, role: 'owner' as const },
+      { ...organization, role: 'owner' as const, permissions: [] },
     ])
     updateData({
       organizationId: organization.id,

--- a/clients/apps/web/src/components/Onboarding/SandboxStep.tsx
+++ b/clients/apps/web/src/components/Onboarding/SandboxStep.tsx
@@ -100,7 +100,7 @@ export function SandboxStep() {
 
     setUserOrganizations((prev) => [
       ...prev,
-      { ...org, role: 'owner' as const },
+      { ...org, role: 'owner' as const, permissions: [] },
     ])
     router.push(`/dashboard/${org.slug}`)
     clearData()

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -28202,6 +28202,11 @@ export interface components {
       capabilities: components['schemas']['OrganizationCapabilities']
       /** @description The user's role on this organization. */
       role: components['schemas']['OrganizationRole']
+      /**
+       * Permissions
+       * @description The permissions the user's role grants on this organization.
+       */
+      permissions: components['schemas']['OrganizationPermission'][]
     }
     /** Pagination */
     Pagination: {

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -16,7 +16,7 @@ from pydantic import (
 from pydantic.json_schema import SkipJsonSchema
 from pydantic.networks import HttpUrl
 
-from polar.auth.permission import OrganizationPermission
+from polar.auth.permission import ROLE_PERMISSIONS, OrganizationPermission
 from polar.config import settings
 from polar.enums import SubscriptionProrationBehavior, TaxBehaviorOption
 from polar.kit.address import CountryAlpha2, CountryAlpha2Input
@@ -500,6 +500,9 @@ class OrganizationWithRole(Organization):
     includes the user's role on the organization."""
 
     role: OrganizationRole = Field(description="The user's role on this organization.")
+    permissions: list[OrganizationPermission] = Field(
+        description="The permissions the user's role grants on this organization."
+    )
 
     @classmethod
     def from_organization(
@@ -507,7 +510,11 @@ class OrganizationWithRole(Organization):
     ) -> "OrganizationWithRole":
         """Build from a SQLAlchemy `Organization` plus the user's role."""
         return cls.model_validate(
-            {**Organization.model_validate(organization).model_dump(), "role": role}
+            {
+                **Organization.model_validate(organization).model_dump(),
+                "role": role,
+                "permissions": sorted(ROLE_PERMISSIONS[role]),
+            }
         )
 
 

--- a/server/tests/user/test_endpoints.py
+++ b/server/tests/user/test_endpoints.py
@@ -2,6 +2,7 @@ import pytest
 from httpx import AsyncClient
 
 from polar.auth.models import AuthSubject
+from polar.auth.permission import OrganizationPermission
 from polar.auth.scope import READ_ONLY_SCOPES
 from polar.kit.utils import utc_now
 from polar.models import Organization, User, UserOrganization
@@ -42,6 +43,29 @@ async def test_get_users_me_embeds_organizations_with_role(
     assert len(organizations) == 1
     assert organizations[0]["id"] == str(organization.id)
     assert organizations[0]["role"] == OrganizationRole.admin.value
+    # Admin embeds the finance scopes the dashboard gates on.
+    permissions = organizations[0]["permissions"]
+    assert OrganizationPermission.finance_read in permissions
+    assert OrganizationPermission.organization_manage in permissions
+
+
+@pytest.mark.asyncio
+@pytest.mark.auth
+async def test_get_users_me_embeds_member_permissions_without_admin_scopes(
+    client: AsyncClient,
+    save_fixture: SaveFixture,
+    organization: Organization,
+    user_organization: UserOrganization,
+) -> None:
+    user_organization.role = OrganizationRole.member
+    await save_fixture(user_organization)
+
+    response = await client.get("/v1/users/me")
+
+    assert response.status_code == 200
+    permissions = response.json()["organizations"][0]["permissions"]
+    assert OrganizationPermission.finance_read not in permissions
+    assert OrganizationPermission.organization_manage not in permissions
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Part 1 of 2 splitting #12846 by @pieterbeulque, check for more context. **Deploy this before Part 2** to reduce risk of having the next cache mismatch with the expected returned data from api.

### What
- See #12846
- Also updated unit test to assert the permissions are there as expected

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

