### PR TITLE
Add customer balance management to backoffice

### DIFF
--- a/server/polar/backoffice/components/_datatable.py
+++ b/server/polar/backoffice/components/_datatable.py
@@ -704,7 +704,11 @@ class Datatable[M, PE: StrEnum]:
 
 @contextlib.contextmanager
 def pagination(
-    request: Request, pagination: PaginationParams, count: int
+    request: Request,
+    pagination: PaginationParams,
+    count: int,
+    *,
+    hx_target: str | None = None,
 ) -> Generator[None]:
     """Render pagination controls for a datatable.
 
@@ -717,6 +721,7 @@ def pagination(
         request: The FastAPI request object for URL generation.
         pagination: Pagination parameters containing current page and limit.
         count: Total number of items across all pages.
+        hx_target: Optional HTMX target for loading pagination links.
 
     Example:
         >>> with pagination(request, PaginationParams(page=2, limit=10), 50):
@@ -755,6 +760,9 @@ def pagination(
             ):
                 if previous_url is None:
                     attr("disabled", True)
+                elif hx_target is not None:
+                    attr("hx-get", str(previous_url))
+                    attr("hx-target", hx_target)
                 text("Previous")
             with tag.a(
                 classes="join-item btn",
@@ -762,6 +770,9 @@ def pagination(
             ):
                 if next_url is None:
                     attr("disabled", True)
+                elif hx_target is not None:
+                    attr("hx-get", str(next_url))
+                    attr("hx-target", hx_target)
                 text("Next")
     yield
 

--- a/server/polar/backoffice/customers/endpoints.py
+++ b/server/polar/backoffice/customers/endpoints.py
@@ -1,13 +1,23 @@
 import uuid
+from collections.abc import Generator, Sequence
+from decimal import Decimal
 from typing import Annotated, Any
 from urllib.parse import urlencode
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
-from pydantic import UUID4, BeforeValidator, EmailStr, Field, ValidationError
+from pydantic import (
+    UUID4,
+    BeforeValidator,
+    EmailStr,
+    Field,
+    ValidationError,
+    ValidationInfo,
+    field_validator,
+)
 from sqlalchemy import func, or_
 from sqlalchemy.orm import contains_eager, joinedload
-from tagflow import document, tag, text
+from tagflow import classes, document, tag, text
 
 from polar.backoffice import forms
 from polar.backoffice.orders.components import orders_datatable
@@ -18,6 +28,7 @@ from polar.customer.schemas.customer import CustomerUpdate
 from polar.customer.service import customer as customer_service
 from polar.customer_session.service import customer_session as customer_session_service
 from polar.exceptions import PolarRequestValidationError
+from polar.kit.currency import PresentmentCurrency, get_currency_decimal_factor
 from polar.kit.pagination import PaginationParamsQuery
 from polar.kit.schemas import empty_str_to_none
 from polar.member.repository import MemberRepository
@@ -30,11 +41,15 @@ from polar.models import (
     Organization,
     Product,
     Subscription,
+    Wallet,
+    WalletTransaction,
 )
+from polar.models.wallet import WalletType
 from polar.order.repository import OrderRepository
 from polar.postgres import AsyncSession, get_db_read_session, get_db_session
 from polar.subscription.repository import SubscriptionRepository
 from polar.subscription.sorting import SubscriptionSortProperty
+from polar.wallet.repository import WalletRepository, WalletTransactionRepository
 from polar.wallet.service import wallet as wallet_service
 from polar.worker import enqueue_job
 
@@ -52,6 +67,73 @@ class UpdateCustomerEmailForm(forms.BaseForm):
         forms.InputField(type="email", placeholder="customer@example.com"),
         Field(title="Email"),
     ]
+
+
+class CreateBalanceTransactionForm(forms.BaseForm):
+    currency: Annotated[
+        PresentmentCurrency,
+        forms.SelectField(
+            options=[
+                (currency.value, currency.value.upper())
+                for currency in PresentmentCurrency
+            ]
+        ),
+        Field(title="Currency"),
+    ]
+    amount: Annotated[
+        Decimal,
+        forms.InputField(type="number", step="any"),
+        Field(title="Amount"),
+    ]
+
+    @field_validator("amount")
+    @classmethod
+    def validate_amount_precision(
+        cls, amount: Decimal, info: ValidationInfo
+    ) -> Decimal:
+        if amount == 0:
+            raise ValueError("Amount must not be zero")
+        currency = info.data.get("currency")
+        if currency is None:
+            return amount
+        decimal_factor = get_currency_decimal_factor(currency)
+        amount_in_smallest_unit = amount * decimal_factor
+        if amount_in_smallest_unit != amount_in_smallest_unit.to_integral_value():
+            decimal_places = 0 if decimal_factor == 1 else 2
+            raise ValueError(
+                f"Amount must have at most {decimal_places} decimal places"
+            )
+        return amount
+
+    def amount_in_smallest_unit(self) -> int:
+        return int(self.amount * get_currency_decimal_factor(self.currency))
+
+
+class WalletTransactionReferenceColumn(datatable.DatatableColumn[WalletTransaction]):
+    def __init__(self) -> None:
+        super().__init__("Reference")
+
+    def render(
+        self, request: Request, item: WalletTransaction
+    ) -> Generator[None] | None:
+        href: str | None = None
+        label: str | None = None
+        if item.refund_id is not None:
+            label = f"Refund {item.refund_id}"
+            if item.refund is not None and item.refund.order_id is not None:
+                href = str(request.url_for("orders:get", id=item.refund.order_id))
+        elif item.order_id is not None:
+            label = f"Order {item.order_id}"
+            href = str(request.url_for("orders:get", id=item.order_id))
+
+        if label is None:
+            text("—")
+        elif href is None:
+            text(label)
+        else:
+            with tag.a(href=href, classes="link"):
+                text(label)
+        return None
 
 
 router = APIRouter()
@@ -165,9 +247,12 @@ async def get(
     )
     orders = await order_repository.get_all(orders_statement)
 
-    # Get credit balance
-    credit_balance = await wallet_service.get_billing_wallet_balance(
-        session, customer, "usd"
+    # Get credit balances
+    billing_wallets = await WalletRepository.from_session(
+        session
+    ).get_all_by_type_customer(
+        WalletType.billing,
+        customer.id,
     )
 
     # Get granted benefits
@@ -341,18 +426,68 @@ async def get(
                 # Credit Balance
                 with tag.div(classes="card card-border w-full shadow-sm"):
                     with tag.div(classes="card-body"):
-                        with tag.h2(classes="card-title"):
-                            text("Credit Balance")
-                        with tag.div(classes="flex items-center gap-2"):
-                            with tag.span(classes="font-semibold"):
-                                text("Available Balance:")
-                            balance_classes = (
-                                "text-lg text-success"
-                                if credit_balance > 0
-                                else "text-lg"
-                            )
-                            with tag.span(classes=balance_classes):
-                                text(currency(credit_balance, "usd"))
+                        with tag.div(classes="flex justify-between items-center"):
+                            with tag.h2(classes="card-title"):
+                                text("Credit Balance")
+                            with button(
+                                hx_get=str(
+                                    request.url_for(
+                                        "customers:create_balance_transaction",
+                                        id=customer.id,
+                                    )
+                                ),
+                                hx_target="#modal",
+                                variant="primary",
+                                size="sm",
+                            ):
+                                text("Add Transaction")
+                        with tag.dl():
+                            balances: Sequence[Wallet | None] = billing_wallets or [
+                                None
+                            ]
+                            for wallet in balances:
+                                balance_currency = (
+                                    wallet.currency if wallet is not None else "usd"
+                                )
+                                balance_amount = (
+                                    wallet.balance if wallet is not None else 0
+                                )
+                                with tag.div(
+                                    classes=("py-2 sm:grid sm:grid-cols-3 sm:gap-4")
+                                ):
+                                    with tag.dt(classes="text-sm/6 font-medium"):
+                                        if wallet is None:
+                                            text(balance_currency.upper())
+                                        else:
+                                            with tag.button(
+                                                type="button",
+                                                classes="link link-hover font-medium",
+                                                hx_get=str(
+                                                    request.url_for(
+                                                        "customers:wallet_transactions",
+                                                        id=customer.id,
+                                                        wallet_id=wallet.id,
+                                                    )
+                                                ),
+                                                hx_target="#modal",
+                                            ):
+                                                text(balance_currency.upper())
+                                    with tag.dd(
+                                        classes=(
+                                            "mt-1 text-sm/6 font-medium tabular-nums "
+                                            "sm:col-span-2 sm:mt-0 sm:text-right"
+                                        )
+                                    ):
+                                        if balance_amount > 0:
+                                            classes("text-success")
+                                        elif balance_amount < 0:
+                                            classes("text-error")
+                                        text(
+                                            currency(
+                                                balance_amount,
+                                                balance_currency,
+                                            )
+                                        )
 
             # Members Section
             with tag.div(classes="mt-8"):
@@ -504,6 +639,104 @@ async def get(
                 else:
                     with tag.div(classes="text-center py-8 text-gray-500"):
                         text("No granted benefits found")
+
+
+@router.api_route(
+    "/{id}/balance-transactions/create",
+    name="customers:create_balance_transaction",
+    methods=["GET", "POST"],
+)
+async def create_balance_transaction(
+    request: Request,
+    id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+) -> Any:
+    customer = await CustomerRepository.from_session(session).get_by_id(id)
+    if customer is None:
+        raise HTTPException(status_code=404)
+
+    validation_error: ValidationError | None = None
+    form_data: dict[str, Any] = {"currency": PresentmentCurrency.usd.value}
+
+    if request.method == "POST":
+        request_form_data = await request.form()
+        form_data = dict(request_form_data)
+        try:
+            form = CreateBalanceTransactionForm.model_validate_form(request_form_data)
+            await wallet_service.create_balance_transaction(
+                session,
+                customer,
+                form.amount_in_smallest_unit(),
+                form.currency.value,
+            )
+            await add_toast(
+                request,
+                "Customer balance transaction created successfully.",
+                "success",
+            )
+            return HXRedirectResponse(
+                request,
+                str(request.url_for("customers:get", id=customer.id)),
+                303,
+            )
+        except ValidationError as e:
+            validation_error = e
+
+    with document() as doc:
+        with tag.div(id="modal"):
+            with modal("Create Balance Transaction", open=True):
+                with CreateBalanceTransactionForm.render(
+                    data=form_data,
+                    validation_error=validation_error,
+                    method="POST",
+                    hx_post=str(
+                        request.url_for(
+                            "customers:create_balance_transaction",
+                            id=customer.id,
+                        )
+                    ),
+                    hx_target="#modal",
+                ):
+                    with tag.div(classes="modal-action"):
+                        with tag.form(method="dialog"):
+                            with button(ghost=True):
+                                text("Cancel")
+                        with button(type="submit", variant="primary"):
+                            text("Create Transaction")
+
+    return HTMLResponse(str(doc))
+
+
+@router.get(
+    "/{id}/wallets/{wallet_id}/transactions",
+    name="customers:wallet_transactions",
+)
+async def wallet_transactions(
+    request: Request,
+    id: UUID4,
+    wallet_id: UUID4,
+    session: AsyncSession = Depends(get_db_read_session),
+) -> Any:
+    wallet = await WalletRepository.from_session(session).get_by_id(wallet_id)
+    if wallet is None or wallet.customer_id != id or wallet.type != WalletType.billing:
+        raise HTTPException(status_code=404)
+
+    transactions = await WalletTransactionRepository.from_session(
+        session
+    ).get_all_by_wallet(wallet.id)
+
+    with document() as doc:
+        with tag.div(id="modal"):
+            with modal(f"{wallet.currency.upper()} Balance Transactions", open=True):
+                with datatable.Datatable[WalletTransaction, Any](
+                    datatable.DatatableDateTimeColumn("timestamp", "Created"),
+                    datatable.DatatableCurrencyColumn("amount", "Amount"),
+                    WalletTransactionReferenceColumn(),
+                    empty_message="No balance transactions found",
+                ).render(request, transactions):
+                    pass
+
+    return HTMLResponse(str(doc))
 
 
 def _render_portal_link_modal(

--- a/server/polar/backoffice/customers/endpoints.py
+++ b/server/polar/backoffice/customers/endpoints.py
@@ -60,6 +60,12 @@ from ..responses import HXRedirectResponse
 from ..toast import add_toast
 from .components import customers_datatable, email_verified_badge
 
+_MAX_CURRENCY_DECIMAL_FACTOR = max(
+    get_currency_decimal_factor(currency) for currency in PresentmentCurrency
+)
+_MINIMUM_BALANCE_AMOUNT = Decimal(-(2**63)) / _MAX_CURRENCY_DECIMAL_FACTOR
+_MAXIMUM_BALANCE_AMOUNT = Decimal(2**63 - 1) / _MAX_CURRENCY_DECIMAL_FACTOR
+
 
 class UpdateCustomerEmailForm(forms.BaseForm):
     email: Annotated[
@@ -83,7 +89,12 @@ class CreateBalanceTransactionForm(forms.BaseForm):
     amount: Annotated[
         Decimal,
         forms.InputField(type="number", step="any"),
-        Field(title="Amount"),
+        Field(
+            title="Amount",
+            ge=_MINIMUM_BALANCE_AMOUNT,
+            le=_MAXIMUM_BALANCE_AMOUNT,
+            allow_inf_nan=False,
+        ),
     ]
 
     @field_validator("amount")
@@ -429,18 +440,19 @@ async def get(
                         with tag.div(classes="flex justify-between items-center"):
                             with tag.h2(classes="card-title"):
                                 text("Credit Balance")
-                            with button(
-                                hx_get=str(
-                                    request.url_for(
-                                        "customers:create_balance_transaction",
-                                        id=customer.id,
-                                    )
-                                ),
-                                hx_target="#modal",
-                                variant="primary",
-                                size="sm",
-                            ):
-                                text("Add Transaction")
+                            if not customer.deleted_at:
+                                with button(
+                                    hx_get=str(
+                                        request.url_for(
+                                            "customers:create_balance_transaction",
+                                            id=customer.id,
+                                        )
+                                    ),
+                                    hx_target="#modal",
+                                    variant="primary",
+                                    size="sm",
+                                ):
+                                    text("Add Transaction")
                         with tag.dl():
                             balances: Sequence[Wallet | None] = billing_wallets or [
                                 None
@@ -715,15 +727,16 @@ async def wallet_transactions(
     request: Request,
     id: UUID4,
     wallet_id: UUID4,
+    pagination: PaginationParamsQuery,
     session: AsyncSession = Depends(get_db_read_session),
 ) -> Any:
     wallet = await WalletRepository.from_session(session).get_by_id(wallet_id)
     if wallet is None or wallet.customer_id != id or wallet.type != WalletType.billing:
         raise HTTPException(status_code=404)
 
-    transactions = await WalletTransactionRepository.from_session(
+    transactions, count = await WalletTransactionRepository.from_session(
         session
-    ).get_all_by_wallet(wallet.id)
+    ).paginate_by_wallet(wallet.id, pagination=pagination)
 
     with document() as doc:
         with tag.div(id="modal"):
@@ -734,6 +747,13 @@ async def wallet_transactions(
                     WalletTransactionReferenceColumn(),
                     empty_message="No balance transactions found",
                 ).render(request, transactions):
+                    pass
+                with datatable.pagination(
+                    request,
+                    pagination,
+                    count,
+                    hx_target="#modal",
+                ):
                     pass
 
     return HTMLResponse(str(doc))

--- a/server/polar/wallet/repository.py
+++ b/server/polar/wallet/repository.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from uuid import UUID
 
 from sqlalchemy import Select, func, select
@@ -44,6 +45,19 @@ class WalletRepository(
             statement = statement.with_for_update()
         return await self.get_one_or_none(statement)
 
+    async def get_all_by_type_customer(
+        self, type: WalletType, customer_id: UUID
+    ) -> Sequence[Wallet]:
+        statement = (
+            self.get_base_statement()
+            .where(
+                Wallet.type == type,
+                Wallet.customer_id == customer_id,
+            )
+            .order_by(Wallet.currency)
+        )
+        return await self.get_all(statement)
+
     def get_statement_by_org_ids(
         self, org_ids: set[AccessibleOrganizationID]
     ) -> Select[tuple[Wallet]]:
@@ -80,6 +94,15 @@ class WalletTransactionRepository(
         )
         result = await self.session.execute(statement)
         return result.scalar_one()
+
+    async def get_all_by_wallet(self, wallet_id: UUID) -> Sequence[WalletTransaction]:
+        statement = (
+            self.get_base_statement()
+            .where(WalletTransaction.wallet_id == wallet_id)
+            .options(joinedload(WalletTransaction.refund))
+            .order_by(WalletTransaction.timestamp.desc())
+        )
+        return await self.get_all(statement)
 
     def get_eager_options(self) -> Options:
         return (

--- a/server/polar/wallet/repository.py
+++ b/server/polar/wallet/repository.py
@@ -5,6 +5,7 @@ from sqlalchemy import Select, func, select
 from sqlalchemy.orm import contains_eager, joinedload
 
 from polar.authz.types import AccessibleOrganizationID
+from polar.kit.pagination import PaginationParams
 from polar.kit.repository import (
     Options,
     RepositoryBase,
@@ -95,14 +96,23 @@ class WalletTransactionRepository(
         result = await self.session.execute(statement)
         return result.scalar_one()
 
-    async def get_all_by_wallet(self, wallet_id: UUID) -> Sequence[WalletTransaction]:
+    async def paginate_by_wallet(
+        self, wallet_id: UUID, *, pagination: PaginationParams
+    ) -> tuple[Sequence[WalletTransaction], int]:
         statement = (
             self.get_base_statement()
             .where(WalletTransaction.wallet_id == wallet_id)
             .options(joinedload(WalletTransaction.refund))
-            .order_by(WalletTransaction.timestamp.desc())
+            .order_by(
+                WalletTransaction.timestamp.desc(),
+                WalletTransaction.id.desc(),
+            )
         )
-        return await self.get_all(statement)
+        return await self.paginate(
+            statement,
+            limit=pagination.limit,
+            page=pagination.page,
+        )
 
     def get_eager_options(self) -> Options:
         return (

--- a/server/tests/backoffice/customers/test_endpoints.py
+++ b/server/tests/backoffice/customers/test_endpoints.py
@@ -1,0 +1,246 @@
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+import pytest_asyncio
+from pytest_mock import MockerFixture
+
+from polar.backoffice import app as backoffice_app
+from polar.backoffice.dependencies import get_admin
+from polar.models import Customer, User, WalletTransaction
+from polar.models.user_session import UserSession
+from polar.postgres import AsyncSession, get_db_read_session, get_db_session
+from polar.wallet.service import wallet as wallet_service
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_order, create_payment, create_refund
+
+
+@pytest_asyncio.fixture
+async def backoffice_client(
+    session: AsyncSession, user: User
+) -> AsyncGenerator[httpx.AsyncClient, None]:
+    user_session = UserSession(token="0" * 64, user_agent="tests", user=user)
+    backoffice_app.dependency_overrides[get_db_session] = lambda: session
+    backoffice_app.dependency_overrides[get_db_read_session] = lambda: session
+    backoffice_app.dependency_overrides[get_admin] = lambda: user_session
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=backoffice_app),
+            base_url="http://test",
+        ) as client:
+            yield client
+    finally:
+        backoffice_app.dependency_overrides.pop(get_db_session, None)
+        backoffice_app.dependency_overrides.pop(get_db_read_session, None)
+        backoffice_app.dependency_overrides.pop(get_admin, None)
+
+
+@pytest.mark.asyncio
+class TestCreateBalanceTransaction:
+    async def test_returns_404_for_unknown_customer(
+        self, backoffice_client: httpx.AsyncClient
+    ) -> None:
+        response = await backoffice_client.get(
+            f"/customers/{uuid.uuid4()}/balance-transactions/create"
+        )
+
+        assert response.status_code == 404
+
+    async def test_get_renders_form(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        customer: Customer,
+    ) -> None:
+        response = await backoffice_client.get(
+            f"/customers/{customer.id}/balance-transactions/create"
+        )
+
+        assert response.status_code == 200
+        assert "Create Balance Transaction" in response.text
+        assert 'name="amount"' in response.text
+        assert 'name="currency"' in response.text
+        assert 'value="usd" selected' in response.text
+
+    @pytest.mark.parametrize(
+        ("amount", "currency", "expected_amount"),
+        [
+            ("-12.34", "usd", -1234),
+            ("125", "jpy", 125),
+        ],
+    )
+    async def test_post_creates_balance_transaction(
+        self,
+        amount: str,
+        currency: str,
+        expected_amount: int,
+        backoffice_client: httpx.AsyncClient,
+        session: AsyncSession,
+        customer: Customer,
+        mocker: MockerFixture,
+    ) -> None:
+        create_balance_transaction_mock = mocker.patch.object(
+            wallet_service,
+            "create_balance_transaction",
+            new=mocker.AsyncMock(),
+        )
+
+        response = await backoffice_client.post(
+            f"/customers/{customer.id}/balance-transactions/create",
+            data={"amount": amount, "currency": currency},
+        )
+
+        assert response.status_code == 303
+        create_balance_transaction_mock.assert_awaited_once_with(
+            session,
+            customer,
+            expected_amount,
+            currency,
+        )
+
+    @pytest.mark.parametrize(
+        ("amount", "currency", "error_message"),
+        [
+            ("0", "usd", "Amount must not be zero"),
+            ("1.001", "usd", "Amount must have at most 2 decimal places"),
+            ("1.1", "jpy", "Amount must have at most 0 decimal places"),
+            ("1", "invalid", "Input should be"),
+        ],
+    )
+    async def test_post_rejects_invalid_form(
+        self,
+        amount: str,
+        currency: str,
+        error_message: str,
+        backoffice_client: httpx.AsyncClient,
+        customer: Customer,
+        mocker: MockerFixture,
+    ) -> None:
+        create_balance_transaction_mock = mocker.patch.object(
+            wallet_service,
+            "create_balance_transaction",
+            new=mocker.AsyncMock(),
+        )
+
+        response = await backoffice_client.post(
+            f"/customers/{customer.id}/balance-transactions/create",
+            data={"amount": amount, "currency": currency},
+        )
+
+        assert response.status_code == 200
+        assert error_message in response.text
+        create_balance_transaction_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+class TestCreditBalance:
+    async def test_displays_all_billing_wallet_currencies(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        session: AsyncSession,
+        customer: Customer,
+    ) -> None:
+        await wallet_service.create_balance_transaction(session, customer, 1234, "usd")
+        await wallet_service.create_balance_transaction(session, customer, -500, "eur")
+        await session.flush()
+
+        response = await backoffice_client.get(f"/customers/{customer.id}")
+
+        assert response.status_code == 200
+        assert "Add Transaction" in response.text
+        assert "USD" in response.text
+        assert "$12.34" in response.text
+        assert "EUR" in response.text
+        assert "€5.00" in response.text
+        assert f"/customers/{customer.id}/wallets/" in response.text
+
+    async def test_displays_usd_zero_balance_without_wallets(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        customer: Customer,
+    ) -> None:
+        response = await backoffice_client.get(f"/customers/{customer.id}")
+
+        assert response.status_code == 200
+        assert "USD" in response.text
+        assert "$0.00" in response.text
+
+
+@pytest.mark.asyncio
+class TestWalletTransactions:
+    async def test_displays_transactions_newest_first_with_references(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+    ) -> None:
+        order = await create_order(save_fixture, customer=customer)
+        payment = await create_payment(
+            save_fixture,
+            customer.organization,
+            order=order,
+        )
+        refund = await create_refund(save_fixture, order, payment)
+
+        order_transaction = await wallet_service.create_balance_transaction(
+            session,
+            customer,
+            1000,
+            "usd",
+            order=order,
+        )
+        order_transaction.timestamp = datetime.now(UTC) - timedelta(days=1)
+        refund_transaction = WalletTransaction(
+            currency="usd",
+            amount=-500,
+            wallet=order_transaction.wallet,
+            refund=refund,
+            timestamp=datetime.now(UTC),
+        )
+        await save_fixture(refund_transaction)
+        await session.flush()
+
+        response = await backoffice_client.get(
+            f"/customers/{customer.id}/wallets/"
+            f"{order_transaction.wallet_id}/transactions"
+        )
+
+        assert response.status_code == 200
+        assert "USD Balance Transactions" in response.text
+        assert "Created" in response.text
+        assert "Amount" in response.text
+        refund_reference = f"Refund {refund.id}"
+        order_reference = f"Order {order.id}"
+        assert response.text.index(refund_reference) < response.text.index(
+            order_reference
+        )
+        assert response.text.count(f"/orders/{order.id}") == 2
+
+    async def test_returns_404_for_wallet_from_another_customer(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+    ) -> None:
+        other_customer = Customer(
+            organization=customer.organization,
+            email="other-customer@example.com",
+            name="Other Customer",
+        )
+        await save_fixture(other_customer)
+        transaction = await wallet_service.create_balance_transaction(
+            session,
+            other_customer,
+            1000,
+            "usd",
+        )
+        await session.flush()
+
+        response = await backoffice_client.get(
+            f"/customers/{customer.id}/wallets/{transaction.wallet_id}/transactions"
+        )
+
+        assert response.status_code == 404

--- a/server/tests/backoffice/customers/test_endpoints.py
+++ b/server/tests/backoffice/customers/test_endpoints.py
@@ -1,3 +1,4 @@
+import re
 import uuid
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime, timedelta
@@ -68,6 +69,8 @@ class TestCreateBalanceTransaction:
         [
             ("-12.34", "usd", -1234),
             ("125", "jpy", 125),
+            ("92233720368547758.07", "usd", 2**63 - 1),
+            ("-92233720368547758.08", "usd", -(2**63)),
         ],
     )
     async def test_post_creates_balance_transaction(
@@ -106,6 +109,12 @@ class TestCreateBalanceTransaction:
             ("1.001", "usd", "Amount must have at most 2 decimal places"),
             ("1.1", "jpy", "Amount must have at most 0 decimal places"),
             ("1", "invalid", "Input should be"),
+            ("Infinity", "usd", "finite number"),
+            ("92233720368547758.08", "usd", "less than or equal"),
+            ("-92233720368547758.09", "usd", "greater than or equal"),
+            ("9223372036854775808", "jpy", "less than or equal"),
+            ("-9223372036854775809", "jpy", "greater than or equal"),
+            ("1e1000000", "usd", "less than or equal"),
         ],
     )
     async def test_post_rejects_invalid_form(
@@ -166,6 +175,21 @@ class TestCreditBalance:
         assert "USD" in response.text
         assert "$0.00" in response.text
 
+    async def test_hides_add_transaction_for_deleted_customer(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        session: AsyncSession,
+        customer: Customer,
+    ) -> None:
+        customer.deleted_at = datetime.now(UTC)
+        await session.flush()
+
+        response = await backoffice_client.get(f"/customers/{customer.id}")
+
+        assert response.status_code == 200
+        assert "Credit Balance" in response.text
+        assert "Add Transaction" not in response.text
+
 
 @pytest.mark.asyncio
 class TestWalletTransactions:
@@ -217,6 +241,48 @@ class TestWalletTransactions:
             order_reference
         )
         assert response.text.count(f"/orders/{order.id}") == 2
+
+    async def test_paginates_transactions(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        session: AsyncSession,
+        customer: Customer,
+    ) -> None:
+        transactions: list[WalletTransaction] = []
+        timestamp = datetime.now(UTC) - timedelta(days=1)
+        for index in range(11):
+            transaction = await wallet_service.create_balance_transaction(
+                session,
+                customer,
+                100 + index,
+                "usd",
+            )
+            transaction.timestamp = timestamp + timedelta(minutes=index)
+            transactions.append(transaction)
+        await session.flush()
+
+        wallet_id = transactions[0].wallet_id
+        first_page = await backoffice_client.get(
+            f"/customers/{customer.id}/wallets/{wallet_id}/transactions"
+        )
+
+        assert first_page.status_code == 200
+        first_page_text = re.sub(r"<[^>]+>", "", first_page.text)
+        assert "Showing 1 to 10 of 11 entries" in first_page_text
+        assert "$1.10" in first_page.text
+        assert "$1.00" not in first_page.text
+        assert 'hx-target="#modal"' in first_page.text
+
+        second_page = await backoffice_client.get(
+            f"/customers/{customer.id}/wallets/{wallet_id}/transactions",
+            params={"page": 2},
+        )
+
+        assert second_page.status_code == 200
+        second_page_text = re.sub(r"<[^>]+>", "", second_page.text)
+        assert "Showing 11 to 11 of 11 entries" in second_page_text
+        assert "$1.00" in second_page.text
+        assert "$1.10" not in second_page.text
 
     async def test_returns_404_for_wallet_from_another_customer(
         self,


### PR DESCRIPTION
## Summary

- add a backoffice modal to create signed customer balance transactions with currency-aware validation
- display customer billing wallet balances as a compact multi-currency list
- add a transaction history modal with newest-first amounts and order/refund references
- prevent transaction history access across customers

## Impact

Backoffice admins can adjust a customer balance in any supported presentment currency and inspect the resulting wallet history directly from the customer details page.

## Validation

- `uv run pytest tests/backoffice/customers/test_endpoints.py -q` (12 passed)
- `uv run task lint`
- `uv run task lint_types`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

