### PR TITLE
fix(subscription): surface wallet-adjusted due_amount in charge/change preview

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -31912,9 +31912,19 @@ export interface components {
       tax_amount: number
       /**
        * Total Amount
-       * @description Total amount in cents (final charge amount)
+       * @description Total amount in cents (net + tax, before applying wallet balance)
        */
       total_amount: number
+      /**
+       * Applied Balance Amount
+       * @description Wallet balance applied to this charge in cents: negative when the customer's account credit reduces the amount due, positive when the charge clears outstanding debt, zero otherwise.
+       */
+      applied_balance_amount: number
+      /**
+       * Due Amount
+       * @description Amount actually due in cents: total_amount plus the applied wallet balance, floored at zero. This is the figure charged today.
+       */
+      due_amount: number
     }
     /**
      * SubscriptionChargePreviewProration

--- a/server/polar/order/amounts.py
+++ b/server/polar/order/amounts.py
@@ -182,3 +182,12 @@ async def compute_order_amounts(
         tax_calculation_processor_id=tax_calculation_processor_id,
         tax_breakdown=tax_breakdown,
     )
+
+
+def apply_wallet_balance(total_amount: int, customer_balance: int) -> int:
+    """Signed balance applied to ``total_amount``: charges consume credit, credits clear debt."""
+    if total_amount >= 0:
+        return -min(total_amount, customer_balance)
+    if customer_balance < 0:
+        return min(-total_amount, -customer_balance)
+    return 0

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1317,20 +1317,23 @@ class OrderService:
                 payment_mode=payment_mode,
             )
 
-    async def _create_order(
+    async def build_subscription_order(
         self,
         session: AsyncSession,
         subscription: Subscription,
         items: Sequence[OrderItem],
         billing_reason: OrderBillingReasonInternal,
         *,
-        payment_mode: PaymentMode = PaymentMode.background,
+        lock_balance: bool,
     ) -> Order:
         """
-        Finalize a subscription order from already-built line items: compute the
-        discount, tax, balance and totals, persist the order, optionally reset
-        meters, and settle or trigger payment. Callers are responsible for
-        building ``items`` (from pending billing entries, carried overage, …).
+        Build an in-memory subscription order from ``items``: compute discount,
+        tax and totals, and apply the customer's wallet balance. Allocates no
+        invoice number, persists nothing, and triggers no side effects — the
+        cycle persists and dispatches it, the preview reads its fields.
+
+        ``lock_balance`` takes a ``FOR UPDATE`` lock on the wallet balance; the
+        persist path must, a preview must not.
         """
         order_id = uuid.uuid4()
         customer = subscription.customer
@@ -1343,60 +1346,75 @@ class OrderService:
         )
         total_amount = amounts.total_amount
 
-        invoice_number = await organization_service.get_next_invoice_number(
+        customer_balance = await wallet_service.get_billing_wallet_balance(
+            session, customer, subscription.currency, for_update=lock_balance
+        )
+
+        if total_amount >= 0:
+            # Charge: consume the available balance
+            applied_balance_amount = -min(total_amount, customer_balance)
+        elif customer_balance < 0:
+            # Credit: clear as much of the outstanding debt as it covers
+            applied_balance_amount = min(-total_amount, -customer_balance)
+        else:
+            applied_balance_amount = 0
+
+        return Order(
+            id=order_id,
+            status=OrderStatus.pending,
+            subtotal_amount=amounts.subtotal_amount,
+            discount_amount=amounts.discount_amount,
+            tax_amount=amounts.tax_amount,
+            net_amount=amounts.net_amount,
+            applied_balance_amount=applied_balance_amount,
+            currency=subscription.currency,
+            billing_reason=billing_reason,
+            billing_name=customer.billing_name,
+            billing_address=customer.billing_address,
+            tax_behavior=amounts.tax_behavior,
+            tax_id=customer.tax_id,
+            tax_breakdown=amounts.tax_breakdown or None,
+            tax_processor=amounts.tax_processor,
+            tax_calculation_processor_id=amounts.tax_calculation_processor_id,
+            organization=subscription.organization,
+            customer=customer,
+            product=subscription.product,
+            discount=subscription.discount,
+            subscription=subscription,
+            checkout=None,
+            items=items,
+            user_metadata=subscription.user_metadata,
+            custom_field_data=subscription.custom_field_data,
+        )
+
+    async def _create_order(
+        self,
+        session: AsyncSession,
+        subscription: Subscription,
+        items: Sequence[OrderItem],
+        billing_reason: OrderBillingReasonInternal,
+        *,
+        payment_mode: PaymentMode = PaymentMode.background,
+    ) -> Order:
+        """Build, persist and dispatch a subscription order from ``items``: invoice
+        number, balance impact, optional meter reset, then payment."""
+        customer = subscription.customer
+
+        order = await self.build_subscription_order(
+            session, subscription, items, billing_reason, lock_balance=True
+        )
+        balance_change = (
+            order.applied_balance_amount
+            if order.total_amount >= 0
+            else -order.total_amount
+        )
+
+        order.invoice_number = await organization_service.get_next_invoice_number(
             session, subscription.organization, customer
         )
 
-        customer_balance = await wallet_service.get_billing_wallet_balance(
-            session, customer, subscription.currency, for_update=True
-        )
-
-        # Calculate balance change and applied amount
-        if total_amount >= 0:
-            # Order is a charge: use customer balance if available
-            balance_change = -min(total_amount, customer_balance)
-            applied_balance_amount = balance_change
-        else:
-            # Order is a credit: always add to balance
-            balance_change = -total_amount
-            # Track how much existing debt was cleared
-            if customer_balance < 0:
-                applied_balance_amount = min(-total_amount, -customer_balance)
-            else:
-                applied_balance_amount = 0
-
         repository = OrderRepository.from_session(session)
-        order = await repository.create(
-            Order(
-                id=order_id,
-                status=OrderStatus.pending,
-                subtotal_amount=amounts.subtotal_amount,
-                discount_amount=amounts.discount_amount,
-                tax_amount=amounts.tax_amount,
-                net_amount=amounts.net_amount,
-                applied_balance_amount=applied_balance_amount,
-                currency=subscription.currency,
-                billing_reason=billing_reason,
-                billing_name=customer.billing_name,
-                billing_address=customer.billing_address,
-                tax_behavior=amounts.tax_behavior,
-                tax_id=customer.tax_id,
-                tax_breakdown=amounts.tax_breakdown or None,
-                tax_processor=amounts.tax_processor,
-                tax_calculation_processor_id=amounts.tax_calculation_processor_id,
-                invoice_number=invoice_number,
-                organization=subscription.organization,
-                customer=customer,
-                product=subscription.product,
-                discount=subscription.discount,
-                subscription=subscription,
-                checkout=None,
-                items=items,
-                user_metadata=subscription.user_metadata,
-                custom_field_data=subscription.custom_field_data,
-            ),
-            flush=True,
-        )
+        order = await repository.create(order, flush=True)
 
         subscription.update_net_amount_from(order)
 

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -127,7 +127,7 @@ from polar.wallet.service import wallet as wallet_service
 from polar.webhook.service import webhook as webhook_service
 from polar.worker import enqueue_job, make_bulk_job_delay_calculator
 
-from .amounts import calculate_tax, compute_order_amounts
+from .amounts import apply_wallet_balance, calculate_tax, compute_order_amounts
 from .repository import OrderRepository
 from .schemas import OrderCreate, OrderInvoice, OrderReceipt, OrderUpdate
 from .sorting import OrderSortProperty
@@ -1349,15 +1349,7 @@ class OrderService:
         customer_balance = await wallet_service.get_billing_wallet_balance(
             session, customer, subscription.currency, for_update=lock_balance
         )
-
-        if total_amount >= 0:
-            # Charge: consume the available balance
-            applied_balance_amount = -min(total_amount, customer_balance)
-        elif customer_balance < 0:
-            # Credit: clear as much of the outstanding debt as it covers
-            applied_balance_amount = min(-total_amount, -customer_balance)
-        else:
-            applied_balance_amount = 0
+        applied_balance_amount = apply_wallet_balance(total_amount, customer_balance)
 
         return Order(
             id=order_id,

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -66,6 +66,7 @@ from polar.logging import Logger
 from polar.models import (
     Checkout,
     Customer,
+    Discount,
     Order,
     OrderItem,
     Organization,
@@ -1325,24 +1326,20 @@ class OrderService:
         billing_reason: OrderBillingReasonInternal,
         *,
         lock_balance: bool,
+        discount: Discount | None,
+        reference: str | None = None,
     ) -> Order:
-        """
-        Build an in-memory subscription order from ``items``: compute discount,
-        tax and totals, and apply the customer's wallet balance. Allocates no
-        invoice number, persists nothing, and triggers no side effects — the
-        cycle persists and dispatches it, the preview reads its fields.
-
-        ``lock_balance`` takes a ``FOR UPDATE`` lock on the wallet balance; the
-        persist path must, a preview must not.
-        """
+        """Build the subscription order for ``items`` without persisting: no invoice
+        number, no side effects. ``lock_balance`` locks the wallet balance (the
+        persist path must; a preview must not); ``reference`` keys the tax calc."""
         order_id = uuid.uuid4()
         customer = subscription.customer
 
         amounts = await compute_order_amounts(
             subscription,
             items,
-            reference=str(order_id),
-            discount=subscription.discount,
+            reference=reference or str(order_id),
+            discount=discount,
         )
         total_amount = amounts.total_amount
 
@@ -1371,7 +1368,7 @@ class OrderService:
             organization=subscription.organization,
             customer=customer,
             product=subscription.product,
-            discount=subscription.discount,
+            discount=discount,
             subscription=subscription,
             checkout=None,
             items=items,
@@ -1393,7 +1390,12 @@ class OrderService:
         customer = subscription.customer
 
         order = await self.build_subscription_order(
-            session, subscription, items, billing_reason, lock_balance=True
+            session,
+            subscription,
+            items,
+            billing_reason,
+            lock_balance=True,
+            discount=subscription.discount,
         )
         balance_change = (
             order.applied_balance_amount

--- a/server/polar/subscription/schemas.py
+++ b/server/polar/subscription/schemas.py
@@ -540,7 +540,22 @@ class SubscriptionChargePreview(Schema):
     discount_amount: int = Field(description="Discount amount in cents")
     net_amount: int = Field(description="Net amount in cents before taxes")
     tax_amount: int = Field(description="Tax amount in cents")
-    total_amount: int = Field(description="Total amount in cents (final charge amount)")
+    total_amount: int = Field(
+        description="Total amount in cents (net + tax, before applying wallet balance)"
+    )
+    applied_balance_amount: int = Field(
+        description=(
+            "Wallet balance applied to this charge in cents: negative when the "
+            "customer's account credit reduces the amount due, positive when the "
+            "charge clears outstanding debt, zero otherwise."
+        )
+    )
+    due_amount: int = Field(
+        description=(
+            "Amount actually due in cents: total_amount plus the applied wallet "
+            "balance, floored at zero. This is the figure charged today."
+        )
+    )
 
 
 class SubscriptionCancelPreview(Schema):

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -92,7 +92,6 @@ from polar.notifications.notification import (
 )
 from polar.notifications.service import PartialNotification
 from polar.notifications.service import notifications as notifications_service
-from polar.order.amounts import apply_wallet_balance, compute_order_amounts
 from polar.order.repository import OrderRepository
 from polar.organization.repository import (
     SUBSCRIPTION_CANCELLATION_STATUSES,
@@ -107,7 +106,6 @@ from polar.product.guard import (
 from polar.product.price_set import NoPricesForCurrencies, PriceSet
 from polar.product.repository import ProductRepository
 from polar.product.service import product as product_service
-from polar.wallet.service import wallet as wallet_service
 from polar.webhook.service import webhook as webhook_service
 from polar.worker import enqueue_job, make_bulk_job_delay_calculator
 
@@ -2273,31 +2271,12 @@ class SubscriptionService:
 
         # Pending mid-period prorations (seat/product changes) already exist as
         # billing entries; surface them so the preview matches the next invoice.
-        prorations: list[SubscriptionChargePreviewProration] = []
-        proration_amount = 0
-        async for (
-            line_item,
-            _,
-        ) in billing_entry_service.compute_pending_subscription_line_items(
-            session, subscription
-        ):
-            if not line_item.proration:
-                continue
-            prorations.append(
-                SubscriptionChargePreviewProration(
-                    label=line_item.label, amount=line_item.amount
-                )
-            )
-            proration_amount += line_item.amount
-            items.append(
-                OrderItem(
-                    label=line_item.label,
-                    amount=line_item.amount,
-                    net_amount=line_item.amount,
-                    tax_amount=0,
-                    proration=True,
-                )
-            )
+        (
+            prorations,
+            proration_items,
+            proration_amount,
+        ) = await self._collect_pending_prorations(session, subscription)
+        items.extend(proration_items)
 
         applicable_discount = None
         # Ensure the discount has not expired yet for the next charge (so at current_period_end)
@@ -2313,28 +2292,16 @@ class SubscriptionService:
             ):
                 applicable_discount = subscription.discount
 
-        amounts = await compute_order_amounts(
+        return await self._build_preview(
+            session,
             subscription,
             items,
-            reference=str(subscription.id),
+            billing_reason=OrderBillingReasonInternal.subscription_cycle,
             discount=applicable_discount,
-        )
-        applied_balance_amount, due_amount = await self._preview_due_amount(
-            session, subscription, amounts.total_amount
-        )
-
-        return SubscriptionChargePreview(
             base_amount=base_price,
             metered_amount=metered_amount,
-            proration_amount=proration_amount,
             prorations=prorations,
-            subtotal_amount=amounts.subtotal_amount,
-            discount_amount=amounts.discount_amount,
-            net_amount=amounts.net_amount,
-            tax_amount=amounts.tax_amount,
-            total_amount=amounts.total_amount,
-            applied_balance_amount=applied_balance_amount,
-            due_amount=due_amount,
+            proration_amount=proration_amount,
         )
 
     async def calculate_cancel_preview(
@@ -2451,7 +2418,7 @@ class SubscriptionService:
                 and self._resolve_trial_end(subscription, product) is None
             ):
                 subscription_update.apply_update()
-                return await self._preview_amounts(
+                return await self._build_preview(
                     session,
                     subscription,
                     [
@@ -2465,11 +2432,23 @@ class SubscriptionService:
                         for spp in subscription.subscription_product_prices
                         if is_static_price(spp.product_price)
                     ],
+                    billing_reason=OrderBillingReasonInternal.subscription_update,
+                    discount=subscription.discount,
+                    base_amount=0,
+                    metered_amount=0,
                     prorations=[],
                     proration_amount=0,
                 )
-            return await self._preview_amounts(
-                session, subscription, [], prorations=[], proration_amount=0
+            return await self._build_preview(
+                session,
+                subscription,
+                [],
+                billing_reason=OrderBillingReasonInternal.subscription_update,
+                discount=subscription.discount,
+                base_amount=0,
+                metered_amount=0,
+                prorations=[],
+                proration_amount=0,
             )
 
         if applies_now:
@@ -2479,37 +2458,18 @@ class SubscriptionService:
                 session.add(entry)
             await session.flush()
 
-        prorations: list[SubscriptionChargePreviewProration] = []
-        proration_amount = 0
-        items: list[OrderItem] = []
-        async for (
-            line_item,
-            _,
-        ) in billing_entry_service.compute_pending_subscription_line_items(
+        prorations, items, proration_amount = await self._collect_pending_prorations(
             session, subscription
-        ):
-            if not line_item.proration:
-                continue
-            prorations.append(
-                SubscriptionChargePreviewProration(
-                    label=line_item.label, amount=line_item.amount
-                )
-            )
-            proration_amount += line_item.amount
-            items.append(
-                OrderItem(
-                    label=line_item.label,
-                    amount=line_item.amount,
-                    net_amount=line_item.amount,
-                    tax_amount=0,
-                    proration=True,
-                )
-            )
+        )
 
-        return await self._preview_amounts(
+        return await self._build_preview(
             session,
             subscription,
             items,
+            billing_reason=OrderBillingReasonInternal.subscription_update,
+            discount=subscription.discount,
+            base_amount=0,
+            metered_amount=0,
             prorations=prorations,
             proration_amount=proration_amount,
         )
@@ -2562,51 +2522,78 @@ class SubscriptionService:
         )
         return None if candidate_trial_end <= utc_now() else candidate_trial_end
 
-    async def _preview_due_amount(
-        self, session: AsyncSession, subscription: Subscription, total_amount: int
-    ) -> tuple[int, int]:
-        """Wallet balance applied to a preview total and the resulting amount due.
+    async def _collect_pending_prorations(
+        self, session: AsyncSession, subscription: Subscription
+    ) -> tuple[Sequence[SubscriptionChargePreviewProration], Sequence[OrderItem], int]:
+        """Pending proration billing entries as display rows, order items and net."""
+        prorations: list[SubscriptionChargePreviewProration] = []
+        items: list[OrderItem] = []
+        proration_amount = 0
+        async for (
+            line_item,
+            _,
+        ) in billing_entry_service.compute_pending_subscription_line_items(
+            session, subscription
+        ):
+            if not line_item.proration:
+                continue
+            prorations.append(
+                SubscriptionChargePreviewProration(
+                    label=line_item.label, amount=line_item.amount
+                )
+            )
+            items.append(
+                OrderItem(
+                    label=line_item.label,
+                    amount=line_item.amount,
+                    net_amount=line_item.amount,
+                    tax_amount=0,
+                    proration=True,
+                )
+            )
+            proration_amount += line_item.amount
+        return prorations, items, proration_amount
 
-        Reads the balance without locking (``for_update=False``): a preview must
-        not block a concurrent charge for the same customer.
-        """
-        customer_balance = await wallet_service.get_billing_wallet_balance(
-            session, subscription.customer, subscription.currency, for_update=False
-        )
-        applied_balance_amount = apply_wallet_balance(total_amount, customer_balance)
-        return applied_balance_amount, max(0, total_amount + applied_balance_amount)
-
-    async def _preview_amounts(
+    async def _build_preview(
         self,
         session: AsyncSession,
         subscription: Subscription,
         items: Sequence[OrderItem],
         *,
+        billing_reason: OrderBillingReasonInternal,
+        discount: Discount | None,
+        base_amount: int,
+        metered_amount: int,
         prorations: Sequence[SubscriptionChargePreviewProration],
         proration_amount: int,
     ) -> SubscriptionChargePreview:
-        amounts = await compute_order_amounts(
+        """Price ``items`` through the cycle's builder and read the resulting order.
+        Non-locking and keyed on the subscription: a preview must not lock the
+        balance, and repeated identical previews reuse the tax calculation."""
+        from polar.order.service import order as order_service
+
+        order = await order_service.build_subscription_order(
+            session,
             subscription,
             items,
+            billing_reason,
+            lock_balance=False,
+            discount=discount,
             reference=str(subscription.id),
-            discount=subscription.discount,
-        )
-        applied_balance_amount, due_amount = await self._preview_due_amount(
-            session, subscription, amounts.total_amount
         )
 
         return SubscriptionChargePreview(
-            base_amount=0,
-            metered_amount=0,
+            base_amount=base_amount,
+            metered_amount=metered_amount,
             proration_amount=proration_amount,
             prorations=list(prorations),
-            subtotal_amount=amounts.subtotal_amount,
-            discount_amount=amounts.discount_amount,
-            net_amount=amounts.net_amount,
-            tax_amount=amounts.tax_amount,
-            total_amount=amounts.total_amount,
-            applied_balance_amount=applied_balance_amount,
-            due_amount=due_amount,
+            subtotal_amount=order.subtotal_amount,
+            discount_amount=order.discount_amount,
+            net_amount=order.net_amount,
+            tax_amount=order.tax_amount,
+            total_amount=order.total_amount,
+            applied_balance_amount=order.applied_balance_amount,
+            due_amount=order.due_amount,
         )
 
     async def _after_subscription_updated(

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -92,7 +92,7 @@ from polar.notifications.notification import (
 )
 from polar.notifications.service import PartialNotification
 from polar.notifications.service import notifications as notifications_service
-from polar.order.amounts import compute_order_amounts
+from polar.order.amounts import apply_wallet_balance, compute_order_amounts
 from polar.order.repository import OrderRepository
 from polar.organization.repository import (
     SUBSCRIPTION_CANCELLATION_STATUSES,
@@ -107,6 +107,7 @@ from polar.product.guard import (
 from polar.product.price_set import NoPricesForCurrencies, PriceSet
 from polar.product.repository import ProductRepository
 from polar.product.service import product as product_service
+from polar.wallet.service import wallet as wallet_service
 from polar.webhook.service import webhook as webhook_service
 from polar.worker import enqueue_job, make_bulk_job_delay_calculator
 
@@ -2318,6 +2319,9 @@ class SubscriptionService:
             reference=str(subscription.id),
             discount=applicable_discount,
         )
+        applied_balance_amount, due_amount = await self._preview_due_amount(
+            session, subscription, amounts.total_amount
+        )
 
         return SubscriptionChargePreview(
             base_amount=base_price,
@@ -2329,6 +2333,8 @@ class SubscriptionService:
             net_amount=amounts.net_amount,
             tax_amount=amounts.tax_amount,
             total_amount=amounts.total_amount,
+            applied_balance_amount=applied_balance_amount,
+            due_amount=due_amount,
         )
 
     async def calculate_cancel_preview(
@@ -2446,6 +2452,7 @@ class SubscriptionService:
             ):
                 subscription_update.apply_update()
                 return await self._preview_amounts(
+                    session,
                     subscription,
                     [
                         OrderItem(
@@ -2462,7 +2469,7 @@ class SubscriptionService:
                     proration_amount=0,
                 )
             return await self._preview_amounts(
-                subscription, [], prorations=[], proration_amount=0
+                session, subscription, [], prorations=[], proration_amount=0
             )
 
         if applies_now:
@@ -2500,6 +2507,7 @@ class SubscriptionService:
             )
 
         return await self._preview_amounts(
+            session,
             subscription,
             items,
             prorations=prorations,
@@ -2554,8 +2562,23 @@ class SubscriptionService:
         )
         return None if candidate_trial_end <= utc_now() else candidate_trial_end
 
+    async def _preview_due_amount(
+        self, session: AsyncSession, subscription: Subscription, total_amount: int
+    ) -> tuple[int, int]:
+        """Wallet balance applied to a preview total and the resulting amount due.
+
+        Reads the balance without locking (``for_update=False``): a preview must
+        not block a concurrent charge for the same customer.
+        """
+        customer_balance = await wallet_service.get_billing_wallet_balance(
+            session, subscription.customer, subscription.currency, for_update=False
+        )
+        applied_balance_amount = apply_wallet_balance(total_amount, customer_balance)
+        return applied_balance_amount, max(0, total_amount + applied_balance_amount)
+
     async def _preview_amounts(
         self,
+        session: AsyncSession,
         subscription: Subscription,
         items: Sequence[OrderItem],
         *,
@@ -2568,6 +2591,9 @@ class SubscriptionService:
             reference=str(subscription.id),
             discount=subscription.discount,
         )
+        applied_balance_amount, due_amount = await self._preview_due_amount(
+            session, subscription, amounts.total_amount
+        )
 
         return SubscriptionChargePreview(
             base_amount=0,
@@ -2579,6 +2605,8 @@ class SubscriptionService:
             net_amount=amounts.net_amount,
             tax_amount=amounts.tax_amount,
             total_amount=amounts.total_amount,
+            applied_balance_amount=applied_balance_amount,
+            due_amount=due_amount,
         )
 
     async def _after_subscription_updated(

--- a/server/tests/subscription/test_service_charge_preview.py
+++ b/server/tests/subscription/test_service_charge_preview.py
@@ -38,6 +38,7 @@ from tests.fixtures.random_objects import (
     create_discount,
     create_meter,
     create_product,
+    create_wallet_billing,
 )
 
 
@@ -99,6 +100,32 @@ class TestCalculateChargePreview:
         assert preview.net_amount == 1000
         assert preview.tax_amount == 0
         assert preview.total_amount == 1000
+
+    async def test_wallet_credit_reduces_due_amount(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        await create_wallet_billing(
+            save_fixture, customer=customer, initial_balance=300
+        )
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+
+        preview = await subscription_service.calculate_charge_preview(
+            session, subscription
+        )
+
+        assert preview.total_amount == 1000
+        assert preview.applied_balance_amount == -300
+        assert preview.due_amount == 700
+        assert preview.due_amount == max(
+            0, preview.total_amount + preview.applied_balance_amount
+        )
+        assert preview.due_amount != preview.total_amount
 
     async def test_cancel_at_period_end_zeroes_base(
         self,


### PR DESCRIPTION
## Summary
The preview returned total_amount, but customers are charged due_amount = max(0, total_amount + applied_balance_amount) — total minus their wallet credit — so credit holders were quoted more than we charge.

Extract a shared build_subscription_order (ℹ : **the cycle persists it, the preview reads it**) and route both previews through it, exposing due_amount and applied_balance_amount on SubscriptionChargePreview (additive, non-breaking).

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes subscription charge/change previews to reflect wallet balance so customers see the correct amount due. Adds a shared order builder so previews and actual charges compute discounts, tax, and wallet balance the same way.

- **Bug Fixes**
  - Previews now show wallet-adjusted amounts: `applied_balance_amount` and `due_amount = max(0, total_amount + applied_balance_amount)`.
  - `total_amount` stays net + tax before wallet balance; use `due_amount` as the amount charged today.
  - API and `v1` client types expose the new fields; tests ensure wallet credit reduces `due_amount`.

- **Refactors**
  - Introduced `build_subscription_order` to price items without persisting; `_create_order` now persists and dispatches.
  - Extracted `apply_wallet_balance(total_amount, customer_balance)` so orders and previews share the same rule.
  - Previews price through the builder via `_build_preview`, and pending prorations are gathered by `_collect_pending_prorations`, removing duplication.

<sup>Written for commit ee7d31c3ad3091ed60910af680ba2246c9b690cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

