### PR TITLE
server: gate reset_user_mfa behind --execute for non-interactive runs

### DIFF
--- a/server/scripts/reset_user_mfa.py
+++ b/server/scripts/reset_user_mfa.py
@@ -6,11 +6,15 @@ own disable-MFA path (``DELETE /totp``): it deletes the user's TOTP enrollment a
 their backup codes. Email OTP is left untouched — that's the login factor the user
 falls back to, so they can sign in again and re-enroll TOTP if they want.
 
+Defaults to a preview; pass --execute to actually reset. Works in a
+non-interactive shell (e.g. a Render one-off job) — there is no prompt.
+
 Usage:
 
-    uv run python -m scripts.reset_user_mfa <user>
+    uv run python -m scripts.reset_user_mfa <user> --execute
 
-    <user>  target user's email or id
+    <user>      target user's email or id
+    --execute   actually reset the MFA (default: preview only)
 """
 
 import asyncio
@@ -36,6 +40,9 @@ def _maybe_uuid(value: str) -> uuid.UUID | None:
 @cli.command()
 def reset_mfa(
     user: str = typer.Argument(..., help="Target user's email or id"),
+    execute: bool = typer.Option(
+        False, "--execute", help="Actually reset the MFA (default: preview only)."
+    ),
 ) -> None:
     async def run() -> None:
         engine = create_async_engine("script")
@@ -86,8 +93,9 @@ def reset_mfa(
                 plan.append("delete backup codes")
             typer.echo("Plan: " + "; ".join(plan))
 
-            if not typer.confirm("Proceed?"):
-                raise typer.Exit(code=1)
+            if not execute:
+                typer.echo("Preview only — pass --execute to reset.")
+                raise typer.Exit(code=0)
 
             if totp_enrollment is not None:
                 await totp_factor.delete(totp_enrollment)


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- issue number -->

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->

## Why

<!-- Explain why this change is needed -->

## How

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `reset_user_mfa` safe by default: it now shows a preview and only performs changes with `--execute`. The confirm prompt is removed so the script runs cleanly in non-interactive environments.

- **Migration**
  - Pass `--execute` to actually reset MFA; otherwise it prints the plan and exits 0.
  - Update any automation to include `--execute`.

<sup>Written for commit ab4d65f229e98b3b5ce7749dda4ee20db4cbd8ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

