### PR TITLE
stop Revenue widget MoM tooltip showing Infinity

### DIFF
--- a/clients/apps/web/src/components/Widgets/RevenueWidget.tsx
+++ b/clients/apps/web/src/components/Widgets/RevenueWidget.tsx
@@ -2,6 +2,7 @@ import { useMetrics } from '@/hooks/queries'
 import { OrganizationContext } from '@/providers/maintainerOrganization'
 import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown'
 import KeyboardArrowUp from '@mui/icons-material/KeyboardArrowUp'
+import RemoveOutlined from '@mui/icons-material/RemoveOutlined'
 import { formatCurrency } from '@polar-sh/currency'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@polar-sh/orbit'
 import { endOfMonth, format, startOfMonth, subMonths } from 'date-fns'
@@ -16,6 +17,31 @@ interface RevenueWidgetProps {
 }
 
 const WIDGET_TITLE = 'Revenue'
+
+type PeriodTrend =
+  | { type: 'change'; value: number }
+  | { type: 'new' }
+  | { type: 'none' }
+
+const getPeriodTrend = (
+  current: number,
+  previous: number | undefined,
+): PeriodTrend => {
+  if (previous === undefined) {
+    return { type: 'none' }
+  }
+
+  if (previous === 0) {
+    return current > 0 ? { type: 'new' } : { type: 'none' }
+  }
+
+  const value = ((current - previous) / Math.abs(previous)) * 100
+  if (!Number.isFinite(value) || value === 0) {
+    return { type: 'none' }
+  }
+
+  return { type: 'change', value }
+}
 
 const RevenueWidget = ({ className }: RevenueWidgetProps) => (
   <WidgetGuard
@@ -39,6 +65,7 @@ const RevenueWidgetContent = ({ className }: RevenueWidgetProps) => {
   })
 
   const maxRevenue = Math.max(
+    1,
     ...(revenueMetrics.data?.periods.map((period) => period.revenue ?? 0) ??
       []),
   )
@@ -53,18 +80,12 @@ const RevenueWidgetContent = ({ className }: RevenueWidgetProps) => {
     >
       <div className="grid flex-1 grid-cols-3 gap-4 pb-6">
         {revenueMetrics.data?.periods.map((period, index, array) => {
-          const currentPeriodValue = period.revenue ?? 0
-          const previousPeriodValue = array[index - 1]?.revenue ?? 0
-
-          const percentageChangeComparedToPreviousPeriod =
-            previousPeriodValue === 0 && currentPeriodValue === 0
-              ? 0
-              : ((currentPeriodValue - previousPeriodValue) /
-                  Math.abs(previousPeriodValue)) *
-                100
-
-          const isTrendFlat = percentageChangeComparedToPreviousPeriod === 0
-          const isTrendingUp = percentageChangeComparedToPreviousPeriod > 0
+          const revenue = period.revenue ?? 0
+          const previous =
+            index > 0 ? (array[index - 1].revenue ?? 0) : undefined
+          const trend = getPeriodTrend(revenue, previous)
+          const isTrendingUp =
+            trend.type === 'new' || (trend.type === 'change' && trend.value > 0)
 
           return (
             <div key={period.timestamp} className="flex flex-col gap-y-2">
@@ -83,14 +104,14 @@ const RevenueWidgetContent = ({ className }: RevenueWidgetProps) => {
                           : 'dark:bg-polar-700 bg-gray-400',
                       )}
                       style={{
-                        height: `${((period.revenue ?? 0) / maxRevenue) * 100}%`,
+                        height: `${(revenue / maxRevenue) * 100}%`,
                       }}
                     />
                   )}
                 </TooltipTrigger>
                 <TooltipContent>
                   <span>
-                    {formatCurrency('compact')(period.revenue ?? 0, 'usd')} in{' '}
+                    {formatCurrency('compact')(revenue, 'usd')} in{' '}
                     {format(period.timestamp, 'MMMM')}
                   </span>
                 </TooltipContent>
@@ -101,9 +122,13 @@ const RevenueWidgetContent = ({ className }: RevenueWidgetProps) => {
                 </span>
                 <div className="flex flex-row items-center justify-between gap-x-2">
                   <span className="dark:text-polar-500 text-sm text-gray-500">
-                    {formatCurrency('statistics')(period.revenue ?? 0, 'usd')}
+                    {formatCurrency('statistics')(revenue, 'usd')}
                   </span>
-                  {!isTrendFlat ? (
+                  {trend.type === 'none' ? (
+                    <span className="dark:bg-polar-700 dark:text-polar-500 flex flex-row items-center gap-x-1 rounded-xs bg-gray-100 p-0.5 text-xs text-gray-500">
+                      <RemoveOutlined fontSize="inherit" />
+                    </span>
+                  ) : (
                     <Tooltip>
                       <TooltipTrigger
                         className={twMerge(
@@ -121,15 +146,13 @@ const RevenueWidgetContent = ({ className }: RevenueWidgetProps) => {
                       </TooltipTrigger>
                       <TooltipContent>
                         <span className="text-xs">
-                          {percentageChangeComparedToPreviousPeriod === Infinity
-                            ? 'Infinity'
-                            : percentageChangeComparedToPreviousPeriod.toFixed(
-                                0,
-                              ) + '%'}
+                          {trend.type === 'new'
+                            ? 'New'
+                            : `${trend.value.toFixed(0)}%`}
                         </span>
                       </TooltipContent>
                     </Tooltip>
-                  ) : null}
+                  )}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
Fix the dashboard home Revenue widget MoM indicator so it never shows `Infinity`, and handle zero-base months with a clear "New" state.
## What
- Treat the first month in the Last 3 Months series as having no previous period (dash), instead of comparing against `$0`
- When a prior in-series month is `$0` and the current month is positive, show green ↑ with tooltip **New** (not `Infinity`)
- For normal MoM changes, keep green/red arrows with a finite `%` tooltip; flat / both-zero stays a dash
- Guard bar height against `maxRevenue === 0` to avoid `NaN%`
## Why
The widget used `previous ?? 0` for the first column and divided by zero when revenue went `$0 → positive`, then rendered the string `Infinity` in the tooltip.
## How
Introduce a small in-file `getPeriodTrend` that returns `none` | `new` | `change`, and render the badge from that instead of a raw percentage that could be non-finite.

## Screenshots

| Before | After |
|---|---|
| <img width="475" height="430" alt="Screenshot 2026-07-21 at 13 42 26" src="https://github.com/user-attachments/assets/d29938a9-ad38-4b41-8ffa-3bef368f375c" /> | <img width="470" height="411" alt="Screenshot 2026-07-21 at 13 42 12" src="https://github.com/user-attachments/assets/ab60077f-20dc-4390-a250-96ac72c9934a" /> |


## Checklist
- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests *(N/A — logic is local to the widget; no separate util/tests by design)*
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

