### PR TITLE
Fix/payment pending intent race

### DIFF
--- a/server/polar/integrations/stripe/endpoints.py
+++ b/server/polar/integrations/stripe/endpoints.py
@@ -28,7 +28,6 @@ router = APIRouter(
 
 
 DIRECT_IMPLEMENTED_WEBHOOKS = {
-    "payment_intent.created",
     "payment_intent.requires_action",
     "payment_intent.succeeded",
     "payment_intent.payment_failed",

--- a/server/polar/integrations/stripe/tasks.py
+++ b/server/polar/integrations/stripe/tasks.py
@@ -125,22 +125,12 @@ async def payment_intent_succeeded(event_id: uuid.UUID) -> None:
                 return
 
 
-@actor(actor_name="stripe.webhook.payment_intent.created", priority=TaskPriority.HIGH)
-@stripe_api_connection_error_retry
-async def payment_intent_created(event_id: uuid.UUID) -> None:
-    await _record_pending_payment_intent(event_id)
-
-
 @actor(
     actor_name="stripe.webhook.payment_intent.requires_action",
     priority=TaskPriority.HIGH,
 )
 @stripe_api_connection_error_retry
 async def payment_intent_requires_action(event_id: uuid.UUID) -> None:
-    await _record_pending_payment_intent(event_id)
-
-
-async def _record_pending_payment_intent(event_id: uuid.UUID) -> None:
     async with AsyncSessionMaker() as session:
         async with external_event_service.handle_stripe(session, event_id) as event:
             payment_intent = cast(

--- a/server/polar/payment/repository.py
+++ b/server/polar/payment/repository.py
@@ -115,7 +115,12 @@ class PaymentRepository(
         return result.scalar() or 0
 
     async def get_by_stripe_payment_intent_id(
-        self, payment_intent_id: str, *, options: Options = ()
+        self,
+        payment_intent_id: str,
+        *,
+        options: Options = (),
+        for_update: bool = False,
+        nowait: bool = False,
     ) -> Payment | None:
         """Get the payment for a PaymentIntent, whether or not it has since been
         re-keyed onto its charge."""
@@ -133,6 +138,9 @@ class PaymentRepository(
             )
             .options(*options)
         )
+        if for_update:
+            statement = statement.with_for_update(of=Payment, nowait=nowait)
+
         return await self.get_one_or_none(statement)
 
     async def get_unresolved_stripe_intents_for_order(

--- a/server/polar/payment/service.py
+++ b/server/polar/payment/service.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 
 import stripe as stripe_lib
 from sqlalchemy import func, or_
+from sqlalchemy.exc import IntegrityError
 
 from polar.auth.models import AuthSubject, Organization, User
 from polar.auth.permission import OrganizationPermission
@@ -221,36 +222,63 @@ class PaymentService:
             return None
 
         repository = PaymentRepository.from_session(session)
-        payment = await repository.get_by_stripe_payment_intent_id(payment_intent.id)
-        if payment is None:
-            payment = Payment(
-                id=generate_uuid(),
-                processor=PaymentProcessor.stripe,
-                processor_id=payment_intent.id,
-                processor_metadata={
-                    STRIPE_PAYMENT_INTENT_METADATA_KEY: payment_intent.id
-                },
-                method=UNKNOWN_PAYMENT_METHOD,
-                method_metadata={},
-            )
+        payment = await repository.get_by_stripe_payment_intent_id(
+            payment_intent.id, for_update=True
+        )
+        # The lock holds off a charge webhook landing between this read and the
+        # write below.
+        if payment is not None and (
+            payment.processor_id != payment_intent.id
+            or payment.status != PaymentStatus.pending
+        ):
+            return None
 
         payment_method = await self._get_stripe_payment_method(
             session, payment_intent.payment_method
         )
 
-        payment.status = PaymentStatus.pending
-        payment.amount = payment_intent.amount
-        payment.currency = payment_intent.currency
-        if payment_method is not None:
-            payment.method = payment_method.type
-            payment.method_metadata = payment_method.method_metadata
-        payment.customer_email = payment_intent.receipt_email
-        payment.trigger = trigger
-        payment.checkout = checkout
-        payment.order = order
-        payment.wallet = wallet
-        payment.organization = organization
+        def apply(payment: Payment) -> None:
+            payment.status = PaymentStatus.pending
+            payment.amount = payment_intent.amount
+            payment.currency = payment_intent.currency
+            if payment_method is not None:
+                payment.method = payment_method.type
+                payment.method_metadata = payment_method.method_metadata
+            payment.customer_email = payment_intent.receipt_email
+            payment.trigger = trigger
+            payment.checkout = checkout
+            payment.order = order
+            payment.wallet = wallet
+            payment.organization = organization
 
+        if payment is not None:
+            apply(payment)
+            return await repository.update(payment, flush=True)
+
+        payment = Payment(
+            id=generate_uuid(),
+            processor=PaymentProcessor.stripe,
+            processor_id=payment_intent.id,
+            processor_metadata={STRIPE_PAYMENT_INTENT_METADATA_KEY: payment_intent.id},
+            method=UNKNOWN_PAYMENT_METHOD,
+            method_metadata={},
+        )
+        apply(payment)
+
+        # Two webhooks for the same intent can both find no row and both insert.
+        nested = await session.begin_nested()
+        try:
+            return await repository.create(payment, flush=True)
+        except IntegrityError:
+            await nested.rollback()
+
+        payment = await repository.get_by_stripe_payment_intent_id(
+            payment_intent.id, for_update=True
+        )
+        if payment is None or payment.processor_id != payment_intent.id:
+            return None
+
+        apply(payment)
         return await repository.update(payment, flush=True)
 
     async def cancel_from_stripe_payment_intent(

--- a/server/scripts/backfill_pending_intent_race_payments.py
+++ b/server/scripts/backfill_pending_intent_race_payments.py
@@ -1,0 +1,244 @@
+"""Repair payments damaged by the pending-intent recorder racing the charge.
+
+``payment_intent.created`` fired at the same moment as ``charge.succeeded``,
+and both handlers wrote a ``Payment`` for the same attempt. That produced two
+kinds of damage:
+
+  - Duplicates: both handlers found no row and both inserted. One row is keyed
+    on the intent, its sibling on the charge, so ``ix_payments_processor_id``
+    never fired. The intent-keyed row is the spurious one — the charge carries
+    the method and the outcome.
+  - Downgrades: the ``created`` payload always reports a null ``latest_charge``,
+    so a late delivery found the charge row through the intent id in its
+    metadata and reset it to ``pending``, blanking the method along the way.
+
+Duplicates are soft-deleted in batches. Downgrades are reconciled one by one
+against Stripe, which is the source of truth for the charge: a row that is
+legitimately pending (ACH and other delayed-notification methods) reads back as
+pending and is written unchanged.
+
+Idempotent: a soft-deleted duplicate drops out of the candidate set, and a
+reconciled row is rewritten with what Stripe already reports.
+
+Usage:
+    cd server
+
+    # Dry-run (default) — counts duplicates and prints the Stripe decision per
+    # downgrade candidate, without writing:
+    uv run python -m scripts.backfill_pending_intent_race_payments
+
+    # Apply:
+    uv run python -m scripts.backfill_pending_intent_race_payments --execute
+"""
+
+from collections.abc import Sequence
+from datetime import datetime
+
+import structlog
+import typer
+from rich.console import Console
+from rich.table import Table
+from sqlalchemy import ColumnElement, Select, exists, func, select, update
+from sqlalchemy.orm import aliased
+
+from polar.enums import PaymentProcessor
+from polar.integrations.stripe.service import stripe as stripe_service
+from polar.kit.db.postgres import create_async_sessionmaker
+from polar.kit.utils import utc_now
+from polar.models import Dispute, Payment, Refund
+from polar.models.payment import STRIPE_PAYMENT_INTENT_METADATA_KEY, PaymentStatus
+from polar.payment.service import UNKNOWN_PAYMENT_METHOD
+from polar.postgres import create_async_engine
+from scripts.helper import (
+    configure_script_console_logging,
+    limit_bindparam,
+    run_batched_update,
+    typer_async,
+)
+
+cli = typer.Typer()
+console = Console()
+configure_script_console_logging()
+log = structlog.get_logger()
+
+# The deploy that introduced the race.
+DEFAULT_SINCE = datetime.fromisoformat("2026-07-22T09:00:00+00:00")
+
+
+def _intent_id() -> ColumnElement[str]:
+    return Payment.processor_metadata[STRIPE_PAYMENT_INTENT_METADATA_KEY].astext
+
+
+def _is_referenced() -> ColumnElement[bool]:
+    return exists(select(Refund.id).where(Refund.payment_id == Payment.id)) | exists(
+        select(Dispute.id).where(Dispute.payment_id == Payment.id)
+    )
+
+
+def _duplicates_where(since: datetime) -> list[ColumnElement[bool]]:
+    """Intent-keyed rows whose charge-keyed sibling is still live."""
+    charge_row = aliased(Payment, name="charge_payment")
+    sibling = (
+        select(charge_row.id)
+        .where(
+            charge_row.processor == PaymentProcessor.stripe,
+            charge_row.deleted_at.is_(None),
+            charge_row.id != Payment.id,
+            charge_row.processor_metadata[STRIPE_PAYMENT_INTENT_METADATA_KEY].astext
+            == Payment.processor_id,
+        )
+        .exists()
+    )
+    return [
+        Payment.processor == PaymentProcessor.stripe,
+        Payment.deleted_at.is_(None),
+        Payment.status == PaymentStatus.pending,
+        Payment.created_at >= since,
+        Payment.processor_id.startswith("pi_"),
+        _intent_id() == Payment.processor_id,
+        sibling,
+        ~_is_referenced(),
+    ]
+
+
+def _downgrades_statement(since: datetime) -> Select[tuple[Payment]]:
+    """Charge-keyed rows sitting at pending, damaged or genuinely pending."""
+    return (
+        select(Payment)
+        .where(
+            Payment.processor == PaymentProcessor.stripe,
+            Payment.deleted_at.is_(None),
+            Payment.status == PaymentStatus.pending,
+            Payment.created_at >= since,
+            Payment.processor_id.startswith("ch_"),
+        )
+        .order_by(Payment.created_at)
+    )
+
+
+def _render(rows: Sequence[tuple[Payment, str, str]]) -> None:
+    table = Table(title=f"Downgrade candidates ({len(rows)})")
+    table.add_column("Payment", style="dim")
+    table.add_column("Charge", style="dim")
+    table.add_column("Stripe status")
+    table.add_column("Action")
+    for payment, stripe_status, action in rows:
+        style = "green" if action.startswith("→") else "yellow"
+        table.add_row(
+            str(payment.id),
+            payment.processor_id,
+            stripe_status,
+            f"[{style}]{action}[/{style}]",
+        )
+    console.print(table)
+
+
+@cli.command()
+@typer_async
+async def backfill_pending_intent_race_payments(
+    execute: bool = typer.Option(False, help="Apply the repair (default: dry-run)"),
+    since: datetime = typer.Option(DEFAULT_SINCE, help="Only consider payments after"),
+    batch_size: int = typer.Option(1000, help="Duplicates soft-deleted per batch"),
+) -> None:
+    engine = create_async_engine("script")
+    sessionmaker = create_async_sessionmaker(engine)
+    mode = "EXECUTE" if execute else "DRY-RUN"
+    console.rule(f"[bold]Repair pending-intent race payments — {mode}")
+
+    rows: list[tuple[Payment, str, str]] = []
+    restored = unchanged = errored = 0
+
+    try:
+        async with sessionmaker() as session:
+            duplicates = (
+                await session.execute(
+                    select(func.count(Payment.id)).where(*_duplicates_where(since))
+                )
+            ).scalar_one()
+            console.print(f"Duplicate intent-keyed payments: [bold]{duplicates}[/bold]")
+
+            payments = (
+                (await session.execute(_downgrades_statement(since))).scalars().all()
+            )
+            for payment in payments:
+                try:
+                    charge = await stripe_service.get_charge(payment.processor_id)
+                except Exception as e:
+                    errored += 1
+                    rows.append((payment, "—", f"error — {type(e).__name__}"))
+                    log.warning(
+                        "Failed to retrieve charge from Stripe",
+                        payment_id=str(payment.id),
+                        charge_id=payment.processor_id,
+                        error=str(e),
+                    )
+                    continue
+
+                status = PaymentStatus.from_stripe_charge(charge.status)
+                if (
+                    status == PaymentStatus.pending
+                    and payment.method != UNKNOWN_PAYMENT_METHOD
+                ):
+                    unchanged += 1
+                    rows.append((payment, charge.status, "skip — pending at Stripe"))
+                    continue
+
+                restored += 1
+                rows.append((payment, charge.status, f"→ {status.value}"))
+                if not execute:
+                    continue
+
+                payment.status = status
+                payment.amount = charge.amount
+                payment.currency = charge.currency
+                payment_method_details = charge.payment_method_details
+                assert payment_method_details is not None
+                payment.method = payment_method_details.type
+                payment.method_metadata = dict(
+                    payment_method_details[payment_method_details.type]
+                )
+                payment.customer_email = charge.billing_details.email
+                session.add(payment)
+
+            _render(rows)
+
+            if execute:
+                await session.commit()
+    finally:
+        await engine.dispose()
+
+    if not execute:
+        log.info(
+            "Dry-run only — re-run with --execute to apply",
+            would_soft_delete=duplicates,
+            would_restore=restored,
+            skip_pending=unchanged,
+            errored=errored,
+        )
+        return
+
+    soft_deleted = await run_batched_update(
+        update(Payment)
+        .values(deleted_at=utc_now())
+        .where(
+            Payment.id.in_(
+                select(Payment.id)
+                .where(*_duplicates_where(since))
+                .order_by(Payment.id)
+                .limit(limit_bindparam())
+                .scalar_subquery()
+            )
+        ),
+        batch_size=batch_size,
+    )
+    log.info(
+        "Repair complete",
+        soft_deleted=soft_deleted,
+        restored=restored,
+        skip_pending=unchanged,
+        errored=errored,
+    )
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/tests/payment/test_service.py
+++ b/server/tests/payment/test_service.py
@@ -416,7 +416,7 @@ class TestUpsertPendingFromStripePaymentIntent:
 
         assert payment is None
 
-    async def test_created_then_requires_action_updates_one_row(
+    async def test_repeated_requires_action_updates_one_row(
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
@@ -425,21 +425,20 @@ class TestUpsertPendingFromStripePaymentIntent:
         organization: Organization,
     ) -> None:
         order = await create_order(save_fixture, product=product, customer=customer)
-        created = build_stripe_payment_intent(status="requires_confirmation")
-        requires_action = build_stripe_payment_intent(status="requires_action")
+        payment_intent = build_stripe_payment_intent(status="requires_action")
 
         first = await payment_service.upsert_pending_from_stripe_payment_intent(
-            session, created, organization, order=order
+            session, payment_intent, organization, order=order
         )
         second = await payment_service.upsert_pending_from_stripe_payment_intent(
-            session, requires_action, organization, order=order
+            session, payment_intent, organization, order=order
         )
 
         assert first is not None
         assert second is not None
         assert first.id == second.id
 
-    async def test_charge_recorded_before_the_intent_is_not_duplicated(
+    async def test_charge_recorded_before_the_intent_is_left_alone(
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
@@ -463,13 +462,12 @@ class TestUpsertPendingFromStripePaymentIntent:
             session, payment_intent, organization, order=order
         )
 
-        assert from_charge.processor_metadata == {
-            "payment_intent_id": payment_intent.id
-        }
-        assert late is not None
-        assert late.id == from_charge.id
+        assert late is None
+        assert from_charge.processor_id == charge.id
+        assert from_charge.status == PaymentStatus.succeeded
+        assert from_charge.method == "card"
 
-    async def test_promoted_payment_is_not_duplicated(
+    async def test_promoted_payment_is_not_downgraded(
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
@@ -477,7 +475,7 @@ class TestUpsertPendingFromStripePaymentIntent:
         customer: Customer,
         organization: Organization,
     ) -> None:
-        """The charge webhook can land before `payment_intent.created`."""
+        """A stalled `requires_action` handler must not undo the charge."""
         order = await create_order(save_fixture, product=product, customer=customer)
         payment_intent = build_stripe_payment_intent(status="requires_action")
         pending = await payment_service.upsert_pending_from_stripe_payment_intent(
@@ -498,8 +496,11 @@ class TestUpsertPendingFromStripePaymentIntent:
             session, payment_intent, organization, order=order
         )
 
-        assert late is not None
-        assert late.id == promoted.id
+        assert late is None
+        assert promoted.id == pending.id
+        assert promoted.processor_id == charge.id
+        assert promoted.status == PaymentStatus.succeeded
+        assert promoted.method == "card"
 
 
 @pytest.mark.asyncio

--- a/server/tests/scripts/test_backfill_pending_intent_race_payments.py
+++ b/server/tests/scripts/test_backfill_pending_intent_race_payments.py
@@ -1,0 +1,176 @@
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy import select
+
+from polar.kit.db.postgres import AsyncSession
+from polar.models import Customer, Organization, Payment, Product
+from polar.models.payment import PaymentStatus
+from scripts.backfill_pending_intent_race_payments import _duplicates_where
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_order, create_payment, create_refund
+
+SINCE = datetime(2026, 7, 22, 9, 0, tzinfo=UTC)
+
+INTENT_ID = "pi_RACE"
+CHARGE_ID = "ch_RACE"
+
+
+async def _duplicate_ids(session: AsyncSession) -> list[Payment]:
+    statement = select(Payment).where(*_duplicates_where(SINCE))
+    return list((await session.execute(statement)).scalars().all())
+
+
+async def _intent_payment(
+    save_fixture: SaveFixture,
+    organization: Organization,
+    *,
+    intent_id: str = INTENT_ID,
+    status: PaymentStatus = PaymentStatus.pending,
+) -> Payment:
+    return await create_payment(
+        save_fixture,
+        organization,
+        status=status,
+        method="unknown",
+        processor_id=intent_id,
+        processor_metadata={"payment_intent_id": intent_id},
+    )
+
+
+async def _charge_payment(
+    save_fixture: SaveFixture,
+    organization: Organization,
+    *,
+    intent_id: str = INTENT_ID,
+) -> Payment:
+    return await create_payment(
+        save_fixture,
+        organization,
+        processor_id=CHARGE_ID,
+        processor_metadata={"payment_intent_id": intent_id},
+    )
+
+
+@pytest.mark.asyncio
+class TestDuplicatesWhere:
+    async def test_selects_the_intent_row_beside_its_charge(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        intent = await _intent_payment(save_fixture, organization)
+        charge = await _charge_payment(save_fixture, organization)
+
+        duplicates = await _duplicate_ids(session)
+
+        assert [payment.id for payment in duplicates] == [intent.id]
+        assert charge.id not in {payment.id for payment in duplicates}
+
+    async def test_keeps_an_intent_row_without_a_charge(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        """A genuine requires_action record: the wedge case the recorder exists for."""
+        await _intent_payment(save_fixture, organization)
+
+        assert await _duplicate_ids(session) == []
+
+    async def test_keeps_an_intent_row_promoted_onto_its_charge(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        await create_payment(
+            save_fixture,
+            organization,
+            processor_id=CHARGE_ID,
+            processor_metadata={"payment_intent_id": INTENT_ID},
+        )
+
+        assert await _duplicate_ids(session) == []
+
+    async def test_keeps_a_resolved_intent_row(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        await _intent_payment(save_fixture, organization, status=PaymentStatus.failed)
+        await _charge_payment(save_fixture, organization)
+
+        assert await _duplicate_ids(session) == []
+
+    async def test_keeps_an_intent_row_for_a_different_intent(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        await _intent_payment(save_fixture, organization)
+        await _charge_payment(save_fixture, organization, intent_id="pi_OTHER")
+
+        assert await _duplicate_ids(session) == []
+
+    async def test_keeps_a_legacy_intent_row_without_metadata(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        """The failure path keys on the intent too, but records no metadata."""
+        await create_payment(
+            save_fixture,
+            organization,
+            status=PaymentStatus.pending,
+            processor_id=INTENT_ID,
+        )
+        await _charge_payment(save_fixture, organization)
+
+        assert await _duplicate_ids(session) == []
+
+    async def test_keeps_a_row_predating_the_deploy(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        intent = await _intent_payment(save_fixture, organization)
+        await _charge_payment(save_fixture, organization)
+        intent.created_at = datetime(2026, 7, 21, tzinfo=UTC)
+        await save_fixture(intent)
+
+        assert await _duplicate_ids(session) == []
+
+    async def test_keeps_a_row_whose_charge_is_soft_deleted(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        await _intent_payment(save_fixture, organization)
+        charge = await _charge_payment(save_fixture, organization)
+        charge.set_deleted_at()
+        await save_fixture(charge)
+
+        assert await _duplicate_ids(session) == []
+
+    async def test_keeps_a_referenced_row(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        """Soft-deleting a refunded payment would orphan the refund."""
+        intent = await _intent_payment(save_fixture, organization)
+        await _charge_payment(save_fixture, organization)
+        order = await create_order(save_fixture, product=product, customer=customer)
+        await create_refund(save_fixture, order, intent)
+
+        assert await _duplicate_ids(session) == []


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- issue number -->

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->

## Why

<!-- Explain why this change is needed -->

## How

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where Stripe payment intent webhooks created duplicate payments or downgraded settled payments to pending. Removes the `payment_intent.created` handler, hardens pending-intent upsert with row locks and conflict handling, and adds a repair script to clean existing data.

- **Bug Fixes**
  - Stop handling `payment_intent.created`; only process `payment_intent.requires_action`.
  - Guard upserts with SELECT FOR UPDATE; skip if the row is re-keyed to a charge or past pending.
  - Handle concurrent inserts via nested transaction + `IntegrityError` retry on read-update path.
  - Repository `get_by_stripe_payment_intent_id` now supports `for_update`/`nowait`.
  - Updated tests to cover repeated `requires_action`, charge-before-intent, and no downgrade after charge.

- **Migration**
  - Run the repair script to soft-delete intent-keyed duplicates and restore charge-keyed rows stuck at pending:
    - Dry-run: `uv run python -m scripts.backfill_pending_intent_race_payments`
    - Apply: `uv run python -m scripts.backfill_pending_intent_race_payments --execute`

<sup>Written for commit eabce571e35f57b53ffaa02c3cfe371792f1e204. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

