### PR TITLE
fix(worker): discard buffered jobs when the transaction rollsback

### DIFF
--- a/server/polar/postgres.py
+++ b/server/polar/postgres.py
@@ -95,6 +95,13 @@ async def get_db_session(request: Request) -> AsyncGenerator[AsyncSession]:
         yield session
     except:
         await session.rollback()
+        # Import deferred to avoid circular dependency with polar.worker
+        from polar.worker import JobQueueManager
+
+        # Jobs enqueued during the request reference state that was just
+        # rolled back; discard them so they aren't flushed if the exception
+        # is converted into an error response by an exception handler.
+        JobQueueManager.get().reset()
         raise
     else:
         await session.commit()

--- a/server/tests/test_postgres.py
+++ b/server/tests/test_postgres.py
@@ -1,0 +1,39 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from starlette.requests import Request
+
+from polar.exceptions import PolarError
+from polar.postgres import get_db_session
+from polar.worker import JobQueueManager, enqueue_job
+
+
+def build_request(session: AsyncMock) -> Request:
+    return Request({"type": "http", "state": {"async_session": session}})
+
+
+@pytest.mark.asyncio
+class TestGetDBSession:
+    async def test_commit_keeps_buffered_jobs(self) -> None:
+        session = AsyncMock()
+        generator = get_db_session(build_request(session))
+        await anext(generator)
+        enqueue_job("test.task")
+
+        with pytest.raises(StopAsyncIteration):
+            await anext(generator)
+
+        session.commit.assert_awaited_once()
+        assert len(JobQueueManager.get()._enqueued_jobs) == 1
+
+    async def test_rollback_discards_buffered_jobs(self) -> None:
+        session = AsyncMock()
+        generator = get_db_session(build_request(session))
+        await anext(generator)
+        enqueue_job("test.task")
+
+        with pytest.raises(PolarError):
+            await generator.athrow(PolarError("error"))
+
+        session.rollback.assert_awaited_once()
+        assert JobQueueManager.get()._enqueued_jobs == []


### PR DESCRIPTION
Jobs enqueued during a request are buffered and flushed by `FlushEnqueuedWorkerJobsMiddleware` at request end. Exceptions with registered handlers (e.g. `PolarError`) are converted into error responses at the route level, so the middleware sees a clean exit and flushes the buffer even though the request transaction was rolled back — the worker then processes jobs referencing state that was never committed. `get_db_session` now discards the buffer on rollback.
Known behavior change, accepted: PAT / organization access token `last_used_at` is no longer recorded when a write request fails with a handled error.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

