### PR TITLE
fix(customer_portal): forbid unknown fields on subscription update

### DIFF
--- a/server/polar/customer_portal/schemas/subscription.py
+++ b/server/polar/customer_portal/schemas/subscription.py
@@ -88,10 +88,14 @@ class CustomerSubscription(SubscriptionBase):
 
 
 class CustomerSubscriptionUpdateProduct(Schema):
+    model_config = ConfigDict(extra="forbid")
+
     product_id: UUID4 = Field(description="Update subscription to another product.")
 
 
 class CustomerSubscriptionUpdateSeats(Schema):
+    model_config = ConfigDict(extra="forbid")
+
     seats: Int32 = Field(
         description="Update the number of seats for this subscription.",
         ge=1,
@@ -122,6 +126,8 @@ CustomerSubscriptionChangePreview = Annotated[
 
 
 class CustomerSubscriptionCancel(Schema):
+    model_config = ConfigDict(extra="forbid")
+
     cancel_at_period_end: bool | None = Field(
         None,
         description=inspect.cleandoc(
@@ -165,6 +171,8 @@ class CustomerSubscriptionRevoke(Schema):
 
 
 class CustomerSubscriptionPause(Schema):
+    model_config = ConfigDict(extra="forbid")
+
     pause_at_period_end: bool = Field(
         description=inspect.cleandoc(
             """
@@ -186,6 +194,8 @@ class CustomerSubscriptionPause(Schema):
 
 
 class CustomerSubscriptionResume(Schema):
+    model_config = ConfigDict(extra="forbid")
+
     resume: Literal[True] = Field(
         description=(
             "Resume a paused subscription immediately, "
@@ -195,6 +205,8 @@ class CustomerSubscriptionResume(Schema):
 
 
 class CustomerSubscriptionUpdateClear(Schema):
+    model_config = ConfigDict(extra="forbid")
+
     pending_update: None = Field(description="Clear the pending subscription update.")
 
 

--- a/server/tests/customer_portal/endpoints/test_subscription.py
+++ b/server/tests/customer_portal/endpoints/test_subscription.py
@@ -210,6 +210,19 @@ class TestCustomerSubscriptionProductUpdate:
 
 
 @pytest.mark.asyncio
+class TestCustomerSubscriptionUpdateUnknownFields:
+    @pytest.mark.auth(CUSTOMER_AUTH_SUBJECT)
+    async def test_unknown_field(
+        self, client: AsyncClient, subscription: Subscription
+    ) -> None:
+        response = await client.patch(
+            f"/v1/customer-portal/subscriptions/{subscription.id}",
+            json=dict(pause_at_periodend=True),
+        )
+        assert response.status_code == 422
+
+
+@pytest.mark.asyncio
 class TestCustomerSubscriptionUpdateCancel:
     async def test_anonymous(
         self,

--- a/server/tests/customer_portal/endpoints/test_subscription.py
+++ b/server/tests/customer_portal/endpoints/test_subscription.py
@@ -226,7 +226,7 @@ class TestCustomerSubscriptionUpdateCancel:
         response = await client.patch(
             f"/v1/customer-portal/subscriptions/{subscription.id}",
             json=dict(
-                cancel_at_period_id=True,
+                cancel_at_period_end=True,
             ),
         )
         assert response.status_code == 401
@@ -247,7 +247,7 @@ class TestCustomerSubscriptionUpdateCancel:
         response = await client.patch(
             f"/v1/customer-portal/subscriptions/{subscription.id}",
             json=dict(
-                cancel_at_period_id=True,
+                cancel_at_period_end=True,
             ),
         )
         assert response.status_code == 404


### PR DESCRIPTION
## Summary

Followup of this: https://github.com/polarsource/polar/pull/13001#discussion_r3535660027

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forbid unknown fields on customer portal subscription update endpoints to prevent silent typos. The API now returns 422 for extra payload keys.

- **Bug Fixes**
  - Set `extra="forbid"` on update schemas: `CustomerSubscriptionUpdateProduct`, `CustomerSubscriptionUpdateSeats`, `CustomerSubscriptionCancel`, `CustomerSubscriptionPause`, `CustomerSubscriptionResume`, `CustomerSubscriptionUpdateClear`.
  - Add test asserting 422 on unknown fields; fix test param typo to `cancel_at_period_end`.

<sup>Written for commit 8692d9cf34cd0396a0bb585ecca046da2d634d73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

