### PR TITLE
Fix free-form metadata SDK types

### DIFF
--- a/sdk/generator/generator/ir.py
+++ b/sdk/generator/generator/ir.py
@@ -153,13 +153,12 @@ class Model(BaseModel):
     A named object schema from components/schemas.
 
     Emitted as a struct, dataclass, or interface by language generators.
-    Models with no fields represent union or composition schemas (oneOf/anyOf
-    at the top level) whose variants are discovered transitively.
     """
 
     name: str
     description: str | None = None
     fields: list[Field]
+    additional_properties: TypeRef | None = None
 
 
 class EnumValue(BaseModel):
@@ -603,7 +602,7 @@ def _convert_typeref(
         )
 
     if schema_type == "object" or schema.properties is not None:
-        if schema.properties is None and schema.additionalProperties is not None:
+        if not schema.properties and schema.additionalProperties is not None:
             if isinstance(schema.additionalProperties, bool):
                 if not schema.additionalProperties:
                     return PrimitiveType(kind="primitive", type="unknown")
@@ -700,8 +699,8 @@ def _schema_to_model(
                 has_example=has_example,
             )
         )
-    # Walk composition keywords so transitive references are discovered even
-    # when a model has no explicit properties (e.g. a discriminated oneOf).
+    # Walk composition keywords so references from object schemas that also use
+    # composition are discovered transitively.
     for variant in (schema.anyOf or []) + (schema.oneOf or []) + (schema.allOf or []):
         _convert_typeref(
             variant,
@@ -711,7 +710,26 @@ def _schema_to_model(
             *context_sets,
             normalize_model_name=normalize_model_name,
         )
-    return Model(name=name, description=schema.description or None, fields=fields)
+    additional_properties = None
+    if not schema.properties and schema.additionalProperties is not None:
+        if isinstance(schema.additionalProperties, bool):
+            if schema.additionalProperties:
+                additional_properties = PrimitiveType(kind="primitive", type="unknown")
+        else:
+            additional_properties = _convert_typeref(
+                schema.additionalProperties,
+                component_schemas,
+                inline_schemas,
+                referenced_names,
+                *context_sets,
+                normalize_model_name=normalize_model_name,
+            )
+    return Model(
+        name=name,
+        description=schema.description or None,
+        fields=fields,
+        additional_properties=additional_properties,
+    )
 
 
 def _schema_to_named_union(

--- a/sdk/generator/python/template/polar/version/inputs.py
+++ b/sdk/generator/python/template/polar/version/inputs.py
@@ -11,6 +11,13 @@ from polar.{{ version }}.literals import (
 {% endif %}
 
 {% for model in api.input_models %}
+{% if model.additional_properties %}
+{{ model.name }}: typing.TypeAlias = dict[str, {{ model.additional_properties | type_annotation }}]
+{% if model.description %}
+"""{{ model.description }}"""
+{% endif %}
+
+{% else %}
 class {{ model.name }}(typing.TypedDict):
 {% if model.description %}
     """{{ model.description }}"""
@@ -29,6 +36,7 @@ class {{ model.name }}(typing.TypedDict):
     ...
 {% endfor %}
 
+{% endif %}
 {% endfor %}
 
 {% for union in api.input_unions %}

--- a/sdk/generator/python/template/polar/version/outputs.py
+++ b/sdk/generator/python/template/polar/version/outputs.py
@@ -12,6 +12,13 @@ from polar.{{ version }}.literals import (
 {% endif %}
 
 {% for model in api.output_models %}
+{% if model.additional_properties %}
+{{ model.name }}: typing.TypeAlias = dict[str, {{ model.additional_properties | type_annotation }}]
+{% if model.description %}
+"""{{ model.description }}"""
+{% endif %}
+
+{% else %}
 @dataclasses.dataclass(kw_only=True, slots=True)
 class {{ model.name }}:
 {% if model.description %}
@@ -32,6 +39,7 @@ class {{ model.name }}:
 {% else %}
     ...
 {% endfor %}
+{% endif %}
 {% endfor %}
 
 {% for union in api.output_unions %}

--- a/sdk/generator/tests/test_ir.py
+++ b/sdk/generator/tests/test_ir.py
@@ -1496,6 +1496,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                         "schemas": {
                             "Metadata": {
                                 "type": "object",
+                                "properties": {},
                                 "additionalProperties": {
                                     "anyOf": [
                                         {"type": "string"},
@@ -1542,6 +1543,15 @@ _STRING = {"kind": "primitive", "type": "string"}
                             {
                                 "name": "Metadata",
                                 "fields": [],
+                                "additional_properties": {
+                                    "kind": "union",
+                                    "variants": [
+                                        {"kind": "primitive", "type": "string"},
+                                        {"kind": "primitive", "type": "integer"},
+                                        {"kind": "primitive", "type": "boolean"},
+                                    ],
+                                    "composition_kind": "anyOf",
+                                },
                             }
                         ],
                         "webhooks": [],
@@ -1551,7 +1561,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                     }
                 ]
             },
-            id="additionalProperties-only objects become MapType; Metadata model fields are empty (no explicit properties).",
+            id="additionalProperties-only models preserve their value type",
         ),
         pytest.param(
             [

--- a/sdk/generator/tests/typescript/test_types.py
+++ b/sdk/generator/tests/typescript/test_types.py
@@ -1,0 +1,14 @@
+from generator.ir import PrimitiveType, UnionType
+from typescript.types import convert_type_to_typescript
+
+
+def test_convert_type_to_typescript_deduplicates_union_members() -> None:
+    type_ref = UnionType(
+        kind="union",
+        variants=[
+            PrimitiveType(kind="primitive", type="integer"),
+            PrimitiveType(kind="primitive", type="number"),
+        ],
+    )
+
+    assert convert_type_to_typescript(type_ref) == "number"

--- a/sdk/generator/typescript/template/src/version/models.ts
+++ b/sdk/generator/typescript/template/src/version/models.ts
@@ -7,12 +7,15 @@ export type {{ enum.name }} = {% for value in enum.values %}{% if value.value is
 {% for model in models %}/**
  * {{ model.description or model.name }}
  */
+{% if model.additional_properties %}export type {{ model.name }} = Record<string, {{ model.additional_properties | ts_type }}>;
+{% else %}
 export interface {{ model.name }}{% if model.fields %} {
   {% for field in model.fields %}  /**
    * {{ field.description or field.name }}
    */
   {{ field.name }}{% if not field.required %}?{% endif %}: {{ field.type | ts_type }};
   {% endfor %}}{% else %} extends Record<string, never> {}{% endif %}
+{% endif %}
 
 {% endfor %}
 

--- a/sdk/generator/typescript/types.py
+++ b/sdk/generator/typescript/types.py
@@ -66,10 +66,10 @@ def convert_type_to_typescript(
     if isinstance(type_ref, UnionType):
         if len(type_ref.variants) == 0:
             return "unknown"
-        variant_strs = [
+        variant_strs = dict.fromkeys(
             convert_type_to_typescript(v, ref_suffix, in_union=True)
             for v in type_ref.variants
-        ]
+        )
         # Join with |, wrapping nullable types in parens if needed
         union = " | ".join(variant_strs)
         if in_union:

--- a/sdk/python/polar/v2026_04/outputs.py
+++ b/sdk/python/polar/v2026_04/outputs.py
@@ -6638,8 +6638,7 @@ class Member:
     role: MemberRole
 
 
-@dataclasses.dataclass(kw_only=True, slots=True)
-class MetadataOutputType: ...
+MetadataOutputType: typing.TypeAlias = dict[str, str | int | float | bool]
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)

--- a/sdk/typescript/src/2026-04/models.ts
+++ b/sdk/typescript/src/2026-04/models.ts
@@ -2853,7 +2853,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * type
    */
@@ -2968,7 +2968,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * The description of the benefit. Will be displayed on products having this benefit.
    */
@@ -3123,7 +3123,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * type
    */
@@ -3258,7 +3258,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * The description of the benefit. Will be displayed on products having this benefit.
    */
@@ -3346,7 +3346,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * type
    */
@@ -3469,7 +3469,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * The description of the benefit. Will be displayed on products having this benefit.
    */
@@ -3560,7 +3560,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * type
    */
@@ -3660,7 +3660,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * The description of the benefit. Will be displayed on products having this benefit.
    */
@@ -3754,7 +3754,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * type
    */
@@ -3889,7 +3889,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * The description of the benefit. Will be displayed on products having this benefit.
    */
@@ -4937,7 +4937,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * type
    */
@@ -5088,7 +5088,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * The description of the benefit. Will be displayed on products having this benefit.
    */
@@ -5182,7 +5182,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * type
    */
@@ -5321,7 +5321,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * The description of the benefit. Will be displayed on products having this benefit.
    */
@@ -5515,7 +5515,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * type
    */
@@ -5665,7 +5665,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * The description of the benefit. Will be displayed on products having this benefit.
    */
@@ -5891,7 +5891,7 @@ export interface Checkout {
   /**
    * Key-value object storing custom field values.
    */
-  custom_field_data?: Record<string, string | number | boolean | string | null>;
+  custom_field_data?: Record<string, string | number | boolean | null>;
   /**
    * payment_processor
    */
@@ -6160,7 +6160,7 @@ export interface CheckoutConfirmStripe {
   /**
    * Key-value object storing custom field values.
    */
-  custom_field_data?: Record<string, string | number | boolean | string | null>;
+  custom_field_data?: Record<string, string | number | boolean | null>;
   /**
    * ID of the product to checkout. Must be present in the checkout's product list.
    */
@@ -6247,11 +6247,11 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * Key-value object storing custom field values.
    */
-  custom_field_data?: Record<string, string | number | boolean | string | null>;
+  custom_field_data?: Record<string, string | number | boolean | null>;
   /**
    * ID of the discount to apply to the checkout.
    */
@@ -6333,7 +6333,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  customer_metadata?: Record<string, string | number | number | boolean>;
+  customer_metadata?: Record<string, string | number | boolean>;
   /**
    * ID of a subscription to upgrade. It must be on a free pricing. If checkout is successful, metadata set on this checkout will be copied to the subscription, and existing keys will be overwritten.
    */
@@ -6702,7 +6702,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * The interval unit for the trial period.
    */
@@ -6767,7 +6767,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * The interval unit for the trial period.
    */
@@ -6830,7 +6830,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * The interval unit for the trial period.
    */
@@ -6982,7 +6982,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * List of products that will be available to select at checkout.
    */
@@ -7149,7 +7149,7 @@ export interface CheckoutPublic {
   /**
    * Key-value object storing custom field values.
    */
-  custom_field_data?: Record<string, string | number | boolean | string | null>;
+  custom_field_data?: Record<string, string | number | boolean | null>;
   /**
    * payment_processor
    */
@@ -7384,7 +7384,7 @@ export interface CheckoutPublicConfirmed {
   /**
    * Key-value object storing custom field values.
    */
-  custom_field_data?: Record<string, string | number | boolean | string | null>;
+  custom_field_data?: Record<string, string | number | boolean | null>;
   /**
    * payment_processor
    */
@@ -7608,7 +7608,7 @@ export interface CheckoutUpdate {
   /**
    * Key-value object storing custom field values.
    */
-  custom_field_data?: Record<string, string | number | boolean | string | null>;
+  custom_field_data?: Record<string, string | number | boolean | null>;
   /**
    * ID of the product to checkout. Must be present in the checkout's product list.
    */
@@ -7674,7 +7674,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * currency
    */
@@ -7712,7 +7712,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  customer_metadata?: Record<string, string | number | number | boolean> | null;
+  customer_metadata?: Record<string, string | number | boolean> | null;
   /**
    * URL where the customer will be redirected after a successful payment.You can add the `checkout_id={CHECKOUT_ID}` query parameter to retrieve the checkout session id.
    */
@@ -7733,7 +7733,7 @@ export interface CheckoutUpdatePublic {
   /**
    * Key-value object storing custom field values.
    */
-  custom_field_data?: Record<string, string | number | boolean | string | null>;
+  custom_field_data?: Record<string, string | number | boolean | null>;
   /**
    * ID of the product to checkout. Must be present in the checkout's product list.
    */
@@ -7910,7 +7910,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * type
    */
@@ -7949,7 +7949,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * type
    */
@@ -7988,7 +7988,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * type
    */
@@ -8027,7 +8027,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * type
    */
@@ -8066,7 +8066,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * type
    */
@@ -8382,7 +8382,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * name
    */
@@ -8417,7 +8417,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * name
    */
@@ -8452,7 +8452,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * name
    */
@@ -8487,7 +8487,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * name
    */
@@ -8522,7 +8522,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * name
    */
@@ -9559,7 +9559,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * The ID of the customer in your system. This must be unique within the organization. Once set, it can't be updated.
    */
@@ -10930,7 +10930,7 @@ export interface CustomerStateSubscription {
   /**
    * Key-value object storing custom field values.
    */
-  custom_field_data?: Record<string, string | number | boolean | string | null>;
+  custom_field_data?: Record<string, string | number | boolean | null>;
   /**
    * metadata
    */
@@ -11568,7 +11568,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * The ID of the customer in your system. This must be unique within the organization. Once set, it can't be updated.
    */
@@ -11623,7 +11623,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * The email address of the customer. This must be unique within the organization.
    */
@@ -11670,7 +11670,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * The email address of the customer. This must be unique within the organization.
    */
@@ -11855,7 +11855,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * Name of the discount. Will be displayed to the customer when the discount is applied.
    */
@@ -12224,7 +12224,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * Name of the discount. Will be displayed to the customer when the discount is applied.
    */
@@ -12625,7 +12625,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * name
    */
@@ -13742,7 +13742,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  conditions?: Record<string, string | number | number | boolean>;
+  conditions?: Record<string, string | number | boolean>;
   /**
    * Key-value object allowing you to store additional information about the activation
 
@@ -13756,7 +13756,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  meta?: Record<string, string | number | number | boolean>;
+  meta?: Record<string, string | number | boolean>;
 }
 /**
  * LicenseKeyActivationBase
@@ -13777,7 +13777,7 @@ export interface LicenseKeyActivationBase {
   /**
    * meta
    */
-  meta: Record<string, string | number | number | boolean>;
+  meta: Record<string, string | number | boolean>;
   /**
    * created_at
    */
@@ -13806,7 +13806,7 @@ export interface LicenseKeyActivationRead {
   /**
    * meta
    */
-  meta: Record<string, string | number | number | boolean>;
+  meta: Record<string, string | number | boolean>;
   /**
    * created_at
    */
@@ -14045,7 +14045,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  conditions?: Record<string, string | number | number | boolean>;
+  conditions?: Record<string, string | number | boolean>;
 }
 /**
  * LicenseKeyWithActivations
@@ -14672,7 +14672,8 @@ export interface MemberUpdate {
 /**
  * MetadataOutputType
  */
-export interface MetadataOutputType extends Record<string, never> {}
+export type MetadataOutputType = Record<string, string | number | boolean>;
+
 /**
  * Meter
  */
@@ -14743,7 +14744,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * The name of the meter. Will be shown on customer's invoices and usage.
    */
@@ -14964,7 +14965,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * The name of the meter. Will be shown on customer's invoices and usage.
    */
@@ -15081,223 +15082,223 @@ export interface MetricPeriod {
   /**
    * active_subscriptions
    */
-  active_subscriptions?: number | number | null;
+  active_subscriptions?: number | null;
   /**
    * committed_subscriptions
    */
-  committed_subscriptions?: number | number | null;
+  committed_subscriptions?: number | null;
   /**
    * monthly_recurring_revenue
    */
-  monthly_recurring_revenue?: number | number | null;
+  monthly_recurring_revenue?: number | null;
   /**
    * trial_monthly_recurring_revenue
    */
-  trial_monthly_recurring_revenue?: number | number | null;
+  trial_monthly_recurring_revenue?: number | null;
   /**
    * committed_monthly_recurring_revenue
    */
-  committed_monthly_recurring_revenue?: number | number | null;
+  committed_monthly_recurring_revenue?: number | null;
   /**
    * trial_committed_monthly_recurring_revenue
    */
-  trial_committed_monthly_recurring_revenue?: number | number | null;
+  trial_committed_monthly_recurring_revenue?: number | null;
   /**
    * average_revenue_per_user
    */
-  average_revenue_per_user?: number | number | null;
+  average_revenue_per_user?: number | null;
   /**
    * checkouts
    */
-  checkouts?: number | number | null;
+  checkouts?: number | null;
   /**
    * succeeded_checkouts
    */
-  succeeded_checkouts?: number | number | null;
+  succeeded_checkouts?: number | null;
   /**
    * churned_subscriptions
    */
-  churned_subscriptions?: number | number | null;
+  churned_subscriptions?: number | null;
   /**
    * churn_rate
    */
-  churn_rate?: number | number | null;
+  churn_rate?: number | null;
   /**
    * seats_total
    */
-  seats_total?: number | number | null;
+  seats_total?: number | null;
   /**
    * seats_claimed
    */
-  seats_claimed?: number | number | null;
+  seats_claimed?: number | null;
   /**
    * seats_pending
    */
-  seats_pending?: number | number | null;
+  seats_pending?: number | null;
   /**
    * seat_customers
    */
-  seat_customers?: number | number | null;
+  seat_customers?: number | null;
   /**
    * new_seat_customers
    */
-  new_seat_customers?: number | number | null;
+  new_seat_customers?: number | null;
   /**
    * churned_seat_customers
    */
-  churned_seat_customers?: number | number | null;
+  churned_seat_customers?: number | null;
   /**
    * orders
    */
-  orders?: number | number | null;
+  orders?: number | null;
   /**
    * revenue
    */
-  revenue?: number | number | null;
+  revenue?: number | null;
   /**
    * net_revenue
    */
-  net_revenue?: number | number | null;
+  net_revenue?: number | null;
   /**
    * cumulative_revenue
    */
-  cumulative_revenue?: number | number | null;
+  cumulative_revenue?: number | null;
   /**
    * net_cumulative_revenue
    */
-  net_cumulative_revenue?: number | number | null;
+  net_cumulative_revenue?: number | null;
   /**
    * costs
    */
-  costs?: number | number | null;
+  costs?: number | null;
   /**
    * cumulative_costs
    */
-  cumulative_costs?: number | number | null;
+  cumulative_costs?: number | null;
   /**
    * average_order_value
    */
-  average_order_value?: number | number | null;
+  average_order_value?: number | null;
   /**
    * net_average_order_value
    */
-  net_average_order_value?: number | number | null;
+  net_average_order_value?: number | null;
   /**
    * cost_per_user
    */
-  cost_per_user?: number | number | null;
+  cost_per_user?: number | null;
   /**
    * active_user_by_event
    */
-  active_user_by_event?: number | number | null;
+  active_user_by_event?: number | null;
   /**
    * one_time_products
    */
-  one_time_products?: number | number | null;
+  one_time_products?: number | null;
   /**
    * one_time_products_revenue
    */
-  one_time_products_revenue?: number | number | null;
+  one_time_products_revenue?: number | null;
   /**
    * one_time_products_net_revenue
    */
-  one_time_products_net_revenue?: number | number | null;
+  one_time_products_net_revenue?: number | null;
   /**
    * new_subscriptions
    */
-  new_subscriptions?: number | number | null;
+  new_subscriptions?: number | null;
   /**
    * new_subscriptions_revenue
    */
-  new_subscriptions_revenue?: number | number | null;
+  new_subscriptions_revenue?: number | null;
   /**
    * new_subscriptions_net_revenue
    */
-  new_subscriptions_net_revenue?: number | number | null;
+  new_subscriptions_net_revenue?: number | null;
   /**
    * renewed_subscriptions
    */
-  renewed_subscriptions?: number | number | null;
+  renewed_subscriptions?: number | null;
   /**
    * renewed_subscriptions_revenue
    */
-  renewed_subscriptions_revenue?: number | number | null;
+  renewed_subscriptions_revenue?: number | null;
   /**
    * renewed_subscriptions_net_revenue
    */
-  renewed_subscriptions_net_revenue?: number | number | null;
+  renewed_subscriptions_net_revenue?: number | null;
   /**
    * canceled_subscriptions
    */
-  canceled_subscriptions?: number | number | null;
+  canceled_subscriptions?: number | null;
   /**
    * canceled_subscriptions_customer_service
    */
-  canceled_subscriptions_customer_service?: number | number | null;
+  canceled_subscriptions_customer_service?: number | null;
   /**
    * canceled_subscriptions_low_quality
    */
-  canceled_subscriptions_low_quality?: number | number | null;
+  canceled_subscriptions_low_quality?: number | null;
   /**
    * canceled_subscriptions_missing_features
    */
-  canceled_subscriptions_missing_features?: number | number | null;
+  canceled_subscriptions_missing_features?: number | null;
   /**
    * canceled_subscriptions_switched_service
    */
-  canceled_subscriptions_switched_service?: number | number | null;
+  canceled_subscriptions_switched_service?: number | null;
   /**
    * canceled_subscriptions_too_complex
    */
-  canceled_subscriptions_too_complex?: number | number | null;
+  canceled_subscriptions_too_complex?: number | null;
   /**
    * canceled_subscriptions_too_expensive
    */
-  canceled_subscriptions_too_expensive?: number | number | null;
+  canceled_subscriptions_too_expensive?: number | null;
   /**
    * canceled_subscriptions_unused
    */
-  canceled_subscriptions_unused?: number | number | null;
+  canceled_subscriptions_unused?: number | null;
   /**
    * canceled_subscriptions_other
    */
-  canceled_subscriptions_other?: number | number | null;
+  canceled_subscriptions_other?: number | null;
   /**
    * annual_recurring_revenue
    */
-  annual_recurring_revenue?: number | number | null;
+  annual_recurring_revenue?: number | null;
   /**
    * committed_annual_recurring_revenue
    */
-  committed_annual_recurring_revenue?: number | number | null;
+  committed_annual_recurring_revenue?: number | null;
   /**
    * checkouts_conversion
    */
-  checkouts_conversion?: number | number | null;
+  checkouts_conversion?: number | null;
   /**
    * ltv
    */
-  ltv?: number | number | null;
+  ltv?: number | null;
   /**
    * gross_margin
    */
-  gross_margin?: number | number | null;
+  gross_margin?: number | null;
   /**
    * gross_margin_percentage
    */
-  gross_margin_percentage?: number | number | null;
+  gross_margin_percentage?: number | null;
   /**
    * cashflow
    */
-  cashflow?: number | number | null;
+  cashflow?: number | null;
   /**
    * average_seats_per_customer
    */
-  average_seats_per_customer?: number | number | null;
+  average_seats_per_customer?: number | null;
   /**
    * seat_utilization_rate
    */
-  seat_utilization_rate?: number | number | null;
+  seat_utilization_rate?: number | null;
 }
 /**
  * Metrics
@@ -15599,223 +15600,223 @@ export interface MetricsTotals {
   /**
    * active_subscriptions
    */
-  active_subscriptions?: number | number | null;
+  active_subscriptions?: number | null;
   /**
    * committed_subscriptions
    */
-  committed_subscriptions?: number | number | null;
+  committed_subscriptions?: number | null;
   /**
    * monthly_recurring_revenue
    */
-  monthly_recurring_revenue?: number | number | null;
+  monthly_recurring_revenue?: number | null;
   /**
    * trial_monthly_recurring_revenue
    */
-  trial_monthly_recurring_revenue?: number | number | null;
+  trial_monthly_recurring_revenue?: number | null;
   /**
    * committed_monthly_recurring_revenue
    */
-  committed_monthly_recurring_revenue?: number | number | null;
+  committed_monthly_recurring_revenue?: number | null;
   /**
    * trial_committed_monthly_recurring_revenue
    */
-  trial_committed_monthly_recurring_revenue?: number | number | null;
+  trial_committed_monthly_recurring_revenue?: number | null;
   /**
    * average_revenue_per_user
    */
-  average_revenue_per_user?: number | number | null;
+  average_revenue_per_user?: number | null;
   /**
    * checkouts
    */
-  checkouts?: number | number | null;
+  checkouts?: number | null;
   /**
    * succeeded_checkouts
    */
-  succeeded_checkouts?: number | number | null;
+  succeeded_checkouts?: number | null;
   /**
    * churned_subscriptions
    */
-  churned_subscriptions?: number | number | null;
+  churned_subscriptions?: number | null;
   /**
    * churn_rate
    */
-  churn_rate?: number | number | null;
+  churn_rate?: number | null;
   /**
    * seats_total
    */
-  seats_total?: number | number | null;
+  seats_total?: number | null;
   /**
    * seats_claimed
    */
-  seats_claimed?: number | number | null;
+  seats_claimed?: number | null;
   /**
    * seats_pending
    */
-  seats_pending?: number | number | null;
+  seats_pending?: number | null;
   /**
    * seat_customers
    */
-  seat_customers?: number | number | null;
+  seat_customers?: number | null;
   /**
    * new_seat_customers
    */
-  new_seat_customers?: number | number | null;
+  new_seat_customers?: number | null;
   /**
    * churned_seat_customers
    */
-  churned_seat_customers?: number | number | null;
+  churned_seat_customers?: number | null;
   /**
    * orders
    */
-  orders?: number | number | null;
+  orders?: number | null;
   /**
    * revenue
    */
-  revenue?: number | number | null;
+  revenue?: number | null;
   /**
    * net_revenue
    */
-  net_revenue?: number | number | null;
+  net_revenue?: number | null;
   /**
    * cumulative_revenue
    */
-  cumulative_revenue?: number | number | null;
+  cumulative_revenue?: number | null;
   /**
    * net_cumulative_revenue
    */
-  net_cumulative_revenue?: number | number | null;
+  net_cumulative_revenue?: number | null;
   /**
    * costs
    */
-  costs?: number | number | null;
+  costs?: number | null;
   /**
    * cumulative_costs
    */
-  cumulative_costs?: number | number | null;
+  cumulative_costs?: number | null;
   /**
    * average_order_value
    */
-  average_order_value?: number | number | null;
+  average_order_value?: number | null;
   /**
    * net_average_order_value
    */
-  net_average_order_value?: number | number | null;
+  net_average_order_value?: number | null;
   /**
    * cost_per_user
    */
-  cost_per_user?: number | number | null;
+  cost_per_user?: number | null;
   /**
    * active_user_by_event
    */
-  active_user_by_event?: number | number | null;
+  active_user_by_event?: number | null;
   /**
    * one_time_products
    */
-  one_time_products?: number | number | null;
+  one_time_products?: number | null;
   /**
    * one_time_products_revenue
    */
-  one_time_products_revenue?: number | number | null;
+  one_time_products_revenue?: number | null;
   /**
    * one_time_products_net_revenue
    */
-  one_time_products_net_revenue?: number | number | null;
+  one_time_products_net_revenue?: number | null;
   /**
    * new_subscriptions
    */
-  new_subscriptions?: number | number | null;
+  new_subscriptions?: number | null;
   /**
    * new_subscriptions_revenue
    */
-  new_subscriptions_revenue?: number | number | null;
+  new_subscriptions_revenue?: number | null;
   /**
    * new_subscriptions_net_revenue
    */
-  new_subscriptions_net_revenue?: number | number | null;
+  new_subscriptions_net_revenue?: number | null;
   /**
    * renewed_subscriptions
    */
-  renewed_subscriptions?: number | number | null;
+  renewed_subscriptions?: number | null;
   /**
    * renewed_subscriptions_revenue
    */
-  renewed_subscriptions_revenue?: number | number | null;
+  renewed_subscriptions_revenue?: number | null;
   /**
    * renewed_subscriptions_net_revenue
    */
-  renewed_subscriptions_net_revenue?: number | number | null;
+  renewed_subscriptions_net_revenue?: number | null;
   /**
    * canceled_subscriptions
    */
-  canceled_subscriptions?: number | number | null;
+  canceled_subscriptions?: number | null;
   /**
    * canceled_subscriptions_customer_service
    */
-  canceled_subscriptions_customer_service?: number | number | null;
+  canceled_subscriptions_customer_service?: number | null;
   /**
    * canceled_subscriptions_low_quality
    */
-  canceled_subscriptions_low_quality?: number | number | null;
+  canceled_subscriptions_low_quality?: number | null;
   /**
    * canceled_subscriptions_missing_features
    */
-  canceled_subscriptions_missing_features?: number | number | null;
+  canceled_subscriptions_missing_features?: number | null;
   /**
    * canceled_subscriptions_switched_service
    */
-  canceled_subscriptions_switched_service?: number | number | null;
+  canceled_subscriptions_switched_service?: number | null;
   /**
    * canceled_subscriptions_too_complex
    */
-  canceled_subscriptions_too_complex?: number | number | null;
+  canceled_subscriptions_too_complex?: number | null;
   /**
    * canceled_subscriptions_too_expensive
    */
-  canceled_subscriptions_too_expensive?: number | number | null;
+  canceled_subscriptions_too_expensive?: number | null;
   /**
    * canceled_subscriptions_unused
    */
-  canceled_subscriptions_unused?: number | number | null;
+  canceled_subscriptions_unused?: number | null;
   /**
    * canceled_subscriptions_other
    */
-  canceled_subscriptions_other?: number | number | null;
+  canceled_subscriptions_other?: number | null;
   /**
    * annual_recurring_revenue
    */
-  annual_recurring_revenue?: number | number | null;
+  annual_recurring_revenue?: number | null;
   /**
    * committed_annual_recurring_revenue
    */
-  committed_annual_recurring_revenue?: number | number | null;
+  committed_annual_recurring_revenue?: number | null;
   /**
    * checkouts_conversion
    */
-  checkouts_conversion?: number | number | null;
+  checkouts_conversion?: number | null;
   /**
    * ltv
    */
-  ltv?: number | number | null;
+  ltv?: number | null;
   /**
    * gross_margin
    */
-  gross_margin?: number | number | null;
+  gross_margin?: number | null;
   /**
    * gross_margin_percentage
    */
-  gross_margin_percentage?: number | number | null;
+  gross_margin_percentage?: number | null;
   /**
    * cashflow
    */
-  cashflow?: number | number | null;
+  cashflow?: number | null;
   /**
    * average_seats_per_customer
    */
-  average_seats_per_customer?: number | number | null;
+  average_seats_per_customer?: number | null;
   /**
    * seat_utilization_rate
    */
-  seat_utilization_rate?: number | number | null;
+  seat_utilization_rate?: number | null;
 }
 /**
  * MissingInvoiceBillingDetails
@@ -16131,7 +16132,7 @@ export interface Order {
   /**
    * Key-value object storing custom field values.
    */
-  custom_field_data?: Record<string, string | number | boolean | string | null>;
+  custom_field_data?: Record<string, string | number | boolean | null>;
   /**
    * Platform fee amount in cents.
    */
@@ -16187,7 +16188,7 @@ export interface OrderCreate {
   /**
    * Key-value object storing custom field values.
    */
-  custom_field_data?: Record<string, string | number | boolean | string | null>;
+  custom_field_data?: Record<string, string | number | boolean | null>;
   /**
    * Key-value object allowing you to store additional information.
 
@@ -16201,7 +16202,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * The ID of the organization the order belongs to. **Required unless you use an organization token.** The customer and product must belong to this organization.
    */
@@ -17910,7 +17911,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * The name of the product.
    */
@@ -17970,7 +17971,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * The name of the product.
    */
@@ -18938,7 +18939,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * The interval unit for the trial period.
    */
@@ -19089,7 +19090,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * order_id
    */
@@ -19563,7 +19564,7 @@ export interface Subscription {
   /**
    * Key-value object storing custom field values.
    */
-  custom_field_data?: Record<string, string | number | boolean | string | null>;
+  custom_field_data?: Record<string, string | number | boolean | null>;
   /**
    * customer
    */
@@ -19844,7 +19845,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * The ID of the recurring product to subscribe to. Must be a free product, otherwise the customer should go through a checkout flow.
    */
@@ -19871,7 +19872,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**.
    */
-  metadata?: Record<string, string | number | number | boolean>;
+  metadata?: Record<string, string | number | boolean>;
   /**
    * The ID of the recurring product to subscribe to. Must be a free product, otherwise the customer should go through a checkout flow.
    */


### PR DESCRIPTION
## What changed

- Preserve `additionalProperties` value types on named object models in the SDK IR.
- Emit additional-properties-only models as dictionary/record aliases in Python and TypeScript.
- Deduplicate rendered TypeScript union members while preserving source order.
- Regenerate the Python and TypeScript SDK declarations and update regression coverage.

## Why

`MetadataOutputType` is correctly described by OpenAPI as an object with arbitrary keys and scalar values, but named component references were reduced to fieldless models in the IR. That produced an empty Python dataclass and an empty TypeScript interface instead of usable dictionary types.

## Impact

SDK consumers now receive:

- Python: `dict[str, str | int | float | bool]`
- TypeScript: `Record<string, string | number | boolean>`

## Validation

- `sdk/generator`: `just lint`, `just test` (81 passed)
- `sdk/python`: `just test` (21 passed)
- `sdk/typescript`: `just lint`, `just typecheck`, `just test` (19 passed)
- ADR review: no violations

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

