### PR TITLE
fix: reject NUL characters globally at the Schema base level

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -12221,24 +12221,6 @@ export interface components {
       product_id?: string
     }
     /**
-     * CheckoutCustomerBillingAddressFields
-     * @description Deprecated: Use CheckoutBillingAddressFields instead.
-     */
-    CheckoutCustomerBillingAddressFields: {
-      /** Country */
-      country: boolean
-      /** State */
-      state: boolean
-      /** City */
-      city: boolean
-      /** Postal Code */
-      postal_code: boolean
-      /** Line1 */
-      line1: boolean
-      /** Line2 */
-      line2: boolean
-    }
-    /**
      * CheckoutDiscountFixedOnceForeverDuration
      * @description Schema for a fixed amount discount that is applied once or forever.
      */

--- a/server/polar/kit/schemas.py
+++ b/server/polar/kit/schemas.py
@@ -1,5 +1,5 @@
 import dataclasses
-from collections.abc import Sequence
+from collections.abc import Collection, Mapping, Sequence
 from datetime import datetime
 from typing import Annotated, Any, Literal, cast, get_args, overload
 
@@ -16,6 +16,7 @@ from pydantic import (
     HttpUrl,
     PlainSerializer,
     UrlConstraints,
+    field_validator,
 )
 from pydantic.json_schema import JsonSchemaValue
 from pydantic_core import CoreSchema, core_schema
@@ -24,6 +25,28 @@ from slugify import slugify
 
 class Schema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
+
+    @field_validator("*", mode="after")
+    @classmethod
+    def _reject_nul_characters(cls, value: Any) -> Any:
+        pending = [value]
+
+        while pending:
+            current = pending.pop()
+            if isinstance(current, str):
+                if "\x00" in current:
+                    raise ValueError("This value contains invalid characters")
+            elif isinstance(current, BaseModel):
+                continue
+            elif isinstance(current, Mapping):
+                pending.extend(current.keys())
+                pending.extend(current.values())
+            elif isinstance(current, Collection) and not isinstance(
+                current, (bytes, bytearray)
+            ):
+                pending.extend(current)
+
+        return value
 
 
 class IDSchema(Schema):

--- a/server/polar/kit/schemas.py
+++ b/server/polar/kit/schemas.py
@@ -30,6 +30,7 @@ class Schema(BaseModel):
     @classmethod
     def _reject_nul_characters(cls, value: Any) -> Any:
         pending = [value]
+        visited: set[int] = set()
 
         while pending:
             current = pending.pop()
@@ -39,11 +40,17 @@ class Schema(BaseModel):
             elif isinstance(current, BaseModel):
                 continue
             elif isinstance(current, Mapping):
+                if id(current) in visited:
+                    continue
+                visited.add(id(current))
                 pending.extend(current.keys())
                 pending.extend(current.values())
             elif isinstance(current, Collection) and not isinstance(
                 current, (bytes, bytearray)
             ):
+                if id(current) in visited:
+                    continue
+                visited.add(id(current))
                 pending.extend(current)
 
         return value

--- a/server/tests/kit/test_schemas.py
+++ b/server/tests/kit/test_schemas.py
@@ -1,0 +1,58 @@
+import pytest
+from pydantic import ValidationError
+
+from polar.kit.schemas import Schema
+
+
+class StringSchema(Schema):
+    value: str
+
+
+class StringListSchema(Schema):
+    value: list[str]
+
+
+class StringDictSchema(Schema):
+    value: dict[str, str]
+
+
+class NonStringSchema(Schema):
+    integer: int
+    boolean: bool
+    none: None
+
+
+def test_rejects_nul_character_in_string() -> None:
+    with pytest.raises(ValidationError, match="This value contains invalid characters"):
+        StringSchema(value="invalid\x00string")
+
+
+def test_rejects_nul_character_in_list() -> None:
+    with pytest.raises(ValidationError, match="This value contains invalid characters"):
+        StringListSchema(value=["valid", "invalid\x00string"])
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        {"invalid\x00key": "valid"},
+        {"valid": "invalid\x00value"},
+    ],
+)
+def test_rejects_nul_character_in_dict(value: dict[str, str]) -> None:
+    with pytest.raises(ValidationError, match="This value contains invalid characters"):
+        StringDictSchema(value=value)
+
+
+def test_accepts_valid_strings_and_collections() -> None:
+    assert StringSchema(value="valid").value == "valid"
+    assert StringListSchema(value=["valid", "strings"]).value == ["valid", "strings"]
+    assert StringDictSchema(value={"valid": "strings"}).value == {"valid": "strings"}
+
+
+def test_leaves_non_string_fields_unchanged() -> None:
+    schema = NonStringSchema(integer=42, boolean=True, none=None)
+
+    assert schema.integer == 42
+    assert schema.boolean is True
+    assert schema.none is None

--- a/server/tests/kit/test_schemas.py
+++ b/server/tests/kit/test_schemas.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 from pydantic import ValidationError
 
@@ -20,6 +22,10 @@ class NonStringSchema(Schema):
     integer: int
     boolean: bool
     none: None
+
+
+class AnySchema(Schema):
+    value: Any
 
 
 def test_rejects_nul_character_in_string() -> None:
@@ -56,3 +62,21 @@ def test_leaves_non_string_fields_unchanged() -> None:
     assert schema.integer == 42
     assert schema.boolean is True
     assert schema.none is None
+
+
+def test_handles_circular_collections() -> None:
+    circular_dict: dict[str, Any] = {}
+    circular_dict["self"] = circular_dict
+    circular_list: list[Any] = []
+    circular_list.append(circular_list)
+
+    assert AnySchema(value=circular_dict).value is circular_dict
+    assert AnySchema(value=circular_list).value is circular_list
+
+
+def test_rejects_nul_character_in_circular_collection() -> None:
+    circular_dict: dict[str, Any] = {"invalid": "invalid\x00string"}
+    circular_dict["self"] = circular_dict
+
+    with pytest.raises(ValidationError, match="This value contains invalid characters"):
+        AnySchema(value=circular_dict)


### PR DESCRIPTION
## Summary

- reject NUL characters from strings validated through the shared `Schema` base class
- traverse mappings and finite collections iteratively, including mapping keys and values
- track visited container identities so circular Python collections terminate safely
- leave nested Pydantic models and binary values to their own validation paths
- add focused coverage for strings, lists, dictionaries, circular collections, valid values, and non-string fields

## Why

PostgreSQL cannot store NUL bytes in text, varchar, or JSONB values. When one reaches persistence today, asyncpg raises an opaque `DBAPIError` during SQLAlchemy autoflush instead of returning a useful request-validation error.

This moves the failure to Pydantic validation so malformed API input receives the normal validation response before any database interaction.

## Implementation note

The inherited wildcard validator uses `mode="after"`. Pydantic 2.13.4 rejects `before`, `wrap`, and `plain` validators on discriminator fields, and Polar has discriminated `Schema` subclasses. The after validator remains global for successfully validated field values, while invalid discriminator strings are rejected by their `Literal` schemas.

`check_fields=False` is not required when the wildcard field name (`"*"`) is used on the fieldless base class.

## Validation

- `uv run task lint`
- `uv run task lint_types`
- `uv run pytest tests/kit/test_schemas.py` — 8 passed
- ADR compliance check — no violations