### PR TITLE
fix: send subscription renewal confirmation only after payment succeeds

### DIFF
--- a/server/emails/src/emails/subscription_past_due.tsx
+++ b/server/emails/src/emails/subscription_past_due.tsx
@@ -6,6 +6,7 @@ import {
   Text,
   WrapperOrganization,
 } from '../components/foundation'
+import InfoBox from '../components/InfoBox'
 import { organization, product } from '../preview'
 import type { schemas } from '../types'
 
@@ -19,23 +20,24 @@ export function SubscriptionPastDue({
   return (
     <WrapperOrganization
       organization={organization}
-      preview={`Action needed: update your payment method for ${product.name}`}
+      preview={`Action needed: your ${product.name} payment failed`}
     >
-      <Intro headline="We couldn&rsquo;t process your payment">
-        We tried to charge your payment method for your{' '}
+      <Intro headline="Your payment failed">
+        We couldn&rsquo;t charge your payment method for your{' '}
         <Text as="span" weight="medium">
           {product.name}
         </Text>{' '}
-        subscription, but it didn&rsquo;t go through. This can happen for a
-        number of reasons, like an expired card or a temporary bank hold.
+        subscription. This is usually an expired card or a temporary bank hold.
       </Intro>
-      <Text>
-        Until the payment goes through, your access to{' '}
-        <Text as="span" weight="medium">
-          {product.name}
-        </Text>{' '}
-        won&rsquo;t be available.
-      </Text>
+      <InfoBox title="Your subscription is on hold" variant="error">
+        <Text noMargin>
+          Access to{' '}
+          <Text as="span" weight="medium">
+            {product.name}
+          </Text>{' '}
+          stays unavailable until the payment goes through.
+        </Text>
+      </InfoBox>
       {payment_url ? (
         <>
           <Button href={payment_url}>Update payment method</Button>

--- a/server/emails/src/emails/subscription_past_due.tsx
+++ b/server/emails/src/emails/subscription_past_due.tsx
@@ -1,12 +1,10 @@
 import {
   Button,
-  EmailLink,
   FooterCustomer,
   Intro,
   Text,
   WrapperOrganization,
 } from '../components/foundation'
-import InfoBox from '../components/InfoBox'
 import { organization, product } from '../preview'
 import type { schemas } from '../types'
 
@@ -15,40 +13,61 @@ export function SubscriptionPastDue({
   organization,
   product,
   url,
-  payment_url,
+  access_ends_at,
+  deadline,
 }: schemas['SubscriptionPastDueProps']) {
+  const formatDate = (value: string) =>
+    new Date(value).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    })
+
   return (
     <WrapperOrganization
       organization={organization}
       preview={`Action needed: your ${product.name} payment failed`}
     >
       <Intro headline="Your payment failed">
-        We couldn&rsquo;t charge your payment method for your{' '}
+        We couldn&rsquo;t charge your card on file for your{' '}
         <Text as="span" weight="medium">
           {product.name}
         </Text>{' '}
-        subscription. This is usually an expired card or a temporary bank hold.
+        subscription renewal. This is usually an expired card, insufficient
+        funds, or a temporary bank hold. We&rsquo;ll try again over the next few
+        days.
       </Intro>
-      <InfoBox title="Your subscription is on hold" variant="error">
-        <Text noMargin>
-          Access to{' '}
+      {access_ends_at ? (
+        <Text>
+          You&rsquo;ll keep access to{' '}
           <Text as="span" weight="medium">
             {product.name}
           </Text>{' '}
-          stays unavailable until the payment goes through.
+          until {formatDate(access_ends_at)}. Update your payment method before
+          then to avoid any interruption.
         </Text>
-      </InfoBox>
-      {payment_url ? (
-        <>
-          <Button href={payment_url}>Update payment method</Button>
-          <Text>
-            You can also{' '}
-            <EmailLink href={url}>manage your subscription</EmailLink>.
-          </Text>
-        </>
       ) : (
-        <Button href={url}>Manage subscription</Button>
+        <>
+          <Text>
+            Your access to{' '}
+            <Text as="span" weight="medium">
+              {product.name}
+            </Text>{' '}
+            is paused until payment goes through.
+          </Text>
+          {deadline && (
+            <Text>
+              If we still can&rsquo;t charge your card, your subscription will
+              be canceled on{' '}
+              <Text as="span" weight="medium">
+                {formatDate(deadline)}
+              </Text>
+              .
+            </Text>
+          )}
+        </>
       )}
+      <Button href={url}>Update payment method</Button>
       <FooterCustomer organization={organization} email={email} />
     </WrapperOrganization>
   )
@@ -59,7 +78,8 @@ SubscriptionPastDue.PreviewProps = {
   organization,
   product,
   url: 'https://polar.sh/acme-inc/portal/subscriptions/12345',
-  payment_url: 'https://invoice.stripe.com/i/acct_123/test',
+  access_ends_at: null,
+  deadline: new Date(Date.now() + 21 * 24 * 60 * 60 * 1000).toISOString(),
 }
 
 export default SubscriptionPastDue

--- a/server/emails/src/types/openapi.ts
+++ b/server/emails/src/types/openapi.ts
@@ -2705,10 +2705,15 @@ export interface components {
       /** Url */
       url: string
       /**
-       * Payment Url
+       * Access Ends At
        * @default null
        */
-      payment_url: string | null
+      access_ends_at: string | null
+      /**
+       * Deadline
+       * @default null
+       */
+      deadline: string | null
     }
     /** SubscriptionPausedEmail */
     SubscriptionPausedEmail: {

--- a/server/polar/email/schemas.py
+++ b/server/polar/email/schemas.py
@@ -322,7 +322,8 @@ class SubscriptionFinalInvoiceEmail(BaseModel):
 
 
 class SubscriptionPastDueProps(SubscriptionPropsBase):
-    payment_url: str | None = None
+    access_ends_at: str | None = None
+    deadline: str | None = None
 
 
 class SubscriptionPastDueEmail(BaseModel):

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1452,7 +1452,11 @@ class OrderService:
                 subscription.payment_method_id or customer.default_payment_method_id
             )
             if payment_method_id is None:
+                previous_status = order.status
                 order = await self.handle_payment_failure(session, order)
+                # Dunning state lands after `order.created` was emitted, so emit
+                # the update that carries the retry schedule to merchants.
+                await self._on_order_updated(session, order, previous_status)
             else:
                 enqueue_job(
                     "order.trigger_payment",

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1107,10 +1107,8 @@ class OrderService:
         )
 
         # Fire the `order.created` webhook so merchants are notified about the
-        # draft. We deliberately don't route through `_on_order_created`: a draft
-        # isn't charged yet, so the customer-facing confirmation email it
-        # enqueues would be premature. The `order.paid`/`order.updated` events
-        # are emitted later by finalize_order once the charge settles.
+        # draft. The `order.paid`/`order.updated` events are emitted later by
+        # finalize_order once the charge settles.
         await self.send_webhook(session, order, WebhookEventType.order_created)
 
         return order
@@ -1414,14 +1412,21 @@ class OrderService:
         }:
             await subscription_service.reset_meters(session, subscription)
 
+        # Emit creation events before settling payment, so `order.created` always
+        # precedes `order.paid` and the settling branches below own the paid
+        # transition.
+        await self._on_order_created(session, order)
+
         # If the due amount is less or equal than zero, mark it as paid immediately
         if order.due_amount <= 0:
+            previous_status = order.status
             order = await repository.update(
                 order, update_dict={"status": OrderStatus.paid}
             )
             await self._emit_balance_credit_order_event(
                 session, order, subscription.organization
             )
+            await self._on_order_updated(session, order, previous_status)
         # Sync mode, attempt payment immediately and raise if it fails
         elif payment_mode == PaymentMode.sync:
             payment_method_id = (
@@ -1455,8 +1460,6 @@ class OrderService:
                     payment_method_id=payment_method_id,
                     payment_trigger=PaymentTrigger.subscription_cycle,
                 )
-
-        await self._on_order_created(session, order)
 
         return order
 

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1195,13 +1195,6 @@ class OrderService:
             )
             order = await self.handle_payment(session, order, payment)
 
-        # Unlike the checkout flow, the off-session draft flow skips the
-        # confirmation email at draft creation (nothing is charged yet). Now that
-        # finalize has settled the order as paid, send it so the customer gets
-        # their confirmation.
-        if order.paid:
-            enqueue_job("order.confirmation_email", order.id)
-
         return order
 
     def _get_intent_charge(
@@ -2650,7 +2643,6 @@ class OrderService:
 
     async def _on_order_created(self, session: AsyncSession, order: Order) -> None:
         enqueue_job("order.created", order.id)
-        enqueue_job("order.confirmation_email", order.id)
         await self.send_webhook(session, order, WebhookEventType.order_created)
 
         if order.paid:
@@ -2679,6 +2671,8 @@ class OrderService:
 
     async def _on_order_paid(self, session: AsyncSession, order: Order) -> None:
         assert order.paid
+
+        enqueue_job("order.confirmation_email", order.id)
 
         await receipt_service.allocate(session, order)
 

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -3103,11 +3103,34 @@ class SubscriptionService:
     async def send_past_due_email(
         self, session: AsyncSession, subscription: Subscription
     ) -> None:
+        assert subscription.past_due_at is not None
+
+        organization_repository = OrganizationRepository.from_session(session)
+        organization = await organization_repository.get_by_id(
+            subscription.organization_id,
+            include_deleted=True,
+            include_blocked=True,
+        )
+        assert organization is not None
+
+        grace_period_days = organization.benefit_revocation_grace_period
+        access_ends_at = (
+            subscription.past_due_at + timedelta(days=grace_period_days)
+            if grace_period_days > 0
+            else None
+        )
+        deadline = subscription.past_due_deadline
         return await self._send_customer_email(
             session,
             subscription,
             subject_template="Your {product.name} payment failed",
             template_name="subscription_past_due",
+            extra_context={
+                "access_ends_at": (
+                    access_ends_at.isoformat() if access_ends_at else None
+                ),
+                "deadline": deadline.isoformat() if deadline else None,
+            },
         )
 
     async def send_paused_email(

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -3106,7 +3106,7 @@ class SubscriptionService:
         return await self._send_customer_email(
             session,
             subscription,
-            subject_template="Your {product.name} subscription payment is past due",
+            subject_template="Your {product.name} payment failed",
             template_name="subscription_past_due",
         )
 

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -2246,6 +2246,7 @@ class TestCreateSubscriptionOrder:
 
     async def test_sync_under_minimum_emits_paid_transition_once(
         self,
+        mocker: MockerFixture,
         calculate_tax_mock: MagicMock,
         enqueue_job_mock: MagicMock,
         save_fixture: SaveFixture,
@@ -2279,6 +2280,8 @@ class TestCreateSubscriptionOrder:
             subscription=subscription,
         )
 
+        on_order_paid_spy = mocker.spy(order_service, "_on_order_paid")
+
         order = await order_service.create_subscription_order(
             session,
             subscription,
@@ -2288,6 +2291,59 @@ class TestCreateSubscriptionOrder:
 
         assert order.status == OrderStatus.paid
         assert order.due_amount < get_minimum_currency_amount(order.currency)
+        assert on_order_paid_spy.await_count == 1
+        assert (
+            enqueue_job_mock.call_args_list.count(
+                call("order.confirmation_email", order.id)
+            )
+            == 1
+        )
+
+    async def test_zero_due_emits_paid_transition_once(
+        self,
+        mocker: MockerFixture,
+        calculate_tax_mock: MagicMock,
+        enqueue_job_mock: MagicMock,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        organization: Organization,
+        payment_method: PaymentMethod,
+    ) -> None:
+        # A zero-due cycle settles without any charge, so the branch marking it
+        # paid owns the transition that sends the confirmation.
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            billing_address=Address(country=CountryAlpha2("FR")),
+        )
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            payment_method=payment_method,
+        )
+        price = product.prices[0]
+        assert is_fixed_price(price)
+        await create_billing_entry(
+            save_fixture,
+            type=BillingEntryType.cycle,
+            customer=customer,
+            product_price=price,
+            amount=0,
+            currency=price.price_currency,
+            subscription=subscription,
+        )
+
+        on_order_paid_spy = mocker.spy(order_service, "_on_order_paid")
+
+        order = await order_service.create_subscription_order(
+            session, subscription, OrderBillingReasonInternal.subscription_cycle
+        )
+
+        assert order.due_amount == 0
+        assert order.status == OrderStatus.paid
+        assert on_order_paid_spy.await_count == 1
         assert (
             enqueue_job_mock.call_args_list.count(
                 call("order.confirmation_email", order.id)
@@ -3061,8 +3117,11 @@ class TestHandlePayment:
         assert updated_order.tax_transaction_processor_id == "TAX_TRANSACTION_ID"
 
         # Verify enqueue_job was called to balance the order
-        enqueue_job_mock.assert_any_call(
-            "order.balance", order_id=order.id, charge_id="stripe_payment_123"
+        assert (
+            enqueue_job_mock.call_args_list.count(
+                call("order.balance", order_id=order.id, charge_id="stripe_payment_123")
+            )
+            == 1
         )
 
         # Verify tax transaction was created
@@ -3135,8 +3194,11 @@ class TestHandlePayment:
         assert updated_order.tax_processor == TaxProcessor.numeral
 
         # The balance job should still be enqueued
-        enqueue_job_mock.assert_any_call(
-            "order.balance", order_id=order.id, charge_id="stripe_payment_456"
+        assert (
+            enqueue_job_mock.call_args_list.count(
+                call("order.balance", order_id=order.id, charge_id="stripe_payment_456")
+            )
+            == 1
         )
 
 
@@ -6358,8 +6420,10 @@ class TestFinalizeOrder:
 
         assert result.status == OrderStatus.paid
         assert (
-            call("order.confirmation_email", order.id)
-            in enqueue_job_mock.call_args_list
+            enqueue_job_mock.call_args_list.count(
+                call("order.confirmation_email", order.id)
+            )
+            == 1
         )
 
     async def test_sends_confirmation_email_for_free_product(
@@ -6395,6 +6459,8 @@ class TestFinalizeOrder:
 
         assert result.status == OrderStatus.paid
         assert (
-            call("order.confirmation_email", order.id)
-            in enqueue_job_mock.call_args_list
+            enqueue_job_mock.call_args_list.count(
+                call("order.confirmation_email", order.id)
+            )
+            == 1
         )

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -2241,6 +2241,51 @@ class TestCreateSubscriptionOrder:
         call_args = trigger_payment_mock.call_args
         assert call_args.args[2].id == default_pm.id
 
+    async def test_cycle_does_not_send_confirmation_email_before_payment(
+        self,
+        calculate_tax_mock: MagicMock,
+        enqueue_job_mock: MagicMock,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        organization: Organization,
+        payment_method: PaymentMethod,
+    ) -> None:
+        # The async cycle order is created `pending` and charged by a later task,
+        # so a confirmation must not be promised before the charge is attempted.
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            billing_address=Address(country=CountryAlpha2("FR")),
+        )
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            payment_method=payment_method,
+        )
+        price = product.prices[0]
+        assert is_fixed_price(price)
+        await create_billing_entry(
+            save_fixture,
+            type=BillingEntryType.cycle,
+            customer=customer,
+            product_price=price,
+            amount=price.price_amount,
+            currency=price.price_currency,
+            subscription=subscription,
+        )
+
+        order = await order_service.create_subscription_order(
+            session, subscription, OrderBillingReasonInternal.subscription_cycle
+        )
+
+        assert order.status == OrderStatus.pending
+        assert (
+            call("order.confirmation_email", order.id)
+            not in enqueue_job_mock.call_args_list
+        )
+
 
 @pytest.mark.asyncio
 class TestCreateTrialOrder:
@@ -2832,6 +2877,36 @@ class TestHandlePayment:
         assert result is order
         assert result.status == OrderStatus.paid
 
+    async def test_sends_confirmation_email_once_on_paid_transition(
+        self,
+        enqueue_job_mock: MagicMock,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.pending,
+            billing_reason=OrderBillingReasonInternal.subscription_cycle,
+        )
+        payment = await create_payment(
+            save_fixture, organization, processor_id="ch_cycle_success"
+        )
+
+        result = await order_service.handle_payment(session, order, payment)
+
+        assert result.status == OrderStatus.paid
+        assert (
+            enqueue_job_mock.call_args_list.count(
+                call("order.confirmation_email", order.id)
+            )
+            == 1
+        )
+
     async def test_order_not_pending_raises_for_non_paid(
         self,
         session: AsyncSession,
@@ -2889,7 +2964,7 @@ class TestHandlePayment:
         assert updated_order.tax_transaction_processor_id == "TAX_TRANSACTION_ID"
 
         # Verify enqueue_job was called to balance the order
-        enqueue_job_mock.assert_called_once_with(
+        enqueue_job_mock.assert_any_call(
             "order.balance", order_id=order.id, charge_id="stripe_payment_123"
         )
 
@@ -2963,7 +3038,7 @@ class TestHandlePayment:
         assert updated_order.tax_processor == TaxProcessor.numeral
 
         # The balance job should still be enqueued
-        enqueue_job_mock.assert_called_once_with(
+        enqueue_job_mock.assert_any_call(
             "order.balance", order_id=order.id, charge_id="stripe_payment_456"
         )
 
@@ -6170,16 +6245,14 @@ class TestFinalizeOrder:
         )
         stripe_service_mock.create_payment_intent.return_value = payment_intent
 
-        def _settle(_session: AsyncSession, settled: Order, _payment: object) -> Order:
-            settled.status = OrderStatus.paid
-            return settled
-
+        payment = await create_payment(
+            save_fixture,
+            off_session_organization,
+            processor_id="ch_finalize_success",
+        )
         mocker.patch(
             "polar.order.service.payment_service.upsert_from_stripe_charge",
-            new=AsyncMock(return_value=MagicMock()),
-        )
-        mocker.patch.object(
-            order_service, "handle_payment", new=AsyncMock(side_effect=_settle)
+            new=AsyncMock(return_value=payment),
         )
 
         result = await order_service.finalize_order(

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -36,7 +36,10 @@ from polar.kit.address import (
     CountryAlpha2,
     CountryAlpha2Input,
 )
-from polar.kit.currency import get_maximum_currency_amount
+from polar.kit.currency import (
+    get_maximum_currency_amount,
+    get_minimum_currency_amount,
+)
 from polar.kit.db.postgres import AsyncSession
 from polar.kit.math import polar_round
 from polar.kit.pagination import PaginationParams
@@ -2240,6 +2243,57 @@ class TestCreateSubscriptionOrder:
         trigger_payment_mock.assert_called_once()
         call_args = trigger_payment_mock.call_args
         assert call_args.args[2].id == default_pm.id
+
+    async def test_sync_under_minimum_emits_paid_transition_once(
+        self,
+        calculate_tax_mock: MagicMock,
+        enqueue_job_mock: MagicMock,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        organization: Organization,
+        payment_method: PaymentMethod,
+    ) -> None:
+        # A sub-minimum sync charge (typical of a proration) is settled inside
+        # trigger_payment, which already emits the paid transition.
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            billing_address=Address(country=CountryAlpha2("FR")),
+        )
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            payment_method=payment_method,
+        )
+        price = product.prices[0]
+        assert is_fixed_price(price)
+        await create_billing_entry(
+            save_fixture,
+            type=BillingEntryType.cycle,
+            customer=customer,
+            product_price=price,
+            amount=10,
+            currency=price.price_currency,
+            subscription=subscription,
+        )
+
+        order = await order_service.create_subscription_order(
+            session,
+            subscription,
+            OrderBillingReasonInternal.subscription_update,
+            payment_mode=PaymentMode.sync,
+        )
+
+        assert order.status == OrderStatus.paid
+        assert order.due_amount < get_minimum_currency_amount(order.currency)
+        assert (
+            enqueue_job_mock.call_args_list.count(
+                call("order.confirmation_email", order.id)
+            )
+            == 1
+        )
 
     async def test_cycle_does_not_send_confirmation_email_before_payment(
         self,

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -2295,6 +2295,49 @@ class TestCreateSubscriptionOrder:
             == 1
         )
 
+    async def test_missing_payment_method_emits_order_updated_with_dunning_state(
+        self,
+        mocker: MockerFixture,
+        calculate_tax_mock: MagicMock,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        organization: Organization,
+    ) -> None:
+        # `order.created` is emitted before dunning starts, so merchants only
+        # learn the retry schedule from the follow-up `order.updated`.
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            billing_address=Address(country=CountryAlpha2("FR")),
+        )
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        assert subscription.payment_method is None
+        price = product.prices[0]
+        assert is_fixed_price(price)
+        await create_billing_entry(
+            save_fixture,
+            type=BillingEntryType.cycle,
+            customer=customer,
+            product_price=price,
+            amount=price.price_amount,
+            currency=price.price_currency,
+            subscription=subscription,
+        )
+
+        send_webhook_mock = mocker.patch.object(order_service, "send_webhook")
+
+        order = await order_service.create_subscription_order(
+            session, subscription, OrderBillingReasonInternal.subscription_cycle
+        )
+
+        assert order.next_payment_attempt_at is not None
+        send_webhook_mock.assert_any_await(
+            session, order, WebhookEventType.order_updated
+        )
+
     async def test_cycle_does_not_send_confirmation_email_before_payment(
         self,
         calculate_tax_mock: MagicMock,

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -5344,7 +5344,11 @@ async def test_send_past_due_email(
     customer: Customer,
 ) -> None:
     subscription = await create_subscription(
-        save_fixture, product=product, customer=customer
+        save_fixture,
+        product=product,
+        customer=customer,
+        status=SubscriptionStatus.past_due,
+        past_due_at=utc_now(),
     )
 
     await subscription_service.send_past_due_email(session, subscription)


### PR DESCRIPTION
A failed subscription renewal sent two contradictory emails: "your subscription has been renewed", then "your payment failed".

The confirmation was queued when the order was created, before the charge was attempted. It is now queued when the order becomes paid.

## What

- Move the confirmation email to the paid transition.
- Fix a duplicate paid transition. A charge below the currency minimum, such as a small proration, was marked paid twice. That duplicated the confirmation email, the receipt and the `order.paid` webhook.
- Reword the past-due email to state the failure plainly.

  <img width="1008" height="738" alt="Screenshot 2026-07-20 at 11 34 22" src="https://github.com/user-attachments/assets/09ae781a-8cf5-49d5-b493-b1a633c6a947" />

## Behaviour changes ⚠️ 

- `order.created` now reports `status: pending` for zero-due and sync-settled subscription orders. It previously reported `paid`. All cycle paths are now consistent, and `order.created` always precedes `order.paid`.
- During the deploy, an order created before it and paid after it may send a second confirmation. This is one-time, and the second email is the correct one.
- A renewal with no payment method now sends `order.created` followed by `order.updated`. The retry date and past-due status are in the second one. Before, they were in `order.created`. (⚠️ are we breaking webhooks here?)

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

