### PR TITLE
sdk: Generate SDK code sample overlays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,5 @@ clients/apps/web/src/app/(main)/onboarding/validate-description/acceptable-use-p
 # `dev snap` run output (screenshots, diff heatmaps, report.html, job.json) — local
 # artifacts; the committed dev/snap-timings.json is the only shared bit.
 screenshots/runs/
+
+sdk/code-samples/

--- a/sdk/generator/cli.py
+++ b/sdk/generator/cli.py
@@ -5,6 +5,7 @@ import sys
 
 import openapi_pydantic as op
 
+from generator.code_samples import write_code_samples_overlays
 from generator.emitter import Prerelease
 from generator.ir import generate_ir
 from generator.release import release_sdk
@@ -20,6 +21,31 @@ parser_generate = subparsers.add_parser(
 parser_generate.add_argument("spec_path", type=str, help="Path to OpenAPI spec file.")
 parser_generate.add_argument(
     "output", type=str, help="Directory to output the generated SDK"
+)
+
+parser_code_samples = subparsers.add_parser(
+    "code-samples", help="Generate SDK code samples as an OpenAPI overlay"
+)
+parser_code_samples.add_argument(
+    "spec_paths",
+    type=str,
+    nargs="+",
+    help="Paths to the OpenAPI spec files, one per API version.",
+)
+parser_code_samples.add_argument(
+    "output", type=str, help="Directory for the generated version overlays."
+)
+parser_code_samples.add_argument(
+    "--language",
+    action="append",
+    choices=["python", "typescript"],
+    help="Language to include. Repeat to select multiple languages (default: both).",
+)
+parser_code_samples.add_argument(
+    "--version",
+    type=str,
+    default="0.0.0",
+    help="SDK version represented by the overlay (default: 0.0.0).",
 )
 parser_generate.add_argument(
     "--language",
@@ -118,6 +144,19 @@ if args.command == "generate":
 
     emitter.emit(args.output)
     emitter.run_post_actions(args.output)
+
+elif args.command == "code-samples":
+    specs = []
+    for spec_path_value in args.spec_paths:
+        spec_path = pathlib.Path(spec_path_value)
+        if not spec_path.is_file():
+            print(f"Error: Spec file {spec_path} does not exist.", file=sys.stderr)
+            sys.exit(1)
+        specs.append(op.OpenAPI.model_validate_json(spec_path.read_text()))
+    ir = generate_ir(*specs)
+    output_path = pathlib.Path(args.output)
+    languages = args.language or ["python", "typescript"]
+    write_code_samples_overlays(output_path, ir, args.version, languages)
 
 elif args.command == "release":
     prerelease = None

--- a/sdk/generator/cli.py
+++ b/sdk/generator/cli.py
@@ -155,6 +155,9 @@ elif args.command == "code-samples":
         specs.append(op.OpenAPI.model_validate_json(spec_path.read_text()))
     ir = generate_ir(*specs)
     output_path = pathlib.Path(args.output)
+    if output_path.exists() and not output_path.is_dir():
+        print(f"Error: Output path {output_path} is not a directory.", file=sys.stderr)
+        sys.exit(1)
     languages = args.language or ["python", "typescript"]
     write_code_samples_overlays(output_path, ir, args.version, languages)
 

--- a/sdk/generator/generator/code_samples.py
+++ b/sdk/generator/generator/code_samples.py
@@ -1,0 +1,413 @@
+import dataclasses
+import importlib
+import json
+import math
+import pathlib
+import re
+import typing
+
+from generator.ir import (
+    APIIR,
+    APIVersion,
+    ArrayType,
+    EnumRef,
+    LiteralType,
+    MapType,
+    Method,
+    ModelRef,
+    NamedUnion,
+    NullableType,
+    Parameter,
+    PrimitiveType,
+    Service,
+    TypeRef,
+    UnionDiscriminator,
+    UnionRef,
+    UnionType,
+)
+
+
+class CodeSampleError(ValueError):
+    pass
+
+
+@dataclasses.dataclass(frozen=True)
+class SampleParameter:
+    parameter: Parameter
+    value: typing.Any
+
+
+@dataclasses.dataclass(frozen=True)
+class OperationSample:
+    api: APIVersion
+    service_path: tuple[str, ...]
+    method: Method
+    path_parameters: tuple[SampleParameter, ...]
+    query_parameters: tuple[SampleParameter, ...]
+    body: typing.Any | None
+
+
+type CodeSampleRenderer = typing.Callable[[OperationSample], str]
+
+
+class CodeSampleLanguage(typing.Protocol):
+    language_label: typing.Callable[[], str]
+    render_code_sample: CodeSampleRenderer
+
+
+class ExampleGenerator:
+    def __init__(self, api: APIVersion) -> None:
+        self.models = {model.name: model for model in api.input_models}
+        self.enums = {enum.name: enum for enum in api.enums}
+        self.unions = {union.name: union for union in api.input_unions}
+
+    def generate(self, type_ref: TypeRef) -> typing.Any:
+        return self._generate(type_ref, ())
+
+    def _generate(self, type_ref: TypeRef, stack: tuple[str, ...]) -> typing.Any:
+        if isinstance(type_ref, LiteralType):
+            return type_ref.value
+        if isinstance(type_ref, PrimitiveType):
+            return self._primitive(type_ref)
+        if isinstance(type_ref, NullableType):
+            return self._generate(type_ref.inner, stack)
+        if isinstance(type_ref, ArrayType):
+            item_count = max(1, type_ref.min_items or 0)
+            if type_ref.max_items is not None:
+                item_count = min(item_count, type_ref.max_items)
+            if type_ref.min_items is not None and item_count < type_ref.min_items:
+                raise CodeSampleError("Array constraints cannot be satisfied")
+            return [self._generate(type_ref.items, stack) for _ in range(item_count)]
+        if isinstance(type_ref, MapType):
+            return {"key": self._generate(type_ref.value_type, stack)}
+        if isinstance(type_ref, EnumRef):
+            enum = self.enums.get(type_ref.name)
+            if enum is None or not enum.values:
+                raise CodeSampleError(f"Enum {type_ref.name} has no values")
+            return enum.values[0].value
+        if isinstance(type_ref, ModelRef):
+            return self._model(type_ref.name, stack)
+        if isinstance(type_ref, UnionRef):
+            union = self.unions.get(type_ref.name)
+            if union is None:
+                raise CodeSampleError(f"Input union {type_ref.name} was not found")
+            return self._named_union(union, stack)
+        if isinstance(type_ref, UnionType):
+            return self._union(
+                type_ref.variants,
+                type_ref.composition_kind,
+                type_ref.discriminator,
+                stack,
+            )
+        raise CodeSampleError(f"Unsupported input type: {type_ref}")
+
+    def _primitive(self, type_ref: PrimitiveType) -> typing.Any:
+        if type_ref.type == "string":
+            formats = {
+                "color": "#000000",
+                "date": "2026-01-01",
+                "date-time": "2026-01-01T00:00:00Z",
+                "duration": "P1D",
+                "email": "customer@example.com",
+                "ipvanyaddress": "192.0.2.1",
+                "uri": "https://example.com",
+                "url": "https://example.com",
+                "uuid": "00000000-0000-4000-8000-000000000000",
+                "uuid4": "00000000-0000-4000-8000-000000000000",
+            }
+            return self._string(type_ref, formats.get(type_ref.format or "", "string"))
+        if type_ref.type == "integer":
+            return self._number(type_ref, integer=True)
+        if type_ref.type == "number":
+            return self._number(type_ref, integer=False)
+        if type_ref.type == "boolean":
+            return True
+        raise CodeSampleError("Cannot generate an example for an unknown schema")
+
+    def _string(self, type_ref: PrimitiveType, fallback: str) -> str:
+        candidates = [
+            fallback,
+            "string",
+            "example",
+            "example-slug",
+            "rk_example",
+            "sk_example",
+            "A123",
+            "1.0",
+            "1",
+            "0",
+            "usd",
+            "image/png",
+        ]
+        pattern = None
+        if type_ref.pattern is not None:
+            try:
+                pattern = re.compile(type_ref.pattern)
+            except re.error as error:
+                raise CodeSampleError(
+                    f"Unsupported string pattern: {type_ref.pattern}"
+                ) from error
+        for candidate in candidates:
+            minimum = type_ref.min_length or 0
+            value = candidate + "x" * max(0, minimum - len(candidate))
+            if type_ref.max_length is not None and len(value) > type_ref.max_length:
+                continue
+            if pattern is None or pattern.search(value):
+                return value
+        raise CodeSampleError("String constraints cannot be satisfied")
+
+    def _number(self, type_ref: PrimitiveType, *, integer: bool) -> int | float:
+        lower = type_ref.minimum
+        lower_exclusive = False
+        if type_ref.exclusive_minimum is not None:
+            lower = type_ref.exclusive_minimum
+            lower_exclusive = True
+        upper = type_ref.maximum
+        upper_exclusive = False
+        if type_ref.exclusive_maximum is not None:
+            upper = type_ref.exclusive_maximum
+            upper_exclusive = True
+
+        if integer:
+            candidate = 1 if lower is None else math.ceil(lower)
+            if lower_exclusive and candidate <= typing.cast(float, lower):
+                candidate += 1
+            if upper is not None and (
+                candidate > upper or (upper_exclusive and candidate >= upper)
+            ):
+                candidate = math.floor(upper)
+                if upper_exclusive and candidate >= upper:
+                    candidate -= 1
+        else:
+            candidate = 1.0
+            if lower is not None and (
+                candidate < lower or (lower_exclusive and candidate <= lower)
+            ):
+                candidate = lower + (1.0 if upper is None else (upper - lower) / 2)
+            if upper is not None and (
+                candidate > upper or (upper_exclusive and candidate >= upper)
+            ):
+                candidate = upper - (1.0 if lower is None else (upper - lower) / 2)
+
+        if lower is not None and (
+            candidate < lower or (lower_exclusive and candidate <= lower)
+        ):
+            raise CodeSampleError("Numeric constraints cannot be satisfied")
+        if upper is not None and (
+            candidate > upper or (upper_exclusive and candidate >= upper)
+        ):
+            raise CodeSampleError("Numeric constraints cannot be satisfied")
+        return candidate
+
+    def _model(self, name: str, stack: tuple[str, ...]) -> dict[str, typing.Any]:
+        key = f"model:{name}"
+        if key in stack:
+            raise CodeSampleError(f"Cyclic input schema: {' -> '.join((*stack, key))}")
+        model = self.models.get(name)
+        if model is None:
+            raise CodeSampleError(f"Input model {name} was not found")
+        value: dict[str, typing.Any] = {}
+        for field in model.fields:
+            if field.read_only:
+                continue
+            if field.has_example:
+                value[field.name] = field.example
+            elif field.has_default:
+                value[field.name] = field.default
+            elif field.required:
+                value[field.name] = self._generate(field.type, (*stack, key))
+        return value
+
+    def _named_union(self, union: NamedUnion, stack: tuple[str, ...]) -> typing.Any:
+        key = f"union:{union.name}"
+        if key in stack:
+            raise CodeSampleError(f"Cyclic input schema: {' -> '.join((*stack, key))}")
+        return self._union(
+            union.variants,
+            union.composition_kind,
+            union.discriminator,
+            (*stack, key),
+        )
+
+    def _union(
+        self,
+        variants: list[TypeRef],
+        composition_kind: str | None,
+        discriminator: UnionDiscriminator | None,
+        stack: tuple[str, ...],
+    ) -> typing.Any:
+        if not variants:
+            raise CodeSampleError("Cannot generate an example for an empty union")
+        if composition_kind == "allOf":
+            value: dict[str, typing.Any] = {}
+            for variant in variants:
+                generated = self._generate(variant, stack)
+                if not isinstance(generated, dict):
+                    raise CodeSampleError("allOf inputs must contain object schemas")
+                value.update(generated)
+            return value
+        variant = next(
+            (
+                candidate
+                for candidate in variants
+                if not (isinstance(candidate, LiteralType) and candidate.value is None)
+            ),
+            variants[0],
+        )
+        value = self._generate(variant, stack)
+        if discriminator is not None and isinstance(value, dict):
+            discriminator_value = self._discriminator_value(discriminator, variant)
+            if discriminator_value is not None:
+                value.setdefault(discriminator.property_name, discriminator_value)
+        return value
+
+    def _discriminator_value(
+        self, discriminator: UnionDiscriminator, variant: TypeRef
+    ) -> str | None:
+        if not isinstance(variant, ModelRef):
+            return None
+        for value, model_name in sorted(discriminator.mapping.items()):
+            if model_name == variant.name:
+                return value
+        return None
+
+
+def generate_code_samples_overlay(
+    api: APIVersion,
+    sdk_version: str,
+    languages: typing.Iterable[str],
+) -> dict[str, typing.Any]:
+    language_modules = _load_language_modules(languages)
+
+    actions: list[dict[str, typing.Any]] = []
+    examples = ExampleGenerator(api)
+    methods = sorted(_iter_methods(api.services), key=lambda item: item[1].operation_id)
+    for service_path, method in methods:
+        sample = _build_operation_sample(api, service_path, method, examples)
+        code_samples = []
+        for language, language_module in language_modules:
+            try:
+                source = language_module.render_code_sample(sample)
+            except CodeSampleError:
+                raise
+            except Exception as error:
+                raise CodeSampleError(
+                    f"Unable to render {language} sample for {method.operation_id}: {error}"
+                ) from error
+            code_samples.append(
+                {"lang": language_module.language_label(), "source": source}
+            )
+        target = (
+            f'$["paths"][{json.dumps(method.path)}]'
+            f'["{method.http_method.value.lower()}"]'
+        )
+        actions.append({"target": target, "update": {"x-codeSamples": code_samples}})
+
+    return {
+        "overlay": "1.1.0",
+        "info": {
+            "title": f"Polar {api.version} SDK code samples",
+            "version": sdk_version,
+        },
+        "actions": actions,
+    }
+
+
+def generate_code_samples_overlays(
+    ir: APIIR,
+    sdk_version: str,
+    languages: typing.Iterable[str],
+) -> dict[str, dict[str, typing.Any]]:
+    if not ir.versions:
+        raise CodeSampleError("The API specification contains no versions")
+    overlays: dict[str, dict[str, typing.Any]] = {}
+    for api in ir.versions:
+        if api.version in overlays:
+            raise CodeSampleError(f"Duplicate API version: {api.version}")
+        overlays[api.version] = generate_code_samples_overlay(
+            api, sdk_version, languages
+        )
+    return overlays
+
+
+def write_code_samples_overlays(
+    output: pathlib.Path | str,
+    ir: APIIR,
+    sdk_version: str,
+    languages: typing.Iterable[str],
+) -> None:
+    output_path = pathlib.Path(output)
+    output_path.mkdir(parents=True, exist_ok=True)
+    for api_version, overlay in generate_code_samples_overlays(
+        ir, sdk_version, languages
+    ).items():
+        if pathlib.Path(api_version).name != api_version:
+            raise CodeSampleError(f"Invalid API version: {api_version}")
+        (output_path / f"{api_version}.overlay.json").write_text(
+            json.dumps(overlay, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+
+def _load_language_modules(
+    languages: typing.Iterable[str],
+) -> list[tuple[str, CodeSampleLanguage]]:
+    language_modules = [
+        (
+            language,
+            typing.cast(
+                CodeSampleLanguage,
+                importlib.import_module(f"{language}.code_samples"),
+            ),
+        )
+        for language in languages
+    ]
+    if not language_modules:
+        raise CodeSampleError("At least one language must be selected")
+    return language_modules
+
+
+def _build_operation_sample(
+    api: APIVersion,
+    service_path: tuple[str, ...],
+    method: Method,
+    examples: ExampleGenerator,
+) -> OperationSample:
+    path_parameters = tuple(
+        SampleParameter(parameter, _parameter_value(parameter, examples))
+        for parameter in method.path_params
+    )
+    query_parameters = tuple(
+        SampleParameter(parameter, _parameter_value(parameter, examples))
+        for parameter in method.query_params
+        if parameter.required or parameter.has_example or parameter.has_default
+    )
+    body = None
+    if method.body is not None:
+        body = examples.generate(method.body)
+    return OperationSample(
+        api=api,
+        service_path=service_path,
+        method=method,
+        path_parameters=path_parameters,
+        query_parameters=query_parameters,
+        body=body,
+    )
+
+
+def _parameter_value(parameter: Parameter, examples: ExampleGenerator) -> typing.Any:
+    if parameter.has_example:
+        return parameter.example
+    if parameter.has_default:
+        return parameter.default
+    return examples.generate(parameter.type)
+
+
+def _iter_methods(
+    services: list[Service], path: tuple[str, ...] = ()
+) -> typing.Iterator[tuple[tuple[str, ...], Method]]:
+    for service in services:
+        service_path = (*path, service.name)
+        for method in service.methods:
+            yield service_path, method
+        yield from _iter_methods(service.services, service_path)

--- a/sdk/generator/generator/code_samples.py
+++ b/sdk/generator/generator/code_samples.py
@@ -258,7 +258,7 @@ class ExampleGenerator:
         if discriminator is not None and isinstance(value, dict):
             discriminator_value = self._discriminator_value(discriminator, variant)
             if discriminator_value is not None:
-                value.setdefault(discriminator.property_name, discriminator_value)
+                value[discriminator.property_name] = discriminator_value
         return value
 
     def _discriminator_value(
@@ -337,12 +337,14 @@ def write_code_samples_overlays(
     languages: typing.Iterable[str],
 ) -> None:
     output_path = pathlib.Path(output)
-    output_path.mkdir(parents=True, exist_ok=True)
-    for api_version, overlay in generate_code_samples_overlays(
-        ir, sdk_version, languages
-    ).items():
+    overlays = generate_code_samples_overlays(ir, sdk_version, languages)
+    for api_version in overlays:
         if pathlib.Path(api_version).name != api_version:
             raise CodeSampleError(f"Invalid API version: {api_version}")
+    output_path.mkdir(parents=True, exist_ok=True)
+    for overlay_path in output_path.glob("*.overlay.json"):
+        overlay_path.unlink()
+    for api_version, overlay in overlays.items():
         (output_path / f"{api_version}.overlay.json").write_text(
             json.dumps(overlay, indent=2, ensure_ascii=False) + "\n",
             encoding="utf-8",

--- a/sdk/generator/generator/ir.py
+++ b/sdk/generator/generator/ir.py
@@ -15,6 +15,13 @@ class PrimitiveType(BaseModel):
     kind: typing.Literal["primitive"]
     type: typing.Literal["string", "integer", "number", "boolean", "unknown"]
     format: str | None = None
+    minimum: float | None = None
+    exclusive_minimum: float | None = None
+    maximum: float | None = None
+    exclusive_maximum: float | None = None
+    min_length: int | None = None
+    max_length: int | None = None
+    pattern: str | None = None
 
 
 class ArrayType(BaseModel):
@@ -22,6 +29,8 @@ class ArrayType(BaseModel):
 
     kind: typing.Literal["array"]
     items: "TypeRef"
+    min_items: int | None = None
+    max_items: int | None = None
 
 
 class ModelRef(BaseModel):
@@ -134,6 +143,9 @@ class Field(BaseModel):
     write_only: bool | None = None
     deprecated: bool | None = None
     default: typing.Any | None = None
+    has_default: bool = False
+    example: typing.Any | None = None
+    has_example: bool = False
 
 
 class Model(BaseModel):
@@ -206,6 +218,9 @@ class Parameter(BaseModel):
     description: str | None = None
     deprecated: bool | None = None
     default: typing.Any | None = None
+    has_default: bool = False
+    example: typing.Any | None = None
+    has_example: bool = False
 
 
 class HTTPMethod(enum.StrEnum):
@@ -239,6 +254,7 @@ class Method(BaseModel):
     """A single API endpoint grouped under a Service."""
 
     name: str
+    operation_id: str
     description: str | None = None
     http_method: HTTPMethod
     path: str
@@ -550,6 +566,13 @@ def _convert_typeref(
             kind="primitive",
             type=schema_type,  # type: ignore[arg-type]
             format=schema.schema_format or None,
+            minimum=schema.minimum,
+            exclusive_minimum=schema.exclusiveMinimum,
+            maximum=schema.maximum,
+            exclusive_maximum=schema.exclusiveMaximum,
+            min_length=schema.minLength,
+            max_length=schema.maxLength,
+            pattern=schema.pattern,
         )
 
     if schema_type == "null":
@@ -567,7 +590,12 @@ def _convert_typeref(
             )
         else:
             items: TypeRef = PrimitiveType(kind="primitive", type="unknown")
-        return ArrayType(kind="array", items=items)
+        return ArrayType(
+            kind="array",
+            items=items,
+            min_items=schema.minItems,
+            max_items=schema.maxItems,
+        )
 
     if schema_type == "object" or schema.properties is not None:
         if schema.properties is None and schema.additionalProperties is not None:
@@ -642,14 +670,16 @@ def _schema_to_model(
         write_only = None
         deprecated = None
         default = None
+        has_default = False
+        has_example, example = _extract_example(prop)
         if isinstance(prop, op.Schema):
             description = prop.description or None
             read_only = True if prop.readOnly else None
             write_only = True if prop.writeOnly else None
             deprecated = True if prop.deprecated else None
-            # Extract default value from schema
-            if hasattr(prop, "default") and prop.default is not None:
+            if "default" in prop.model_fields_set:
                 default = prop.default
+                has_default = True
         fields.append(
             Field(
                 name=prop_name,
@@ -660,6 +690,9 @@ def _schema_to_model(
                 write_only=write_only,
                 deprecated=deprecated,
                 default=default,
+                has_default=has_default,
+                example=example,
+                has_example=has_example,
             )
         )
     # Walk composition keywords so transitive references are discovered even
@@ -728,6 +761,24 @@ def _get_body_schema_raw(
         return None
 
     return media_type.media_type_schema
+
+
+def _extract_example(*sources: typing.Any) -> tuple[bool, typing.Any]:
+    for source in sources:
+        if source is None:
+            continue
+        fields_set = getattr(source, "model_fields_set", set())
+        if "example" in fields_set:
+            return True, getattr(source, "example", None)
+        examples = getattr(source, "examples", None)
+        if isinstance(examples, list) and examples:
+            return True, examples[0]
+        if isinstance(examples, dict) and examples:
+            first_example = examples[sorted(examples)[0]]
+            value_fields_set = getattr(first_example, "model_fields_set", set())
+            if "value" in value_fields_set:
+                return True, getattr(first_example, "value", None)
+    return False, None
 
 
 def _get_response_type_schema(
@@ -842,18 +893,16 @@ def _convert_parameter_ir(
     else:
         type_ = PrimitiveType(kind="primitive", type="unknown")
 
-    # Extract default value from parameter schema
     default = None
+    has_default = False
     if parameter.param_schema is not None and isinstance(
         parameter.param_schema, op.Schema
     ):
-        # OpenAPI default values can be in param_schema.default
-        # For OpenAPI 3.1, the default is a field on the schema
-        if (
-            hasattr(parameter.param_schema, "default")
-            and parameter.param_schema.default is not None
-        ):
+        if "default" in parameter.param_schema.model_fields_set:
             default = parameter.param_schema.default
+            has_default = True
+
+    has_example, example = _extract_example(parameter, parameter.param_schema)
 
     # Determine the parameter_name
     # If the parameter name conflicts with a field in the body, disambiguate it
@@ -877,6 +926,9 @@ def _convert_parameter_ir(
         description=parameter.description or None,
         deprecated=True if parameter.deprecated else None,
         default=default,
+        has_default=has_default,
+        example=example,
+        has_example=has_example,
     )
 
 
@@ -977,6 +1029,7 @@ def _generate_ir_version(
     input_names: set[str] = set()
     output_names: set[str] = set()
     webhook_names: set[str] = set()
+    operation_ids: set[str] = set()
     # Map from normalized names to original names for component schemas
     normalized_to_original: dict[str, str] = {}
     for original_name in component_schemas:
@@ -989,6 +1042,12 @@ def _generate_ir_version(
             for http_method, operation in _get_operations(path_item):
                 if is_private_operation(operation):
                     continue
+
+                if operation.operationId in operation_ids:
+                    raise ValueError(
+                        f"Duplicate operation ID: {operation.operationId}."
+                    )
+                operation_ids.add(typing.cast(str, operation.operationId))
 
                 service_key = get_service_key(operation)
                 method_name = get_method_name(operation)
@@ -1032,7 +1091,6 @@ def _generate_ir_version(
                 ]
 
                 raw_body = _get_body_schema_raw(operation, spec)
-
                 path_params = [
                     _convert_parameter_ir(
                         p,
@@ -1143,6 +1201,7 @@ def _generate_ir_version(
 
                 method = Method(
                     name=method_name,
+                    operation_id=typing.cast(str, operation.operationId),
                     description=operation.description or None,
                     http_method=http_method,
                     path=path,

--- a/sdk/generator/generator/ir.py
+++ b/sdk/generator/generator/ir.py
@@ -427,13 +427,14 @@ def _resolve_reference[T](ref: op.Reference | T, spec: op.OpenAPI) -> T:
 
 def _extract_discriminator(
     discriminator: op.Discriminator | None,
+    normalize_model_name: ModelNameNormalizer,
 ) -> UnionDiscriminator | None:
     if discriminator is None:
         return None
     mapping = {}
     if discriminator.mapping:
         for key, ref_path in discriminator.mapping.items():
-            mapping[key] = ref_path.split("/")[-1]
+            mapping[key] = normalize_model_name(ref_path.split("/")[-1])
     return UnionDiscriminator(property_name=discriminator.propertyName, mapping=mapping)
 
 
@@ -501,7 +502,9 @@ def _convert_typeref(
             )
             for v in schema.anyOf
         ]
-        discriminator = _extract_discriminator(schema.discriminator)
+        discriminator = _extract_discriminator(
+            schema.discriminator, normalize_model_name
+        )
         return UnionType(
             kind="union",
             variants=variants,
@@ -521,7 +524,9 @@ def _convert_typeref(
             )
             for v in schema.oneOf
         ]
-        discriminator = _extract_discriminator(schema.discriminator)
+        discriminator = _extract_discriminator(
+            schema.discriminator, normalize_model_name
+        )
         return UnionType(
             kind="union",
             variants=variants,
@@ -742,7 +747,9 @@ def _schema_to_named_union(
         name=name,
         description=schema.description or None,
         variants=variants,
-        discriminator=_extract_discriminator(schema.discriminator),
+        discriminator=_extract_discriminator(
+            schema.discriminator, normalize_model_name
+        ),
         composition_kind=composition_kind,
     )
 
@@ -774,10 +781,11 @@ def _extract_example(*sources: typing.Any) -> tuple[bool, typing.Any]:
         if isinstance(examples, list) and examples:
             return True, examples[0]
         if isinstance(examples, dict) and examples:
-            first_example = examples[sorted(examples)[0]]
-            value_fields_set = getattr(first_example, "model_fields_set", set())
-            if "value" in value_fields_set:
-                return True, getattr(first_example, "value", None)
+            for example_name in sorted(examples):
+                example = examples[example_name]
+                value_fields_set = getattr(example, "model_fields_set", set())
+                if "value" in value_fields_set:
+                    return True, getattr(example, "value", None)
     return False, None
 
 

--- a/sdk/generator/generator/release.py
+++ b/sdk/generator/generator/release.py
@@ -10,6 +10,7 @@ GENERATOR_DIR = pathlib.Path(__file__).parent.parent
 ROOT = GENERATOR_DIR.parent.parent
 LANGUAGES = ["python", "typescript"]
 GENERATED_SDK_PATHS = ["sdk/python", "sdk/typescript"]
+CODE_SAMPLES_PATH = ROOT / "sdk" / "code-samples"
 
 
 def validate_version(version: str) -> bool:
@@ -68,6 +69,28 @@ def generate_all_sdks(version: str, prerelease: Prerelease | None = None) -> Non
                 raise
 
 
+def generate_code_samples(version: str, prerelease: Prerelease | None = None) -> None:
+    release_label = f"{version}-{prerelease}" if prerelease else version
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "cli",
+            "code-samples",
+            str(GENERATOR_DIR / "openapi.json"),
+            str(CODE_SAMPLES_PATH),
+            "--language",
+            "python",
+            "--language",
+            "typescript",
+            "--version",
+            release_label,
+        ],
+        cwd=GENERATOR_DIR,
+        check=True,
+    )
+
+
 def create_git_commit(version: str, prerelease: Prerelease | None = None) -> None:
     release_label = f"{version}-{prerelease}" if prerelease else version
     for path in GENERATED_SDK_PATHS:
@@ -100,6 +123,7 @@ def release_sdk(
             print("  - Regenerate OpenAPI spec")
         print("  - Regenerate Python SDK")
         print("  - Regenerate TypeScript SDK")
+        print("  - Regenerate SDK code samples overlay")
         if not skip_commit:
             print("  - Create git commit")
         return
@@ -110,6 +134,7 @@ def release_sdk(
             regenerate_openapi()
 
         generate_all_sdks(version, prerelease)
+        generate_code_samples(version, prerelease)
 
         if not skip_commit:
             print("Creating git commit...")

--- a/sdk/generator/justfile
+++ b/sdk/generator/justfile
@@ -26,6 +26,9 @@ generate-all:
   uv run -m cli generate openapi.json ../python --language python --clear
   uv run -m cli generate openapi.json ../typescript --language typescript --clear
 
+code-samples version="0.0.0":
+  uv run -m cli code-samples openapi.json ../code-samples --language python --language typescript --version {{version}}
+
 release version:
   uv run -m cli release {{version}}
 

--- a/sdk/generator/python/code_samples.py
+++ b/sdk/generator/python/code_samples.py
@@ -1,0 +1,56 @@
+import pathlib
+import pprint
+import typing
+
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+from generator.code_samples import CodeSampleError, OperationSample
+from python.naming import operation_name, paginator_name, service_name
+
+TEMPLATE_DIRECTORY = pathlib.Path(__file__).parent / "template"
+ENVIRONMENT = Environment(
+    loader=FileSystemLoader(TEMPLATE_DIRECTORY),
+    undefined=StrictUndefined,
+    keep_trailing_newline=True,
+)
+ENVIRONMENT.filters["python_literal"] = lambda value: pprint.pformat(
+    value, width=72, sort_dicts=False
+)
+TEMPLATE = ENVIRONMENT.get_template("code_sample.py.jinja")
+
+
+def language_label() -> str:
+    return "Python"
+
+
+def render_code_sample(sample: OperationSample) -> str:
+    positional_arguments = [
+        sample_parameter.value for sample_parameter in sample.path_parameters
+    ]
+    keyword_arguments: dict[str, typing.Any] = {}
+    for sample_parameter in sample.query_parameters:
+        keyword_arguments[sample_parameter.parameter.parameter_name] = (
+            sample_parameter.value
+        )
+    if sample.method.body is not None:
+        if not isinstance(sample.body, dict):
+            raise CodeSampleError("Python request bodies must be object schemas")
+        keyword_arguments.update(sample.body)
+
+    client_path = ".".join(service_name(name) for name in sample.service_path)
+    method_name = (
+        paginator_name(sample.method.name)
+        if sample.method.pagination is not None
+        else operation_name(sample.method.name)
+    )
+    return (
+        TEMPLATE.render(
+            version=f"v{sample.api.version.replace('-', '_').replace('.', '_')}",
+            call_path=f"polar.{client_path}.{method_name}",
+            positional_arguments=positional_arguments,
+            keyword_arguments=keyword_arguments,
+            pagination=sample.method.pagination is not None,
+            has_response=sample.method.response_type != "none",
+        ).rstrip()
+        + "\n"
+    )

--- a/sdk/generator/python/template/code_sample.py.jinja
+++ b/sdk/generator/python/template/code_sample.py.jinja
@@ -1,0 +1,20 @@
+{% macro render_call() %}
+{%- if positional_arguments or keyword_arguments -%}
+{{ call_path }}(
+{% for argument in positional_arguments %}    {{ argument | python_literal | indent(4) }},
+{% endfor %}{% for name, argument in keyword_arguments.items() %}    {{ name }}={{ argument | python_literal | indent(4) }},
+{% endfor %})
+{%- else -%}
+{{ call_path }}()
+{%- endif -%}
+{% endmacro -%}
+from polar.{{ version }} import Polar
+
+polar = Polar("polar_oat_xxx")
+
+{% if pagination %}for item in {{ render_call() }}:
+    print(item)
+{% elif has_response %}response = {{ render_call() }}
+print(response)
+{% else %}{{ render_call() }}
+{% endif %}

--- a/sdk/generator/tests/conftest.py
+++ b/sdk/generator/tests/conftest.py
@@ -1,0 +1,234 @@
+import openapi_pydantic as op
+import pytest
+
+
+@pytest.fixture
+def code_samples_spec() -> op.OpenAPI:
+    return op.OpenAPI.model_validate(
+        {
+            "openapi": "3.1.0",
+            "info": {"title": "Samples", "version": "2026-04"},
+            "servers": [
+                {
+                    "url": "https://api.example.com",
+                    "x-polar-environment": "production",
+                }
+            ],
+            "paths": {
+                "/health": {
+                    "get": {
+                        "operationId": "health:get",
+                        "responses": {"204": {"description": "Healthy"}},
+                    }
+                },
+                "/accounts/{account_id}/payment-methods": {
+                    "get": {
+                        "operationId": "accounts:payment_methods:list",
+                        "parameters": [
+                            {
+                                "name": "account_id",
+                                "in": "path",
+                                "required": True,
+                                "schema": {"type": "string", "format": "uuid"},
+                            },
+                            {
+                                "name": "page",
+                                "in": "query",
+                                "schema": {"type": "integer", "default": 1},
+                            },
+                            {
+                                "name": "label",
+                                "in": "query",
+                                "schema": {
+                                    "anyOf": [
+                                        {"type": "string"},
+                                        {"type": "null"},
+                                    ],
+                                    "examples": ["primary"],
+                                },
+                            },
+                        ],
+                        "responses": {
+                            "200": {
+                                "description": "Success",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "$ref": "#/components/schemas/PaymentMethodList"
+                                        }
+                                    }
+                                },
+                            }
+                        },
+                        "x-polar-pagination": {
+                            "type": "page_limit",
+                            "item_schema": {
+                                "$ref": "#/components/schemas/PaymentMethod"
+                            },
+                        },
+                    }
+                },
+                "/widgets": {
+                    "post": {
+                        "operationId": "widgets:create",
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "$ref": "#/components/schemas/WidgetCreate"
+                                    }
+                                }
+                            },
+                        },
+                        "responses": {
+                            "200": {
+                                "description": "Success",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "$ref": "#/components/schemas/Widget"
+                                        }
+                                    }
+                                },
+                            }
+                        },
+                    }
+                },
+                "/private": {
+                    "get": {
+                        "operationId": "private:get",
+                        "tags": ["private"],
+                        "responses": {"204": {"description": "Private"}},
+                    }
+                },
+            },
+            "webhooks": {
+                "widget.created": {
+                    "post": {
+                        "operationId": "webhooks:widget_created",
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "application/json": {
+                                    "schema": {"$ref": "#/components/schemas/Widget"}
+                                }
+                            },
+                        },
+                        "responses": {"204": {"description": "Accepted"}},
+                    }
+                }
+            },
+            "components": {
+                "schemas": {
+                    "PaymentMethod": {
+                        "type": "object",
+                        "title": "PaymentMethod",
+                        "properties": {"id": {"type": "string"}},
+                        "required": ["id"],
+                    },
+                    "PaymentMethodList": {
+                        "type": "object",
+                        "title": "PaymentMethodList",
+                        "properties": {
+                            "items": {
+                                "type": "array",
+                                "items": {"$ref": "#/components/schemas/PaymentMethod"},
+                            }
+                        },
+                        "required": ["items"],
+                    },
+                    "WidgetKind": {
+                        "type": "string",
+                        "title": "WidgetKind",
+                        "enum": ["physical", "digital"],
+                    },
+                    "PhysicalWidget": {
+                        "type": "object",
+                        "title": "PhysicalWidget",
+                        "properties": {
+                            "type": {"type": "string", "const": "physical"},
+                            "weight": {"type": "number"},
+                        },
+                        "required": ["type", "weight"],
+                    },
+                    "DigitalWidget": {
+                        "type": "object",
+                        "title": "DigitalWidget",
+                        "properties": {
+                            "type": {"type": "string", "const": "digital"},
+                            "url": {"type": "string", "format": "uri"},
+                        },
+                        "required": ["type", "url"],
+                    },
+                    "WidgetDetails": {
+                        "title": "WidgetDetails",
+                        "oneOf": [
+                            {"$ref": "#/components/schemas/PhysicalWidget"},
+                            {"$ref": "#/components/schemas/DigitalWidget"},
+                        ],
+                        "discriminator": {
+                            "propertyName": "type",
+                            "mapping": {
+                                "physical": "#/components/schemas/PhysicalWidget",
+                                "digital": "#/components/schemas/DigitalWidget",
+                            },
+                        },
+                    },
+                    "WidgetCreate": {
+                        "type": "object",
+                        "title": "WidgetCreate",
+                        "properties": {
+                            "name": {"type": "string", "examples": ["Desk clock"]},
+                            "kind": {"$ref": "#/components/schemas/WidgetKind"},
+                            "details": {"$ref": "#/components/schemas/WidgetDetails"},
+                            "note": {
+                                "anyOf": [
+                                    {"type": "string"},
+                                    {"type": "null"},
+                                ],
+                                "examples": ["Limited edition"],
+                            },
+                            "code": {
+                                "type": "string",
+                                "pattern": "^A[A-Z0-9]+$",
+                                "minLength": 2,
+                                "maxLength": 8,
+                            },
+                            "score": {
+                                "type": "number",
+                                "exclusiveMinimum": 0,
+                                "maximum": 0.5,
+                            },
+                            "tags": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "minItems": 2,
+                            },
+                            "archived_at": {
+                                "anyOf": [
+                                    {"type": "string", "format": "date-time"},
+                                    {"type": "null"},
+                                ],
+                                "default": None,
+                            },
+                        },
+                        "required": [
+                            "name",
+                            "kind",
+                            "details",
+                            "code",
+                            "score",
+                            "tags",
+                        ],
+                    },
+                    "Widget": {
+                        "type": "object",
+                        "title": "Widget",
+                        "properties": {"id": {"type": "string"}},
+                        "required": ["id"],
+                    },
+                }
+            },
+        }
+    )

--- a/sdk/generator/tests/python/test_code_samples.py
+++ b/sdk/generator/tests/python/test_code_samples.py
@@ -1,0 +1,39 @@
+import ast
+
+import openapi_pydantic as op
+
+from generator.code_samples import generate_code_samples_overlay
+from generator.ir import generate_ir
+
+
+def test_renders_code_samples(
+    code_samples_spec: op.OpenAPI,
+) -> None:
+    api = generate_ir(code_samples_spec).versions[0]
+    overlay = generate_code_samples_overlay(api, "1.2.3", ["python"])
+    sources = {
+        action["target"]: action["update"]["x-codeSamples"][0]["source"]
+        for action in overlay["actions"]
+    }
+
+    assert sources['$["paths"]["/health"]["get"]'] == (
+        "from polar.v2026_04 import Polar\n"
+        "\n"
+        'polar = Polar("polar_oat_xxx")\n'
+        "\n"
+        "polar.health.get()\n"
+    )
+    pagination = sources['$["paths"]["/accounts/{account_id}/payment-methods"]["get"]']
+    assert "for item in polar.accounts.payment_methods.iter_list(" in pagination
+    assert "'00000000-0000-4000-8000-000000000000'," in pagination
+    assert "account_id=" not in pagination
+    assert "os.environ" not in pagination
+    assert "with Polar" not in pagination
+
+    widget = sources['$["paths"]["/widgets"]["post"]']
+    assert "kind='physical'" in widget
+    assert "details={'type': 'physical', 'weight': 1.0}" in widget
+    assert "note='Limited edition'" in widget
+    assert "archived_at=None" in widget
+    for source in sources.values():
+        ast.parse(source)

--- a/sdk/generator/tests/test_code_samples.py
+++ b/sdk/generator/tests/test_code_samples.py
@@ -1,0 +1,80 @@
+import json
+import pathlib
+
+import openapi_pydantic as op
+import pytest
+
+from generator.code_samples import (
+    CodeSampleError,
+    generate_code_samples_overlay,
+    generate_code_samples_overlays,
+    write_code_samples_overlays,
+)
+from generator.ir import generate_ir
+
+
+def test_overlay_is_complete_and_excludes_non_sdk_operations(
+    code_samples_spec: op.OpenAPI,
+) -> None:
+    api = generate_ir(code_samples_spec).versions[0]
+    overlay = generate_code_samples_overlay(api, "1.2.3", ["python", "typescript"])
+
+    assert overlay["overlay"] == "1.1.0"
+    assert overlay["info"]["title"] == "Polar 2026-04 SDK code samples"
+    assert overlay["info"]["version"] == "1.2.3"
+    assert len(overlay["actions"]) == 3
+    targets = [action["target"] for action in overlay["actions"]]
+    assert len(targets) == len(set(targets))
+    assert all(
+        [sample["lang"] for sample in action["update"]["x-codeSamples"]]
+        == ["Python", "TypeScript"]
+        for action in overlay["actions"]
+    )
+    assert all("/private" not in action["target"] for action in overlay["actions"])
+    assert all("webhook" not in action["target"] for action in overlay["actions"])
+
+
+def test_writes_one_overlay_per_api_version(
+    tmp_path: pathlib.Path, code_samples_spec: op.OpenAPI
+) -> None:
+    previous_spec = code_samples_spec.model_copy(deep=True)
+    previous_spec.info.version = "2025-01"
+    ir = generate_ir(previous_spec, code_samples_spec)
+
+    write_code_samples_overlays(tmp_path, ir, "1.2.3", ["python", "typescript"])
+
+    assert sorted(path.name for path in tmp_path.iterdir()) == [
+        "2025-01.overlay.json",
+        "2026-04.overlay.json",
+    ]
+    assert (
+        json.loads((tmp_path / "2025-01.overlay.json").read_text())["info"]["title"]
+        == "Polar 2025-01 SDK code samples"
+    )
+
+
+def test_code_samples_fail_on_cycles(code_samples_spec: op.OpenAPI) -> None:
+    spec = code_samples_spec.model_dump(by_alias=True, exclude_none=True)
+    spec["components"]["schemas"]["WidgetCreate"] = {
+        "type": "object",
+        "title": "WidgetCreate",
+        "properties": {"child": {"$ref": "#/components/schemas/WidgetCreate"}},
+        "required": ["child"],
+    }
+
+    with pytest.raises(CodeSampleError, match="Cyclic input schema"):
+        generate_code_samples_overlays(
+            generate_ir(op.OpenAPI.model_validate(spec)),
+            "1.2.3",
+            ["python", "typescript"],
+        )
+
+
+def test_duplicate_operation_ids_are_rejected(
+    code_samples_spec: op.OpenAPI,
+) -> None:
+    spec = code_samples_spec.model_dump(by_alias=True, exclude_none=True)
+    spec["paths"]["/health"]["get"]["operationId"] = "widgets:create"
+
+    with pytest.raises(ValueError, match="Duplicate operation ID"):
+        generate_ir(op.OpenAPI.model_validate(spec))

--- a/sdk/generator/tests/test_code_samples.py
+++ b/sdk/generator/tests/test_code_samples.py
@@ -6,6 +6,7 @@ import pytest
 
 from generator.code_samples import (
     CodeSampleError,
+    ExampleGenerator,
     generate_code_samples_overlay,
     generate_code_samples_overlays,
     write_code_samples_overlays,
@@ -51,6 +52,58 @@ def test_writes_one_overlay_per_api_version(
         json.loads((tmp_path / "2025-01.overlay.json").read_text())["info"]["title"]
         == "Polar 2025-01 SDK code samples"
     )
+
+
+def test_discriminator_mapping_overrides_generated_property(
+    code_samples_spec: op.OpenAPI,
+) -> None:
+    spec = code_samples_spec.model_dump(by_alias=True, exclude_none=True)
+    spec["components"]["schemas"]["PhysicalWidget"]["properties"]["type"] = {
+        "type": "string"
+    }
+    api = generate_ir(op.OpenAPI.model_validate(spec)).versions[0]
+    method = next(
+        method
+        for service in api.services
+        for method in service.methods
+        if method.operation_id == "widgets:create"
+    )
+    assert method.body is not None
+
+    body = ExampleGenerator(api).generate(method.body)
+
+    assert body["details"]["type"] == "physical"
+
+
+def test_discriminator_mapping_targets_are_normalized(
+    code_samples_spec: op.OpenAPI,
+) -> None:
+    spec = code_samples_spec.model_dump(by_alias=True, exclude_none=True)
+    schemas = spec["components"]["schemas"]
+    physical_widget = schemas.pop("PhysicalWidget")
+    physical_widget["properties"].pop("type")
+    physical_widget["required"].remove("type")
+    schemas["physical_widget"] = physical_widget
+    details = schemas["WidgetDetails"]
+    details["oneOf"][0]["$ref"] = "#/components/schemas/physical_widget"
+    details["discriminator"]["mapping"]["physical"] = (
+        "#/components/schemas/physical_widget"
+    )
+    api = generate_ir(op.OpenAPI.model_validate(spec)).versions[0]
+    union = next(union for union in api.input_unions if union.name == "WidgetDetails")
+    method = next(
+        method
+        for service in api.services
+        for method in service.methods
+        if method.operation_id == "widgets:create"
+    )
+    assert union.discriminator is not None
+    assert method.body is not None
+
+    body = ExampleGenerator(api).generate(method.body)
+
+    assert union.discriminator.mapping["physical"] == "PhysicalWidget"
+    assert body["details"]["type"] == "physical"
 
 
 def test_code_samples_fail_on_cycles(code_samples_spec: op.OpenAPI) -> None:

--- a/sdk/generator/tests/test_ir.py
+++ b/sdk/generator/tests/test_ir.py
@@ -92,6 +92,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                 "methods": [
                                     {
                                         "name": "list",
+                                        "operation_id": "products:list",
                                         "description": "List products",
                                         "http_method": "GET",
                                         "path": "/products",
@@ -112,6 +113,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                 "methods": [
                                     {
                                         "name": "list",
+                                        "operation_id": "users:list",
                                         "description": "List users",
                                         "http_method": "GET",
                                         "path": "/users",
@@ -129,18 +131,38 @@ _STRING = {"kind": "primitive", "type": "string"}
                             {
                                 "name": "Product",
                                 "fields": [
-                                    {"name": "id", "type": _STRING, "required": True},
-                                    {"name": "name", "type": _STRING, "required": True},
+                                    {
+                                        "name": "id",
+                                        "type": _STRING,
+                                        "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
+                                    },
+                                    {
+                                        "name": "name",
+                                        "type": _STRING,
+                                        "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
+                                    },
                                 ],
                             },
                             {
                                 "name": "User",
                                 "fields": [
-                                    {"name": "name", "type": _STRING, "required": True},
+                                    {
+                                        "name": "name",
+                                        "type": _STRING,
+                                        "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
+                                    },
                                     {
                                         "name": "email",
                                         "type": _STRING,
                                         "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
                                     },
                                 ],
                             },
@@ -283,13 +305,21 @@ _STRING = {"kind": "primitive", "type": "string"}
                                         "name": "company_name",
                                         "type": _STRING,
                                         "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
                                     }
                                 ],
                             },
                             {
                                 "name": "Customer",
                                 "fields": [
-                                    {"name": "id", "type": _STRING, "required": True},
+                                    {
+                                        "name": "id",
+                                        "type": _STRING,
+                                        "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
+                                    },
                                     {
                                         "name": "status",
                                         "type": {
@@ -297,6 +327,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                             "name": "CustomerStatus",
                                         },
                                         "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
                                     },
                                     {
                                         "name": "subject",
@@ -305,6 +337,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                             "name": "CustomerSubject",
                                         },
                                         "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
                                     },
                                 ],
                             },
@@ -315,6 +349,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                         "name": "name",
                                         "type": _STRING,
                                         "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
                                     }
                                 ],
                             },
@@ -331,6 +367,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                             "value": "customer.created",
                                         },
                                         "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
                                     },
                                     {
                                         "name": "data",
@@ -339,6 +377,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                             "name": "Customer",
                                         },
                                         "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
                                     },
                                 ],
                             },
@@ -353,6 +393,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                             "value": "customer.updated",
                                         },
                                         "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
                                     },
                                     {
                                         "name": "data",
@@ -361,6 +403,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                             "name": "Customer",
                                         },
                                         "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
                                     },
                                 ],
                             },
@@ -463,6 +507,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                 "methods": [
                                     {
                                         "name": "create",
+                                        "operation_id": "users:create",
                                         "description": "Create a user",
                                         "http_method": "POST",
                                         "path": "/users",
@@ -487,11 +532,15 @@ _STRING = {"kind": "primitive", "type": "string"}
                                         "name": "name",
                                         "type": _STRING,
                                         "required": False,
+                                        "has_default": False,
+                                        "has_example": False,
                                     },
                                     {
                                         "name": "email",
                                         "type": _STRING,
                                         "required": False,
+                                        "has_default": False,
+                                        "has_example": False,
                                     },
                                 ],
                             },
@@ -500,16 +549,26 @@ _STRING = {"kind": "primitive", "type": "string"}
                             {
                                 "name": "UserResponse",
                                 "fields": [
-                                    {"name": "id", "type": _STRING, "required": False},
+                                    {
+                                        "name": "id",
+                                        "type": _STRING,
+                                        "required": False,
+                                        "has_default": False,
+                                        "has_example": False,
+                                    },
                                     {
                                         "name": "name",
                                         "type": _STRING,
                                         "required": False,
+                                        "has_default": False,
+                                        "has_example": False,
                                     },
                                     {
                                         "name": "type",
                                         "type": {"kind": "enum", "name": "UserType"},
                                         "required": False,
+                                        "has_default": False,
+                                        "has_example": False,
                                     },
                                 ],
                             },
@@ -653,6 +712,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                 "methods": [
                                     {
                                         "name": "list",
+                                        "operation_id": "products:list",
                                         "description": "List products",
                                         "http_method": "GET",
                                         "path": "/products",
@@ -663,6 +723,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                                 "parameter_name": "category",
                                                 "type": _STRING,
                                                 "required": False,
+                                                "has_default": False,
+                                                "has_example": False,
                                                 "description": "Filter products by category",
                                             }
                                         ],
@@ -675,6 +737,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                     },
                                     {
                                         "name": "get",
+                                        "operation_id": "products:get",
                                         "description": "Get a product by ID",
                                         "http_method": "GET",
                                         "path": "/products/{id}",
@@ -684,6 +747,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                                 "parameter_name": "id",
                                                 "type": _STRING,
                                                 "required": True,
+                                                "has_default": False,
+                                                "has_example": False,
                                                 "description": "The ID of the product",
                                             }
                                         ],
@@ -703,8 +768,20 @@ _STRING = {"kind": "primitive", "type": "string"}
                             {
                                 "name": "Product",
                                 "fields": [
-                                    {"name": "id", "type": _STRING, "required": True},
-                                    {"name": "name", "type": _STRING, "required": True},
+                                    {
+                                        "name": "id",
+                                        "type": _STRING,
+                                        "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
+                                    },
+                                    {
+                                        "name": "name",
+                                        "type": _STRING,
+                                        "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
+                                    },
                                 ],
                             },
                         ],
@@ -791,6 +868,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                 "methods": [
                                     {
                                         "name": "list",
+                                        "operation_id": "orders:list",
                                         "description": "List orders",
                                         "http_method": "GET",
                                         "path": "/orders",
@@ -817,6 +895,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                                     ],
                                                 },
                                                 "required": False,
+                                                "has_default": False,
+                                                "has_example": False,
                                                 "description": "Filter by order status",
                                             }
                                         ],
@@ -832,11 +912,19 @@ _STRING = {"kind": "primitive", "type": "string"}
                             {
                                 "name": "Order",
                                 "fields": [
-                                    {"name": "id", "type": _STRING, "required": True},
+                                    {
+                                        "name": "id",
+                                        "type": _STRING,
+                                        "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
+                                    },
                                     {
                                         "name": "status",
                                         "type": {"kind": "enum", "name": "OrderStatus"},
                                         "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
                                     },
                                 ],
                             }
@@ -930,6 +1018,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                         "methods": [
                                             {
                                                 "name": "list",
+                                                "operation_id": "products:variants:list",
                                                 "description": "List variants of a product",
                                                 "http_method": "GET",
                                                 "path": "/products/{product_id}/variants",
@@ -939,6 +1028,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                                         "parameter_name": "product_id",
                                                         "type": _STRING,
                                                         "required": True,
+                                                        "has_default": False,
+                                                        "has_example": False,
                                                         "description": "The product ID",
                                                     }
                                                 ],
@@ -948,6 +1039,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                             },
                                             {
                                                 "name": "get",
+                                                "operation_id": "products:variants:get",
                                                 "description": "Get a variant of a product",
                                                 "http_method": "GET",
                                                 "path": "/products/{product_id}/variants/{variant_id}",
@@ -957,6 +1049,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                                         "parameter_name": "product_id",
                                                         "type": _STRING,
                                                         "required": True,
+                                                        "has_default": False,
+                                                        "has_example": False,
                                                         "description": "The product ID",
                                                     },
                                                     {
@@ -964,6 +1058,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                                         "parameter_name": "variant_id",
                                                         "type": _STRING,
                                                         "required": True,
+                                                        "has_default": False,
+                                                        "has_example": False,
                                                         "description": "The variant ID",
                                                     },
                                                 ],
@@ -977,6 +1073,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                 "methods": [
                                     {
                                         "name": "list",
+                                        "operation_id": "products:list",
                                         "description": "List products",
                                         "http_method": "GET",
                                         "path": "/products",
@@ -1056,6 +1153,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                 "methods": [
                                     {
                                         "name": "list",
+                                        "operation_id": "accounts:list",
                                         "description": "List accounts",
                                         "http_method": "GET",
                                         "path": "/accounts",
@@ -1076,7 +1174,13 @@ _STRING = {"kind": "primitive", "type": "string"}
                             {
                                 "name": "Account",
                                 "fields": [
-                                    {"name": "id", "type": _STRING, "required": True},
+                                    {
+                                        "name": "id",
+                                        "type": _STRING,
+                                        "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
+                                    },
                                     {
                                         "name": "modified_at",
                                         "type": {
@@ -1088,6 +1192,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                             },
                                         },
                                         "required": False,
+                                        "has_default": False,
+                                        "has_example": False,
                                     },
                                 ],
                             }
@@ -1170,6 +1276,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                 "methods": [
                                     {
                                         "name": "list",
+                                        "operation_id": "events:list",
                                         "description": "List events",
                                         "http_method": "GET",
                                         "path": "/events",
@@ -1194,6 +1301,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                         "name": "source",
                                         "type": _STRING,
                                         "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
                                     }
                                 ],
                             },
@@ -1204,6 +1313,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                         "name": "source",
                                         "type": _STRING,
                                         "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
                                     }
                                 ],
                             },
@@ -1295,6 +1406,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                 "methods": [
                                     {
                                         "name": "list",
+                                        "operation_id": "payments:list",
                                         "description": "List payments",
                                         "http_method": "GET",
                                         "path": "/payments",
@@ -1315,13 +1427,25 @@ _STRING = {"kind": "primitive", "type": "string"}
                             {
                                 "name": "BankPayment",
                                 "fields": [
-                                    {"name": "iban", "type": _STRING, "required": True}
+                                    {
+                                        "name": "iban",
+                                        "type": _STRING,
+                                        "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
+                                    }
                                 ],
                             },
                             {
                                 "name": "CardPayment",
                                 "fields": [
-                                    {"name": "last4", "type": _STRING, "required": True}
+                                    {
+                                        "name": "last4",
+                                        "type": _STRING,
+                                        "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
+                                    }
                                 ],
                             },
                         ],
@@ -1397,6 +1521,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                 "methods": [
                                     {
                                         "name": "get",
+                                        "operation_id": "metadata:get",
                                         "description": "Get metadata",
                                         "http_method": "GET",
                                         "path": "/metadata",
@@ -1518,6 +1643,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                 "methods": [
                                     {
                                         "name": "get",
+                                        "operation_id": "products:get",
                                         "description": "Get a product",
                                         "http_method": "GET",
                                         "path": "/products/{id}",
@@ -1527,6 +1653,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                                 "parameter_name": "id",
                                                 "type": _STRING,
                                                 "required": True,
+                                                "has_default": False,
+                                                "has_example": False,
                                             }
                                         ],
                                         "query_params": [],
@@ -1576,13 +1704,21 @@ _STRING = {"kind": "primitive", "type": "string"}
                                         "name": "detail",
                                         "type": _STRING,
                                         "required": False,
+                                        "has_default": False,
+                                        "has_example": False,
                                     },
                                 ],
                             },
                             {
                                 "name": "Product",
                                 "fields": [
-                                    {"name": "id", "type": _STRING, "required": True},
+                                    {
+                                        "name": "id",
+                                        "type": _STRING,
+                                        "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
+                                    },
                                 ],
                             },
                             {
@@ -1592,6 +1728,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                         "name": "detail",
                                         "type": _STRING,
                                         "required": False,
+                                        "has_default": False,
+                                        "has_example": False,
                                     },
                                 ],
                             },
@@ -1716,6 +1854,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                 "methods": [
                                     {
                                         "name": "list",
+                                        "operation_id": "items:list",
                                         "description": "List items",
                                         "http_method": "GET",
                                         "path": "/items",
@@ -1727,6 +1866,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                     },
                                     {
                                         "name": "create",
+                                        "operation_id": "items:create",
                                         "description": "Create an item",
                                         "http_method": "POST",
                                         "path": "/items",
@@ -1739,6 +1879,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                     },
                                     {
                                         "name": "update",
+                                        "operation_id": "items:update",
                                         "description": "Update an item",
                                         "http_method": "PUT",
                                         "path": "/items/{id}",
@@ -1756,8 +1897,20 @@ _STRING = {"kind": "primitive", "type": "string"}
                             {
                                 "name": "Item",
                                 "fields": [
-                                    {"name": "id", "type": _STRING, "required": True},
-                                    {"name": "name", "type": _STRING, "required": True},
+                                    {
+                                        "name": "id",
+                                        "type": _STRING,
+                                        "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
+                                    },
+                                    {
+                                        "name": "name",
+                                        "type": _STRING,
+                                        "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
+                                    },
                                 ],
                             },
                             {
@@ -1767,6 +1920,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                         "name": "name",
                                         "type": _STRING,
                                         "required": False,
+                                        "has_default": False,
+                                        "has_example": False,
                                     },
                                 ],
                             },
@@ -1775,8 +1930,20 @@ _STRING = {"kind": "primitive", "type": "string"}
                             {
                                 "name": "Item",
                                 "fields": [
-                                    {"name": "id", "type": _STRING, "required": True},
-                                    {"name": "name", "type": _STRING, "required": True},
+                                    {
+                                        "name": "id",
+                                        "type": _STRING,
+                                        "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
+                                    },
+                                    {
+                                        "name": "name",
+                                        "type": _STRING,
+                                        "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
+                                    },
                                 ],
                             },
                         ],
@@ -1856,6 +2023,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                 "methods": [
                                     {
                                         "name": "create",
+                                        "operation_id": "items:create",
                                         "description": "Create an item",
                                         "http_method": "POST",
                                         "path": "/items",
@@ -1880,6 +2048,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                         "name": "name",
                                         "type": _STRING,
                                         "required": False,
+                                        "has_default": False,
+                                        "has_example": False,
                                     },
                                 ],
                             },
@@ -1888,8 +2058,20 @@ _STRING = {"kind": "primitive", "type": "string"}
                             {
                                 "name": "ItemResponse",
                                 "fields": [
-                                    {"name": "id", "type": _STRING, "required": True},
-                                    {"name": "name", "type": _STRING, "required": True},
+                                    {
+                                        "name": "id",
+                                        "type": _STRING,
+                                        "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
+                                    },
+                                    {
+                                        "name": "name",
+                                        "type": _STRING,
+                                        "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
+                                    },
                                 ],
                             },
                         ],
@@ -1967,6 +2149,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                 "methods": [
                                     {
                                         "name": "create",
+                                        "operation_id": "checkout:create",
                                         "description": "Create checkout",
                                         "http_method": "POST",
                                         "path": "/checkout",
@@ -1994,6 +2177,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                         "name": "product_id",
                                         "type": _STRING,
                                         "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
                                     },
                                     {
                                         "name": "quantity",
@@ -2002,6 +2187,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                             "type": "integer",
                                         },
                                         "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
                                     },
                                 ],
                             },
@@ -2014,6 +2201,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                         "name": "product_id",
                                         "type": _STRING,
                                         "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
                                     },
                                     {
                                         "name": "quantity",
@@ -2022,6 +2211,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                             "type": "integer",
                                         },
                                         "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
                                     },
                                 ],
                             },
@@ -2110,6 +2301,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                 "methods": [
                                     {
                                         "name": "get",
+                                        "operation_id": "payment:get",
                                         "description": "Get payment method",
                                         "http_method": "GET",
                                         "path": "/payment",
@@ -2130,7 +2322,13 @@ _STRING = {"kind": "primitive", "type": "string"}
                             {
                                 "name": "BankPayment",
                                 "fields": [
-                                    {"name": "iban", "type": _STRING, "required": True}
+                                    {
+                                        "name": "iban",
+                                        "type": _STRING,
+                                        "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
+                                    }
                                 ],
                             },
                             {
@@ -2140,6 +2338,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                         "name": "card_type",
                                         "type": _STRING,
                                         "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
                                     }
                                 ],
                             },
@@ -2150,6 +2350,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                         "name": "card_type",
                                         "type": _STRING,
                                         "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
                                     }
                                 ],
                             },
@@ -2245,6 +2447,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                 "methods": [
                                     {
                                         "name": "upload",
+                                        "operation_id": "files:upload",
                                         "description": "Upload a file",
                                         "http_method": "POST",
                                         "path": "/files/{id}",
@@ -2254,6 +2457,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                                 "parameter_name": "id_path",
                                                 "type": _STRING,
                                                 "required": True,
+                                                "has_default": False,
+                                                "has_example": False,
                                             }
                                         ],
                                         "query_params": [
@@ -2262,6 +2467,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                                 "parameter_name": "file_name_query",
                                                 "type": _STRING,
                                                 "required": False,
+                                                "has_default": False,
+                                                "has_example": False,
                                             }
                                         ],
                                         "body": {"kind": "model", "name": "FileUpload"},
@@ -2275,11 +2482,19 @@ _STRING = {"kind": "primitive", "type": "string"}
                             {
                                 "name": "FileUpload",
                                 "fields": [
-                                    {"name": "id", "type": _STRING, "required": False},
+                                    {
+                                        "name": "id",
+                                        "type": _STRING,
+                                        "required": False,
+                                        "has_default": False,
+                                        "has_example": False,
+                                    },
                                     {
                                         "name": "file_name",
                                         "type": _STRING,
                                         "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
                                     },
                                     {
                                         "name": "file_size",
@@ -2288,6 +2503,8 @@ _STRING = {"kind": "primitive", "type": "string"}
                                             "type": "integer",
                                         },
                                         "required": True,
+                                        "has_default": False,
+                                        "has_example": False,
                                     },
                                 ],
                             }
@@ -2379,6 +2596,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                 "methods": [
                                     {
                                         "name": "data",
+                                        "operation_id": "export:data",
                                         "description": "Export data as CSV",
                                         "http_method": "GET",
                                         "path": "/export",
@@ -2393,6 +2611,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                     },
                                     {
                                         "name": "json",
+                                        "operation_id": "export:json",
                                         "description": "Export data as JSON",
                                         "http_method": "GET",
                                         "path": "/export-json",
@@ -2407,6 +2626,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                     },
                                     {
                                         "name": "mixed",
+                                        "operation_id": "export:mixed",
                                         "description": "Export with both CSV and JSON",
                                         "http_method": "GET",
                                         "path": "/export-mixed",
@@ -2421,6 +2641,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                     },
                                     {
                                         "name": "none",
+                                        "operation_id": "export:none",
                                         "description": "Export with no content type",
                                         "http_method": "GET",
                                         "path": "/export-none",

--- a/sdk/generator/tests/typescript/test_code_samples.py
+++ b/sdk/generator/tests/typescript/test_code_samples.py
@@ -1,0 +1,38 @@
+import openapi_pydantic as op
+
+from generator.code_samples import generate_code_samples_overlay
+from generator.ir import generate_ir
+
+
+def test_renders_code_samples(
+    code_samples_spec: op.OpenAPI,
+) -> None:
+    api = generate_ir(code_samples_spec).versions[0]
+    overlay = generate_code_samples_overlay(api, "1.2.3", ["typescript"])
+    sources = {
+        action["target"]: action["update"]["x-codeSamples"][0]["source"]
+        for action in overlay["actions"]
+    }
+
+    assert sources['$["paths"]["/health"]["get"]'] == (
+        'import { createPolar } from "@polar-sh/sdk/2026-04";\n'
+        "\n"
+        "const polar = createPolar({\n"
+        '  accessToken: "polar_oat_xxx",\n'
+        "});\n"
+        "\n"
+        "await polar.health.get();\n"
+    )
+    pagination = sources['$["paths"]["/accounts/{account_id}/payment-methods"]["get"]']
+    assert (
+        "for await (const item of polar.accounts.paymentMethods.iterList(" in pagination
+    )
+    assert '"label": "primary"' in pagination
+    assert "process.env" not in pagination
+    assert "async function" not in pagination
+
+    widget = sources['$["paths"]["/widgets"]["post"]']
+    assert '"kind": "physical"' in widget
+    assert '"type": "physical"' in widget
+    assert '"note": "Limited edition"' in widget
+    assert '"archived_at": null' in widget

--- a/sdk/generator/typescript/code_samples.py
+++ b/sdk/generator/typescript/code_samples.py
@@ -1,0 +1,57 @@
+import json
+import pathlib
+import typing
+
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+from generator.code_samples import OperationSample
+from typescript.naming import operation_name, paginator_name, service_name
+
+TEMPLATE_DIRECTORY = pathlib.Path(__file__).parent / "template"
+ENVIRONMENT = Environment(
+    loader=FileSystemLoader(TEMPLATE_DIRECTORY),
+    undefined=StrictUndefined,
+    keep_trailing_newline=True,
+)
+ENVIRONMENT.filters["typescript_literal"] = lambda value: json.dumps(
+    value, indent=2, ensure_ascii=False
+)
+TEMPLATE = ENVIRONMENT.get_template("code_sample.ts.jinja")
+
+
+def language_label() -> str:
+    return "TypeScript"
+
+
+def render_code_sample(sample: OperationSample) -> str:
+    arguments: list[typing.Any] = [
+        sample_parameter.value for sample_parameter in sample.path_parameters
+    ]
+    if sample.method.query_params and (
+        sample.query_parameters or sample.method.body is not None
+    ):
+        arguments.append(
+            {
+                sample_parameter.parameter.name: sample_parameter.value
+                for sample_parameter in sample.query_parameters
+            }
+        )
+    if sample.method.body is not None:
+        arguments.append(sample.body)
+
+    client_path = ".".join(service_name(name) for name in sample.service_path)
+    method_name = (
+        paginator_name(sample.method.name)
+        if sample.method.pagination is not None
+        else operation_name(sample.method.name)
+    )
+    return (
+        TEMPLATE.render(
+            version=sample.api.version,
+            call_path=f"polar.{client_path}.{method_name}",
+            arguments=arguments,
+            pagination=sample.method.pagination is not None,
+            has_response=sample.method.response_type != "none",
+        ).rstrip()
+        + "\n"
+    )

--- a/sdk/generator/typescript/template/code_sample.ts.jinja
+++ b/sdk/generator/typescript/template/code_sample.ts.jinja
@@ -1,0 +1,22 @@
+{% macro render_call() %}
+{%- if arguments -%}
+{{ call_path }}(
+{% for argument in arguments %}  {{ argument | typescript_literal | indent(2) }},
+{% endfor %})
+{%- else -%}
+{{ call_path }}()
+{%- endif -%}
+{% endmacro -%}
+import { createPolar } from "@polar-sh/sdk/{{ version }}";
+
+const polar = createPolar({
+  accessToken: "polar_oat_xxx",
+});
+
+{% if pagination %}for await (const item of {{ render_call() }}) {
+  console.log(item);
+}
+{% elif has_response %}const response = await {{ render_call() }};
+console.log(response);
+{% else %}await {{ render_call() }};
+{% endif %}


### PR DESCRIPTION
## Summary

- preserve operation IDs and example-generation metadata in the SDK IR
- generate deterministic OpenAPI Overlay 1.1 files with Python and TypeScript `x-codeSamples`
- render concise, version-aware samples through language-specific Jinja templates
- emit one ignored overlay artifact per API version and regenerate it during SDK releases

## Impact

SDK release jobs can generate complete code-sample overlays for each versioned OpenAPI schema. Private operations and webhooks are excluded, while unsupported or cyclic public request shapes fail generation.

The existing Speakeasy-backed documentation workflow is unchanged.

## Validation

- `just lint`
- `just test` (78 tests)
- `uv run -m cli code-samples openapi.json <temporary-output> --version 1.0.0-alpha.12`
- verified generated `2026-04.overlay.json` contains Python and TypeScript samples
- ADR review: no violations

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13292?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

