### PR TITLE
sdk: add webhook signature verification helpers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 clients/packages/client/src/v1.ts linguist-generated=true
+sdk/python/** linguist-generated=true
+sdk/typescript/** linguist-generated=true

--- a/sdk/generator/generator/emitter.py
+++ b/sdk/generator/generator/emitter.py
@@ -8,7 +8,7 @@ from typing import Literal
 
 from jinja2 import Environment, FileSystemLoader, Template
 
-from generator.ir import APIIR, APIVersion
+from generator.ir import APIIR, APIVersion, LiteralType
 
 _LOOP_DIRECTORY_PATTERN = re.compile(r"^\[\[([\w\.]+)\]\]$")
 
@@ -92,7 +92,12 @@ class EmitterBase(abc.ABC):
 
         Override this method in subclasses to add custom context variables for a specific version.
         """
-        return {"ir": self.ir, "api": api, "version": self.get_version_string(api)}
+        return {
+            "ir": self.ir,
+            "api": api,
+            "version": self.get_version_string(api),
+            "webhook_event_types": self._get_webhook_event_types(api),
+        }
 
     def copy_file(
         self, source: pathlib.Path | str, destination: pathlib.Path | str
@@ -149,3 +154,15 @@ class EmitterBase(abc.ABC):
         if isinstance(template, str):
             template = self._load_template(template)
         return template.render(**context)
+
+    def _get_webhook_event_types(self, api: APIVersion) -> list[str]:
+        event_types: set[str] = set()
+        for model in api.webhooks:
+            for field in model.fields:
+                if (
+                    field.name == "type"
+                    and isinstance(field.type, LiteralType)
+                    and isinstance(field.type.value, str)
+                ):
+                    event_types.add(field.type.value)
+        return sorted(event_types)

--- a/sdk/generator/python/emitter.py
+++ b/sdk/generator/python/emitter.py
@@ -86,8 +86,10 @@ class PythonEmitter(EmitterBase):
             (".zed", "settings.json"),
             ("polar", "__init__.py"),
             ("polar", "base.py"),
+            ("polar", "webhooks.py"),
             ("tests", "__init__.py"),
             ("tests", "test_base.py"),
+            ("tests", "test_webhooks.py"),
             (".python-version",),
             ("justfile",),
             ("LICENSE",),
@@ -149,7 +151,6 @@ class PythonEmitter(EmitterBase):
                     "enum_imports": self._get_webhook_enum_imports(api),
                 },
             )
-
             errors = self._collect_all_errors(api)
             self.render_file(
                 "polar/version/errors.py",

--- a/sdk/generator/python/template/README.md
+++ b/sdk/generator/python/template/README.md
@@ -36,3 +36,47 @@ separate.
 
 Keep organization access tokens on the server and never expose them in browser or client-side
 code.
+
+## Webhooks
+
+Use `validate_event` to verify that a webhook was sent by Polar and parse it into a typed payload
+for the selected API version. Pass the raw request body, the request headers, and your webhook
+signing secret:
+
+```python
+import os
+
+from fastapi import FastAPI, HTTPException, Request
+
+from polar.v{{ ir.versions[0].version | replace("-", "_") | replace(".", "_") }}.webhooks import (
+    PolarWebhookError,
+    PolarWebhookVerificationError,
+    validate_event,
+)
+
+app = FastAPI()
+webhook_secret = os.environ["POLAR_WEBHOOK_SECRET"]
+
+
+@app.post("/webhooks/polar")
+async def polar_webhook(request: Request) -> dict[str, bool]:
+    try:
+        event = validate_event(
+            await request.body(),
+            dict(request.headers),
+            webhook_secret,
+        )
+    except PolarWebhookVerificationError as exc:
+        raise HTTPException(status_code=403, detail="Invalid webhook signature") from exc
+    except PolarWebhookError as exc:
+        raise HTTPException(status_code=400, detail="Invalid webhook payload") from exc
+
+    if event.type == "order.created":
+        print(event.data.id)
+
+    return {"received": True}
+```
+
+The signature is checked before the body is parsed. `validate_event` raises
+`PolarWebhookVerificationError` for invalid signatures and `PolarWebhookUnknownTypeError` when the
+event is not supported by the selected API version. Both inherit from `PolarWebhookError`.

--- a/sdk/generator/python/template/polar/version/webhooks.py
+++ b/sdk/generator/python/template/polar/version/webhooks.py
@@ -3,6 +3,13 @@ from __future__ import annotations
 import dataclasses
 import typing
 
+from polar.base import retort
+from polar.webhooks import (
+    PolarWebhookError as PolarWebhookError,
+    PolarWebhookUnknownTypeError as PolarWebhookUnknownTypeError,
+    PolarWebhookVerificationError as PolarWebhookVerificationError,
+    validate_event as _validate_event,
+)
 {% if enum_imports %}
 from polar.{{ version }}.literals import (
 {% for enum_name in enum_imports %}
@@ -50,3 +57,20 @@ WebhookPayload: typing.TypeAlias = (
 {% else %}
 WebhookPayload: typing.TypeAlias = typing.Never
 {% endif %}
+
+_KNOWN_EVENT_TYPES = frozenset({
+{% for event_type in webhook_event_types %}
+    {{ event_type | format_default }},
+{% endfor %}
+})
+
+
+def validate_event(
+    body: str | bytes, headers: dict[str, str], secret: str
+) -> WebhookPayload:
+    """Verify a raw Polar webhook request and load its typed payload."""
+    return _validate_event(body, headers, secret, _KNOWN_EVENT_TYPES, _load_payload)
+
+
+def _load_payload(data: dict[str, typing.Any]) -> WebhookPayload:
+    return typing.cast(WebhookPayload, retort.load(data, WebhookPayload))

--- a/sdk/generator/python/template/polar/webhooks.py
+++ b/sdk/generator/python/template/polar/webhooks.py
@@ -1,0 +1,105 @@
+import base64
+import binascii
+import hashlib
+import hmac
+import json
+import math
+import time
+import typing
+
+from polar.base import PolarError
+
+_WEBHOOK_TOLERANCE_SECONDS = 5 * 60
+_PayloadT = typing.TypeVar("_PayloadT")
+
+
+class PolarWebhookError(PolarError):
+    """Base error raised while processing a Polar webhook."""
+
+
+class PolarWebhookVerificationError(PolarWebhookError):
+    """Raised when a Polar webhook signature cannot be verified."""
+
+
+class PolarWebhookUnknownTypeError(PolarWebhookError):
+    """Raised when a verified webhook type is unknown to this SDK version."""
+
+    def __init__(self, event_type: str | None) -> None:
+        self.event_type = event_type
+        super().__init__(f"Unknown webhook event type: {event_type!r}")
+
+
+def validate_event(
+    body: str | bytes,
+    headers: dict[str, str],
+    secret: str,
+    event_types: frozenset[str],
+    payload_loader: typing.Callable[[dict[str, typing.Any]], _PayloadT],
+) -> _PayloadT:
+    """Verify a raw Polar webhook request and load its typed payload."""
+
+    try:
+        body_text = body.decode() if isinstance(body, bytes) else body
+    except UnicodeDecodeError as e:
+        raise PolarWebhookError("Failed to parse webhook payload") from e
+
+    _verify_signature(body_text, headers, secret)
+
+    try:
+        data = json.loads(body_text)
+    except (TypeError, ValueError) as e:
+        raise PolarWebhookError("Failed to parse webhook payload") from e
+
+    event_type = data.get("type") if isinstance(data, dict) else None
+    if not isinstance(event_type, str) or event_type not in event_types:
+        raise PolarWebhookUnknownTypeError(
+            event_type if isinstance(event_type, str) else None
+        )
+
+    try:
+        return payload_loader(data)
+    except Exception as e:
+        raise PolarWebhookError("Failed to parse webhook payload") from e
+
+
+def _verify_signature(body: str, headers: dict[str, str], secret: str) -> None:
+    if not secret:
+        raise PolarWebhookVerificationError("Secret can't be empty")
+
+    normalized_headers = {key.lower(): value for key, value in headers.items()}
+    webhook_id = normalized_headers.get("webhook-id")
+    webhook_timestamp = normalized_headers.get("webhook-timestamp")
+    webhook_signature = normalized_headers.get("webhook-signature")
+    if not webhook_id or not webhook_timestamp or not webhook_signature:
+        raise PolarWebhookVerificationError("Missing required headers")
+
+    try:
+        timestamp = float(webhook_timestamp)
+    except ValueError as e:
+        raise PolarWebhookVerificationError("Invalid signature headers") from e
+    if not math.isfinite(timestamp):
+        raise PolarWebhookVerificationError("Invalid signature headers")
+
+    now = time.time()
+    if timestamp < now - _WEBHOOK_TOLERANCE_SECONDS:
+        raise PolarWebhookVerificationError("Message timestamp too old")
+    if timestamp > now + _WEBHOOK_TOLERANCE_SECONDS:
+        raise PolarWebhookVerificationError("Message timestamp too new")
+
+    signed_content = f"{webhook_id}.{math.floor(timestamp)}.{body}".encode()
+    expected_signature = hmac.new(
+        secret.encode(), signed_content, hashlib.sha256
+    ).digest()
+
+    for versioned_signature in webhook_signature.split():
+        version, separator, signature = versioned_signature.partition(",")
+        if version != "v1" or not separator:
+            continue
+        try:
+            decoded_signature = base64.b64decode(signature, validate=True)
+        except (binascii.Error, ValueError):
+            continue
+        if hmac.compare_digest(expected_signature, decoded_signature):
+            return
+
+    raise PolarWebhookVerificationError("No matching signature found")

--- a/sdk/generator/python/template/pyproject.toml
+++ b/sdk/generator/python/template/pyproject.toml
@@ -31,7 +31,7 @@ path = "polar/__init__.py"
 packages = ["polar"]
 
 [dependency-groups]
-dev = ["ty", "ruff", "pytest"]
+dev = ["ty", "ruff", "pytest", "standardwebhooks>=1.0.0,<2.0.0"]
 
 [tool.ruff]
 target-version = "py311"

--- a/sdk/generator/python/template/tests/test_webhooks.py
+++ b/sdk/generator/python/template/tests/test_webhooks.py
@@ -1,0 +1,110 @@
+import base64
+import dataclasses
+import datetime
+import json
+import typing
+
+import pytest
+from standardwebhooks.webhooks import Webhook
+
+from polar.base import PolarError, retort
+from polar.webhooks import (
+    PolarWebhookError,
+    PolarWebhookUnknownTypeError,
+    PolarWebhookVerificationError,
+    validate_event,
+)
+
+_SECRET = "test-secret"
+_BASE64_SECRET = base64.b64encode(_SECRET.encode()).decode()
+_EVENT_TYPE = "dummy.event"
+_EVENT_TYPES = frozenset({_EVENT_TYPE})
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class DummyPayload:
+    type: typing.Literal["dummy.event"]
+    value: str
+
+
+def _get_headers(
+    body: str, timestamp: datetime.datetime | None = None
+) -> dict[str, str]:
+    timestamp = timestamp or datetime.datetime.now(tz=datetime.UTC)
+    signature = Webhook(_BASE64_SECRET).sign("test-webhook", timestamp, body)
+    return {
+        "Webhook-Id": "test-webhook",
+        "Webhook-Timestamp": str(int(timestamp.timestamp())),
+        "Webhook-Signature": signature,
+    }
+
+
+def _load_payload(data: dict[str, typing.Any]) -> DummyPayload:
+    return retort.load(data, DummyPayload)
+
+
+def _validate_event(
+    body: str | bytes, headers: dict[str, str], secret: str = _SECRET
+) -> DummyPayload:
+    return validate_event(body, headers, secret, _EVENT_TYPES, _load_payload)
+
+
+@pytest.mark.parametrize("as_bytes", [False, True])
+def test_validate_event(as_bytes: bool) -> None:
+    body = json.dumps({"type": _EVENT_TYPE, "value": "payload"})
+    raw_body = body.encode() if as_bytes else body
+
+    assert _validate_event(raw_body, _get_headers(body)) == DummyPayload(
+        type=_EVENT_TYPE, value="payload"
+    )
+
+
+def test_validate_event_rejects_invalid_signature() -> None:
+    body = json.dumps({"type": _EVENT_TYPE, "value": "payload"})
+
+    with pytest.raises(PolarWebhookVerificationError):
+        _validate_event(body, _get_headers("{}"))
+
+
+def test_validate_event_rejects_missing_headers() -> None:
+    body = json.dumps({"type": _EVENT_TYPE, "value": "payload"})
+
+    with pytest.raises(PolarWebhookVerificationError):
+        _validate_event(body, {})
+
+
+def test_validate_event_rejects_stale_timestamp() -> None:
+    body = json.dumps({"type": _EVENT_TYPE, "value": "payload"})
+    timestamp = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(minutes=6)
+
+    with pytest.raises(PolarWebhookVerificationError):
+        _validate_event(body, _get_headers(body, timestamp))
+
+
+def test_validate_event_rejects_unknown_type() -> None:
+    body = json.dumps({"type": "future.event", "value": "payload"})
+
+    with pytest.raises(PolarWebhookUnknownTypeError) as exception_info:
+        _validate_event(body, _get_headers(body))
+
+    assert exception_info.value.event_type == "future.event"
+
+
+def test_validate_event_rejects_malformed_known_payload() -> None:
+    body = json.dumps({"type": _EVENT_TYPE})
+
+    with pytest.raises(PolarWebhookError):
+        _validate_event(body, _get_headers(body))
+
+
+def test_validate_event_rejects_malformed_json() -> None:
+    body = "{"
+
+    with pytest.raises(PolarWebhookError):
+        _validate_event(body, _get_headers(body))
+
+
+def test_webhook_error_hierarchy() -> None:
+    assert issubclass(PolarWebhookError, PolarError)
+    assert issubclass(PolarWebhookVerificationError, PolarWebhookError)
+    assert issubclass(PolarWebhookUnknownTypeError, PolarWebhookError)

--- a/sdk/generator/typescript/emitter.py
+++ b/sdk/generator/typescript/emitter.py
@@ -76,6 +76,16 @@ class TypeScriptEmitter(EmitterBase):
             self.get_context(),
         )
         self.render_file(
+            "src/webhooks.ts",
+            src_dir / "webhooks.ts",
+            self.get_context(),
+        )
+        self.render_file(
+            "src/webhooks.test.ts",
+            src_dir / "webhooks.test.ts",
+            self.get_context(),
+        )
+        self.render_file(
             "src/index.ts",
             src_dir / "index.ts",
             self.get_context(),
@@ -108,7 +118,6 @@ class TypeScriptEmitter(EmitterBase):
             # Emit models
             self._emit_models(version_dir, api)
             self._emit_webhooks(version_dir, api)
-
             # Emit services
             for service in api.services:
                 self._emit_service(service, api, version_dir / "services")

--- a/sdk/generator/typescript/template/README.md
+++ b/sdk/generator/typescript/template/README.md
@@ -70,39 +70,36 @@ if (!webhookSecret) {
   throw new Error("POLAR_WEBHOOK_SECRET is required");
 }
 
-app.post(
-  "/webhooks/polar",
-  express.raw({ type: "application/json" }),
-  (request, response) => {
-    try {
-      const event = webhooks.validateEvent(
-        request.body,
-        {
-          "webhook-id": request.header("webhook-id") ?? "",
-          "webhook-timestamp": request.header("webhook-timestamp") ?? "",
-          "webhook-signature": request.header("webhook-signature") ?? "",
-        },
-        webhookSecret,
-      );
+const rawBody = express.raw({ type: "application/json" });
+app.post("/webhooks/polar", rawBody, async (request, response) => {
+  try {
+    const event = await webhooks.validateEvent(
+      request.body,
+      {
+        "webhook-id": request.header("webhook-id") ?? "",
+        "webhook-timestamp": request.header("webhook-timestamp") ?? "",
+        "webhook-signature": request.header("webhook-signature") ?? "",
+      },
+      webhookSecret,
+    );
 
-      if (event.type === "order.created") {
-        console.log(event.data.id);
-      }
-
-      response.status(200).json({ received: true });
-    } catch (error) {
-      if (error instanceof webhooks.PolarWebhookVerificationError) {
-        response.status(403).json({ error: "Invalid webhook signature" });
-        return;
-      }
-      if (error instanceof webhooks.PolarWebhookError) {
-        response.status(400).json({ error: "Invalid webhook payload" });
-        return;
-      }
-      throw error;
+    if (event.type === "order.created") {
+      console.log(event.data.id);
     }
-  },
-);
+
+    response.status(200).json({ received: true });
+  } catch (error) {
+    if (error instanceof webhooks.PolarWebhookVerificationError) {
+      response.status(403).json({ error: "Invalid webhook signature" });
+      return;
+    }
+    if (error instanceof webhooks.PolarWebhookError) {
+      response.status(400).json({ error: "Invalid webhook payload" });
+      return;
+    }
+    throw error;
+  }
+});
 ```
 
 The `express.raw` middleware is required because the signature must be checked against the body

--- a/sdk/generator/typescript/template/README.md
+++ b/sdk/generator/typescript/template/README.md
@@ -52,3 +52,60 @@ const polar = createPolarCore({
 const customerState = await getStateExternalCustomers(polar)("customer_external_id");
 console.log(customerState);
 ```
+
+## Webhooks
+
+Use `webhooks.validateEvent` to verify that a webhook was sent by Polar and parse it into a typed
+payload for the selected API version. Pass the raw request body, the request headers, and your
+webhook signing secret:
+
+```typescript
+import express from "express";
+import { webhooks } from "@polar-sh/sdk/{{ ir.versions[0].version }}";
+
+const app = express();
+const webhookSecret = process.env.POLAR_WEBHOOK_SECRET;
+
+if (!webhookSecret) {
+  throw new Error("POLAR_WEBHOOK_SECRET is required");
+}
+
+app.post(
+  "/webhooks/polar",
+  express.raw({ type: "application/json" }),
+  (request, response) => {
+    try {
+      const event = webhooks.validateEvent(
+        request.body,
+        {
+          "webhook-id": request.header("webhook-id") ?? "",
+          "webhook-timestamp": request.header("webhook-timestamp") ?? "",
+          "webhook-signature": request.header("webhook-signature") ?? "",
+        },
+        webhookSecret,
+      );
+
+      if (event.type === "order.created") {
+        console.log(event.data.id);
+      }
+
+      response.status(200).json({ received: true });
+    } catch (error) {
+      if (error instanceof webhooks.PolarWebhookVerificationError) {
+        response.status(403).json({ error: "Invalid webhook signature" });
+        return;
+      }
+      if (error instanceof webhooks.PolarWebhookError) {
+        response.status(400).json({ error: "Invalid webhook payload" });
+        return;
+      }
+      throw error;
+    }
+  },
+);
+```
+
+The `express.raw` middleware is required because the signature must be checked against the body
+before it is parsed. `validateEvent` throws `PolarWebhookVerificationError` for invalid signatures
+and `PolarWebhookUnknownTypeError` when the event is not supported by the selected API version.
+Both inherit from `PolarWebhookError`.

--- a/sdk/generator/typescript/template/package.json
+++ b/sdk/generator/typescript/template/package.json
@@ -7,7 +7,7 @@
   "files": [
     "dist", "README.md", "LICENSE"
   ],
-  "engines": { "node": ">=18" },
+  "engines": { "node": ">=22" },
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",
   "exports": {

--- a/sdk/generator/typescript/template/package.json
+++ b/sdk/generator/typescript/template/package.json
@@ -46,8 +46,10 @@
     "test": "vitest run"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "oxfmt": "^0.56.0",
     "oxlint": "^1.71.0",
+    "standardwebhooks": "^1.0.0",
     "tsdown": "^0.22.3",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"

--- a/sdk/generator/typescript/template/src/version/webhooks.ts
+++ b/sdk/generator/typescript/template/src/version/webhooks.ts
@@ -1,8 +1,17 @@
+import { Buffer } from "node:buffer";
+
+import { validateWebhook } from "../webhooks";
 {% if imports %}import type {
 {% for name in imports %}  {{ name }},
 {% endfor %}} from "./models";
 
-{% endif %}{% for model in api.webhooks %}/**
+{% endif %}export {
+  PolarWebhookError,
+  PolarWebhookUnknownTypeError,
+  PolarWebhookVerificationError,
+} from "../webhooks";
+
+{% for model in api.webhooks %}/**
 {{ (model.description or model.name) | format_description }}
  */
 export interface {{ model.name }}{% if model.fields %} {
@@ -13,3 +22,18 @@ export interface {{ model.name }}{% if model.fields %} {
   {% endfor %}}{% else %} extends Record<string, never> {}{% endif %}
 
 {% endfor %}export type WebhookPayload = {% if api.webhooks %}{% for model in api.webhooks %}{{ model.name }}{% if not loop.last %} | {% endif %}{% endfor %}{% else %}never{% endif %};
+
+const knownEventTypes = new Set<string>([
+{% for event_type in webhook_event_types %}  {{ event_type | format_default }},
+{% endfor %}]);
+
+/**
+ * Verify a raw Polar webhook request and return its typed payload.
+ */
+export const validateEvent = (
+  body: string | Buffer,
+  headers: Record<string, string>,
+  secret: string,
+): WebhookPayload => {
+  return validateWebhook<WebhookPayload>(body, headers, secret, knownEventTypes);
+};

--- a/sdk/generator/typescript/template/src/version/webhooks.ts
+++ b/sdk/generator/typescript/template/src/version/webhooks.ts
@@ -1,5 +1,3 @@
-import { Buffer } from "node:buffer";
-
 import { validateWebhook } from "../webhooks";
 {% if imports %}import type {
 {% for name in imports %}  {{ name }},
@@ -31,9 +29,9 @@ const knownEventTypes = new Set<string>([
  * Verify a raw Polar webhook request and return its typed payload.
  */
 export const validateEvent = (
-  body: string | Buffer,
+  body: string | Uint8Array,
   headers: Record<string, string>,
   secret: string,
-): WebhookPayload => {
+): Promise<WebhookPayload> => {
   return validateWebhook<WebhookPayload>(body, headers, secret, knownEventTypes);
 };

--- a/sdk/generator/typescript/template/src/webhooks.test.ts
+++ b/sdk/generator/typescript/template/src/webhooks.test.ts
@@ -1,0 +1,113 @@
+import { Buffer } from "node:buffer";
+
+import { Webhook } from "standardwebhooks";
+import { describe, expect, test } from "vitest";
+
+import { PolarError } from "./base";
+import {
+  PolarWebhookError,
+  PolarWebhookUnknownTypeError,
+  PolarWebhookVerificationError,
+  validateWebhook,
+} from "./webhooks";
+
+interface DummyPayload {
+  type: "dummy.event";
+  value: string;
+}
+
+const secret = "test-secret";
+const base64Secret = Buffer.from(secret, "utf8").toString("base64");
+const eventTypes = new Set(["dummy.event"]);
+
+const getHeaders = (
+  body: string,
+  timestamp: Date = new Date(),
+): Record<string, string> => {
+  const signature = new Webhook(base64Secret).sign(
+    "test-webhook",
+    timestamp,
+    body,
+  );
+  return {
+    "Webhook-Id": "test-webhook",
+    "Webhook-Timestamp": String(Math.floor(timestamp.getTime() / 1000)),
+    "Webhook-Signature": signature,
+  };
+};
+
+const validateEvent = (
+  body: string | Buffer,
+  headers: Record<string, string>,
+): DummyPayload => {
+  return validateWebhook<DummyPayload>(body, headers, secret, eventTypes);
+};
+
+describe("validateWebhook", () => {
+  test.each([false, true])("validates a known event (buffer: %s)", (asBuffer) => {
+    const body = JSON.stringify({ type: "dummy.event", value: "payload" });
+    const rawBody = asBuffer ? Buffer.from(body) : body;
+
+    expect(validateEvent(rawBody, getHeaders(body))).toEqual({
+      type: "dummy.event",
+      value: "payload",
+    });
+  });
+
+  test("rejects an invalid signature", () => {
+    const body = JSON.stringify({ type: "dummy.event", value: "payload" });
+
+    expect(() => validateEvent(body, getHeaders("{}"))).toThrow(
+      PolarWebhookVerificationError,
+    );
+  });
+
+  test("rejects missing headers", () => {
+    const body = JSON.stringify({ type: "dummy.event", value: "payload" });
+
+    expect(() => validateEvent(body, {})).toThrow(
+      PolarWebhookVerificationError,
+    );
+  });
+
+  test("rejects a stale timestamp", () => {
+    const body = JSON.stringify({ type: "dummy.event", value: "payload" });
+    const timestamp = new Date(Date.now() - 6 * 60 * 1000);
+
+    expect(() => validateEvent(body, getHeaders(body, timestamp))).toThrow(
+      PolarWebhookVerificationError,
+    );
+  });
+
+  test("rejects an unknown event type", () => {
+    const body = JSON.stringify({ type: "future.event", value: "payload" });
+
+    try {
+      validateEvent(body, getHeaders(body));
+      throw new Error("Expected validateEvent to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PolarWebhookUnknownTypeError);
+      expect((error as PolarWebhookUnknownTypeError).eventType).toBe(
+        "future.event",
+      );
+    }
+  });
+
+  test("wraps malformed signed payloads", () => {
+    const body = "{";
+
+    expect(() => validateEvent(body, getHeaders(body))).toThrow(
+      PolarWebhookError,
+    );
+  });
+
+  test("uses the Polar webhook error hierarchy", () => {
+    expect(new PolarWebhookError("error")).toBeInstanceOf(PolarError);
+    expect(new PolarWebhookVerificationError("error")).toBeInstanceOf(
+      PolarWebhookError,
+    );
+    expect(new PolarWebhookUnknownTypeError("future.event")).toBeInstanceOf(
+      PolarWebhookError,
+    );
+  });
+});

--- a/sdk/generator/typescript/template/src/webhooks.test.ts
+++ b/sdk/generator/typescript/template/src/webhooks.test.ts
@@ -37,53 +37,70 @@ const getHeaders = (
 };
 
 const validateEvent = (
-  body: string | Buffer,
+  body: string | Uint8Array,
   headers: Record<string, string>,
-): DummyPayload => {
+): Promise<DummyPayload> => {
   return validateWebhook<DummyPayload>(body, headers, secret, eventTypes);
 };
 
 describe("validateWebhook", () => {
-  test.each([false, true])("validates a known event (buffer: %s)", (asBuffer) => {
+  test.each([
+    ["string", (body: string) => body],
+    ["Buffer", (body: string) => Buffer.from(body)],
+    ["Uint8Array", (body: string) => new TextEncoder().encode(body)],
+  ])("validates a known event from a %s", async (_type, getRawBody) => {
     const body = JSON.stringify({ type: "dummy.event", value: "payload" });
-    const rawBody = asBuffer ? Buffer.from(body) : body;
 
-    expect(validateEvent(rawBody, getHeaders(body))).toEqual({
+    await expect(
+      validateEvent(getRawBody(body), getHeaders(body)),
+    ).resolves.toEqual({
       type: "dummy.event",
       value: "payload",
     });
   });
 
-  test("rejects an invalid signature", () => {
+  test("rejects an invalid signature", async () => {
     const body = JSON.stringify({ type: "dummy.event", value: "payload" });
 
-    expect(() => validateEvent(body, getHeaders("{}"))).toThrow(
+    await expect(validateEvent(body, getHeaders("{}"))).rejects.toThrow(
       PolarWebhookVerificationError,
     );
   });
 
-  test("rejects missing headers", () => {
+  test("rejects malformed signature encoding", async () => {
     const body = JSON.stringify({ type: "dummy.event", value: "payload" });
+    const headers = getHeaders(body);
+    headers["Webhook-Signature"] = "v1,not-base64!";
 
-    expect(() => validateEvent(body, {})).toThrow(
+    await expect(validateEvent(body, headers)).rejects.toThrow(
       PolarWebhookVerificationError,
     );
   });
 
-  test("rejects a stale timestamp", () => {
+  test("rejects missing headers", async () => {
+    const body = JSON.stringify({ type: "dummy.event", value: "payload" });
+
+    await expect(validateEvent(body, {})).rejects.toThrow(
+      PolarWebhookVerificationError,
+    );
+  });
+
+  test("rejects a stale timestamp", async () => {
     const body = JSON.stringify({ type: "dummy.event", value: "payload" });
     const timestamp = new Date(Date.now() - 6 * 60 * 1000);
 
-    expect(() => validateEvent(body, getHeaders(body, timestamp))).toThrow(
+    await expect(
+      validateEvent(body, getHeaders(body, timestamp)),
+    ).rejects.toThrow(
       PolarWebhookVerificationError,
     );
   });
 
-  test("rejects an unknown event type", () => {
+  test("rejects an unknown event type", async () => {
     const body = JSON.stringify({ type: "future.event", value: "payload" });
 
     try {
-      validateEvent(body, getHeaders(body));
+      await validateEvent(body, getHeaders(body));
       throw new Error("Expected validateEvent to throw");
     } catch (error) {
       expect(error).toBeInstanceOf(PolarWebhookUnknownTypeError);
@@ -93,10 +110,10 @@ describe("validateWebhook", () => {
     }
   });
 
-  test("wraps malformed signed payloads", () => {
+  test("wraps malformed signed payloads", async () => {
     const body = "{";
 
-    expect(() => validateEvent(body, getHeaders(body))).toThrow(
+    await expect(validateEvent(body, getHeaders(body))).rejects.toThrow(
       PolarWebhookError,
     );
   });

--- a/sdk/generator/typescript/template/src/webhooks.ts
+++ b/sdk/generator/typescript/template/src/webhooks.ts
@@ -1,0 +1,113 @@
+import { Buffer } from "node:buffer";
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+import { PolarError } from "./base";
+
+const webhookToleranceSeconds = 5 * 60;
+
+export class PolarWebhookError extends PolarError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "PolarWebhookError";
+  }
+}
+
+export class PolarWebhookVerificationError extends PolarWebhookError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "PolarWebhookVerificationError";
+  }
+}
+
+export class PolarWebhookUnknownTypeError extends PolarWebhookError {
+  constructor(public readonly eventType: string | null) {
+    super(`Unknown webhook event type: ${JSON.stringify(eventType)}`);
+    this.name = "PolarWebhookUnknownTypeError";
+  }
+}
+
+export const validateWebhook = <Payload>(
+  body: string | Buffer,
+  headers: Record<string, string>,
+  secret: string,
+  eventTypes: ReadonlySet<string>,
+): Payload => {
+  const bodyText = body.toString();
+  verifySignature(bodyText, headers, secret);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(bodyText);
+  } catch (error) {
+    throw new PolarWebhookError("Failed to parse webhook payload", {
+      cause: error,
+    });
+  }
+
+  const eventType =
+    typeof parsed === "object" &&
+    parsed !== null &&
+    "type" in parsed &&
+    typeof parsed.type === "string"
+      ? parsed.type
+      : null;
+  if (eventType === null || !eventTypes.has(eventType)) {
+    throw new PolarWebhookUnknownTypeError(eventType);
+  }
+
+  return parsed as Payload;
+};
+
+const verifySignature = (
+  body: string,
+  headers: Record<string, string>,
+  secret: string,
+): void => {
+  if (secret.length === 0) {
+    throw new PolarWebhookVerificationError("Secret can't be empty");
+  }
+
+  const normalizedHeaders = Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]),
+  );
+  const webhookId = normalizedHeaders["webhook-id"];
+  const webhookTimestamp = normalizedHeaders["webhook-timestamp"];
+  const webhookSignature = normalizedHeaders["webhook-signature"];
+  if (!webhookId || !webhookTimestamp || !webhookSignature) {
+    throw new PolarWebhookVerificationError("Missing required headers");
+  }
+
+  const timestamp = Number(webhookTimestamp);
+  if (!Number.isFinite(timestamp)) {
+    throw new PolarWebhookVerificationError("Invalid signature headers");
+  }
+
+  const now = Date.now() / 1000;
+  if (timestamp < now - webhookToleranceSeconds) {
+    throw new PolarWebhookVerificationError("Message timestamp too old");
+  }
+  if (timestamp > now + webhookToleranceSeconds) {
+    throw new PolarWebhookVerificationError("Message timestamp too new");
+  }
+
+  const signedContent = `${webhookId}.${Math.floor(timestamp)}.${body}`;
+  const expectedSignature = createHmac("sha256", secret)
+    .update(signedContent)
+    .digest();
+
+  for (const versionedSignature of webhookSignature.split(" ")) {
+    const [version, signature] = versionedSignature.split(",", 2);
+    if (version !== "v1" || signature === undefined) {
+      continue;
+    }
+    const decodedSignature = Buffer.from(signature, "base64");
+    if (
+      decodedSignature.length === expectedSignature.length &&
+      timingSafeEqual(expectedSignature, decodedSignature)
+    ) {
+      return;
+    }
+  }
+
+  throw new PolarWebhookVerificationError("No matching signature found");
+};

--- a/sdk/generator/typescript/template/src/webhooks.ts
+++ b/sdk/generator/typescript/template/src/webhooks.ts
@@ -1,6 +1,3 @@
-import { Buffer } from "node:buffer";
-import { createHmac, timingSafeEqual } from "node:crypto";
-
 import { PolarError } from "./base";
 
 const webhookToleranceSeconds = 5 * 60;
@@ -26,14 +23,14 @@ export class PolarWebhookUnknownTypeError extends PolarWebhookError {
   }
 }
 
-export const validateWebhook = <Payload>(
-  body: string | Buffer,
+export const validateWebhook = async <Payload>(
+  body: string | Uint8Array,
   headers: Record<string, string>,
   secret: string,
   eventTypes: ReadonlySet<string>,
-): Payload => {
-  const bodyText = body.toString();
-  verifySignature(bodyText, headers, secret);
+): Promise<Payload> => {
+  const bodyText = typeof body === "string" ? body : new TextDecoder().decode(body);
+  await verifySignature(bodyText, headers, secret);
 
   let parsed: unknown;
   try {
@@ -58,11 +55,11 @@ export const validateWebhook = <Payload>(
   return parsed as Payload;
 };
 
-const verifySignature = (
+const verifySignature = async (
   body: string,
   headers: Record<string, string>,
   secret: string,
-): void => {
+): Promise<void> => {
   if (secret.length === 0) {
     throw new PolarWebhookVerificationError("Secret can't be empty");
   }
@@ -91,23 +88,47 @@ const verifySignature = (
   }
 
   const signedContent = `${webhookId}.${Math.floor(timestamp)}.${body}`;
-  const expectedSignature = createHmac("sha256", secret)
-    .update(signedContent)
-    .digest();
+  const textEncoder = new TextEncoder();
+  const signedContentBytes = textEncoder.encode(signedContent);
+  const signingKey = await globalThis.crypto.subtle.importKey(
+    "raw",
+    textEncoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["verify"],
+  );
 
   for (const versionedSignature of webhookSignature.split(" ")) {
     const [version, signature] = versionedSignature.split(",", 2);
     if (version !== "v1" || signature === undefined) {
       continue;
     }
-    const decodedSignature = Buffer.from(signature, "base64");
+    const decodedSignature = decodeBase64(signature);
     if (
-      decodedSignature.length === expectedSignature.length &&
-      timingSafeEqual(expectedSignature, decodedSignature)
+      decodedSignature !== null &&
+      (await globalThis.crypto.subtle.verify(
+        "HMAC",
+        signingKey,
+        decodedSignature,
+        signedContentBytes,
+      ))
     ) {
       return;
     }
   }
 
   throw new PolarWebhookVerificationError("No matching signature found");
+};
+
+const decodeBase64 = (value: string): Uint8Array<ArrayBuffer> | null => {
+  try {
+    const decodedValue = globalThis.atob(value);
+    const bytes = new Uint8Array(new ArrayBuffer(decodedValue.length));
+    for (let index = 0; index < decodedValue.length; index++) {
+      bytes[index] = decodedValue.charCodeAt(index);
+    }
+    return bytes;
+  } catch {
+    return null;
+  }
 };

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -36,3 +36,47 @@ separate.
 
 Keep organization access tokens on the server and never expose them in browser or client-side
 code.
+
+## Webhooks
+
+Use `validate_event` to verify that a webhook was sent by Polar and parse it into a typed payload
+for the selected API version. Pass the raw request body, the request headers, and your webhook
+signing secret:
+
+```python
+import os
+
+from fastapi import FastAPI, HTTPException, Request
+
+from polar.v2026_04.webhooks import (
+    PolarWebhookError,
+    PolarWebhookVerificationError,
+    validate_event,
+)
+
+app = FastAPI()
+webhook_secret = os.environ["POLAR_WEBHOOK_SECRET"]
+
+
+@app.post("/webhooks/polar")
+async def polar_webhook(request: Request) -> dict[str, bool]:
+    try:
+        event = validate_event(
+            await request.body(),
+            dict(request.headers),
+            webhook_secret,
+        )
+    except PolarWebhookVerificationError as exc:
+        raise HTTPException(status_code=403, detail="Invalid webhook signature") from exc
+    except PolarWebhookError as exc:
+        raise HTTPException(status_code=400, detail="Invalid webhook payload") from exc
+
+    if event.type == "order.created":
+        print(event.data.id)
+
+    return {"received": True}
+```
+
+The signature is checked before the body is parsed. `validate_event` raises
+`PolarWebhookVerificationError` for invalid signatures and `PolarWebhookUnknownTypeError` when the
+event is not supported by the selected API version. Both inherit from `PolarWebhookError`.

--- a/sdk/python/polar/v2026_04/webhooks.py
+++ b/sdk/python/polar/v2026_04/webhooks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import dataclasses
 import typing
 
+from polar.base import retort
 from polar.v2026_04.outputs import (
     Benefit,
     BenefitGrantWebhook,
@@ -16,6 +17,18 @@ from polar.v2026_04.outputs import (
     Product,
     Refund,
     Subscription,
+)
+from polar.webhooks import (
+    PolarWebhookError as PolarWebhookError,
+)
+from polar.webhooks import (
+    PolarWebhookUnknownTypeError as PolarWebhookUnknownTypeError,
+)
+from polar.webhooks import (
+    PolarWebhookVerificationError as PolarWebhookVerificationError,
+)
+from polar.webhooks import (
+    validate_event as _validate_event,
 )
 
 
@@ -612,3 +625,56 @@ WebhookPayload: typing.TypeAlias = (
     | WebhookSubscriptionUncanceledPayload
     | WebhookSubscriptionUpdatedPayload
 )
+
+_KNOWN_EVENT_TYPES = frozenset(
+    {
+        "benefit.created",
+        "benefit.updated",
+        "benefit_grant.created",
+        "benefit_grant.cycled",
+        "benefit_grant.revoked",
+        "benefit_grant.updated",
+        "checkout.created",
+        "checkout.expired",
+        "checkout.updated",
+        "customer.created",
+        "customer.deleted",
+        "customer.state_changed",
+        "customer.updated",
+        "customer_seat.assigned",
+        "customer_seat.claimed",
+        "customer_seat.revoked",
+        "member.created",
+        "member.deleted",
+        "member.updated",
+        "order.created",
+        "order.paid",
+        "order.refunded",
+        "order.updated",
+        "organization.updated",
+        "product.created",
+        "product.updated",
+        "refund.created",
+        "refund.updated",
+        "subscription.active",
+        "subscription.canceled",
+        "subscription.created",
+        "subscription.past_due",
+        "subscription.paused",
+        "subscription.resumed",
+        "subscription.revoked",
+        "subscription.uncanceled",
+        "subscription.updated",
+    }
+)
+
+
+def validate_event(
+    body: str | bytes, headers: dict[str, str], secret: str
+) -> WebhookPayload:
+    """Verify a raw Polar webhook request and load its typed payload."""
+    return _validate_event(body, headers, secret, _KNOWN_EVENT_TYPES, _load_payload)
+
+
+def _load_payload(data: dict[str, typing.Any]) -> WebhookPayload:
+    return typing.cast(WebhookPayload, retort.load(data, WebhookPayload))

--- a/sdk/python/polar/webhooks.py
+++ b/sdk/python/polar/webhooks.py
@@ -1,0 +1,105 @@
+import base64
+import binascii
+import hashlib
+import hmac
+import json
+import math
+import time
+import typing
+
+from polar.base import PolarError
+
+_WEBHOOK_TOLERANCE_SECONDS = 5 * 60
+_PayloadT = typing.TypeVar("_PayloadT")
+
+
+class PolarWebhookError(PolarError):
+    """Base error raised while processing a Polar webhook."""
+
+
+class PolarWebhookVerificationError(PolarWebhookError):
+    """Raised when a Polar webhook signature cannot be verified."""
+
+
+class PolarWebhookUnknownTypeError(PolarWebhookError):
+    """Raised when a verified webhook type is unknown to this SDK version."""
+
+    def __init__(self, event_type: str | None) -> None:
+        self.event_type = event_type
+        super().__init__(f"Unknown webhook event type: {event_type!r}")
+
+
+def validate_event(
+    body: str | bytes,
+    headers: dict[str, str],
+    secret: str,
+    event_types: frozenset[str],
+    payload_loader: typing.Callable[[dict[str, typing.Any]], _PayloadT],
+) -> _PayloadT:
+    """Verify a raw Polar webhook request and load its typed payload."""
+
+    try:
+        body_text = body.decode() if isinstance(body, bytes) else body
+    except UnicodeDecodeError as e:
+        raise PolarWebhookError("Failed to parse webhook payload") from e
+
+    _verify_signature(body_text, headers, secret)
+
+    try:
+        data = json.loads(body_text)
+    except (TypeError, ValueError) as e:
+        raise PolarWebhookError("Failed to parse webhook payload") from e
+
+    event_type = data.get("type") if isinstance(data, dict) else None
+    if not isinstance(event_type, str) or event_type not in event_types:
+        raise PolarWebhookUnknownTypeError(
+            event_type if isinstance(event_type, str) else None
+        )
+
+    try:
+        return payload_loader(data)
+    except Exception as e:
+        raise PolarWebhookError("Failed to parse webhook payload") from e
+
+
+def _verify_signature(body: str, headers: dict[str, str], secret: str) -> None:
+    if not secret:
+        raise PolarWebhookVerificationError("Secret can't be empty")
+
+    normalized_headers = {key.lower(): value for key, value in headers.items()}
+    webhook_id = normalized_headers.get("webhook-id")
+    webhook_timestamp = normalized_headers.get("webhook-timestamp")
+    webhook_signature = normalized_headers.get("webhook-signature")
+    if not webhook_id or not webhook_timestamp or not webhook_signature:
+        raise PolarWebhookVerificationError("Missing required headers")
+
+    try:
+        timestamp = float(webhook_timestamp)
+    except ValueError as e:
+        raise PolarWebhookVerificationError("Invalid signature headers") from e
+    if not math.isfinite(timestamp):
+        raise PolarWebhookVerificationError("Invalid signature headers")
+
+    now = time.time()
+    if timestamp < now - _WEBHOOK_TOLERANCE_SECONDS:
+        raise PolarWebhookVerificationError("Message timestamp too old")
+    if timestamp > now + _WEBHOOK_TOLERANCE_SECONDS:
+        raise PolarWebhookVerificationError("Message timestamp too new")
+
+    signed_content = f"{webhook_id}.{math.floor(timestamp)}.{body}".encode()
+    expected_signature = hmac.new(
+        secret.encode(), signed_content, hashlib.sha256
+    ).digest()
+
+    for versioned_signature in webhook_signature.split():
+        version, separator, signature = versioned_signature.partition(",")
+        if version != "v1" or not separator:
+            continue
+        try:
+            decoded_signature = base64.b64decode(signature, validate=True)
+        except (binascii.Error, ValueError):
+            continue
+        if hmac.compare_digest(expected_signature, decoded_signature):
+            return
+
+    raise PolarWebhookVerificationError("No matching signature found")

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -31,7 +31,7 @@ path = "polar/__init__.py"
 packages = ["polar"]
 
 [dependency-groups]
-dev = ["ty", "ruff", "pytest"]
+dev = ["ty", "ruff", "pytest", "standardwebhooks>=1.0.0,<2.0.0"]
 
 [tool.ruff]
 target-version = "py311"

--- a/sdk/python/tests/test_webhooks.py
+++ b/sdk/python/tests/test_webhooks.py
@@ -1,0 +1,110 @@
+import base64
+import dataclasses
+import datetime
+import json
+import typing
+
+import pytest
+from standardwebhooks.webhooks import Webhook
+
+from polar.base import PolarError, retort
+from polar.webhooks import (
+    PolarWebhookError,
+    PolarWebhookUnknownTypeError,
+    PolarWebhookVerificationError,
+    validate_event,
+)
+
+_SECRET = "test-secret"
+_BASE64_SECRET = base64.b64encode(_SECRET.encode()).decode()
+_EVENT_TYPE = "dummy.event"
+_EVENT_TYPES = frozenset({_EVENT_TYPE})
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class DummyPayload:
+    type: typing.Literal["dummy.event"]
+    value: str
+
+
+def _get_headers(
+    body: str, timestamp: datetime.datetime | None = None
+) -> dict[str, str]:
+    timestamp = timestamp or datetime.datetime.now(tz=datetime.UTC)
+    signature = Webhook(_BASE64_SECRET).sign("test-webhook", timestamp, body)
+    return {
+        "Webhook-Id": "test-webhook",
+        "Webhook-Timestamp": str(int(timestamp.timestamp())),
+        "Webhook-Signature": signature,
+    }
+
+
+def _load_payload(data: dict[str, typing.Any]) -> DummyPayload:
+    return retort.load(data, DummyPayload)
+
+
+def _validate_event(
+    body: str | bytes, headers: dict[str, str], secret: str = _SECRET
+) -> DummyPayload:
+    return validate_event(body, headers, secret, _EVENT_TYPES, _load_payload)
+
+
+@pytest.mark.parametrize("as_bytes", [False, True])
+def test_validate_event(as_bytes: bool) -> None:
+    body = json.dumps({"type": _EVENT_TYPE, "value": "payload"})
+    raw_body = body.encode() if as_bytes else body
+
+    assert _validate_event(raw_body, _get_headers(body)) == DummyPayload(
+        type=_EVENT_TYPE, value="payload"
+    )
+
+
+def test_validate_event_rejects_invalid_signature() -> None:
+    body = json.dumps({"type": _EVENT_TYPE, "value": "payload"})
+
+    with pytest.raises(PolarWebhookVerificationError):
+        _validate_event(body, _get_headers("{}"))
+
+
+def test_validate_event_rejects_missing_headers() -> None:
+    body = json.dumps({"type": _EVENT_TYPE, "value": "payload"})
+
+    with pytest.raises(PolarWebhookVerificationError):
+        _validate_event(body, {})
+
+
+def test_validate_event_rejects_stale_timestamp() -> None:
+    body = json.dumps({"type": _EVENT_TYPE, "value": "payload"})
+    timestamp = datetime.datetime.now(tz=datetime.UTC) - datetime.timedelta(minutes=6)
+
+    with pytest.raises(PolarWebhookVerificationError):
+        _validate_event(body, _get_headers(body, timestamp))
+
+
+def test_validate_event_rejects_unknown_type() -> None:
+    body = json.dumps({"type": "future.event", "value": "payload"})
+
+    with pytest.raises(PolarWebhookUnknownTypeError) as exception_info:
+        _validate_event(body, _get_headers(body))
+
+    assert exception_info.value.event_type == "future.event"
+
+
+def test_validate_event_rejects_malformed_known_payload() -> None:
+    body = json.dumps({"type": _EVENT_TYPE})
+
+    with pytest.raises(PolarWebhookError):
+        _validate_event(body, _get_headers(body))
+
+
+def test_validate_event_rejects_malformed_json() -> None:
+    body = "{"
+
+    with pytest.raises(PolarWebhookError):
+        _validate_event(body, _get_headers(body))
+
+
+def test_webhook_error_hierarchy() -> None:
+    assert issubclass(PolarWebhookError, PolarError)
+    assert issubclass(PolarWebhookVerificationError, PolarWebhookError)
+    assert issubclass(PolarWebhookUnknownTypeError, PolarWebhookError)

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -29,6 +29,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.6.17"
 source = { registry = "https://pypi.org/simple" }
@@ -44,6 +53,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
 ]
 
 [[package]]
@@ -131,6 +152,7 @@ dependencies = [
 dev = [
     { name = "pytest" },
     { name = "ruff" },
+    { name = "standardwebhooks" },
     { name = "ty" },
 ]
 
@@ -144,6 +166,7 @@ requires-dist = [
 dev = [
     { name = "pytest" },
     { name = "ruff" },
+    { name = "standardwebhooks", specifier = ">=1.0.0,<2.0.0" },
     { name = "ty" },
 ]
 
@@ -173,6 +196,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.20"
 source = { registry = "https://pypi.org/simple" }
@@ -196,6 +231,29 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
     { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
 ]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "standardwebhooks"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "deprecated" },
+    { name = "httpx" },
+    { name = "python-dateutil" },
+    { name = "types-deprecated" },
+    { name = "types-python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/7d/04fc3aa177403472d3ddae90953d8f878dc5fd21ba29c02fc9e97e10703f/standardwebhooks-1.0.1.tar.gz", hash = "sha256:b557bb2e4b16ada179a517ec0fe6cbec5acf976c5619922bf29c457f89a451bd", size = 5103, upload-time = "2026-02-18T19:13:06.793Z" }
 
 [[package]]
 name = "ty"
@@ -223,10 +281,103 @@ wheels = [
 ]
 
 [[package]]
+name = "types-deprecated"
+version = "1.3.1.20260520"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/86/8cc66b0a4d01826e64f86e0001b8755105d1b6052c654e2448a0e72750ee/types_deprecated-1.3.1.20260520.tar.gz", hash = "sha256:4d0d9e5521432d9ce88169fb8b793b45d70d8e8cc1a7ecd5a4465abbf83c9ab4", size = 8649, upload-time = "2026-05-20T05:55:57.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/27/e8fd41f0d41b964870d370e7fc78311193910fe9a15c7399ade4a4aeea58/types_deprecated-1.3.1.20260520-py3-none-any.whl", hash = "sha256:8af853b7ccd3b7685159f3ab2e3b6f7999b6cd7e425cda02749e32a42a96c7d6", size = 9105, upload-time = "2026-05-20T05:55:56.259Z" },
+]
+
+[[package]]
+name = "types-python-dateutil"
+version = "2.9.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/e8/c01bdf0d7c3659428c091fbd693177093639565bcbc86bc20098e6d37cc6/types_python_dateutil-2.9.0.20260518.tar.gz", hash = "sha256:51f02dc03b61c7f6a07df45797d4dfe8a1aa47f0b7db9ad89f6fd3a1a70e1b51", size = 17082, upload-time = "2026-05-18T06:05:24.508Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/22/169273273ca34e9ab0ae2f387ba72ed7e09faaaf834da01d6b89c2bea71a/types_python_dateutil-2.9.0.20260518-py3-none-any.whl", hash = "sha256:d6a9c5bd0de61460c8fdef8ab2b400f956a1a1075cce08d4e2b4434e478c50b8", size = 18431, upload-time = "2026-05-18T06:05:23.641Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/15/0c2d55168707465abfc41f33c0b23d792a5fa9b65c26983606940900a120/wrapt-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f1a2ff355ece6a111ca7a20dc86df6659c9205d3fcee674ca34f2a2854fd4e73", size = 80782, upload-time = "2026-06-20T23:47:44.367Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b5/5c0b093eb48f8a062ef6267d3cb36e9bb1b88440181f6545a383c60efdf8/wrapt-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55b9a899e6fff5444f229d30aa6e9ac92d2216d9d60f33c771b5d76a760d5f8e", size = 81678, upload-time = "2026-06-20T23:47:45.857Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f3/de70937472dd3e8a4e6811192f9c6075efdffd4a2cd9b4596bf160f89668/wrapt-2.2.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a2d78c363f97d8bd718ee40432c66395685e9e98528ccaa423c3355d1715a26d", size = 159671, upload-time = "2026-06-20T23:47:47.345Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/40aed2330e7f02ecf74386ffcfef9ccb7108c6a430f15b6a252b663b1bed/wrapt-2.2.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d619e1eed9bd4f6ed9f24cd61971aa086fa86505289628d464bcf8a2c2e3f328", size = 160785, upload-time = "2026-06-20T23:47:48.759Z" },
+    { url = "https://files.pythonhosted.org/packages/45/04/aa5309beed5344b00220ae6b3b24055852192656194c27947bee1736306a/wrapt-2.2.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:518b0c5e323511ec56a38894802ddd5e1222626484e68efe63f201854ad788e5", size = 153699, upload-time = "2026-06-20T23:47:50.177Z" },
+    { url = "https://files.pythonhosted.org/packages/01/df/2def7e99d1fe87eea413f95f671924cdddcb08823b1ffd212748dfa6d062/wrapt-2.2.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4bccea5cdecffa9dd70e343741f0e41e0a16619313d04b72f78bb525162ebcd0", size = 159695, upload-time = "2026-06-20T23:47:51.602Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f6/a906d01a2ce12157bad2404957b3e2140da354b8a70b2fa48bbf282871c0/wrapt-2.2.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:209112cafd963710a05d199aae431d79a28bc76eb8e6d1bbbb8ad24340722cae", size = 152813, upload-time = "2026-06-20T23:47:53.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/49/bc0086292d239575b4c08f4cf8a4079fa58abbad58ec23abf84833a283ed/wrapt-2.2.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e5a5290e4bf2f332fc29ce72ffb9a2fff678aaac047e2e9f5f7165cd7792e099", size = 158809, upload-time = "2026-06-20T23:47:54.391Z" },
+    { url = "https://files.pythonhosted.org/packages/55/83/8fbd034de1f3e907edaa18786d5dd8f6932874edee0826c7cecb5cab03a1/wrapt-2.2.2-cp311-cp311-win32.whl", hash = "sha256:5499236ad1dc116012e2a5dd943f3f31af12fce452128e2bbcbd55a7d3d4d14c", size = 77414, upload-time = "2026-06-20T23:47:55.882Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/9c/23695baa331c6de4e874c3d78b8e0bed92e1d2a274e665b29858f6841672/wrapt-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:8636809939152be6ae20a6cef0fed9fe60f411b47847d0426a826884b469e971", size = 80368, upload-time = "2026-06-20T23:47:57.237Z" },
+    { url = "https://files.pythonhosted.org/packages/08/49/40cefc342bf89b234a4490d741290fce781774b831aefb39c25471da96c9/wrapt-2.2.2-cp311-cp311-win_arm64.whl", hash = "sha256:5d0a142f7af07caeb5e5da87493162a7b8efa19ba919e550a746f7446e13fb30", size = 79489, upload-time = "2026-06-20T23:47:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
+    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
+    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -52,3 +52,56 @@ const polar = createPolarCore({
 const customerState = await getStateExternalCustomers(polar)("customer_external_id");
 console.log(customerState);
 ```
+
+## Webhooks
+
+Use `webhooks.validateEvent` to verify that a webhook was sent by Polar and parse it into a typed
+payload for the selected API version. Pass the raw request body, the request headers, and your
+webhook signing secret:
+
+```typescript
+import express from "express";
+import { webhooks } from "@polar-sh/sdk/2026-04";
+
+const app = express();
+const webhookSecret = process.env.POLAR_WEBHOOK_SECRET;
+
+if (!webhookSecret) {
+    throw new Error("POLAR_WEBHOOK_SECRET is required");
+}
+
+app.post("/webhooks/polar", express.raw({ type: "application/json" }), (request, response) => {
+    try {
+        const event = webhooks.validateEvent(
+            request.body,
+            {
+                "webhook-id": request.header("webhook-id") ?? "",
+                "webhook-timestamp": request.header("webhook-timestamp") ?? "",
+                "webhook-signature": request.header("webhook-signature") ?? "",
+            },
+            webhookSecret,
+        );
+
+        if (event.type === "order.created") {
+            console.log(event.data.id);
+        }
+
+        response.status(200).json({ received: true });
+    } catch (error) {
+        if (error instanceof webhooks.PolarWebhookVerificationError) {
+            response.status(403).json({ error: "Invalid webhook signature" });
+            return;
+        }
+        if (error instanceof webhooks.PolarWebhookError) {
+            response.status(400).json({ error: "Invalid webhook payload" });
+            return;
+        }
+        throw error;
+    }
+});
+```
+
+The `express.raw` middleware is required because the signature must be checked against the body
+before it is parsed. `validateEvent` throws `PolarWebhookVerificationError` for invalid signatures
+and `PolarWebhookUnknownTypeError` when the event is not supported by the selected API version.
+Both inherit from `PolarWebhookError`.

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -70,9 +70,10 @@ if (!webhookSecret) {
     throw new Error("POLAR_WEBHOOK_SECRET is required");
 }
 
-app.post("/webhooks/polar", express.raw({ type: "application/json" }), (request, response) => {
+const rawBody = express.raw({ type: "application/json" });
+app.post("/webhooks/polar", rawBody, async (request, response) => {
     try {
-        const event = webhooks.validateEvent(
+        const event = await webhooks.validateEvent(
             request.body,
             {
                 "webhook-id": request.header("webhook-id") ?? "",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -96,8 +96,10 @@
     "test": "vitest run"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "oxfmt": "^0.56.0",
     "oxlint": "^1.71.0",
+    "standardwebhooks": "^1.0.0",
     "tsdown": "^0.22.3",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"

--- a/sdk/typescript/pnpm-lock.yaml
+++ b/sdk/typescript/pnpm-lock.yaml
@@ -8,12 +8,18 @@ importers:
 
   .:
     devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.1
       oxfmt:
         specifier: ^0.56.0
         version: 0.56.0
       oxlint:
         specifier: ^1.71.0
         version: 1.73.0
+      standardwebhooks:
+        specifier: ^1.0.0
+        version: 1.0.0
       tsdown:
         specifier: ^0.22.3
         version: 0.22.4(typescript@6.0.3)
@@ -22,7 +28,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(vite@8.1.4)
+        version: 4.1.10(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1))
 
 packages:
 
@@ -392,6 +398,9 @@ packages:
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -406,6 +415,9 @@ packages:
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
   '@vitest/expect@4.1.10':
     resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
@@ -610,6 +622,9 @@ packages:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -806,6 +821,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
@@ -876,6 +894,9 @@ packages:
 
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   vite@8.1.4:
     resolution: {integrity: sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==}
@@ -1173,6 +1194,8 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.3':
@@ -1189,6 +1212,10 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/node@22.20.1':
+    dependencies:
+      undici-types: 6.21.0
+
   '@vitest/expect@4.1.10':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -1198,13 +1225,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.1.4)':
+  '@vitest/mocker@4.1.10(vite@8.1.4(@types/node@22.20.1))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.4
+      vite: 8.1.4(@types/node@22.20.1)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -1323,6 +1350,8 @@ snapshots:
       '@types/estree': 1.0.9
 
   expect-type@1.4.0: {}
+
+  fast-sha256@1.3.0: {}
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -1501,6 +1530,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   std-env@4.2.0: {}
 
   tinybench@2.9.0: {}
@@ -1553,7 +1587,9 @@ snapshots:
       '@quansync/fs': 1.0.0
       quansync: 1.0.0
 
-  vite@8.1.4:
+  undici-types@6.21.0: {}
+
+  vite@8.1.4(@types/node@22.20.1):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
@@ -1561,12 +1597,13 @@ snapshots:
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
+      '@types/node': 22.20.1
       fsevents: 2.3.3
 
-  vitest@4.1.10(vite@8.1.4):
+  vitest@4.1.10(@types/node@22.20.1)(vite@8.1.4(@types/node@22.20.1)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.4)
+      '@vitest/mocker': 4.1.10(vite@8.1.4(@types/node@22.20.1))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -1583,8 +1620,10 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.4
+      vite: 8.1.4(@types/node@22.20.1)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.20.1
     transitivePeerDependencies:
       - msw
 

--- a/sdk/typescript/pnpm-lock.yaml
+++ b/sdk/typescript/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 1.0.0
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.4(typescript@6.0.3)
+        version: 0.22.7(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -448,125 +448,125 @@ packages:
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
-  '@yuku-codegen/binding-darwin-arm64@0.5.44':
-    resolution: {integrity: sha512-mpZc7hrjl/qxcbEMS6vVLE0lO4DjiXCvrp3gYbZ58bbmsSxSGCTlOCA0lpeLXAKOZxe0ZrVoqKteaewFF2Vbuw==}
+  '@yuku-codegen/binding-darwin-arm64@0.6.1':
+    resolution: {integrity: sha512-LDJtpOKtcv9f3V0eDUwFmmy47t2VC+DAuN+gq80R1IA+fa0d408i6sHsVtt6n+g5rf8f86ySoPSAe94lHt6Ixw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@yuku-codegen/binding-darwin-x64@0.5.44':
-    resolution: {integrity: sha512-PCt776PnGtnQYimxk18IyvPf/BQ6CNU95W+6eaoQfeME8ra+7v3pNNoTAmLfSveUC9KZPaoajR9NqkKfEVjA2Q==}
+  '@yuku-codegen/binding-darwin-x64@0.6.1':
+    resolution: {integrity: sha512-fBwpBOh33W7N87F94SVNExwm2KUV3ROhk51okr3Oy2ost1/JJuBWINVjcgwd2WPKZEFzUXgCzj/03UR/G+WIrQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@yuku-codegen/binding-freebsd-x64@0.5.44':
-    resolution: {integrity: sha512-5MNu1R4ysytPLMdl1UlGyjgAbUdT8fguW/QRo+pyEymbuWRN5n8JEHCFpm4AsWdP61fStagSpPDJcwN+mwC9Lg==}
+  '@yuku-codegen/binding-freebsd-x64@0.6.1':
+    resolution: {integrity: sha512-UpMkskQV3a5oPnJV+GFFupIqnLwSBD4ZsZAVUZuNVkrqct433FHKqTwuG+P5JhHZbmhf+++3Ie/V2sgduyXrAQ==}
     cpu: [x64]
     os: [freebsd]
 
-  '@yuku-codegen/binding-linux-arm-gnu@0.5.44':
-    resolution: {integrity: sha512-xbP2qQ7/h6ZZKeckCiI2osB5SE5PBfLb4uzIfO1BSTX+9rlBKTqomxDaCib7aPf2X1CXMiIq+i7AK1EhBa5a7A==}
+  '@yuku-codegen/binding-linux-arm-gnu@0.6.1':
+    resolution: {integrity: sha512-HICjDelfEDeD6TD8OEz/Dvt8KHxJiETR+paI/Fr7eVTQbjMfRrXJz8O1qV1qGH5SHZUGl2SAw2Rp+MLtXOjCrQ==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-codegen/binding-linux-arm-musl@0.5.44':
-    resolution: {integrity: sha512-gmXKMCpgkUm5PllGMKBMoBmqgbTQkx+S85eE46LctuwTSKS/K7u65NE6t4zk6cLDvZpV67enycKXBORWn6q7xA==}
+  '@yuku-codegen/binding-linux-arm-musl@0.6.1':
+    resolution: {integrity: sha512-pUswnwa+WOmtH2ZGOWL05kFLMNY7/TnEAryfIv1yVFzKQnmSy9TKYi3oIOxGZL3w+cdUKCZ6Q+jaD0oI10ztzA==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@yuku-codegen/binding-linux-arm64-gnu@0.5.44':
-    resolution: {integrity: sha512-eOoejNUtnHs1/TMn4wryOAG/TarvlOqSZtRPeS56liBKp/GVQSirqTM9AITSGPLSdK1u7fZWMdj5IOEoJp3ruw==}
+  '@yuku-codegen/binding-linux-arm64-gnu@0.6.1':
+    resolution: {integrity: sha512-Zro0FOu9clLCmqCnUKzEWHAu30tss0iEfhs+KDXm9Dpm1FkIHAKu43tF6FQU2hsTA7a8xd93NGddzc2EOJFKUg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-codegen/binding-linux-arm64-musl@0.5.44':
-    resolution: {integrity: sha512-xTzrhEMy1mdv5+SbJPPlwqlMrhXGPntE2f12TLi+dNPXhif4iXCGJpoh8pV9nwZFE/cq1ITuTnjIfTFj/PifzA==}
+  '@yuku-codegen/binding-linux-arm64-musl@0.6.1':
+    resolution: {integrity: sha512-NZaT+mp9toqWuFEA4MYW5HMRxgIa8DCqnTTnM5SrrojZgm4QoMI/mJfifVet1ZHgl/Dly5m6H6GPpq43uXVj8g==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-codegen/binding-linux-x64-gnu@0.5.44':
-    resolution: {integrity: sha512-2bvgIU4P+f4q18grdHoGnt9L6XlAciq/8GWpM06fmwj8qqruS8qwwwZXBk3/0U2+IHGv9pXRR8GtSXzl5n/blg==}
+  '@yuku-codegen/binding-linux-x64-gnu@0.6.1':
+    resolution: {integrity: sha512-M5macseSCBPvJ4yfKNyQpMc7nBQBtj39MNfMt0r+8UkTnR5qJE00JJx06puHgPxT5hnGxMAuAWZ+3a9H2ngqAw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-codegen/binding-linux-x64-musl@0.5.44':
-    resolution: {integrity: sha512-EzX5hWK0MmU4fbqY9coc5PJ0y0LYjrBdAF7mjSyetdK/yWRGBfHi9nh0dUJ0lqb47653hxB8/r9byfYgg6ecbA==}
+  '@yuku-codegen/binding-linux-x64-musl@0.6.1':
+    resolution: {integrity: sha512-liAyBZI5AbazZGeeNfWj0jCD/TE2L84hgVYh4KkjJA/N9bNzFQCDf4BvWP76nEO89r2tIGEUjbXdM4mM26riHg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-codegen/binding-win32-arm64@0.5.44':
-    resolution: {integrity: sha512-/ajGFWcOLGtmVUdxWKXDW6Ixtez68xxtmd2l95xNg8Lzs4aqbV2cy0Ns2Bzg9vjHsgDIooQlLXHpWh6HsHcy6w==}
+  '@yuku-codegen/binding-win32-arm64@0.6.1':
+    resolution: {integrity: sha512-qItzfH3x6MYChPeGfvh22rHD92WLgXQRSuwvspRVSnLvpnubEfZd+9REPRQVT2l9fIuETDCEkDNRqkDROQTkgA==}
     cpu: [arm64]
     os: [win32]
 
-  '@yuku-codegen/binding-win32-x64@0.5.44':
-    resolution: {integrity: sha512-geuJQ7FKI8YUtBgW8w72ChMfMvYy3gSytACxB4HOkylsoutrhH6lUNYHk1ny/p8u8t47NGxktpnzVJzI8IzJkA==}
+  '@yuku-codegen/binding-win32-x64@0.6.1':
+    resolution: {integrity: sha512-DFFkKROZ9ZAHmFMUFRtRTkosZds1KH8BOx5t3UpNULIjT3iuUmEx9V5pWR0xOi66sANY38Ap77nz1kOZraQxEg==}
     cpu: [x64]
     os: [win32]
 
-  '@yuku-parser/binding-darwin-arm64@0.5.44':
-    resolution: {integrity: sha512-EXSW5w1YOIMyxu53MFxP43gTDeHlQueOjk8AEI9tuLF5976bDq3MXuIgzQvZKPVAirxGZu8+ANVXH1WcAH1G6A==}
+  '@yuku-parser/binding-darwin-arm64@0.6.1':
+    resolution: {integrity: sha512-jORysyRZg5zGDgVw15LGMsjZDh7jwjpUIJRBHgFt0ir15O5pEazfvuF2dnwvrJiTF0IT1EgHAVbTAYJWwQLCjg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@yuku-parser/binding-darwin-x64@0.5.44':
-    resolution: {integrity: sha512-pJBHsKxqR/nPwwaXgkkYTVo3G9dJ/AXhWsYyKyadU1zLg9gGfVwVTMehqwwutMCONDsLqOmEv/UqItmhpVsQJw==}
+  '@yuku-parser/binding-darwin-x64@0.6.1':
+    resolution: {integrity: sha512-dTeYFkkFlbP/WCB2DtezXas3NApOPtFlXSdssB7wGtY9wpNp4HAkVo1KBwI5mcHK0e2joyUcqTSf44mFE+q7vg==}
     cpu: [x64]
     os: [darwin]
 
-  '@yuku-parser/binding-freebsd-x64@0.5.44':
-    resolution: {integrity: sha512-fOqYX5BQML94uj9hd3a+LlBNz54OoDm6l+wgUIZ8UUkOBfPV+w2lux1jj9FKXT85wwjDOFhgZ/XQYSEDK/N9mA==}
+  '@yuku-parser/binding-freebsd-x64@0.6.1':
+    resolution: {integrity: sha512-GExDp3rebo28mt3EAjvKQs0ZC3gkznAErV0I9TUNDa9muuhvD35kft61Mpsc6+NWeE+BG+kUyKbm6iO5B6ZMMA==}
     cpu: [x64]
     os: [freebsd]
 
-  '@yuku-parser/binding-linux-arm-gnu@0.5.44':
-    resolution: {integrity: sha512-kA2jRNh2cbbHDbhBN9IR8CnYI4UZHNQg0OVz6+V16Ph5VlLYpfv/6GdCmvQQoTGAnhFlbQiRoQys03ey91FTew==}
+  '@yuku-parser/binding-linux-arm-gnu@0.6.1':
+    resolution: {integrity: sha512-a9MjABj4J0VE3Z2oROGhmeddZZrhwwrnl4ZWZOuHUhD/smDtDiNtr0LpCbKB7rEYaQ29snopOPdZ/0T3YgLglQ==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-arm-musl@0.5.44':
-    resolution: {integrity: sha512-TQ82L8c5Lxl3HBOmw0uGfCcsyw0mp7DVGwCuW24OdDWak6BKaumvB8/Ep1llPOvhk5xgSFB7fsqgh6sIwkNRew==}
+  '@yuku-parser/binding-linux-arm-musl@0.6.1':
+    resolution: {integrity: sha512-ctuvXJgDRKKlmJfHxT4RsTvcAcHEFNJHTCsGbtt4rluQpVDc+ezk9JvQ534ehoIfZ9T0eIHSBgqYAZ4xCatNmQ==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@yuku-parser/binding-linux-arm64-gnu@0.5.44':
-    resolution: {integrity: sha512-o6up+m/MsoMEtq6h4JTzmzKOvH9o3o41vK8oiok0LOZoPOFOqOSqC+N5V2ArD1O54m5LUq6ErghAbGWiPsMsqg==}
+  '@yuku-parser/binding-linux-arm64-gnu@0.6.1':
+    resolution: {integrity: sha512-vRtyoTtT0Ltowuh9LWOl/ZNU9h79J89ilOz5SEGspcw0jfhoUt19i07VNitll4jjfg5p2EN00q+MqX0pAobrFw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-arm64-musl@0.5.44':
-    resolution: {integrity: sha512-3XZoiHhtrjWKgk7CJC/sGzk1TE57SDPYzOFXUg6CZrigRZ+c0Q5ItzJpyAvhzlxv5ruNRYiuGvFbaRSIDnp2BA==}
+  '@yuku-parser/binding-linux-arm64-musl@0.6.1':
+    resolution: {integrity: sha512-vCsc3GOe1ylmRyfo/WLjIhjiCmaTtJbWNF4ZtgjNegDjpsRsFuCcP9duXB41QcfnJK38repKVFqFh0LR3l48FA==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-parser/binding-linux-x64-gnu@0.5.44':
-    resolution: {integrity: sha512-7KYCySZI6cjsdeiiIwvviDfJFd4Xj5gjNBzm9akUpwxRXNwaHHuEq2yGkVdGqj3BT6dJsiNhJIhtS6k7/HJdFA==}
+  '@yuku-parser/binding-linux-x64-gnu@0.6.1':
+    resolution: {integrity: sha512-gw3d81RdUHSYwjDW2IG6gEtm4VDoPP4ZOqpuC6Nc8+UBfos+4gTWOgzmuxIOVhkSV2fJCcUDpSJIlPzEU0FLZw==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-x64-musl@0.5.44':
-    resolution: {integrity: sha512-SLU/nXwOjET2XlOiO984sAzCloiWw0+JdcWpGzXLz3JQWbdiblxWC9cIvB0fCtKdDhX1mIutKNEH+RRRJADYcQ==}
+  '@yuku-parser/binding-linux-x64-musl@0.6.1':
+    resolution: {integrity: sha512-nzU+Doq9UgZvYYvald36lZJ2Neeyheije6WE/YpoFt/oJiNmnjArRgr2CMtb/7gWBl80YSMwcHK4Ju0E+7wfWg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-parser/binding-win32-arm64@0.5.44':
-    resolution: {integrity: sha512-LGmaJtB2mVqPD7Gu/RKAu9aIVxlaKPOgKB8RPHeFFD5Tf/apCiWZix1tkBjdOAo9cVEAoR9qnVHE6zJ+OG0drQ==}
+  '@yuku-parser/binding-win32-arm64@0.6.1':
+    resolution: {integrity: sha512-r3tXFVDliWCPe7TL6DVxUkT4rkqnXyeFVSEDf+V9My6Gztq99/gIe3POQqFbshTRuSrpEYMGMbGxeFh+m+stxA==}
     cpu: [arm64]
     os: [win32]
 
-  '@yuku-parser/binding-win32-x64@0.5.44':
-    resolution: {integrity: sha512-2i0FTklLuhBIgILvtEQ3IN3J4qaTMKlxptseWNrz4F5mimL9UpQFUniVju9OOInwP2O1vgLdZn8EBjEXGNCHmg==}
+  '@yuku-parser/binding-win32-x64@0.6.1':
+    resolution: {integrity: sha512-FqYMOqeCS2XTdn5yvaKlOhtSQ84mVO3aTXp6LGfMd9Zq8RsV4H8qLWv+sxJsgPCXfuBV64u8/f+CTr3uIwNLWA==}
     cpu: [x64]
     os: [win32]
 
@@ -612,8 +612,8 @@ packages:
     resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
     engines: {node: '>=14'}
 
-  es-module-lexer@2.3.0:
-    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -727,8 +727,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -772,8 +772,8 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.18:
+    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   quansync@1.0.0:
@@ -782,8 +782,8 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
-  rolldown-plugin-dts@0.27.2:
-    resolution: {integrity: sha512-BzyD3qqF4DAg12c8QTVia73dXReDcsMsYHPvKxxjCeBolDbVxtYIy+YanF6osBLn5WGp2F43McOSUhxplgEZuQ==}
+  rolldown-plugin-dts@0.27.8:
+    resolution: {integrity: sha512-IjBTFpkrYYJPRUmIjUJFsZdR1zeHskFcEwFDzSfFDoC2pZcSNgLrBUcDFY9K0Q+A1TZJR3q9MlVomxMDP8AuLQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
     peerDependencies:
       '@ts-macro/tsc': ^0.3.6
@@ -850,18 +850,18 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
-  tsdown@0.22.4:
-    resolution: {integrity: sha512-3a5FsNL2fH2jw3ozvFUuPMBgS0xXjX9wpZShHyB4klXelVhyaNw5Q5WA9TPCNeoGYpRZEc4OZdMx5wT4Fkma3A==}
+  tsdown@0.22.7:
+    resolution: {integrity: sha512-4egbOzc9dxVv/QS+gDV75FIxDIjQQeOnXBlUuikyjmn0ozuc6FW11djJjEEo3vqkuJRygpnKHurnj+Iwftk4VA==}
     engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
     peerDependencies:
       '@arethetypeswrong/core': ^0.18.1
-      '@tsdown/css': 0.22.4
-      '@tsdown/exe': 0.22.4
+      '@tsdown/css': 0.22.7
+      '@tsdown/exe': 0.22.7
       '@vitejs/devtools': '*'
       publint: ^0.3.8
       tsx: '*'
-      typescript: ^5.0.0 || ^6.0.0
+      typescript: ^5.0.0 || ^6.0.0 || ^7.0.0
       unplugin-unused: ^0.5.0
       unrun: '*'
     peerDependenciesMeta:
@@ -990,11 +990,11 @@ packages:
   yuku-ast@0.1.7:
     resolution: {integrity: sha512-2RiMEWv500TixY5rJy6OZd4fSy9WYZKWh6gGbIJ7y7vAGcuCugWOWwOLGaQcRZrXcPUfqtLtvpaJ3SdXtWlhKA==}
 
-  yuku-codegen@0.5.44:
-    resolution: {integrity: sha512-0rhtgWGz+bR3Pe7xqJ5E4VqxI1vqNtkeJRkeXM0Qd3tgldYClQipxa9bRZyuNOOfk0Ri02scrjnkoAHM16/f2g==}
+  yuku-codegen@0.6.1:
+    resolution: {integrity: sha512-6RJqqON2xYhMEp/sZv5oOSI3uOpWwRwzAi2fc/rMcRFjcqedAC5Fyp4AD9Vn2b8SB7hf9ESqVW+YwbDs/KvyKA==}
 
-  yuku-parser@0.5.44:
-    resolution: {integrity: sha512-mAhpQZ/bXjxZmKiGUqEWskC9mZTcTBv6/fdzVdzdjM6XuD1DP3IavdLVWdM39L9ewK9vS9OtJmaKNeWgRzpy0w==}
+  yuku-parser@0.6.1:
+    resolution: {integrity: sha512-dPE3/+H2VBw9LhjoIVeW/axKidYGd+XzNtrwGGseZ0325cQFl0Dpwyh0R74XWe/WqQn4M8CR5YApsv2KF2zN1A==}
 
 snapshots:
 
@@ -1257,70 +1257,70 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@yuku-codegen/binding-darwin-arm64@0.5.44':
+  '@yuku-codegen/binding-darwin-arm64@0.6.1':
     optional: true
 
-  '@yuku-codegen/binding-darwin-x64@0.5.44':
+  '@yuku-codegen/binding-darwin-x64@0.6.1':
     optional: true
 
-  '@yuku-codegen/binding-freebsd-x64@0.5.44':
+  '@yuku-codegen/binding-freebsd-x64@0.6.1':
     optional: true
 
-  '@yuku-codegen/binding-linux-arm-gnu@0.5.44':
+  '@yuku-codegen/binding-linux-arm-gnu@0.6.1':
     optional: true
 
-  '@yuku-codegen/binding-linux-arm-musl@0.5.44':
+  '@yuku-codegen/binding-linux-arm-musl@0.6.1':
     optional: true
 
-  '@yuku-codegen/binding-linux-arm64-gnu@0.5.44':
+  '@yuku-codegen/binding-linux-arm64-gnu@0.6.1':
     optional: true
 
-  '@yuku-codegen/binding-linux-arm64-musl@0.5.44':
+  '@yuku-codegen/binding-linux-arm64-musl@0.6.1':
     optional: true
 
-  '@yuku-codegen/binding-linux-x64-gnu@0.5.44':
+  '@yuku-codegen/binding-linux-x64-gnu@0.6.1':
     optional: true
 
-  '@yuku-codegen/binding-linux-x64-musl@0.5.44':
+  '@yuku-codegen/binding-linux-x64-musl@0.6.1':
     optional: true
 
-  '@yuku-codegen/binding-win32-arm64@0.5.44':
+  '@yuku-codegen/binding-win32-arm64@0.6.1':
     optional: true
 
-  '@yuku-codegen/binding-win32-x64@0.5.44':
+  '@yuku-codegen/binding-win32-x64@0.6.1':
     optional: true
 
-  '@yuku-parser/binding-darwin-arm64@0.5.44':
+  '@yuku-parser/binding-darwin-arm64@0.6.1':
     optional: true
 
-  '@yuku-parser/binding-darwin-x64@0.5.44':
+  '@yuku-parser/binding-darwin-x64@0.6.1':
     optional: true
 
-  '@yuku-parser/binding-freebsd-x64@0.5.44':
+  '@yuku-parser/binding-freebsd-x64@0.6.1':
     optional: true
 
-  '@yuku-parser/binding-linux-arm-gnu@0.5.44':
+  '@yuku-parser/binding-linux-arm-gnu@0.6.1':
     optional: true
 
-  '@yuku-parser/binding-linux-arm-musl@0.5.44':
+  '@yuku-parser/binding-linux-arm-musl@0.6.1':
     optional: true
 
-  '@yuku-parser/binding-linux-arm64-gnu@0.5.44':
+  '@yuku-parser/binding-linux-arm64-gnu@0.6.1':
     optional: true
 
-  '@yuku-parser/binding-linux-arm64-musl@0.5.44':
+  '@yuku-parser/binding-linux-arm64-musl@0.6.1':
     optional: true
 
-  '@yuku-parser/binding-linux-x64-gnu@0.5.44':
+  '@yuku-parser/binding-linux-x64-gnu@0.6.1':
     optional: true
 
-  '@yuku-parser/binding-linux-x64-musl@0.5.44':
+  '@yuku-parser/binding-linux-x64-musl@0.6.1':
     optional: true
 
-  '@yuku-parser/binding-win32-arm64@0.5.44':
+  '@yuku-parser/binding-win32-arm64@0.6.1':
     optional: true
 
-  '@yuku-parser/binding-win32-x64@0.5.44':
+  '@yuku-parser/binding-win32-x64@0.6.1':
     optional: true
 
   '@yuku-toolchain/types@0.5.43': {}
@@ -1343,7 +1343,7 @@ snapshots:
 
   empathic@2.0.1: {}
 
-  es-module-lexer@2.3.0: {}
+  es-module-lexer@2.3.1: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -1421,7 +1421,7 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.16: {}
 
   obug@2.1.3: {}
 
@@ -1477,9 +1477,9 @@ snapshots:
 
   picomatch@4.0.5: {}
 
-  postcss@8.5.16:
+  postcss@8.5.18:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -1487,15 +1487,15 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  rolldown-plugin-dts@0.27.2(rolldown@1.1.5)(typescript@6.0.3):
+  rolldown-plugin-dts@0.27.8(rolldown@1.1.5)(typescript@6.0.3):
     dependencies:
       dts-resolver: 3.0.0
       get-tsconfig: 5.0.0-beta.5
       obug: 2.1.3
       rolldown: 1.1.5
       yuku-ast: 0.1.7
-      yuku-codegen: 0.5.44
-      yuku-parser: 0.5.44
+      yuku-codegen: 0.6.1
+      yuku-parser: 0.6.1
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -1552,7 +1552,7 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  tsdown@0.22.4(typescript@6.0.3):
+  tsdown@0.22.7(typescript@6.0.3):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -1563,7 +1563,7 @@ snapshots:
       obug: 2.1.3
       picomatch: 4.0.5
       rolldown: 1.1.5
-      rolldown-plugin-dts: 0.27.2(rolldown@1.1.5)(typescript@6.0.3)
+      rolldown-plugin-dts: 0.27.8(rolldown@1.1.5)(typescript@6.0.3)
       semver: 7.8.5
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
@@ -1593,7 +1593,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.16
+      postcss: 8.5.18
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -1609,7 +1609,7 @@ snapshots:
       '@vitest/snapshot': 4.1.10
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.0
+      es-module-lexer: 2.3.1
       expect-type: 1.4.0
       magic-string: 0.30.21
       obug: 2.1.3
@@ -1636,34 +1636,34 @@ snapshots:
     dependencies:
       '@yuku-toolchain/types': 0.5.43
 
-  yuku-codegen@0.5.44:
+  yuku-codegen@0.6.1:
     dependencies:
       '@yuku-toolchain/types': 0.5.43
     optionalDependencies:
-      '@yuku-codegen/binding-darwin-arm64': 0.5.44
-      '@yuku-codegen/binding-darwin-x64': 0.5.44
-      '@yuku-codegen/binding-freebsd-x64': 0.5.44
-      '@yuku-codegen/binding-linux-arm-gnu': 0.5.44
-      '@yuku-codegen/binding-linux-arm-musl': 0.5.44
-      '@yuku-codegen/binding-linux-arm64-gnu': 0.5.44
-      '@yuku-codegen/binding-linux-arm64-musl': 0.5.44
-      '@yuku-codegen/binding-linux-x64-gnu': 0.5.44
-      '@yuku-codegen/binding-linux-x64-musl': 0.5.44
-      '@yuku-codegen/binding-win32-arm64': 0.5.44
-      '@yuku-codegen/binding-win32-x64': 0.5.44
+      '@yuku-codegen/binding-darwin-arm64': 0.6.1
+      '@yuku-codegen/binding-darwin-x64': 0.6.1
+      '@yuku-codegen/binding-freebsd-x64': 0.6.1
+      '@yuku-codegen/binding-linux-arm-gnu': 0.6.1
+      '@yuku-codegen/binding-linux-arm-musl': 0.6.1
+      '@yuku-codegen/binding-linux-arm64-gnu': 0.6.1
+      '@yuku-codegen/binding-linux-arm64-musl': 0.6.1
+      '@yuku-codegen/binding-linux-x64-gnu': 0.6.1
+      '@yuku-codegen/binding-linux-x64-musl': 0.6.1
+      '@yuku-codegen/binding-win32-arm64': 0.6.1
+      '@yuku-codegen/binding-win32-x64': 0.6.1
 
-  yuku-parser@0.5.44:
+  yuku-parser@0.6.1:
     dependencies:
       '@yuku-toolchain/types': 0.5.43
     optionalDependencies:
-      '@yuku-parser/binding-darwin-arm64': 0.5.44
-      '@yuku-parser/binding-darwin-x64': 0.5.44
-      '@yuku-parser/binding-freebsd-x64': 0.5.44
-      '@yuku-parser/binding-linux-arm-gnu': 0.5.44
-      '@yuku-parser/binding-linux-arm-musl': 0.5.44
-      '@yuku-parser/binding-linux-arm64-gnu': 0.5.44
-      '@yuku-parser/binding-linux-arm64-musl': 0.5.44
-      '@yuku-parser/binding-linux-x64-gnu': 0.5.44
-      '@yuku-parser/binding-linux-x64-musl': 0.5.44
-      '@yuku-parser/binding-win32-arm64': 0.5.44
-      '@yuku-parser/binding-win32-x64': 0.5.44
+      '@yuku-parser/binding-darwin-arm64': 0.6.1
+      '@yuku-parser/binding-darwin-x64': 0.6.1
+      '@yuku-parser/binding-freebsd-x64': 0.6.1
+      '@yuku-parser/binding-linux-arm-gnu': 0.6.1
+      '@yuku-parser/binding-linux-arm-musl': 0.6.1
+      '@yuku-parser/binding-linux-arm64-gnu': 0.6.1
+      '@yuku-parser/binding-linux-arm64-musl': 0.6.1
+      '@yuku-parser/binding-linux-x64-gnu': 0.6.1
+      '@yuku-parser/binding-linux-x64-musl': 0.6.1
+      '@yuku-parser/binding-win32-arm64': 0.6.1
+      '@yuku-parser/binding-win32-x64': 0.6.1

--- a/sdk/typescript/src/2026-04/models.ts
+++ b/sdk/typescript/src/2026-04/models.ts
@@ -916,7 +916,7 @@ export type PaymentTrigger =
   | "retry_payment_method_update"
   | "retry_admin";
 /**
- * The permission level to grant. Read more about roles and their permissions on [GitHub documentation](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role).
+ * Permission
  */
 export type Permission = "pull" | "triage" | "push" | "maintain" | "admin";
 /**

--- a/sdk/typescript/src/2026-04/webhooks.ts
+++ b/sdk/typescript/src/2026-04/webhooks.ts
@@ -1,5 +1,3 @@
-import { Buffer } from "node:buffer";
-
 import type {
   Benefit,
   BenefitGrantWebhook,
@@ -882,9 +880,9 @@ const knownEventTypes = new Set<string>([
  * Verify a raw Polar webhook request and return its typed payload.
  */
 export const validateEvent = (
-  body: string | Buffer,
+  body: string | Uint8Array,
   headers: Record<string, string>,
   secret: string,
-): WebhookPayload => {
+): Promise<WebhookPayload> => {
   return validateWebhook<WebhookPayload>(body, headers, secret, knownEventTypes);
 };

--- a/sdk/typescript/src/2026-04/webhooks.ts
+++ b/sdk/typescript/src/2026-04/webhooks.ts
@@ -1,3 +1,5 @@
+import { Buffer } from "node:buffer";
+
 import type {
   Benefit,
   BenefitGrantWebhook,
@@ -12,6 +14,14 @@ import type {
   Refund,
   Subscription,
 } from "./models";
+
+import { validateWebhook } from "../webhooks";
+
+export {
+  PolarWebhookError,
+  PolarWebhookUnknownTypeError,
+  PolarWebhookVerificationError,
+} from "../webhooks";
 
 /**
  * Sent when a new benefit is created.
@@ -827,3 +837,54 @@ export type WebhookPayload =
   | WebhookSubscriptionRevokedPayload
   | WebhookSubscriptionUncanceledPayload
   | WebhookSubscriptionUpdatedPayload;
+
+const knownEventTypes = new Set<string>([
+  "benefit.created",
+  "benefit.updated",
+  "benefit_grant.created",
+  "benefit_grant.cycled",
+  "benefit_grant.revoked",
+  "benefit_grant.updated",
+  "checkout.created",
+  "checkout.expired",
+  "checkout.updated",
+  "customer.created",
+  "customer.deleted",
+  "customer.state_changed",
+  "customer.updated",
+  "customer_seat.assigned",
+  "customer_seat.claimed",
+  "customer_seat.revoked",
+  "member.created",
+  "member.deleted",
+  "member.updated",
+  "order.created",
+  "order.paid",
+  "order.refunded",
+  "order.updated",
+  "organization.updated",
+  "product.created",
+  "product.updated",
+  "refund.created",
+  "refund.updated",
+  "subscription.active",
+  "subscription.canceled",
+  "subscription.created",
+  "subscription.past_due",
+  "subscription.paused",
+  "subscription.resumed",
+  "subscription.revoked",
+  "subscription.uncanceled",
+  "subscription.updated",
+]);
+
+/**
+ * Verify a raw Polar webhook request and return its typed payload.
+ */
+export const validateEvent = (
+  body: string | Buffer,
+  headers: Record<string, string>,
+  secret: string,
+): WebhookPayload => {
+  return validateWebhook<WebhookPayload>(body, headers, secret, knownEventTypes);
+};

--- a/sdk/typescript/src/webhooks.test.ts
+++ b/sdk/typescript/src/webhooks.test.ts
@@ -28,47 +28,63 @@ const getHeaders = (body: string, timestamp: Date = new Date()): Record<string, 
   };
 };
 
-const validateEvent = (body: string | Buffer, headers: Record<string, string>): DummyPayload => {
+const validateEvent = (
+  body: string | Uint8Array,
+  headers: Record<string, string>,
+): Promise<DummyPayload> => {
   return validateWebhook<DummyPayload>(body, headers, secret, eventTypes);
 };
 
 describe("validateWebhook", () => {
-  test.each([false, true])("validates a known event (buffer: %s)", (asBuffer) => {
+  test.each([
+    ["string", (body: string) => body],
+    ["Buffer", (body: string) => Buffer.from(body)],
+    ["Uint8Array", (body: string) => new TextEncoder().encode(body)],
+  ])("validates a known event from a %s", async (_type, getRawBody) => {
     const body = JSON.stringify({ type: "dummy.event", value: "payload" });
-    const rawBody = asBuffer ? Buffer.from(body) : body;
 
-    expect(validateEvent(rawBody, getHeaders(body))).toEqual({
+    await expect(validateEvent(getRawBody(body), getHeaders(body))).resolves.toEqual({
       type: "dummy.event",
       value: "payload",
     });
   });
 
-  test("rejects an invalid signature", () => {
+  test("rejects an invalid signature", async () => {
     const body = JSON.stringify({ type: "dummy.event", value: "payload" });
 
-    expect(() => validateEvent(body, getHeaders("{}"))).toThrow(PolarWebhookVerificationError);
-  });
-
-  test("rejects missing headers", () => {
-    const body = JSON.stringify({ type: "dummy.event", value: "payload" });
-
-    expect(() => validateEvent(body, {})).toThrow(PolarWebhookVerificationError);
-  });
-
-  test("rejects a stale timestamp", () => {
-    const body = JSON.stringify({ type: "dummy.event", value: "payload" });
-    const timestamp = new Date(Date.now() - 6 * 60 * 1000);
-
-    expect(() => validateEvent(body, getHeaders(body, timestamp))).toThrow(
+    await expect(validateEvent(body, getHeaders("{}"))).rejects.toThrow(
       PolarWebhookVerificationError,
     );
   });
 
-  test("rejects an unknown event type", () => {
+  test("rejects malformed signature encoding", async () => {
+    const body = JSON.stringify({ type: "dummy.event", value: "payload" });
+    const headers = getHeaders(body);
+    headers["Webhook-Signature"] = "v1,not-base64!";
+
+    await expect(validateEvent(body, headers)).rejects.toThrow(PolarWebhookVerificationError);
+  });
+
+  test("rejects missing headers", async () => {
+    const body = JSON.stringify({ type: "dummy.event", value: "payload" });
+
+    await expect(validateEvent(body, {})).rejects.toThrow(PolarWebhookVerificationError);
+  });
+
+  test("rejects a stale timestamp", async () => {
+    const body = JSON.stringify({ type: "dummy.event", value: "payload" });
+    const timestamp = new Date(Date.now() - 6 * 60 * 1000);
+
+    await expect(validateEvent(body, getHeaders(body, timestamp))).rejects.toThrow(
+      PolarWebhookVerificationError,
+    );
+  });
+
+  test("rejects an unknown event type", async () => {
     const body = JSON.stringify({ type: "future.event", value: "payload" });
 
     try {
-      validateEvent(body, getHeaders(body));
+      await validateEvent(body, getHeaders(body));
       throw new Error("Expected validateEvent to throw");
     } catch (error) {
       expect(error).toBeInstanceOf(PolarWebhookUnknownTypeError);
@@ -76,10 +92,10 @@ describe("validateWebhook", () => {
     }
   });
 
-  test("wraps malformed signed payloads", () => {
+  test("wraps malformed signed payloads", async () => {
     const body = "{";
 
-    expect(() => validateEvent(body, getHeaders(body))).toThrow(PolarWebhookError);
+    await expect(validateEvent(body, getHeaders(body))).rejects.toThrow(PolarWebhookError);
   });
 
   test("uses the Polar webhook error hierarchy", () => {

--- a/sdk/typescript/src/webhooks.test.ts
+++ b/sdk/typescript/src/webhooks.test.ts
@@ -1,0 +1,90 @@
+import { Buffer } from "node:buffer";
+import { Webhook } from "standardwebhooks";
+import { describe, expect, test } from "vitest";
+
+import { PolarError } from "./base";
+import {
+  PolarWebhookError,
+  PolarWebhookUnknownTypeError,
+  PolarWebhookVerificationError,
+  validateWebhook,
+} from "./webhooks";
+
+interface DummyPayload {
+  type: "dummy.event";
+  value: string;
+}
+
+const secret = "test-secret";
+const base64Secret = Buffer.from(secret, "utf8").toString("base64");
+const eventTypes = new Set(["dummy.event"]);
+
+const getHeaders = (body: string, timestamp: Date = new Date()): Record<string, string> => {
+  const signature = new Webhook(base64Secret).sign("test-webhook", timestamp, body);
+  return {
+    "Webhook-Id": "test-webhook",
+    "Webhook-Timestamp": String(Math.floor(timestamp.getTime() / 1000)),
+    "Webhook-Signature": signature,
+  };
+};
+
+const validateEvent = (body: string | Buffer, headers: Record<string, string>): DummyPayload => {
+  return validateWebhook<DummyPayload>(body, headers, secret, eventTypes);
+};
+
+describe("validateWebhook", () => {
+  test.each([false, true])("validates a known event (buffer: %s)", (asBuffer) => {
+    const body = JSON.stringify({ type: "dummy.event", value: "payload" });
+    const rawBody = asBuffer ? Buffer.from(body) : body;
+
+    expect(validateEvent(rawBody, getHeaders(body))).toEqual({
+      type: "dummy.event",
+      value: "payload",
+    });
+  });
+
+  test("rejects an invalid signature", () => {
+    const body = JSON.stringify({ type: "dummy.event", value: "payload" });
+
+    expect(() => validateEvent(body, getHeaders("{}"))).toThrow(PolarWebhookVerificationError);
+  });
+
+  test("rejects missing headers", () => {
+    const body = JSON.stringify({ type: "dummy.event", value: "payload" });
+
+    expect(() => validateEvent(body, {})).toThrow(PolarWebhookVerificationError);
+  });
+
+  test("rejects a stale timestamp", () => {
+    const body = JSON.stringify({ type: "dummy.event", value: "payload" });
+    const timestamp = new Date(Date.now() - 6 * 60 * 1000);
+
+    expect(() => validateEvent(body, getHeaders(body, timestamp))).toThrow(
+      PolarWebhookVerificationError,
+    );
+  });
+
+  test("rejects an unknown event type", () => {
+    const body = JSON.stringify({ type: "future.event", value: "payload" });
+
+    try {
+      validateEvent(body, getHeaders(body));
+      throw new Error("Expected validateEvent to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PolarWebhookUnknownTypeError);
+      expect((error as PolarWebhookUnknownTypeError).eventType).toBe("future.event");
+    }
+  });
+
+  test("wraps malformed signed payloads", () => {
+    const body = "{";
+
+    expect(() => validateEvent(body, getHeaders(body))).toThrow(PolarWebhookError);
+  });
+
+  test("uses the Polar webhook error hierarchy", () => {
+    expect(new PolarWebhookError("error")).toBeInstanceOf(PolarError);
+    expect(new PolarWebhookVerificationError("error")).toBeInstanceOf(PolarWebhookError);
+    expect(new PolarWebhookUnknownTypeError("future.event")).toBeInstanceOf(PolarWebhookError);
+  });
+});

--- a/sdk/typescript/src/webhooks.ts
+++ b/sdk/typescript/src/webhooks.ts
@@ -1,0 +1,107 @@
+import { Buffer } from "node:buffer";
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+import { PolarError } from "./base";
+
+const webhookToleranceSeconds = 5 * 60;
+
+export class PolarWebhookError extends PolarError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "PolarWebhookError";
+  }
+}
+
+export class PolarWebhookVerificationError extends PolarWebhookError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "PolarWebhookVerificationError";
+  }
+}
+
+export class PolarWebhookUnknownTypeError extends PolarWebhookError {
+  constructor(public readonly eventType: string | null) {
+    super(`Unknown webhook event type: ${JSON.stringify(eventType)}`);
+    this.name = "PolarWebhookUnknownTypeError";
+  }
+}
+
+export const validateWebhook = <Payload>(
+  body: string | Buffer,
+  headers: Record<string, string>,
+  secret: string,
+  eventTypes: ReadonlySet<string>,
+): Payload => {
+  const bodyText = body.toString();
+  verifySignature(bodyText, headers, secret);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(bodyText);
+  } catch (error) {
+    throw new PolarWebhookError("Failed to parse webhook payload", {
+      cause: error,
+    });
+  }
+
+  const eventType =
+    typeof parsed === "object" &&
+    parsed !== null &&
+    "type" in parsed &&
+    typeof parsed.type === "string"
+      ? parsed.type
+      : null;
+  if (eventType === null || !eventTypes.has(eventType)) {
+    throw new PolarWebhookUnknownTypeError(eventType);
+  }
+
+  return parsed as Payload;
+};
+
+const verifySignature = (body: string, headers: Record<string, string>, secret: string): void => {
+  if (secret.length === 0) {
+    throw new PolarWebhookVerificationError("Secret can't be empty");
+  }
+
+  const normalizedHeaders = Object.fromEntries(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]),
+  );
+  const webhookId = normalizedHeaders["webhook-id"];
+  const webhookTimestamp = normalizedHeaders["webhook-timestamp"];
+  const webhookSignature = normalizedHeaders["webhook-signature"];
+  if (!webhookId || !webhookTimestamp || !webhookSignature) {
+    throw new PolarWebhookVerificationError("Missing required headers");
+  }
+
+  const timestamp = Number(webhookTimestamp);
+  if (!Number.isFinite(timestamp)) {
+    throw new PolarWebhookVerificationError("Invalid signature headers");
+  }
+
+  const now = Date.now() / 1000;
+  if (timestamp < now - webhookToleranceSeconds) {
+    throw new PolarWebhookVerificationError("Message timestamp too old");
+  }
+  if (timestamp > now + webhookToleranceSeconds) {
+    throw new PolarWebhookVerificationError("Message timestamp too new");
+  }
+
+  const signedContent = `${webhookId}.${Math.floor(timestamp)}.${body}`;
+  const expectedSignature = createHmac("sha256", secret).update(signedContent).digest();
+
+  for (const versionedSignature of webhookSignature.split(" ")) {
+    const [version, signature] = versionedSignature.split(",", 2);
+    if (version !== "v1" || signature === undefined) {
+      continue;
+    }
+    const decodedSignature = Buffer.from(signature, "base64");
+    if (
+      decodedSignature.length === expectedSignature.length &&
+      timingSafeEqual(expectedSignature, decodedSignature)
+    ) {
+      return;
+    }
+  }
+
+  throw new PolarWebhookVerificationError("No matching signature found");
+};

--- a/sdk/typescript/src/webhooks.ts
+++ b/sdk/typescript/src/webhooks.ts
@@ -1,6 +1,3 @@
-import { Buffer } from "node:buffer";
-import { createHmac, timingSafeEqual } from "node:crypto";
-
 import { PolarError } from "./base";
 
 const webhookToleranceSeconds = 5 * 60;
@@ -26,14 +23,14 @@ export class PolarWebhookUnknownTypeError extends PolarWebhookError {
   }
 }
 
-export const validateWebhook = <Payload>(
-  body: string | Buffer,
+export const validateWebhook = async <Payload>(
+  body: string | Uint8Array,
   headers: Record<string, string>,
   secret: string,
   eventTypes: ReadonlySet<string>,
-): Payload => {
-  const bodyText = body.toString();
-  verifySignature(bodyText, headers, secret);
+): Promise<Payload> => {
+  const bodyText = typeof body === "string" ? body : new TextDecoder().decode(body);
+  await verifySignature(bodyText, headers, secret);
 
   let parsed: unknown;
   try {
@@ -58,7 +55,11 @@ export const validateWebhook = <Payload>(
   return parsed as Payload;
 };
 
-const verifySignature = (body: string, headers: Record<string, string>, secret: string): void => {
+const verifySignature = async (
+  body: string,
+  headers: Record<string, string>,
+  secret: string,
+): Promise<void> => {
   if (secret.length === 0) {
     throw new PolarWebhookVerificationError("Secret can't be empty");
   }
@@ -87,21 +88,47 @@ const verifySignature = (body: string, headers: Record<string, string>, secret: 
   }
 
   const signedContent = `${webhookId}.${Math.floor(timestamp)}.${body}`;
-  const expectedSignature = createHmac("sha256", secret).update(signedContent).digest();
+  const textEncoder = new TextEncoder();
+  const signedContentBytes = textEncoder.encode(signedContent);
+  const signingKey = await globalThis.crypto.subtle.importKey(
+    "raw",
+    textEncoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["verify"],
+  );
 
   for (const versionedSignature of webhookSignature.split(" ")) {
     const [version, signature] = versionedSignature.split(",", 2);
     if (version !== "v1" || signature === undefined) {
       continue;
     }
-    const decodedSignature = Buffer.from(signature, "base64");
+    const decodedSignature = decodeBase64(signature);
     if (
-      decodedSignature.length === expectedSignature.length &&
-      timingSafeEqual(expectedSignature, decodedSignature)
+      decodedSignature !== null &&
+      (await globalThis.crypto.subtle.verify(
+        "HMAC",
+        signingKey,
+        decodedSignature,
+        signedContentBytes,
+      ))
     ) {
       return;
     }
   }
 
   throw new PolarWebhookVerificationError("No matching signature found");
+};
+
+const decodeBase64 = (value: string): Uint8Array<ArrayBuffer> | null => {
+  try {
+    const decodedValue = globalThis.atob(value);
+    const bytes = new Uint8Array(new ArrayBuffer(decodedValue.length));
+    for (let index = 0; index < decodedValue.length; index++) {
+      bytes[index] = decodedValue.charCodeAt(index);
+    }
+    return bytes;
+  } catch {
+    return null;
+  }
 };


### PR DESCRIPTION
## Summary

- generate typed webhook verification helpers for the Python and TypeScript SDKs
- verify Standard Webhooks signatures with Python and Node standard-library primitives in a shared, unversioned module
- keep Standard Webhooks test-only while binding each API version to its known event types and payload union
- add root-level compatibility tests with dummy payload models and signatures generated by the reference library

## Why

The generated SDKs expose webhook payload types but did not provide a lightweight way to authenticate incoming webhook requests and return the matching typed payload. Keeping the verification core unversioned avoids duplicating cryptographic logic across API versions and avoids adding Standard Webhooks' transitive dependencies to SDK users.

## Validation

- `cd sdk/generator && just lint && just test` — 61 tests passed
- Python SDK: Ruff and ty passed; 21 tests passed
- TypeScript SDK: formatting, lint, type-check, build passed; 17 tests passed
- verified production dependency trees exclude `standardwebhooks`

Closes #13252

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

