### PR TITLE
Fix stale Gemini model reference causing AI product-creation 500s

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/new/ai/chat/route.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/new/ai/chat/route.ts
@@ -375,12 +375,12 @@ export async function POST(req: Request) {
     .join('\n---\n')
 
   const geminiLite = phClient
-    ? withTracing(google('gemini-3.1-flash-lite-preview'), phClient, {
+    ? withTracing(google('gemini-3.1-flash-lite'), phClient, {
         posthogDistinctId: user.id,
         posthogTraceId: conversationId,
         posthogGroups: { organization: organizationId },
       })
-    : google('gemini-3.1-flash-lite-preview')
+    : google('gemini-3.1-flash-lite')
 
   const gemini = phClient
     ? withTracing(google('gemini-3-flash-preview'), phClient, {

--- a/clients/apps/web/src/app/(main)/feedback/question/validation.ts
+++ b/clients/apps/web/src/app/(main)/feedback/question/validation.ts
@@ -48,7 +48,7 @@ export const validateFeedbackQuestion = async (
   tracing: TracingContext,
 ): Promise<ValidationStatus> => {
   const model = wrapWithTracing(
-    google('gemini-3.1-flash-lite-preview'),
+    google('gemini-3.1-flash-lite'),
     tracing,
   )
   try {

--- a/clients/apps/web/src/app/(main)/feedback/question/validation.ts
+++ b/clients/apps/web/src/app/(main)/feedback/question/validation.ts
@@ -47,10 +47,7 @@ export const validateFeedbackQuestion = async (
   question: string,
   tracing: TracingContext,
 ): Promise<ValidationStatus> => {
-  const model = wrapWithTracing(
-    google('gemini-3.1-flash-lite'),
-    tracing,
-  )
+  const model = wrapWithTracing(google('gemini-3.1-flash-lite'), tracing)
   try {
     const result = await generateObject({
       model,


### PR DESCRIPTION
## Summary 
### Problem:
`/products/new/ai/chat and /feedback/question/validation` both call `gemini-3.1-flash-lite-preview` via the Pydantic AI Gateway. That model was deprecated May 11, 2026 and shut down May 25, 2026, so every call 404s (Publisher model ... was not found). Confirmed 355 occurrences in Logfire's ai-gateway/PAIG project over the last 7 days, ~40-58/day, ongoing. This is what's causing the AI product-creation feature to 500 (reported via tweet).

### Fix: 
Swap the deprecated model string for a supported one in both call sites:
clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/new/ai/chat/route.ts: geminiLite (gemini-3.1-flash-lite-preview → gemini-3.1-flash-lite, or gemini-3.5-flash-lite)
clients/apps/web/src/app/(main)/feedback/question/validation.ts: same swap


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

