### PR TITLE
server/auth: protect email OTP requests with Turnstile

### DIFF
--- a/clients/apps/web/next.config.mjs
+++ b/clients/apps/web/next.config.mjs
@@ -34,8 +34,8 @@ const S3_PUBLIC_IMAGES_BUCKET_ORIGIN = process.env
 const baseCSP = `
     default-src 'self';
     connect-src 'self' ${process.env.NEXT_PUBLIC_API_URL} ${process.env.S3_UPLOAD_ORIGINS} https://api.stripe.com https://maps.googleapis.com https://*.google-analytics.com https://chat.uk.plain.com https://prod-uk-services-attachm-attachmentsuploadbucket2-1l2e4906o2asm.s3.eu-west-2.amazonaws.com;
-    frame-src 'self' https://*.js.stripe.com https://js.stripe.com https://hooks.stripe.com https://customer-wl21dabnj6qtvcai.cloudflarestream.com videodelivery.net *.cloudflarestream.com;
-    script-src 'self' 'unsafe-eval' 'unsafe-inline' https://*.js.stripe.com https://js.stripe.com https://maps.googleapis.com https://www.googletagmanager.com https://chat.cdn-plain.com https://embed.cloudflarestream.com;
+    frame-src 'self' https://challenges.cloudflare.com https://*.js.stripe.com https://js.stripe.com https://hooks.stripe.com https://customer-wl21dabnj6qtvcai.cloudflarestream.com videodelivery.net *.cloudflarestream.com;
+    script-src 'self' 'unsafe-eval' 'unsafe-inline' https://challenges.cloudflare.com https://*.js.stripe.com https://js.stripe.com https://maps.googleapis.com https://www.googletagmanager.com https://chat.cdn-plain.com https://embed.cloudflarestream.com;
     style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
     img-src 'self' blob: data: https://www.gravatar.com https://img.logo.dev https://lh3.googleusercontent.com https://avatars.githubusercontent.com ${S3_PUBLIC_IMAGES_BUCKET_ORIGIN} https://uploads.polar.sh https://prod-uk-services-workspac-workspacefilespublicbuck-vs4gjqpqjkh6.s3.amazonaws.com https://prod-uk-services-attachm-attachmentsbucket28b3ccf-uwfssb4vt2us.s3.eu-west-2.amazonaws.com https://i0.wp.com;
     font-src 'self';

--- a/clients/apps/web/src/components/Auth/EmailOTPForm.tsx
+++ b/clients/apps/web/src/components/Auth/EmailOTPForm.tsx
@@ -14,6 +14,7 @@ import {
   FormMessage,
 } from '@polar-sh/ui/components/ui/form'
 import { useRouter } from 'next/navigation'
+import Script from 'next/script'
 import { useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 
@@ -21,6 +22,12 @@ interface EmailOTPFormProps {
   authenticationSession: schemas['AuthenticationSession'] | null
   returnTo?: string
   signup?: boolean
+}
+
+interface TurnstileWindow extends Window {
+  turnstile?: {
+    reset: () => void
+  }
 }
 
 const EmailOTPForm = ({
@@ -40,7 +47,22 @@ const EmailOTPForm = ({
   const posthog = usePostHog()
   const router = useRouter()
 
-  const onSubmit: SubmitHandler<{ email: string }> = async ({ email }) => {
+  const onSubmit: SubmitHandler<{ email: string }> = async (
+    { email },
+    event,
+  ) => {
+    const formElement = event?.target
+    const turnstileToken =
+      formElement instanceof HTMLFormElement
+        ? new FormData(formElement).get('cf-turnstile-response')
+        : null
+    if (typeof turnstileToken !== 'string' || !turnstileToken) {
+      setError('email', {
+        message: 'Please complete the verification challenge.',
+      })
+      return
+    }
+
     setLoading(true)
     try {
       let eventName: EventName = 'global:user:login:submit'
@@ -56,7 +78,10 @@ const EmailOTPForm = ({
         await authSessionStart.mutateAsync(returnTo)
       }
 
-      const { error } = await emailOTPRequest.mutateAsync(email)
+      const { error } = await emailOTPRequest.mutateAsync({
+        email,
+        turnstileToken,
+      })
       if (error) {
         if (isValidationError(error.detail)) {
           setValidationErrors(error.detail, setError)
@@ -76,47 +101,63 @@ const EmailOTPForm = ({
         message: 'An unexpected error occurred. Please try again.',
       })
     } finally {
+      const turnstileWindow = window as TurnstileWindow
+      turnstileWindow.turnstile?.reset()
       setLoading(false)
     }
   }
 
   return (
-    <Form {...form}>
-      <form className="flex w-full flex-col" onSubmit={handleSubmit(onSubmit)}>
-        <FormField
-          control={control}
-          name="email"
-          render={({ field }) => {
-            return (
-              <FormItem>
-                <FormControl className="w-full">
-                  <div className="flex w-full flex-col gap-2">
-                    <Input
-                      type="email"
-                      required
-                      placeholder="Email"
-                      autoComplete="off"
-                      data-1p-ignore
-                      {...field}
-                    />
-                    <Button
-                      type="submit"
-                      variant="secondary"
-                      fullWidth
-                      loading={loading}
-                      disabled={loading}
-                    >
-                      {signup ? 'Sign up with email' : 'Sign in with email'}
-                    </Button>
-                  </div>
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )
-          }}
-        />
-      </form>
-    </Form>
+    <>
+      <Script
+        src="https://challenges.cloudflare.com/turnstile/v0/api.js"
+        strategy="afterInteractive"
+      />
+      <Form {...form}>
+        <form
+          className="flex w-full flex-col"
+          onSubmit={handleSubmit(onSubmit)}
+        >
+          <FormField
+            control={control}
+            name="email"
+            render={({ field }) => {
+              return (
+                <FormItem>
+                  <FormControl className="w-full">
+                    <div className="flex w-full flex-col gap-2">
+                      <Input
+                        type="email"
+                        required
+                        placeholder="Email"
+                        autoComplete="off"
+                        data-1p-ignore
+                        {...field}
+                      />
+                      <div
+                        className="cf-turnstile"
+                        data-sitekey="0x4AAAAAAD7cBrbpX3kX8K9g"
+                        data-action="turnstile-spin-v2"
+                      />
+                      <Button
+                        type="submit"
+                        variant="secondary"
+                        fullWidth
+                        loading={loading}
+                        disabled={loading}
+                      >
+                        {signup ? 'Sign up with email' : 'Sign in with email'}
+                      </Button>
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )
+            }}
+          />
+        </form>
+      </Form>
+    </>
   )
 }
 

--- a/clients/apps/web/src/hooks/auth.ts
+++ b/clients/apps/web/src/hooks/auth.ts
@@ -74,8 +74,16 @@ export const useOrgAuthSessionStart = (slug: string) =>
 
 export const useEmailOTPRequest = () =>
   useMutation({
-    mutationFn: (email: string) =>
-      api.POST('/v1/auth/email-otp/request', { body: { email } }),
+    mutationFn: ({
+      email,
+      turnstileToken,
+    }: {
+      email: string
+      turnstileToken: string
+    }) =>
+      api.POST('/v1/auth/email-otp/request', {
+        body: { email, 'cf-turnstile-response': turnstileToken },
+      }),
   })
 
 export const useEmailOTPVerify = () =>

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -20540,6 +20540,8 @@ export interface components {
        * Format: email
        */
       email: string
+      /** Cf-Turnstile-Response */
+      'cf-turnstile-response': string
     }
     /** EmailOTPVerify */
     EmailOTPVerify: {
@@ -40137,6 +40139,15 @@ export interface operations {
         }
         content: {
           'application/json': unknown
+        }
+      }
+      /** @description Turnstile verification failed */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['NotPermitted']
         }
       }
       /** @description Validation Error */

--- a/server/polar/auth/endpoints.py
+++ b/server/polar/auth/endpoints.py
@@ -31,6 +31,7 @@ from polar.auth.oauth2.google import get_google_factor
 from polar.authz.dependencies import AuthorizeWebUserRead, AuthorizeWebUserWriteFresh
 from polar.config import settings
 from polar.exceptions import NotPermitted, ResourceNotFound
+from polar.kit.http import get_ip_address
 from polar.models import UserSession as UserSession
 from polar.openapi import APITag
 from polar.postgres import AsyncSession, get_db_session
@@ -70,6 +71,7 @@ from .schemas import (
 )
 from .service import auth as auth_service
 from .sso.endpoints import router as sso_login_router
+from .turnstile import verify_turnstile
 
 TOTP_ISSUER = (
     "Polar" if settings.is_production() else f"Polar {settings.ENV.value.capitalize()}"
@@ -185,15 +187,27 @@ async def complete(
     return response
 
 
-@router.post("/email-otp/request", status_code=202)
+@router.post(
+    "/email-otp/request",
+    status_code=202,
+    responses={
+        403: {
+            "description": "Turnstile verification failed",
+            "model": NotPermitted.schema(),
+        }
+    },
+)
 async def email_otp_request(
     email_otp_request: EmailOTPRequest,
+    request: Request,
     authentication_session: AuthenticationSession = Depends(get_authentication_session),
     authentication_session_service: AuthenticationSessionService = Depends(
         get_authentication_session_service
     ),
     email_otp_factor: EmailOTPFactor = Depends(get_email_otp_factor),
 ) -> None:
+    await verify_turnstile(email_otp_request.turnstile_token, get_ip_address(request))
+
     factors = await authentication_session_service.get_available_factors(
         authentication_session
     )

--- a/server/polar/auth/schemas.py
+++ b/server/polar/auth/schemas.py
@@ -68,6 +68,7 @@ class AuthenticationSession(Schema):
 
 class EmailOTPRequest(Schema):
     email: EmailStr
+    turnstile_token: str = Field(alias="cf-turnstile-response")
 
 
 class EmailOTPVerify(Schema):

--- a/server/polar/auth/turnstile.py
+++ b/server/polar/auth/turnstile.py
@@ -1,0 +1,26 @@
+import httpx
+
+from polar.config import settings
+from polar.exceptions import NotPermitted
+
+turnstile_client = httpx.AsyncClient(
+    base_url="https://challenges.cloudflare.com/turnstile/v0"
+)
+
+
+async def verify_turnstile(token: str, remote_ip: str | None) -> None:
+    try:
+        response = await turnstile_client.post(
+            "/siteverify",
+            data={
+                "secret": settings.TURNSTILE_SECRET,
+                "response": token,
+                "remoteip": remote_ip or "",
+            },
+        )
+        result = response.json()
+    except httpx.HTTPError as e:
+        raise NotPermitted("Turnstile verification failed") from e
+
+    if not isinstance(result, dict) or result.get("success") is not True:
+        raise NotPermitted("Turnstile verification failed")

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -211,6 +211,8 @@ class Settings(BaseSettings):
     EMAIL_DEFAULT_REPLY_TO_NAME: str = "Polar Support"
     EMAIL_DEFAULT_REPLY_TO_EMAIL_ADDRESS: str = "support@polar.sh"
 
+    TURNSTILE_SECRET: str = ""
+
     # Github App
     GITHUB_CLIENT_ID: str = ""
     GITHUB_CLIENT_SECRET: str = ""

--- a/server/tests/auth/test_turnstile.py
+++ b/server/tests/auth/test_turnstile.py
@@ -1,0 +1,32 @@
+from urllib.parse import parse_qs
+
+import pytest
+import respx
+from httpx import Response
+
+from polar.auth.turnstile import verify_turnstile
+from polar.exceptions import NotPermitted
+
+
+@pytest.mark.asyncio
+class TestVerifyTurnstile:
+    async def test_success(self, respx_mock: respx.MockRouter) -> None:
+        route = respx_mock.post(
+            "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+        ).mock(return_value=Response(200, json={"success": True}))
+
+        await verify_turnstile("test-token", "203.0.113.1")
+
+        request = route.calls.last.request
+        assert request.headers["content-type"] == "application/x-www-form-urlencoded"
+        payload = parse_qs(request.content.decode())
+        assert payload["response"] == ["test-token"]
+        assert payload["remoteip"] == ["203.0.113.1"]
+
+    async def test_failure(self, respx_mock: respx.MockRouter) -> None:
+        respx_mock.post(
+            "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+        ).mock(return_value=Response(200, json={"success": False}))
+
+        with pytest.raises(NotPermitted):
+            await verify_turnstile("invalid-token", "203.0.113.1")


### PR DESCRIPTION
## Summary

- embed the existing Cloudflare Turnstile widget in the shared email OTP sign-in/sign-up form
- verify each token server-side with Cloudflare siteverify before requesting an OTP
- pass the trusted client IP, fail closed unless `success` is exactly `true`, and expose the typed 403 response
- allow the Turnstile script/frame in the frontend CSP and regenerate the TypeScript API client

## Why

Email OTP requests were publicly callable without a bot challenge. This adds Turnstile at the existing request boundary without changing OTP delivery or verification behavior.

## Impact

All dashboard email OTP requests require a valid Turnstile token. The widget resets after submission so failed requests can be retried.

Terraform support landed in #13340. Populate `turnstile_secret` in the Terraform Cloud variable sets before merging or deploying this PR.

## Validation

- `uv run task lint_check`
- `uv run task lint_types`
- `uv run pytest tests/auth -q` (46 passed)
- `pnpm --filter web lint`
- `pnpm --filter web typecheck`
- `pnpm --filter @polar-sh/client lint`
- Polar conventions review: no findings
- ADR compliance review: no violations

The live secret-backed siteverify probe remains pending until the environment secret is populated.