### PR TITLE
sdk: Normalize SDK generator names

### DIFF
--- a/sdk/generator/python/emitter.py
+++ b/sdk/generator/python/emitter.py
@@ -15,6 +15,7 @@ from generator.ir import (
     UnionRef,
     UnionType,
 )
+from python.naming import operation_name, paginator_name, service_name
 from python.types import (
     collect_enum_imports,
     convert_type_to_annotation,
@@ -183,6 +184,9 @@ class PythonEmitter(EmitterBase):
         self.env.filters["type_annotation"] = convert_type_to_annotation
         self.env.filters["wrap_nullable"] = wrap_nullable_type
         self.env.filters["snake"] = to_snake_case
+        self.env.filters["operation_name"] = operation_name
+        self.env.filters["paginator_name"] = paginator_name
+        self.env.filters["service_name"] = service_name
         self.env.filters["format_default"] = format_default_value
         self.env.filters["format_default_dataclass"] = format_default_value_dataclass
 
@@ -191,12 +195,12 @@ class PythonEmitter(EmitterBase):
     ) -> None:
         """Emit a single service file, recursively going to sub-services."""
         if service.services:
-            sub_service_path = output_path / to_snake_case(service.name)
+            sub_service_path = output_path / service_name(service.name)
             for sub_service in service.services:
                 self._emit_service(sub_service, api, sub_service_path)
             service_path = sub_service_path / "__init__.py"
         else:
-            service_path = output_path / f"{to_snake_case(service.name)}.py"
+            service_path = output_path / f"{service_name(service.name)}.py"
 
         self.render_file(
             "polar/version/services/service.py",

--- a/sdk/generator/python/naming.py
+++ b/sdk/generator/python/naming.py
@@ -1,0 +1,13 @@
+from generator.casing import to_snake_case
+
+
+def operation_name(name: str) -> str:
+    return to_snake_case(name)
+
+
+def paginator_name(name: str) -> str:
+    return f"iter_{operation_name(name)}"
+
+
+def service_name(name: str) -> str:
+    return to_snake_case(name)

--- a/sdk/generator/python/template/polar/version/client.py
+++ b/sdk/generator/python/template/polar/version/client.py
@@ -4,8 +4,8 @@ import typing
 from polar.base import AsyncClientBase, SyncClientBase, resolve_base_url
 
 {% for service in api.services %}
-from polar.{{ version }}.services.{{ service.name | snake }} import {{ service.name }}Async
-from polar.{{ version }}.services.{{ service.name | snake }} import {{ service.name }}Sync
+from polar.{{ version }}.services.{{ service.name | service_name }} import {{ service.name }}Async
+from polar.{{ version }}.services.{{ service.name | service_name }} import {{ service.name }}Sync
 {% endfor %}
 
 Environment = typing.Literal[{% for server in api.servers %}"{{ server.environment }}"{% if not loop.last %}, {% endif %}{% endfor %}]
@@ -29,7 +29,7 @@ class Polar:
         resolved_base_url = resolve_base_url(SERVERS, environment, base_url)
         self._client = SyncClientBase(resolved_base_url, self.version, access_token)
 {% for service in api.services %}
-        self.{{ service.name | snake }} = {{ service.name }}Sync(self._client)
+        self.{{ service.name | service_name }} = {{ service.name }}Sync(self._client)
 {% endfor %}
 
     def __enter__(self) -> typing.Self:
@@ -58,7 +58,7 @@ class PolarAsync:
         resolved_base_url = resolve_base_url(SERVERS, environment, base_url)
         self._client = AsyncClientBase(resolved_base_url, self.version, access_token)
 {% for service in api.services %}
-        self.{{ service.name | snake }} = {{ service.name }}Async(self._client)
+        self.{{ service.name | service_name }} = {{ service.name }}Async(self._client)
 {% endfor %}
 
     async def __aenter__(self) -> typing.Self:

--- a/sdk/generator/python/template/polar/version/services/service.py
+++ b/sdk/generator/python/template/polar/version/services/service.py
@@ -41,20 +41,20 @@ from polar.{{ version }}.errors import (
 )
 {% endif %}
 {% for sub_service in service.services %}
-from .{{ sub_service.name | snake }} import {{ sub_service.name }}Async
-from .{{ sub_service.name | snake }} import {{ sub_service.name }}Sync
+from .{{ sub_service.name | service_name }} import {{ sub_service.name }}Async
+from .{{ sub_service.name | service_name }} import {{ sub_service.name }}Sync
 {% endfor %}
 
 
 class {{ service.name }}Sync(SyncServiceBase):
 {% for sub_service in service.services %}
-    {{ sub_service.name | snake }}: {{ sub_service.name }}Sync
+    {{ sub_service.name | service_name }}: {{ sub_service.name }}Sync
 {% endfor %}
 {% if service.services %}
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         super().__init__(*args, **kwargs)
 {% for sub_service in service.services %}
-        self.{{ sub_service.name | snake }} = {{ sub_service.name}}Sync.from_service(self)
+        self.{{ sub_service.name | service_name }} = {{ sub_service.name}}Sync.from_service(self)
 {% endfor %}
 {% endif %}
 {% for method in service.methods %}
@@ -63,7 +63,7 @@ class {{ service.name }}Sync(SyncServiceBase):
 {% for variant in method.body.variants %}
 {% if variant.kind == 'model' %}
     @typing.overload
-    def {{ method.name | snake }}(
+    def {{ method.name | operation_name }}(
         self,
         {% for param in method.path_params %}
         {{ param.name }}: {{ param.type | type_annotation }},
@@ -90,7 +90,7 @@ class {{ service.name }}Sync(SyncServiceBase):
 {% for variant in union_model.variants %}
 {% if variant.kind == 'model' %}
     @typing.overload
-    def {{ method.name | snake }}(
+    def {{ method.name | operation_name }}(
         self,
         {% for param in method.path_params %}
         {{ param.name }}: {{ param.type | type_annotation }},
@@ -115,7 +115,7 @@ class {{ service.name }}Sync(SyncServiceBase):
 {% endfor %}
 {% endif %}
 {% endif %}
-    def {{ method.name | snake }}(
+    def {{ method.name | operation_name }}(
         self,
         {% for param in method.path_params %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }},
@@ -202,7 +202,7 @@ Raises:
 {% for variant in method.body.variants %}
 {% if variant.kind == 'model' %}
     @typing.overload
-    def iter_{{ method.name | snake }}(
+    def {{ method.name | paginator_name }}(
         self,
         {% for param in method.path_params %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }},
@@ -229,7 +229,7 @@ Raises:
 {% for variant in union_model.variants %}
 {% if variant.kind == 'model' %}
     @typing.overload
-    def iter_{{ method.name | snake }}(
+    def {{ method.name | paginator_name }}(
         self,
         {% for param in method.path_params %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }},
@@ -254,7 +254,7 @@ Raises:
 {% endfor %}
 {% endif %}
 {% endif %}
-    def iter_{{ method.name | snake }}(
+    def {{ method.name | paginator_name }}(
         self,
         {% for param in method.path_params %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }},
@@ -308,7 +308,7 @@ Raises:
     PolarServerError: Raised when the server returns a 5xx error response.
         """
         while True:
-            response = self.{{ method.name | snake }}(
+            response = self.{{ method.name | operation_name }}(
                 {% for param in method.path_params %}
                 {{ param.parameter_name }}={{ param.parameter_name }},
                 {% endfor %}
@@ -329,13 +329,13 @@ Raises:
 
 class {{ service.name }}Async(AsyncServiceBase):
 {% for sub_service in service.services %}
-    {{ sub_service.name | snake }}: {{ sub_service.name }}Async
+    {{ sub_service.name | service_name }}: {{ sub_service.name }}Async
 {% endfor %}
 {% if service.services %}
     def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
         super().__init__(*args, **kwargs)
 {% for sub_service in service.services %}
-        self.{{ sub_service.name | snake }} = {{ sub_service.name}}Async.from_service(self)
+        self.{{ sub_service.name | service_name }} = {{ sub_service.name}}Async.from_service(self)
 {% endfor %}
 {% endif %}
 {% for method in service.methods %}
@@ -344,7 +344,7 @@ class {{ service.name }}Async(AsyncServiceBase):
 {% for variant in method.body.variants %}
 {% if variant.kind == 'model' %}
     @typing.overload
-    async def {{ method.name | snake }}(
+    async def {{ method.name | operation_name }}(
         self,
         {% for param in method.path_params %}
         {{ param.name }}: {{ param.type | type_annotation }},
@@ -371,7 +371,7 @@ class {{ service.name }}Async(AsyncServiceBase):
 {% for variant in union_model.variants %}
 {% if variant.kind == 'model' %}
     @typing.overload
-    async def {{ method.name | snake }}(
+    async def {{ method.name | operation_name }}(
         self,
         {% for param in method.path_params %}
         {{ param.name }}: {{ param.type | type_annotation }},
@@ -396,7 +396,7 @@ class {{ service.name }}Async(AsyncServiceBase):
 {% endfor %}
 {% endif %}
 {% endif %}
-    async def {{ method.name | snake }}(
+    async def {{ method.name | operation_name }}(
         self,
         {% for param in method.path_params %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }},
@@ -483,7 +483,7 @@ Raises:
 {% for variant in method.body.variants %}
 {% if variant.kind == 'model' %}
     @typing.overload
-    async def iter_{{ method.name | snake }}(
+    async def {{ method.name | paginator_name }}(
         self,
         {% for param in method.path_params %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }},
@@ -510,7 +510,7 @@ Raises:
 {% for variant in union_model.variants %}
 {% if variant.kind == 'model' %}
     @typing.overload
-    async def iter_{{ method.name | snake }}(
+    async def {{ method.name | paginator_name }}(
         self,
         {% for param in method.path_params %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }},
@@ -535,7 +535,7 @@ Raises:
 {% endfor %}
 {% endif %}
 {% endif %}
-    async def iter_{{ method.name | snake }}(
+    async def {{ method.name | paginator_name }}(
         self,
         {% for param in method.path_params %}
         {{ param.parameter_name }}: {{ param.type | type_annotation }},
@@ -586,7 +586,7 @@ Raises:
     PolarServerError: Raised when the server returns a 5xx error response.
         """
         while True:
-            response = await self.{{ method.name | snake }}(
+            response = await self.{{ method.name | operation_name }}(
                 {% for param in method.path_params %}
                 {{ param.parameter_name }}={{ param.parameter_name }},
                 {% endfor %}

--- a/sdk/generator/tests/python/test_naming.py
+++ b/sdk/generator/tests/python/test_naming.py
@@ -1,0 +1,20 @@
+import pytest
+
+from python.naming import operation_name, paginator_name, service_name
+
+
+@pytest.mark.parametrize(
+    ("method_name", "expected"),
+    [
+        ("list", "iter_list"),
+        ("list_payment_methods", "iter_list_payment_methods"),
+        ("list_webhook_endpoints", "iter_list_webhook_endpoints"),
+    ],
+)
+def test_paginator_name(method_name: str, expected: str) -> None:
+    assert paginator_name(method_name) == expected
+
+
+def test_regular_operation_and_service_names() -> None:
+    assert operation_name("get_state_external") == "get_state_external"
+    assert service_name("CustomerPortal") == "customer_portal"

--- a/sdk/generator/tests/typescript/test_naming.py
+++ b/sdk/generator/tests/typescript/test_naming.py
@@ -1,0 +1,32 @@
+import pytest
+
+from typescript.naming import (
+    exported_paginator_name,
+    operation_name,
+    paginator_name,
+    service_name,
+)
+
+
+@pytest.mark.parametrize(
+    ("method_name", "expected"),
+    [
+        ("list", "iterList"),
+        ("list_payment_methods", "iterListPaymentMethods"),
+        ("list_webhook_endpoints", "iterListWebhookEndpoints"),
+    ],
+)
+def test_paginator_name(method_name: str, expected: str) -> None:
+    assert paginator_name(method_name) == expected
+
+
+def test_exported_paginator_name() -> None:
+    assert (
+        exported_paginator_name("list_payment_methods", "Customers")
+        == "iterListPaymentMethodsCustomers"
+    )
+
+
+def test_regular_operation_and_service_names() -> None:
+    assert operation_name("get_state_external") == "getStateExternal"
+    assert service_name("CustomerPortal") == "customerPortal"

--- a/sdk/generator/typescript/emitter.py
+++ b/sdk/generator/typescript/emitter.py
@@ -10,6 +10,13 @@ from generator.ir import (
     Service,
     UnionRef,
 )
+from typescript.naming import (
+    exported_operation_name,
+    exported_paginator_name,
+    operation_name,
+    paginator_name,
+    service_name,
+)
 from typescript.types import (
     collect_enum_names,
     collect_type_imports,
@@ -139,6 +146,11 @@ class TypeScriptEmitter(EmitterBase):
             convert_type_to_typescript(type_ref, ref_suffix)
         )
         self.env.filters["camel"] = to_camel_case
+        self.env.filters["operation_name"] = operation_name
+        self.env.filters["paginator_name"] = paginator_name
+        self.env.filters["service_name"] = service_name
+        self.env.filters["exported_operation_name"] = exported_operation_name
+        self.env.filters["exported_paginator_name"] = exported_paginator_name
         self.env.filters["pascal"] = to_pascal_case
         self.env.filters["snake"] = to_snake_case
         self.env.filters["format_default"] = format_default_value_ts

--- a/sdk/generator/typescript/naming.py
+++ b/sdk/generator/typescript/naming.py
@@ -1,0 +1,21 @@
+from generator.casing import to_camel_case
+
+
+def operation_name(name: str) -> str:
+    return to_camel_case(name)
+
+
+def service_name(name: str) -> str:
+    return to_camel_case(name)
+
+
+def paginator_name(name: str) -> str:
+    return to_camel_case(f"iter_{name}")
+
+
+def exported_operation_name(name: str, service_name: str) -> str:
+    return f"{operation_name(name)}{service_name}"
+
+
+def exported_paginator_name(name: str, service_name: str) -> str:
+    return f"{paginator_name(name)}{service_name}"

--- a/sdk/generator/typescript/template/src/version/client.ts
+++ b/sdk/generator/typescript/template/src/version/client.ts
@@ -38,7 +38,7 @@ export function createPolar(options: PolarOptions) {
 
   return {
     {% for service in api.services %}
-    {{ service.name | camel }}: create{{ service.name }}Service(client),{% if not loop.last %}
+    {{ service.name | service_name }}: create{{ service.name }}Service(client),{% if not loop.last %}
     {% endif %}
     {% endfor %}
   };

--- a/sdk/generator/typescript/template/src/version/services/service.ts
+++ b/sdk/generator/typescript/template/src/version/services/service.ts
@@ -10,7 +10,7 @@ import { create{{ sub_service.name }}Service } from "./{{ sub_service.name | sna
 {% endfor %}
 
 {% for method in service.methods %}
-export const {{ method.name | camel }}{{ service.name }} = (
+export const {{ method.name | exported_operation_name(service.name) }} = (
   client: ClientBase,
 ) => {
 /**
@@ -103,7 +103,7 @@ export const {{ method.name | camel }}{{ service.name }} = (
 * @throws {{'{'}}{{ error.name }}{{'}'}} {{ error.description or 'Error with status code ' + error.status_code }}
 {% endfor %}
 */
-export const iter{{ method.name | camel }}{{ service.name }} = (
+export const {{ method.name | exported_paginator_name(service.name) }} = (
   client: ClientBase,
 ) => {
   return async function* (
@@ -140,7 +140,7 @@ export const iter{{ method.name | camel }}{{ service.name }} = (
     {% endif %}
 
     while (true) {
-      const response = await {{ method.name | camel }}{{ service.name }}(client)(
+      const response = await {{ method.name | exported_operation_name(service.name) }}(client)(
         {% for param in method.path_params %}
         {{ param.parameter_name }},
         {% endfor %}
@@ -169,13 +169,13 @@ export const iter{{ method.name | camel }}{{ service.name }} = (
 export function create{{ service.name }}Service(client: ClientBase) {
   return {
     {% for method in service.methods %}
-    {{ method.name | camel }}: {{ method.name | camel }}{{ service.name }}(client),{% endfor %}
+    {{ method.name | operation_name }}: {{ method.name | exported_operation_name(service.name) }}(client),{% endfor %}
     {% for method in service.methods %}
     {% if method.pagination %}
-    iter{{ method.name | camel }}: iter{{ method.name | camel }}{{ service.name }}(client),{% endif %}
+    {{ method.name | paginator_name }}: {{ method.name | exported_paginator_name(service.name) }}(client),{% endif %}
     {% endfor %}
     {% for sub_service in service.services %}
-    {{ sub_service.name | camel }}: create{{ sub_service.name }}Service(client),{% endfor %}
+    {{ sub_service.name | service_name }}: create{{ sub_service.name }}Service(client),{% endfor %}
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/benefit_grants.ts
+++ b/sdk/typescript/src/2026-04/services/benefit_grants.ts
@@ -60,7 +60,7 @@ export const listBenefitGrants = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistBenefitGrants = (client: ClientBase) => {
+export const iterListBenefitGrants = (client: ClientBase) => {
   return async function* (query?: {
     organization_id?: string | string[] | null;
     customer_id?: string | string[] | null;
@@ -91,7 +91,7 @@ export const iterlistBenefitGrants = (client: ClientBase) => {
 export function createBenefitGrantsService(client: ClientBase) {
   return {
     list: listBenefitGrants(client),
-    iterlist: iterlistBenefitGrants(client),
+    iterList: iterListBenefitGrants(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/benefits.ts
+++ b/sdk/typescript/src/2026-04/services/benefits.ts
@@ -75,7 +75,7 @@ export const listBenefits = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistBenefits = (client: ClientBase) => {
+export const iterListBenefits = (client: ClientBase) => {
   return async function* (query?: {
     organization_id?: string | string[] | null;
     type?: BenefitType | BenefitType[] | null;
@@ -311,7 +311,7 @@ export const grantsBenefits = (client: ClientBase) => {
  * @throws {ResourceNotFound} Benefit not found.
  * @throws {HTTPValidationError} Validation Error
  */
-export const itergrantsBenefits = (client: ClientBase) => {
+export const iterGrantsBenefits = (client: ClientBase) => {
   return async function* (
     id: string,
     query?: {
@@ -348,8 +348,8 @@ export function createBenefitsService(client: ClientBase) {
     delete: deleteBenefits(client),
     update: updateBenefits(client),
     grants: grantsBenefits(client),
-    iterlist: iterlistBenefits(client),
-    itergrants: itergrantsBenefits(client),
+    iterList: iterListBenefits(client),
+    iterGrants: iterGrantsBenefits(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/checkout_links.ts
+++ b/sdk/typescript/src/2026-04/services/checkout_links.ts
@@ -62,7 +62,7 @@ export const listCheckoutLinks = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistCheckoutLinks = (client: ClientBase) => {
+export const iterListCheckoutLinks = (client: ClientBase) => {
   return async function* (query?: {
     organization_id?: string | string[] | null;
     product_id?: string | string[] | null;
@@ -224,7 +224,7 @@ export function createCheckoutLinksService(client: ClientBase) {
     get: getCheckoutLinks(client),
     delete: deleteCheckoutLinks(client),
     update: updateCheckoutLinks(client),
-    iterlist: iterlistCheckoutLinks(client),
+    iterList: iterListCheckoutLinks(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/checkouts.ts
+++ b/sdk/typescript/src/2026-04/services/checkouts.ts
@@ -83,7 +83,7 @@ export const listCheckouts = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistCheckouts = (client: ClientBase) => {
+export const iterListCheckouts = (client: ClientBase) => {
   return async function* (query?: {
     organization_id?: string | string[] | null;
     product_id?: string | string[] | null;
@@ -326,7 +326,7 @@ export function createCheckoutsService(client: ClientBase) {
     clientGet: clientGetCheckouts(client),
     clientUpdate: clientUpdateCheckouts(client),
     clientConfirm: clientConfirmCheckouts(client),
-    iterlist: iterlistCheckouts(client),
+    iterList: iterListCheckouts(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/custom_fields.ts
+++ b/sdk/typescript/src/2026-04/services/custom_fields.ts
@@ -65,7 +65,7 @@ export const listCustomFields = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistCustomFields = (client: ClientBase) => {
+export const iterListCustomFields = (client: ClientBase) => {
   return async function* (query?: {
     organization_id?: string | string[] | null;
     query?: string | null;
@@ -228,7 +228,7 @@ export function createCustomFieldsService(client: ClientBase) {
     get: getCustomFields(client),
     delete: deleteCustomFields(client),
     update: updateCustomFields(client),
-    iterlist: iterlistCustomFields(client),
+    iterList: iterListCustomFields(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/customer_meters.ts
+++ b/sdk/typescript/src/2026-04/services/customer_meters.ts
@@ -64,7 +64,7 @@ export const listCustomerMeters = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistCustomerMeters = (client: ClientBase) => {
+export const iterListCustomerMeters = (client: ClientBase) => {
   return async function* (query?: {
     organization_id?: string | string[] | null;
     customer_id?: string | string[] | null;
@@ -129,7 +129,7 @@ export function createCustomerMetersService(client: ClientBase) {
   return {
     list: listCustomerMeters(client),
     get: getCustomerMeters(client),
-    iterlist: iterlistCustomerMeters(client),
+    iterList: iterListCustomerMeters(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/customer_portal/benefit_grants.ts
+++ b/sdk/typescript/src/2026-04/services/customer_portal/benefit_grants.ts
@@ -72,7 +72,7 @@ export const listBenefitGrants = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistBenefitGrants = (client: ClientBase) => {
+export const iterListBenefitGrants = (client: ClientBase) => {
   return async function* (query?: {
     query?: string | null;
     type?: BenefitType | BenefitType[] | null;
@@ -177,7 +177,7 @@ export function createBenefitGrantsService(client: ClientBase) {
     list: listBenefitGrants(client),
     get: getBenefitGrants(client),
     update: updateBenefitGrants(client),
-    iterlist: iterlistBenefitGrants(client),
+    iterList: iterListBenefitGrants(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/customer_portal/customer_meters.ts
+++ b/sdk/typescript/src/2026-04/services/customer_portal/customer_meters.ts
@@ -60,7 +60,7 @@ export const listCustomerMeters = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistCustomerMeters = (client: ClientBase) => {
+export const iterListCustomerMeters = (client: ClientBase) => {
   return async function* (query?: {
     meter_id?: string | string[] | null;
     query?: string | null;
@@ -123,7 +123,7 @@ export function createCustomerMetersService(client: ClientBase) {
   return {
     list: listCustomerMeters(client),
     get: getCustomerMeters(client),
-    iterlist: iterlistCustomerMeters(client),
+    iterList: iterListCustomerMeters(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/customer_portal/customers.ts
+++ b/sdk/typescript/src/2026-04/services/customer_portal/customers.ts
@@ -118,7 +118,7 @@ export const listPaymentMethodsCustomers = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistPaymentMethodsCustomers = (client: ClientBase) => {
+export const iterListPaymentMethodsCustomers = (client: ClientBase) => {
   return async function* (query?: {
     page?: number;
     limit?: number;
@@ -336,7 +336,7 @@ export function createCustomersService(client: ClientBase) {
     requestEmailUpdate: requestEmailUpdateCustomers(client),
     checkEmailUpdate: checkEmailUpdateCustomers(client),
     verifyEmailUpdate: verifyEmailUpdateCustomers(client),
-    iterlistPaymentMethods: iterlistPaymentMethodsCustomers(client),
+    iterListPaymentMethods: iterListPaymentMethodsCustomers(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/customer_portal/downloadables.ts
+++ b/sdk/typescript/src/2026-04/services/customer_portal/downloadables.ts
@@ -48,7 +48,7 @@ export const listDownloadables = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistDownloadables = (client: ClientBase) => {
+export const iterListDownloadables = (client: ClientBase) => {
   return async function* (query?: {
     benefit_id?: string | string[] | null;
     page?: number;
@@ -75,7 +75,7 @@ export const iterlistDownloadables = (client: ClientBase) => {
 export function createDownloadablesService(client: ClientBase) {
   return {
     list: listDownloadables(client),
-    iterlist: iterlistDownloadables(client),
+    iterList: iterListDownloadables(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/customer_portal/license_keys.ts
+++ b/sdk/typescript/src/2026-04/services/customer_portal/license_keys.ts
@@ -63,7 +63,7 @@ export const listLicenseKeys = (client: ClientBase) => {
  * @throws {ResourceNotFound} License key not found.
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistLicenseKeys = (client: ClientBase) => {
+export const iterListLicenseKeys = (client: ClientBase) => {
   return async function* (query?: {
     benefit_id?: string | null;
     page?: number;
@@ -231,7 +231,7 @@ export function createLicenseKeysService(client: ClientBase) {
     validate: validateLicenseKeys(client),
     activate: activateLicenseKeys(client),
     deactivate: deactivateLicenseKeys(client),
-    iterlist: iterlistLicenseKeys(client),
+    iterList: iterListLicenseKeys(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/customer_portal/members.ts
+++ b/sdk/typescript/src/2026-04/services/customer_portal/members.ts
@@ -76,7 +76,7 @@ export const listMembersMembers = (client: ClientBase) => {
  * @throws {ListMembers403Error} Not permitted - requires owner or billing manager role
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistMembersMembers = (client: ClientBase) => {
+export const iterListMembersMembers = (client: ClientBase) => {
   return async function* (query?: {
     page?: number;
     limit?: number;
@@ -231,7 +231,7 @@ export function createMembersService(client: ClientBase) {
     addMember: addMemberMembers(client),
     removeMember: removeMemberMembers(client),
     updateMember: updateMemberMembers(client),
-    iterlistMembers: iterlistMembersMembers(client),
+    iterListMembers: iterListMembersMembers(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/customer_portal/orders.ts
+++ b/sdk/typescript/src/2026-04/services/customer_portal/orders.ts
@@ -75,7 +75,7 @@ export const listOrders = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistOrders = (client: ClientBase) => {
+export const iterListOrders = (client: ClientBase) => {
   return async function* (query?: {
     product_id?: string | string[] | null;
     product_billing_type?: ProductBillingType | ProductBillingType[] | null;
@@ -341,7 +341,7 @@ export function createOrdersService(client: ClientBase) {
     receipt: receiptOrders(client),
     getPaymentStatus: getPaymentStatusOrders(client),
     confirmRetryPayment: confirmRetryPaymentOrders(client),
-    iterlist: iterlistOrders(client),
+    iterList: iterListOrders(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/customer_portal/seats.ts
+++ b/sdk/typescript/src/2026-04/services/customer_portal/seats.ts
@@ -219,7 +219,7 @@ export const listClaimedSubscriptionsSeats = (client: ClientBase) => {
  * @throws {ListClaimedSubscriptions401Error} Authentication required
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistClaimedSubscriptionsSeats = (client: ClientBase) => {
+export const iterListClaimedSubscriptionsSeats = (client: ClientBase) => {
   return async function* (query?: {
     page?: number;
     limit?: number;
@@ -249,7 +249,7 @@ export function createSeatsService(client: ClientBase) {
     revokeSeat: revokeSeatSeats(client),
     resendInvitation: resendInvitationSeats(client),
     listClaimedSubscriptions: listClaimedSubscriptionsSeats(client),
-    iterlistClaimedSubscriptions: iterlistClaimedSubscriptionsSeats(client),
+    iterListClaimedSubscriptions: iterListClaimedSubscriptionsSeats(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/customer_portal/subscriptions.ts
+++ b/sdk/typescript/src/2026-04/services/customer_portal/subscriptions.ts
@@ -69,7 +69,7 @@ export const listSubscriptions = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistSubscriptions = (client: ClientBase) => {
+export const iterListSubscriptions = (client: ClientBase) => {
   return async function* (query?: {
     product_id?: string | string[] | null;
     active?: boolean | null;
@@ -204,7 +204,7 @@ export function createSubscriptionsService(client: ClientBase) {
     get: getSubscriptions(client),
     cancel: cancelSubscriptions(client),
     update: updateSubscriptions(client),
-    iterlist: iterlistSubscriptions(client),
+    iterList: iterListSubscriptions(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/customer_portal/wallets.ts
+++ b/sdk/typescript/src/2026-04/services/customer_portal/wallets.ts
@@ -52,7 +52,7 @@ export const listWallets = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistWallets = (client: ClientBase) => {
+export const iterListWallets = (client: ClientBase) => {
   return async function* (query?: {
     page?: number;
     limit?: number;
@@ -111,7 +111,7 @@ export function createWalletsService(client: ClientBase) {
   return {
     list: listWallets(client),
     get: getWallets(client),
-    iterlist: iterlistWallets(client),
+    iterList: iterListWallets(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/customers/index.ts
+++ b/sdk/typescript/src/2026-04/services/customers/index.ts
@@ -74,7 +74,7 @@ export const listCustomers = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistCustomers = (client: ClientBase) => {
+export const iterListCustomers = (client: ClientBase) => {
   return async function* (query?: {
     organization_id?: string | string[] | null;
     email?: string | null;
@@ -525,7 +525,7 @@ export const listPaymentMethodsCustomers = (client: ClientBase) => {
  * @throws {ResourceNotFound} Customer not found.
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistPaymentMethodsCustomers = (client: ClientBase) => {
+export const iterListPaymentMethodsCustomers = (client: ClientBase) => {
   return async function* (
     id: string,
     query?: {
@@ -607,7 +607,7 @@ export const listPaymentMethodsExternalCustomers = (client: ClientBase) => {
  * @throws {ResourceNotFound} Customer not found.
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistPaymentMethodsExternalCustomers = (client: ClientBase) => {
+export const iterListPaymentMethodsExternalCustomers = (client: ClientBase) => {
   return async function* (
     external_id: string,
     query?: {
@@ -652,9 +652,9 @@ export function createCustomersService(client: ClientBase) {
     getStateExternal: getStateExternalCustomers(client),
     listPaymentMethods: listPaymentMethodsCustomers(client),
     listPaymentMethodsExternal: listPaymentMethodsExternalCustomers(client),
-    iterlist: iterlistCustomers(client),
-    iterlistPaymentMethods: iterlistPaymentMethodsCustomers(client),
-    iterlistPaymentMethodsExternal: iterlistPaymentMethodsExternalCustomers(client),
+    iterList: iterListCustomers(client),
+    iterListPaymentMethods: iterListPaymentMethodsCustomers(client),
+    iterListPaymentMethodsExternal: iterListPaymentMethodsExternalCustomers(client),
     members: createMembersService(client),
   };
 }

--- a/sdk/typescript/src/2026-04/services/discounts.ts
+++ b/sdk/typescript/src/2026-04/services/discounts.ts
@@ -62,7 +62,7 @@ export const listDiscounts = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistDiscounts = (client: ClientBase) => {
+export const iterListDiscounts = (client: ClientBase) => {
   return async function* (query?: {
     organization_id?: string | string[] | null;
     query?: string | null;
@@ -218,7 +218,7 @@ export function createDiscountsService(client: ClientBase) {
     get: getDiscounts(client),
     delete: deleteDiscounts(client),
     update: updateDiscounts(client),
-    iterlist: iterlistDiscounts(client),
+    iterList: iterListDiscounts(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/disputes.ts
+++ b/sdk/typescript/src/2026-04/services/disputes.ts
@@ -52,7 +52,7 @@ export const listDisputes = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistDisputes = (client: ClientBase) => {
+export const iterListDisputes = (client: ClientBase) => {
   return async function* (query?: {
     organization_id?: string | string[] | null;
     order_id?: string | string[] | null;
@@ -155,7 +155,7 @@ export function createDisputesService(client: ClientBase) {
     list: listDisputes(client),
     get: getDisputes(client),
     accept: acceptDisputes(client),
-    iterlist: iterlistDisputes(client),
+    iterList: iterListDisputes(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/event_types.ts
+++ b/sdk/typescript/src/2026-04/services/event_types.ts
@@ -73,7 +73,7 @@ export const listEventTypes = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistEventTypes = (client: ClientBase) => {
+export const iterListEventTypes = (client: ClientBase) => {
   return async function* (query?: {
     organization_id?: string | string[] | null;
     customer_id?: string | string[] | null;
@@ -142,7 +142,7 @@ export function createEventTypesService(client: ClientBase) {
   return {
     list: listEventTypes(client),
     update: updateEventTypes(client),
-    iterlist: iterlistEventTypes(client),
+    iterList: iterListEventTypes(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/events.ts
+++ b/sdk/typescript/src/2026-04/services/events.ts
@@ -135,7 +135,7 @@ export const listNamesEvents = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistNamesEvents = (client: ClientBase) => {
+export const iterListNamesEvents = (client: ClientBase) => {
   return async function* (query?: {
     organization_id?: string | string[] | null;
     customer_id?: string | string[] | null;
@@ -226,7 +226,7 @@ export function createEventsService(client: ClientBase) {
     listNames: listNamesEvents(client),
     get: getEvents(client),
     ingest: ingestEvents(client),
-    iterlistNames: iterlistNamesEvents(client),
+    iterListNames: iterListNamesEvents(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/files.ts
+++ b/sdk/typescript/src/2026-04/services/files.ts
@@ -55,7 +55,7 @@ export const listFiles = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistFiles = (client: ClientBase) => {
+export const iterListFiles = (client: ClientBase) => {
   return async function* (query?: {
     organization_id?: string | string[] | null;
     ids?: string | string[] | null;
@@ -211,7 +211,7 @@ export function createFilesService(client: ClientBase) {
     uploaded: uploadedFiles(client),
     delete: deleteFiles(client),
     update: updateFiles(client),
-    iterlist: iterlistFiles(client),
+    iterList: iterListFiles(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/license_keys.ts
+++ b/sdk/typescript/src/2026-04/services/license_keys.ts
@@ -73,7 +73,7 @@ export const listLicenseKeys = (client: ClientBase) => {
  * @throws {ResourceNotFound} License key not found.
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistLicenseKeys = (client: ClientBase) => {
+export const iterListLicenseKeys = (client: ClientBase) => {
   return async function* (query?: {
     organization_id?: string | string[] | null;
     benefit_id?: string | string[] | null;
@@ -311,7 +311,7 @@ export function createLicenseKeysService(client: ClientBase) {
     validate: validateLicenseKeys(client),
     activate: activateLicenseKeys(client),
     deactivate: deactivateLicenseKeys(client),
-    iterlist: iterlistLicenseKeys(client),
+    iterList: iterListLicenseKeys(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/members.ts
+++ b/sdk/typescript/src/2026-04/services/members.ts
@@ -52,7 +52,7 @@ export const listMembersMembers = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistMembersMembers = (client: ClientBase) => {
+export const iterListMembersMembers = (client: ClientBase) => {
   return async function* (query?: {
     customer_id?: string | null;
     external_customer_id?: string | null;
@@ -82,7 +82,7 @@ export const iterlistMembersMembers = (client: ClientBase) => {
 export function createMembersService(client: ClientBase) {
   return {
     listMembers: listMembersMembers(client),
-    iterlistMembers: iterlistMembersMembers(client),
+    iterListMembers: iterListMembersMembers(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/meters.ts
+++ b/sdk/typescript/src/2026-04/services/meters.ts
@@ -65,7 +65,7 @@ export const listMeters = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistMeters = (client: ClientBase) => {
+export const iterListMeters = (client: ClientBase) => {
   return async function* (query?: {
     organization_id?: string | string[] | null;
     query?: string | null;
@@ -239,7 +239,7 @@ export function createMetersService(client: ClientBase) {
     get: getMeters(client),
     update: updateMeters(client),
     quantities: quantitiesMeters(client),
-    iterlist: iterlistMeters(client),
+    iterList: iterListMeters(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/orders.ts
+++ b/sdk/typescript/src/2026-04/services/orders.ts
@@ -83,7 +83,7 @@ export const listOrders = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistOrders = (client: ClientBase) => {
+export const iterListOrders = (client: ClientBase) => {
   return async function* (query?: {
     organization_id?: string | string[] | null;
     product_id?: string | string[] | null;
@@ -397,7 +397,7 @@ export function createOrdersService(client: ClientBase) {
     invoice: invoiceOrders(client),
     generateInvoice: generateInvoiceOrders(client),
     receipt: receiptOrders(client),
-    iterlist: iterlistOrders(client),
+    iterList: iterListOrders(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/organizations.ts
+++ b/sdk/typescript/src/2026-04/services/organizations.ts
@@ -66,7 +66,7 @@ export const listOrganizations = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistOrganizations = (client: ClientBase) => {
+export const iterListOrganizations = (client: ClientBase) => {
   return async function* (query?: {
     slug?: string | null;
     page?: number;
@@ -199,7 +199,7 @@ export function createOrganizationsService(client: ClientBase) {
     create: createOrganizations(client),
     get: getOrganizations(client),
     update: updateOrganizations(client),
-    iterlist: iterlistOrganizations(client),
+    iterList: iterListOrganizations(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/payments.ts
+++ b/sdk/typescript/src/2026-04/services/payments.ts
@@ -60,7 +60,7 @@ export const listPayments = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistPayments = (client: ClientBase) => {
+export const iterListPayments = (client: ClientBase) => {
   return async function* (query?: {
     organization_id?: string | string[] | null;
     checkout_id?: string | string[] | null;
@@ -128,7 +128,7 @@ export function createPaymentsService(client: ClientBase) {
   return {
     list: listPayments(client),
     get: getPayments(client),
-    iterlist: iterlistPayments(client),
+    iterList: iterListPayments(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/products.ts
+++ b/sdk/typescript/src/2026-04/services/products.ts
@@ -71,7 +71,7 @@ export const listProducts = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistProducts = (client: ClientBase) => {
+export const iterListProducts = (client: ClientBase) => {
   return async function* (query?: {
     id?: string | string[] | null;
     organization_id?: string | string[] | null;
@@ -238,7 +238,7 @@ export function createProductsService(client: ClientBase) {
     get: getProducts(client),
     update: updateProducts(client),
     updateBenefits: updateBenefitsProducts(client),
-    iterlist: iterlistProducts(client),
+    iterList: iterListProducts(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/refunds.ts
+++ b/sdk/typescript/src/2026-04/services/refunds.ts
@@ -60,7 +60,7 @@ export const listRefunds = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistRefunds = (client: ClientBase) => {
+export const iterListRefunds = (client: ClientBase) => {
   return async function* (query?: {
     id?: string | string[] | null;
     organization_id?: string | string[] | null;
@@ -120,7 +120,7 @@ export function createRefundsService(client: ClientBase) {
   return {
     list: listRefunds(client),
     create: createRefunds(client),
-    iterlist: iterlistRefunds(client),
+    iterList: iterListRefunds(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/subscriptions.ts
+++ b/sdk/typescript/src/2026-04/services/subscriptions.ts
@@ -92,7 +92,7 @@ export const listSubscriptions = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistSubscriptions = (client: ClientBase) => {
+export const iterListSubscriptions = (client: ClientBase) => {
   return async function* (query?: {
     organization_id?: string | string[] | null;
     product_id?: string | string[] | null;
@@ -313,7 +313,7 @@ export function createSubscriptionsService(client: ClientBase) {
     get: getSubscriptions(client),
     revoke: revokeSubscriptions(client),
     update: updateSubscriptions(client),
-    iterlist: iterlistSubscriptions(client),
+    iterList: iterListSubscriptions(client),
   };
 }
 

--- a/sdk/typescript/src/2026-04/services/webhooks.ts
+++ b/sdk/typescript/src/2026-04/services/webhooks.ts
@@ -60,7 +60,7 @@ export const listWebhookEndpointsWebhooks = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistWebhookEndpointsWebhooks = (client: ClientBase) => {
+export const iterListWebhookEndpointsWebhooks = (client: ClientBase) => {
   return async function* (query?: {
     organization_id?: string | string[] | null;
     page?: number;
@@ -310,7 +310,7 @@ export const listWebhookDeliveriesWebhooks = (client: ClientBase) => {
  * @throws {PolarServerError} When the server returns a 5xx error
  * @throws {HTTPValidationError} Validation Error
  */
-export const iterlistWebhookDeliveriesWebhooks = (client: ClientBase) => {
+export const iterListWebhookDeliveriesWebhooks = (client: ClientBase) => {
   return async function* (query?: {
     endpoint_id?: string | string[] | null;
     start_timestamp?: string | null;
@@ -383,8 +383,8 @@ export function createWebhooksService(client: ClientBase) {
     resetWebhookEndpointSecret: resetWebhookEndpointSecretWebhooks(client),
     listWebhookDeliveries: listWebhookDeliveriesWebhooks(client),
     redeliverWebhookEvent: redeliverWebhookEventWebhooks(client),
-    iterlistWebhookEndpoints: iterlistWebhookEndpointsWebhooks(client),
-    iterlistWebhookDeliveries: iterlistWebhookDeliveriesWebhooks(client),
+    iterListWebhookEndpoints: iterListWebhookEndpointsWebhooks(client),
+    iterListWebhookDeliveries: iterListWebhookDeliveriesWebhooks(client),
   };
 }
 


### PR DESCRIPTION
## What changed

- Add target-specific naming helpers for the Python and TypeScript generators.
- Route generator templates through those helpers without changing regular operation names.
- Normalize TypeScript paginator identifiers from `iterlist*`/`itergrants*` to `iterList*`/`iterGrants*`, including tree-shakable exports and service properties.
- Regenerate the TypeScript SDK and add language-specific naming tests.

## Why

Paginator names were formed by concatenating `iter` with an already camel-cased operation name. This produced incorrect lowercase compounds such as `iterlistOrganizations`. Casing the complete logical name produces the expected `iterListOrganizations` and `iterList` API.

This is an intentional breaking rename with no compatibility aliases because the SDK is prerelease.

## Validation

- `sdk/generator`: `just lint`
- `sdk/generator`: `just test` (70 passed)
- `sdk/typescript`: formatting/lint checks
- `sdk/typescript`: TypeScript type check
- `sdk/typescript`: test suite (19 passed)
- Verified generated sources contain no `iterlist*` or `itergrants*` identifiers.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

