### PR TITLE
backoffice: sort support cases by dispute evidence due

### DIFF
--- a/server/polar/backoffice/components/__init__.py
+++ b/server/polar/backoffice/components/__init__.py
@@ -8,6 +8,7 @@ from ._alert import alert
 from ._button import button
 from ._confirmation_dialog import confirmation_dialog
 from ._dispute_status_badge import dispute_status_badge
+from ._evidence_due_label import evidence_due_label
 from ._layout import layout
 from ._metric_card import metric_card
 from ._modal import modal
@@ -28,6 +29,7 @@ __all__ = [
     "description_list",
     "dispute_status_badge",
     "empty_state",
+    "evidence_due_label",
     "input",
     "layout",
     "loading_state",

--- a/server/polar/backoffice/components/_evidence_due_label.py
+++ b/server/polar/backoffice/components/_evidence_due_label.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+
+from tagflow import tag, text
+
+from polar.models.dispute import DisputeStatus
+
+
+def evidence_due_label(
+    evidence_due_by: datetime | None,
+    past_due: bool | None,
+    status: DisputeStatus | None,
+) -> None:
+    """Dispute evidence deadline. The red "Past due" marker only shows while a
+    response is still owed: resolved or under-review disputes keep their stale
+    ``past_due`` flag and deadline stamped, so status is the discriminator."""
+    if evidence_due_by is None:
+        with tag.span(classes="text-base-content/50"):
+            text("—")
+        return
+    when = evidence_due_by.strftime("%b %-d, %Y %H:%M UTC")
+    if past_due and status == DisputeStatus.needs_response:
+        with tag.span(classes="text-error font-medium"):
+            text(f"{when} · Past due")
+    else:
+        text(when)
+
+
+__all__ = ["evidence_due_label"]

--- a/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
@@ -26,7 +26,7 @@ from polar.models.support_case import (
 from polar.support_case.pdf import is_mergeable
 
 from .... import formatters
-from ....components import button, card, dispute_status_badge
+from ....components import button, card, dispute_status_badge, evidence_due_label
 from ....support_cases.urls import append_return_to
 
 _AUTHOR_LABELS: dict[SupportCaseMessageAuthorKind, str] = {
@@ -442,7 +442,9 @@ class SupportCaseSection:
                 with self._fact("Reason"):
                     text(self._dispute_reason(dispute))
                 with self._fact("Evidence due"):
-                    self._render_evidence_due(dispute)
+                    evidence_due_label(
+                        dispute.evidence_due_by, dispute.past_due, dispute.status
+                    )
                 with self._fact("Evidence"):
                     if dispute.has_evidence:
                         text(f"Submitted ({dispute.submission_count})")
@@ -576,18 +578,6 @@ class SupportCaseSection:
         else:
             with tag.span(classes="font-mono text-xs break-all"):
                 text(processor_id)
-
-    def _render_evidence_due(self, dispute: Dispute) -> None:
-        if dispute.evidence_due_by is None:
-            with tag.span(classes="text-base-content/50"):
-                text("—")
-            return
-        when = dispute.evidence_due_by.strftime("%b %-d, %Y %H:%M UTC")
-        if dispute.past_due:
-            with tag.span(classes="text-error font-medium"):
-                text(f"{when} · Past due")
-        else:
-            text(when)
 
     @staticmethod
     def _dispute_reason(dispute: Dispute) -> str:

--- a/server/polar/backoffice/organizations_v2/views/sections/support_cases_list_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/support_cases_list_section.py
@@ -57,6 +57,8 @@ class SupportCasesListSection:
                         awaiting_platform,
                         unread,
                         dispute_status,
+                        _evidence_due_by,
+                        _evidence_past_due,
                     ) in self.rows:
                         case_url = case_detail_url(
                             request, case.id, return_to=return_to

--- a/server/polar/backoffice/support_cases/endpoints.py
+++ b/server/polar/backoffice/support_cases/endpoints.py
@@ -33,7 +33,12 @@ from polar.support_case.repository import (
 from polar.support_case.service import support_case as support_case_service
 from polar.worker import enqueue_job
 
-from ..components import datatable, dispute_status_badge, support_tier_badge
+from ..components import (
+    datatable,
+    dispute_status_badge,
+    evidence_due_label,
+    support_tier_badge,
+)
 from ..components._tab_nav import Tab, tab_nav
 from ..dependencies import get_admin
 from ..layout import layout
@@ -188,14 +193,16 @@ def _type_badge(case_type: SupportCaseType) -> None:
         text(TYPE_LABELS.get(case_type, case_type.value))
 
 
-def _tier_sort_header(request: Request, sort: str) -> None:
-    """Clickable 'Tier' header that toggles the opt-in tier sort, preserving
-    the current tab/assignment filters."""
+def _sort_header(request: Request, label: str, target_sort: str, active: bool) -> None:
+    """Clickable column header toggling a sort mode: click activates it,
+    clicking the active one returns to the default recency sort. Re-sorting
+    drops the current page — the interesting rows move to page 1."""
     params = dict(request.query_params)
-    params["sort"] = "recency" if sort == "tier" else "tier"
+    params.pop("page", None)
+    params["sort"] = "recency" if active else target_sort
     href = f"{request.url_for('support_cases:list')}?{urlencode(params)}"
     with tag.a(href=href, classes="link link-hover"):
-        text("Tier ↓" if sort == "tier" else "Tier")
+        text(f"{label} ↓" if active else label)
 
 
 def _render_table(request: Request, rows: Sequence[Row], sort: str) -> None:
@@ -206,15 +213,28 @@ def _render_table(request: Request, rows: Sequence[Row], sort: str) -> None:
                     with tag.th():
                         text("Organization")
                     with tag.th():
-                        _tier_sort_header(request, sort)
-                    for header in (
-                        "Type",
-                        "Status",
-                        "Assignee",
-                        "Opened",
-                    ):
+                        _sort_header(request, "Tier", "tier", sort == "tier")
+                    for header in ("Type", "Status"):
                         with tag.th():
                             text(header)
+                    with tag.th():
+                        _sort_header(
+                            request,
+                            "Evidence due",
+                            "evidence_due",
+                            sort == "evidence_due",
+                        )
+                    with tag.th():
+                        text("Assignee")
+                    with tag.th():
+                        # target "recency" on purpose: Opened's sort IS the
+                        # default, so both toggle directions lead there.
+                        _sort_header(
+                            request,
+                            "Opened",
+                            "recency",
+                            sort not in ("tier", "evidence_due"),
+                        )
             with tag.tbody():
                 for (
                     case,
@@ -224,6 +244,8 @@ def _render_table(request: Request, rows: Sequence[Row], sort: str) -> None:
                     _awaiting_platform,
                     unread,
                     dispute_status,
+                    evidence_due_by,
+                    evidence_past_due,
                 ) in rows:
                     case_url = str(
                         request.url_for("support_cases:detail", case_id=case.id)
@@ -253,6 +275,10 @@ def _render_table(request: Request, rows: Sequence[Row], sort: str) -> None:
                                         data_tip="Unread",
                                     ):
                                         text("●")
+                        with tag.td(classes="text-base-content/60"):
+                            evidence_due_label(
+                                evidence_due_by, evidence_past_due, dispute_status
+                            )
                         with tag.td():
                             if assignee_email:
                                 text(assignee_email)

--- a/server/polar/backoffice/support_cases/queries.py
+++ b/server/polar/backoffice/support_cases/queries.py
@@ -6,6 +6,7 @@ appeals link through their review, disputes through their dispute → order.
 """
 
 from collections.abc import Sequence
+from datetime import datetime
 from typing import Any, cast
 from uuid import UUID
 
@@ -27,9 +28,18 @@ from polar.models.support_case import (
 from polar.support_case.repository import SupportCaseMessageRepository
 
 # (case, organization, is_open, assignee_email, awaiting_platform, unread,
-#  dispute_status) — dispute_status is None for non-dispute cases.
+#  dispute_status, evidence_due_by, evidence_past_due) — the dispute fields are
+#  None for non-dispute cases.
 Row = tuple[
-    SupportCase, Organization, bool, str | None, bool, bool, DisputeStatus | None
+    SupportCase,
+    Organization,
+    bool,
+    str | None,
+    bool,
+    bool,
+    DisputeStatus | None,
+    datetime | None,
+    bool | None,
 ]
 
 # Human-readable label per case type, shared by every case list.
@@ -57,8 +67,9 @@ def cases_statement(
     ``status`` (open/closed/all), ``assigned`` (me/unassigned/all),
     ``case_type`` (review_appeal/dispute/all) and ``self_service``
     (enabled/disabled/all, on the org's ``disputes_enabled`` flag) narrow the
-    set; ``sort`` is either pure recency or support tier first with recency as
-    the tiebreaker.
+    set; ``sort`` is pure recency, support tier first, or the dispute evidence
+    deadline soonest-first (rows without one last), each with recency as the
+    tiebreaker.
     """
     is_open = SupportCaseMessageRepository.is_open_expression()
     awaiting_platform = SupportCaseMessageRepository.awaiting_platform_expression()
@@ -100,6 +111,8 @@ def cases_statement(
             awaiting_platform.label("awaiting_platform"),
             unread.label("unread"),
             Dispute.status.label("dispute_status"),
+            Dispute.evidence_due_by.label("evidence_due_by"),
+            Dispute.past_due.label("evidence_past_due"),
         )
         .outerjoin(
             OrganizationReview,
@@ -133,15 +146,16 @@ def cases_statement(
         statement = statement.where(disputes_enabled.is_(True))
     elif self_service == "disabled":
         statement = statement.where(disputes_enabled.isnot(True))
-
     order_by: tuple[Any, ...]
     if sort == "tier":
-        order_by = (
-            Organization.support_tier.desc().nullslast(),
-            SupportCase.created_at.desc(),
-        )
+        order_by = (Organization.support_tier.desc().nullslast(),)
+    elif sort == "evidence_due":
+        # Soonest deadline first; appeals and undated disputes sink to the
+        # bottom rather than being dropped.
+        order_by = (Dispute.evidence_due_by.asc().nullslast(),)
     else:
-        order_by = (SupportCase.created_at.desc(),)
+        order_by = ()
+    order_by = (*order_by, SupportCase.created_at.desc())
     # ``assignee_email`` is NULL for unassigned cases (outer join), which the
     # column type doesn't capture; ``Row`` models it as ``str | None``.
     return cast("Select[Row]", statement.order_by(*order_by))

--- a/server/tests/backoffice/components/test_evidence_due_label.py
+++ b/server/tests/backoffice/components/test_evidence_due_label.py
@@ -1,0 +1,48 @@
+"""Tests for the shared evidence-due label: the red "Past due" marker must
+only show while a response is still owed — resolved disputes keep a stale
+``past_due`` flag stamped by the processor."""
+
+from datetime import UTC, datetime
+
+from tagflow import document, tag
+
+from polar.backoffice.components import evidence_due_label
+from polar.models.dispute import DisputeStatus
+
+DEADLINE = datetime(2026, 7, 20, 8, 29, tzinfo=UTC)
+
+
+def _render(
+    evidence_due_by: datetime | None,
+    past_due: bool | None,
+    status: DisputeStatus | None,
+) -> str:
+    with document() as doc:
+        with tag.div():
+            evidence_due_label(evidence_due_by, past_due, status)
+    return doc.to_html()
+
+
+class TestEvidenceDueLabel:
+    def test_past_due_needs_response_shows_marker(self) -> None:
+        html = _render(DEADLINE, True, DisputeStatus.needs_response)
+        assert "Past due" in html
+        assert "Jul 20, 2026 08:29 UTC" in html
+
+    def test_past_due_resolved_dispute_suppresses_marker(self) -> None:
+        for status in (
+            DisputeStatus.lost,
+            DisputeStatus.won,
+            DisputeStatus.under_review,
+        ):
+            html = _render(DEADLINE, True, status)
+            assert "Past due" not in html
+            assert "Jul 20, 2026 08:29 UTC" in html
+
+    def test_upcoming_deadline_has_no_marker(self) -> None:
+        html = _render(DEADLINE, False, DisputeStatus.needs_response)
+        assert "Past due" not in html
+        assert "Jul 20, 2026 08:29 UTC" in html
+
+    def test_no_deadline_renders_dash(self) -> None:
+        assert "—" in _render(None, False, None)

--- a/server/tests/backoffice/support_cases/test_queries.py
+++ b/server/tests/backoffice/support_cases/test_queries.py
@@ -138,8 +138,7 @@ class TestCasesStatement:
         rows = await _rows(
             session, organization_id=organization.id, viewer_user_id=user.id
         )
-        *_, unread, _dispute_status = rows[0]
-        assert unread is True
+        assert rows[0][5] is True  # unread
 
         await save_fixture(
             SupportCaseParticipant(
@@ -152,14 +151,12 @@ class TestCasesStatement:
         rows = await _rows(
             session, organization_id=organization.id, viewer_user_id=user.id
         )
-        *_, unread, _dispute_status = rows[0]
-        assert unread is False
+        assert rows[0][5] is False
 
         rows = await _rows(
             session, organization_id=organization.id, viewer_user_id=uuid4()
         )
-        *_, unread, _dispute_status = rows[0]
-        assert unread is True
+        assert rows[0][5] is True
 
         await save_fixture(
             SupportCaseMessage(
@@ -174,8 +171,90 @@ class TestCasesStatement:
         rows = await _rows(
             session, organization_id=organization.id, viewer_user_id=user.id
         )
-        *_, unread, _dispute_status = rows[0]
-        assert unread is True
+        assert rows[0][5] is True
+
+
+@pytest.mark.asyncio
+class TestCasesStatementEvidenceDueSort:
+    async def test_orders_by_soonest_deadline_dropping_nothing(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        now = datetime.now(UTC)
+        appeal = await create_appeal_case(save_fixture, organization)
+        later = await create_dispute_case(
+            save_fixture,
+            organization,
+            customer,
+            product,
+            evidence_due_by=now + timedelta(days=7),
+            payment_processor_id="STRIPE_DISPUTE_LATER",
+        )
+        soon = await create_dispute_case(
+            save_fixture,
+            organization,
+            customer,
+            product,
+            evidence_due_by=now + timedelta(days=1),
+            payment_processor_id="STRIPE_DISPUTE_SOON",
+        )
+        undated = await create_dispute_case(
+            save_fixture,
+            organization,
+            customer,
+            product,
+            payment_processor_id="STRIPE_DISPUTE_NO_DEADLINE",
+        )
+
+        rows = await _rows(
+            session, organization_id=organization.id, sort="evidence_due"
+        )
+
+        ids = [row[0].id for row in rows]
+        assert ids[:2] == [soon.id, later.id]
+        # Rows without a deadline sink to the bottom instead of disappearing.
+        assert set(ids[2:]) == {undated.id, appeal.id}
+
+    async def test_resolved_past_due_dispute_sorts_first_and_exposes_fields(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        now = datetime.now(UTC)
+        lost = await create_dispute_case(
+            save_fixture,
+            organization,
+            customer,
+            product,
+            dispute_status=DisputeStatus.lost,
+            evidence_due_by=now - timedelta(days=20),
+            past_due=True,
+            payment_processor_id="STRIPE_DISPUTE_LOST",
+        )
+        upcoming = await create_dispute_case(
+            save_fixture,
+            organization,
+            customer,
+            product,
+            evidence_due_by=now + timedelta(days=3),
+            payment_processor_id="STRIPE_DISPUTE_UPCOMING",
+        )
+
+        rows = await _rows(
+            session, organization_id=organization.id, sort="evidence_due"
+        )
+
+        assert [row[0].id for row in rows] == [lost.id, upcoming.id]
+        _case, _org, *_rest, evidence_due_by, evidence_past_due = rows[0]
+        assert evidence_due_by is not None
+        assert evidence_past_due is True
 
 
 @pytest.mark.asyncio

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -2574,6 +2574,8 @@ async def create_dispute(
     payment_processor_id: str | None = "STRIPE_DISPUTE_ID",
     alert_processor: DisputeAlertProcessor | None = None,
     alert_processor_id: str | None = None,
+    evidence_due_by: datetime | None = None,
+    past_due: bool = False,
 ) -> Dispute:
     dispute = Dispute(
         status=status,
@@ -2584,6 +2586,8 @@ async def create_dispute(
         payment_processor_id=payment_processor_id,
         dispute_alert_processor=alert_processor,
         dispute_alert_processor_id=alert_processor_id,
+        evidence_due_by=evidence_due_by,
+        past_due=past_due,
         order=order,
         payment=payment,
     )
@@ -2659,10 +2663,22 @@ async def create_dispute_case(
     product: Product,
     *,
     opened: bool = True,
+    dispute_status: DisputeStatus = DisputeStatus.needs_response,
+    payment_processor_id: str | None = "STRIPE_DISPUTE_ID",
+    evidence_due_by: datetime | None = None,
+    past_due: bool = False,
 ) -> DisputeSupportCase:
     order = await create_order(save_fixture, customer=customer, product=product)
     payment = await create_payment(save_fixture, organization, order=order)
-    dispute = await create_dispute(save_fixture, order, payment)
+    dispute = await create_dispute(
+        save_fixture,
+        order,
+        payment,
+        status=dispute_status,
+        payment_processor_id=payment_processor_id,
+        evidence_due_by=evidence_due_by,
+        past_due=past_due,
+    )
     case = DisputeSupportCase(dispute=dispute, organization=organization)
     await save_fixture(case)
     if opened:


### PR DESCRIPTION
## Problem

When triaging dispute support cases in the backoffice, there was no way to toggle or order the Cases list by evidence due date — the deadline only exists on each case's detail page, so finding which dispute needs evidence next meant opening cases one at a time. With Stripe's response windows being hard deadlines, the list should surface them directly.

## Solution

- New **Evidence due** column on `/backoffice/support-cases/` showing each dispute's deadline (`—` for appeals/undated disputes).
- The column **header is clickable** (same idiom as the Tier header): sorts soonest-deadline-first with undated rows last — nothing is filtered out, so further filters can layer on later. **Opened** is clickable the same way to return to recency order. Re-sorting resets pagination so the soonest deadlines are actually shown.
- Red `· Past due` marker only while the dispute still `needs_response` — resolved disputes keep a stale `past_due` flag from Stripe that shouldn't read as urgency.
- Extracted `evidence_due_label` as a shared component so the list and the case detail page render deadlines identically.

## Tests

Query-ordering tests (nothing dropped, nulls last, past-due field exposure, fixture passthroughs) plus render tests pinning the status-gated "Past due" marker.
