### PR TITLE
accept and enforce payment_method on checkout API

### DIFF
--- a/clients/packages/checkout/src/test-utils/makeCheckout.ts
+++ b/clients/packages/checkout/src/test-utils/makeCheckout.ts
@@ -129,6 +129,7 @@ const defaults: ProductCheckoutPublic = {
   customer_billing_name: null,
   customer_billing_address: null,
   customer_tax_id: null,
+  payment_method_type: null,
   payment_processor_metadata: {},
   billing_address_fields: {
     country: 'required',

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -12002,7 +12002,7 @@ export interface components {
       locale?: string | null
       /**
        * Payment Method Type
-       * @description Payment method type selected by the customer in the checkout form, e.g. `card`, `apple_pay` or `upi`. Some payment methods require a full billing address: keeping this value in sync allows `billing_address_fields` to reflect the fields to display.
+       * @description Payment method type selected by the customer in the checkout form, e.g. `card`, `apple_pay` or `upi`.
        */
       payment_method_type: string | null
       /** Payment Processor Metadata */
@@ -12126,7 +12126,7 @@ export interface components {
       locale?: string | null
       /**
        * Payment Method Type
-       * @description Payment method type selected by the customer in the checkout form, e.g. `card`, `apple_pay` or `upi`. Some payment methods require a full billing address: keeping this value in sync allows `billing_address_fields` to reflect the fields to display.
+       * @description Payment method type selected by the customer in the checkout form, e.g. `card`, `apple_pay` or `upi`.
        */
       payment_method_type?: string | null
       /**
@@ -13704,7 +13704,7 @@ export interface components {
       locale?: string | null
       /**
        * Payment Method Type
-       * @description Payment method type selected by the customer in the checkout form, e.g. `card`, `apple_pay` or `upi`. Some payment methods require a full billing address: keeping this value in sync allows `billing_address_fields` to reflect the fields to display.
+       * @description Payment method type selected by the customer in the checkout form, e.g. `card`, `apple_pay` or `upi`.
        */
       payment_method_type: string | null
       /** Payment Processor Metadata */
@@ -13975,7 +13975,7 @@ export interface components {
       locale?: string | null
       /**
        * Payment Method Type
-       * @description Payment method type selected by the customer in the checkout form, e.g. `card`, `apple_pay` or `upi`. Some payment methods require a full billing address: keeping this value in sync allows `billing_address_fields` to reflect the fields to display.
+       * @description Payment method type selected by the customer in the checkout form, e.g. `card`, `apple_pay` or `upi`.
        */
       payment_method_type: string | null
       /** Payment Processor Metadata */
@@ -14090,7 +14090,7 @@ export interface components {
       locale?: string | null
       /**
        * Payment Method Type
-       * @description Payment method type selected by the customer in the checkout form, e.g. `card`, `apple_pay` or `upi`. Some payment methods require a full billing address: keeping this value in sync allows `billing_address_fields` to reflect the fields to display.
+       * @description Payment method type selected by the customer in the checkout form, e.g. `card`, `apple_pay` or `upi`.
        */
       payment_method_type?: string | null
       /** @description The interval unit for the trial period. */
@@ -14218,7 +14218,7 @@ export interface components {
       locale?: string | null
       /**
        * Payment Method Type
-       * @description Payment method type selected by the customer in the checkout form, e.g. `card`, `apple_pay` or `upi`. Some payment methods require a full billing address: keeping this value in sync allows `billing_address_fields` to reflect the fields to display.
+       * @description Payment method type selected by the customer in the checkout form, e.g. `card`, `apple_pay` or `upi`.
        */
       payment_method_type?: string | null
       /**

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -12120,6 +12120,11 @@ export interface components {
       /** Locale */
       locale?: string | null
       /**
+       * Payment Method
+       * @description Payment method type selected by the customer in the checkout form, e.g. `card`, `apple_pay` or `upi`. Some payment methods require a full billing address: keeping this value in sync allows `billing_address_fields` to reflect the fields to display.
+       */
+      payment_method?: string | null
+      /**
        * Discount Code
        * @description Discount code to apply to the checkout.
        */
@@ -14068,6 +14073,11 @@ export interface components {
       customer_tax_id?: string | null
       /** Locale */
       locale?: string | null
+      /**
+       * Payment Method
+       * @description Payment method type selected by the customer in the checkout form, e.g. `card`, `apple_pay` or `upi`. Some payment methods require a full billing address: keeping this value in sync allows `billing_address_fields` to reflect the fields to display.
+       */
+      payment_method?: string | null
       /** @description The interval unit for the trial period. */
       trial_interval?: components['schemas']['TrialInterval'] | null
       /**
@@ -14191,6 +14201,11 @@ export interface components {
       customer_tax_id?: string | null
       /** Locale */
       locale?: string | null
+      /**
+       * Payment Method
+       * @description Payment method type selected by the customer in the checkout form, e.g. `card`, `apple_pay` or `upi`. Some payment methods require a full billing address: keeping this value in sync allows `billing_address_fields` to reflect the fields to display.
+       */
+      payment_method?: string | null
       /**
        * Discount Code
        * @description Discount code to apply to the checkout.

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -14088,11 +14088,6 @@ export interface components {
       customer_tax_id?: string | null
       /** Locale */
       locale?: string | null
-      /**
-       * Payment Method Type
-       * @description Payment method type selected by the customer in the checkout form, e.g. `card`, `apple_pay` or `upi`.
-       */
-      payment_method_type?: string | null
       /** @description The interval unit for the trial period. */
       trial_interval?: components['schemas']['TrialInterval'] | null
       /**

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -12000,6 +12000,11 @@ export interface components {
       customer_tax_id: string | null
       /** Locale */
       locale?: string | null
+      /**
+       * Payment Method Type
+       * @description Payment method type selected by the customer in the checkout form, e.g. `card`, `apple_pay` or `upi`. Some payment methods require a full billing address: keeping this value in sync allows `billing_address_fields` to reflect the fields to display.
+       */
+      payment_method_type: string | null
       /** Payment Processor Metadata */
       payment_processor_metadata: {
         [key: string]: string
@@ -12120,10 +12125,10 @@ export interface components {
       /** Locale */
       locale?: string | null
       /**
-       * Payment Method
+       * Payment Method Type
        * @description Payment method type selected by the customer in the checkout form, e.g. `card`, `apple_pay` or `upi`. Some payment methods require a full billing address: keeping this value in sync allows `billing_address_fields` to reflect the fields to display.
        */
-      payment_method?: string | null
+      payment_method_type?: string | null
       /**
        * Discount Code
        * @description Discount code to apply to the checkout.
@@ -13697,6 +13702,11 @@ export interface components {
       customer_tax_id: string | null
       /** Locale */
       locale?: string | null
+      /**
+       * Payment Method Type
+       * @description Payment method type selected by the customer in the checkout form, e.g. `card`, `apple_pay` or `upi`. Some payment methods require a full billing address: keeping this value in sync allows `billing_address_fields` to reflect the fields to display.
+       */
+      payment_method_type: string | null
       /** Payment Processor Metadata */
       payment_processor_metadata: {
         [key: string]: string
@@ -13963,6 +13973,11 @@ export interface components {
       customer_tax_id: string | null
       /** Locale */
       locale?: string | null
+      /**
+       * Payment Method Type
+       * @description Payment method type selected by the customer in the checkout form, e.g. `card`, `apple_pay` or `upi`. Some payment methods require a full billing address: keeping this value in sync allows `billing_address_fields` to reflect the fields to display.
+       */
+      payment_method_type: string | null
       /** Payment Processor Metadata */
       payment_processor_metadata: {
         [key: string]: string
@@ -14074,10 +14089,10 @@ export interface components {
       /** Locale */
       locale?: string | null
       /**
-       * Payment Method
+       * Payment Method Type
        * @description Payment method type selected by the customer in the checkout form, e.g. `card`, `apple_pay` or `upi`. Some payment methods require a full billing address: keeping this value in sync allows `billing_address_fields` to reflect the fields to display.
        */
-      payment_method?: string | null
+      payment_method_type?: string | null
       /** @description The interval unit for the trial period. */
       trial_interval?: components['schemas']['TrialInterval'] | null
       /**
@@ -14202,10 +14217,10 @@ export interface components {
       /** Locale */
       locale?: string | null
       /**
-       * Payment Method
+       * Payment Method Type
        * @description Payment method type selected by the customer in the checkout form, e.g. `card`, `apple_pay` or `upi`. Some payment methods require a full billing address: keeping this value in sync allows `billing_address_fields` to reflect the fields to display.
        */
-      payment_method?: string | null
+      payment_method_type?: string | null
       /**
        * Discount Code
        * @description Discount code to apply to the checkout.

--- a/server/polar/checkout/schemas.py
+++ b/server/polar/checkout/schemas.py
@@ -40,6 +40,7 @@ from polar.kit.metadata import (
     MetadataOutputMixin,
 )
 from polar.kit.schemas import (
+    EmptyStrToNone,
     EmptyStrToNoneValidator,
     HttpUrlToStr,
     IDSchema,
@@ -123,6 +124,20 @@ EmbedOrigin = Annotated[
             "set this to the Origin of the embedding page. "
             "It'll allow the Polar iframe to communicate with the parent page."
         ),
+    ),
+]
+
+_payment_method_description = (
+    "Payment method type selected by the customer in the checkout form, "
+    "e.g. `card`, `apple_pay` or `upi`. "
+    "Some payment methods require a full billing address: keeping this value "
+    "in sync allows `billing_address_fields` to reflect the fields to display."
+)
+PaymentMethodInput = Annotated[
+    EmptyStrToNone,
+    Field(
+        description=_payment_method_description,
+        serialization_alias="payment_method_type",
     ),
 ]
 
@@ -375,6 +390,7 @@ class CheckoutUpdateBase(CustomFieldDataInputMixin, Schema):
     customer_billing_address: CustomerBillingAddressInput | None = None
     customer_tax_id: Annotated[str | None, EmptyStrToNoneValidator] = None
     locale: Locale | None = None
+    payment_method: PaymentMethodInput = None
 
 
 class CheckoutUpdate(
@@ -595,6 +611,10 @@ class CheckoutBase(CustomFieldDataOutputMixin, TimestampedSchema, IDSchema):
         validation_alias=AliasChoices("customer_tax_id_number", "customer_tax_id")
     )
     locale: str | None = None
+    payment_method: str | None = Field(
+        validation_alias=AliasChoices("payment_method_type", "payment_method"),
+        description=_payment_method_description,
+    )
 
     payment_processor_metadata: dict[str, str]
 

--- a/server/polar/checkout/schemas.py
+++ b/server/polar/checkout/schemas.py
@@ -385,7 +385,6 @@ class CheckoutUpdateBase(CustomFieldDataInputMixin, Schema):
     customer_billing_address: CustomerBillingAddressInput | None = None
     customer_tax_id: Annotated[str | None, EmptyStrToNoneValidator] = None
     locale: Locale | None = None
-    payment_method_type: PaymentMethodTypeInput = None
 
 
 class CheckoutUpdate(
@@ -416,6 +415,7 @@ class CheckoutUpdate(
 class CheckoutUpdatePublic(CheckoutUpdateBase):
     """Update an existing checkout session using the client secret."""
 
+    payment_method_type: PaymentMethodTypeInput = None
     discount_code: Annotated[str, StripValidator] | None = Field(
         default=None, description="Discount code to apply to the checkout."
     )

--- a/server/polar/checkout/schemas.py
+++ b/server/polar/checkout/schemas.py
@@ -133,12 +133,9 @@ _payment_method_description = (
     "Some payment methods require a full billing address: keeping this value "
     "in sync allows `billing_address_fields` to reflect the fields to display."
 )
-PaymentMethodInput = Annotated[
+PaymentMethodTypeInput = Annotated[
     EmptyStrToNone,
-    Field(
-        description=_payment_method_description,
-        serialization_alias="payment_method_type",
-    ),
+    Field(description=_payment_method_description),
 ]
 
 _external_customer_id_description = (
@@ -390,7 +387,7 @@ class CheckoutUpdateBase(CustomFieldDataInputMixin, Schema):
     customer_billing_address: CustomerBillingAddressInput | None = None
     customer_tax_id: Annotated[str | None, EmptyStrToNoneValidator] = None
     locale: Locale | None = None
-    payment_method: PaymentMethodInput = None
+    payment_method_type: PaymentMethodTypeInput = None
 
 
 class CheckoutUpdate(
@@ -611,10 +608,7 @@ class CheckoutBase(CustomFieldDataOutputMixin, TimestampedSchema, IDSchema):
         validation_alias=AliasChoices("customer_tax_id_number", "customer_tax_id")
     )
     locale: str | None = None
-    payment_method: str | None = Field(
-        validation_alias=AliasChoices("payment_method_type", "payment_method"),
-        description=_payment_method_description,
-    )
+    payment_method_type: str | None = Field(description=_payment_method_description)
 
     payment_processor_metadata: dict[str, str]
 

--- a/server/polar/checkout/schemas.py
+++ b/server/polar/checkout/schemas.py
@@ -129,9 +129,7 @@ EmbedOrigin = Annotated[
 
 _payment_method_type_description = (
     "Payment method type selected by the customer in the checkout form, "
-    "e.g. `card`, `apple_pay` or `upi`. "
-    "Some payment methods require a full billing address: keeping this value "
-    "in sync allows `billing_address_fields` to reflect the fields to display."
+    "e.g. `card`, `apple_pay` or `upi`."
 )
 PaymentMethodTypeInput = Annotated[
     EmptyStrToNone,

--- a/server/polar/checkout/schemas.py
+++ b/server/polar/checkout/schemas.py
@@ -127,7 +127,7 @@ EmbedOrigin = Annotated[
     ),
 ]
 
-_payment_method_description = (
+_payment_method_type_description = (
     "Payment method type selected by the customer in the checkout form, "
     "e.g. `card`, `apple_pay` or `upi`. "
     "Some payment methods require a full billing address: keeping this value "
@@ -135,7 +135,7 @@ _payment_method_description = (
 )
 PaymentMethodTypeInput = Annotated[
     EmptyStrToNone,
-    Field(description=_payment_method_description),
+    Field(description=_payment_method_type_description),
 ]
 
 _external_customer_id_description = (
@@ -608,7 +608,9 @@ class CheckoutBase(CustomFieldDataOutputMixin, TimestampedSchema, IDSchema):
         validation_alias=AliasChoices("customer_tax_id_number", "customer_tax_id")
     )
     locale: str | None = None
-    payment_method_type: str | None = Field(description=_payment_method_description)
+    payment_method_type: str | None = Field(
+        description=_payment_method_type_description
+    )
 
     payment_processor_metadata: dict[str, str]
 

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -940,14 +940,13 @@ class CheckoutService:
         except TaxCalculationLogicalError:
             pass
 
-        # Reset is_business_customer if payment form is no longer required
+        # Reset payment form fields if it's no longer required
         # This handles the case where a 100% discount is applied and the
-        # billing address section disappears from the frontend
-        if (
-            not checkout.is_payment_form_required
-            and not checkout.require_billing_address
-        ):
-            checkout.is_business_customer = False
+        # payment and billing address sections disappear from the frontend
+        if not checkout.is_payment_form_required:
+            checkout.payment_method_type = None
+            if not checkout.require_billing_address:
+                checkout.is_business_customer = False
 
         await self._after_checkout_updated(session, checkout)
         return checkout
@@ -1075,7 +1074,7 @@ class CheckoutService:
                     }
                 )
 
-        if checkout.require_billing_address or checkout.is_business_customer:
+        if checkout.is_billing_address_required:
             if (
                 checkout.customer_billing_address is None
                 or not checkout.customer_billing_address.has_address()

--- a/server/tests/checkout/test_endpoints.py
+++ b/server/tests/checkout/test_endpoints.py
@@ -852,6 +852,25 @@ class TestClientUpdate:
         assert updated_checkout is not None
         assert updated_checkout.user_metadata == {}
 
+    async def test_payment_method(
+        self,
+        api_prefix: str,
+        client: AsyncClient,
+        checkout_open: Checkout,
+    ) -> None:
+        response = await client.patch(
+            f"{api_prefix}/client/{checkout_open.client_secret}",
+            json={"payment_method_type": "upi"},
+        )
+
+        assert response.status_code == 200
+
+        json = response.json()
+        assert json["payment_method_type"] == "upi"
+        assert json["billing_address_fields"]["line1"] == "required"
+        assert json["billing_address_fields"]["city"] == "required"
+        assert json["billing_address_fields"]["postal_code"] == "required"
+
     async def test_update_with_discount_code(
         self,
         api_prefix: str,

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -66,7 +66,7 @@ from polar.models import (
     User,
     UserOrganization,
 )
-from polar.models.checkout import CheckoutStatus
+from polar.models.checkout import BillingAddressFieldMode, CheckoutStatus
 from polar.models.custom_field import CustomFieldType
 from polar.models.customer import CustomerType
 from polar.models.customer_seat import SeatStatus
@@ -3688,6 +3688,40 @@ class TestUpdate:
 
         assert checkout.discount == discount_fixed_once
 
+    async def test_payment_method_updates_billing_address_fields(
+        self,
+        session: AsyncSession,
+        checkout_one_time_fixed: Checkout,
+    ) -> None:
+        checkout = await checkout_service.update(
+            session,
+            checkout_one_time_fixed,
+            CheckoutUpdatePublic(payment_method="upi"),
+        )
+
+        assert checkout.payment_method_type == "upi"
+        assert (
+            checkout.billing_address_fields["line1"] == BillingAddressFieldMode.required
+        )
+        assert (
+            checkout.billing_address_fields["city"] == BillingAddressFieldMode.required
+        )
+        assert (
+            checkout.billing_address_fields["postal_code"]
+            == BillingAddressFieldMode.required
+        )
+
+        checkout = await checkout_service.update(
+            session,
+            checkout,
+            CheckoutUpdatePublic(payment_method="card"),
+        )
+
+        assert checkout.payment_method_type == "card"
+        assert (
+            checkout.billing_address_fields["line1"] == BillingAddressFieldMode.disabled
+        )
+
     async def test_full_discount_resets_is_business_customer(
         self,
         save_fixture: SaveFixture,
@@ -3712,6 +3746,30 @@ class TestUpdate:
         assert checkout.discount == discount_percentage_100
         assert checkout.is_payment_form_required is False
         assert checkout.is_business_customer is False
+
+    async def test_full_discount_resets_payment_method(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        checkout_one_time_fixed: Checkout,
+        discount_percentage_100: Discount,
+    ) -> None:
+        checkout_one_time_fixed.payment_method_type = "upi"
+        await save_fixture(checkout_one_time_fixed)
+
+        assert checkout_one_time_fixed.is_billing_address_required is True
+
+        checkout = await checkout_service.update(
+            session,
+            checkout_one_time_fixed,
+            CheckoutUpdatePublic(
+                discount_code=discount_percentage_100.code,
+            ),
+        )
+
+        assert checkout.is_payment_form_required is False
+        assert checkout.payment_method_type is None
+        assert checkout.is_billing_address_required is False
 
     async def test_multiple_subscriptions_allowed(
         self,

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -3696,7 +3696,7 @@ class TestUpdate:
         checkout = await checkout_service.update(
             session,
             checkout_one_time_fixed,
-            CheckoutUpdatePublic(payment_method="upi"),
+            CheckoutUpdatePublic(payment_method_type="upi"),
         )
 
         assert checkout.payment_method_type == "upi"
@@ -3714,7 +3714,7 @@ class TestUpdate:
         checkout = await checkout_service.update(
             session,
             checkout,
-            CheckoutUpdatePublic(payment_method="card"),
+            CheckoutUpdatePublic(payment_method_type="card"),
         )
 
         assert checkout.payment_method_type == "card"
@@ -4355,6 +4355,39 @@ class TestConfirm:
         error_locations = {error["loc"] for error in errors}
         for missing_field in missing_fields:
             assert ("body", *missing_field) in error_locations
+
+    async def test_full_billing_address_required_for_payment_method(
+        self,
+        stripe_service_mock: MagicMock,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Anonymous],
+        checkout_one_time_fixed: Checkout,
+    ) -> None:
+        confirmation_token = MagicMock(spec=stripe_lib.ConfirmationToken)
+        confirmation_token.payment_method_preview = MagicMock()
+        confirmation_token.payment_method_preview.billing_details = MagicMock()
+        confirmation_token.payment_method_preview.billing_details.name = None
+        stripe_service_mock.get_confirmation_token.return_value = confirmation_token
+
+        with pytest.raises(PolarRequestValidationError) as e:
+            await checkout_service.confirm(
+                session,
+                auth_subject,
+                checkout_one_time_fixed,
+                CheckoutConfirmStripe.model_validate(
+                    {
+                        "confirmation_token_id": "CONFIRMATION_TOKEN_ID",
+                        "customer_name": "Customer Name",
+                        "customer_email": "customer@example.com",
+                        "payment_method_type": "upi",
+                        "customer_billing_address": {"country": "IN"},
+                    }
+                ),
+            )
+
+        errors = e.value.errors()
+        error_locations = {error["loc"] for error in errors}
+        assert ("body", "customer_billing_address") in error_locations
 
     async def test_wallet_name_from_confirmation_token(
         self,


### PR DESCRIPTION
## Summary

**Related Issue**: https://github.com/polarsource/polar/issues/13280

PR *(2/3)* (based on #13296) for tracking the payment method selected by the customer on the checkout form. Wires the `payment_method` column into the API: the checkout form can now sync the customer's selected payment method, `billing_address_fields` reacts to it, and confirm-time validation enforces it.

## What

- `payment_method_type` accepted on checkout updates (`CheckoutUpdatePublicBase`, so
  both the client-secret and authenticated endpoints)
- `payment_method_type` exposed on the checkout read schemas.
- `payment_method_type` is reset whenever the payment form is no longer required
  (e.g. a 100% discount), mirroring the existing `is_business_customer`
  reset.
- Tests: update round-trip via the public endpoint, `billing_address_fields`
  flipping with the selection, confirm-time 422 for UPI without a full
  address, and the discount-reset behavior.

## Why

Some payment methods require a full billing address regardless of country.
The server needs to know the current selection to render the right form
fields and to reject confirmation when required address data is missing,
today this is only enforced by country/merchant config.

## How

The field flows through the existing generic update path (no special-case
service code for persistence). Enforcement and display share a single
source (`is_full_billing_address_required`), so they cannot drift.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

