### PR TITLE
server: provision users and memberships on SSO login

### DIFF
--- a/server/polar/auth/sso/endpoints.py
+++ b/server/polar/auth/sso/endpoints.py
@@ -23,10 +23,12 @@ from polar.exceptions import ResourceNotFound
 from polar.models import Organization, OrganizationSSOConnection
 from polar.openapi import APITag
 from polar.organization.repository import OrganizationRepository
+from polar.organization.service import organization as organization_service
 from polar.postgres import AsyncSession, get_db_session
 from polar.routing import APIRouter
 from polar.sso.repository import OrganizationSSOConnectionRepository
 from polar.user.repository import UserRepository
+from polar.user.service import user as user_service
 from polar.user_organization.repository import UserOrganizationRepository
 
 from ..authentication_session import (
@@ -190,6 +192,7 @@ async def callback(
     error_description: str | None = Query(None),
     error_uri: str | None = Query(None),
     state: str | None = Query(None),
+    organization: Organization = Depends(get_login_organization),
     authentication_session: AuthenticationSession = Depends(
         get_org_authentication_session
     ),
@@ -259,17 +262,17 @@ async def callback(
     if email is None:
         raise PolarAuthRedirectionError("The identity provider did not assert an email")
 
-    user_repository = UserRepository.from_session(session)
-    user = await user_repository.get_by_email(email)
-    if user is None:
-        raise PolarAuthRedirectionError("No Polar account matches this identity")
+    user, created = await user_service.get_by_email_or_create(session, email)
+    if created:
+        user.email_verified = True
+        session.add(user)
 
     user_organization_repository = UserOrganizationRepository.from_session(session)
     membership = await user_organization_repository.get_by_user_and_organization(
         user.id, connection.organization_id
     )
     if membership is None:
-        raise PolarAuthRedirectionError("You are not a member of this organization")
+        await organization_service.add_user(session, organization, user)
 
     # Mark that SSO authenticated this session for the organization, so any
     # completion path (including the global 2FA pages) mints an org-scoped

--- a/server/tests/auth/sso/test_flow.py
+++ b/server/tests/auth/sso/test_flow.py
@@ -28,6 +28,7 @@ from polar.models.organization_sso_connection import (
     OIDCConfiguration,
     OrganizationSSOConnectionType,
 )
+from polar.models.user_organization import OrganizationRole
 from polar.postgres import AsyncSession
 from tests.fixtures.base import IsolatedSessionTestClient
 from tests.fixtures.database import SaveFixture
@@ -197,6 +198,23 @@ async def _user_session_count(session: AsyncSession, user: User) -> int:
     return len(result.scalars().unique().all())
 
 
+async def _get_user_by_email(session: AsyncSession, email: str) -> User | None:
+    result = await session.execute(select(User).where(User.email == email))
+    return result.scalars().unique().one_or_none()
+
+
+async def _get_membership(
+    session: AsyncSession, user: User, organization: Organization
+) -> UserOrganization | None:
+    result = await session.execute(
+        select(UserOrganization).where(
+            UserOrganization.user_id == user.id,
+            UserOrganization.organization_id == organization.id,
+        )
+    )
+    return result.scalars().unique().one_or_none()
+
+
 @pytest.mark.asyncio
 class TestSSOAuthorize:
     async def test_authorization_parameters_are_appended(
@@ -329,31 +347,6 @@ class TestSSOLoginFlow:
         )
         assert [scope.organization_id for scope in scopes] == [organization.id]
 
-    async def test_rejects_non_member(
-        self,
-        sso_client: httpx.AsyncClient,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        organization: Organization,
-        user_second: User,
-        idp_key: rsa.RSAPrivateKey,
-    ) -> None:
-        connection = await create_sso_connection(save_fixture, organization)
-
-        with respx.mock(assert_all_mocked=False) as mock:
-            callback = await drive_to_callback(
-                sso_client,
-                session,
-                mock,
-                idp_key,
-                slug=organization.slug,
-                connection_id=connection.id,
-                email=user_second.email,
-            )
-
-        assert "error=" in callback.headers["location"]
-        assert await _user_session_count(session, user_second) == 0
-
     async def test_rejects_unverified_email(
         self,
         sso_client: httpx.AsyncClient,
@@ -427,3 +420,149 @@ class TestSSOLoginFlow:
         # Driving it to a different organization's endpoint is rejected.
         complete = await sso_client.get(f"/v1/auth/{organization_second.slug}/complete")
         assert "error=" in complete.headers["location"]
+
+
+NEWCOMER_EMAIL = "newcomer@example.test"
+
+
+@pytest.mark.asyncio
+class TestSSOJITProvisioning:
+    async def test_provisions_unknown_email(
+        self,
+        sso_client: httpx.AsyncClient,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        idp_key: rsa.RSAPrivateKey,
+    ) -> None:
+        connection = await create_sso_connection(save_fixture, organization)
+
+        with respx.mock(assert_all_mocked=False) as mock:
+            callback = await drive_to_callback(
+                sso_client,
+                session,
+                mock,
+                idp_key,
+                slug=organization.slug,
+                connection_id=connection.id,
+                email=NEWCOMER_EMAIL,
+            )
+            assert callback.status_code == 303
+
+            await sso_client.get(f"/v1/auth/{organization.slug}/complete")
+
+        user = await _get_user_by_email(session, NEWCOMER_EMAIL)
+        assert user is not None
+        assert user.email_verified is True
+
+        membership = await _get_membership(session, user, organization)
+        assert membership is not None
+        assert membership.role == OrganizationRole.member
+
+        user_session = (
+            (
+                await session.execute(
+                    select(UserSession).where(UserSession.user_id == user.id)
+                )
+            )
+            .scalars()
+            .unique()
+            .one()
+        )
+        scopes = (
+            (
+                await session.execute(
+                    select(UserSessionOrganization).where(
+                        UserSessionOrganization.user_session_id == user_session.id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert [scope.organization_id for scope in scopes] == [organization.id]
+
+    async def test_provisions_existing_user_without_membership(
+        self,
+        sso_client: httpx.AsyncClient,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_second: User,
+        idp_key: rsa.RSAPrivateKey,
+    ) -> None:
+        connection = await create_sso_connection(save_fixture, organization)
+
+        with respx.mock(assert_all_mocked=False) as mock:
+            callback = await drive_to_callback(
+                sso_client,
+                session,
+                mock,
+                idp_key,
+                slug=organization.slug,
+                connection_id=connection.id,
+                email=user_second.email,
+            )
+            assert callback.status_code == 303
+
+            await sso_client.get(f"/v1/auth/{organization.slug}/complete")
+
+        membership = await _get_membership(session, user_second, organization)
+        assert membership is not None
+        assert membership.role == OrganizationRole.member
+
+    async def test_keeps_existing_member_role(
+        self,
+        sso_client: httpx.AsyncClient,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+        user_organization: UserOrganization,
+        idp_key: rsa.RSAPrivateKey,
+    ) -> None:
+        user_organization.role = OrganizationRole.admin
+        await save_fixture(user_organization)
+
+        connection = await create_sso_connection(save_fixture, organization)
+
+        with respx.mock(assert_all_mocked=False) as mock:
+            callback = await drive_to_callback(
+                sso_client,
+                session,
+                mock,
+                idp_key,
+                slug=organization.slug,
+                connection_id=connection.id,
+                email=user.email,
+            )
+            assert callback.status_code == 303
+
+        membership = await _get_membership(session, user, organization)
+        assert membership is not None
+        assert membership.role == OrganizationRole.admin
+
+    async def test_rejects_unverified_email_before_provisioning(
+        self,
+        sso_client: httpx.AsyncClient,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        idp_key: rsa.RSAPrivateKey,
+    ) -> None:
+        connection = await create_sso_connection(save_fixture, organization)
+
+        with respx.mock(assert_all_mocked=False) as mock:
+            callback = await drive_to_callback(
+                sso_client,
+                session,
+                mock,
+                idp_key,
+                slug=organization.slug,
+                connection_id=connection.id,
+                email=NEWCOMER_EMAIL,
+                email_verified=False,
+            )
+
+        assert "error=" in callback.headers["location"]
+        assert await _get_user_by_email(session, NEWCOMER_EMAIL) is None


### PR DESCRIPTION

## Provision users and memberships on SSO login

Signing in through an organization's identity provider now creates the Polar account and the membership if they don't exist. The IdP vouches for the email, so authenticating through it is what makes someone a member — no manual invite before a first login.

New members get the `member` role. Role mapping from an ID token claim is a nice to have follow-up.

The `email_verified` gate keeps its position ahead of provisioning: an unverified address is rejected before any row is written.

### Note for operators

`add_user` un-deletes soft-deleted memberships, so removing someone from the Polar dashboard no longer sticks — they return on their next SSO login. Remove them in your identity provider instead. This matches how Okta and Google Workspace behave.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

