### PR TITLE
sync selected payment method to the checkout API

### DIFF
--- a/clients/packages/checkout/src/components/CheckoutForm.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.tsx
@@ -861,16 +861,7 @@ const StripeCheckoutForm = (props: CheckoutFormProps) => {
           <BaseCheckoutForm
             {...props}
             checkout={checkout}
-            confirm={(data) =>
-              confirm(
-                // Not in form state, comes from Stripe PaymentElement.
-                selectedPaymentMethod
-                  ? { ...data, payment_method_type: selectedPaymentMethod }
-                  : data,
-                stripe,
-                elements,
-              )
-            }
+            confirm={(data) => confirm(data, stripe, elements)}
             isWalletPayment={isWalletPayment}
           >
             {checkout.is_payment_form_required && (

--- a/clients/packages/checkout/src/components/CheckoutForm.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.tsx
@@ -795,15 +795,15 @@ const StripeCheckoutForm = (props: CheckoutFormProps) => {
   const onPaymentElementChange = useCallback(
     async (event: StripePaymentElementChangeEvent) => {
       setSelectedPaymentMethod(event.value.type)
-      if (event.value.type !== checkout.payment_method) {
+      if (event.value.type !== checkout.payment_method_type) {
         try {
-          await update({ payment_method: event.value.type })
+          await update({ payment_method_type: event.value.type })
         } catch {
           /* API errors handled by provider */
         }
       }
     },
-    [checkout.payment_method, update],
+    [checkout.payment_method_type, update],
   )
 
   const elementsOptions = useMemo<StripeElementsOptions>(() => {
@@ -865,7 +865,7 @@ const StripeCheckoutForm = (props: CheckoutFormProps) => {
               confirm(
                 // Not in form state, comes from Stripe PaymentElement.
                 selectedPaymentMethod
-                  ? { ...data, payment_method: selectedPaymentMethod }
+                  ? { ...data, payment_method_type: selectedPaymentMethod }
                   : data,
                 stripe,
                 elements,

--- a/clients/packages/checkout/src/components/CheckoutForm.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.tsx
@@ -767,7 +767,13 @@ interface CheckoutFormProps {
 }
 
 const StripeCheckoutForm = (props: CheckoutFormProps) => {
-  const { checkout, confirm, themePreset: themePresetProps, locale } = props
+  const {
+    checkout,
+    confirm,
+    update,
+    themePreset: themePresetProps,
+    locale,
+  } = props
   const {
     payment_processor_metadata: { publishable_key },
   } = checkout
@@ -785,6 +791,18 @@ const StripeCheckoutForm = (props: CheckoutFormProps) => {
   const isWalletPayment = selectedPaymentMethod
     ? WALLET_PAYMENT_METHODS.includes(selectedPaymentMethod)
     : false
+
+  const onPaymentElementChange = useCallback(
+    (event: StripePaymentElementChangeEvent) => {
+      setSelectedPaymentMethod(event.value.type)
+      if (event.value.type !== checkout.payment_method) {
+        update({ payment_method: event.value.type }).catch(() => {
+          /* API errors handled by provider */
+        })
+      }
+    },
+    [checkout.payment_method, update],
+  )
 
   const elementsOptions = useMemo<StripeElementsOptions>(() => {
     if (
@@ -841,7 +859,15 @@ const StripeCheckoutForm = (props: CheckoutFormProps) => {
           <BaseCheckoutForm
             {...props}
             checkout={checkout}
-            confirm={(data) => confirm(data, stripe, elements)}
+            confirm={(data) =>
+              confirm(
+                selectedPaymentMethod
+                  ? { ...data, payment_method: selectedPaymentMethod }
+                  : data,
+                stripe,
+                elements,
+              )
+            }
             isWalletPayment={isWalletPayment}
           >
             {checkout.is_payment_form_required && (
@@ -871,9 +897,7 @@ const StripeCheckoutForm = (props: CheckoutFormProps) => {
                     usBankAccount: 'never',
                   },
                 }}
-                onChange={(event: StripePaymentElementChangeEvent) => {
-                  setSelectedPaymentMethod(event.value.type)
-                }}
+                onChange={onPaymentElementChange}
               />
             )}
           </BaseCheckoutForm>

--- a/clients/packages/checkout/src/components/CheckoutForm.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.tsx
@@ -793,12 +793,14 @@ const StripeCheckoutForm = (props: CheckoutFormProps) => {
     : false
 
   const onPaymentElementChange = useCallback(
-    (event: StripePaymentElementChangeEvent) => {
+    async (event: StripePaymentElementChangeEvent) => {
       setSelectedPaymentMethod(event.value.type)
       if (event.value.type !== checkout.payment_method) {
-        update({ payment_method: event.value.type }).catch(() => {
+        try {
+          await update({ payment_method: event.value.type })
+        } catch {
           /* API errors handled by provider */
-        })
+        }
       }
     },
     [checkout.payment_method, update],
@@ -861,6 +863,7 @@ const StripeCheckoutForm = (props: CheckoutFormProps) => {
             checkout={checkout}
             confirm={(data) =>
               confirm(
+                // Not in form state, comes from Stripe PaymentElement.
                 selectedPaymentMethod
                   ? { ...data, payment_method: selectedPaymentMethod }
                   : data,


### PR DESCRIPTION
## Summary

**Related Issue**: https://github.com/polarsource/polar/issues/13280

PR *(3/3)* for tracking the payment method selected by the customer on the checkout form (based on
#13297. The checkout form keeps the customer's selected payment method in sync with the API so the billing address fields react to the selection, so selecting UPI reveals the full address form, switching back to card hides it.

## What

- `CheckoutForm` PATCHes `{ payment_method }` from the `PaymentElement`
  change event whenever the selection differs from the checkout's stored
  value. The has recomputed `billing_address_fields` from serverside, so the
  address inputs show/hide as the customer switches methods.

## Why

The server-side rules from PRs 1–2 are not used until the client reports the
selection. This closes the loop: select UPI → full address fields render →
confirm enforces them.

## How

We listen to the Stripe PaymentElement's change event and send the selected
payment method to the checkout API. The updated checkout comes back with
recomputed `billing_address_fields`, and the form re-renders the address
inputs from it. On submit, we include the selection in the confirm call so
the server validates against what the customer actually chose.


## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests — the PaymentElement is mocked
      in vitest, so the sync path is exercised end-to-end by the stack's
      server tests (update round-trip, field flipping, confirm enforcement)
- [x] Linting and type checking pass
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

