### PR TITLE
server: bind SSO to a Polar plan benefit

### DIFF
--- a/clients/apps/web/src/components/Landing/Pricing.tsx
+++ b/clients/apps/web/src/components/Landing/Pricing.tsx
@@ -60,6 +60,7 @@ const TIERS: Tier[] = [
       'Preview access to new features',
       'Shared Slack channel',
       'P1 Support',
+      'Single Sign-On',
     ],
   },
 ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -120,6 +120,7 @@
               "features/analytics",
               "features/customer-management",
               "features/team-management",
+              "features/sso",
               {
                 "group": "Customer Portal",
                 "pages": [

--- a/docs/features/sso.mdx
+++ b/docs/features/sso.mdx
@@ -1,0 +1,101 @@
+---
+title: "Single Sign-On"
+sidebarTitle: "SSO"
+description: "Let your team sign in to Polar through your own identity provider, and become members automatically."
+---
+
+<Note>
+  Single Sign-On is included in the **Scale** plan. Upgrade from [**Settings →
+  Billing**](https://polar.sh/to/dashboard/settings/billing) — SSO becomes available as soon as the
+  subscription is active.
+</Note>
+
+Single Sign-On connects your organization to your own identity provider. Your team signs in with the credentials they already use, and anyone who authenticates becomes a member of your organization.
+
+Polar supports any provider that implements OpenID Connect, including Google Workspace, Okta, Microsoft Entra ID, and Keycloak.
+
+SSO lives under [**Settings → SSO**](https://polar.sh/to/dashboard/settings/sso) in your dashboard.
+
+## How people become members
+
+Anyone who signs in through your connection becomes a member of your organization. You don't invite them first — authenticating against your identity provider is what grants membership.
+
+New members join with the **Member** role. To grant more access, [change their role](/features/team-management#changing-a-members-role) after their first sign-in.
+
+Your identity provider decides who can authenticate, so it also decides who can join. Grant and revoke access to the Polar application there.
+
+<Warning>
+**Removing a member in Polar does not keep them out.** If they can still authenticate against your identity provider, they rejoin on their next sign-in. To remove someone's access, revoke it in your identity provider.
+</Warning>
+
+Polar only accepts an identity whose email address your provider marks as verified. If the email is unverified, the sign-in is refused and no account is created.
+
+## Setting up a connection
+
+<Steps>
+  <Step title="Add the connection in Polar">
+    Go to [**Settings → SSO**](https://polar.sh/to/dashboard/settings/sso) and click **Add connection**. Pick **Google Workspace** or **Custom OIDC provider**.
+  </Step>
+  <Step title="Register the callback URL">
+    Copy the **Callback URL** shown at the top of the form and register it as a redirect URI in your identity provider.
+  </Step>
+  <Step title="Fill in the provider details">
+    Enter the **Issuer URL** and **Client ID** from your provider. You can paste the discovery URL into the issuer field — Polar strips the `/.well-known/openid-configuration` suffix.
+
+    For **Client secret** authentication, paste the secret. For **Private key JWT**, copy the **JWKS URL** into your provider so it can fetch Polar's public keys.
+  </Step>
+  <Step title="Enable it">
+    Connections are created disabled. Once your provider is configured, click **Enable** on the connection row.
+  </Step>
+</Steps>
+
+Share the **Login link** from the SSO settings page with your team. It takes them straight to your organization's sign-in page.
+
+### Authorization parameters
+
+You can append extra parameters to the authorization request. The most common is `hd`, which pins a Google Workspace domain so users outside it can't sign in.
+
+Polar sets `response_type`, `client_id`, `redirect_uri`, `scope`, `state`, `nonce`, and the PKCE parameters itself. You can't override them.
+
+## Enforcing SSO
+
+By default, members can sign in either through SSO or through the standard methods — email code, Google, GitHub, or Apple. Enforcing SSO removes the alternatives: members reach your organization only through your identity provider.
+
+To enforce it, you need an enabled connection, and you must already be signed in through this organization's SSO. That proves the connection works before it becomes the only way in.
+
+<Warning>
+Enforcing SSO disconnects every member and every authorized third-party app. They must sign in again through your identity provider.
+</Warning>
+
+Enforcement makes your identity provider the only door. Anyone who can't authenticate there loses access, including members you invited by email — they keep their membership, but they can't reach the organization until you add them to your provider.
+
+You can stop enforcing at any time from the same screen.
+
+<Note>
+Enforcement applies to dashboard sessions. Personal access tokens and organization access tokens keep working, so scripts and integrations aren't interrupted.
+</Note>
+
+## Frequently asked questions
+
+<AccordionGroup>
+  <Accordion title="Do members need a Polar account before their first sign-in?">
+    No. Polar creates the account on their first sign-in through your connection, and adds them to your organization.
+  </Accordion>
+  <Accordion title="What happens to someone who already has a Polar account?">
+    They keep it. Signing in through your connection adds your organization to their existing account — it doesn't create a second one, and it doesn't give your organization access to anything else they own.
+  </Accordion>
+  <Accordion title="Can I still invite members by email?">
+    Yes, as long as you don't enforce SSO. [Invitations](/features/team-management#inviting-a-member) work alongside it, which is useful for contractors who aren't in your identity provider.
+
+    Once you enforce SSO, invitations stop being a way in. The invited person becomes a member, but reaching your organization requires signing in through your identity provider. Add them there instead.
+  </Accordion>
+  <Accordion title="Can I use more than one identity provider?">
+    Yes. Add a connection per provider. Each one appears as a separate button on your organization's sign-in page, so give them names.
+  </Accordion>
+  <Accordion title="How do I remove someone's access?">
+    Revoke their access to the Polar application in your identity provider. Removing them in Polar alone doesn't stop them from rejoining on their next sign-in.
+  </Accordion>
+  <Accordion title="What happens if I leave the Scale plan?">
+    SSO turns off, and enforcement is lifted with it, so your members sign in with the standard methods again. Your connections are kept — upgrading to Scale again restores them as they were. Everyone who joined through SSO stays a member.
+  </Accordion>
+</AccordionGroup>

--- a/docs/features/team-management.mdx
+++ b/docs/features/team-management.mdx
@@ -8,6 +8,11 @@ Polar organizations support multiple users. You can invite teammates to collabor
 
 Team management lives under [**Settings → Members**](https://polar.sh/to/dashboard/settings/members) in your dashboard.
 
+<Note>
+  On the Scale plan you can connect your own identity provider instead of inviting people one by
+  one. See [Single Sign-On](/features/sso).
+</Note>
+
 ## Roles
 
 Every member of an organization has one of three roles:
@@ -51,6 +56,10 @@ New members join with the **Member** role by default. To grant additional access
 **Already a member?** If you invite an email that's already part of your organization, no new invite is sent — the existing membership is shown instead.
 </Note>
 
+<Warning>
+**Enforcing [SSO](/features/sso)?** Invitations stop being a way in. The invited person becomes a member, but reaching the organization requires signing in through your identity provider. Add them there instead.
+</Warning>
+
 ## Changing a member's role
 
 Only **admins** and **owners** can change roles.
@@ -81,6 +90,10 @@ The removed member immediately loses access to the organization. They keep their
 **You can't remove the owner.** Every organization always has exactly one owner — to remove the current owner, ownership must first be transferred to another member who has completed identity verification. Please [contact support](/support) to request an ownership transfer.
 </Warning>
 
+<Warning>
+**Using [SSO](/features/sso)?** Removing a member here doesn't keep them out. Anyone who can still authenticate against your identity provider rejoins on their next sign-in. Revoke their access in your identity provider instead.
+</Warning>
+
 ## Leaving an organization
 
 If you want to leave an organization yourself:
@@ -99,6 +112,9 @@ You can't leave an organization if you are:
 <AccordionGroup>
   <Accordion title="Do invited users need an existing Polar account?">
     No. If the invited email doesn't have a Polar account yet, one is created automatically. The user signs in to claim it when they accept the invitation.
+  </Accordion>
+  <Accordion title="Can people join without an invitation?">
+    Yes, if your organization uses [Single Sign-On](/features/sso). Anyone who authenticates through your identity provider becomes a member with the Member role — no invitation needed. Your identity provider controls who can do that.
   </Accordion>
   <Accordion title="Can a user belong to more than one organization?">
     Yes. A user can be a member of any number of organizations and may have different roles in each one. You can switch between them from the organization picker in the dashboard.

--- a/docs/merchant-of-record/fees.mdx
+++ b/docs/merchant-of-record/fees.mdx
@@ -7,12 +7,12 @@ description: "Transparent, public pricing — pick the plan that fits"
 
 Polar offers a free Starter plan plus three optional paid plans — Pro, Growth, and Scale — that lower your variable rate and prioritize your support inquiries. You can switch between plans anytime, and your rate adjusts immediately.
 
-| Plan | Monthly fee | Per transaction | Support |
-| --- | --- | --- | --- |
-| **Starter** | Free | 5% + 50¢ | Standard Support |
-| **Pro** | $20 /mo | 3.8% + 40¢ | Prioritized Support |
-| **Growth** | $100 /mo | 3.6% + 35¢ | Prioritized Support |
-| **Scale** | $400 /mo | 3.4% + 30¢ | Slack + Prioritized Support |
+| Plan | Monthly fee | Per transaction | Support | Included |
+| --- | --- | --- | --- | --- |
+| **Starter** | Free | 5% + 50¢ | Standard Support | |
+| **Pro** | $20 /mo | 3.8% + 40¢ | Prioritized Support | |
+| **Growth** | $100 /mo | 3.6% + 35¢ | Prioritized Support | |
+| **Scale** | $400 /mo | 3.4% + 30¢ | Slack + Prioritized Support | [Single Sign-On](/features/sso) |
 
 The paid plans replace the per-transaction Merchant of Record premium with a fixed monthly fee and a lower variable rate.
 

--- a/server/polar/auth/factors.py
+++ b/server/polar/auth/factors.py
@@ -309,7 +309,11 @@ async def get_org_factors(
         raise ResourceNotFound()
 
     sso_repository = OrganizationSSOConnectionRepository.from_session(session)
-    connections = await sso_repository.get_enabled_by_organization(organization.id)
+    connections = (
+        await sso_repository.get_enabled_by_organization(organization.id)
+        if organization.is_sso_enabled
+        else []
+    )
 
     sso_factors: set[FactorBase[typing.Any]] = {
         build_sso_factor(

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -3580,10 +3580,16 @@ async def edit_features(
                 **feature_flags,
             }
 
+            update_dict: dict[str, Any] = {"feature_settings": updated_feature_settings}
+            # Enforcement outliving SSO would strand the organization: no SSO
+            # session can be minted, and enforcement hides it from every other one.
+            if not updated_feature_settings.get("sso_enabled", False):
+                update_dict["sso_enforced"] = False
+
             # Update organization
             organization = await repository.update(
                 organization,
-                update_dict={"feature_settings": updated_feature_settings},
+                update_dict=update_dict,
             )
 
             # Trigger backfill when member_model transitions False → True

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -709,6 +709,7 @@ class PolarSelfService:
                 "transaction_fee",
                 "support",
                 "preview_access",
+                "sso",
             ):
                 return
 
@@ -727,6 +728,8 @@ class PolarSelfService:
                     await self._apply_preview_access(
                         session, organization_id, active_grant
                     )
+                case "sso":
+                    await self._apply_sso(session, organization_id, active_grant)
 
     async def handle_order_created_event(
         self, payload: WebhookOrderCreatedPayload
@@ -1158,6 +1161,36 @@ class PolarSelfService:
                 **organization.feature_settings,
                 **{flag: enabled for flag in self.PREVIEW_ACCESS_FEATURE_FLAGS},
             }
+
+    async def _apply_sso(
+        self,
+        session: AsyncSession,
+        organization_id: uuid.UUID,
+        grant: "BenefitGrant | None",
+    ) -> None:
+        enabled = grant is not None
+
+        organization_repository = OrganizationRepository.from_session(session)
+        organization = await organization_repository.get_by_id(
+            organization_id, include_blocked=True
+        )
+        if organization is None:
+            return
+
+        with logfire.span(
+            "polar_self.webhook.sso.applied",
+            organization_id=str(organization_id),
+            enabled=enabled,
+        ):
+            organization.feature_settings = {
+                **organization.feature_settings,
+                "sso_enabled": enabled,
+            }
+            if not enabled:
+                # Enforcement outlasting SSO would shut the organization out: its
+                # login page offers no SSO factor, and an unscoped session can't
+                # reach an enforcing organization.
+                organization.sso_enforced = False
 
     async def _fetch_active_grant(
         self, customer_id: str, benefit_type: str

--- a/server/scripts/seed_polar_for_polar.py
+++ b/server/scripts/seed_polar_for_polar.py
@@ -106,6 +106,12 @@ BENEFITS: list[dict[str, object]] = [
             "plain_tier_external_id": "scale",
         },
     },
+    {
+        "description": "Single Sign-On",
+        "metadata": {
+            "type": "sso",
+        },
+    },
 ]
 
 PRODUCTS: list[dict[str, object]] = [
@@ -142,9 +148,13 @@ PRODUCTS: list[dict[str, object]] = [
             "custom": False,
             "order": 4,
             "description": "For fast growing businesses.",
-            "features": "All features on Growth, Slack Channel, P1 Support",
+            "features": "All features on Growth, Slack Channel, P1 Support, Single Sign-On",
         },
-        "benefits": ["Transaction Fee (Tier 4)", "Support (Tier 4)"],
+        "benefits": [
+            "Transaction Fee (Tier 4)",
+            "Support (Tier 4)",
+            "Single Sign-On",
+        ],
     },
 ]
 

--- a/server/tests/auth/sso/test_endpoints.py
+++ b/server/tests/auth/sso/test_endpoints.py
@@ -28,6 +28,11 @@ async def create_sso_connection(
         "auth_method": OIDCAuthMethod.client_secret,
         "client_secret": "secret",
     }
+    organization.feature_settings = {
+        **organization.feature_settings,
+        "sso_enabled": True,
+    }
+    await save_fixture(organization)
     connection = OrganizationSSOConnection(
         organization=organization,
         type=OrganizationSSOConnectionType.oidc,

--- a/server/tests/auth/sso/test_flow.py
+++ b/server/tests/auth/sso/test_flow.py
@@ -123,6 +123,11 @@ async def create_sso_connection(
     }
     if authorization_parameters is not None:
         configuration["authorization_parameters"] = authorization_parameters
+    organization.feature_settings = {
+        **organization.feature_settings,
+        "sso_enabled": True,
+    }
+    await save_fixture(organization)
     connection = OrganizationSSOConnection(
         organization=organization,
         type=OrganizationSSOConnectionType.oidc,

--- a/server/tests/auth/test_factors.py
+++ b/server/tests/auth/test_factors.py
@@ -15,6 +15,16 @@ from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
 
 
+async def enable_sso(
+    save_fixture: SaveFixture, organization: Organization, *, enabled: bool = True
+) -> None:
+    organization.feature_settings = {
+        **organization.feature_settings,
+        "sso_enabled": enabled,
+    }
+    await save_fixture(organization)
+
+
 async def create_sso_connection(
     save_fixture: SaveFixture,
     organization: Organization,
@@ -54,6 +64,7 @@ class TestGetOrgFactors:
         save_fixture: SaveFixture,
         organization: Organization,
     ) -> None:
+        await enable_sso(save_fixture, organization)
         enabled = await create_sso_connection(save_fixture, organization, enabled=True)
         await create_sso_connection(save_fixture, organization, enabled=False)
 
@@ -72,6 +83,7 @@ class TestGetOrgFactors:
         save_fixture: SaveFixture,
         organization: Organization,
     ) -> None:
+        await enable_sso(save_fixture, organization)
         connection = await create_sso_connection(
             save_fixture, organization, enabled=True
         )
@@ -97,6 +109,7 @@ class TestGetOrgFactors:
         save_fixture: SaveFixture,
         organization: Organization,
     ) -> None:
+        await enable_sso(save_fixture, organization)
         connection = await create_sso_connection(
             save_fixture, organization, enabled=True
         )
@@ -113,3 +126,21 @@ class TestGetOrgFactors:
 
         assert base_factor not in factors
         assert {factor.identifier for factor in factors} == {str(connection.id)}
+
+    async def test_no_sso_factors_when_feature_disabled(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        await create_sso_connection(save_fixture, organization, enabled=True)
+        base_factor = MagicMock()
+
+        factors = await get_org_factors(
+            slug=organization.slug,
+            base_factors={base_factor},
+            session=session,
+            state_service=OAuth2StateService(session),
+        )
+
+        assert factors == {base_factor}

--- a/server/tests/backoffice/organizations_v2/test_endpoints.py
+++ b/server/tests/backoffice/organizations_v2/test_endpoints.py
@@ -358,3 +358,45 @@ class TestDetailRiskSignals:
         assert response.status_code == 200
         assert "Risk Signals" not in response.text
         assert self.TAB_DOT not in response.text
+
+
+@pytest.mark.asyncio
+class TestEditFeatures:
+    async def test_disabling_sso_lifts_enforcement(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        organization.feature_settings = {"sso_enabled": True}
+        organization.sso_enforced = True
+        await save_fixture(organization)
+
+        # Unchecked boxes are absent from the form, so an empty body disables
+        # every flag.
+        response = await backoffice_client.post(
+            f"/organizations/{organization.id}/edit-features", data={}
+        )
+
+        assert response.status_code == 303
+        assert organization.feature_settings["sso_enabled"] is False
+        assert organization.sso_enforced is False
+
+    async def test_keeps_enforcement_while_sso_enabled(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        organization.feature_settings = {"sso_enabled": True}
+        organization.sso_enforced = True
+        await save_fixture(organization)
+
+        response = await backoffice_client.post(
+            f"/organizations/{organization.id}/edit-features",
+            data={"sso_enabled": "on"},
+        )
+
+        assert response.status_code == 303
+        assert organization.feature_settings["sso_enabled"] is True
+        assert organization.sso_enforced is True

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -160,6 +160,10 @@ def _make_preview_grant(*, benefit_id: str = _BENEFIT_ID) -> BenefitGrant:
     return _make_grant(benefit_id=benefit_id, metadata={"type": "preview_access"})
 
 
+def _make_sso_grant(*, benefit_id: str = _BENEFIT_ID) -> BenefitGrant:
+    return _make_grant(benefit_id=benefit_id, metadata={"type": "sso"})
+
+
 def _make_payload(
     event_type: str,
     *,
@@ -243,6 +247,22 @@ def preview_access_org_repository_mock(mocker: MockerFixture) -> MagicMock:
     repository = MagicMock()
     organization = MagicMock(spec=Organization)
     organization.feature_settings = {}
+    repository.get_by_id = AsyncMock(return_value=organization)
+    mocker.patch(
+        "polar.integrations.polar.service.OrganizationRepository.from_session",
+        return_value=repository,
+    )
+    return repository
+
+
+@pytest.fixture
+def sso_org_repository_mock(mocker: MockerFixture) -> MagicMock:
+    """Repository whose organization enforces SSO and carries a real
+    feature_settings dict, so revocation can be observed on both."""
+    repository = MagicMock()
+    organization = MagicMock(spec=Organization)
+    organization.feature_settings = {"sso_enabled": True}
+    organization.sso_enforced = True
     repository.get_by_id = AsyncMock(return_value=organization)
     mocker.patch(
         "polar.integrations.polar.service.OrganizationRepository.from_session",
@@ -1055,6 +1075,59 @@ class TestHandleBenefitGrantEvent:
         organization = preview_access_org_repository_mock.get_by_id.return_value
         assert organization.feature_settings == _PREVIEW_FLAGS_ENABLED
 
+    async def test_sso_created_enables_flag(
+        self,
+        session_mock: AsyncSession,
+        sso_org_repository_mock: MagicMock,
+        list_grants_mock: AsyncMock,
+    ) -> None:
+        list_grants_mock.return_value = [_make_sso_grant()]
+        payload = WebhookBenefitGrantCreatedPayload.model_validate(
+            _make_payload("benefit_grant.created", metadata={"type": "sso"})
+        )
+
+        await polar_self.handle_benefit_grant_event(session_mock, payload)
+
+        list_grants_mock.assert_awaited_once_with(customer_id=_CUSTOMER_ID)
+        organization = sso_org_repository_mock.get_by_id.return_value
+        assert organization.feature_settings == {"sso_enabled": True}
+
+    async def test_sso_revoked_disables_flag_and_lifts_enforcement(
+        self,
+        session_mock: AsyncSession,
+        sso_org_repository_mock: MagicMock,
+        list_grants_mock: AsyncMock,
+    ) -> None:
+        list_grants_mock.return_value = []
+        payload = WebhookBenefitGrantRevokedPayload.model_validate(
+            _make_payload("benefit_grant.revoked", metadata={"type": "sso"})
+        )
+
+        await polar_self.handle_benefit_grant_event(session_mock, payload)
+
+        organization = sso_org_repository_mock.get_by_id.return_value
+        assert organization.feature_settings == {"sso_enabled": False}
+        assert organization.sso_enforced is False
+
+    async def test_sso_revoked_with_remaining_grant_keeps_flag(
+        self,
+        session_mock: AsyncSession,
+        sso_org_repository_mock: MagicMock,
+        list_grants_mock: AsyncMock,
+    ) -> None:
+        # A replayed or late revoke must not disable a feature the customer still
+        # holds: the handler re-reads active grants instead of trusting the event.
+        list_grants_mock.return_value = [_make_sso_grant(benefit_id="other")]
+        payload = WebhookBenefitGrantRevokedPayload.model_validate(
+            _make_payload("benefit_grant.revoked", metadata={"type": "sso"})
+        )
+
+        await polar_self.handle_benefit_grant_event(session_mock, payload)
+
+        organization = sso_org_repository_mock.get_by_id.return_value
+        assert organization.feature_settings == {"sso_enabled": True}
+        assert organization.sso_enforced is True
+
 
 @pytest.mark.asyncio
 class TestApplyPreviewAccess:
@@ -1100,6 +1173,62 @@ class TestApplyPreviewAccess:
         await polar_self._apply_preview_access(
             session_mock, ORG_A, _make_preview_grant()
         )
+
+
+@pytest.mark.asyncio
+class TestApplySSO:
+    async def test_active_grant_enables_and_preserves_other_flags(
+        self,
+        session_mock: AsyncSession,
+        sso_org_repository_mock: MagicMock,
+    ) -> None:
+        organization = sso_org_repository_mock.get_by_id.return_value
+        organization.feature_settings = {"member_model_enabled": True}
+        organization.sso_enforced = False
+
+        await polar_self._apply_sso(session_mock, ORG_A, _make_sso_grant())
+
+        sso_org_repository_mock.get_by_id.assert_awaited_once_with(
+            ORG_A, include_blocked=True
+        )
+        assert organization.feature_settings == {
+            "member_model_enabled": True,
+            "sso_enabled": True,
+        }
+
+    async def test_active_grant_leaves_enforcement_alone(
+        self,
+        session_mock: AsyncSession,
+        sso_org_repository_mock: MagicMock,
+    ) -> None:
+        organization = sso_org_repository_mock.get_by_id.return_value
+
+        await polar_self._apply_sso(session_mock, ORG_A, _make_sso_grant())
+
+        assert organization.sso_enforced is True
+
+    async def test_no_grant_disables_flag_and_lifts_enforcement(
+        self,
+        session_mock: AsyncSession,
+        sso_org_repository_mock: MagicMock,
+    ) -> None:
+        organization = sso_org_repository_mock.get_by_id.return_value
+
+        await polar_self._apply_sso(session_mock, ORG_A, None)
+
+        # Enforcement must go with the feature: an enforcing organization whose
+        # login page offers no SSO factor is unreachable.
+        assert organization.feature_settings == {"sso_enabled": False}
+        assert organization.sso_enforced is False
+
+    async def test_missing_organization_is_silent_noop(
+        self,
+        session_mock: AsyncSession,
+        sso_org_repository_mock: MagicMock,
+    ) -> None:
+        sso_org_repository_mock.get_by_id.return_value = None
+
+        await polar_self._apply_sso(session_mock, ORG_A, None)
 
 
 def _make_product(


### PR DESCRIPTION
## Description

SSO is gated by a staff-set flag today. 

This binds it to a `benefit_grant.*` webhook keyed on `metadata.type == "sso"`, so attaching the benefit to the Scale product grants it and leaving the plan revokes it.

The flag now also gates the login page. Without that, revoking changed nothing — members kept signing in through SSO indefinitely.

Revoking lifts `sso_enforced` with it, and the backoffice feature editor does the same when staff uncheck the flag. 

### Before merging

Deploy before creating the benefit. 

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

