### PR TITLE
move account review submit button to bottom

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPageDetailsRequired.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPageDetailsRequired.tsx
@@ -97,36 +97,39 @@ export const AccountPageDetailsRequired = ({ organization }: Props) => {
       onClick={handleSubmit}
       disabled={!canSubmit || isExiting}
       loading={isExiting}
+      className="w-full sm:w-auto"
     >
       Submit for review
     </Button>
   )
 
+  const submitAction =
+    canSubmit || remainingSteps.length === 0 ? (
+      submitButton
+    ) : (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Box display="block" width={{ base: '100%', sm: 'auto' }}>
+            {submitButton}
+          </Box>
+        </TooltipTrigger>
+        <TooltipContent>
+          <Box flexDirection="column" rowGap="xs">
+            <Text variant="caption">Still needed before you submit:</Text>
+            {remainingSteps.map((step) => (
+              <Text key={step.key} variant="caption" color="muted">
+                {STEP_LABELS[step.key]}
+              </Text>
+            ))}
+          </Box>
+        </TooltipContent>
+      </Tooltip>
+    )
+
   return (
     <DashboardBody
       wrapperClassName="max-w-(--breakpoint-sm)!"
       title="Account Review"
-      header={
-        canSubmit || remainingSteps.length === 0 ? (
-          submitButton
-        ) : (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Box display="block">{submitButton}</Box>
-            </TooltipTrigger>
-            <TooltipContent>
-              <Box flexDirection="column" rowGap="xs">
-                <Text variant="caption">Still needed before you submit:</Text>
-                {remainingSteps.map((step) => (
-                  <Text key={step.key} variant="caption" color="muted">
-                    {STEP_LABELS[step.key]}
-                  </Text>
-                ))}
-              </Box>
-            </TooltipContent>
-          </Tooltip>
-        )
-      }
     >
       <Box flexDirection="column" rowGap="xl" paddingBottom="3xl">
         <Text variant="body" color="muted">
@@ -140,6 +143,9 @@ export const AccountPageDetailsRequired = ({ organization }: Props) => {
           rowStagger={ROW_STAGGER}
           rowDuration={ROW_DURATION}
         />
+        <Box flexDirection="column" alignSelf={{ base: 'stretch', sm: 'end' }}>
+          {submitAction}
+        </Box>
       </Box>
     </DashboardBody>
   )


### PR DESCRIPTION
## Summary

Moves the Submit button to the bottom right to keep the logical top to bottom flow. Previously it caused some confusion.

Also makes more sense on mobile.

| Before | After |
|---|---|
| <img width="1890" height="964" alt="Screenshot 2026-07-20 at 12 14 57" src="https://github.com/user-attachments/assets/16bbd23d-4d91-441e-bc12-c274b26ab2c1" /> | <img width="1486" height="898" alt="Screenshot 2026-07-20 at 12 13 12" src="https://github.com/user-attachments/assets/88d23ff9-f0c8-4687-bf07-20d9edaed430" /> |



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

