### PR TITLE
fix(script): bound exist to created_at to avoid timeout

### DIFF
--- a/server/scripts/backfill_pending_intent_race_payments.py
+++ b/server/scripts/backfill_pending_intent_race_payments.py
@@ -76,27 +76,30 @@ def _is_referenced() -> ColumnElement[bool]:
 
 
 def _duplicates_where(since: datetime) -> list[ColumnElement[bool]]:
-    """Intent-keyed rows whose charge-keyed sibling is still live."""
+    """Intent-keyed rows whose charge-keyed sibling is still live.
+
+    Both sides are bound to the window so the planner can drive off
+    ``ix_payments_created_at``; the intent id itself carries no index, and
+    correlating on it alone scans the table once per candidate.
+    """
     charge_row = aliased(Payment, name="charge_payment")
-    sibling = (
-        select(charge_row.id)
-        .where(
-            charge_row.processor == PaymentProcessor.stripe,
-            charge_row.deleted_at.is_(None),
-            charge_row.id != Payment.id,
-            charge_row.processor_metadata[STRIPE_PAYMENT_INTENT_METADATA_KEY].astext
-            == Payment.processor_id,
-        )
-        .exists()
+    charge_intent_id = charge_row.processor_metadata[
+        STRIPE_PAYMENT_INTENT_METADATA_KEY
+    ].astext
+    promoted_intents = select(charge_intent_id).where(
+        charge_row.processor == PaymentProcessor.stripe,
+        charge_row.deleted_at.is_(None),
+        charge_row.created_at >= since,
+        charge_intent_id.is_not(None),
+        charge_row.processor_id != charge_intent_id,
     )
     return [
         Payment.processor == PaymentProcessor.stripe,
         Payment.deleted_at.is_(None),
         Payment.status == PaymentStatus.pending,
         Payment.created_at >= since,
-        Payment.processor_id.startswith("pi_"),
         _intent_id() == Payment.processor_id,
-        sibling,
+        Payment.processor_id.in_(promoted_intents),
         ~_is_referenced(),
     ]
 
@@ -231,6 +234,10 @@ async def backfill_pending_intent_race_payments(
         ),
         batch_size=batch_size,
     )
+    # rich leaves the cursor on the progress line, swallowing what follows.
+    console.print()
+    console.print(f"Soft-deleted duplicates: [bold]{soft_deleted}[/bold]")
+    console.print(f"Restored downgrades:     [bold]{restored}[/bold]")
     log.info(
         "Repair complete",
         soft_deleted=soft_deleted,


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- issue number -->

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->

## Why

<!-- Explain why this change is needed -->

## How

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents timeouts in the payment backfill script by bounding the duplicate search to the created_at window and using an indexed subquery. Also prints final counts after the progress bar.

- **Bug Fixes**
  - Replace correlated EXISTS on intent id with an IN subquery of promoted charge intents, both bounded by created_at >= since to use the created_at index.
  - Remove per-candidate full scans; duplicate detection runs within the time window.
  - Print final “Soft-deleted duplicates” and “Restored downgrades” lines after progress so `rich` doesn’t swallow them.

<sup>Written for commit 72ec52265b4d7e01c7abe8697df3878a00a2eb83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

