### PR TITLE
fix(auth): adapt to reauth breaking change

### DIFF
--- a/server/polar/auth/sso/factor.py
+++ b/server/polar/auth/sso/factor.py
@@ -22,9 +22,6 @@ def _discovery_endpoint(issuer: str) -> str:
 class SSOFactorMixin:
     """Shared behavior for organization SSO OIDC factors.
 
-    The discovery endpoint is resolved per connection from its issuer, so it's an
-    instance property here rather than reauth's class-level constant.
-
     An SSO login resolves the user from the verified `id_token` email and never
     persists an enrollment, so the storage hooks go unused: enrollment lookups
     return `None` (steering reauth's callback to its identity-less path) and the
@@ -34,15 +31,6 @@ class SSOFactorMixin:
     connection_id: uuid.UUID
     organization_slug: str
     name: str | None
-    _discovery_endpoint: str
-
-    @property
-    def DISCOVERY_ENDPOINT(self) -> str:
-        return self._discovery_endpoint
-
-    @DISCOVERY_ENDPOINT.setter
-    def DISCOVERY_ENDPOINT(self, value: str) -> None:
-        self._discovery_endpoint = value
 
     async def get_enrollment(
         self, identity_id: uuid.UUID
@@ -77,12 +65,12 @@ class SSOClientSecretFactor(SSOFactorMixin, OIDCFactor):
             identifier=str(connection_id),
             client_id=client_id,
             client_secret=client_secret,
+            discovery_endpoint=_discovery_endpoint(issuer),
             state_service=state_service,
         )
         self.connection_id = connection_id
         self.organization_slug = organization_slug
         self.name = name
-        self.DISCOVERY_ENDPOINT = _discovery_endpoint(issuer)
 
 
 class SSOPrivateKeyJWTFactor(SSOFactorMixin, PrivateKeyJWTOIDCFactor):
@@ -101,12 +89,12 @@ class SSOPrivateKeyJWTFactor(SSOFactorMixin, PrivateKeyJWTOIDCFactor):
             client_id=client_id,
             jwks=jwt.PyJWKSet.from_dict(settings.JWKS.as_dict(is_private=True)),
             kid=settings.CURRENT_JWK_KID,
+            discovery_endpoint=_discovery_endpoint(issuer),
             state_service=state_service,
         )
         self.connection_id = connection_id
         self.organization_slug = organization_slug
         self.name = name
-        self.DISCOVERY_ENDPOINT = _discovery_endpoint(issuer)
 
 
 def build_sso_factor(

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -65,7 +65,7 @@ dependencies = [
   "anyio>=4.14.0",
   "markdown-it-py>=4.2.0",
   "tzdata>=2026.2",
-  "reauth==0.2.0",
+  "reauth==0.2.1",
   "langcodes>=3.5.1",
   "pypdf>=6.14.2",
   "google-auth[requests]>=2.38.0",

--- a/server/tests/auth/sso/test_factor.py
+++ b/server/tests/auth/sso/test_factor.py
@@ -54,7 +54,7 @@ class TestBuildSSOFactor:
         assert factor.organization_slug == "acme"
         assert factor.client_id == "client-id"
         assert (
-            factor.DISCOVERY_ENDPOINT
+            factor.discovery_endpoint
             == "https://idp.example.com/.well-known/openid-configuration"
         )
 
@@ -100,6 +100,6 @@ class TestBuildSSOFactor:
         )
 
         assert (
-            factor.DISCOVERY_ENDPOINT
+            factor.discovery_endpoint
             == "https://idp.example.com/.well-known/openid-configuration"
         )

--- a/server/uv.lock
+++ b/server/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-03T12:32:28.494865Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -2605,7 +2605,7 @@ requires-dist = [
     { name = "python-slugify", specifier = ">=8.0.1" },
     { name = "python-snappy", specifier = ">=0.7.3" },
     { name = "python-stdnum", specifier = ">=2.1" },
-    { name = "reauth", specifier = "==0.2.0" },
+    { name = "reauth", specifier = "==0.2.1" },
     { name = "redis", specifier = ">=5.0.4" },
     { name = "safe-redirect-url", specifier = ">=0.1.1" },
     { name = "sentry-sdk", extras = ["fastapi", "sqlalchemy"], specifier = ">=2.64.0" },
@@ -3344,7 +3344,7 @@ wheels = [
 
 [[package]]
 name = "reauth"
-version = "0.2.0"
+version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3352,9 +3352,9 @@ dependencies = [
     { name = "httpx" },
     { name = "pyjwt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/b5/f8f6a72dedc3257ff1115574db7152f861964b71dc77eeab9a537382217d/reauth-0.2.0.tar.gz", hash = "sha256:fde02aac9e4a5e708eff056fce8e2f557043b484baf8e343836be53d0ded5acb", size = 517335, upload-time = "2026-06-30T08:18:57.363Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cf/51/93217308c5ac99a47c823ddd8d1c5fc510e28f4b74d478205a13b1391a44/reauth-0.2.1.tar.gz", hash = "sha256:741f807a5eddceca42097125b785cb33179f814ee73540cbd4e9a73872b45318", size = 517311, upload-time = "2026-07-16T15:12:30.548Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/b2/905fd001c3730334bc9e0f38e4dc6b954c2fb9880fe9e2283d3e276c1cb9/reauth-0.2.0-py3-none-any.whl", hash = "sha256:00e8fa95d812b9d8907567cfa072c4d71099c7754b1ea29e101fd5f6d7fea688", size = 39329, upload-time = "2026-06-30T08:18:56.422Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/c3/54ad76f384195a6fa926e18c00c435d76b465ca8495830752f6e2b33b958/reauth-0.2.1-py3-none-any.whl", hash = "sha256:e56b76dbbb1fdfbabaeed67587b359032e10a6280fb9eec62fefe2cba44a0d75", size = 39309, upload-time = "2026-07-16T15:12:29.149Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
https://github.com/frankie567/reauth/pull/5

needs to wait for the lib to be tagged and released.


## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adapt SSO OIDC factors to the new `reauth` API by passing the discovery endpoint into constructors. Removes the old instance property and updates tests.

- **Refactors**
  - Pass `discovery_endpoint=_discovery_endpoint(issuer)` to `reauth` factor constructors.
  - Remove `DISCOVERY_ENDPOINT` property and related getter/setter from `SSOFactorMixin`.
  - Update tests to assert `factor.discovery_endpoint` and keep issuer normalization behavior.

- **Dependencies**
  - Bump `reauth` to `0.2.1`.

<sup>Written for commit 5495740c4d4ba74fbfe9dd029cfbbf766c11c802. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

