### PR TITLE
fix: sync organization website to Stripe before website risk evaluation

### DIFF
--- a/server/polar/integrations/stripe/service.py
+++ b/server/polar/integrations/stripe/service.py
@@ -116,6 +116,10 @@ class StripeService:
             obj["business_profile"] = {"name": name}
         await stripe_lib.Account.modify_async(id, **obj)
 
+    async def update_account_website(self, id: str, url: str) -> None:
+        log.info("stripe.account.update_website", account_id=id, url=url)
+        await stripe_lib.Account.modify_async(id, business_profile={"url": url})
+
     async def account_exists(self, id: str) -> bool:
         try:
             account = await stripe_lib.Account.retrieve_async(id)

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -7,6 +7,7 @@ from urllib.parse import urlparse
 from uuid import UUID
 
 import email_validator
+import stripe as stripe_lib
 import structlog
 from pydantic import BaseModel, Field, TypeAdapter
 from pydantic import ValidationError as PydanticValidationError
@@ -31,6 +32,7 @@ from polar.integrations.stripe.account_risk import (
     AccountRiskSignal,
 )
 from polar.integrations.stripe.service import StripeAccountRejectReason
+from polar.integrations.stripe.service import stripe as stripe_service
 from polar.kit.anonymization import anonymize_email_for_deletion, anonymize_for_deletion
 from polar.kit.currency import PresentmentCurrency
 from polar.kit.http import check_url_reachable
@@ -1563,6 +1565,78 @@ class OrganizationService:
         if enqueue_review:
             enqueue_job("organization.under_review", organization_id=organization.id)
         return organization
+
+    async def evaluate_website_risk(
+        self, session: AsyncSession, organization: Organization
+    ) -> None:
+        # Gate the whole feature on the receiving side being configured.
+        if not settings.STRIPE_ACCOUNT_RISK_WEBHOOK_SECRET:
+            log.info(
+                "organization.evaluate_website_risk.skipped",
+                reason="webhook_secret_not_configured",
+                organization_id=str(organization.id),
+            )
+            return
+
+        if organization.payout_account_id is None:
+            log.info(
+                "organization.evaluate_website_risk.skipped",
+                reason="no_payout_account",
+                organization_id=str(organization.id),
+            )
+            return
+
+        website = organization.website.strip() if organization.website else ""
+        if not website:
+            log.info(
+                "organization.evaluate_website_risk.skipped",
+                reason="no_website",
+                organization_id=str(organization.id),
+            )
+            return
+
+        payout_account_repository = PayoutAccountRepository.from_session(session)
+        payout_account = await payout_account_repository.get_by_id(
+            organization.payout_account_id
+        )
+        if payout_account is None or payout_account.stripe_id is None:
+            log.info(
+                "organization.evaluate_website_risk.skipped",
+                reason="no_stripe_account",
+                organization_id=str(organization.id),
+            )
+            return
+
+        # Stripe evaluates the website attached to the account, so sync it
+        # first. InvalidRequestError is a deterministic rejection (a URL
+        # Stripe won't accept, an account missing required fields): retrying
+        # can't succeed, so log instead of raising.
+        try:
+            await stripe_service.update_account_website(
+                payout_account.stripe_id, website
+            )
+        except stripe_lib.InvalidRequestError as e:
+            log.warning(
+                "organization.evaluate_website_risk.rejected",
+                step="sync_website",
+                organization_id=str(organization.id),
+                stripe_account_id=payout_account.stripe_id,
+                error=str(e),
+            )
+            return
+
+        try:
+            await stripe_service.create_website_risk_evaluation(
+                payout_account.stripe_id
+            )
+        except stripe_lib.InvalidRequestError as e:
+            log.warning(
+                "organization.evaluate_website_risk.rejected",
+                step="create_evaluation",
+                organization_id=str(organization.id),
+                stripe_account_id=payout_account.stripe_id,
+                error=str(e),
+            )
 
     async def handle_account_risk_signal(
         self,

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -1219,7 +1219,10 @@ async def evaluate_website_risk(organization_id: uuid.UUID) -> None:
     async with AsyncSessionMaker() as session:
         repository = OrganizationRepository.from_session(session)
         organization = await repository.get_by_id(organization_id)
-        if organization is None or organization.payout_account_id is None:
+        if organization is None:
+            raise OrganizationDoesNotExist(organization_id)
+
+        if organization.payout_account_id is None:
             log.info(
                 "organization.evaluate_website_risk.skipped",
                 reason="no_payout_account",
@@ -1227,7 +1230,8 @@ async def evaluate_website_risk(organization_id: uuid.UUID) -> None:
             )
             return
 
-        if not organization.website:
+        website = organization.website.strip() if organization.website else ""
+        if not website:
             log.info(
                 "organization.evaluate_website_risk.skipped",
                 reason="no_website",
@@ -1247,19 +1251,32 @@ async def evaluate_website_risk(organization_id: uuid.UUID) -> None:
             )
             return
 
-        # Stripe evaluates the website attached to the account, so sync it first.
-        await stripe_service.update_account_website(
-            payout_account.stripe_id, organization.website
-        )
+        # Stripe evaluates the website attached to the account, so sync it
+        # first. InvalidRequestError is a deterministic rejection (a URL
+        # Stripe won't accept, an account missing required fields): retrying
+        # can't succeed, so log instead of raising.
+        try:
+            await stripe_service.update_account_website(
+                payout_account.stripe_id, website
+            )
+        except stripe_lib.InvalidRequestError as e:
+            log.warning(
+                "organization.evaluate_website_risk.rejected",
+                step="sync_website",
+                organization_id=str(organization_id),
+                stripe_account_id=payout_account.stripe_id,
+                error=str(e),
+            )
+            return
+
         try:
             await stripe_service.create_website_risk_evaluation(
                 payout_account.stripe_id
             )
         except stripe_lib.InvalidRequestError as e:
-            # Deterministic rejection (e.g. account still missing required
-            # fields): retrying can't succeed, so log instead of raising.
             log.warning(
                 "organization.evaluate_website_risk.rejected",
+                step="create_evaluation",
                 organization_id=str(organization_id),
                 stripe_account_id=payout_account.stripe_id,
                 error=str(e),

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -1,6 +1,7 @@
 import uuid
 from typing import Any, cast
 
+import stripe as stripe_lib
 import structlog
 from sqlalchemy import CursorResult, select
 from sqlalchemy.orm import joinedload
@@ -1208,12 +1209,30 @@ async def _prepare_benefit_grants(
 async def evaluate_website_risk(organization_id: uuid.UUID) -> None:
     # Gate the whole feature on the receiving side being configured.
     if not settings.STRIPE_ACCOUNT_RISK_WEBHOOK_SECRET:
+        log.info(
+            "organization.evaluate_website_risk.skipped",
+            reason="webhook_secret_not_configured",
+            organization_id=str(organization_id),
+        )
         return
 
     async with AsyncSessionMaker() as session:
         repository = OrganizationRepository.from_session(session)
         organization = await repository.get_by_id(organization_id)
         if organization is None or organization.payout_account_id is None:
+            log.info(
+                "organization.evaluate_website_risk.skipped",
+                reason="no_payout_account",
+                organization_id=str(organization_id),
+            )
+            return
+
+        if not organization.website:
+            log.info(
+                "organization.evaluate_website_risk.skipped",
+                reason="no_website",
+                organization_id=str(organization_id),
+            )
             return
 
         payout_account_repository = PayoutAccountRepository.from_session(session)
@@ -1221,6 +1240,27 @@ async def evaluate_website_risk(organization_id: uuid.UUID) -> None:
             organization.payout_account_id
         )
         if payout_account is None or payout_account.stripe_id is None:
+            log.info(
+                "organization.evaluate_website_risk.skipped",
+                reason="no_stripe_account",
+                organization_id=str(organization_id),
+            )
             return
 
-        await stripe_service.create_website_risk_evaluation(payout_account.stripe_id)
+        # Stripe evaluates the website attached to the account, so sync it first.
+        await stripe_service.update_account_website(
+            payout_account.stripe_id, organization.website
+        )
+        try:
+            await stripe_service.create_website_risk_evaluation(
+                payout_account.stripe_id
+            )
+        except stripe_lib.InvalidRequestError as e:
+            # Deterministic rejection (e.g. account still missing required
+            # fields): retrying can't succeed, so log instead of raising.
+            log.warning(
+                "organization.evaluate_website_risk.rejected",
+                organization_id=str(organization_id),
+                stripe_account_id=payout_account.stripe_id,
+                error=str(e),
+            )

--- a/server/polar/organization/tasks.py
+++ b/server/polar/organization/tasks.py
@@ -1,12 +1,10 @@
 import uuid
 from typing import Any, cast
 
-import stripe as stripe_lib
 import structlog
 from sqlalchemy import CursorResult, select
 from sqlalchemy.orm import joinedload
 
-from polar.config import settings
 from polar.customer.repository import CustomerRepository
 from polar.email.schemas import (
     OrganizationOffboardedEmail,
@@ -15,7 +13,6 @@ from polar.email.schemas import (
 from polar.email.sender import enqueue_email_template
 from polar.exceptions import PolarTaskError
 from polar.integrations.plain.service import plain as plain_service
-from polar.integrations.stripe.service import stripe as stripe_service
 from polar.member.repository import MemberRepository
 from polar.member.service import member_service
 from polar.models import Customer, CustomerSeat, Organization
@@ -23,7 +20,6 @@ from polar.models.benefit_grant import BenefitGrant
 from polar.models.customer_seat import SeatStatus
 from polar.models.member import Member, MemberRole
 from polar.models.organization import OrganizationStatus
-from polar.payout_account.repository import PayoutAccountRepository
 from polar.postgres import AsyncSession
 from polar.user.repository import UserRepository
 from polar.user_organization.service import (
@@ -1207,77 +1203,10 @@ async def _prepare_benefit_grants(
 
 @actor(actor_name="organization.evaluate_website_risk", priority=TaskPriority.LOW)
 async def evaluate_website_risk(organization_id: uuid.UUID) -> None:
-    # Gate the whole feature on the receiving side being configured.
-    if not settings.STRIPE_ACCOUNT_RISK_WEBHOOK_SECRET:
-        log.info(
-            "organization.evaluate_website_risk.skipped",
-            reason="webhook_secret_not_configured",
-            organization_id=str(organization_id),
-        )
-        return
-
     async with AsyncSessionMaker() as session:
         repository = OrganizationRepository.from_session(session)
         organization = await repository.get_by_id(organization_id)
         if organization is None:
             raise OrganizationDoesNotExist(organization_id)
 
-        if organization.payout_account_id is None:
-            log.info(
-                "organization.evaluate_website_risk.skipped",
-                reason="no_payout_account",
-                organization_id=str(organization_id),
-            )
-            return
-
-        website = organization.website.strip() if organization.website else ""
-        if not website:
-            log.info(
-                "organization.evaluate_website_risk.skipped",
-                reason="no_website",
-                organization_id=str(organization_id),
-            )
-            return
-
-        payout_account_repository = PayoutAccountRepository.from_session(session)
-        payout_account = await payout_account_repository.get_by_id(
-            organization.payout_account_id
-        )
-        if payout_account is None or payout_account.stripe_id is None:
-            log.info(
-                "organization.evaluate_website_risk.skipped",
-                reason="no_stripe_account",
-                organization_id=str(organization_id),
-            )
-            return
-
-        # Stripe evaluates the website attached to the account, so sync it
-        # first. InvalidRequestError is a deterministic rejection (a URL
-        # Stripe won't accept, an account missing required fields): retrying
-        # can't succeed, so log instead of raising.
-        try:
-            await stripe_service.update_account_website(
-                payout_account.stripe_id, website
-            )
-        except stripe_lib.InvalidRequestError as e:
-            log.warning(
-                "organization.evaluate_website_risk.rejected",
-                step="sync_website",
-                organization_id=str(organization_id),
-                stripe_account_id=payout_account.stripe_id,
-                error=str(e),
-            )
-            return
-
-        try:
-            await stripe_service.create_website_risk_evaluation(
-                payout_account.stripe_id
-            )
-        except stripe_lib.InvalidRequestError as e:
-            log.warning(
-                "organization.evaluate_website_risk.rejected",
-                step="create_evaluation",
-                organization_id=str(organization_id),
-                stripe_account_id=payout_account.stripe_id,
-                error=str(e),
-            )
+        await organization_service.evaluate_website_risk(session, organization)

--- a/server/tests/organization/test_tasks.py
+++ b/server/tests/organization/test_tasks.py
@@ -2,6 +2,7 @@ import uuid
 from unittest.mock import AsyncMock
 
 import pytest
+import stripe as stripe_lib
 from pytest_mock import MockerFixture
 
 from polar.config import settings
@@ -164,8 +165,14 @@ class TestEvaluateWebsiteRisk:
         mocker.patch.object(
             settings, "STRIPE_ACCOUNT_RISK_WEBHOOK_SECRET", "whsec_test"
         )
+        organization.website = "https://example.com"
+        await save_fixture(organization)
         payout_account = await create_payout_account(
             save_fixture, organization, user, stripe_id="acct_website_test"
+        )
+        update_website_mock = mocker.patch(
+            "polar.organization.tasks.stripe_service.update_account_website",
+            new=AsyncMock(),
         )
         evaluate_mock = mocker.patch(
             "polar.organization.tasks.stripe_service.create_website_risk_evaluation",
@@ -174,7 +181,69 @@ class TestEvaluateWebsiteRisk:
 
         await evaluate_website_risk(organization.id)
 
+        update_website_mock.assert_awaited_once_with(
+            payout_account.stripe_id, "https://example.com"
+        )
         evaluate_mock.assert_awaited_once_with(payout_account.stripe_id)
+
+    async def test_noop_without_website(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        mocker.patch.object(
+            settings, "STRIPE_ACCOUNT_RISK_WEBHOOK_SECRET", "whsec_test"
+        )
+        await create_payout_account(
+            save_fixture, organization, user, stripe_id="acct_website_test"
+        )
+        update_website_mock = mocker.patch(
+            "polar.organization.tasks.stripe_service.update_account_website",
+            new=AsyncMock(),
+        )
+        evaluate_mock = mocker.patch(
+            "polar.organization.tasks.stripe_service.create_website_risk_evaluation",
+            new=AsyncMock(),
+        )
+
+        await evaluate_website_risk(organization.id)
+
+        update_website_mock.assert_not_awaited()
+        evaluate_mock.assert_not_awaited()
+
+    async def test_evaluation_rejection_does_not_raise(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        mocker.patch.object(
+            settings, "STRIPE_ACCOUNT_RISK_WEBHOOK_SECRET", "whsec_test"
+        )
+        organization.website = "https://example.com"
+        await save_fixture(organization)
+        await create_payout_account(
+            save_fixture, organization, user, stripe_id="acct_website_test"
+        )
+        mocker.patch(
+            "polar.organization.tasks.stripe_service.update_account_website",
+            new=AsyncMock(),
+        )
+        mocker.patch(
+            "polar.organization.tasks.stripe_service.create_website_risk_evaluation",
+            new=AsyncMock(
+                side_effect=stripe_lib.InvalidRequestError(
+                    "The account or account data does not have the required fields"
+                    " to perform requested evaluations.",
+                    None,
+                )
+            ),
+        )
+
+        await evaluate_website_risk(organization.id)
 
     async def test_noop_when_secret_unset(
         self,

--- a/server/tests/organization/test_tasks.py
+++ b/server/tests/organization/test_tasks.py
@@ -155,6 +155,17 @@ class TestOrganizationCancelExpiredSubscriptions:
 
 @pytest.mark.asyncio
 class TestEvaluateWebsiteRisk:
+    async def test_not_existing_organization(
+        self, mocker: MockerFixture, session: AsyncSession
+    ) -> None:
+        mocker.patch.object(
+            settings, "STRIPE_ACCOUNT_RISK_WEBHOOK_SECRET", "whsec_test"
+        )
+        session.expunge_all()
+
+        with pytest.raises(OrganizationDoesNotExist):
+            await evaluate_website_risk(uuid.uuid4())
+
     async def test_triggers_evaluation_for_org_with_stripe_account(
         self,
         mocker: MockerFixture,
@@ -244,6 +255,36 @@ class TestEvaluateWebsiteRisk:
         )
 
         await evaluate_website_risk(organization.id)
+
+    async def test_website_sync_rejection_does_not_raise(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        mocker.patch.object(
+            settings, "STRIPE_ACCOUNT_RISK_WEBHOOK_SECRET", "whsec_test"
+        )
+        organization.website = "https://example.com"
+        await save_fixture(organization)
+        await create_payout_account(
+            save_fixture, organization, user, stripe_id="acct_website_test"
+        )
+        mocker.patch(
+            "polar.organization.tasks.stripe_service.update_account_website",
+            new=AsyncMock(
+                side_effect=stripe_lib.InvalidRequestError("Invalid URL", None)
+            ),
+        )
+        evaluate_mock = mocker.patch(
+            "polar.organization.tasks.stripe_service.create_website_risk_evaluation",
+            new=AsyncMock(),
+        )
+
+        await evaluate_website_risk(organization.id)
+
+        evaluate_mock.assert_not_awaited()
 
     async def test_noop_when_secret_unset(
         self,

--- a/server/tests/organization/test_tasks.py
+++ b/server/tests/organization/test_tasks.py
@@ -182,11 +182,11 @@ class TestEvaluateWebsiteRisk:
             save_fixture, organization, user, stripe_id="acct_website_test"
         )
         update_website_mock = mocker.patch(
-            "polar.organization.tasks.stripe_service.update_account_website",
+            "polar.organization.service.stripe_service.update_account_website",
             new=AsyncMock(),
         )
         evaluate_mock = mocker.patch(
-            "polar.organization.tasks.stripe_service.create_website_risk_evaluation",
+            "polar.organization.service.stripe_service.create_website_risk_evaluation",
             new=AsyncMock(return_value={}),
         )
 
@@ -211,11 +211,11 @@ class TestEvaluateWebsiteRisk:
             save_fixture, organization, user, stripe_id="acct_website_test"
         )
         update_website_mock = mocker.patch(
-            "polar.organization.tasks.stripe_service.update_account_website",
+            "polar.organization.service.stripe_service.update_account_website",
             new=AsyncMock(),
         )
         evaluate_mock = mocker.patch(
-            "polar.organization.tasks.stripe_service.create_website_risk_evaluation",
+            "polar.organization.service.stripe_service.create_website_risk_evaluation",
             new=AsyncMock(),
         )
 
@@ -240,11 +240,11 @@ class TestEvaluateWebsiteRisk:
             save_fixture, organization, user, stripe_id="acct_website_test"
         )
         mocker.patch(
-            "polar.organization.tasks.stripe_service.update_account_website",
+            "polar.organization.service.stripe_service.update_account_website",
             new=AsyncMock(),
         )
         mocker.patch(
-            "polar.organization.tasks.stripe_service.create_website_risk_evaluation",
+            "polar.organization.service.stripe_service.create_website_risk_evaluation",
             new=AsyncMock(
                 side_effect=stripe_lib.InvalidRequestError(
                     "The account or account data does not have the required fields"
@@ -272,13 +272,13 @@ class TestEvaluateWebsiteRisk:
             save_fixture, organization, user, stripe_id="acct_website_test"
         )
         mocker.patch(
-            "polar.organization.tasks.stripe_service.update_account_website",
+            "polar.organization.service.stripe_service.update_account_website",
             new=AsyncMock(
                 side_effect=stripe_lib.InvalidRequestError("Invalid URL", None)
             ),
         )
         evaluate_mock = mocker.patch(
-            "polar.organization.tasks.stripe_service.create_website_risk_evaluation",
+            "polar.organization.service.stripe_service.create_website_risk_evaluation",
             new=AsyncMock(),
         )
 
@@ -293,7 +293,7 @@ class TestEvaluateWebsiteRisk:
     ) -> None:
         mocker.patch.object(settings, "STRIPE_ACCOUNT_RISK_WEBHOOK_SECRET", "")
         evaluate_mock = mocker.patch(
-            "polar.organization.tasks.stripe_service.create_website_risk_evaluation",
+            "polar.organization.service.stripe_service.create_website_risk_evaluation",
             new=AsyncMock(),
         )
 
@@ -310,7 +310,7 @@ class TestEvaluateWebsiteRisk:
             settings, "STRIPE_ACCOUNT_RISK_WEBHOOK_SECRET", "whsec_test"
         )
         evaluate_mock = mocker.patch(
-            "polar.organization.tasks.stripe_service.create_website_risk_evaluation",
+            "polar.organization.service.stripe_service.create_website_risk_evaluation",
             new=AsyncMock(),
         )
 


### PR DESCRIPTION
## Summary

Stripe's fraudulent-website risk evaluation failed in production with "The account or account data does not have the required fields to perform requested evaluations." We create connected accounts with only a business name, so Stripe had no website to evaluate.

## What

- Push the organization's website to the Stripe account (`business_profile.url`) before requesting the evaluation.
- Skip orgs without a website, with a structured log line for every early exit so no-op runs show up in telemetry.
- Catch Stripe's `InvalidRequestError` on both calls and log it (with a `step` field) instead of raising, since retrying a deterministic rejection can never succeed.
- Raise `OrganizationDoesNotExist` for a missing org, matching the other tasks in the module.

## Why

The evaluation task ran but always failed on Stripe's side, so no risk signal events were ever generated. With the URL synced first, evaluations can complete and the webhook pipeline receives signals.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

