### PR TITLE
server/order: unlock stale payment lock order

### DIFF
--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -569,6 +569,7 @@ class Settings(BaseSettings):
         timedelta(days=7),  # Fourth retry after 21 days (2 + 5 + 7 + 7)
     ]
     CUSTOMER_RETRY_MAX_ATTEMPTS: int = 5
+    PAYMENT_LOCK_STALE_THRESHOLD: timedelta = timedelta(hours=1)
 
     TAX_PROCESSORS: list[TaxProcessor] = [TaxProcessor.stripe]
     TAX_RECORD_PROCESSOR: TaxProcessor = TaxProcessor.stripe

--- a/server/polar/models/order.py
+++ b/server/polar/models/order.py
@@ -22,6 +22,7 @@ from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
+from polar.config import settings
 from polar.custom_field.data import CustomFieldDataMixin
 from polar.enums import TaxBehavior, TaxProcessor
 from polar.exceptions import PolarError
@@ -29,6 +30,7 @@ from polar.kit.address import Address, AddressType
 from polar.kit.db.models import RecordModel
 from polar.kit.extensions.sqlalchemy.types import StringEnum
 from polar.kit.metadata import MetadataMixin
+from polar.kit.utils import utc_now
 from polar.models.order_item import OrderItem
 from polar.tax.calculation import TaxBreakdownItem
 from polar.tax.tax_id import TaxID, TaxIDType
@@ -393,6 +395,21 @@ class Order(CustomFieldDataMixin, MetadataMixin, RecordModel):
     @classmethod
     def _is_void_expression(cls) -> ColumnElement[bool]:
         return cls.status == OrderStatus.void
+
+    @hybrid_property
+    def is_payment_lock_stale(self) -> bool:
+        if self.payment_lock_acquired_at is None:
+            return False
+        return self.payment_lock_acquired_at <= (
+            utc_now() - settings.PAYMENT_LOCK_STALE_THRESHOLD
+        )
+
+    @is_payment_lock_stale.inplace.expression
+    @classmethod
+    def _is_payment_lock_stale_expression(cls) -> ColumnElement[bool]:
+        return cls.payment_lock_acquired_at <= (
+            func.now() - settings.PAYMENT_LOCK_STALE_THRESHOLD
+        )
 
     @property
     def is_invoice_generated(self) -> bool:

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -1,4 +1,4 @@
-from collections.abc import Sequence
+from collections.abc import AsyncGenerator, Sequence
 from datetime import datetime
 from typing import TYPE_CHECKING, cast
 from uuid import UUID
@@ -388,6 +388,15 @@ class OrderRepository(
         )
         result = cast(CursorResult[Order], await self.session.execute(statement))
         return result.rowcount > 0
+
+    async def stream_stale_payment_lock(self) -> AsyncGenerator[Order, None]:
+        statement = (
+            self.get_base_statement()
+            .where(Order.is_payment_lock_stale.is_(True))
+            .order_by(Order.payment_lock_acquired_at.asc())
+        )
+        async for order in self.stream(statement):
+            yield order
 
     def get_statement_by_org_ids(
         self, org_ids: set[AccessibleOrganizationID]

--- a/server/polar/order/tasks.py
+++ b/server/polar/order/tasks.py
@@ -249,6 +249,37 @@ async def process_dunning_order(order_id: uuid.UUID) -> None:
 
 
 @actor(
+    actor_name="order.enqueue_stale_payment_locks",
+    cron_trigger=CronTrigger.from_crontab("15 * * * *"),
+    priority=TaskPriority.MEDIUM,
+)
+async def enqueue_stale_payment_locks() -> None:
+    async with AsyncSessionMaker() as session:
+        order_repository = OrderRepository.from_session(session)
+        async for order in order_repository.stream_stale_payment_lock():
+            enqueue_job("order.process_stale_payment_lock", order.id)
+
+
+@actor(actor_name="order.process_stale_payment_lock", priority=TaskPriority.MEDIUM)
+async def process_stale_payment_lock(order_id: uuid.UUID) -> None:
+    async with AsyncSessionMaker() as session:
+        order_repository = OrderRepository.from_session(session)
+        order = await order_repository.get_by_id(
+            order_id, options=order_repository.get_eager_options()
+        )
+        if order is None:
+            raise OrderDoesNotExist(order_id)
+
+        if not order.is_payment_lock_stale:
+            log.info("Order payment lock is not stale, skipping", order_id=order.id)
+            return
+
+        # Treat stale payment locks as manual retry payment failures,
+        # so we the lock is released, but the dunning sequence is untouched.
+        await order_service.handle_payment_failure(session, order, skip_dunning=True)
+
+
+@actor(
     actor_name="order.void_pending_orders_for_subscription", priority=TaskPriority.LOW
 )
 async def void_pending_orders_for_subscription(subscription_id: uuid.UUID) -> None:

--- a/server/polar/order/tasks.py
+++ b/server/polar/order/tasks.py
@@ -275,7 +275,7 @@ async def process_stale_payment_lock(order_id: uuid.UUID) -> None:
             return
 
         # Treat stale payment locks as manual retry payment failures,
-        # so we the lock is released, but the dunning sequence is untouched.
+        # so the lock is released, but the dunning sequence is untouched.
         await order_service.handle_payment_failure(session, order, skip_dunning=True)
 
 

--- a/server/polar/order/tasks.py
+++ b/server/polar/order/tasks.py
@@ -265,7 +265,7 @@ async def process_stale_payment_lock(order_id: uuid.UUID) -> None:
     async with AsyncSessionMaker() as session:
         order_repository = OrderRepository.from_session(session)
         order = await order_repository.get_by_id(
-            order_id, options=order_repository.get_eager_options()
+            order_id, options=order_repository.get_eager_options(), for_update=True
         )
         if order is None:
             raise OrderDoesNotExist(order_id)

--- a/server/tests/order/test_tasks.py
+++ b/server/tests/order/test_tasks.py
@@ -18,8 +18,10 @@ from polar.order.repository import OrderRepository
 from polar.order.service import order as order_service
 from polar.order.tasks import (
     OrderDoesNotExist,
+    enqueue_stale_payment_locks,
     process_dunning,
     process_dunning_order,
+    process_stale_payment_lock,
     trigger_payment,
 )
 from polar.subscription.repository import SubscriptionRepository
@@ -432,6 +434,66 @@ class TestProcessDunningOrder:
         updated_subscription = await subscription_repo.get_by_id(subscription.id)
         assert updated_subscription is not None
         assert updated_subscription.status == SubscriptionStatus.canceled
+
+
+@pytest.mark.asyncio
+class TestEnqueueStalePaymentLocks:
+    async def test_enqueues_stale_payment_lock(
+        self,
+        save_fixture: SaveFixture,
+        product: Product,
+        organization: Organization,
+        mocker: MockerFixture,
+    ) -> None:
+        customer = await create_customer(save_fixture, organization=organization)
+        stale_order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            payment_lock_acquired_at=utc_now()
+            - settings.PAYMENT_LOCK_STALE_THRESHOLD
+            - timedelta(minutes=1),
+        )
+        await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+        )
+        enqueue_job_mock = mocker.patch("polar.order.tasks.enqueue_job")
+
+        await enqueue_stale_payment_locks()
+
+        enqueue_job_mock.assert_called_once_with(
+            "order.process_stale_payment_lock", stale_order.id
+        )
+
+
+@pytest.mark.asyncio
+class TestProcessStalePaymentLock:
+    async def test_releases_payment_lock(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        organization: Organization,
+    ) -> None:
+        customer = await create_customer(save_fixture, organization=organization)
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.pending,
+            payment_lock_acquired_at=utc_now()
+            - settings.PAYMENT_LOCK_STALE_THRESHOLD
+            - timedelta(minutes=1),
+        )
+
+        await process_stale_payment_lock(order.id)
+
+        repository = OrderRepository.from_session(session)
+        updated_order = await repository.get_by_id(order.id)
+        assert updated_order is not None
+        assert updated_order.payment_lock_acquired_at is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION

More straighforward fix for #13124. We simply unlock the orders that have a too old payment lock, and resume dunning.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

