### PR TITLE
server: add script to reset a user's MFA

### DIFF
--- a/server/scripts/reset_user_mfa.py
+++ b/server/scripts/reset_user_mfa.py
@@ -1,0 +1,107 @@
+"""Reset (disable) a user's MFA to unblock them at login.
+
+Out-of-band engineer tool for the case where a user has lost their authenticator
+app or backup codes and can't complete MFA to sign in. It mirrors the product's
+own disable-MFA path (``DELETE /totp``): it deletes the user's TOTP enrollment and
+their backup codes. Email OTP is left untouched — that's the login factor the user
+falls back to, so they can sign in again and re-enroll TOTP if they want.
+
+Usage:
+
+    uv run python -m scripts.reset_user_mfa <user>
+
+    <user>  target user's email or id
+"""
+
+import asyncio
+import uuid
+
+import typer
+
+from polar.auth.factors import BackupCodesFactor, TOTPFactor
+from polar.kit.db.postgres import create_async_sessionmaker
+from polar.postgres import create_async_engine
+from polar.user.repository import UserRepository
+
+cli = typer.Typer()
+
+
+def _maybe_uuid(value: str) -> uuid.UUID | None:
+    try:
+        return uuid.UUID(value)
+    except ValueError:
+        return None
+
+
+@cli.command()
+def reset_mfa(
+    user: str = typer.Argument(..., help="Target user's email or id"),
+) -> None:
+    async def run() -> None:
+        engine = create_async_engine("script")
+        sessionmaker = create_async_sessionmaker(engine)
+        async with sessionmaker() as session:
+            user_repository = UserRepository.from_session(session)
+
+            user_id = _maybe_uuid(user)
+            target_user = (
+                await user_repository.get_by_id(user_id)
+                if user_id is not None
+                else await user_repository.get_by_email(user)
+            )
+            if target_user is None:
+                typer.echo(f"User '{user}' not found.")
+                raise typer.Exit(code=1)
+
+            totp_factor = TOTPFactor(session)
+            backup_codes_factor = BackupCodesFactor(session)
+
+            totp_enrollment = await totp_factor.get_by_identity_id(target_user.id)
+            backup_codes_enrollment = await backup_codes_factor.get_enrollment(
+                target_user.id
+            )
+
+            typer.echo(f"User        : {target_user.email} ({target_user.id})")
+            typer.echo(
+                "TOTP        : "
+                + (
+                    f"enrolled ({'enabled' if totp_enrollment.enabled else 'disabled'})"
+                    if totp_enrollment is not None
+                    else "<none>"
+                )
+            )
+            typer.echo(
+                "Backup codes: "
+                + ("enrolled" if backup_codes_enrollment is not None else "<none>")
+            )
+
+            if totp_enrollment is None and backup_codes_enrollment is None:
+                typer.echo("No MFA enrolled — nothing to reset.")
+                raise typer.Exit(code=0)
+
+            plan = []
+            if totp_enrollment is not None:
+                plan.append("delete TOTP enrollment")
+            if backup_codes_enrollment is not None:
+                plan.append("delete backup codes")
+            typer.echo("Plan: " + "; ".join(plan))
+
+            if not typer.confirm("Proceed?"):
+                raise typer.Exit(code=1)
+
+            if totp_enrollment is not None:
+                await totp_factor.delete(totp_enrollment)
+            if backup_codes_enrollment is not None:
+                await backup_codes_factor.delete(backup_codes_enrollment)
+
+            await session.commit()
+            typer.echo(
+                f"Reset MFA for {target_user.email}. "
+                "They can sign in with an email code and re-enroll TOTP."
+            )
+
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- issue number -->

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->

## Why

<!-- Explain why this change is needed -->

## How

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CLI script to reset a user’s MFA to unblock login. It deletes TOTP enrollment and backup codes while leaving email OTP so the user can sign in and re-enroll.

- **New Features**
  - Adds `server/scripts/reset_user_mfa.py`; run with `uv run python -m scripts.reset_user_mfa <user>`.
  - Accepts email or UUID; shows current MFA status, planned actions, and asks for confirmation.
  - Mirrors product `DELETE /totp` flow and uses `UserRepository`, `TOTPFactor`, and `BackupCodesFactor` with async DB session.

<sup>Written for commit 8b2cd2f272f23b9da737fd4b5e619b3244bf6eba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

