### PR TITLE
checkout: require full billing address when UPI is selected

### DIFF
--- a/clients/packages/checkout/src/components/CheckoutForm.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.tsx
@@ -45,6 +45,7 @@ import PolarLogo from './PolarLogo'
 import { CheckoutBanner } from './CheckoutBanner'
 
 const WALLET_PAYMENT_METHODS = ['apple_pay', 'google_pay', 'link']
+const FULL_BILLING_ADDRESS_PAYMENT_METHODS = ['upi']
 
 const XIcon = ({ className }: { className?: string }) => {
   return (
@@ -81,6 +82,7 @@ interface BaseCheckoutFormProps {
   isUpdatePending?: boolean
   locale?: AcceptedLocale
   isWalletPayment?: boolean
+  requireFullBillingAddress?: boolean
   beforeSubmit?: React.ReactNode
   embed?: boolean
 }
@@ -97,6 +99,7 @@ const BaseCheckoutForm = ({
   children,
   locale: localeProp,
   isWalletPayment,
+  requireFullBillingAddress,
   beforeSubmit,
   embed,
 }: React.PropsWithChildren<BaseCheckoutFormProps>) => {
@@ -124,6 +127,16 @@ const BaseCheckoutForm = ({
   const locale: AcceptedLocale = localeProp || 'en'
 
   const t = useTranslations(locale)
+
+  const billingAddressFields = requireFullBillingAddress
+    ? {
+        ...checkout.billing_address_fields,
+        line1: 'required' as const,
+        line2: 'optional' as const,
+        city: 'required' as const,
+        postal_code: 'required' as const,
+      }
+    : checkout.billing_address_fields
 
   const country = watch('customer_billing_address.country')
   const watcher: WatchObserver<schemas['CheckoutUpdatePublic']> = useCallback(
@@ -350,7 +363,7 @@ const BaseCheckoutForm = ({
                       {t('checkout.form.billingAddress.label')}
                     </FormLabel>
                     {isDisplayedField(
-                      checkout.billing_address_fields.line1,
+                      billingAddressFields.line1,
                     ) && (
                       <FormControl>
                         <FormField
@@ -358,7 +371,7 @@ const BaseCheckoutForm = ({
                           name="customer_billing_address.line1"
                           rules={{
                             required: isRequiredField(
-                              checkout.billing_address_fields.line1,
+                              billingAddressFields.line1,
                             )
                               ? t('checkout.form.fieldRequired')
                               : false,
@@ -381,7 +394,7 @@ const BaseCheckoutForm = ({
                       </FormControl>
                     )}
                     {isDisplayedField(
-                      checkout.billing_address_fields.line2,
+                      billingAddressFields.line2,
                     ) && (
                       <FormControl>
                         <FormField
@@ -389,7 +402,7 @@ const BaseCheckoutForm = ({
                           name="customer_billing_address.line2"
                           rules={{
                             required: isRequiredField(
-                              checkout.billing_address_fields.line2,
+                              billingAddressFields.line2,
                             )
                               ? t('checkout.form.fieldRequired')
                               : false,
@@ -412,14 +425,14 @@ const BaseCheckoutForm = ({
                       </FormControl>
                     )}
                     {(isDisplayedField(
-                      checkout.billing_address_fields.postal_code,
+                      billingAddressFields.postal_code,
                     ) ||
                       isDisplayedField(
-                        checkout.billing_address_fields.city,
+                        billingAddressFields.city,
                       )) && (
                       <div className="grid grid-cols-2 gap-x-2">
                         {isDisplayedField(
-                          checkout.billing_address_fields.postal_code,
+                          billingAddressFields.postal_code,
                         ) && (
                           <FormControl>
                             <FormField
@@ -427,7 +440,7 @@ const BaseCheckoutForm = ({
                               name="customer_billing_address.postal_code"
                               rules={{
                                 required: isRequiredField(
-                                  checkout.billing_address_fields.postal_code,
+                                  billingAddressFields.postal_code,
                                 )
                                   ? t('checkout.form.fieldRequired')
                                   : false,
@@ -450,7 +463,7 @@ const BaseCheckoutForm = ({
                           </FormControl>
                         )}
                         {isDisplayedField(
-                          checkout.billing_address_fields.city,
+                          billingAddressFields.city,
                         ) && (
                           <FormControl>
                             <FormField
@@ -458,7 +471,7 @@ const BaseCheckoutForm = ({
                               name="customer_billing_address.city"
                               rules={{
                                 required: isRequiredField(
-                                  checkout.billing_address_fields.city,
+                                  billingAddressFields.city,
                                 )
                                   ? t('checkout.form.fieldRequired')
                                   : false,
@@ -483,7 +496,7 @@ const BaseCheckoutForm = ({
                       </div>
                     )}
                     {isDisplayedField(
-                      checkout.billing_address_fields.state,
+                      billingAddressFields.state,
                     ) && (
                       <FormControl>
                         <FormField
@@ -491,7 +504,7 @@ const BaseCheckoutForm = ({
                           name="customer_billing_address.state"
                           rules={{
                             required: isRequiredField(
-                              checkout.billing_address_fields.state,
+                              billingAddressFields.state,
                             )
                               ? t('checkout.form.fieldRequired')
                               : false,
@@ -519,7 +532,7 @@ const BaseCheckoutForm = ({
                       </FormControl>
                     )}
                     {isDisplayedField(
-                      checkout.billing_address_fields.country,
+                      billingAddressFields.country,
                     ) && (
                       <FormControl>
                         <FormField
@@ -527,7 +540,7 @@ const BaseCheckoutForm = ({
                           name="customer_billing_address.country"
                           rules={{
                             required: isRequiredField(
-                              checkout.billing_address_fields.country,
+                              billingAddressFields.country,
                             )
                               ? t('checkout.form.fieldRequired')
                               : false,
@@ -785,6 +798,9 @@ const StripeCheckoutForm = (props: CheckoutFormProps) => {
   const isWalletPayment = selectedPaymentMethod
     ? WALLET_PAYMENT_METHODS.includes(selectedPaymentMethod)
     : false
+  const requireFullBillingAddress = selectedPaymentMethod
+    ? FULL_BILLING_ADDRESS_PAYMENT_METHODS.includes(selectedPaymentMethod)
+    : false
 
   const elementsOptions = useMemo<StripeElementsOptions>(() => {
     if (
@@ -843,6 +859,7 @@ const StripeCheckoutForm = (props: CheckoutFormProps) => {
             checkout={checkout}
             confirm={(data) => confirm(data, stripe, elements)}
             isWalletPayment={isWalletPayment}
+            requireFullBillingAddress={requireFullBillingAddress}
           >
             {checkout.is_payment_form_required && (
               <PaymentElement

--- a/clients/packages/checkout/src/components/CheckoutForm.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.tsx
@@ -37,7 +37,11 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { UseFormReturn, WatchObserver } from 'react-hook-form'
 import { hasProductCheckout, isLegacyRecurringProductPrice } from '../guards'
 import { useDebouncedCallback } from '../hooks/debounce'
-import { isDisplayedField, isRequiredField } from '../utils/address'
+import {
+  isDisplayedField,
+  isRequiredField,
+  resolveBillingAddressFields,
+} from '../utils/address'
 import { convertLocaleToStripeElementLocale } from '../utils/locale'
 import { useCheckoutForm } from '../providers/CheckoutFormProvider'
 import CustomFieldInput from './CustomFieldInput'
@@ -128,15 +132,10 @@ const BaseCheckoutForm = ({
 
   const t = useTranslations(locale)
 
-  const billingAddressFields = requireFullBillingAddress
-    ? {
-        ...checkout.billing_address_fields,
-        line1: 'required' as const,
-        line2: 'optional' as const,
-        city: 'required' as const,
-        postal_code: 'required' as const,
-      }
-    : checkout.billing_address_fields
+  const billingAddressFields = resolveBillingAddressFields(
+    checkout.billing_address_fields,
+    requireFullBillingAddress,
+  )
 
   const country = watch('customer_billing_address.country')
   const watcher: WatchObserver<schemas['CheckoutUpdatePublic']> = useCallback(
@@ -362,9 +361,7 @@ const BaseCheckoutForm = ({
                     <FormLabel>
                       {t('checkout.form.billingAddress.label')}
                     </FormLabel>
-                    {isDisplayedField(
-                      billingAddressFields.line1,
-                    ) && (
+                    {isDisplayedField(billingAddressFields.line1) && (
                       <FormControl>
                         <FormField
                           control={control}
@@ -393,9 +390,7 @@ const BaseCheckoutForm = ({
                         />
                       </FormControl>
                     )}
-                    {isDisplayedField(
-                      billingAddressFields.line2,
-                    ) && (
+                    {isDisplayedField(billingAddressFields.line2) && (
                       <FormControl>
                         <FormField
                           control={control}
@@ -424,16 +419,10 @@ const BaseCheckoutForm = ({
                         />
                       </FormControl>
                     )}
-                    {(isDisplayedField(
-                      billingAddressFields.postal_code,
-                    ) ||
-                      isDisplayedField(
-                        billingAddressFields.city,
-                      )) && (
+                    {(isDisplayedField(billingAddressFields.postal_code) ||
+                      isDisplayedField(billingAddressFields.city)) && (
                       <div className="grid grid-cols-2 gap-x-2">
-                        {isDisplayedField(
-                          billingAddressFields.postal_code,
-                        ) && (
+                        {isDisplayedField(billingAddressFields.postal_code) && (
                           <FormControl>
                             <FormField
                               control={control}
@@ -462,9 +451,7 @@ const BaseCheckoutForm = ({
                             />
                           </FormControl>
                         )}
-                        {isDisplayedField(
-                          billingAddressFields.city,
-                        ) && (
+                        {isDisplayedField(billingAddressFields.city) && (
                           <FormControl>
                             <FormField
                               control={control}
@@ -495,9 +482,7 @@ const BaseCheckoutForm = ({
                         )}
                       </div>
                     )}
-                    {isDisplayedField(
-                      billingAddressFields.state,
-                    ) && (
+                    {isDisplayedField(billingAddressFields.state) && (
                       <FormControl>
                         <FormField
                           control={control}
@@ -531,9 +516,7 @@ const BaseCheckoutForm = ({
                         />
                       </FormControl>
                     )}
-                    {isDisplayedField(
-                      billingAddressFields.country,
-                    ) && (
+                    {isDisplayedField(billingAddressFields.country) && (
                       <FormControl>
                         <FormField
                           control={control}

--- a/clients/packages/checkout/src/utils/address.test.ts
+++ b/clients/packages/checkout/src/utils/address.test.ts
@@ -1,5 +1,10 @@
+import type { schemas } from '@polar-sh/client'
 import { describe, expect, it } from 'vitest'
-import { isDisplayedField, isRequiredField } from './address'
+import {
+  isDisplayedField,
+  isRequiredField,
+  resolveBillingAddressFields,
+} from './address'
 
 describe('isDisplayedField', () => {
   it('returns true for required', () => {
@@ -26,5 +31,45 @@ describe('isRequiredField', () => {
 
   it('returns false for disabled', () => {
     expect(isRequiredField('disabled')).toBe(false)
+  })
+})
+
+describe('resolveBillingAddressFields', () => {
+  const minimalFields: schemas['CheckoutBillingAddressFields'] = {
+    country: 'required',
+    state: 'disabled',
+    line1: 'disabled',
+    line2: 'disabled',
+    city: 'disabled',
+    postal_code: 'disabled',
+  }
+
+  it('returns backend fields unchanged when full address is not required', () => {
+    expect(resolveBillingAddressFields(minimalFields, false)).toBe(
+      minimalFields,
+    )
+  })
+
+  it('requires line1, city and postal_code when full address is required', () => {
+    expect(resolveBillingAddressFields(minimalFields, true)).toEqual({
+      country: 'required',
+      state: 'disabled',
+      line1: 'required',
+      line2: 'optional',
+      city: 'required',
+      postal_code: 'required',
+    })
+  })
+
+  it('is unchanged when the backend already requires the full address', () => {
+    const fullFields: schemas['CheckoutBillingAddressFields'] = {
+      country: 'required',
+      state: 'required',
+      line1: 'required',
+      line2: 'optional',
+      city: 'required',
+      postal_code: 'required',
+    }
+    expect(resolveBillingAddressFields(fullFields, true)).toEqual(fullFields)
   })
 })

--- a/clients/packages/checkout/src/utils/address.ts
+++ b/clients/packages/checkout/src/utils/address.ts
@@ -11,3 +11,19 @@ export const isRequiredField = (
 ): mode is 'required' => {
   return mode === 'required'
 }
+
+export const resolveBillingAddressFields = (
+  fields: schemas['CheckoutBillingAddressFields'],
+  requireFullBillingAddress: boolean | undefined,
+): schemas['CheckoutBillingAddressFields'] => {
+  if (!requireFullBillingAddress) {
+    return fields
+  }
+  return {
+    ...fields,
+    line1: 'required',
+    line2: 'optional',
+    city: 'required',
+    postal_code: 'required',
+  }
+}


### PR DESCRIPTION
## Summary

**Related Issue**: #13280 and two Plain issues inside where customers recorded being blocked in checkout.

This PR makes checkout require a full billing address when the customer selects UPI as their payment method.

The alternative may be to enforce billing address requirement for India as whole on backend in `checkout.py`, similar as for US. But this would also make the normal card payment in India require billing address instead of only UPI. Therefore the change is in client checkout form, which also is where the payment method state lives so it kinda makes sense.

If we want to enforce billing address on all checkouts in india, this could be a small fix in backend instead.

The major con is that this somewhat diludes the state for billing_address visibility to not only be on the checkout in backend, but also handled by frontend too. Tests added to make sure it never loosens the requirements though.

## What

When UPI is selected, checkout now treats `line1`, `city`, and `postal_code` as required (and `line2` as optional), overriding the default `billing_address_fields` from the checkout session. Other payment methods are unchanged.

## Why

UPI needs a complete billing address for payment collection. Without forcing those fields, customers can submit with an incomplete address and fail at confirmation.

## How

- Added a `FULL_BILLING_ADDRESS_PAYMENT_METHODS` list (`upi`) in `CheckoutForm`
- Derived `requireFullBillingAddress` from the selected Stripe payment method (same pattern as wallet methods)
- Passed it into `BaseCheckoutForm`, which merges required address fields when set and drives field visibility/validation from that merged config

## Recording
https://github.com/user-attachments/assets/315a936b-ed56-43a8-9b5d-26127b2d0ea0



## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

