### PR TITLE
fix(payouts): stop telling merchants to redo completed Stripe onboarding

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPageRouter.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/finance/account/AccountPageRouter.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { PayoutOnboardingReturnAlert } from '@/components/Finance/PayoutOnboardingReturnAlert'
 import { useOrganizationReviewStatus } from '@/hooks/queries/org'
 import { schemas } from '@polar-sh/client'
 import { useRouter } from 'next/navigation'
@@ -62,13 +63,18 @@ export const AccountPageRouter = ({
       reviewStatus?.appeal_decision === 'approved' ||
       hasAccountAccess
 
-  if (requireDetails) {
-    return <AccountPageDetailsRequired organization={organization} />
-  }
+  const page = requireDetails ? (
+    <AccountPageDetailsRequired organization={organization} />
+  ) : isApproved ? (
+    <AccountPageApproved organization={organization} />
+  ) : (
+    <AccountPageInReview organization={organization} />
+  )
 
-  if (isApproved) {
-    return <AccountPageApproved organization={organization} />
-  }
-
-  return <AccountPageInReview organization={organization} />
+  return (
+    <>
+      <PayoutOnboardingReturnAlert organization={organization} />
+      {page}
+    </>
+  )
 }

--- a/clients/apps/web/src/components/Finance/Account/sections/PayoutAccountSection.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/PayoutAccountSection.tsx
@@ -7,9 +7,10 @@ import { api } from '@/utils/client'
 import { schemas } from '@polar-sh/client'
 import { Box } from '@polar-sh/orbit/Box'
 import { Button } from '@polar-sh/orbit'
-import { ArrowRight, BanknoteIcon } from 'lucide-react'
+import { ArrowRight } from 'lucide-react'
 import { useCallback, useState } from 'react'
 import { CheckPayoutStatusButton } from '../../CheckPayoutStatusButton'
+import { ManualPayoutStatusBlock } from '../../ManualPayoutStatusBlock'
 import { getPayoutAccountPresentation } from '../../payoutAccountPresentation'
 import { payoutOnboardingReturnPath } from '../../payoutOnboardingReturn'
 import { PathCardBanner } from './PathCardBanner'
@@ -83,23 +84,7 @@ export const PayoutAccountSection = ({
   if (isManualAccount) {
     return (
       <>
-        <StatusBlock
-          tone="neutral"
-          icon={BanknoteIcon}
-          title="Manual payouts"
-          description={
-            <>
-              You are receiving manual payouts.{' '}
-              <a
-                href="mailto:support@polar.sh"
-                className="underline hover:no-underline"
-              >
-                Reach out to support
-              </a>{' '}
-              to request a payout or change this.
-            </>
-          }
-        />
+        <ManualPayoutStatusBlock />
         {modals}
         {banners}
       </>

--- a/clients/apps/web/src/components/Finance/Account/sections/PayoutAccountSection.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/PayoutAccountSection.tsx
@@ -56,7 +56,12 @@ export const PayoutAccountSection = ({
       {
         params: {
           path: { id: payoutAccount.id },
-          query: { return_path: returnPath },
+          query: {
+            return_path: payoutOnboardingReturnPath(
+              organization.slug,
+              payoutAccount.id,
+            ),
+          },
         },
       },
     )
@@ -70,7 +75,7 @@ export const PayoutAccountSection = ({
       return
     }
     window.location.href = data.url
-  }, [payoutAccount, returnPath, openManage])
+  }, [payoutAccount, organization.slug, openManage])
 
   const isStripeAccount = payoutAccount?.type === 'stripe'
   const isManualAccount = payoutAccount && !isStripeAccount

--- a/clients/apps/web/src/components/Finance/Account/sections/PayoutAccountSection.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/PayoutAccountSection.tsx
@@ -7,8 +7,9 @@ import { api } from '@/utils/client'
 import { schemas } from '@polar-sh/client'
 import { Box } from '@polar-sh/orbit/Box'
 import { Button } from '@polar-sh/orbit'
-import { ArrowRight, BanknoteIcon, CheckIcon } from 'lucide-react'
+import { ArrowRight, BanknoteIcon } from 'lucide-react'
 import { useCallback, useState } from 'react'
+import { getPayoutAccountPresentation } from '../../payoutAccountPresentation'
 import { PathCardBanner } from './PathCardBanner'
 import { StatusBlock } from './StatusBlock'
 
@@ -99,37 +100,43 @@ export const PayoutAccountSection = ({
   }
 
   if (isStripeAccount) {
-    const ready = payoutAccount.is_payout_ready
+    const presentation = getPayoutAccountPresentation(payoutAccount)
+    const { state } = presentation
+
+    const primaryAction =
+      state === 'incomplete' ? (
+        <Button onClick={resumeOnboarding} loading={resumeLoading}>
+          Finish payout setup
+          <ArrowRight className="ml-2 h-4 w-4" />
+        </Button>
+      ) : state === 'paused' ? (
+        <Button onClick={() => window.open('mailto:support@polar.sh')}>
+          Contact support
+          <ArrowRight className="ml-2 h-4 w-4" />
+        </Button>
+      ) : null
+
     return (
       <>
         <StatusBlock
-          tone={ready ? 'success' : 'pending'}
-          icon={ready ? CheckIcon : BanknoteIcon}
-          title={
-            ready ? 'Payout account connected' : 'Payout account needs setup'
-          }
-          description={
-            ready
-              ? 'Your Stripe payout account is configured and ready to receive payouts.'
-              : 'Your Stripe payout account is connected but onboarding isn’t complete yet.'
-          }
+          tone={presentation.tone}
+          icon={presentation.icon}
+          title={presentation.title}
+          description={presentation.description}
           action={
-            ready ? (
-              <Button onClick={openManage}>
-                Manage payout accounts
-                <ArrowRight className="ml-2 h-4 w-4" />
-              </Button>
-            ) : (
-              <Box flexDirection="column" alignItems="center" rowGap="s">
-                <Button onClick={resumeOnboarding} loading={resumeLoading}>
-                  Finish payout setup
-                  <ArrowRight className="ml-2 h-4 w-4" />
-                </Button>
+            <Box flexDirection="column" alignItems="center" rowGap="s">
+              {primaryAction}
+              {primaryAction ? (
                 <Button variant="ghost" size="sm" onClick={openManage}>
                   Manage payout accounts
                 </Button>
-              </Box>
-            )
+              ) : (
+                <Button onClick={openManage}>
+                  Manage payout accounts
+                  <ArrowRight className="ml-2 h-4 w-4" />
+                </Button>
+              )}
+            </Box>
           }
         />
         {modals}
@@ -138,13 +145,15 @@ export const PayoutAccountSection = ({
     )
   }
 
+  const presentation = getPayoutAccountPresentation(undefined)
+
   return (
     <>
       <StatusBlock
-        tone="neutral"
-        icon={BanknoteIcon}
-        title="Connect payout account"
-        description="Connect or create a Stripe account to receive payments from your customers."
+        tone={presentation.tone}
+        icon={presentation.icon}
+        title={presentation.title}
+        description={presentation.description}
         action={
           <Button onClick={openPrimary}>
             Connect payout account

--- a/clients/apps/web/src/components/Finance/Account/sections/PayoutAccountSection.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/PayoutAccountSection.tsx
@@ -11,6 +11,7 @@ import { ArrowRight, BanknoteIcon } from 'lucide-react'
 import { useCallback, useState } from 'react'
 import { CheckPayoutStatusButton } from '../../CheckPayoutStatusButton'
 import { getPayoutAccountPresentation } from '../../payoutAccountPresentation'
+import { payoutOnboardingReturnPath } from '../../payoutOnboardingReturn'
 import { PathCardBanner } from './PathCardBanner'
 import { StatusBlock } from './StatusBlock'
 
@@ -42,7 +43,7 @@ export const PayoutAccountSection = ({
     true,
     initialOrg,
   )
-  const returnPath = `/dashboard/${organization.slug}/finance/account`
+  const returnPath = payoutOnboardingReturnPath(organization.slug)
   const { payoutAccount, openManage, openPrimary, modals } =
     usePayoutAccountSetup(organization, returnPath)
 

--- a/clients/apps/web/src/components/Finance/Account/sections/PayoutAccountSection.tsx
+++ b/clients/apps/web/src/components/Finance/Account/sections/PayoutAccountSection.tsx
@@ -9,6 +9,7 @@ import { Box } from '@polar-sh/orbit/Box'
 import { Button } from '@polar-sh/orbit'
 import { ArrowRight, BanknoteIcon } from 'lucide-react'
 import { useCallback, useState } from 'react'
+import { CheckPayoutStatusButton } from '../../CheckPayoutStatusButton'
 import { getPayoutAccountPresentation } from '../../payoutAccountPresentation'
 import { PathCardBanner } from './PathCardBanner'
 import { StatusBlock } from './StatusBlock'
@@ -116,6 +117,8 @@ export const PayoutAccountSection = ({
         </Button>
       ) : null
 
+    const canCheckStatus = state === 'under_review' || state === 'paused'
+
     return (
       <>
         <StatusBlock
@@ -126,6 +129,12 @@ export const PayoutAccountSection = ({
           action={
             <Box flexDirection="column" alignItems="center" rowGap="s">
               {primaryAction}
+              {canCheckStatus && (
+                <CheckPayoutStatusButton
+                  payoutAccount={payoutAccount}
+                  variant={primaryAction ? 'ghost' : 'default'}
+                />
+              )}
               {primaryAction ? (
                 <Button variant="ghost" size="sm" onClick={openManage}>
                   Manage payout accounts

--- a/clients/apps/web/src/components/Finance/CheckPayoutStatusButton.tsx
+++ b/clients/apps/web/src/components/Finance/CheckPayoutStatusButton.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { toast } from '@/components/Toast/use-toast'
+import { useSyncPayoutAccount } from '@/hooks/queries/payout_accounts'
+import { schemas } from '@polar-sh/client'
+import { Button } from '@polar-sh/orbit'
+import { RefreshCwIcon } from 'lucide-react'
+import { useCallback } from 'react'
+
+interface Props {
+  payoutAccount: schemas['PayoutAccount']
+  variant?: 'default' | 'ghost'
+}
+
+export const CheckPayoutStatusButton = ({
+  payoutAccount,
+  variant = 'ghost',
+}: Props) => {
+  const syncPayoutAccount = useSyncPayoutAccount(payoutAccount.id)
+
+  const checkStatus = useCallback(async () => {
+    try {
+      const synced = await syncPayoutAccount.mutateAsync()
+      if (synced.status === payoutAccount.status) {
+        toast({
+          title: 'No change yet',
+          description: 'Stripe has not updated this account since last time.',
+        })
+      }
+    } catch {
+      toast({
+        title: 'Could not reach Stripe',
+        description: 'Please try again in a moment.',
+      })
+    }
+  }, [syncPayoutAccount, payoutAccount.status])
+
+  return (
+    <Button
+      variant={variant}
+      size={variant === 'ghost' ? 'sm' : undefined}
+      onClick={checkStatus}
+      loading={syncPayoutAccount.isPending}
+    >
+      <RefreshCwIcon className="mr-2 h-4 w-4" />
+      Check status
+    </Button>
+  )
+}

--- a/clients/apps/web/src/components/Finance/ManualPayoutStatusBlock.tsx
+++ b/clients/apps/web/src/components/Finance/ManualPayoutStatusBlock.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { BanknoteIcon } from 'lucide-react'
+import { StatusBlock } from './Account/sections/StatusBlock'
+
+export const ManualPayoutStatusBlock = () => (
+  <StatusBlock
+    tone="neutral"
+    icon={BanknoteIcon}
+    title="Manual payouts"
+    description={
+      <>
+        You are receiving manual payouts.{' '}
+        <a
+          href="mailto:support@polar.sh"
+          className="underline hover:no-underline"
+        >
+          Reach out to support
+        </a>{' '}
+        to request a payout or change this.
+      </>
+    }
+  />
+)

--- a/clients/apps/web/src/components/Finance/PayoutOnboardingReturnAlert.tsx
+++ b/clients/apps/web/src/components/Finance/PayoutOnboardingReturnAlert.tsx
@@ -7,9 +7,12 @@ import {
 import { schemas } from '@polar-sh/client'
 import { Alert } from '@polar-sh/orbit'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { getPayoutAccountPresentation } from './payoutAccountPresentation'
-import { PAYOUT_ONBOARDING_RETURN_PARAM } from './payoutOnboardingReturn'
+import {
+  PAYOUT_ONBOARDING_ACCOUNT_PARAM,
+  PAYOUT_ONBOARDING_RETURN_PARAM,
+} from './payoutOnboardingReturn'
 
 const ALERT_VARIANTS = {
   success: 'success',
@@ -29,7 +32,11 @@ export const PayoutOnboardingReturnAlert = ({ organization }: Props) => {
   const pathname = usePathname()
 
   const isReturn = searchParams.get(PAYOUT_ONBOARDING_RETURN_PARAM) === 'return'
-  const payoutAccountId = organization.payout_account_id ?? undefined
+  // Onboarding can be resumed for an account that isn't the active one.
+  const payoutAccountId =
+    searchParams.get(PAYOUT_ONBOARDING_ACCOUNT_PARAM) ??
+    organization.payout_account_id ??
+    undefined
 
   const [visible, setVisible] = useState(isReturn)
   const syncedRef = useRef(false)
@@ -37,21 +44,25 @@ export const PayoutOnboardingReturnAlert = ({ organization }: Props) => {
   const { data: payoutAccount } = usePayoutAccount(payoutAccountId)
   const syncPayoutAccount = useSyncPayoutAccount(payoutAccountId ?? '')
 
+  // Only clear the marker once the sync succeeded — a failed sync must not leave the
+  // page claiming a status we never confirmed.
+  const sync = useCallback(() => {
+    syncPayoutAccount.mutate(undefined, {
+      onSuccess: () => router.replace(pathname),
+    })
+  }, [syncPayoutAccount, router, pathname])
+
   useEffect(() => {
     if (!isReturn || !payoutAccountId || syncedRef.current) return
     syncedRef.current = true
-    // Stripe decides on its own schedule, so read the account back rather than
-    // waiting on the `account.updated` webhook.
-    syncPayoutAccount.mutate(undefined, {
-      onSettled: () => router.replace(pathname),
-    })
-  }, [isReturn, payoutAccountId, syncPayoutAccount, router, pathname])
+    sync()
+  }, [isReturn, payoutAccountId, sync])
 
   if (!visible || !payoutAccountId) {
     return null
   }
 
-  if (syncPayoutAccount.isPending || !payoutAccount) {
+  if (syncPayoutAccount.isPending) {
     return (
       <Alert
         variant="info"
@@ -60,6 +71,22 @@ export const PayoutOnboardingReturnAlert = ({ organization }: Props) => {
         description="One moment while we confirm your payout account."
       />
     )
+  }
+
+  if (syncPayoutAccount.isError) {
+    return (
+      <Alert
+        variant="warning"
+        title="Could not confirm with Stripe"
+        description="We couldn't check your payout account just now. Your setup may still have gone through."
+        actions={[{ text: 'Try again', onClick: sync }]}
+        onDismiss={() => setVisible(false)}
+      />
+    )
+  }
+
+  if (!payoutAccount) {
+    return null
   }
 
   const { tone, title, description } =

--- a/clients/apps/web/src/components/Finance/PayoutOnboardingReturnAlert.tsx
+++ b/clients/apps/web/src/components/Finance/PayoutOnboardingReturnAlert.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import {
+  usePayoutAccount,
+  useSyncPayoutAccount,
+} from '@/hooks/queries/payout_accounts'
+import { schemas } from '@polar-sh/client'
+import { Alert } from '@polar-sh/orbit'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { useEffect, useRef, useState } from 'react'
+import { getPayoutAccountPresentation } from './payoutAccountPresentation'
+import { PAYOUT_ONBOARDING_RETURN_PARAM } from './payoutOnboardingReturn'
+
+const ALERT_VARIANTS = {
+  success: 'success',
+  warning: 'warning',
+  danger: 'danger',
+  pending: 'info',
+  neutral: 'info',
+} as const
+
+interface Props {
+  organization: schemas['Organization']
+}
+
+export const PayoutOnboardingReturnAlert = ({ organization }: Props) => {
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const pathname = usePathname()
+
+  const isReturn = searchParams.get(PAYOUT_ONBOARDING_RETURN_PARAM) === 'return'
+  const payoutAccountId = organization.payout_account_id ?? undefined
+
+  const [visible, setVisible] = useState(isReturn)
+  const syncedRef = useRef(false)
+
+  const { data: payoutAccount } = usePayoutAccount(payoutAccountId)
+  const syncPayoutAccount = useSyncPayoutAccount(payoutAccountId ?? '')
+
+  useEffect(() => {
+    if (!isReturn || !payoutAccountId || syncedRef.current) return
+    syncedRef.current = true
+    // Stripe decides on its own schedule, so read the account back rather than
+    // waiting on the `account.updated` webhook.
+    syncPayoutAccount.mutate(undefined, {
+      onSettled: () => router.replace(pathname),
+    })
+  }, [isReturn, payoutAccountId, syncPayoutAccount, router, pathname])
+
+  if (!visible || !payoutAccountId) {
+    return null
+  }
+
+  if (syncPayoutAccount.isPending || !payoutAccount) {
+    return (
+      <Alert
+        variant="info"
+        loading
+        title="Checking with Stripe"
+        description="One moment while we confirm your payout account."
+      />
+    )
+  }
+
+  const { tone, title, description } =
+    getPayoutAccountPresentation(payoutAccount)
+
+  return (
+    <Alert
+      variant={ALERT_VARIANTS[tone]}
+      title={title}
+      description={description}
+      onDismiss={() => setVisible(false)}
+    />
+  )
+}

--- a/clients/apps/web/src/components/Finance/PayoutOnboardingReturnAlert.tsx
+++ b/clients/apps/web/src/components/Finance/PayoutOnboardingReturnAlert.tsx
@@ -32,13 +32,15 @@ export const PayoutOnboardingReturnAlert = ({ organization }: Props) => {
   const pathname = usePathname()
 
   const isReturn = searchParams.get(PAYOUT_ONBOARDING_RETURN_PARAM) === 'return'
-  // Onboarding can be resumed for an account that isn't the active one.
-  const payoutAccountId =
-    searchParams.get(PAYOUT_ONBOARDING_ACCOUNT_PARAM) ??
-    organization.payout_account_id ??
-    undefined
 
   const [visible, setVisible] = useState(isReturn)
+  // Read once: clearing the marker drops it from the URL.
+  const [returnedAccountId] = useState(
+    () => searchParams.get(PAYOUT_ONBOARDING_ACCOUNT_PARAM) ?? undefined,
+  )
+  const payoutAccountId =
+    returnedAccountId ?? organization.payout_account_id ?? undefined
+
   const syncedRef = useRef(false)
 
   const { data: payoutAccount } = usePayoutAccount(payoutAccountId)

--- a/clients/apps/web/src/components/Finance/Steps/PayoutAccountStep.tsx
+++ b/clients/apps/web/src/components/Finance/Steps/PayoutAccountStep.tsx
@@ -4,12 +4,28 @@ import { usePayoutAccountSetup } from '@/hooks/usePayoutAccountSetup'
 import { api } from '@/utils/client'
 import { schemas, unwrap } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
-import { ArrowRight, CheckIcon, ExternalLink } from 'lucide-react'
+import { Box } from '@polar-sh/orbit/Box'
+import { ArrowRight, BanknoteIcon, ExternalLink } from 'lucide-react'
 import { useCallback, useState } from 'react'
+import { StatusBlock } from '../Account/sections/StatusBlock'
+import { getPayoutAccountPresentation } from '../payoutAccountPresentation'
 
 interface PayoutAccountStepProps {
   organization: schemas['Organization']
 }
+
+const Card = ({ children }: { children: React.ReactNode }) => (
+  <Box
+    flexDirection="column"
+    borderRadius="l"
+    borderWidth={1}
+    borderStyle="solid"
+    borderColor="border-primary"
+    backgroundColor="background-card"
+  >
+    {children}
+  </Box>
+)
 
 export default function PayoutAccountStep({
   organization,
@@ -20,28 +36,22 @@ export default function PayoutAccountStep({
     returnPath,
   )
 
-  const isAccountSetupComplete = payoutAccount && payoutAccount.is_payout_ready
-
   const [isLoadingDashboard, setIsLoadingDashboard] = useState(false)
 
   const handleStartAccountSetup = useCallback(async () => {
     if (!payoutAccount) {
       openPrimary()
-    } else {
-      const link = await unwrap(
-        api.POST('/v1/payout-accounts/{id}/onboarding-link', {
-          params: {
-            path: {
-              id: payoutAccount.id,
-            },
-            query: {
-              return_path: returnPath,
-            },
-          },
-        }),
-      )
-      window.location.href = link.url
+      return
     }
+    const link = await unwrap(
+      api.POST('/v1/payout-accounts/{id}/onboarding-link', {
+        params: {
+          path: { id: payoutAccount.id },
+          query: { return_path: returnPath },
+        },
+      }),
+    )
+    window.location.href = link.url
   }, [payoutAccount, returnPath, openPrimary])
 
   const handleOpenStripeDashboard = useCallback(async () => {
@@ -59,62 +69,75 @@ export default function PayoutAccountStep({
     }
   }, [payoutAccount])
 
-  if (isAccountSetupComplete) {
-    const isStripe = payoutAccount.type === 'stripe'
+  if (payoutAccount && payoutAccount.type !== 'stripe') {
+    return (
+      <Card>
+        <StatusBlock
+          tone="neutral"
+          icon={BanknoteIcon}
+          title="Manual payouts"
+          description={
+            <>
+              You are receiving manual payouts.{' '}
+              <a
+                href="mailto:support@polar.sh"
+                className="underline hover:no-underline"
+              >
+                Reach out to support
+              </a>{' '}
+              to request a payout or change this.
+            </>
+          }
+        />
+      </Card>
+    )
+  }
 
-    if (isStripe) {
-      return (
-        <div className="dark:bg-polar-800 rounded-2xl border bg-white p-8 text-center">
-          <span className="dark:bg-polar-700 mb-3 inline-flex h-8 w-8 items-center justify-center rounded-full bg-gray-100">
-            <CheckIcon className="dark:text-polar-400 h-4 w-4 text-gray-500" />
-          </span>
-          <h4 className="mb-2 font-medium">Account setup complete</h4>
-          <p className="dark:text-polar-400 mx-auto mb-6 max-w-sm text-sm text-balance text-gray-600">
-            Your Stripe payout account is configured and ready to receive
-            payouts.
-          </p>
+  const { state, tone, icon, title, description } =
+    getPayoutAccountPresentation(payoutAccount)
+
+  const action = () => {
+    switch (state) {
+      case 'ready':
+        return (
           <Button
             onClick={handleOpenStripeDashboard}
             loading={isLoadingDashboard}
-            className="w-auto"
           >
             Open in Stripe
             <ExternalLink className="ml-2 h-4 w-4" />
           </Button>
-        </div>
-      )
+        )
+      case 'paused':
+        return (
+          <Button onClick={() => window.open('mailto:support@polar.sh')}>
+            Contact support
+            <ArrowRight className="ml-2 h-4 w-4" />
+          </Button>
+        )
+      case 'under_review':
+        return null
+      default:
+        return (
+          <Button onClick={handleStartAccountSetup}>
+            Continue with Account Setup
+            <ArrowRight className="ml-2 h-4 w-4" />
+          </Button>
+        )
     }
-
-    return (
-      <div className="dark:bg-polar-800 rounded-2xl border bg-white p-8 text-center">
-        <h4 className="mb-2 font-medium">Manual payouts</h4>
-        <p className="dark:text-polar-400 mx-auto max-w-sm text-sm text-balance text-gray-600">
-          You&apos;re receiving manual payouts.{' '}
-          <a
-            href="mailto:support@polar.sh"
-            className="underline hover:no-underline"
-          >
-            Reach out to support
-          </a>{' '}
-          to request a payout or change this.
-        </p>
-      </div>
-    )
   }
 
   return (
     <>
-      <div className="dark:bg-polar-800 rounded-2xl border bg-white p-8 text-center">
-        <h4 className="mb-2 font-medium">Connect payout account</h4>
-        <p className="dark:text-polar-400 mx-auto mb-6 max-w-sm text-sm text-balance text-gray-600">
-          Connect or create a Stripe account to receive payments from your
-          customers.
-        </p>
-        <Button onClick={handleStartAccountSetup} className="w-auto">
-          Continue with Account Setup
-          <ArrowRight className="ml-2 h-4 w-4" />
-        </Button>
-      </div>
+      <Card>
+        <StatusBlock
+          tone={tone}
+          icon={icon}
+          title={title}
+          description={description}
+          action={action()}
+        />
+      </Card>
       {modals}
     </>
   )

--- a/clients/apps/web/src/components/Finance/Steps/PayoutAccountStep.tsx
+++ b/clients/apps/web/src/components/Finance/Steps/PayoutAccountStep.tsx
@@ -49,12 +49,17 @@ export default function PayoutAccountStep({
       api.POST('/v1/payout-accounts/{id}/onboarding-link', {
         params: {
           path: { id: payoutAccount.id },
-          query: { return_path: returnPath },
+          query: {
+            return_path: payoutOnboardingReturnPath(
+              organization.slug,
+              payoutAccount.id,
+            ),
+          },
         },
       }),
     )
     window.location.href = link.url
-  }, [payoutAccount, returnPath, openPrimary])
+  }, [payoutAccount, organization.slug, openPrimary])
 
   const handleOpenStripeDashboard = useCallback(async () => {
     if (!payoutAccount) return

--- a/clients/apps/web/src/components/Finance/Steps/PayoutAccountStep.tsx
+++ b/clients/apps/web/src/components/Finance/Steps/PayoutAccountStep.tsx
@@ -10,6 +10,7 @@ import { useCallback, useState } from 'react'
 import { StatusBlock } from '../Account/sections/StatusBlock'
 import { CheckPayoutStatusButton } from '../CheckPayoutStatusButton'
 import { getPayoutAccountPresentation } from '../payoutAccountPresentation'
+import { payoutOnboardingReturnPath } from '../payoutOnboardingReturn'
 
 interface PayoutAccountStepProps {
   organization: schemas['Organization']
@@ -31,7 +32,7 @@ const Card = ({ children }: { children: React.ReactNode }) => (
 export default function PayoutAccountStep({
   organization,
 }: PayoutAccountStepProps) {
-  const returnPath = `/dashboard/${organization.slug}/finance/account`
+  const returnPath = payoutOnboardingReturnPath(organization.slug)
   const { payoutAccount, openPrimary, modals } = usePayoutAccountSetup(
     organization,
     returnPath,

--- a/clients/apps/web/src/components/Finance/Steps/PayoutAccountStep.tsx
+++ b/clients/apps/web/src/components/Finance/Steps/PayoutAccountStep.tsx
@@ -8,6 +8,7 @@ import { Box } from '@polar-sh/orbit/Box'
 import { ArrowRight, BanknoteIcon, ExternalLink } from 'lucide-react'
 import { useCallback, useState } from 'react'
 import { StatusBlock } from '../Account/sections/StatusBlock'
+import { CheckPayoutStatusButton } from '../CheckPayoutStatusButton'
 import { getPayoutAccountPresentation } from '../payoutAccountPresentation'
 
 interface PayoutAccountStepProps {
@@ -96,7 +97,17 @@ export default function PayoutAccountStep({
   const { state, tone, icon, title, description } =
     getPayoutAccountPresentation(payoutAccount)
 
+  const startSetupAction = (
+    <Button onClick={handleStartAccountSetup}>
+      Continue with Account Setup
+      <ArrowRight className="ml-2 h-4 w-4" />
+    </Button>
+  )
+
   const action = () => {
+    if (!payoutAccount) {
+      return startSetupAction
+    }
     switch (state) {
       case 'ready':
         return (
@@ -110,20 +121,23 @@ export default function PayoutAccountStep({
         )
       case 'paused':
         return (
-          <Button onClick={() => window.open('mailto:support@polar.sh')}>
-            Contact support
-            <ArrowRight className="ml-2 h-4 w-4" />
-          </Button>
+          <Box flexDirection="column" alignItems="center" rowGap="s">
+            <Button onClick={() => window.open('mailto:support@polar.sh')}>
+              Contact support
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Button>
+            <CheckPayoutStatusButton payoutAccount={payoutAccount} />
+          </Box>
         )
       case 'under_review':
-        return null
-      default:
         return (
-          <Button onClick={handleStartAccountSetup}>
-            Continue with Account Setup
-            <ArrowRight className="ml-2 h-4 w-4" />
-          </Button>
+          <CheckPayoutStatusButton
+            payoutAccount={payoutAccount}
+            variant="default"
+          />
         )
+      default:
+        return startSetupAction
     }
   }
 

--- a/clients/apps/web/src/components/Finance/Steps/PayoutAccountStep.tsx
+++ b/clients/apps/web/src/components/Finance/Steps/PayoutAccountStep.tsx
@@ -5,10 +5,11 @@ import { api } from '@/utils/client'
 import { schemas, unwrap } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
-import { ArrowRight, BanknoteIcon, ExternalLink } from 'lucide-react'
+import { ArrowRight, ExternalLink } from 'lucide-react'
 import { useCallback, useState } from 'react'
 import { StatusBlock } from '../Account/sections/StatusBlock'
 import { CheckPayoutStatusButton } from '../CheckPayoutStatusButton'
+import { ManualPayoutStatusBlock } from '../ManualPayoutStatusBlock'
 import { getPayoutAccountPresentation } from '../payoutAccountPresentation'
 import { payoutOnboardingReturnPath } from '../payoutOnboardingReturn'
 
@@ -79,23 +80,7 @@ export default function PayoutAccountStep({
   if (payoutAccount && payoutAccount.type !== 'stripe') {
     return (
       <Card>
-        <StatusBlock
-          tone="neutral"
-          icon={BanknoteIcon}
-          title="Manual payouts"
-          description={
-            <>
-              You are receiving manual payouts.{' '}
-              <a
-                href="mailto:support@polar.sh"
-                className="underline hover:no-underline"
-              >
-                Reach out to support
-              </a>{' '}
-              to request a payout or change this.
-            </>
-          }
-        />
+        <ManualPayoutStatusBlock />
       </Card>
     )
   }

--- a/clients/apps/web/src/components/Finance/payoutAccountPresentation.ts
+++ b/clients/apps/web/src/components/Finance/payoutAccountPresentation.ts
@@ -1,0 +1,70 @@
+import { schemas } from '@polar-sh/client'
+import {
+  AlertCircleIcon,
+  BanknoteIcon,
+  CheckIcon,
+  ClockIcon,
+  type LucideIcon,
+} from 'lucide-react'
+
+export type PayoutAccountState =
+  | 'not_connected'
+  | schemas['PayoutAccountStatus']
+
+type Tone = 'success' | 'warning' | 'danger' | 'pending' | 'neutral'
+
+export interface PayoutAccountPresentation {
+  state: PayoutAccountState
+  tone: Tone
+  icon: LucideIcon
+  title: string
+  description: string
+}
+
+const PRESENTATIONS: Record<
+  PayoutAccountState,
+  Omit<PayoutAccountPresentation, 'state'>
+> = {
+  not_connected: {
+    tone: 'neutral',
+    icon: BanknoteIcon,
+    title: 'Connect payout account',
+    description:
+      'Connect or create a Stripe account to receive payments from your customers.',
+  },
+  incomplete: {
+    tone: 'warning',
+    icon: AlertCircleIcon,
+    title: 'Finish payout setup',
+    description:
+      'Stripe needs more information before you can receive payouts. Pick up where you left off.',
+  },
+  under_review: {
+    tone: 'pending',
+    icon: ClockIcon,
+    title: 'Stripe is reviewing your account',
+    description:
+      'You have completed setup. Stripe is verifying your details, which usually takes a day or two. Nothing is needed from you.',
+  },
+  paused: {
+    tone: 'danger',
+    icon: AlertCircleIcon,
+    title: 'Payouts are paused',
+    description:
+      'Stripe has paused payouts on this account. Contact support and we will look into it.',
+  },
+  ready: {
+    tone: 'success',
+    icon: CheckIcon,
+    title: 'Payout account connected',
+    description:
+      'Your Stripe payout account is configured and ready to receive payouts.',
+  },
+}
+
+export const getPayoutAccountPresentation = (
+  payoutAccount: schemas['PayoutAccount'] | undefined,
+): PayoutAccountPresentation => {
+  const state: PayoutAccountState = payoutAccount?.status ?? 'not_connected'
+  return { state, ...PRESENTATIONS[state] }
+}

--- a/clients/apps/web/src/components/Finance/payoutOnboardingReturn.ts
+++ b/clients/apps/web/src/components/Finance/payoutOnboardingReturn.ts
@@ -1,8 +1,20 @@
 export const PAYOUT_ONBOARDING_RETURN_PARAM = 'payout_onboarding'
+export const PAYOUT_ONBOARDING_ACCOUNT_PARAM = 'payout_account_id'
 
 /**
- * Where Stripe sends the merchant after Connect onboarding. The marker is what
- * tells the page it is a return rather than an ordinary visit.
+ * Where Stripe sends the merchant after Connect onboarding. The marker tells the page it
+ * is a return rather than an ordinary visit, and names the account that was onboarded —
+ * which is not always the organization's active one.
  */
-export const payoutOnboardingReturnPath = (organizationSlug: string): string =>
-  `/dashboard/${organizationSlug}/finance/account?${PAYOUT_ONBOARDING_RETURN_PARAM}=return`
+export const payoutOnboardingReturnPath = (
+  organizationSlug: string,
+  payoutAccountId?: string,
+): string => {
+  const params = new URLSearchParams({
+    [PAYOUT_ONBOARDING_RETURN_PARAM]: 'return',
+  })
+  if (payoutAccountId) {
+    params.set(PAYOUT_ONBOARDING_ACCOUNT_PARAM, payoutAccountId)
+  }
+  return `/dashboard/${organizationSlug}/finance/account?${params.toString()}`
+}

--- a/clients/apps/web/src/components/Finance/payoutOnboardingReturn.ts
+++ b/clients/apps/web/src/components/Finance/payoutOnboardingReturn.ts
@@ -1,0 +1,8 @@
+export const PAYOUT_ONBOARDING_RETURN_PARAM = 'payout_onboarding'
+
+/**
+ * Where Stripe sends the merchant after Connect onboarding. The marker is what
+ * tells the page it is a return rather than an ordinary visit.
+ */
+export const payoutOnboardingReturnPath = (organizationSlug: string): string =>
+  `/dashboard/${organizationSlug}/finance/account?${PAYOUT_ONBOARDING_RETURN_PARAM}=return`

--- a/clients/apps/web/src/components/Payouts/ManagePayoutAccountModal.tsx
+++ b/clients/apps/web/src/components/Payouts/ManagePayoutAccountModal.tsx
@@ -66,7 +66,10 @@ const ManagePayoutAccountModal: React.FC<ManagePayoutAccountModalProps> = ({
                 params: {
                   path: { id: payoutAccount.id },
                   query: {
-                    return_path: payoutOnboardingReturnPath(_organization.slug),
+                    return_path: payoutOnboardingReturnPath(
+                      _organization.slug,
+                      payoutAccount.id,
+                    ),
                   },
                 },
               }),

--- a/clients/apps/web/src/components/Payouts/ManagePayoutAccountModal.tsx
+++ b/clients/apps/web/src/components/Payouts/ManagePayoutAccountModal.tsx
@@ -3,6 +3,7 @@ import {
   usePayoutAccounts,
   useSetOrganizationPayoutAccount,
 } from '@/hooks/queries/payout_accounts'
+import { payoutOnboardingReturnPath } from '@/components/Finance/payoutOnboardingReturn'
 import { toast } from '@/components/Toast/use-toast'
 import { api } from '@/utils/client'
 import { schemas, unwrap } from '@polar-sh/client'
@@ -65,7 +66,7 @@ const ManagePayoutAccountModal: React.FC<ManagePayoutAccountModalProps> = ({
                 params: {
                   path: { id: payoutAccount.id },
                   query: {
-                    return_path: `/dashboard/${_organization.slug}/finance/account`,
+                    return_path: payoutOnboardingReturnPath(_organization.slug),
                   },
                 },
               }),

--- a/clients/apps/web/src/hooks/queries/payout_accounts.ts
+++ b/clients/apps/web/src/hooks/queries/payout_accounts.ts
@@ -23,6 +23,27 @@ export const usePayoutAccounts = () =>
     retry: defaultRetry,
   })
 
+export const useSyncPayoutAccount = (payoutAccountId: string) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: () =>
+      unwrap(
+        api.POST('/v1/payout-accounts/{id}/sync', {
+          params: { path: { id: payoutAccountId } },
+        }),
+      ),
+    onSuccess: (payoutAccount) => {
+      queryClient.setQueryData(
+        ['payoutAccount', payoutAccountId],
+        payoutAccount,
+      )
+      queryClient.invalidateQueries({ queryKey: ['organizations'] })
+      queryClient.invalidateQueries({ queryKey: ['payoutAccounts'] })
+      queryClient.invalidateQueries({ queryKey: ['organizationReviewState'] })
+    },
+  })
+}
+
 export const useDeletePayoutAccount = () => {
   const queryClient = useQueryClient()
   return useMutation({

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -28559,6 +28559,17 @@ export interface components {
      * @enum {string}
      */
     PayoutAccountStatus: 'incomplete' | 'under_review' | 'paused' | 'ready'
+    /** PayoutAccountSyncFailed */
+    PayoutAccountSyncFailed: {
+      /**
+       * Error
+       * @example PayoutAccountSyncFailed
+       * @constant
+       */
+      error: 'PayoutAccountSyncFailed'
+      /** Detail */
+      detail: string
+    }
     /** PayoutAccountSyncUnsupported */
     PayoutAccountSyncUnsupported: {
       /**
@@ -55231,6 +55242,15 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+      /** @description Service Unavailable */
+      503: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PayoutAccountSyncFailed']
         }
       }
     }

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -28559,6 +28559,17 @@ export interface components {
      * @enum {string}
      */
     PayoutAccountStatus: 'incomplete' | 'under_review' | 'paused' | 'ready'
+    /** PayoutAccountStripeAccountDoesNotExist */
+    PayoutAccountStripeAccountDoesNotExist: {
+      /**
+       * Error
+       * @example PayoutAccountStripeAccountDoesNotExist
+       * @constant
+       */
+      error: 'PayoutAccountStripeAccountDoesNotExist'
+      /** Detail */
+      detail: string
+    }
     /** PayoutAccountSyncFailed */
     PayoutAccountSyncFailed: {
       /**
@@ -55235,13 +55246,13 @@ export interface operations {
           'application/json': components['schemas']['PayoutAccountSyncUnsupported']
         }
       }
-      /** @description Validation Error */
+      /** @description Unprocessable Content */
       422: {
         headers: {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['HTTPValidationError']
+          'application/json': components['schemas']['PayoutAccountStripeAccountDoesNotExist']
         }
       }
       /** @description Service Unavailable */

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -28512,6 +28512,7 @@ export interface components {
       currency: string
       /** Is Payout Ready */
       is_payout_ready: boolean
+      status: components['schemas']['PayoutAccountStatus']
     }
     /** PayoutAccountCreate */
     PayoutAccountCreate: {
@@ -28533,6 +28534,11 @@ export interface components {
       /** Url */
       url: string
     }
+    /**
+     * PayoutAccountStatus
+     * @enum {string}
+     */
+    PayoutAccountStatus: 'incomplete' | 'under_review' | 'paused' | 'ready'
     /**
      * PayoutAccountType
      * @enum {string}
@@ -64494,6 +64500,9 @@ export const paymentTriggerValues: ReadonlyArray<
   'retry_payment_method_update',
   'retry_admin',
 ]
+export const payoutAccountStatusValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['PayoutAccountStatus']
+> = ['incomplete', 'under_review', 'paused', 'ready']
 export const payoutAccountTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['PayoutAccountType']
 > = ['stripe', 'manual']

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -5827,6 +5827,26 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/payout-accounts/{id}/sync': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Sync
+     * @description **Scopes**: `payouts:read` `payouts:write`
+     */
+    post: operations['payout_accounts:sync']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/payout-accounts/{id}/onboarding-link': {
     parameters: {
       query?: never
@@ -28539,6 +28559,17 @@ export interface components {
      * @enum {string}
      */
     PayoutAccountStatus: 'incomplete' | 'under_review' | 'paused' | 'ready'
+    /** PayoutAccountSyncUnsupported */
+    PayoutAccountSyncUnsupported: {
+      /**
+       * Error
+       * @example PayoutAccountSyncUnsupported
+       * @constant
+       */
+      error: 'PayoutAccountSyncUnsupported'
+      /** Detail */
+      detail: string
+    }
     /**
      * PayoutAccountType
      * @enum {string}
@@ -55152,6 +55183,46 @@ export interface operations {
           [name: string]: unknown
         }
         content?: never
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'payout_accounts:sync': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PayoutAccount']
+        }
+      }
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PayoutAccountSyncUnsupported']
+        }
       }
       /** @description Validation Error */
       422: {

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -4227,10 +4227,7 @@ async def resync_stripe_account(
             status_code=400, detail="Payout account is not a Stripe account"
         )
 
-    stripe_account = await stripe_lib.Account.retrieve_async(payout_account.stripe_id)
-    await payout_account_service.update_account_from_stripe(
-        session, stripe_account=stripe_account
-    )
+    await payout_account_service.sync_from_stripe(session, payout_account)
 
     logger.info(
         "Stripe account resynced from backoffice",

--- a/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/overview_section.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from fastapi import Request
 from tagflow import tag, text
 
+from polar.enums import PayoutAccountStatus
 from polar.models import Organization
 from polar.models.organization_risk_signal import OrganizationRiskSignal
 from polar.organization_review.report import AnyAgentReport
@@ -31,6 +32,13 @@ from ._shared import (
     render_review_context_badge,
 )
 from .risk_signals import render_risk_signals_block
+
+_PAYOUT_STATUS_DOTS = {
+    PayoutAccountStatus.ready: "bg-success",
+    PayoutAccountStatus.under_review: "bg-warning",
+    PayoutAccountStatus.incomplete: "bg-warning",
+    PayoutAccountStatus.paused: "bg-error",
+}
 
 
 class OverviewSection(ChecklistMixin):
@@ -753,6 +761,42 @@ class OverviewSection(ChecklistMixin):
                         text(
                             f"{self.unrefunded_orders_count} unrefunded order{'s' if self.unrefunded_orders_count != 1 else ''} — should be auto-refunded before approval."
                         )
+
+                self._render_payout_account_row()
+
+    def _render_payout_account_row(self) -> None:
+        """Payout status with Stripe's raw `disabled_reason`.
+
+        The merchant only ever sees a generic message for the paused reasons, so
+        this is the one place the actual reason is readable.
+        """
+        payout_account = self.org.payout_account
+
+        if payout_account is None:
+            render_checklist_row("Payout Account", False, None)
+            return
+
+        status = payout_account.status
+        dot_class = _PAYOUT_STATUS_DOTS[status]
+        requirements = payout_account.data.get("requirements") or {}
+        disabled_reason = requirements.get("disabled_reason")
+
+        value = status.value.replace("_", " ").capitalize()
+        if disabled_reason:
+            value = f"{value} — {disabled_reason}"
+
+        with tag.div(
+            classes="flex items-center justify-between py-2 border-b border-base-200"
+        ):
+            with tag.div(classes="flex items-center gap-2"):
+                with tag.span(
+                    classes=f"w-2.5 h-2.5 rounded-full {dot_class} inline-block"
+                ):
+                    pass
+                with tag.span(classes="text-sm font-medium"):
+                    text("Payout Account")
+            with tag.span(classes="text-sm"):
+                text(value)
 
     # ------------------------------------------------------------------
     # Main render: AI review first, then supporting evidence

--- a/server/polar/enums.py
+++ b/server/polar/enums.py
@@ -55,6 +55,13 @@ class PayoutAccountType(StrEnum):
         }[self]
 
 
+class PayoutAccountStatus(StrEnum):
+    incomplete = "incomplete"
+    under_review = "under_review"
+    paused = "paused"
+    ready = "ready"
+
+
 class RecurringInterval(StrEnum):
     day = "day"
     week = "week"

--- a/server/polar/integrations/stripe/endpoints.py
+++ b/server/polar/integrations/stripe/endpoints.py
@@ -1,12 +1,18 @@
 import stripe
 import structlog
 from fastapi import Depends, HTTPException, Query, Request
+from pydantic import UUID4
 from starlette.responses import RedirectResponse
 
+from polar.auth.dependencies import WebUserOrAnonymous
+from polar.auth.models import is_user
 from polar.config import settings
 from polar.external_event.service import external_event as external_event_service
 from polar.kit.http import get_safe_return_url
 from polar.models.external_event import ExternalEventSource
+from polar.payout_account.repository import PayoutAccountRepository
+from polar.payout_account.service import PayoutAccountExternalLinkUnsupported
+from polar.payout_account.service import payout_account as payout_account_service
 from polar.postgres import AsyncSession, get_db_session
 from polar.routing import APIRouter
 
@@ -61,11 +67,33 @@ async def enqueue(session: AsyncSession, event: stripe.Event) -> None:
 
 @router.get("/refresh", name="integrations.stripe.refresh")
 async def stripe_connect_refresh(
+    auth_subject: WebUserOrAnonymous,
     return_path: str | None = Query(None),
+    id: UUID4 | None = Query(None),
+    session: AsyncSession = Depends(get_db_session),
 ) -> RedirectResponse:
+    """Mint a replacement Account Link when Stripe reports the current one is stale."""
     if return_path is None:
         raise HTTPException(404)
-    return RedirectResponse(get_safe_return_url(return_path))
+
+    dashboard = RedirectResponse(get_safe_return_url(return_path))
+
+    # Links minted before this parameter existed carry no `id`.
+    if id is None or not is_user(auth_subject):
+        return dashboard
+
+    repository = PayoutAccountRepository.from_session(session)
+    payout_account = await repository.get_by_id(id)
+    if payout_account is None or payout_account.admin_id != auth_subject.subject.id:
+        return dashboard
+
+    try:
+        link = await payout_account_service.onboarding_link(payout_account, return_path)
+    except (PayoutAccountExternalLinkUnsupported, stripe.StripeError):
+        log.warning("stripe.connect.refresh_link_failed", payout_account_id=str(id))
+        return dashboard
+
+    return RedirectResponse(link.url)
 
 
 class WebhookEventGetter:

--- a/server/polar/integrations/stripe/service.py
+++ b/server/polar/integrations/stripe/service.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from collections.abc import AsyncGenerator, AsyncIterator
 from typing import TYPE_CHECKING, Any, Literal, Unpack, cast, overload
 from urllib.parse import urlencode
@@ -160,10 +161,15 @@ class StripeService:
         return (cast(str, account.default_currency), 0)
 
     async def create_account_link(
-        self, stripe_id: str, return_path: str
+        self, stripe_id: str, return_path: str, payout_account_id: uuid.UUID
     ) -> stripe_lib.AccountLink:
+        # Account links are single-use and short-lived. Stripe sends the merchant to
+        # `refresh_url` once one goes stale, and we mint a replacement from `id`.
+        refresh_query = urlencode(
+            {"return_path": return_path, "id": str(payout_account_id)}
+        )
         refresh_url = settings.generate_external_url(
-            f"/v1/integrations/stripe/refresh?{urlencode({'return_path': return_path})}"
+            f"/v1/integrations/stripe/refresh?{refresh_query}"
         )
         return_url = get_safe_return_url(return_path)
         return await stripe_lib.AccountLink.create_async(

--- a/server/polar/integrations/stripe/service.py
+++ b/server/polar/integrations/stripe/service.py
@@ -120,6 +120,9 @@ class StripeService:
         log.info("stripe.account.update_website", account_id=id, url=url)
         await stripe_lib.Account.modify_async(id, business_profile={"url": url})
 
+    async def retrieve_account(self, id: str) -> stripe_lib.Account:
+        return await stripe_lib.Account.retrieve_async(id)
+
     async def account_exists(self, id: str) -> bool:
         try:
             account = await stripe_lib.Account.retrieve_async(id)

--- a/server/polar/models/payout_account.py
+++ b/server/polar/models/payout_account.py
@@ -5,12 +5,22 @@ from sqlalchemy import Boolean, ForeignKey, String, Uuid
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
-from polar.enums import PayoutAccountType
+from polar.enums import PayoutAccountStatus, PayoutAccountType
 from polar.kit.db.models import RecordModel
 from polar.kit.extensions.sqlalchemy import StringEnum
 
 if TYPE_CHECKING:
     from .user import User
+
+# Stripe `requirements.disabled_reason` values the merchant can act on themselves.
+ACTION_REQUIRED_DISABLED_REASONS = frozenset(
+    {"requirements.past_due", "action_required.requested_capabilities"}
+)
+# Values meaning Stripe is still deciding. Anything else — `listed`, `rejected.*`,
+# `platform_paused`, `other` — is a compliance outcome we don't disclose to the merchant.
+AWAITING_STRIPE_DISABLED_REASONS = frozenset(
+    {"requirements.pending_verification", "under_review"}
+)
 
 
 class PayoutAccount(RecordModel):
@@ -57,3 +67,26 @@ class PayoutAccount(RecordModel):
         return self.type != PayoutAccountType.stripe or (
             self.is_payouts_enabled and self.stripe_id is not None
         )
+
+    @property
+    def status(self) -> PayoutAccountStatus:
+        if self.is_payout_ready:
+            return PayoutAccountStatus.ready
+
+        requirements = self.data.get("requirements") or {}
+        disabled_reason = requirements.get("disabled_reason")
+
+        if (
+            self.stripe_id is None
+            or not self.is_details_submitted
+            or disabled_reason in ACTION_REQUIRED_DISABLED_REASONS
+        ):
+            return PayoutAccountStatus.incomplete
+
+        if (
+            disabled_reason is None
+            or disabled_reason in AWAITING_STRIPE_DISABLED_REASONS
+        ):
+            return PayoutAccountStatus.under_review
+
+        return PayoutAccountStatus.paused

--- a/server/polar/payout_account/endpoints.py
+++ b/server/polar/payout_account/endpoints.py
@@ -21,7 +21,11 @@ from polar.routing import APIRouter
 
 from .schemas import PayoutAccount as PayoutAccountSchema
 from .schemas import PayoutAccountCreate, PayoutAccountLink
-from .service import PayoutAccountSyncFailed, PayoutAccountSyncUnsupported
+from .service import (
+    PayoutAccountStripeAccountDoesNotExist,
+    PayoutAccountSyncFailed,
+    PayoutAccountSyncUnsupported,
+)
 from .service import payout_account as payout_account_service
 
 router = APIRouter(prefix="/payout-accounts", tags=["payout_accounts", APITag.private])
@@ -74,6 +78,7 @@ async def delete(
     response_model=PayoutAccountSchema,
     responses={
         404: {"model": PayoutAccountSyncUnsupported.schema()},
+        422: {"model": PayoutAccountStripeAccountDoesNotExist.schema()},
         503: {"model": PayoutAccountSyncFailed.schema()},
     },
 )

--- a/server/polar/payout_account/endpoints.py
+++ b/server/polar/payout_account/endpoints.py
@@ -21,6 +21,7 @@ from polar.routing import APIRouter
 
 from .schemas import PayoutAccount as PayoutAccountSchema
 from .schemas import PayoutAccountCreate, PayoutAccountLink
+from .service import PayoutAccountSyncUnsupported
 from .service import payout_account as payout_account_service
 
 router = APIRouter(prefix="/payout-accounts", tags=["payout_accounts", APITag.private])
@@ -66,6 +67,18 @@ async def delete(
     session: AsyncSession = Depends(get_db_session),
 ) -> None:
     await payout_account_service.delete(session, authz.payout_account)
+
+
+@router.post(
+    "/{id}/sync",
+    response_model=PayoutAccountSchema,
+    responses={404: {"model": PayoutAccountSyncUnsupported.schema()}},
+)
+async def sync(
+    authz: AuthorizePayoutAccountWrite,
+    session: AsyncSession = Depends(get_db_session),
+) -> PayoutAccount:
+    return await payout_account_service.sync_from_stripe(session, authz.payout_account)
 
 
 @router.post("/{id}/onboarding-link", response_model=PayoutAccountLink)

--- a/server/polar/payout_account/endpoints.py
+++ b/server/polar/payout_account/endpoints.py
@@ -21,7 +21,7 @@ from polar.routing import APIRouter
 
 from .schemas import PayoutAccount as PayoutAccountSchema
 from .schemas import PayoutAccountCreate, PayoutAccountLink
-from .service import PayoutAccountSyncUnsupported
+from .service import PayoutAccountSyncFailed, PayoutAccountSyncUnsupported
 from .service import payout_account as payout_account_service
 
 router = APIRouter(prefix="/payout-accounts", tags=["payout_accounts", APITag.private])
@@ -72,7 +72,10 @@ async def delete(
 @router.post(
     "/{id}/sync",
     response_model=PayoutAccountSchema,
-    responses={404: {"model": PayoutAccountSyncUnsupported.schema()}},
+    responses={
+        404: {"model": PayoutAccountSyncUnsupported.schema()},
+        503: {"model": PayoutAccountSyncFailed.schema()},
+    },
 )
 async def sync(
     authz: AuthorizePayoutAccountWrite,

--- a/server/polar/payout_account/schemas.py
+++ b/server/polar/payout_account/schemas.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from pydantic import BeforeValidator, Field
 
-from polar.enums import PayoutAccountType
+from polar.enums import PayoutAccountStatus, PayoutAccountType
 from polar.kit.address import upper_if_str
 from polar.kit.schemas import IDSchema, Schema, TimestampedSchema
 
@@ -145,6 +145,7 @@ class PayoutAccount(TimestampedSchema, IDSchema):
     country: str
     currency: str
     is_payout_ready: bool
+    status: PayoutAccountStatus
 
 
 class PayoutAccountLink(Schema):

--- a/server/polar/payout_account/service.py
+++ b/server/polar/payout_account/service.py
@@ -247,6 +247,17 @@ class PayoutAccountService:
 
         try:
             stripe_account = await stripe.retrieve_account(payout_account.stripe_id)
+        except (stripe_lib.PermissionError, stripe_lib.InvalidRequestError) as e:
+            # Deleted, or we lost access. Retrying can't repair it, so it must not read
+            # as a transient outage.
+            log.warning(
+                "payout_account.sync_account_gone",
+                stripe_id=payout_account.stripe_id,
+                error=str(e),
+            )
+            raise PayoutAccountStripeAccountDoesNotExist(
+                payout_account.stripe_id
+            ) from e
         except stripe_lib.StripeError as e:
             log.warning(
                 "payout_account.sync_failed",

--- a/server/polar/payout_account/service.py
+++ b/server/polar/payout_account/service.py
@@ -136,7 +136,7 @@ class PayoutAccountService:
             case PayoutAccountType.stripe:
                 assert payout_account.stripe_id is not None
                 account_link = await stripe.create_account_link(
-                    payout_account.stripe_id, return_path
+                    payout_account.stripe_id, return_path, payout_account.id
                 )
                 return PayoutAccountLink(url=account_link.url)
             case _:

--- a/server/polar/payout_account/service.py
+++ b/server/polar/payout_account/service.py
@@ -4,6 +4,7 @@ import uuid
 from collections.abc import Sequence
 
 import stripe as stripe_lib
+import structlog
 
 from polar.auth.models import AuthSubject
 from polar.authz.service import get_accessible_org_ids
@@ -19,6 +20,8 @@ from polar.postgres import AsyncSession
 
 from .repository import PayoutAccountRepository
 from .schemas import PayoutAccountCreate, PayoutAccountLink
+
+log = structlog.get_logger()
 
 
 class PayoutAccountServiceError(PolarError):
@@ -44,6 +47,13 @@ class PayoutAccountSyncUnsupported(PayoutAccountServiceError):
         self.account_type = account_type
         message = f"Unsupported payout account type for sync: {account_type}"
         super().__init__(message, 404)
+
+
+class PayoutAccountSyncFailed(PayoutAccountServiceError):
+    def __init__(self, stripe_id: str) -> None:
+        self.stripe_id = stripe_id
+        message = "Could not reach Stripe to refresh this payout account."
+        super().__init__(message, 503)
 
 
 class PayoutAccountStripeAccountDoesNotExist(PayoutAccountServiceError):
@@ -235,7 +245,16 @@ class PayoutAccountService:
         ):
             raise PayoutAccountSyncUnsupported(payout_account.type)
 
-        stripe_account = await stripe.retrieve_account(payout_account.stripe_id)
+        try:
+            stripe_account = await stripe.retrieve_account(payout_account.stripe_id)
+        except stripe_lib.StripeError as e:
+            log.warning(
+                "payout_account.sync_failed",
+                stripe_id=payout_account.stripe_id,
+                error=str(e),
+            )
+            raise PayoutAccountSyncFailed(payout_account.stripe_id) from e
+
         return await self.update_account_from_stripe(
             session, stripe_account=stripe_account
         )

--- a/server/polar/payout_account/service.py
+++ b/server/polar/payout_account/service.py
@@ -39,6 +39,13 @@ class PayoutAccountExternalLinkUnsupported(PayoutAccountServiceError):
         super().__init__(message, 404)
 
 
+class PayoutAccountSyncUnsupported(PayoutAccountServiceError):
+    def __init__(self, account_type: PayoutAccountType) -> None:
+        self.account_type = account_type
+        message = f"Unsupported payout account type for sync: {account_type}"
+        super().__init__(message, 404)
+
+
 class PayoutAccountStripeAccountDoesNotExist(PayoutAccountServiceError):
     def __init__(self, stripe_id: str) -> None:
         self.stripe_id = stripe_id
@@ -213,6 +220,25 @@ class PayoutAccountService:
         if not await stripe.account_exists(payout_account.stripe_id):
             return
         await stripe.reject_account(payout_account.stripe_id, reason)
+
+    async def sync_from_stripe(
+        self, session: AsyncSession, payout_account: PayoutAccount
+    ) -> PayoutAccount:
+        """Refresh a payout account from Stripe, bypassing the `account.updated` webhook.
+
+        Stripe can enable or disable payouts without firing the webhook, and a merchant
+        stuck on a stale status has no other way to recheck.
+        """
+        if (
+            payout_account.type != PayoutAccountType.stripe
+            or payout_account.stripe_id is None
+        ):
+            raise PayoutAccountSyncUnsupported(payout_account.type)
+
+        stripe_account = await stripe.retrieve_account(payout_account.stripe_id)
+        return await self.update_account_from_stripe(
+            session, stripe_account=stripe_account
+        )
 
     async def update_account_from_stripe(
         self, session: AsyncSession, *, stripe_account: stripe_lib.Account

--- a/server/polar/rate_limit.py
+++ b/server/polar/rate_limit.py
@@ -240,6 +240,12 @@ _BASE_RULES: dict[str, Sequence[Rule]] = {
             hour=60,
             zone="payout-account-sync",
         ),
+        Rule(
+            group=RateLimitGroup.pending_auth,
+            minute=10,
+            hour=60,
+            zone="payout-account-sync",
+        ),
     ],
     "^/v1/feedbacks/": [
         Rule(hour=5, block_time=3600, zone="feedback-submit"),

--- a/server/polar/rate_limit.py
+++ b/server/polar/rate_limit.py
@@ -230,6 +230,17 @@ _BASE_RULES: dict[str, Sequence[Rule]] = {
             zone="checkout-confirm",
         ),
     ],
+    # Each call is a live Stripe API read, so it's capped well below the `web` group's
+    # catch-all allowance.
+    "^/v1/payout-accounts/[^/]+/sync": [
+        Rule(minute=10, hour=60, zone="payout-account-sync"),
+        Rule(
+            group=RateLimitGroup.web,
+            minute=10,
+            hour=60,
+            zone="payout-account-sync",
+        ),
+    ],
     "^/v1/feedbacks/": [
         Rule(hour=5, block_time=3600, zone="feedback-submit"),
         Rule(

--- a/server/tests/integrations/stripe/test_endpoints.py
+++ b/server/tests/integrations/stripe/test_endpoints.py
@@ -1,10 +1,25 @@
+import uuid
+
 import pytest
+import stripe as stripe_lib
 from fastapi import HTTPException
 from httpx import AsyncClient
+from pytest_mock import MockerFixture
 from starlette.requests import Request
 
 from polar.config import settings
 from polar.integrations.stripe.endpoints import WebhookEventGetter
+from polar.integrations.stripe.service import StripeService
+from polar.models import Organization, User
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_payout_account
+
+
+@pytest.fixture
+def stripe_service_mock(mocker: MockerFixture) -> StripeService:
+    mock = mocker.MagicMock(spec=StripeService)
+    mocker.patch("polar.payout_account.service.stripe", new=mock)
+    return mock
 
 
 @pytest.mark.asyncio
@@ -44,6 +59,96 @@ class TestStripeConnectRefresh:
         assert response.status_code == 307
         assert response.headers["location"] == settings.generate_frontend_url(
             settings.FRONTEND_DEFAULT_RETURN_PATH
+        )
+
+    @pytest.mark.auth
+    async def test_mints_a_new_account_link(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+        stripe_service_mock: StripeService,
+    ) -> None:
+        payout_account = await create_payout_account(save_fixture, organization, user)
+        stripe_service_mock.create_account_link.return_value = (  # type: ignore[attr-defined]
+            stripe_lib.AccountLink.construct_from(
+                {"url": "https://connect.stripe.com/setup/fresh"}, None
+            )
+        )
+
+        response = await client.get(
+            "/v1/integrations/stripe/refresh",
+            params={
+                "return_path": "/dashboard/acme/finance/account",
+                "id": str(payout_account.id),
+            },
+        )
+
+        assert response.status_code == 307
+        assert response.headers["location"] == "https://connect.stripe.com/setup/fresh"
+
+    async def test_anonymous_falls_back_to_dashboard(self, client: AsyncClient) -> None:
+        return_path = "/dashboard/acme/finance/account"
+
+        response = await client.get(
+            "/v1/integrations/stripe/refresh",
+            params={"return_path": return_path, "id": str(uuid.uuid4())},
+        )
+
+        assert response.status_code == 307
+        assert response.headers["location"] == settings.generate_frontend_url(
+            return_path
+        )
+
+    @pytest.mark.auth
+    async def test_other_users_account_falls_back_to_dashboard(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_second: User,
+        stripe_service_mock: StripeService,
+    ) -> None:
+        return_path = "/dashboard/acme/finance/account"
+        payout_account = await create_payout_account(
+            save_fixture, organization, user_second
+        )
+
+        response = await client.get(
+            "/v1/integrations/stripe/refresh",
+            params={"return_path": return_path, "id": str(payout_account.id)},
+        )
+
+        assert response.status_code == 307
+        assert response.headers["location"] == settings.generate_frontend_url(
+            return_path
+        )
+        stripe_service_mock.create_account_link.assert_not_called()  # type: ignore[attr-defined]
+
+    @pytest.mark.auth
+    async def test_stripe_error_falls_back_to_dashboard(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+        stripe_service_mock: StripeService,
+    ) -> None:
+        return_path = "/dashboard/acme/finance/account"
+        payout_account = await create_payout_account(save_fixture, organization, user)
+        stripe_service_mock.create_account_link.side_effect = (  # type: ignore[attr-defined]
+            stripe_lib.APIConnectionError("boom")
+        )
+
+        response = await client.get(
+            "/v1/integrations/stripe/refresh",
+            params={"return_path": return_path, "id": str(payout_account.id)},
+        )
+
+        assert response.status_code == 307
+        assert response.headers["location"] == settings.generate_frontend_url(
+            return_path
         )
 
 

--- a/server/tests/models/test_payout_account.py
+++ b/server/tests/models/test_payout_account.py
@@ -1,0 +1,92 @@
+from typing import Any
+
+import pytest
+
+from polar.enums import PayoutAccountStatus, PayoutAccountType
+from polar.models import PayoutAccount
+
+
+def build_payout_account(
+    *,
+    type: PayoutAccountType = PayoutAccountType.stripe,
+    stripe_id: str | None = "STRIPE_ID",
+    is_details_submitted: bool = True,
+    is_payouts_enabled: bool = False,
+    disabled_reason: str | None = None,
+) -> PayoutAccount:
+    data: dict[str, Any] = {"requirements": {"disabled_reason": disabled_reason}}
+    return PayoutAccount(
+        type=type,
+        stripe_id=stripe_id,
+        country="US",
+        currency="usd",
+        is_details_submitted=is_details_submitted,
+        is_charges_enabled=True,
+        is_payouts_enabled=is_payouts_enabled,
+        data=data,
+    )
+
+
+class TestStatus:
+    def test_ready(self) -> None:
+        payout_account = build_payout_account(is_payouts_enabled=True)
+        assert payout_account.status == PayoutAccountStatus.ready
+
+    def test_manual_account_is_ready(self) -> None:
+        payout_account = build_payout_account(
+            type=PayoutAccountType.manual, stripe_id=None
+        )
+        assert payout_account.status == PayoutAccountStatus.ready
+
+    def test_details_not_submitted(self) -> None:
+        payout_account = build_payout_account(is_details_submitted=False)
+        assert payout_account.status == PayoutAccountStatus.incomplete
+
+    def test_disconnected_account(self) -> None:
+        payout_account = build_payout_account(stripe_id=None)
+        assert payout_account.status == PayoutAccountStatus.incomplete
+
+    @pytest.mark.parametrize(
+        "disabled_reason",
+        ["requirements.past_due", "action_required.requested_capabilities"],
+    )
+    def test_action_required(self, disabled_reason: str) -> None:
+        payout_account = build_payout_account(disabled_reason=disabled_reason)
+        assert payout_account.status == PayoutAccountStatus.incomplete
+
+    @pytest.mark.parametrize(
+        "disabled_reason",
+        [None, "requirements.pending_verification", "under_review"],
+    )
+    def test_awaiting_stripe(self, disabled_reason: str | None) -> None:
+        payout_account = build_payout_account(disabled_reason=disabled_reason)
+        assert payout_account.status == PayoutAccountStatus.under_review
+
+    @pytest.mark.parametrize(
+        "disabled_reason",
+        [
+            "listed",
+            "rejected.listed",
+            "rejected.fraud",
+            "rejected.terms_of_service",
+            "platform_paused",
+            "other",
+            "a_reason_stripe_added_after_we_shipped_this",
+        ],
+    )
+    def test_paused(self, disabled_reason: str) -> None:
+        payout_account = build_payout_account(disabled_reason=disabled_reason)
+        assert payout_account.status == PayoutAccountStatus.paused
+
+    def test_missing_requirements(self) -> None:
+        payout_account = PayoutAccount(
+            type=PayoutAccountType.stripe,
+            stripe_id="STRIPE_ID",
+            country="US",
+            currency="usd",
+            is_details_submitted=True,
+            is_charges_enabled=True,
+            is_payouts_enabled=False,
+            data={},
+        )
+        assert payout_account.status == PayoutAccountStatus.under_review

--- a/server/tests/payout_account/test_endpoints.py
+++ b/server/tests/payout_account/test_endpoints.py
@@ -255,3 +255,24 @@ class TestDashboardLink:
         )
 
         assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestSync:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.post(f"/v1/payout-accounts/{uuid.uuid4()}/sync")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_user_cannot_access_other_organization_account(
+        self,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        payout_account_organization_second: PayoutAccount,
+    ) -> None:
+        response = await client.post(
+            f"/v1/payout-accounts/{payout_account_organization_second.id}/sync"
+        )
+
+        assert response.status_code == 404

--- a/server/tests/payout_account/test_service.py
+++ b/server/tests/payout_account/test_service.py
@@ -295,7 +295,29 @@ class TestSyncFromStripe:
 
         stripe_service_mock.retrieve_account.assert_not_called()  # type: ignore[attr-defined]
 
-    async def test_stripe_error_raises_sync_failed(
+    @pytest.mark.parametrize(
+        "error",
+        [
+            stripe_lib.PermissionError("no access"),
+            stripe_lib.InvalidRequestError("no such account", param="account"),
+        ],
+    )
+    async def test_inaccessible_account_is_not_transient(
+        self,
+        error: stripe_lib.StripeError,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+        stripe_service_mock: StripeService,
+    ) -> None:
+        payout_account = await create_payout_account(save_fixture, organization, user)
+        stripe_service_mock.retrieve_account.side_effect = error  # type: ignore[attr-defined]
+
+        with pytest.raises(PayoutAccountStripeAccountDoesNotExist):
+            await payout_account_service.sync_from_stripe(session, payout_account)
+
+    async def test_unreachable_stripe_raises_sync_failed(
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
@@ -305,7 +327,7 @@ class TestSyncFromStripe:
     ) -> None:
         payout_account = await create_payout_account(save_fixture, organization, user)
         stripe_service_mock.retrieve_account.side_effect = (  # type: ignore[attr-defined]
-            stripe_lib.PermissionError("no access")
+            stripe_lib.APIConnectionError("boom")
         )
 
         with pytest.raises(PayoutAccountSyncFailed):

--- a/server/tests/payout_account/test_service.py
+++ b/server/tests/payout_account/test_service.py
@@ -12,6 +12,7 @@ from polar.payout_account.service import (
     PayoutAccountLinkedToOrganization,
     PayoutAccountNonZeroBalance,
     PayoutAccountStripeAccountDoesNotExist,
+    PayoutAccountSyncFailed,
     PayoutAccountSyncUnsupported,
 )
 from polar.payout_account.service import (
@@ -293,3 +294,19 @@ class TestSyncFromStripe:
             await payout_account_service.sync_from_stripe(session, payout_account)
 
         stripe_service_mock.retrieve_account.assert_not_called()  # type: ignore[attr-defined]
+
+    async def test_stripe_error_raises_sync_failed(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+        stripe_service_mock: StripeService,
+    ) -> None:
+        payout_account = await create_payout_account(save_fixture, organization, user)
+        stripe_service_mock.retrieve_account.side_effect = (  # type: ignore[attr-defined]
+            stripe_lib.PermissionError("no access")
+        )
+
+        with pytest.raises(PayoutAccountSyncFailed):
+            await payout_account_service.sync_from_stripe(session, payout_account)

--- a/server/tests/payout_account/test_service.py
+++ b/server/tests/payout_account/test_service.py
@@ -1,8 +1,9 @@
 import pytest
+import stripe as stripe_lib
 from pytest_mock import MockerFixture
 
 from polar.auth.models import AuthSubject
-from polar.enums import PayoutAccountType
+from polar.enums import PayoutAccountStatus, PayoutAccountType
 from polar.integrations.stripe.service import StripeService
 from polar.models import Organization, User
 from polar.models.payout_attempt import PayoutAttemptStatus
@@ -11,6 +12,7 @@ from polar.payout_account.service import (
     PayoutAccountLinkedToOrganization,
     PayoutAccountNonZeroBalance,
     PayoutAccountStripeAccountDoesNotExist,
+    PayoutAccountSyncUnsupported,
 )
 from polar.payout_account.service import (
     payout_account as payout_account_service,
@@ -235,3 +237,59 @@ class TestRejectStripeAccount:
         )
 
         stripe_service_mock.reject_account.assert_not_called()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+class TestSyncFromStripe:
+    async def test_updates_account_from_stripe(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+        stripe_service_mock: StripeService,
+    ) -> None:
+        payout_account = await create_payout_account(
+            save_fixture, organization, user, is_payouts_enabled=False
+        )
+        stripe_service_mock.retrieve_account.return_value = (  # type: ignore[attr-defined]
+            stripe_lib.Account.construct_from(
+                {
+                    "id": payout_account.stripe_id,
+                    "email": "merchant@example.com",
+                    "country": "DE",
+                    "default_currency": "eur",
+                    "details_submitted": True,
+                    "charges_enabled": True,
+                    "payouts_enabled": True,
+                    "requirements": {"disabled_reason": None},
+                },
+                None,
+            )
+        )
+
+        updated = await payout_account_service.sync_from_stripe(session, payout_account)
+
+        assert updated.is_payouts_enabled is True
+        assert updated.status == PayoutAccountStatus.ready
+
+    async def test_manual_account_is_unsupported(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user: User,
+        stripe_service_mock: StripeService,
+    ) -> None:
+        payout_account = await create_payout_account(
+            save_fixture,
+            organization,
+            user,
+            type=PayoutAccountType.manual,
+            stripe_id=None,
+        )
+
+        with pytest.raises(PayoutAccountSyncUnsupported):
+            await payout_account_service.sync_from_stripe(session, payout_account)
+
+        stripe_service_mock.retrieve_account.assert_not_called()  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Merchants who finished Stripe Connect onboarding were told to start over. Five different situations all rendered the same card, so a merchant waiting on Stripe read the identical prompt as one who had never begun — and clicked it again, for days.

## What

- Derive a `PayoutAccountStatus` (`ready` / `under_review` / `paused` / `incomplete`) from  columns and the `requirements` payload we already store. No migration.
- Render five distinct states across both payout cards, from one shared presentation map.
- Add `POST /v1/payout-accounts/{id}/sync`, an authoritative read from Stripe that bypasses the `account.updated` webhook, rate limited to 10/minute. The backoffice resync moves onto  the same service method.
- Add a "Check status" button, shown only where waiting is the situation.
- Confirm the outcome on return from Stripe, instead of leaving the merchant on an unchanged page.
- Make `refresh_url` mint a fresh Account Link, as Stripe's contract expects.
- Surface Stripe's raw `disabled_reason` in the backoffice Setup & Checklist card.

#### `paused` reasons are never shown to the merchant, `listed` means Stripe's sanctions screening matched them.
Support reads the exact reason in the backoffice instead: 

<img width="519" height="679" alt="Screenshot 2026-07-21 at 14 54 31" src="https://github.com/user-attachments/assets/411f1005-7c86-404b-a0ad-523af4abc40f" />


#### `incomplete` and `under_review` reasons are safe and get plain-English copy. 

<table>
<tr>
<td width="50%">
<b>Paused</b> — Stripe pulled payouts. Generic message, support link, no reason disclosed.
<img width="100%" alt="Payouts are paused" src="https://github.com/user-attachments/assets/4b34738d-8246-4045-bd4b-7abd4b7b8558" />
</td>
<td width="50%">
<b>Under review</b> — setup is complete and nothing is needed from the merchant.
<img width="100%" alt="Stripe is reviewing your account" src="https://github.com/user-attachments/assets/df77d972-5972-4f79-8a45-3d6654258a46" />
</td>
</tr>
<tr>
<td width="50%">
<b>Incomplete</b> — Stripe wants more information. Sends them back to finish.
<img width="100%" alt="Finish payout setup" src="https://github.com/user-attachments/assets/4751b7e0-0b13-4a2d-8ca8-d80c31e58e44" />
</td>
<td width="50%">
<b>Not connected</b> — the only state that should ever say "Connect payout account".
<img width="100%" alt="Connect payout account" src="https://github.com/user-attachments/assets/8149a930-ea7a-4aaf-8336-22a1fae43892" />
</td>
</tr>
<tr>
<td width="50%">
<b>Ready</b> — payouts enabled.
<img width="100%" alt="Payout account connected" src="https://github.com/user-attachments/assets/c91b210e-268f-498d-9519-b2bcfd5e8960" />
</td>
<td width="50%">
<b>Before this PR</b>, the first four all rendered as the fourth: <i>"Connect payout account
— Continue with Account Setup"</i>.
</td>
</tr>
</table>

> [!WARNING]
> **Not verified end to end.** The live Stripe redirect path — onboarding → return, and stale link → `refresh_url` — wasn't exercised against Stripe's servers. (Enabling Connect and completing the platform profile locally, now routed through Stripe's new Sandbox environment)
>
> Covered instead by four tests on the refresh endpoint: mints a fresh link, and falls back to the dashboard for anonymous callers, another user's account, and Stripe errors. 

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

