### PR TITLE
sdk: expose model deserialization

### DIFF
--- a/sdk/generator/python/template/README.md
+++ b/sdk/generator/python/template/README.md
@@ -94,6 +94,17 @@ separate.
 Keep organization access tokens on the server and never expose them in browser or client-side
 code.
 
+## Deserializing Data
+
+Use `deserialize` to convert arbitrary data into a generated SDK model or union type:
+
+```python
+from polar import deserialize
+from polar.v{{ ir.versions[0].version | replace("-", "_") | replace(".", "_") }}.outputs import Customer
+
+customer = deserialize(data, Customer)
+```
+
 ## Webhooks
 
 Use `validate_event` to verify that a webhook was sent by Polar and parse it into a typed payload

--- a/sdk/generator/python/template/polar/__init__.py
+++ b/sdk/generator/python/template/polar/__init__.py
@@ -1,4 +1,10 @@
-from polar.base import PolarError, PolarNetworkError, PolarServerError, PolarClientError
+from polar.base import (
+    PolarClientError,
+    PolarError,
+    PolarNetworkError,
+    PolarServerError,
+    deserialize,
+)
 
 __version__ = "{{ version }}"
 __all__ = [
@@ -6,4 +12,5 @@ __all__ = [
     "PolarNetworkError",
     "PolarServerError",
     "PolarClientError",
+    "deserialize",
 ]

--- a/sdk/generator/python/template/polar/base.py
+++ b/sdk/generator/python/template/polar/base.py
@@ -5,8 +5,10 @@ import typing
 
 import adaptix
 import httpx
+import typing_extensions
 
 _EnvironmentT = typing.TypeVar("_EnvironmentT", bound=str)
+_ModelT = typing.TypeVar("_ModelT")
 
 
 class PolarError(Exception):
@@ -162,7 +164,13 @@ class AsyncServiceBase:
         return cls(service.client)
 
 
-retort = adaptix.Retort()
+_retort = adaptix.Retort()
+
+
+def deserialize(
+    data: object, model: typing_extensions.TypeForm[_ModelT]
+) -> _ModelT:
+    return typing.cast(_ModelT, _retort.load(data, model))
 
 E = typing.TypeVar("E", bound=PolarClientError)
 
@@ -191,7 +199,8 @@ def _handle_errors(
                     raise error_class(status_code, response.text)
                 case _:
                     raise error_class(
-                        status_code, retort.load(response.json(), error_class.error_type)
+                        status_code,
+                        deserialize(response.json(), error_class.error_type),
                     )
         except KeyError:
             raise PolarClientError(status_code, response.text)
@@ -205,7 +214,7 @@ def parse_response_json(
     _handle_errors(response, errors)
 
     if response_model is not None:
-        return retort.load(response.json(), response_model)
+        return deserialize(response.json(), response_model)
 
     return response.json()
 

--- a/sdk/generator/python/template/polar/version/webhooks.py
+++ b/sdk/generator/python/template/polar/version/webhooks.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import typing
 
-from polar.base import retort
+from polar.base import deserialize
 from polar.webhooks import (
     PolarWebhookError as PolarWebhookError,
     PolarWebhookUnknownTypeError as PolarWebhookUnknownTypeError,
@@ -73,4 +73,4 @@ def validate_event(
 
 
 def _load_payload(data: dict[str, typing.Any]) -> WebhookPayload:
-    return typing.cast(WebhookPayload, retort.load(data, WebhookPayload))
+    return deserialize(data, WebhookPayload)

--- a/sdk/generator/python/template/pyproject.toml
+++ b/sdk/generator/python/template/pyproject.toml
@@ -14,7 +14,11 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
 ]
 requires-python = ">=3.11"
-dependencies = ["httpx>=0.28.1", "adaptix==3.0.0b12"]
+dependencies = [
+  "httpx>=0.28.1",
+  "adaptix==3.0.0b12",
+  "typing-extensions>=4.13.0",
+]
 
 [project.urls]
 homepage = "https://polar.sh"

--- a/sdk/generator/python/template/tests/test_base.py
+++ b/sdk/generator/python/template/tests/test_base.py
@@ -1,13 +1,44 @@
+import dataclasses
 import typing
 
 import pytest
 
+from polar import deserialize
 from polar.base import AsyncClientBase, SyncClientBase, resolve_base_url
 
 SERVERS = {
     "production": "https://api.polar.sh",
     "sandbox": "https://sandbox-api.polar.sh",
 }
+
+
+@dataclasses.dataclass
+class Cat:
+    type: typing.Literal["cat"]
+    lives: int
+
+
+@dataclasses.dataclass
+class Dog:
+    type: typing.Literal["dog"]
+    breed: str
+
+
+Animal: typing.TypeAlias = Cat | Dog
+
+
+def test_deserialize_model() -> None:
+    cat = deserialize({"type": "cat", "lives": 9}, Cat)
+
+    typing.assert_type(cat, Cat)
+    assert cat == Cat(type="cat", lives=9)
+
+
+def test_deserialize_union() -> None:
+    animal = deserialize({"type": "dog", "breed": "Samoyed"}, Animal)
+
+    typing.assert_type(animal, Cat | Dog)
+    assert animal == Dog(type="dog", breed="Samoyed")
 
 
 @pytest.mark.parametrize(

--- a/sdk/generator/python/template/tests/test_webhooks.py
+++ b/sdk/generator/python/template/tests/test_webhooks.py
@@ -7,7 +7,7 @@ import typing
 import pytest
 from standardwebhooks.webhooks import Webhook
 
-from polar.base import PolarError, retort
+from polar.base import PolarError, deserialize
 from polar.webhooks import (
     PolarWebhookError,
     PolarWebhookUnknownTypeError,
@@ -40,7 +40,7 @@ def _get_headers(
 
 
 def _load_payload(data: dict[str, typing.Any]) -> DummyPayload:
-    return retort.load(data, DummyPayload)
+    return deserialize(data, DummyPayload)
 
 
 def _validate_event(

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -94,6 +94,17 @@ separate.
 Keep organization access tokens on the server and never expose them in browser or client-side
 code.
 
+## Deserializing Data
+
+Use `deserialize` to convert arbitrary data into a generated SDK model or union type:
+
+```python
+from polar import deserialize
+from polar.v2026_04.outputs import Customer
+
+customer = deserialize(data, Customer)
+```
+
 ## Webhooks
 
 Use `validate_event` to verify that a webhook was sent by Polar and parse it into a typed payload

--- a/sdk/python/polar/__init__.py
+++ b/sdk/python/polar/__init__.py
@@ -1,4 +1,10 @@
-from polar.base import PolarClientError, PolarError, PolarNetworkError, PolarServerError
+from polar.base import (
+    PolarClientError,
+    PolarError,
+    PolarNetworkError,
+    PolarServerError,
+    deserialize,
+)
 
 __version__ = "1.0.0a13"
 __all__ = [
@@ -6,4 +12,5 @@ __all__ = [
     "PolarNetworkError",
     "PolarServerError",
     "PolarClientError",
+    "deserialize",
 ]

--- a/sdk/python/polar/base.py
+++ b/sdk/python/polar/base.py
@@ -5,8 +5,10 @@ import typing
 
 import adaptix
 import httpx
+import typing_extensions
 
 _EnvironmentT = typing.TypeVar("_EnvironmentT", bound=str)
+_ModelT = typing.TypeVar("_ModelT")
 
 
 class PolarError(Exception):
@@ -164,7 +166,12 @@ class AsyncServiceBase:
         return cls(service.client)
 
 
-retort = adaptix.Retort()
+_retort = adaptix.Retort()
+
+
+def deserialize(data: object, model: typing_extensions.TypeForm[_ModelT]) -> _ModelT:
+    return typing.cast(_ModelT, _retort.load(data, model))
+
 
 E = typing.TypeVar("E", bound=PolarClientError)
 
@@ -194,7 +201,7 @@ def _handle_errors(
                 case _:
                     raise error_class(
                         status_code,
-                        retort.load(response.json(), error_class.error_type),
+                        deserialize(response.json(), error_class.error_type),
                     )
         except KeyError:
             raise PolarClientError(status_code, response.text)
@@ -208,7 +215,7 @@ def parse_response_json(
     _handle_errors(response, errors)
 
     if response_model is not None:
-        return retort.load(response.json(), response_model)
+        return deserialize(response.json(), response_model)
 
     return response.json()
 

--- a/sdk/python/polar/v2026_04/webhooks.py
+++ b/sdk/python/polar/v2026_04/webhooks.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import typing
 
-from polar.base import retort
+from polar.base import deserialize
 from polar.v2026_04.outputs import (
     Benefit,
     BenefitGrantWebhook,
@@ -677,4 +677,4 @@ def validate_event(
 
 
 def _load_payload(data: dict[str, typing.Any]) -> WebhookPayload:
-    return typing.cast(WebhookPayload, retort.load(data, WebhookPayload))
+    return deserialize(data, WebhookPayload)

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -14,7 +14,11 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
 ]
 requires-python = ">=3.11"
-dependencies = ["httpx>=0.28.1", "adaptix==3.0.0b12"]
+dependencies = [
+  "httpx>=0.28.1",
+  "adaptix==3.0.0b12",
+  "typing-extensions>=4.13.0",
+]
 
 [project.urls]
 homepage = "https://polar.sh"

--- a/sdk/python/tests/test_base.py
+++ b/sdk/python/tests/test_base.py
@@ -1,13 +1,44 @@
+import dataclasses
 import typing
 
 import pytest
 
+from polar import deserialize
 from polar.base import AsyncClientBase, SyncClientBase, resolve_base_url
 
 SERVERS = {
     "production": "https://api.polar.sh",
     "sandbox": "https://sandbox-api.polar.sh",
 }
+
+
+@dataclasses.dataclass
+class Cat:
+    type: typing.Literal["cat"]
+    lives: int
+
+
+@dataclasses.dataclass
+class Dog:
+    type: typing.Literal["dog"]
+    breed: str
+
+
+Animal: typing.TypeAlias = Cat | Dog
+
+
+def test_deserialize_model() -> None:
+    cat = deserialize({"type": "cat", "lives": 9}, Cat)
+
+    typing.assert_type(cat, Cat)
+    assert cat == Cat(type="cat", lives=9)
+
+
+def test_deserialize_union() -> None:
+    animal = deserialize({"type": "dog", "breed": "Samoyed"}, Animal)
+
+    typing.assert_type(animal, Cat | Dog)
+    assert animal == Dog(type="dog", breed="Samoyed")
 
 
 @pytest.mark.parametrize(

--- a/sdk/python/tests/test_webhooks.py
+++ b/sdk/python/tests/test_webhooks.py
@@ -7,7 +7,7 @@ import typing
 import pytest
 from standardwebhooks.webhooks import Webhook
 
-from polar.base import PolarError, retort
+from polar.base import PolarError, deserialize
 from polar.webhooks import (
     PolarWebhookError,
     PolarWebhookUnknownTypeError,
@@ -40,7 +40,7 @@ def _get_headers(
 
 
 def _load_payload(data: dict[str, typing.Any]) -> DummyPayload:
-    return retort.load(data, DummyPayload)
+    return deserialize(data, DummyPayload)
 
 
 def _validate_event(

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -146,6 +146,7 @@ source = { editable = "." }
 dependencies = [
     { name = "adaptix" },
     { name = "httpx" },
+    { name = "typing-extensions" },
 ]
 
 [package.dev-dependencies]
@@ -160,6 +161,7 @@ dev = [
 requires-dist = [
     { name = "adaptix", specifier = "==3.0.0b12" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

- add a public `polar.deserialize` function for converting arbitrary data into generated SDK models and union types
- keep the Adaptix Retort private and route API responses, errors, and webhooks through the public deserialization boundary
- add concrete-model and union coverage, documentation, and the `typing-extensions` dependency required for `TypeForm`

## Why

SDK users currently need to import the internal Retort instance to deserialize data. A public function provides a stable API and supports generated union aliases that cannot expose a classmethod.

## Impact

Users can now deserialize generated models with precise return-type inference:

```python
from polar import deserialize
from polar.v2026_04.outputs import Customer

customer = deserialize(data, Customer)
```

## Validation

- `cd sdk/python && just lint`
- `cd sdk/python && just test` — 23 passed
- `cd sdk/generator && just lint`
- `cd sdk/generator && just test` — 80 passed
- ADR check — no violations

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

