### PR TITLE
scripts: payment transaction recovery

### DIFF
--- a/server/scripts/payment_transaction_recovery.py
+++ b/server/scripts/payment_transaction_recovery.py
@@ -1,0 +1,68 @@
+import asyncio
+import logging.config
+from functools import wraps
+from typing import Any
+
+import dramatiq
+import structlog
+import typer
+
+from polar.integrations.stripe.payment import resolve_order
+from polar.integrations.stripe.service import stripe as stripe_service
+from polar.kit.db.postgres import create_async_sessionmaker
+from polar.postgres import create_async_engine
+from polar.redis import create_redis
+from polar.transaction.service.payment import (
+    payment_transaction as payment_transaction_service,
+)
+from polar.worker import JobQueueManager, enqueue_job
+
+cli = typer.Typer()
+
+
+def drop_all(*args: Any, **kwargs: Any) -> Any:
+    raise structlog.DropEvent
+
+
+structlog.configure(processors=[drop_all])
+logging.config.dictConfig(
+    {
+        "version": 1,
+        "disable_existing_loggers": True,
+    }
+)
+
+
+def typer_async(f):  # type: ignore
+    # From https://github.com/tiangolo/typer/issues/85
+    @wraps(f)
+    def wrapper(*args, **kwargs):  # type: ignore
+        return asyncio.run(f(*args, **kwargs))
+
+    return wrapper
+
+
+@cli.command()
+@typer_async
+async def payment_transaction_recovery(
+    charge_id: str = typer.Option(
+        help="Charge ID to write to as payment transaction.",
+    ),
+) -> None:
+    engine = create_async_engine("script")
+    sessionmaker = create_async_sessionmaker(engine)
+    redis = create_redis("script")
+    async with sessionmaker() as session:
+        async with JobQueueManager.open(dramatiq.get_broker(), redis):
+            charge = await stripe_service.get_charge(charge_id)
+            await payment_transaction_service.create_payment(session, charge=charge)
+
+            order = await resolve_order(session, charge, None)
+            if order is not None:
+                enqueue_job("order.balance", order_id=order.id, charge_id=charge_id)
+
+            await session.commit()
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION

Add a script to recover missing payment transactions from the database. The reason we have this case is that we got a `charge.succeeded` event from Stripe, but never a `charge.updated` from Stripe. Likely because the refund happened super quickly after the success event.

The problem in this case is that we were not able to create the payment transaction, which is done during `charge.updated`: the balance transaction we need to calculate the amout usually comes a few minutes after. Here it never came.

So this is not a fix but just a script to recover the missing payment transactions.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

