### PR TITLE
feat: show organization risk signals in backoffice and review agent

### DIFF
--- a/server/polar/backoffice/components/_tab_nav.py
+++ b/server/polar/backoffice/components/_tab_nav.py
@@ -25,7 +25,7 @@ def _render_tab_indicator(tab: Tab) -> None:
     variant = tab.badge_variant or "neutral"
     if tab.dot:
         with tag.span(
-            classes=f"ml-2 inline-block w-1.5 h-1.5 rounded-full bg-{variant}"
+            classes=f"tab-dot ml-2 inline-block w-1.5 h-1.5 rounded-full bg-{variant}"
         ):
             pass
     elif tab.count is not None:

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -82,7 +82,10 @@ from polar.organization_review.appeal_case import (
 from polar.organization_review.appeal_case import (
     appeal_case as appeal_case_service,
 )
-from polar.organization_review.repository import OrganizationReviewRepository
+from polar.organization_review.repository import (
+    OrganizationReviewRepository,
+    OrganizationRiskSignalRepository,
+)
 from polar.organization_review.schemas import (
     AUP_SECTION_LABELS,
     AUPSection,
@@ -896,6 +899,11 @@ async def get_organization_detail(
             message_repository = SupportCaseMessageRepository.from_session(session)
             appeal_case_open = await message_repository.is_open(appeal_case.id)
 
+    # External risk signals (e.g. Stripe Radar). Shown as a banner on the
+    # overview, a card on the reviews tab, and a dot on the Reviews tab.
+    risk_signal_repo = OrganizationRiskSignalRepository.from_session(session)
+    risk_signals = await risk_signal_repo.list_by_organization(organization_id)
+
     # Any open case (appeal or dispute) lights the Support Cases nav badge.
     open_case_count = await session.scalar(
         select(func.count()).select_from(
@@ -914,6 +922,7 @@ async def get_organization_detail(
         impersonate_user=impersonate_user,
         startup_program_status=startup_program_status,
         has_open_case=has_open_case,
+        has_risk_signals=bool(risk_signals),
     )
 
     # Fetch analytics data for overview section
@@ -1080,6 +1089,7 @@ async def get_organization_detail(
                     agent_report=parsed_agent_report,
                     agent_reviewed_at=agent_reviewed_at,
                     has_open_appeal_case=appeal_case is not None and appeal_case_open,
+                    risk_signals=risk_signals,
                 )
                 with overview.render(
                     request, setup_data=setup_data, payment_stats=payment_stats
@@ -1130,7 +1140,9 @@ async def get_organization_detail(
             elif section == "reviews":
                 agent_reviews = await review_repo.get_all_agent_reviews(organization_id)
                 reviews_section = ReviewsSection(
-                    organization, agent_reviews=agent_reviews
+                    organization,
+                    agent_reviews=agent_reviews,
+                    risk_signals=risk_signals,
                 )
                 with reviews_section.render(request):
                     pass

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -60,7 +60,6 @@ from polar.models.organization import (
 )
 from polar.models.organization_agent_review import OrganizationAgentReview
 from polar.models.organization_review import OrganizationReview
-from polar.models.organization_risk_signal import OrganizationRiskSignal
 from polar.models.support_case import (
     ReviewAppealSupportCase,
     SupportCaseMessageAuthorKind,
@@ -900,17 +899,11 @@ async def get_organization_detail(
             message_repository = SupportCaseMessageRepository.from_session(session)
             appeal_case_open = await message_repository.is_open(appeal_case.id)
 
-    # External risk signals (e.g. Stripe Radar). Only the overview and reviews
-    # sections render the rows; every section needs existence for the tab dot.
+    # External risk signals (e.g. Stripe Radar), rendered on the overview and
+    # reviews sections and driving the Reviews tab dot.
     risk_signal_repo = OrganizationRiskSignalRepository.from_session(session)
-    risk_signals: Sequence[OrganizationRiskSignal] = []
-    if section in ("overview", "reviews"):
-        risk_signals = await risk_signal_repo.list_by_organization(
-            organization_id, limit=100
-        )
-        has_risk_signals = bool(risk_signals)
-    else:
-        has_risk_signals = await risk_signal_repo.has_any(organization_id)
+    risk_signals = await risk_signal_repo.list_by_organization(organization_id)
+    has_risk_signals = bool(risk_signals)
 
     # Any open case (appeal or dispute) lights the Support Cases nav badge.
     open_case_count = await session.scalar(

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -60,6 +60,7 @@ from polar.models.organization import (
 )
 from polar.models.organization_agent_review import OrganizationAgentReview
 from polar.models.organization_review import OrganizationReview
+from polar.models.organization_risk_signal import OrganizationRiskSignal
 from polar.models.support_case import (
     ReviewAppealSupportCase,
     SupportCaseMessageAuthorKind,
@@ -899,10 +900,17 @@ async def get_organization_detail(
             message_repository = SupportCaseMessageRepository.from_session(session)
             appeal_case_open = await message_repository.is_open(appeal_case.id)
 
-    # External risk signals (e.g. Stripe Radar). Shown as a banner on the
-    # overview, a card on the reviews tab, and a dot on the Reviews tab.
+    # External risk signals (e.g. Stripe Radar). Only the overview and reviews
+    # sections render the rows; every section needs existence for the tab dot.
     risk_signal_repo = OrganizationRiskSignalRepository.from_session(session)
-    risk_signals = await risk_signal_repo.list_by_organization(organization_id)
+    risk_signals: Sequence[OrganizationRiskSignal] = []
+    if section in ("overview", "reviews"):
+        risk_signals = await risk_signal_repo.list_by_organization(
+            organization_id, limit=100
+        )
+        has_risk_signals = bool(risk_signals)
+    else:
+        has_risk_signals = await risk_signal_repo.has_any(organization_id)
 
     # Any open case (appeal or dispute) lights the Support Cases nav badge.
     open_case_count = await session.scalar(
@@ -922,7 +930,7 @@ async def get_organization_detail(
         impersonate_user=impersonate_user,
         startup_program_status=startup_program_status,
         has_open_case=has_open_case,
-        has_risk_signals=bool(risk_signals),
+        has_risk_signals=has_risk_signals,
     )
 
     # Fetch analytics data for overview section

--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -46,12 +46,14 @@ class OrganizationDetailView:
         impersonate_user: User | None = None,
         startup_program_status: str | None = None,
         has_open_case: bool = False,
+        has_risk_signals: bool = False,
     ):
         self.org = organization
         self.ai_verdict = ai_verdict
         self.owner_email = owner_email
         self.impersonate_user = impersonate_user
         self.has_open_case = has_open_case
+        self.has_risk_signals = has_risk_signals
         # Startup Program status string is derived via the Polar API and
         # populated by the endpoint; ``None`` means "feature disabled" OR
         # "not invited". The card collapses both into the same rendering.
@@ -102,6 +104,8 @@ class OrganizationDetailView:
                 )
                 + "?section=reviews",
                 active=current_section == "reviews",
+                dot=self.has_risk_signals,
+                badge_variant="error",
             ),
             Tab(
                 "Support Cases",

--- a/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
@@ -2,13 +2,14 @@
 
 import contextlib
 import json
-from collections.abc import Generator
+from collections.abc import Generator, Sequence
 from datetime import datetime
 
 from fastapi import Request
 from tagflow import tag, text
 
 from polar.models import Organization
+from polar.models.organization_risk_signal import OrganizationRiskSignal
 from polar.organization_review.report import AnyAgentReport
 from polar.organization_review.schemas import DimensionAssessment, ReviewVerdict
 from polar.organization_review.thresholds import (
@@ -29,6 +30,7 @@ from ._shared import (
     render_checklist_row,
     render_review_context_badge,
 )
+from .risk_signals import render_risk_signals_block
 
 
 class OverviewSection(ChecklistMixin):
@@ -42,6 +44,7 @@ class OverviewSection(ChecklistMixin):
         agent_report: AnyAgentReport | None = None,
         agent_reviewed_at: datetime | None = None,
         has_open_appeal_case: bool = False,
+        risk_signals: Sequence[OrganizationRiskSignal] = (),
     ) -> None:
         self.org = organization
         self.orders_count = orders_count
@@ -49,6 +52,7 @@ class OverviewSection(ChecklistMixin):
         self.agent_report = agent_report
         self.agent_reviewed_at = agent_reviewed_at
         self.has_open_appeal_case = has_open_appeal_case
+        self.risk_signals = risk_signals
 
     # ------------------------------------------------------------------
     # Full-width: Organization Review card (primary content)
@@ -214,6 +218,8 @@ class OverviewSection(ChecklistMixin):
                     with tag.p(classes="text-sm text-base-content/60 mb-4"):
                         text("No agent review yet")
 
+                render_risk_signals_block(self.risk_signals)
+
                 yield
                 return
 
@@ -310,6 +316,8 @@ class OverviewSection(ChecklistMixin):
                             with tag.div(classes="space-y-3"):
                                 for dim in low:
                                     self._render_dimension_card(dim)
+
+            render_risk_signals_block(self.risk_signals)
 
             # Appeal information
             if self.org.review and self.org.review.appeal_submitted_at:

--- a/server/polar/backoffice/organizations_v2/views/sections/reviews_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/reviews_section.py
@@ -9,6 +9,7 @@ from tagflow import tag, text
 
 from polar.models import Organization
 from polar.models.organization_agent_review import OrganizationAgentReview
+from polar.models.organization_risk_signal import OrganizationRiskSignal
 from polar.organization_review.schemas import AUP_SECTION_LABELS, ActorType
 
 from ....components import card
@@ -18,6 +19,7 @@ from ._shared import (
     render_dimension,
     render_review_context_badge,
 )
+from .risk_signals import render_risk_signals_card
 
 # Badge classes for decision types
 DECISION_BADGE: dict[str, str] = {
@@ -35,14 +37,18 @@ class ReviewsSection:
         self,
         organization: Organization,
         agent_reviews: Sequence[OrganizationAgentReview],
+        risk_signals: Sequence[OrganizationRiskSignal] = (),
     ) -> None:
         self.org = organization
         self.agent_reviews = agent_reviews
+        self.risk_signals = risk_signals
 
     @contextlib.contextmanager
     def render(self, request: Request) -> Generator[None]:
         """Render the reviews section."""
         with tag.div(classes="space-y-6"):
+            render_risk_signals_card(self.risk_signals)
+
             with card(bordered=True):
                 with tag.div(classes="mb-4"):
                     with tag.h2(classes="text-lg font-bold"):

--- a/server/polar/backoffice/organizations_v2/views/sections/reviews_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/reviews_section.py
@@ -37,7 +37,7 @@ class ReviewsSection:
         self,
         organization: Organization,
         agent_reviews: Sequence[OrganizationAgentReview],
-        risk_signals: Sequence[OrganizationRiskSignal] = (),
+        risk_signals: Sequence[OrganizationRiskSignal],
     ) -> None:
         self.org = organization
         self.agent_reviews = agent_reviews

--- a/server/polar/backoffice/organizations_v2/views/sections/risk_signals.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/risk_signals.py
@@ -5,7 +5,6 @@ from collections.abc import Sequence
 
 from tagflow import tag, text
 
-from polar.integrations.stripe.account_risk import StripeAccountRiskLevel
 from polar.models.organization_risk_signal import OrganizationRiskSignal
 
 from ....components import card
@@ -15,8 +14,14 @@ def _signal_type_label(signal: OrganizationRiskSignal) -> str:
     return signal.type.value.replace("_", " ").title()
 
 
+def _render_signal_list(signals: Sequence[OrganizationRiskSignal]) -> None:
+    with tag.div(classes="space-y-3"):
+        for signal in signals:
+            _render_signal_row(signal)
+
+
 def _render_signal_row(signal: OrganizationRiskSignal) -> None:
-    is_highest = signal.risk_level == StripeAccountRiskLevel.HIGHEST
+    is_highest = signal.risk_level == OrganizationRiskSignal.HIGHEST_RISK_LEVEL
     badge_class = "badge-error" if is_highest else "badge-warning"
     accent = "border-l-error" if is_highest else "border-l-warning"
 
@@ -62,9 +67,7 @@ def render_risk_signals_card(signals: Sequence[OrganizationRiskSignal]) -> None:
                     "high-severity signals are recorded."
                 )
 
-        with tag.div(classes="space-y-3"):
-            for signal in signals:
-                _render_signal_row(signal)
+        _render_signal_list(signals)
 
 
 def render_risk_signals_block(signals: Sequence[OrganizationRiskSignal]) -> None:
@@ -75,9 +78,7 @@ def render_risk_signals_block(signals: Sequence[OrganizationRiskSignal]) -> None
     with tag.div(classes="mb-4"):
         with tag.h3(classes="text-sm font-bold mb-3"):
             text("External Risk Signals")
-        with tag.div(classes="space-y-3"):
-            for signal in signals:
-                _render_signal_row(signal)
+        _render_signal_list(signals)
 
 
 __all__ = [

--- a/server/polar/backoffice/organizations_v2/views/sections/risk_signals.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/risk_signals.py
@@ -5,25 +5,20 @@ from collections.abc import Sequence
 
 from tagflow import tag, text
 
+from polar.integrations.stripe.account_risk import StripeAccountRiskLevel
 from polar.models.organization_risk_signal import OrganizationRiskSignal
 
 from ....components import card
-
-# DaisyUI badge class per risk level. Only 'elevated' and 'highest' are
-# recorded today; anything else falls back to a neutral badge.
-SIGNAL_RISK_BADGE: dict[str, str] = {
-    "elevated": "badge-warning",
-    "highest": "badge-error",
-}
 
 
 def _signal_type_label(signal: OrganizationRiskSignal) -> str:
     return signal.type.value.replace("_", " ").title()
 
 
-def render_risk_signal_row(signal: OrganizationRiskSignal) -> None:
-    badge_class = SIGNAL_RISK_BADGE.get(signal.risk_level, "badge-ghost")
-    accent = "border-l-error" if signal.risk_level == "highest" else "border-l-warning"
+def _render_signal_row(signal: OrganizationRiskSignal) -> None:
+    is_highest = signal.risk_level == StripeAccountRiskLevel.HIGHEST
+    badge_class = "badge-error" if is_highest else "badge-warning"
+    accent = "border-l-error" if is_highest else "border-l-warning"
 
     with tag.div(classes=f"border border-base-200 rounded p-3 border-l-4 {accent}"):
         with tag.div(classes="flex flex-wrap items-center gap-x-2 gap-y-1 mb-1"):
@@ -63,13 +58,13 @@ def render_risk_signals_card(signals: Sequence[OrganizationRiskSignal]) -> None:
                 text("Risk Signals")
             with tag.span(classes="text-sm text-base-content/60"):
                 text(
-                    "Raised by external fraud-detection systems. Only 'elevated' "
-                    "and 'highest' severity signals are recorded."
+                    "Raised by external fraud-detection systems. Only "
+                    "high-severity signals are recorded."
                 )
 
         with tag.div(classes="space-y-3"):
             for signal in signals:
-                render_risk_signal_row(signal)
+                _render_signal_row(signal)
 
 
 def render_risk_signals_block(signals: Sequence[OrganizationRiskSignal]) -> None:
@@ -82,11 +77,10 @@ def render_risk_signals_block(signals: Sequence[OrganizationRiskSignal]) -> None
             text("External Risk Signals")
         with tag.div(classes="space-y-3"):
             for signal in signals:
-                render_risk_signal_row(signal)
+                _render_signal_row(signal)
 
 
 __all__ = [
-    "render_risk_signal_row",
     "render_risk_signals_block",
     "render_risk_signals_card",
 ]

--- a/server/polar/backoffice/organizations_v2/views/sections/risk_signals.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/risk_signals.py
@@ -1,0 +1,92 @@
+"""Rendering helpers for external risk signals (e.g. Stripe Radar)."""
+
+import json
+from collections.abc import Sequence
+
+from tagflow import tag, text
+
+from polar.models.organization_risk_signal import OrganizationRiskSignal
+
+from ....components import card
+
+# DaisyUI badge class per risk level. Only 'elevated' and 'highest' are
+# recorded today; anything else falls back to a neutral badge.
+SIGNAL_RISK_BADGE: dict[str, str] = {
+    "elevated": "badge-warning",
+    "highest": "badge-error",
+}
+
+
+def _signal_type_label(signal: OrganizationRiskSignal) -> str:
+    return signal.type.value.replace("_", " ").title()
+
+
+def render_risk_signal_row(signal: OrganizationRiskSignal) -> None:
+    badge_class = SIGNAL_RISK_BADGE.get(signal.risk_level, "badge-ghost")
+    accent = "border-l-error" if signal.risk_level == "highest" else "border-l-warning"
+
+    with tag.div(classes=f"border border-base-200 rounded p-3 border-l-4 {accent}"):
+        with tag.div(classes="flex flex-wrap items-center gap-x-2 gap-y-1 mb-1"):
+            with tag.span(classes="text-sm font-medium"):
+                text(_signal_type_label(signal))
+            with tag.div(classes="badge badge-sm badge-ghost badge-outline"):
+                text(signal.source.value)
+            with tag.div(classes=f"badge badge-sm {badge_class}"):
+                text(signal.risk_level)
+            with tag.span(classes="text-xs text-base-content/60 ml-auto"):
+                text(signal.created_at.strftime("%Y-%m-%d %H:%M UTC"))
+
+        if signal.description:
+            with tag.p(classes="text-xs text-base-content/70 mt-1"):
+                text(signal.description)
+
+        if signal.payload:
+            with tag.details(classes="mt-2"):
+                with tag.summary(
+                    classes="text-xs text-base-content/60 cursor-pointer hover:text-base-content"
+                ):
+                    text("View raw payload")
+                with tag.pre(
+                    classes="text-xs bg-base-200 p-3 rounded mt-2 overflow-x-auto max-h-64 overflow-y-auto"
+                ):
+                    text(json.dumps(signal.payload, indent=2, default=str))
+
+
+def render_risk_signals_card(signals: Sequence[OrganizationRiskSignal]) -> None:
+    """Full list of risk signals, shown on the Reviews tab."""
+    if not signals:
+        return
+
+    with card(bordered=True):
+        with tag.div(classes="mb-4"):
+            with tag.h2(classes="text-lg font-bold"):
+                text("Risk Signals")
+            with tag.span(classes="text-sm text-base-content/60"):
+                text(
+                    "Raised by external fraud-detection systems. Only 'elevated' "
+                    "and 'highest' severity signals are recorded."
+                )
+
+        with tag.div(classes="space-y-3"):
+            for signal in signals:
+                render_risk_signal_row(signal)
+
+
+def render_risk_signals_block(signals: Sequence[OrganizationRiskSignal]) -> None:
+    """Signal rows with a sub-heading, embedded in the review card."""
+    if not signals:
+        return
+
+    with tag.div(classes="mb-4"):
+        with tag.h3(classes="text-sm font-bold mb-3"):
+            text("External Risk Signals")
+        with tag.div(classes="space-y-3"):
+            for signal in signals:
+                render_risk_signal_row(signal)
+
+
+__all__ = [
+    "render_risk_signal_row",
+    "render_risk_signals_block",
+    "render_risk_signals_card",
+]

--- a/server/polar/models/organization_risk_signal.py
+++ b/server/polar/models/organization_risk_signal.py
@@ -28,6 +28,10 @@ class OrganizationRiskSignal(RecordModel):
         FRAUDULENT_WEBSITE = "fraudulent_website"
         FRAUDULENT_MERCHANT = "fraudulent_merchant"
 
+    # risk_level is a free-form string so future sources can use their own
+    # vocabulary; this is the one value all consumers treat as most severe.
+    HIGHEST_RISK_LEVEL = "highest"
+
     __tablename__ = "organization_risk_signals"
 
     organization_id: Mapped[UUID] = mapped_column(

--- a/server/polar/organization_review/agent.py
+++ b/server/polar/organization_review/agent.py
@@ -350,7 +350,7 @@ async def _collect_prior_feedback(organization_id: UUID) -> PriorFeedbackData:
 async def _collect_risk_signals(organization_id: UUID) -> RiskSignalData:
     async with AsyncReadSessionMaker() as session:
         repo = OrganizationRiskSignalRepository.from_session(session)
-        signals = await repo.list_by_organization(organization_id, limit=100)
+        signals = await repo.list_by_organization(organization_id)
         return collect_risk_signal_data(signals)
 
 

--- a/server/polar/organization_review/agent.py
+++ b/server/polar/organization_review/agent.py
@@ -23,11 +23,15 @@ from .collectors import (
     collect_metrics_data,
     collect_organization_data,
     collect_products_data,
+    collect_risk_signal_data,
     collect_setup_data,
     collect_website_data,
 )
 from .collectors.setup import resolve_url_redirects
-from .repository import OrganizationReviewRepository
+from .repository import (
+    OrganizationReviewRepository,
+    OrganizationRiskSignalRepository,
+)
 from .schemas import (
     AgentReviewResult,
     DataSnapshot,
@@ -38,6 +42,7 @@ from .schemas import (
     PriorFeedbackData,
     ProductsData,
     ReviewContext,
+    RiskSignalData,
     SetupData,
     UsageInfo,
     WebsiteData,
@@ -342,6 +347,13 @@ async def _collect_prior_feedback(organization_id: UUID) -> PriorFeedbackData:
         return collect_feedback_data(records)
 
 
+async def _collect_risk_signals(organization_id: UUID) -> RiskSignalData:
+    async with AsyncReadSessionMaker() as session:
+        repo = OrganizationRiskSignalRepository.from_session(session)
+        signals = await repo.list_by_organization(organization_id)
+        return collect_risk_signal_data(signals)
+
+
 async def _collect_data(
     organization: Organization,
     context: ReviewContext,
@@ -370,6 +382,7 @@ async def _collect_data(
             tuple[PayoutAccountData, IdentityData],
             WebsiteData | None,
             PriorFeedbackData,
+            RiskSignalData,
         ],
         await asyncio.gather(
             _collect_products(organization.id, context),
@@ -379,6 +392,7 @@ async def _collect_data(
             _collect_account_identity(organization, context),
             _collect_website(organization),
             _collect_prior_feedback(organization.id),
+            _collect_risk_signals(organization.id),
         ),
     )
     (
@@ -389,6 +403,7 @@ async def _collect_data(
         (account_data, identity_data),
         website_data,
         prior_feedback_data,
+        risk_signal_data,
     ) = results
 
     return DataSnapshot(
@@ -402,5 +417,6 @@ async def _collect_data(
         setup=setup_data,
         website=website_data,
         prior_feedback=prior_feedback_data,
+        risk_signals=risk_signal_data,
         collected_at=datetime.now(UTC),
     )

--- a/server/polar/organization_review/agent.py
+++ b/server/polar/organization_review/agent.py
@@ -350,7 +350,7 @@ async def _collect_prior_feedback(organization_id: UUID) -> PriorFeedbackData:
 async def _collect_risk_signals(organization_id: UUID) -> RiskSignalData:
     async with AsyncReadSessionMaker() as session:
         repo = OrganizationRiskSignalRepository.from_session(session)
-        signals = await repo.list_by_organization(organization_id)
+        signals = await repo.list_by_organization(organization_id, limit=100)
         return collect_risk_signal_data(signals)
 
 

--- a/server/polar/organization_review/analyzer.py
+++ b/server/polar/organization_review/analyzer.py
@@ -587,10 +587,12 @@ data contradicts it, APPROVE.
 - If the appeal is vague, evasive, or does not address the original concern, \
 DENY.
 - If the appeal asserts something that directly contradicts hard data \
-(prohibited products visible on Polar, Stripe fraud signals), DENY \
-regardless of the appeal text. Do NOT use prior denied or blocked \
-organizations as a signal at the appeal stage — judge this organization \
-on its own merits and the appeal text.
+(prohibited products visible on Polar, Stripe account fraud indicators \
+such as fraudulent verification documents), DENY regardless of the \
+appeal text. Probabilistic entries under "## External Risk Signals" are \
+NOT hard data by themselves — weigh them together with the appeal. Do \
+NOT use prior denied or blocked organizations as a signal at the appeal \
+stage — judge this organization on its own merits and the appeal text.
 - A short or generic appeal ("please approve me", "I disagree") with no \
 specific information is grounds for DENY.
 
@@ -1022,18 +1024,23 @@ class ReviewAnalyzer:
                 "products match what the signal flags, and weigh them into "
                 "POLICY_COMPLIANCE and PRODUCT_LEGITIMACY."
             )
-            for signal in risk_signals.entries[:20]:
-                date_str = (
-                    signal.created_at.strftime("%Y-%m-%d")
-                    if signal.created_at
-                    else "unknown date"
-                )
+            # Highest severity first so the cap never drops the worst signals.
+            entries = sorted(
+                risk_signals.entries,
+                key=lambda e: 0 if e.risk_level == "highest" else 1,
+            )
+            shown = entries[:20]
+            for signal in shown:
+                date_str = signal.created_at.strftime("%Y-%m-%d")
                 parts.append(
                     f"- [{date_str}] {signal.source}: {signal.type} "
                     f"(risk level: {signal.risk_level})"
                 )
                 if signal.description:
-                    parts.append(f"  Details: {signal.description}")
+                    parts.append(f"  Details: {signal.description[:500]}")
+            omitted = len(entries) - len(shown)
+            if omitted > 0:
+                parts.append(f"({omitted} more signal(s) omitted)")
 
         # Prior History
         parts.append("\n## User History")

--- a/server/polar/organization_review/analyzer.py
+++ b/server/polar/organization_review/analyzer.py
@@ -5,6 +5,7 @@ import structlog
 from pydantic_ai import Agent
 
 from polar.config import settings
+from polar.models.organization_risk_signal import OrganizationRiskSignal
 from polar.observability.baggage import organization_baggage
 
 from .known_domains import known_domains_for_prompt, match_known_domain
@@ -1027,7 +1028,11 @@ class ReviewAnalyzer:
             # Highest severity first so the cap never drops the worst signals.
             entries = sorted(
                 risk_signals.entries,
-                key=lambda e: 0 if e.risk_level == "highest" else 1,
+                key=lambda e: (
+                    0
+                    if e.risk_level == OrganizationRiskSignal.HIGHEST_RISK_LEVEL
+                    else 1
+                ),
             )
             shown = entries[:20]
             for signal in shown:

--- a/server/polar/organization_review/analyzer.py
+++ b/server/polar/organization_review/analyzer.py
@@ -1009,6 +1009,32 @@ class ReviewAnalyzer:
                 f"Disputes: {metrics.dispute_count} (${metrics.dispute_amount_cents / 100:,.2f})"
             )
 
+        # External risk signals (e.g. Stripe Radar for Platforms)
+        risk_signals = snapshot.risk_signals
+        if risk_signals.entries:
+            parts.append("\n## External Risk Signals")
+            parts.append(
+                "⚠️ The following risk signals were raised against this organization "
+                "by external fraud-detection systems. Only signals at 'elevated' or "
+                "'highest' severity are recorded, so every entry below is significant. "
+                "They are probabilistic — not proof of fraud on their own — but treat "
+                "them as strong corroborating evidence: verify whether the website and "
+                "products match what the signal flags, and weigh them into "
+                "POLICY_COMPLIANCE and PRODUCT_LEGITIMACY."
+            )
+            for signal in risk_signals.entries[:20]:
+                date_str = (
+                    signal.created_at.strftime("%Y-%m-%d")
+                    if signal.created_at
+                    else "unknown date"
+                )
+                parts.append(
+                    f"- [{date_str}] {signal.source}: {signal.type} "
+                    f"(risk level: {signal.risk_level})"
+                )
+                if signal.description:
+                    parts.append(f"  Details: {signal.description}")
+
         # Prior History
         parts.append("\n## User History")
         if history.user_blocked_at:

--- a/server/polar/organization_review/collectors/__init__.py
+++ b/server/polar/organization_review/collectors/__init__.py
@@ -5,6 +5,7 @@ from .metrics import collect_metrics_data
 from .organization import collect_organization_data
 from .payout_account import collect_payout_account_data
 from .products import collect_products_data
+from .risk_signals import collect_risk_signal_data
 from .setup import collect_setup_data
 from .website import collect_website_data
 
@@ -16,6 +17,7 @@ __all__ = [
     "collect_organization_data",
     "collect_payout_account_data",
     "collect_products_data",
+    "collect_risk_signal_data",
     "collect_setup_data",
     "collect_website_data",
 ]

--- a/server/polar/organization_review/collectors/risk_signals.py
+++ b/server/polar/organization_review/collectors/risk_signals.py
@@ -1,0 +1,20 @@
+from polar.models.organization_risk_signal import OrganizationRiskSignal
+
+from ..schemas import RiskSignalData, RiskSignalEntry
+
+
+def collect_risk_signal_data(
+    signals: list[OrganizationRiskSignal],
+) -> RiskSignalData:
+    return RiskSignalData(
+        entries=[
+            RiskSignalEntry(
+                source=signal.source,
+                type=signal.type,
+                risk_level=signal.risk_level,
+                description=signal.description,
+                created_at=signal.created_at,
+            )
+            for signal in signals
+        ]
+    )

--- a/server/polar/organization_review/repository.py
+++ b/server/polar/organization_review/repository.py
@@ -494,26 +494,14 @@ class OrganizationRiskSignalRepository(
     model = OrganizationRiskSignal
 
     async def list_by_organization(
-        self, organization_id: UUID, *, limit: int | None = None
+        self, organization_id: UUID, *, limit: int = 100
     ) -> list[OrganizationRiskSignal]:
-        """Signals for an organization, most recent first."""
+        """Signals for an organization, most recent first, capped at `limit`."""
         statement = (
             self.get_base_statement()
             .where(OrganizationRiskSignal.organization_id == organization_id)
             .order_by(OrganizationRiskSignal.created_at.desc())
+            .limit(limit)
         )
-        if limit is not None:
-            statement = statement.limit(limit)
         result = await self.session.execute(statement)
         return list(result.scalars().all())
-
-    async def has_any(self, organization_id: UUID) -> bool:
-        """Whether the organization has at least one signal, without loading rows."""
-        statement = (
-            self.get_base_statement()
-            .where(OrganizationRiskSignal.organization_id == organization_id)
-            .with_only_columns(OrganizationRiskSignal.id)
-            .limit(1)
-        )
-        result = await self.session.execute(statement)
-        return result.scalar_one_or_none() is not None

--- a/server/polar/organization_review/repository.py
+++ b/server/polar/organization_review/repository.py
@@ -494,7 +494,7 @@ class OrganizationRiskSignalRepository(
     model = OrganizationRiskSignal
 
     async def list_by_organization(
-        self, organization_id: UUID
+        self, organization_id: UUID, *, limit: int | None = None
     ) -> list[OrganizationRiskSignal]:
         """Signals for an organization, most recent first."""
         statement = (
@@ -502,5 +502,18 @@ class OrganizationRiskSignalRepository(
             .where(OrganizationRiskSignal.organization_id == organization_id)
             .order_by(OrganizationRiskSignal.created_at.desc())
         )
+        if limit is not None:
+            statement = statement.limit(limit)
         result = await self.session.execute(statement)
         return list(result.scalars().all())
+
+    async def has_any(self, organization_id: UUID) -> bool:
+        """Whether the organization has at least one signal, without loading rows."""
+        statement = (
+            self.get_base_statement()
+            .where(OrganizationRiskSignal.organization_id == organization_id)
+            .with_only_columns(OrganizationRiskSignal.id)
+            .limit(1)
+        )
+        result = await self.session.execute(statement)
+        return result.scalar_one_or_none() is not None

--- a/server/polar/organization_review/schemas.py
+++ b/server/polar/organization_review/schemas.py
@@ -485,7 +485,7 @@ class RiskSignalEntry(Schema):
         description="Severity reported by the source, e.g. 'elevated' or 'highest'"
     )
     description: str | None = None
-    created_at: datetime | None = None
+    created_at: datetime
 
 
 class RiskSignalData(Schema):

--- a/server/polar/organization_review/schemas.py
+++ b/server/polar/organization_review/schemas.py
@@ -474,6 +474,26 @@ class PriorFeedbackData(Schema):
     entries: list[PriorFeedbackEntry] = Field(default_factory=list)
 
 
+class RiskSignalEntry(Schema):
+    """A single external risk signal recorded against the organization."""
+
+    source: str = Field(description="Where the signal came from, e.g. 'stripe'")
+    type: str = Field(
+        description="Signal type, e.g. fraudulent_website or fraudulent_merchant"
+    )
+    risk_level: str = Field(
+        description="Severity reported by the source, e.g. 'elevated' or 'highest'"
+    )
+    description: str | None = None
+    created_at: datetime | None = None
+
+
+class RiskSignalData(Schema):
+    """External risk signals recorded against the organization."""
+
+    entries: list[RiskSignalEntry] = Field(default_factory=list)
+
+
 class DataSnapshot(Schema):
     """All collected data for the AI analyzer."""
 
@@ -487,6 +507,7 @@ class DataSnapshot(Schema):
     setup: SetupData = Field(default_factory=SetupData)
     website: WebsiteData | None = None
     prior_feedback: PriorFeedbackData = Field(default_factory=PriorFeedbackData)
+    risk_signals: RiskSignalData = Field(default_factory=RiskSignalData)
     appeal_reason: str | None = None
     original_denial_reason: str | None = None
     collected_at: datetime

--- a/server/tests/backoffice/organizations_v2/test_endpoints.py
+++ b/server/tests/backoffice/organizations_v2/test_endpoints.py
@@ -308,8 +308,8 @@ class TestDetailRiskSignals:
         await save_fixture(signal)
         return signal
 
-    # The exact class list of the tab "needs attention" dot (tab_nav component).
-    TAB_DOT = "ml-2 inline-block w-1.5 h-1.5 rounded-full bg-error"
+    # Semantic marker class of the tab "needs attention" dot (tab_nav component).
+    TAB_DOT = "tab-dot"
 
     async def test_reviews_section_shows_signals(
         self,

--- a/server/tests/backoffice/organizations_v2/test_endpoints.py
+++ b/server/tests/backoffice/organizations_v2/test_endpoints.py
@@ -308,6 +308,9 @@ class TestDetailRiskSignals:
         await save_fixture(signal)
         return signal
 
+    # The exact class list of the tab "needs attention" dot (tab_nav component).
+    TAB_DOT = "ml-2 inline-block w-1.5 h-1.5 rounded-full bg-error"
+
     async def test_reviews_section_shows_signals(
         self,
         backoffice_client: httpx.AsyncClient,
@@ -325,6 +328,23 @@ class TestDetailRiskSignals:
         assert "Fraudulent Website" in response.text
         assert "elevated" in response.text
         assert "Indicators: suspicious_content" in response.text
+        assert self.TAB_DOT in response.text
+
+    async def test_overview_section_shows_signals(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        await self._create_signal(save_fixture, organization)
+
+        response = await backoffice_client.get(
+            f"/organizations/{organization.id}?section=overview"
+        )
+
+        assert response.status_code == 200
+        assert "External Risk Signals" in response.text
+        assert "Fraudulent Website" in response.text
 
     async def test_reviews_section_without_signals(
         self,
@@ -337,3 +357,4 @@ class TestDetailRiskSignals:
 
         assert response.status_code == 200
         assert "Risk Signals" not in response.text
+        assert self.TAB_DOT not in response.text

--- a/server/tests/backoffice/organizations_v2/test_endpoints.py
+++ b/server/tests/backoffice/organizations_v2/test_endpoints.py
@@ -11,6 +11,7 @@ from polar.backoffice.dependencies import get_admin
 from polar.backoffice.organizations_v2.endpoints import _stripe_reject_reason_for_aup
 from polar.models import PayoutAccount
 from polar.models.organization import Organization, OrganizationStatus
+from polar.models.organization_risk_signal import OrganizationRiskSignal
 from polar.models.user import User
 from polar.models.user_session import UserSession
 from polar.organization_review.repository import OrganizationReviewRepository
@@ -289,3 +290,50 @@ class TestDeletePayoutAccount:
 
         assert response.status_code == 200
         assert "Delete Payout Account" in response.text
+
+
+@pytest.mark.asyncio
+class TestDetailRiskSignals:
+    async def _create_signal(
+        self, save_fixture: SaveFixture, organization: Organization
+    ) -> OrganizationRiskSignal:
+        signal = OrganizationRiskSignal(
+            organization=organization,
+            source=OrganizationRiskSignal.Source.STRIPE,
+            type=OrganizationRiskSignal.Type.FRAUDULENT_WEBSITE,
+            risk_level="elevated",
+            description="Indicators: suspicious_content",
+            payload={"risk_level": "elevated"},
+        )
+        await save_fixture(signal)
+        return signal
+
+    async def test_reviews_section_shows_signals(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        await self._create_signal(save_fixture, organization)
+
+        response = await backoffice_client.get(
+            f"/organizations/{organization.id}?section=reviews"
+        )
+
+        assert response.status_code == 200
+        assert "Risk Signals" in response.text
+        assert "Fraudulent Website" in response.text
+        assert "elevated" in response.text
+        assert "Indicators: suspicious_content" in response.text
+
+    async def test_reviews_section_without_signals(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        organization: Organization,
+    ) -> None:
+        response = await backoffice_client.get(
+            f"/organizations/{organization.id}?section=reviews"
+        )
+
+        assert response.status_code == 200
+        assert "Risk Signals" not in response.text

--- a/server/tests/organization_review/collectors/test_risk_signals.py
+++ b/server/tests/organization_review/collectors/test_risk_signals.py
@@ -1,0 +1,41 @@
+from datetime import UTC, datetime
+
+from polar.models.organization_risk_signal import OrganizationRiskSignal
+from polar.organization_review.collectors import collect_risk_signal_data
+
+
+def _make_signal(
+    *,
+    risk_level: str = "elevated",
+    description: str | None = "Indicators: suspicious_content. Probability: 87%",
+) -> OrganizationRiskSignal:
+    signal = OrganizationRiskSignal(
+        source=OrganizationRiskSignal.Source.STRIPE,
+        type=OrganizationRiskSignal.Type.FRAUDULENT_WEBSITE,
+        risk_level=risk_level,
+        description=description,
+        payload={"risk_level": risk_level},
+    )
+    signal.created_at = datetime(2026, 7, 1, tzinfo=UTC)
+    return signal
+
+
+class TestCollectRiskSignalData:
+    def test_empty(self) -> None:
+        data = collect_risk_signal_data([])
+        assert data.entries == []
+
+    def test_maps_fields(self) -> None:
+        data = collect_risk_signal_data([_make_signal()])
+
+        assert len(data.entries) == 1
+        entry = data.entries[0]
+        assert entry.source == "stripe"
+        assert entry.type == "fraudulent_website"
+        assert entry.risk_level == "elevated"
+        assert entry.description == ("Indicators: suspicious_content. Probability: 87%")
+        assert entry.created_at == datetime(2026, 7, 1, tzinfo=UTC)
+
+    def test_no_description(self) -> None:
+        data = collect_risk_signal_data([_make_signal(description=None)])
+        assert data.entries[0].description is None

--- a/server/tests/organization_review/test_analyzer.py
+++ b/server/tests/organization_review/test_analyzer.py
@@ -22,6 +22,8 @@ from polar.organization_review.schemas import (
     PayoutAccountData,
     ProductsData,
     ReviewContext,
+    RiskSignalData,
+    RiskSignalEntry,
     WebsiteData,
     WebsitePage,
 )
@@ -152,6 +154,46 @@ def _stub_analyzer_io(
         "run",
         new=AsyncMock(side_effect=run_side_effect),
     )
+
+
+class TestBuildPromptRiskSignals:
+    def test_no_section_without_signals(self, review_analyzer: ReviewAnalyzer) -> None:
+        prompt = review_analyzer._build_prompt(_minimal_snapshot())
+        assert "## External Risk Signals" not in prompt
+
+    def test_renders_signals(self, review_analyzer: ReviewAnalyzer) -> None:
+        snapshot = _minimal_snapshot().model_copy(
+            update={
+                "risk_signals": RiskSignalData(
+                    entries=[
+                        RiskSignalEntry(
+                            source="stripe",
+                            type="fraudulent_website",
+                            risk_level="elevated",
+                            description="Indicators: suspicious_content",
+                            created_at=datetime(2026, 7, 1, tzinfo=UTC),
+                        ),
+                        RiskSignalEntry(
+                            source="stripe",
+                            type="fraudulent_merchant",
+                            risk_level="highest",
+                        ),
+                    ]
+                )
+            }
+        )
+
+        prompt = review_analyzer._build_prompt(snapshot)
+
+        assert "## External Risk Signals" in prompt
+        assert (
+            "- [2026-07-01] stripe: fraudulent_website (risk level: elevated)" in prompt
+        )
+        assert "  Details: Indicators: suspicious_content" in prompt
+        assert (
+            "- [unknown date] stripe: fraudulent_merchant (risk level: highest)"
+            in prompt
+        )
 
 
 @pytest.mark.asyncio

--- a/server/tests/organization_review/test_analyzer.py
+++ b/server/tests/organization_review/test_analyzer.py
@@ -177,6 +177,7 @@ class TestBuildPromptRiskSignals:
                             source="stripe",
                             type="fraudulent_merchant",
                             risk_level="highest",
+                            created_at=datetime(2026, 6, 15, tzinfo=UTC),
                         ),
                     ]
                 )
@@ -191,9 +192,43 @@ class TestBuildPromptRiskSignals:
         )
         assert "  Details: Indicators: suspicious_content" in prompt
         assert (
-            "- [unknown date] stripe: fraudulent_merchant (risk level: highest)"
-            in prompt
+            "- [2026-06-15] stripe: fraudulent_merchant (risk level: highest)" in prompt
         )
+        # Highest severity sorts first so a cap never drops the worst signals.
+        assert prompt.index("fraudulent_merchant") < prompt.index(
+            "fraudulent_website (risk level: elevated)"
+        )
+        assert "omitted" not in prompt
+
+    def test_caps_signals_and_notes_omission(
+        self, review_analyzer: ReviewAnalyzer
+    ) -> None:
+        entries = [
+            RiskSignalEntry(
+                source="stripe",
+                type="fraudulent_website",
+                risk_level="elevated",
+                created_at=datetime(2026, 7, 1, tzinfo=UTC),
+            )
+            for _ in range(24)
+        ]
+        entries.append(
+            RiskSignalEntry(
+                source="stripe",
+                type="fraudulent_merchant",
+                risk_level="highest",
+                created_at=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+        )
+        snapshot = _minimal_snapshot().model_copy(
+            update={"risk_signals": RiskSignalData(entries=entries)}
+        )
+
+        prompt = review_analyzer._build_prompt(snapshot)
+
+        # The old 'highest' signal survives the cap because severity sorts first.
+        assert "fraudulent_merchant (risk level: highest)" in prompt
+        assert "(5 more signal(s) omitted)" in prompt
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Risk signals recorded from Stripe Radar are now visible to reviewers and to the AI review agent. Before this, signals were stored but nothing showed them.

<img width="1200" height="897" alt="image" src="https://github.com/user-attachments/assets/fb5b705c-6383-479c-88bf-c7ff58bc0129" />


## What

- Backoffice org detail:
  - The Overview review card shows an "External Risk Signals" block under the dimension breakdown.
  - The Reviews tab shows a card with each signal: type, source, severity badge, description, and the raw payload (collapsed).
  - The Reviews tab shows a red dot when the org has signals.
- Review agent:
  - A new collector adds signals to the data snapshot.
  - The prompt gets an "External Risk Signals" section. Highest severity comes first, capped at 20 entries with an omission note.
  - The appeal prompt now says these signals are probabilistic, so they do not force an automatic deny on their own.

## Why

Signals should pull the reviewer's eye to the risk right where decisions happen, and the agent should weigh the same evidence a human sees.

## How

- New `risk_signals` collector feeding `DataSnapshot`, rendered by the analyzer prompt.
- Shared tagflow helpers render the signal rows in both backoffice spots.
- One bounded repository query (newest first, limit 100) serves the page and the tab dot.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

