### PR TITLE
Add route-level permission guards to dashboard sections

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/layout.tsx
@@ -1,0 +1,21 @@
+import OrganizationPermissionGuard from '@/components/Auth/OrganizationPermissionGuard'
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ organization: string }>
+}) {
+  const { organization } = await params
+
+  return (
+    <OrganizationPermissionGuard
+      organizationSlug={organization}
+      permission="analytics:read"
+      standalone
+    >
+      {children}
+    </OrganizationPermissionGuard>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/compass/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/compass/layout.tsx
@@ -1,0 +1,21 @@
+import OrganizationPermissionGuard from '@/components/Auth/OrganizationPermissionGuard'
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ organization: string }>
+}) {
+  const { organization } = await params
+
+  return (
+    <OrganizationPermissionGuard
+      organizationSlug={organization}
+      permission="analytics:read"
+      standalone
+    >
+      {children}
+    </OrganizationPermissionGuard>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/layout.tsx
@@ -1,3 +1,4 @@
+import OrganizationPermissionGuard from '@/components/Auth/OrganizationPermissionGuard'
 import { CustomerListSidebar } from '@/components/Customer/CustomerListSidebar'
 import { MasterDetailLayout } from '@/components/Layout/MasterDetailLayout'
 import { getServerSideAPI } from '@/utils/client/serverside'
@@ -9,18 +10,36 @@ export default async function Layout(
     params: Promise<{ organization: string }>
   }>,
 ) {
-  const params = await props.params
+  const { organization } = await props.params
+
+  return (
+    <OrganizationPermissionGuard
+      organizationSlug={organization}
+      permission="customers:read"
+      standalone
+    >
+      <CustomersLayoutShell organizationSlug={organization}>
+        {props.children}
+      </CustomersLayoutShell>
+    </OrganizationPermissionGuard>
+  )
+}
+
+async function CustomersLayoutShell({
+  organizationSlug,
+  children,
+}: PropsWithChildren<{ organizationSlug: string }>) {
   const api = await getServerSideAPI()
   const organization = await getOrganizationBySlugOrNotFound(
     api,
-    params.organization,
+    organizationSlug,
   )
 
   return (
     <MasterDetailLayout
       listView={<CustomerListSidebar organization={organization} />}
     >
-      {props.children}
+      {children}
     </MasterDetailLayout>
   )
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/layout.tsx
@@ -1,0 +1,21 @@
+import OrganizationPermissionGuard from '@/components/Auth/OrganizationPermissionGuard'
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ organization: string }>
+}) {
+  const { organization } = await params
+
+  return (
+    <OrganizationPermissionGuard
+      organizationSlug={organization}
+      permission="products:read"
+      standalone
+    >
+      {children}
+    </OrganizationPermissionGuard>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/layout.tsx
@@ -1,0 +1,21 @@
+import OrganizationPermissionGuard from '@/components/Auth/OrganizationPermissionGuard'
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ organization: string }>
+}) {
+  const { organization } = await params
+
+  return (
+    <OrganizationPermissionGuard
+      organizationSlug={organization}
+      permission="sales:read"
+      standalone
+    >
+      {children}
+    </OrganizationPermissionGuard>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/BillingPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/BillingPage.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import AccessRestricted from '@/components/Finance/AccessRestricted'
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import { Modal } from '@polar-sh/orbit'
 import { useModal } from '@/components/Modal/useModal'
@@ -16,7 +15,6 @@ import { StartupProgramCallout } from '@/components/Settings/Billing/StartupProg
 import { Section, SectionDescription } from '@/components/Settings/Section'
 import { LoadingBox } from '@/components/Shared/LoadingBox'
 import { toast } from '@/components/Toast/use-toast'
-import { useHasPermission } from '@/hooks/permissions'
 import { usePostHog } from '@/hooks/posthog'
 import { useBillingPlanCompleteListener } from '@/hooks/useBillingPlanTelemetry'
 import {
@@ -46,15 +44,9 @@ export default function BillingPage({
   const theme = useTheme()
   const posthog = usePostHog()
 
-  const canManageBilling = useHasPermission(
-    organization.id,
-    'organization:manage',
-  )
-  const gatedOrgId = canManageBilling ? organization.id : undefined
-
-  const subscriptionQuery = useOrganizationSubscription(gatedOrgId)
-  const plansQuery = useOrganizationPlans(gatedOrgId)
-  const ordersQuery = useOrganizationOrders(gatedOrgId)
+  const subscriptionQuery = useOrganizationSubscription(organization.id)
+  const plansQuery = useOrganizationPlans(organization.id)
+  const ordersQuery = useOrganizationOrders(organization.id)
 
   const customerSessionQuery = useOrganizationCustomerSession(organization.id)
 
@@ -118,17 +110,6 @@ export default function BillingPage({
       current_plan_product_id: subscriptionQuery.data?.product_id ?? null,
     })
     router.push(`/dashboard/${organization.slug}/settings/billing/change-plan`)
-  }
-
-  if (canManageBilling === false) {
-    return (
-      <DashboardBody
-        wrapperClassName="max-w-(--breakpoint-md)!"
-        title="Billing"
-      >
-        <AccessRestricted message="You don't have permission to manage billing for this organization. Ask an admin if you need access." />
-      </DashboardBody>
-    )
   }
 
   if (CONFIG.IS_SANDBOX) {

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/change-plan/ChangePlanPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/change-plan/ChangePlanPage.tsx
@@ -1,12 +1,10 @@
 'use client'
 
-import AccessRestricted from '@/components/Finance/AccessRestricted'
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import { ConfirmModal } from '@/components/Modal/ConfirmModal'
 import { useModal } from '@/components/Modal/useModal'
 import { LoadingBox } from '@/components/Shared/LoadingBox'
 import { toast } from '@/components/Toast/use-toast'
-import { useHasPermission } from '@/hooks/permissions'
 import { usePostHog } from '@/hooks/posthog'
 import {
   useCancelSubscription,
@@ -46,18 +44,13 @@ export default function ChangePlanPage({
 }) {
   const router = useRouter()
   const posthog = usePostHog()
-  const canManageBilling = useHasPermission(
-    organization.id,
-    'organization:manage',
-  )
   const { buildUrls } = useBillingPlanTelemetry({
     source: 'change_plan',
     organizationId: organization.id,
     successPath: `/dashboard/${organization.slug}/settings/billing`,
   })
-  const gatedOrgId = canManageBilling ? organization.id : undefined
-  const subscriptionQuery = useOrganizationSubscription(gatedOrgId)
-  const plansQuery = useOrganizationPlans(gatedOrgId)
+  const subscriptionQuery = useOrganizationSubscription(organization.id)
+  const plansQuery = useOrganizationPlans(organization.id)
   const changePlan = useChangeSubscriptionPlan(organization.id)
   const cancelSubscription = useCancelSubscription(organization.id)
   const startCheckout = useStartSubscriptionCheckout(organization.id)
@@ -249,14 +242,6 @@ export default function ChangePlanPage({
         : changeKind === 'downgrade'
           ? 'Downgrade plan'
           : 'Confirm'
-
-  if (canManageBilling === false) {
-    return (
-      <DashboardBody title={null} wide>
-        <AccessRestricted message="You don't have permission to manage billing for this organization. Ask an admin if you need access." />
-      </DashboardBody>
-    )
-  }
 
   return (
     <DashboardBody title={null} wide>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/billing/layout.tsx
@@ -1,0 +1,21 @@
+import OrganizationPermissionGuard from '@/components/Auth/OrganizationPermissionGuard'
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ organization: string }>
+}) {
+  const { organization } = await params
+
+  return (
+    <OrganizationPermissionGuard
+      organizationSlug={organization}
+      permission="organization:manage"
+      standalone
+    >
+      {children}
+    </OrganizationPermissionGuard>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/custom-fields/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/custom-fields/layout.tsx
@@ -1,0 +1,21 @@
+import OrganizationPermissionGuard from '@/components/Auth/OrganizationPermissionGuard'
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ organization: string }>
+}) {
+  const { organization } = await params
+
+  return (
+    <OrganizationPermissionGuard
+      organizationSlug={organization}
+      permission="custom_fields:manage"
+      standalone
+    >
+      {children}
+    </OrganizationPermissionGuard>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/members/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/members/layout.tsx
@@ -1,0 +1,21 @@
+import OrganizationPermissionGuard from '@/components/Auth/OrganizationPermissionGuard'
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ organization: string }>
+}) {
+  const { organization } = await params
+
+  return (
+    <OrganizationPermissionGuard
+      organizationSlug={organization}
+      permission="members:read"
+      standalone
+    >
+      {children}
+    </OrganizationPermissionGuard>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/layout.tsx
@@ -1,0 +1,21 @@
+import OrganizationPermissionGuard from '@/components/Auth/OrganizationPermissionGuard'
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ organization: string }>
+}) {
+  const { organization } = await params
+
+  return (
+    <OrganizationPermissionGuard
+      organizationSlug={organization}
+      permission="organization:manage"
+      standalone
+    >
+      {children}
+    </OrganizationPermissionGuard>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/sso/SSOPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/sso/SSOPage.tsx
@@ -1,9 +1,7 @@
 'use client'
 
-import AccessRestricted from '@/components/Finance/AccessRestricted'
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import SSOSettings from '@/components/Settings/SSO/SSOSettings'
-import { useHasPermission } from '@/hooks/permissions'
 import { schemas } from '@polar-sh/client'
 
 export default function ClientPage({
@@ -11,16 +9,6 @@ export default function ClientPage({
 }: {
   organization: schemas['Organization']
 }) {
-  const canManageSSO = useHasPermission(org.id, 'organization:manage')
-
-  if (canManageSSO === false) {
-    return (
-      <DashboardBody title="Single Sign-On">
-        <AccessRestricted message="You don't have permission to manage single sign-on for this organization. Ask an admin if you need access." />
-      </DashboardBody>
-    )
-  }
-
   return (
     <DashboardBody title="Single Sign-On">
       <SSOSettings org={org} />

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/sso/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/sso/layout.tsx
@@ -1,0 +1,21 @@
+import OrganizationPermissionGuard from '@/components/Auth/OrganizationPermissionGuard'
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ organization: string }>
+}) {
+  const { organization } = await params
+
+  return (
+    <OrganizationPermissionGuard
+      organizationSlug={organization}
+      permission="organization:manage"
+      standalone
+    >
+      {children}
+    </OrganizationPermissionGuard>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/webhooks/WebhooksPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/webhooks/WebhooksPage.tsx
@@ -1,9 +1,7 @@
 'use client'
 
-import AccessRestricted from '@/components/Finance/AccessRestricted'
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import WebhookSettings from '@/components/Settings/Webhook/WebhookSettings'
-import { useHasPermission } from '@/hooks/permissions'
 import { schemas } from '@polar-sh/client'
 
 export default function ClientPage({
@@ -11,16 +9,6 @@ export default function ClientPage({
 }: {
   organization: schemas['Organization']
 }) {
-  const canManageWebhooks = useHasPermission(org.id, 'organization:manage')
-
-  if (canManageWebhooks === false) {
-    return (
-      <DashboardBody title="Webhooks">
-        <AccessRestricted message="You don't have permission to manage webhooks for this organization. Ask an admin if you need access." />
-      </DashboardBody>
-    )
-  }
-
   return (
     <DashboardBody title="Webhooks">
       <WebhookSettings org={org} />

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/webhooks/endpoints/[id]/EndpointsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/webhooks/endpoints/[id]/EndpointsPage.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import AccessRestricted from '@/components/Finance/AccessRestricted'
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import { DateRange } from '@/components/Metrics/DateRangePicker'
 import { ConfirmModal } from '@/components/Modal/ConfirmModal'
@@ -10,7 +9,6 @@ import DeliveriesTable from '@/components/Settings/Webhook/WebhookDeliveriesTabl
 import { WebhookFilter } from '@/components/Settings/Webhook/WebhookFilter'
 import { toast } from '@/components/Toast/use-toast'
 import { getStatusRedirect } from '@/components/Toast/utils'
-import { useHasPermission } from '@/hooks/permissions'
 import {
   useDeleteWebhookEndpoint,
   useEditWebhookEndpoint,
@@ -41,10 +39,6 @@ export default function ClientPage({
 }) {
   const { id }: { id: string } = useParams()
   const router = useRouter()
-  const canManageWebhooks = useHasPermission(
-    organization.id,
-    'organization:manage',
-  )
   const [dateRange, setDateRange] = useState<DateRange | undefined>()
 
   const [succeeded, setSucceeded] = useQueryState(
@@ -151,14 +145,6 @@ export default function ClientPage({
       ),
     )
   }, [deleteWebhookEndpoint, hideDeleteModal, router, endpoint, organization])
-
-  if (canManageWebhooks === false) {
-    return (
-      <DashboardBody title="Webhook">
-        <AccessRestricted message="You don't have permission to manage webhooks for this organization. Ask an admin if you need access." />
-      </DashboardBody>
-    )
-  }
 
   if (!endpoint) {
     return null

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/webhooks/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/webhooks/layout.tsx
@@ -1,0 +1,21 @@
+import OrganizationPermissionGuard from '@/components/Auth/OrganizationPermissionGuard'
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ organization: string }>
+}) {
+  const { organization } = await params
+
+  return (
+    <OrganizationPermissionGuard
+      organizationSlug={organization}
+      permission="organization:manage"
+      standalone
+    >
+      {children}
+    </OrganizationPermissionGuard>
+  )
+}


### PR DESCRIPTION
## Summary

Adds OrganizationPermissionGuard to all pages in dashboard, replacing some client side permission checks and gating some pages without permission guards to prepare for future possible RBAC roles. (see https://github.com/polarsource/polar/compare/claude/finance-role-prototype-kli3zj etc)

## What

Added a small layout.tsx guard per section:

- analytics, compass → analytics:read
- customers → customers:read
- products → products:read
- sales → sales:read
- settings/members → members:read
- settings/custom-fields → custom_fields:manage
- settings/migrations, sso, webhooks, billing → organization:manage

Removed the old in-page checks in webhooks, sso, and billing since the guard replaces them.

## Why

Most pages had no access check, and the few that did each rolled their own. In the layout it's one consistent "no access" screen, no loading flicker (permissions come from the auth payload), and pages you can't see never load their data.

## How

Each section is guarded on its read permission, what most people on a team have. most manage actions (refunds, editing) still check for themselves for now keeping view and manage separate is what lets a future role view without editing.

Gating is intentionally general, and In future could be more fine-tuned (for example analytics/ route has one guard since same permission, but easy to add specific guards for costs/ metrics/ etc.

Left out for now: the home dashboard (mixed widgets, needs per-widget handling), onboarding, and hiding manage buttons for read-only users as this is a UX gate, not real security as API enforces it. In future we probably also want the guard to accept multiple permissions if page requires multiple permission, but for now it's the 'loosest' option.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (uv run task lint && uv run task lint_types)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

