### PR TITLE
server/integrations/polar: try to retrieve customer first before creating

### DIFF
--- a/server/polar/integrations/polar/client.py
+++ b/server/polar/integrations/polar/client.py
@@ -15,6 +15,7 @@ from polar.base import (
 from polar.config import settings
 from polar.exceptions import PolarError as InternalPolarError
 from polar.v2026_04 import PolarAsync as PolarSDK
+from polar.v2026_04.errors import ResourceNotFound
 from polar.v2026_04.inputs import (
     CostMetadataInput,
     CustomerBenefitGrantUpdate,
@@ -105,6 +106,15 @@ class PolarSelfClient:
     ) -> Customer:
         with logfire.span("polar.create_customer", external_id=external_id) as span:
             try:
+                return await self._sdk.customers.get_external(external_id)
+            except ResourceNotFound:
+                pass
+            except (PolarClientError, PolarServerError) as e:
+                _raise_error(span, e, "create_customer.fetch_existing")
+            except PolarNetworkError as e:
+                _raise_network_error(span, e, "create_customer.fetch_existing")
+
+            try:
                 return await self._sdk.customers.create(
                     type="team",
                     name=name,
@@ -117,18 +127,9 @@ class PolarSelfClient:
                     },
                 )
             except (PolarClientError, PolarServerError) as e:
-                if e.status_code != 409:
-                    _raise_error(span, e, "create_customer")
-                span.set_attribute("conflict", True)
+                _raise_error(span, e, "create_customer")
             except PolarNetworkError as e:
                 _raise_network_error(span, e, "create_customer")
-
-            try:
-                return await self._sdk.customers.get_external(external_id)
-            except (PolarClientError, PolarServerError) as e:
-                _raise_error(span, e, "create_customer.fetch_existing")
-            except PolarNetworkError as e:
-                _raise_network_error(span, e, "create_customer.fetch_existing")
 
     async def cancel_subscription(self, *, subscription_id: str) -> Subscription:
         with logfire.span(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Retrieve existing Polar customer by external_id before creating to avoid conflicts and noisy errors. Simplifies the flow and reduces unnecessary create attempts.

- **Bug Fixes**
  - Check `customers.get_external(external_id)` first; on `ResourceNotFound`, fall back to `customers.create(...)`.
  - Remove 409-conflict fallback and the "conflict" span attribute; non-404 client/server errors now surface immediately.
  - Import `ResourceNotFound` from `polar.v2026_04.errors`; network error handling unchanged.

<sup>Written for commit b098b9ae22a47da3504671d6d539f691c4868888. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

