### PR TITLE
Add organization_id to Dispute model

### DIFF
--- a/server/migrations/versions/2026-07-17-1200_add_organization_id_to_disputes.py
+++ b/server/migrations/versions/2026-07-17-1200_add_organization_id_to_disputes.py
@@ -1,0 +1,49 @@
+"""add organization_id to disputes
+
+Revision ID: b7e3f2a19c4d
+Revises: 638a2f04c7ce
+Create Date: 2026-07-17 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "b7e3f2a19c4d"
+down_revision = "638a2f04c7ce"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "disputes",
+        sa.Column("organization_id", sa.Uuid(), nullable=True),
+    )
+    op.create_foreign_key(
+        op.f("disputes_organization_id_fkey"),
+        "disputes",
+        "organizations",
+        ["organization_id"],
+        ["id"],
+        ondelete="restrict",
+    )
+    with op.get_context().autocommit_block():
+        op.create_index(
+            op.f("ix_disputes_organization_id"),
+            "disputes",
+            ["organization_id"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        op.f("disputes_organization_id_fkey"), "disputes", type_="foreignkey"
+    )
+    op.drop_index(op.f("ix_disputes_organization_id"), table_name="disputes")
+    op.drop_column("disputes", "organization_id")

--- a/server/migrations/versions/2026-07-28-1200_add_organization_id_to_disputes.py
+++ b/server/migrations/versions/2026-07-28-1200_add_organization_id_to_disputes.py
@@ -1,8 +1,8 @@
 """add organization_id to disputes
 
 Revision ID: b7e3f2a19c4d
-Revises: 638a2f04c7ce
-Create Date: 2026-07-17 12:00:00.000000
+Revises: d3f5a9c47e21
+Create Date: 2026-07-28 12:00:00.000000
 
 """
 
@@ -13,7 +13,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "b7e3f2a19c4d"
-down_revision = "638a2f04c7ce"
+down_revision = "d3f5a9c47e21"
 branch_labels: tuple[str] | None = None
 depends_on: tuple[str] | None = None
 

--- a/server/polar/dispute/repository.py
+++ b/server/polar/dispute/repository.py
@@ -49,6 +49,7 @@ class DisputeRepository(
                 tax_amount=tax_amount,
                 currency=currency,
                 order_id=order.id,
+                organization_id=order.organization_id,
                 payment_id=payment.id,
             )
             .on_conflict_do_nothing(

--- a/server/polar/dispute/service.py
+++ b/server/polar/dispute/service.py
@@ -343,6 +343,7 @@ class DisputeService:
                     payment_processor=PaymentProcessor.stripe,
                     payment_processor_id=None,  # We don't know the dispute ID yet
                     order=order,
+                    organization_id=order.organization_id,
                     payment=payment,
                     status=DisputeStatus.early_warning,
                 )

--- a/server/polar/models/dispute.py
+++ b/server/polar/models/dispute.py
@@ -15,6 +15,7 @@ from sqlalchemy import (
     Uuid,
     select,
 )
+from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import (
     Mapped,
@@ -29,7 +30,7 @@ from polar.kit.db.models import RecordModel
 from polar.kit.extensions.sqlalchemy.types import StringEnum
 
 if TYPE_CHECKING:
-    from polar.models import Customer, Order, Payment
+    from polar.models import Customer, Order, Organization, Payment
 
 
 class DisputeStatus(StrEnum):
@@ -124,6 +125,17 @@ class Dispute(RecordModel):
     @declared_attr
     def order(cls) -> Mapped["Order"]:
         return relationship("Order", lazy="raise")
+
+    organization_id: Mapped[UUID | None] = mapped_column(
+        Uuid,
+        ForeignKey("organizations.id", ondelete="restrict"),
+        nullable=True,
+        index=True,
+    )
+
+    organization: AssociationProxy["Organization"] = association_proxy(
+        "order", "organization"
+    )
 
     payment_id: Mapped[UUID] = mapped_column(
         Uuid, ForeignKey("payments.id"), nullable=False, index=True

--- a/server/scripts/backfill_dispute_organization_id.py
+++ b/server/scripts/backfill_dispute_organization_id.py
@@ -1,0 +1,56 @@
+import asyncio
+from functools import wraps
+
+import typer
+from sqlalchemy import select, update
+
+from polar.models import Dispute, Order
+from scripts.helper import (
+    configure_script_logging,
+    limit_bindparam,
+    run_batched_update,
+)
+
+cli = typer.Typer()
+
+configure_script_logging()
+
+
+def typer_async(f):  # type: ignore
+    @wraps(f)
+    def wrapper(*args, **kwargs):  # type: ignore
+        return asyncio.run(f(*args, **kwargs))
+
+    return wrapper
+
+
+@cli.command()
+@typer_async
+async def backfill_dispute_organization_id(
+    batch_size: int = typer.Option(5000, help="Number of rows to process per batch"),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+) -> None:
+    await run_batched_update(
+        (
+            update(Dispute)
+            .values(
+                organization_id=select(Order.organization_id)
+                .where(Order.id == Dispute.order_id)
+                .correlate(Dispute)
+                .scalar_subquery()
+            )
+            .where(
+                Dispute.id.in_(
+                    select(Dispute.id)
+                    .where(Dispute.organization_id.is_(None))
+                    .limit(limit_bindparam())
+                ),
+            )
+        ),
+        batch_size=batch_size,
+        sleep_seconds=sleep_seconds,
+    )
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -2610,6 +2610,7 @@ async def create_dispute(
         evidence_due_by=evidence_due_by,
         past_due=past_due,
         order=order,
+        organization_id=order.organization_id,
         payment=payment,
     )
     await save_fixture(dispute)


### PR DESCRIPTION
## Summary

Add `organization_id` field to the Dispute model to denormalize the organization relationship from the associated Order, enabling more efficient queries and filtering by organization.

## What

- Added `organization_id` column to the `disputes` table via migration
- Added `organization_id` field and `organization` association proxy to the `Dispute` model
- Updated dispute creation in repository and service layers to populate `organization_id` from the related order
- Created backfill script to populate `organization_id` for existing disputes
- Updated test fixtures to include `organization_id` when creating disputes

## Why

This denormalization improves query performance when filtering disputes by organization and simplifies the data model by making the organization relationship explicit on the Dispute entity rather than requiring a join through Order.

## How

1. **Migration**: Added nullable `organization_id` column with foreign key constraint and index
2. **Model**: Added mapped column and association proxy to access organization through the order relationship
3. **Data Population**: Updated creation paths (repository and service) to set `organization_id` from `order.organization_id`
4. **Backfill**: Created async batched script to populate existing dispute records
5. **Tests**: Updated fixture to maintain consistency

## Checklist

- [x] This PR addresses a single concern (adding organization_id denormalization)
- [x] The diff is reasonably sized and easy to review
- [x] Existing tests pass with updated fixtures
- [x] Migration and backfill script follow established patterns

https://claude.ai/code/session_01XmWcbi2frbiqtTp1HDNWeE

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13255?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

