### PR TITLE
fix(order): negate tax breakdown lines on credit orders

### DIFF
--- a/server/polar/order/amounts.py
+++ b/server/polar/order/amounts.py
@@ -96,17 +96,23 @@ async def calculate_tax(
             if taxable_amount >= 0:
                 tax_calculation_processor_id = tax_calculation["processor_id"]
                 tax_amount = tax_calculation["amount"]
+                tax_breakdown = tax_calculation["tax_breakdown"]
             else:
                 # When the taxable amount is negative it's usually due to a credit proration
                 # this means we "owe" the customer money -- but we don't pay it back at this
                 # point. This also means that there's no money transaction going on, and we
                 # don't have to record the tax transaction either.
+                # The calculation ran on the absolute value, so negate the tax
+                # amount and each breakdown line to match the credited order.
                 tax_calculation_processor_id = None
                 tax_amount = -tax_calculation["amount"]
+                tax_breakdown = [
+                    {**item, "amount": -item["amount"]}
+                    for item in tax_calculation["tax_breakdown"]
+                ]
 
         if tax_calculation is not None:
             tax_behavior = tax_calculation["tax_behavior"]
-            tax_breakdown = tax_calculation["tax_breakdown"]
 
     return (
         tax_processor,

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -1739,6 +1739,11 @@ class TestCreateSubscriptionOrder:
             assert order.status == OrderStatus.paid
             assert order.tax_calculation_processor_id is None
             assert order.tax_transaction_processor_id is None
+            assert order.tax_breakdown is not None
+            assert all(item["amount"] <= 0 for item in order.tax_breakdown)
+            assert (
+                sum(item["amount"] for item in order.tax_breakdown) == order.tax_amount
+            )
         else:
             assert order.status == OrderStatus.pending
             assert order.tax_calculation_processor_id == "TAX_PROCESSOR_ID"


### PR DESCRIPTION
## Summary

**Related Issue**: #13088

The tax calculation runs on the absolute value, so credit orders persisted positive breakdown lines against a negative tax_amount, rendering invoices whose tax lines contradict the total.


## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix incorrect tax lines on credit order invoices by negating tax breakdown entries when the taxable amount is negative. Addresses #13088 by making breakdown lines and the total use the same sign.

- **Bug Fixes**
  - Negate each `tax_breakdown` amount for negative taxable amounts so totals and lines match.
  - Add test to ensure all breakdown amounts are <= 0 and sum to `tax_amount`.

<sup>Written for commit e0c5e55673c8a5192aa4991fc11936b8b011b283. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

