### PR TITLE
feat(subscriptions): finalize pause rollout

### DIFF
--- a/clients/apps/web/src/components/Settings/OrganizationCustomerPortalSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationCustomerPortalSettings.tsx
@@ -26,6 +26,10 @@ const OrganizationCustomerPortalSettings: React.FC<
   const form = useForm<schemas['OrganizationCustomerPortalSettings']>({
     defaultValues: {
       ...organization.customer_portal_settings,
+      subscription: {
+        pause: false,
+        ...organization.customer_portal_settings.subscription,
+      },
       customer: {
         allow_email_change: false,
         ...organization.customer_portal_settings.customer,
@@ -150,6 +154,28 @@ const OrganizationCustomerPortalSettings: React.FC<
             <FormField
               control={control}
               name="subscription.update_plan"
+              render={({ field }) => (
+                <FormItem>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                      disabled={readOnly}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </SettingsGroupItem>
+
+          <SettingsGroupItem
+            title="Enable subscription pausing"
+            description="Allow customers to pause and resume their subscriptions from the portal."
+          >
+            <FormField
+              control={control}
+              name="subscription.pause"
               render={({ field }) => (
                 <FormItem>
                   <FormControl>

--- a/docs/features/analytics.mdx
+++ b/docs/features/analytics.mdx
@@ -14,11 +14,11 @@ When you pick a date range, Polar splits it into equal-width **intervals** — o
 
 ## Subscriptions
 
-- **Monthly Recurring Revenue (MRR)** — Sum of every active subscription's amount, normalized to a monthly rate (yearly plans are divided by 12). Trialing subscriptions are excluded.
-- **Committed MRR** — MRR restricted to subscriptions still inside a committed billing period. Subscriptions that have been canceled but are running out the clock until period end are excluded.
+- **Monthly Recurring Revenue (MRR)** — Sum of every ongoing subscription's amount, normalized to a monthly rate (yearly plans are divided by 12). Trialing subscriptions are excluded. Paused and past-due subscriptions are included: a subscriber counts towards MRR until their subscription actually ends.
+- **Committed MRR** — MRR restricted to subscriptions still inside a committed billing period. Subscriptions that have been canceled but are running out the clock until period end are excluded. As with MRR, paused and past-due subscriptions are included.
 - **Trial MRR Including Canceled Trials** — Monthly-normalized amount of every subscription currently in a trial, including trials that have already been canceled.
 - **Trial Committed MRR** — Trial MRR for trials still inside their committed billing period (i.e. canceled trials are excluded).
-- **Active Subscriptions** — Count of subscriptions in the `active` state at the end of each interval. Subscriptions stay active until the end of the period they paid for, even after cancellation.
+- **Active Subscriptions** — Count of ongoing subscriptions at the end of each interval, based on when each subscription started and ended rather than its current status. A subscription counts until it actually ends: those that have been canceled but are running out the clock until period end, as well as paused and past-due subscriptions, are all still included.
 - **New Subscriptions** — Subscriptions whose first paid order falls inside the interval. Each subscription is counted once, at creation.
 - **Committed Subscriptions** — Active subscriptions that have not been canceled, or whose cancellation date is after the interval. These are the subscriptions you can reasonably expect to renew.
 - **Renewed Subscriptions** — Number of orders with billing reason `subscription_cycle` in the interval — i.e. renewals on existing subscriptions.

--- a/docs/features/analytics.mdx
+++ b/docs/features/analytics.mdx
@@ -14,7 +14,7 @@ When you pick a date range, Polar splits it into equal-width **intervals** — o
 
 ## Subscriptions
 
-- **Monthly Recurring Revenue (MRR)** — Sum of every ongoing subscription's amount, normalized to a monthly rate (yearly plans are divided by 12). Trialing subscriptions are excluded. Paused and past-due subscriptions are included: a subscriber counts towards MRR until their subscription actually ends.
+- **Monthly Recurring Revenue (MRR)** — Sum of every ongoing subscription's net amount, normalized to a monthly rate (yearly plans are divided by 12). Trialing subscriptions are excluded. Paused and past-due subscriptions are included: a subscriber counts towards MRR until their subscription actually ends.
 - **Committed MRR** — MRR restricted to subscriptions still inside a committed billing period. Subscriptions that have been canceled but are running out the clock until period end are excluded. As with MRR, paused and past-due subscriptions are included.
 - **Trial MRR Including Canceled Trials** — Monthly-normalized amount of every subscription currently in a trial, including trials that have already been canceled.
 - **Trial Committed MRR** — Trial MRR for trials still inside their committed billing period (i.e. canceled trials are excluded).

--- a/server/tests/metrics/test_paused_verification.py
+++ b/server/tests/metrics/test_paused_verification.py
@@ -1,0 +1,110 @@
+from datetime import UTC, date, datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from polar.auth.models import AuthSubject
+from polar.auth.scope import Scope
+from polar.enums import SubscriptionRecurringInterval
+from polar.kit.time_queries import TimeInterval
+from polar.metrics.service import metrics as metrics_service
+from polar.models import Organization, User, UserOrganization
+from polar.models.subscription import SubscriptionStatus
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import (
+    create_active_subscription,
+    create_customer,
+    create_product,
+)
+
+SQL_METRICS = [
+    "active_subscriptions",
+    "monthly_recurring_revenue",
+    "churn_rate",
+    "churned_subscriptions",
+]
+
+
+@pytest.mark.asyncio
+async def test_paused_subscription_in_metrics(
+    session: AsyncSession,
+    save_fixture: SaveFixture,
+    user: User,
+    organization: Organization,
+    user_organization: UserOrganization,
+) -> None:
+    product = await create_product(
+        save_fixture,
+        organization=organization,
+        recurring_interval=SubscriptionRecurringInterval.month,
+        prices=[(1000, "usd")],
+    )
+    started_at = datetime(2024, 1, 1, tzinfo=UTC)
+
+    active_customer = await create_customer(
+        save_fixture, organization=organization, email="active@example.com"
+    )
+    active_sub = await create_active_subscription(
+        save_fixture,
+        product=product,
+        customer=active_customer,
+        started_at=started_at,
+    )
+
+    paused_customer = await create_customer(
+        save_fixture, organization=organization, email="paused@example.com"
+    )
+    paused_sub = await create_active_subscription(
+        save_fixture,
+        product=product,
+        customer=paused_customer,
+        started_at=started_at,
+    )
+    # Mirror the cycle() pause transition: status flips, paused_at is stamped,
+    # ended_at / ends_at / canceled_at stay untouched.
+    paused_sub.status = SubscriptionStatus.paused
+    paused_sub.paused_at = datetime(2024, 3, 1, tzinfo=UTC)
+    await save_fixture(paused_sub)
+
+    # Control: a genuinely canceled subscription, ended within the queried
+    # window, so the churn metric is proven to fire (not vacuously zero).
+    canceled_customer = await create_customer(
+        save_fixture, organization=organization, email="canceled@example.com"
+    )
+    canceled_sub = await create_active_subscription(
+        save_fixture,
+        product=product,
+        customer=canceled_customer,
+        started_at=started_at,
+    )
+    canceled_sub.status = SubscriptionStatus.canceled
+    canceled_sub.canceled_at = datetime(2024, 4, 10, tzinfo=UTC)
+    canceled_sub.ended_at = datetime(2024, 4, 15, tzinfo=UTC)
+    await save_fixture(canceled_sub)
+
+    auth_subject: AuthSubject[User] = AuthSubject(user, {Scope.metrics_read}, None)
+
+    metrics = await metrics_service.get_metrics(
+        session,
+        auth_subject,
+        start_date=date(2024, 4, 1),
+        end_date=date(2024, 4, 30),
+        timezone=ZoneInfo("UTC"),
+        interval=TimeInterval.month,
+        organization_id=[organization.id],
+        metrics=SQL_METRICS,
+        now=datetime(2024, 4, 30, tzinfo=UTC),
+    )
+
+    period = metrics.periods[0]
+
+    expected_mrr = active_sub.net_amount + paused_sub.net_amount
+
+    # Paused subscription is counted exactly once alongside the active one;
+    # the canceled control ended before this window and drops out.
+    assert period.active_subscriptions == 2
+    # Its recurring amount is included in MRR.
+    assert period.monthly_recurring_revenue == expected_mrr
+    # Only the canceled control counts as churn — pause does not.
+    assert period.churned_subscriptions == 1


### PR DESCRIPTION
## Summary

Documents that paused subscriptions are counted in MRR and Active Subscriptions but excluded from churn (matching the past-due treatment), with a regression test pinning that behavior, and lets merchants self-serve the customer-portal pause toggle from settings.


https://github.com/user-attachments/assets/fd8cc7cb-0abb-44b7-a9a1-1978d7bc8e18




## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

