### PR TITLE
Improve Update Subscription product picker UX

### DIFF
--- a/clients/apps/web/src/components/Products/ProductCombobox.tsx
+++ b/clients/apps/web/src/components/Products/ProductCombobox.tsx
@@ -1,0 +1,246 @@
+'use client'
+
+import { useProduct, useProducts } from '@/hooks/queries'
+import { hasLegacyRecurringPrices } from '@/utils/product'
+import { schemas } from '@polar-sh/client'
+import { Box } from '@polar-sh/orbit/Box'
+import { Text } from '@polar-sh/orbit'
+import { Button } from '@polar-sh/orbit/ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@polar-sh/ui/components/ui/command'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@polar-sh/ui/components/ui/popover'
+import { Check, ChevronsUpDown, Loader2 } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { twMerge } from 'tailwind-merge'
+import ProductPriceLabel from './ProductPriceLabel'
+
+const ProductComboboxOption = ({
+  product,
+  currency,
+  showNewPricing,
+  layout = 'menu',
+}: {
+  product: schemas['Product']
+  currency: string
+  showNewPricing?: boolean
+  layout?: 'menu' | 'trigger'
+}) => {
+  if (layout === 'trigger') {
+    return (
+      <Box
+        alignItems="center"
+        columnGap="s"
+        minWidth={0}
+        flexGrow={1}
+        overflow="hidden"
+      >
+        <span className="min-w-0 flex-1 truncate">{product.name}</span>
+        <span className="shrink-0 opacity-70 [&_*]:!text-current">
+          <ProductPriceLabel product={product} currency={currency} />
+        </span>
+      </Box>
+    )
+  }
+
+  return (
+    <Box
+      flexDirection="column"
+      rowGap="none"
+      minWidth={0}
+      flexGrow={1}
+      overflow="hidden"
+      paddingRight="s"
+    >
+      <span className="truncate leading-snug">{product.name}</span>
+      <span className="flex items-center gap-2 text-xs leading-snug opacity-70 [&_*]:!text-current">
+        <ProductPriceLabel product={product} currency={currency} />
+        {showNewPricing ? <span>· New pricing</span> : null}
+      </span>
+    </Box>
+  )
+}
+
+const hasNewPricing = (
+  product: schemas['Product'],
+  currentPriceIds: string[],
+) => {
+  const productPriceIds = product.prices.map(({ id }) => id)
+  if (productPriceIds.length !== currentPriceIds.length) return true
+  return !productPriceIds.every((id) => currentPriceIds.includes(id))
+}
+
+export const ProductCombobox = ({
+  organizationId,
+  value,
+  onChange,
+  currency,
+  currentProductId,
+  currentPriceIds,
+}: {
+  organizationId: string
+  value: string | undefined
+  onChange: (productId: string) => void
+  currency: string
+  currentProductId: string
+  currentPriceIds: string[]
+}) => {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const normalizedQuery = query.trim()
+
+  const { data: queriedProducts, isFetching } = useProducts(organizationId, {
+    is_recurring: true,
+    ...(normalizedQuery ? { query: normalizedQuery } : {}),
+    sorting: ['price_amount'],
+    limit: 100,
+  })
+  const { data: fetchedSelectedProduct } = useProduct(value)
+  const { data: currentProduct } = useProduct(currentProductId)
+
+  const products = useMemo(() => {
+    let items = (queriedProducts?.items ?? []).filter(
+      (product) => !hasLegacyRecurringPrices(product),
+    )
+
+    items = items.filter(
+      (product) =>
+        product.id !== currentProductId ||
+        hasNewPricing(product, currentPriceIds),
+    )
+
+    if (
+      !normalizedQuery &&
+      currentProduct &&
+      !hasLegacyRecurringPrices(currentProduct) &&
+      hasNewPricing(currentProduct, currentPriceIds) &&
+      !items.some((product) => product.id === currentProduct.id)
+    ) {
+      items = [currentProduct, ...items]
+    }
+
+    return items
+  }, [
+    queriedProducts,
+    normalizedQuery,
+    currentProduct,
+    currentProductId,
+    currentPriceIds,
+  ])
+
+  const selectedProduct = useMemo(
+    () =>
+      products.find((product) => product.id === value) ??
+      fetchedSelectedProduct ??
+      undefined,
+    [products, value, fetchedSelectedProduct],
+  )
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(nextOpen) => {
+        setOpen(nextOpen)
+        if (!nextOpen) setQuery('')
+      }}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className={twMerge(
+            'dark:bg-polar-800 dark:hover:bg-polar-700 dark:hover:border-polar-700 dark:border-polar-700 flex h-10 w-full flex-row items-center justify-between gap-x-2 rounded-xl border border-gray-200 bg-white px-3 font-normal shadow-xs transition-colors hover:bg-gray-50 hover:text-black dark:hover:text-white',
+          )}
+        >
+          <span className="flex min-w-0 flex-1 items-center text-left">
+            {selectedProduct ? (
+              <ProductComboboxOption
+                product={selectedProduct}
+                currency={currency}
+                layout="trigger"
+              />
+            ) : (
+              <Text as="span" color="muted">
+                Select a new product
+              </Text>
+            )}
+          </span>
+          <ChevronsUpDown className="size-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="dark:bg-polar-800 dark:border-polar-700 w-(--radix-popover-trigger-width) rounded-xl border p-0"
+      >
+        <Command
+          shouldFilter={false}
+          className="dark:bg-polar-800 rounded-xl bg-white text-gray-950 dark:text-white"
+        >
+          <CommandInput
+            placeholder="Search products…"
+            className="h-9 border-0 focus:ring-0 focus:outline-0"
+            value={query}
+            onValueChange={setQuery}
+          />
+          <CommandList className="dark:[scrollbar-color:var(--color-polar-500)_transparent]">
+            {isFetching ? (
+              <Box
+                alignItems="center"
+                justifyContent="center"
+                paddingVertical="xl"
+              >
+                <Loader2 className="h-4 w-4 animate-spin opacity-50" />
+              </Box>
+            ) : products.length === 0 ? (
+              <CommandEmpty>No products found</CommandEmpty>
+            ) : (
+              <CommandGroup>
+                {products.map((product) => {
+                  const isSelected = value === product.id
+
+                  return (
+                    <CommandItem
+                      key={product.id}
+                      value={product.id}
+                      onSelect={() => {
+                        onChange(product.id)
+                        setOpen(false)
+                        setQuery('')
+                      }}
+                      className="data-[selected=true]:text-accent-foreground items-center rounded-md text-gray-950 dark:text-white"
+                    >
+                      <span className="min-w-0 flex-1">
+                        <ProductComboboxOption
+                          product={product}
+                          currency={currency}
+                          showNewPricing={product.id === currentProductId}
+                        />
+                      </span>
+                      <Check
+                        className={twMerge(
+                          'ml-2 size-4 shrink-0',
+                          isSelected ? 'opacity-100' : 'opacity-0',
+                        )}
+                      />
+                    </CommandItem>
+                  )
+                })}
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionProductForm.tsx
+++ b/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionProductForm.tsx
@@ -1,20 +1,12 @@
 'use client'
 
-import { useProducts } from '@/hooks/queries'
+import { useProduct } from '@/hooks/queries'
 import { useUpdateSubscription } from '@/hooks/queries/subscriptions'
 import { setValidationErrors } from '@/utils/api/errors'
-import { hasLegacyRecurringPrices } from '@/utils/product'
 import { useTrialChangeOutcome } from '@/utils/trial-change'
 import { isValidationError, schemas } from '@polar-sh/client'
-import {
-  Button,
-  Pill,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { Button, Text } from '@polar-sh/orbit'
 import {
   Form,
   FormControl,
@@ -25,9 +17,10 @@ import {
 } from '@polar-sh/ui/components/ui/form'
 import { useCallback, useMemo } from 'react'
 import { useForm } from 'react-hook-form'
-import ProductPriceLabel from '../Products/ProductPriceLabel'
 import { ProrationBehavior } from '../Settings/ProrationBehavior'
+import AmountLabel from '../Shared/AmountLabel'
 import { toast } from '../Toast/use-toast'
+import { ProductCombobox } from '../Products/ProductCombobox'
 import { subscriptionUpdateValidationDiscriminators } from './utils'
 import { UpdateSubscriptionProductWarning } from './UpdateSubscriptionProductWarning'
 
@@ -51,45 +44,15 @@ export const UpdateSubscriptionProductForm = ({
     },
   })
   const { control, handleSubmit, setError, watch } = form
-  const { data: allProducts } = useProducts(
-    subscription.product.organization_id,
-    {
-      is_recurring: true,
-      limit: 100,
-      sorting: ['price_amount'],
-    },
-  )
 
-  const activePriceIds = useMemo(
+  const currentPriceIds = useMemo(
     () => subscription.prices.map(({ id }) => id),
     [subscription],
   )
-  const products = useMemo(() => {
-    if (!allProducts) return []
-
-    return allProducts.items
-      .filter((product) => !hasLegacyRecurringPrices(product))
-      .filter((product) => {
-        if (subscription.product_id !== product.id) {
-          return true
-        }
-
-        const productPriceIds = product.prices.map(({ id }) => id)
-
-        if (productPriceIds.length !== activePriceIds.length) {
-          return true
-        }
-        return !productPriceIds.every((id) => activePriceIds.includes(id))
-      })
-  }, [allProducts, activePriceIds, subscription])
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const selectedProductId = watch('product_id')
-  const selectedProduct = useMemo(
-    () => products.find((product) => product.id === selectedProductId),
-    [products, selectedProductId],
-  )
-
+  const { data: selectedProduct } = useProduct(selectedProductId)
   const trialOutcome = useTrialChangeOutcome(subscription, selectedProduct)
 
   const onSubmit = useCallback(
@@ -129,45 +92,44 @@ export const UpdateSubscriptionProductForm = ({
         className="flex grow flex-col justify-between gap-y-6"
         onSubmit={handleSubmit(onSubmit)}
       >
-        <div className="flex flex-col gap-y-6">
+        <Box flexDirection="column" rowGap="xl">
           <FormField
             control={control}
             name="product_id"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>New product</FormLabel>
+                <Box flexDirection="column" rowGap="none">
+                  <FormLabel>New product</FormLabel>
+                  <Box
+                    alignItems="baseline"
+                    justifyContent="between"
+                    columnGap="s"
+                    flexWrap="wrap"
+                    color="text-secondary"
+                    paddingTop="xs"
+                  >
+                    <Text variant="caption" color="muted">
+                      Current: {subscription.product.name}
+                    </Text>
+                    <span className="text-xs leading-none [&_*]:!text-inherit">
+                      <AmountLabel
+                        amount={subscription.amount}
+                        currency={subscription.currency}
+                        interval={subscription.recurring_interval}
+                        intervalCount={subscription.recurring_interval_count}
+                      />
+                    </span>
+                  </Box>
+                </Box>
                 <FormControl>
-                  <div>
-                    <Select
-                      onValueChange={field.onChange}
-                      defaultValue={field.value || undefined}
-                    >
-                      <SelectTrigger className="h-14">
-                        <SelectValue placeholder="Select a new product" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {products.map((product) => (
-                          <SelectItem key={product.id} value={product.id}>
-                            <div className="flex flex-row items-center justify-between gap-1">
-                              {product.name}
-                              {product.id === subscription.product_id && (
-                                <Pill
-                                  color="green"
-                                  className="px-3 py-1 text-xs"
-                                >
-                                  New Pricing
-                                </Pill>
-                              )}
-                            </div>
-                            <ProductPriceLabel
-                              product={product}
-                              currency={subscription.currency}
-                            />
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
+                  <ProductCombobox
+                    organizationId={subscription.product.organization_id}
+                    value={field.value ?? undefined}
+                    onChange={field.onChange}
+                    currency={subscription.currency}
+                    currentProductId={subscription.product_id}
+                    currentPriceIds={currentPriceIds}
+                  />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -194,8 +156,8 @@ export const UpdateSubscriptionProductForm = ({
               )}
             />
           )}
-        </div>
-        <div className="flex flex-col gap-4">
+        </Box>
+        <Box flexDirection="column" rowGap="l">
           <Button
             type="submit"
             size="lg"
@@ -213,7 +175,7 @@ export const UpdateSubscriptionProductForm = ({
               trialOutcome={trialOutcome}
             />
           ) : null}
-        </div>
+        </Box>
       </form>
     </Form>
   )

--- a/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionProductWarning.tsx
+++ b/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionProductWarning.tsx
@@ -1,6 +1,6 @@
 import { formatTrialEnd, type TrialChangeOutcome } from '@/utils/trial-change'
 import { schemas } from '@polar-sh/client'
-import { Box } from '@polar-sh/orbit/Box'
+import { Alert } from '@polar-sh/orbit'
 
 export const UpdateSubscriptionProductWarning = ({
   subscription,
@@ -15,40 +15,38 @@ export const UpdateSubscriptionProductWarning = ({
     return null
   }
 
+  const title =
+    trialOutcome?.kind === 'ends'
+      ? 'Trial ends & customer charged immediately'
+      : trialOutcome?.kind === 'continues'
+        ? 'Trial continues'
+        : 'Product change'
+
   return (
-    <Box
-      padding="m"
-      borderRadius="m"
-      backgroundColor="background-warning"
-      flexDirection="column"
-      rowGap="s"
-    >
-      {trialOutcome?.kind === 'ends' && (
-        <p className="text-sm text-yellow-700">
-          This change will end the current trial and{' '}
-          <strong className="font-medium">
-            charge the customer immediately
-          </strong>{' '}
-          for the first billing period of{' '}
-          <strong className="font-medium">{selectedProduct.name}</strong>.
-        </p>
-      )}
-      {trialOutcome?.kind === 'continues' && (
-        <p className="text-sm text-yellow-700">
-          The trial will continue until{' '}
-          <strong className="font-medium">
-            {formatTrialEnd(trialOutcome.trialEnd)}
-          </strong>
-          . The customer won&apos;t be charged before then.
-        </p>
-      )}
-      <p className="text-sm text-yellow-700">
-        By updating this subscription, the customer will get access to{' '}
-        <strong className="font-medium">{selectedProduct.name}</strong>{' '}
-        benefits, and lose access to{' '}
-        <strong className="font-medium">{subscription.product.name}</strong>{' '}
-        benefits.
-      </p>
-    </Box>
+    <Alert
+      variant="warning"
+      title={title}
+      description={
+        <>
+          {trialOutcome?.kind === 'ends' && (
+            <>
+              This change will end the current trial and{' '}
+              <strong>charge the customer immediately</strong> for the first
+              billing period of <strong>{selectedProduct.name}</strong>.{' '}
+            </>
+          )}
+          {trialOutcome?.kind === 'continues' && (
+            <>
+              The trial will continue until{' '}
+              <strong>{formatTrialEnd(trialOutcome.trialEnd)}</strong>. The
+              customer won&apos;t be charged before then.{' '}
+            </>
+          )}
+          By updating this subscription, the customer will get access to{' '}
+          <strong>{selectedProduct.name}</strong> benefits, and lose access to{' '}
+          <strong>{subscription.product.name}</strong> benefits.
+        </>
+      }
+    />
   )
 }

--- a/clients/apps/web/src/utils/trial-change.ts
+++ b/clients/apps/web/src/utils/trial-change.ts
@@ -52,6 +52,7 @@ export const formatTrialEnd = (date: Date): string =>
       date.getUTCFullYear() === new Date().getUTCFullYear()
         ? undefined
         : 'numeric',
+    timeZone: 'UTC',
   })
 
 /**


### PR DESCRIPTION
## Summary
Replace the Product tab `Select` with a searchable picker that handles long product names and pricing more clearly, and render the product-change warning with Orbit `Alert`.
Depends on: split Update Subscription modal PR #13277. Merge this refactor first.
## What
- Add `SubscriptionProductPicker` (Command + Popover)
- Show current product context and clearer price presentation
- Swap the product-change warning to Orbit `Alert`
## Why
The old dropdown truncated long names poorly but mosts importantly wasn't searchable. The picker improves scanability without changing subscription update behavior.
## How
Build a dedicated Command/Popover picker for product + price options, wire it into `UpdateSubscriptionProductForm`, and update the warning component to use Orbit `Alert`. Did not use the existing `Combobox` as these items can only show one string as value. Can refactor out this later into reusable component if need to exist on multiple places.
## Checklist
- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [X] No new functionality requiring tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

