### PR TITLE
add payment_method column to checkouts

### DIFF
--- a/server/migrations/versions/2026-07-21-1000_add_payment_method_to_checkouts.py
+++ b/server/migrations/versions/2026-07-21-1000_add_payment_method_to_checkouts.py
@@ -1,0 +1,30 @@
+"""add payment_method to checkouts
+
+Revision ID: a1c2f95b7d31
+Revises: 55a5e94aaf9d
+Create Date: 2026-07-21 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "a1c2f95b7d31"
+down_revision = "55a5e94aaf9d"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.add_column("checkouts", sa.Column("payment_method", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    op.execute("SET LOCAL lock_timeout = '5s'")
+    op.drop_column("checkouts", "payment_method")

--- a/server/migrations/versions/2026-07-21-1000_add_payment_method_type_to_checkouts.py
+++ b/server/migrations/versions/2026-07-21-1000_add_payment_method_type_to_checkouts.py
@@ -1,4 +1,4 @@
-"""add payment_method to checkouts
+"""add payment_method_type to checkouts
 
 Revision ID: a1c2f95b7d31
 Revises: 55a5e94aaf9d
@@ -21,10 +21,12 @@ depends_on: tuple[str] | None = None
 def upgrade() -> None:
     # Ensures we don't break app by applying a deadlock-inducing migration
     op.execute("SET LOCAL lock_timeout = '5s'")
-    op.add_column("checkouts", sa.Column("payment_method", sa.String(), nullable=True))
+    op.add_column(
+        "checkouts", sa.Column("payment_method_type", sa.String(), nullable=True)
+    )
 
 
 def downgrade() -> None:
     # Ensures we don't break app by applying a deadlock-inducing migration
     op.execute("SET LOCAL lock_timeout = '5s'")
-    op.drop_column("checkouts", "payment_method")
+    op.drop_column("checkouts", "payment_method_type")

--- a/server/polar/models/checkout.py
+++ b/server/polar/models/checkout.py
@@ -391,7 +391,7 @@ class Checkout(
     ] = association_proxy("product", "attached_custom_fields")
 
     @property
-    def is_full_billing_address_required(self) -> bool:
+    def is_billing_address_required(self) -> bool:
         return (
             self.require_billing_address
             or self.is_business_customer
@@ -403,7 +403,7 @@ class Checkout(
         address = self.customer_billing_address
         country = address.country if address else None
         is_us = country == "US"
-        require_billing_address = self.is_full_billing_address_required or is_us
+        require_billing_address = self.is_billing_address_required or is_us
         return {
             "country": True,
             "state": country in {"US", "CA"},
@@ -418,7 +418,7 @@ class Checkout(
         address = self.customer_billing_address
         country = address.country if address else None
         is_us = country == "US"
-        require_billing_address = self.is_full_billing_address_required or is_us
+        require_billing_address = self.is_billing_address_required or is_us
         return {
             "country": BillingAddressFieldMode.required,
             "state": BillingAddressFieldMode.required

--- a/server/polar/models/checkout.py
+++ b/server/polar/models/checkout.py
@@ -121,7 +121,7 @@ class Checkout(
     payment_processor_metadata: Mapped[dict[str, Any]] = mapped_column(
         JSONB, nullable=False, default=dict
     )
-    payment_method: Mapped[str | None] = mapped_column(
+    payment_method_type: Mapped[str | None] = mapped_column(
         String, nullable=True, default=None
     )
     return_url: Mapped[str | None] = mapped_column(String, nullable=True, default=None)
@@ -395,7 +395,7 @@ class Checkout(
         return (
             self.require_billing_address
             or self.is_business_customer
-            or self.payment_method in FULL_BILLING_ADDRESS_PAYMENT_METHODS
+            or self.payment_method_type in FULL_BILLING_ADDRESS_PAYMENT_METHODS
         )
 
     @property

--- a/server/polar/models/checkout.py
+++ b/server/polar/models/checkout.py
@@ -96,6 +96,11 @@ class CheckoutAnalyticsMetadata(TypedDict, total=False):
     distinct_id: str | None
 
 
+# Payment methods for which the processor requires a full billing address
+# to process the payment, regardless of the customer's country.
+FULL_BILLING_ADDRESS_PAYMENT_METHODS: frozenset[str] = frozenset({"upi"})
+
+
 class Checkout(
     TrialConfigurationMixin, CustomFieldDataMixin, MetadataMixin, RecordModel
 ):
@@ -115,6 +120,9 @@ class Checkout(
     )
     payment_processor_metadata: Mapped[dict[str, Any]] = mapped_column(
         JSONB, nullable=False, default=dict
+    )
+    payment_method: Mapped[str | None] = mapped_column(
+        String, nullable=True, default=None
     )
     return_url: Mapped[str | None] = mapped_column(String, nullable=True, default=None)
     _success_url: Mapped[str | None] = mapped_column(
@@ -383,13 +391,19 @@ class Checkout(
     ] = association_proxy("product", "attached_custom_fields")
 
     @property
+    def is_full_billing_address_required(self) -> bool:
+        return (
+            self.require_billing_address
+            or self.is_business_customer
+            or self.payment_method in FULL_BILLING_ADDRESS_PAYMENT_METHODS
+        )
+
+    @property
     def customer_billing_address_fields(self) -> CheckoutCustomerBillingAddressFields:
         address = self.customer_billing_address
         country = address.country if address else None
         is_us = country == "US"
-        require_billing_address = (
-            self.require_billing_address or self.is_business_customer or is_us
-        )
+        require_billing_address = self.is_full_billing_address_required or is_us
         return {
             "country": True,
             "state": country in {"US", "CA"},
@@ -404,9 +418,7 @@ class Checkout(
         address = self.customer_billing_address
         country = address.country if address else None
         is_us = country == "US"
-        require_billing_address = (
-            self.require_billing_address or self.is_business_customer or is_us
-        )
+        require_billing_address = self.is_full_billing_address_required or is_us
         return {
             "country": BillingAddressFieldMode.required,
             "state": BillingAddressFieldMode.required


### PR DESCRIPTION
## Summary

**Related Issue**: https://github.com/polarsource/polar/issues/13280

Migration + model PR *(1/3)* for tracking the payment method selected by the
customer on the checkout form.

Better version than initial bad version: https://github.com/polarsource/polar/pull/13288

## What

- New nullable `payment_method` column on `checkouts` (Stripe payment method
  type string, e.g. `card`, `apple_pay`, `upi`), with migration.
- `FULL_BILLING_ADDRESS_PAYMENT_METHODS` (currently `{"upi"}`): payment
  methods that require a full billing address regardless of country.
- New `Checkout.is_full_billing_address_required` property combining the
  condition previously duplicated inline

## Why

Whether the billing address form is required currently depends on country
and merchant config only. Payment processors require a full billing address
for specific payment methods, so the checkout needs to know which method is
selected to show (and later enforce) the right fields.

## How

Column is nullable with no default and nothing writes it yet, so behavior is
provably unchanged (`payment_method IS NULL` for every row → the new
condition is always false).

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to re
- [x] New functionality is covered by tests — behavior is inert here; the
      update/confirm tests exercising it land in PR 2 (all 425 existing
      checkout tests pass on this branch)
- [x] Linting and type checking pass (`uv run task_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

