### PR TITLE
feat(order): add partial index on payment_lock_acquired_at

### DIFF
--- a/server/migrations/versions/2026-07-20-1816_add_partial_index_on_orders_payment_.py
+++ b/server/migrations/versions/2026-07-20-1816_add_partial_index_on_orders_payment_.py
@@ -1,0 +1,49 @@
+"""add partial index on orders payment_lock_acquired_at
+
+Revision ID: 55a5e94aaf9d
+Revises: c3553f7b8b0c
+Create Date: 2026-07-20 18:16:46.705800
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "55a5e94aaf9d"
+down_revision = "c3553f7b8b0c"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+INDEX = "ix_orders_payment_lock_acquired_at"
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        # Drop any INVALID leftover from an interrupted concurrent build first.
+        op.drop_index(
+            INDEX,
+            table_name="orders",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            INDEX,
+            "orders",
+            ["payment_lock_acquired_at"],
+            unique=False,
+            postgresql_concurrently=True,
+            postgresql_where=sa.text("payment_lock_acquired_at IS NOT NULL"),
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            INDEX,
+            table_name="orders",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )

--- a/server/polar/models/order.py
+++ b/server/polar/models/order.py
@@ -108,6 +108,11 @@ class Order(CustomFieldDataMixin, MetadataMixin, RecordModel):
             unique=True,
             postgresql_where=text("receipt_number IS NOT NULL"),
         ),
+        Index(
+            "ix_orders_payment_lock_acquired_at",
+            "payment_lock_acquired_at",
+            postgresql_where=text("payment_lock_acquired_at IS NOT NULL"),
+        ),
     )
 
     search_vector: Mapped[str] = mapped_column(TSVECTOR, nullable=True, deferred=True)


### PR DESCRIPTION
## Summary

Adds a partial index on `orders.payment_lock_acquired_at`, backing the stale payment lock sweep introduced in #13272.

That sweep runs hourly and filters `payment_lock_acquired_at IS NOT NULL AND < threshold`, ordered by the same column — a sequential scan and sort over the full orders table without an index.

Partial rather than plain: btrees index NULLs, and almost every order has no lock held, so restricting to `IS NOT NULL` keeps the index a few pages wide.

Built `CONCURRENTLY` — `orders` is too large for a plain `CREATE INDEX`, which blocks writes for the duration.

Migration only, no consuming code. Deploy before #13272.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

