### PR TITLE
fix: harden Update Subscription form validation and a11y

### DIFF
--- a/clients/apps/web/src/components/Products/ProductCombobox.tsx
+++ b/clients/apps/web/src/components/Products/ProductCombobox.tsx
@@ -38,11 +38,14 @@ const ProductComboboxOption = ({
   if (layout === 'trigger') {
     return (
       <Box
+        as="span"
+        display="inline-flex"
         alignItems="center"
         columnGap="s"
         minWidth={0}
         flexGrow={1}
         overflow="hidden"
+        width="100%"
       >
         <span className="min-w-0 flex-1 truncate">{product.name}</span>
         <span className="shrink-0 opacity-70 [&_*]:!text-current">
@@ -163,7 +166,16 @@ export const ProductCombobox = ({
             'dark:bg-polar-800 dark:hover:bg-polar-700 dark:hover:border-polar-700 dark:border-polar-700 flex h-10 w-full flex-row items-center justify-between gap-x-2 rounded-xl border border-gray-200 bg-white px-3 font-normal shadow-xs transition-colors hover:bg-gray-50 hover:text-black dark:hover:text-white',
           )}
         >
-          <span className="flex min-w-0 flex-1 items-center text-left">
+          <Box
+            as="span"
+            display="inline-flex"
+            minWidth={0}
+            flexGrow={1}
+            alignItems="center"
+            overflow="hidden"
+            textAlign="left"
+            width="100%"
+          >
             {selectedProduct ? (
               <ProductComboboxOption
                 product={selectedProduct}
@@ -175,7 +187,7 @@ export const ProductCombobox = ({
                 Select a new product
               </Text>
             )}
-          </span>
+          </Box>
           <ChevronsUpDown className="size-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
@@ -220,13 +232,11 @@ export const ProductCombobox = ({
                       }}
                       className="data-[selected=true]:text-accent-foreground items-center rounded-md text-gray-950 dark:text-white"
                     >
-                      <span className="min-w-0 flex-1">
-                        <ProductComboboxOption
-                          product={product}
-                          currency={currency}
-                          showNewPricing={product.id === currentProductId}
-                        />
-                      </span>
+                      <ProductComboboxOption
+                        product={product}
+                        currency={currency}
+                        showNewPricing={product.id === currentProductId}
+                      />
                       <Check
                         className={twMerge(
                           'ml-2 size-4 shrink-0',

--- a/clients/apps/web/src/components/Products/ProductPriceLabel.tsx
+++ b/clients/apps/web/src/components/Products/ProductPriceLabel.tsx
@@ -49,7 +49,7 @@ const ProductPriceLabel: React.FC<ProductPriceLabelProps> = ({
       const hasMultipleTiers = tiers.length > 1
 
       return (
-        <div className="flex items-baseline gap-1.5">
+        <span className="inline-flex items-baseline gap-1.5">
           {hasMultipleTiers && (
             <span className="dark:text-polar-500 text-xs text-gray-500">
               From
@@ -63,14 +63,14 @@ const ProductPriceLabel: React.FC<ProductPriceLabelProps> = ({
           <span className="dark:text-polar-500 text-xs text-gray-500">
             / seat
           </span>
-        </div>
+        </span>
       )
     }
     return null
   } else if (staticPrice.amount_type === 'custom') {
-    return <div className="text-[min(1em,24px)]">Pay what you want</div>
+    return <span className="text-[min(1em,24px)]">Pay what you want</span>
   } else {
-    return <div className="text-[min(1em,24px)]">Free</div>
+    return <span className="text-[min(1em,24px)]">Free</span>
   }
 }
 

--- a/clients/apps/web/src/components/Shared/AmountLabel.tsx
+++ b/clients/apps/web/src/components/Shared/AmountLabel.tsx
@@ -56,10 +56,10 @@ const AmountLabel: React.FC<AmountLabelProps> = ({
   }, [interval, intervalCount])
 
   return (
-    <div className="flex flex-row items-baseline gap-x-1">
+    <span className="inline-flex flex-row items-baseline gap-x-1">
       {formatCurrency('compact')(amount, currency)}
       <span className="text-[max(12px,0.5em)]">{intervalDisplay}</span>
-    </div>
+    </span>
   )
 }
 

--- a/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionBillingPeriodForm.tsx
+++ b/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionBillingPeriodForm.tsx
@@ -34,7 +34,12 @@ export const UpdateSubscriptionBillingPeriodForm = ({
       current_billing_period_end: subscription.current_period_end || undefined,
     },
   })
-  const { control, handleSubmit, setError } = form
+  const {
+    control,
+    handleSubmit,
+    setError,
+    formState: { isDirty },
+  } = form
 
   const onSubmit = useCallback(
     async (body: schemas['SubscriptionUpdateBillingPeriod']) => {
@@ -109,7 +114,7 @@ export const UpdateSubscriptionBillingPeriodForm = ({
           <Button
             type="submit"
             loading={updateSubscription.isPending}
-            disabled={updateSubscription.isPending}
+            disabled={!isDirty || updateSubscription.isPending}
             className="w-fit"
           >
             Update Billing Period

--- a/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionBillingPeriodForm.tsx
+++ b/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionBillingPeriodForm.tsx
@@ -27,7 +27,12 @@ export const UpdateSubscriptionBillingPeriodForm = ({
 }) => {
   const updateSubscription = useUpdateSubscription(subscription.id)
 
-  const minDate = useMemo<Date>(() => new Date(), [])
+  const minDate = useMemo<Date>(() => {
+    const tomorrow = new Date()
+    tomorrow.setHours(0, 0, 0, 0)
+    tomorrow.setDate(tomorrow.getDate() + 1)
+    return tomorrow
+  }, [])
 
   const form = useForm<schemas['SubscriptionUpdateBillingPeriod']>({
     defaultValues: {

--- a/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionBillingPeriodForm.tsx
+++ b/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionBillingPeriodForm.tsx
@@ -34,12 +34,7 @@ export const UpdateSubscriptionBillingPeriodForm = ({
       current_billing_period_end: subscription.current_period_end || undefined,
     },
   })
-  const {
-    control,
-    handleSubmit,
-    setError,
-    formState: { isDirty },
-  } = form
+  const { control, handleSubmit, setError } = form
 
   const onSubmit = useCallback(
     async (body: schemas['SubscriptionUpdateBillingPeriod']) => {
@@ -88,6 +83,12 @@ export const UpdateSubscriptionBillingPeriodForm = ({
           <FormField
             control={control}
             name="current_billing_period_end"
+            rules={{
+              required: 'Please select a billing period end date',
+              validate: (value) =>
+                value !== subscription.current_period_end ||
+                'Select a new end date to extend the billing period.',
+            }}
             render={({ field }) => {
               return (
                 <FormItem className="flex flex-col gap-y-2">
@@ -114,7 +115,7 @@ export const UpdateSubscriptionBillingPeriodForm = ({
           <Button
             type="submit"
             loading={updateSubscription.isPending}
-            disabled={!isDirty || updateSubscription.isPending}
+            disabled={updateSubscription.isPending}
             className="w-fit"
           >
             Update Billing Period

--- a/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionDiscountForm.tsx
+++ b/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionDiscountForm.tsx
@@ -132,6 +132,7 @@ export const UpdateSubscriptionDiscountForm = ({
                         size="icon"
                         variant="ghost"
                         type="button"
+                        aria-label="Remove discount"
                         onClick={() => field.onChange(null)}
                       >
                         <XIcon className="h-4 w-4" />

--- a/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionDiscountForm.tsx
+++ b/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionDiscountForm.tsx
@@ -50,12 +50,7 @@ export const UpdateSubscriptionDiscountForm = ({
       discount_id: subscription.discount_id ?? null,
     },
   })
-  const {
-    control,
-    handleSubmit,
-    setError,
-    formState: { isDirty },
-  } = form
+  const { control, handleSubmit, setError } = form
 
   const onSubmit = useCallback(
     async (body: schemas['SubscriptionUpdateBase']) => {
@@ -98,6 +93,11 @@ export const UpdateSubscriptionDiscountForm = ({
           <FormField
             control={control}
             name="discount_id"
+            rules={{
+              validate: (value) =>
+                (value ?? null) !== (subscription.discount_id ?? null) ||
+                'Select a different discount to apply a change.',
+            }}
             render={({ field }) => {
               const selectedItem =
                 selectedDiscount?.id === field.value
@@ -153,7 +153,7 @@ export const UpdateSubscriptionDiscountForm = ({
             type="submit"
             size="lg"
             loading={updateSubscription.isPending}
-            disabled={!isDirty || updateSubscription.isPending}
+            disabled={updateSubscription.isPending}
           >
             Update Subscription
           </Button>

--- a/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionDiscountForm.tsx
+++ b/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionDiscountForm.tsx
@@ -47,10 +47,15 @@ export const UpdateSubscriptionDiscountForm = ({
 
   const form = useForm<schemas['SubscriptionUpdateBase']>({
     defaultValues: {
-      discount_id: subscription.discount_id || '',
+      discount_id: subscription.discount_id ?? null,
     },
   })
-  const { control, handleSubmit, setError } = form
+  const {
+    control,
+    handleSubmit,
+    setError,
+    formState: { isDirty },
+  } = form
 
   const onSubmit = useCallback(
     async (body: schemas['SubscriptionUpdateBase']) => {
@@ -107,7 +112,7 @@ export const UpdateSubscriptionDiscountForm = ({
                       items={discounts?.items || []}
                       value={field.value || null}
                       selectedItem={selectedItem || null}
-                      onChange={(value) => field.onChange(value || '')}
+                      onChange={(value) => field.onChange(value)}
                       onQueryChange={setDiscountQuery}
                       getItemValue={(discount) => discount.id}
                       getItemLabel={(discount) => discount.name}
@@ -147,7 +152,7 @@ export const UpdateSubscriptionDiscountForm = ({
             type="submit"
             size="lg"
             loading={updateSubscription.isPending}
-            disabled={updateSubscription.isPending}
+            disabled={!isDirty || updateSubscription.isPending}
           >
             Update Subscription
           </Button>

--- a/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionProductForm.tsx
+++ b/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionProductForm.tsx
@@ -96,6 +96,7 @@ export const UpdateSubscriptionProductForm = ({
           <FormField
             control={control}
             name="product_id"
+            rules={{ required: 'Please select a product' }}
             render={({ field }) => (
               <FormItem>
                 <Box flexDirection="column" rowGap="none">

--- a/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionTrialForm.tsx
+++ b/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionTrialForm.tsx
@@ -50,13 +50,7 @@ export const UpdateSubscriptionTrialForm = ({
       trial_end: subscription.trial_end || undefined,
     },
   })
-  const {
-    control,
-    handleSubmit,
-    setError,
-    reset,
-    formState: { isDirty },
-  } = form
+  const { control, handleSubmit, setError, reset } = form
 
   const handleEndTrialNow = useCallback(async () => {
     setIsEndingTrial(true)
@@ -187,7 +181,7 @@ export const UpdateSubscriptionTrialForm = ({
               <Button
                 type="submit"
                 loading={updateSubscription.isPending}
-                disabled={!isDirty || updateSubscription.isPending}
+                disabled={updateSubscription.isPending}
                 className="w-fit"
               >
                 Update Trial

--- a/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionTrialForm.tsx
+++ b/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionTrialForm.tsx
@@ -36,8 +36,8 @@ export const UpdateSubscriptionTrialForm = ({
   } = useModal()
 
   const minDate = useMemo<Date | undefined>(() => {
-    if (subscription.status === 'trialing' && subscription.trial_start) {
-      return new Date(subscription.trial_start)
+    if (subscription.status === 'trialing') {
+      return new Date()
     }
     if (subscription.current_period_end) {
       return new Date(subscription.current_period_end)

--- a/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionTrialForm.tsx
+++ b/clients/apps/web/src/components/Subscriptions/UpdateSubscriptionTrialForm.tsx
@@ -50,7 +50,13 @@ export const UpdateSubscriptionTrialForm = ({
       trial_end: subscription.trial_end || undefined,
     },
   })
-  const { control, handleSubmit, setError, reset } = form
+  const {
+    control,
+    handleSubmit,
+    setError,
+    reset,
+    formState: { isDirty },
+  } = form
 
   const handleEndTrialNow = useCallback(async () => {
     setIsEndingTrial(true)
@@ -150,6 +156,7 @@ export const UpdateSubscriptionTrialForm = ({
               <FormField
                 control={control}
                 name="trial_end"
+                rules={{ required: 'Please select a trial end date' }}
                 render={({ field }) => {
                   return (
                     <FormItem className="flex flex-col gap-y-2">
@@ -180,7 +187,7 @@ export const UpdateSubscriptionTrialForm = ({
               <Button
                 type="submit"
                 loading={updateSubscription.isPending}
-                disabled={updateSubscription.isPending}
+                disabled={!isDirty || updateSubscription.isPending}
                 className="w-fit"
               >
                 Update Trial


### PR DESCRIPTION
## Summary
- Prevent no-op / invalid submits on the Discount, Product, and Trial tabs (null discount_id + dirty gate, required product_id, required/dirty trial_end)
- Block past trial end dates for trialing subscriptions (picker min = now; End Trial stays the immediate path)
- Add an accessible name to the clear-discount control
## Depends on
This branch is stacked on two earlier PRs and should merge after them (or retarget as each lands):

- [#13277](https://github.com/polarsource/polar/pull/13277) villiam/split-update-subscription-modal — splits the modal into per-tab forms (UpdateSubscription*Form). These fixes live in those extracted components.
- [#13278](https://github.com/polarsource/polar/pull/13278) villiam/update-subscription-product-picker — product combobox + trial warning work this branch builds on (and where product submit UX was already partly touched).

Stack: #13277 → #13278 → this PR.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

