### PR TITLE
Add subscription meters to backoffice

### DIFF
--- a/server/polar/backoffice/subscriptions/endpoints.py
+++ b/server/polar/backoffice/subscriptions/endpoints.py
@@ -6,12 +6,19 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import UUID4, BeforeValidator, ValidationError
 from sqlalchemy import func, or_
-from sqlalchemy.orm import contains_eager, joinedload
-from tagflow import classes, tag, text
+from sqlalchemy.orm import contains_eager, joinedload, selectinload
+from tagflow import attr, classes, tag, text
 
 from polar.kit.pagination import PaginationParamsQuery
 from polar.kit.schemas import empty_str_to_none
-from polar.models import Customer, Order, Organization, Product, Subscription
+from polar.models import (
+    Customer,
+    Order,
+    Organization,
+    Product,
+    Subscription,
+    SubscriptionMeter,
+)
 from polar.models.subscription import SubscriptionStatus
 from polar.order.repository import OrderRepository
 from polar.postgres import AsyncSession, get_db_read_session, get_db_session
@@ -21,7 +28,14 @@ from polar.subscription.service import SubscriptionUpdateContext
 from polar.subscription.service import subscription as subscription_service
 from polar.subscription.sorting import SubscriptionSortProperty
 
-from ..components import button, datatable, description_list, input, modal
+from ..components import (
+    button,
+    confirmation_dialog,
+    datatable,
+    description_list,
+    input,
+    modal,
+)
 from ..layout import layout
 from ..orders.components import orders_datatable
 from ..responses import HXRedirectResponse
@@ -60,6 +74,17 @@ class OrganizationColumn(
         self.href_getter = lambda r, i: str(
             r.url_for("organizations:detail", organization_id=i.product.organization_id)
         )
+
+
+class SubscriptionMeterAmountColumn(
+    datatable.DatatableCurrencyColumn[SubscriptionMeter, SubscriptionSortProperty]
+):
+    def __init__(self, currency: str) -> None:
+        super().__init__("amount", "Amount")
+        self.currency = currency
+
+    def get_currency(self, item: SubscriptionMeter) -> str:
+        return self.currency
 
 
 @contextlib.contextmanager
@@ -206,6 +231,7 @@ async def get(
             joinedload(Subscription.customer),
             joinedload(Subscription.product).joinedload(Product.organization),
             joinedload(Subscription.discount),
+            selectinload(Subscription.meters).joinedload(SubscriptionMeter.meter),
         ),
     )
 
@@ -376,12 +402,90 @@ async def get(
                             ).render(request, subscription):
                                 pass
 
-            # Orders table
+            with tag.div(classes="flex flex-col gap-4"):
+                with tag.h2(classes="text-2xl"):
+                    text("Meters")
+                with datatable.Datatable[SubscriptionMeter, SubscriptionSortProperty](
+                    datatable.DatatableAttrColumn("meter.name", "Meter"),
+                    datatable.DatatableAttrColumn("consumed_units", "Consumed Units"),
+                    datatable.DatatableAttrColumn("credited_units", "Credited Units"),
+                    SubscriptionMeterAmountColumn(subscription.currency),
+                    datatable.DatatableActionsColumn[SubscriptionMeter](
+                        "",
+                        datatable.DatatableActionHTMX[SubscriptionMeter](
+                            "Reset",
+                            lambda r, i: str(
+                                r.url_for(
+                                    "subscriptions:reset_meter",
+                                    id=i.subscription_id,
+                                    subscription_meter_id=i.id,
+                                )
+                            ),
+                            target="#modal",
+                        ),
+                    ),
+                ).render(request, subscription.meters):
+                    pass
+
             with tag.div(classes="flex flex-col gap-4"):
                 with tag.h2(classes="text-2xl"):
                     text("Orders")
                 with orders_datatable(request, orders):
                     pass
+
+
+@router.api_route(
+    "/{id}/meters/{subscription_meter_id}/reset",
+    name="subscriptions:reset_meter",
+    methods=["GET", "POST"],
+)
+async def reset_meter(
+    request: Request,
+    id: UUID4,
+    subscription_meter_id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+) -> Any:
+    subscription_repository = SubscriptionRepository.from_session(session)
+    subscription = await subscription_repository.get_by_id(
+        id, options=subscription_repository.get_eager_options()
+    )
+
+    if subscription is None:
+        raise HTTPException(status_code=404)
+
+    subscription_meter = next(
+        (
+            subscription_meter
+            for subscription_meter in subscription.meters
+            if subscription_meter.id == subscription_meter_id
+        ),
+        None,
+    )
+    if subscription_meter is None:
+        raise HTTPException(status_code=404)
+
+    if request.method == "POST":
+        await subscription_service.reset_meter(
+            session, subscription, subscription_meter
+        )
+        await add_toast(
+            request,
+            f"Meter {subscription_meter.meter.name} has been reset.",
+            "success",
+        )
+        return HXRedirectResponse(
+            request, str(request.url_for("subscriptions:get", id=id)), 303
+        )
+
+    with confirmation_dialog(
+        "Reset meter",
+        f"Reset {subscription_meter.meter.name} for this subscription? "
+        "Any rollover units will be credited to the new meter period.",
+        confirm_text="Reset",
+        open=True,
+    ):
+        attr("hx-post", str(request.url))
+        attr("hx-target", "#modal")
 
 
 @router.api_route("/{id}/cancel", name="subscriptions:cancel", methods=["GET", "POST"])

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -995,34 +995,42 @@ class SubscriptionService:
         This should be called when creating a new subscription or cycling an
         existing one.
         """
-        customer = subscription.customer
         for subscription_meter in subscription.meters:
-            rollover_units = await customer_meter_service.get_rollover_units(
-                session, customer, subscription_meter.meter
-            )
+            await self.reset_meter(session, subscription, subscription_meter)
+
+    async def reset_meter(
+        self,
+        session: AsyncSession,
+        subscription: Subscription,
+        subscription_meter: SubscriptionMeter,
+    ) -> None:
+        customer = subscription.customer
+        rollover_units = await customer_meter_service.get_rollover_units(
+            session, customer, subscription_meter.meter
+        )
+        await event_service.create_event(
+            session,
+            build_system_event(
+                SystemEvent.meter_reset,
+                customer=customer,
+                organization=subscription.organization,
+                metadata={"meter_id": str(subscription_meter.meter_id)},
+            ),
+        )
+        if rollover_units > 0:
             await event_service.create_event(
                 session,
                 build_system_event(
-                    SystemEvent.meter_reset,
+                    SystemEvent.meter_credited,
                     customer=customer,
                     organization=subscription.organization,
-                    metadata={"meter_id": str(subscription_meter.meter_id)},
+                    metadata={
+                        "meter_id": str(subscription_meter.meter_id),
+                        "units": rollover_units,
+                        "rollover": True,
+                    },
                 ),
             )
-            if rollover_units > 0:
-                await event_service.create_event(
-                    session,
-                    build_system_event(
-                        SystemEvent.meter_credited,
-                        customer=customer,
-                        organization=subscription.organization,
-                        metadata={
-                            "meter_id": str(subscription_meter.meter_id),
-                            "units": rollover_units,
-                            "rollover": True,
-                        },
-                    ),
-                )
 
     async def _after_subscription_created(
         self, session: AsyncSession, subscription: Subscription

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -2781,6 +2781,70 @@ async def update_meters_fixtures(
 
 
 @pytest.mark.asyncio
+class TestResetMeter:
+    async def test_without_rollover(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product_recurring_metered: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product_recurring_metered, customer=customer
+        )
+        subscription_meter = subscription.meters[0]
+        get_rollover_units_mock = mocker.patch(
+            "polar.subscription.service.customer_meter_service.get_rollover_units",
+            return_value=0,
+        )
+
+        await subscription_service.reset_meter(
+            session, subscription, subscription_meter
+        )
+
+        get_rollover_units_mock.assert_awaited_once_with(
+            session, customer, subscription_meter.meter
+        )
+        reset_events = await get_all_by_name(session, SystemEvent.meter_reset)
+        assert len(reset_events) == 1
+        assert reset_events[0].user_metadata == {
+            "meter_id": str(subscription_meter.meter_id)
+        }
+        credited_events = await get_all_by_name(session, SystemEvent.meter_credited)
+        assert len(credited_events) == 0
+
+    async def test_with_rollover(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product_recurring_metered: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product_recurring_metered, customer=customer
+        )
+        subscription_meter = subscription.meters[0]
+        mocker.patch(
+            "polar.subscription.service.customer_meter_service.get_rollover_units",
+            return_value=25,
+        )
+
+        await subscription_service.reset_meter(
+            session, subscription, subscription_meter
+        )
+
+        credited_events = await get_all_by_name(session, SystemEvent.meter_credited)
+        assert len(credited_events) == 1
+        assert credited_events[0].user_metadata == {
+            "meter_id": str(subscription_meter.meter_id),
+            "units": 25,
+            "rollover": True,
+        }
+
+
+@pytest.mark.asyncio
 class TestUpdateMeters:
     async def test_no_entries(
         self,


### PR DESCRIPTION
## What changed

- Show associated subscription meters on the subscription backoffice page, including meter name, consumed units, credited units, and amount.
- Add a confirmation-backed action to reset an individual subscription meter.
- Extract the single-meter reset logic from `reset_meters` so bulk and individual resets share rollover behavior.

## Why

The subscription backoffice page did not expose metered subscription usage, and operators could only reset every meter through the bulk service flow. This adds the missing visibility and a targeted operational action.

## Impact

Backoffice operators can inspect current usage and reset one subscription meter without affecting the others. Reset events continue to credit rollover units when applicable.

## Validation

- Ruff formatting and lint checks
- Mypy on the changed production modules
- Focused subscription service tests: 3 passed
- Accepted ADR compliance check: no violations

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

