### PR TITLE
fix(currency): apply statistics thresholds to negative amounts

### DIFF
--- a/clients/packages/currency/src/index.test.ts
+++ b/clients/packages/currency/src/index.test.ts
@@ -174,9 +174,9 @@ describe('formatCurrency', () => {
       expect(formatCurrency('statistics', 'en-US')(-123456700, 'usd')).toEqual(
         '-$1.235M',
       )
-      expect(formatCurrency('statistics', 'en-US')(-12345678900, 'usd')).toEqual(
-        '-$123.46M',
-      )
+      expect(
+        formatCurrency('statistics', 'en-US')(-12345678900, 'usd'),
+      ).toEqual('-$123.46M')
     })
   })
 

--- a/clients/packages/currency/src/index.test.ts
+++ b/clients/packages/currency/src/index.test.ts
@@ -160,6 +160,24 @@ describe('formatCurrency', () => {
         '¥123.46M',
       )
     })
+
+    it('should apply the same thresholds to negative values', () => {
+      expect(formatCurrency('statistics', 'en-US')(-12345, 'usd')).toEqual(
+        '-$123.45',
+      )
+      expect(formatCurrency('statistics', 'en-US')(-1234500, 'usd')).toEqual(
+        '-$12,345',
+      )
+      expect(formatCurrency('statistics', 'en-US')(-12345678, 'usd')).toEqual(
+        '-$123,456',
+      )
+      expect(formatCurrency('statistics', 'en-US')(-123456700, 'usd')).toEqual(
+        '-$1.235M',
+      )
+      expect(formatCurrency('statistics', 'en-US')(-12345678900, 'usd')).toEqual(
+        '-$123.46M',
+      )
+    })
   })
 
   describe('Subcent mode', () => {

--- a/clients/packages/currency/src/index.ts
+++ b/clients/packages/currency/src/index.ts
@@ -128,7 +128,7 @@ const formatCurrencyStatistics = (
   const displayValue = cents / decimalFactor
 
   // >= $1M: compact notation with multipliers
-  if (displayValue >= 1_000_000) {
+  if (Math.abs(displayValue) >= 1_000_000) {
     return new Intl.NumberFormat(locales, {
       style: 'currency',
       currency,
@@ -142,7 +142,7 @@ const formatCurrencyStatistics = (
   }
 
   // $10K–$999K: no decimals, truncated
-  if (displayValue >= 10_000) {
+  if (Math.abs(displayValue) >= 10_000) {
     return new Intl.NumberFormat(locales, {
       style: 'currency',
       currency,


### PR DESCRIPTION
## Summary

**Related Issue**: polarsource/feedback#284

`formatCurrency('statistics', ...)` skipped its compact/truncated formatting tiers for negative amounts, so large negatives rendered in full notation while positive equivalents were compacted (e.g. `-$1,000,000` instead of `-$1.00M`, `-$10,000` instead of a truncated form).

## What

- Compare `Math.abs(displayValue)` against the `$1M` (compact notation) and `$10K` (truncated, no decimals) thresholds in `formatCurrencyStatistics`.
- Add tests asserting negative values match the formatting of their positive equivalents.

## Why

Both tier checks compared `displayValue` directly against positive thresholds, so any negative `displayValue` never satisfied them and fell through to default full-notation formatting. This produced inconsistent UI output between positive and negative values of the same magnitude, affecting the `gross_margin` and `cashflow` metrics on the customer page.

Introduced in c7023910f6, which added the tiered thresholds but used `displayValue >= threshold` checks that never match negative values.

## How

Wrap the two threshold comparisons in `Math.abs()`. `Math.trunc` already truncates toward zero, so the truncated tier stays correct for negatives.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HXfaoVaTXF9SA9emJJEdH

---
_Generated by [Claude Code](https://claude.ai/code/session_018HXfaoVaTXF9SA9emJJEdH)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

