### PR TITLE
terraform: configure Turnstile secret

### DIFF
--- a/terraform/global/production.tf
+++ b/terraform/global/production.tf
@@ -620,3 +620,11 @@ resource "tfe_variable" "stripe_app_client_link_id_production" {
   sensitive       = false
   variable_set_id = tfe_variable_set.production.id
 }
+
+resource "tfe_variable" "turnstile_secret_production" {
+  key             = "turnstile_secret"
+  category        = "terraform"
+  description     = "Cloudflare Turnstile secret for production"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.production.id
+}

--- a/terraform/global/sandbox.tf
+++ b/terraform/global/sandbox.tf
@@ -534,3 +534,11 @@ resource "tfe_variable" "stripe_app_client_link_id_sandbox" {
   sensitive       = false
   variable_set_id = tfe_variable_set.sandbox.id
 }
+
+resource "tfe_variable" "turnstile_secret_sandbox" {
+  key             = "turnstile_secret"
+  category        = "terraform"
+  description     = "Cloudflare Turnstile secret for sandbox"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.sandbox.id
+}

--- a/terraform/global/test.tf
+++ b/terraform/global/test.tf
@@ -520,3 +520,11 @@ resource "tfe_variable" "stripe_app_client_link_id_test" {
   sensitive       = false
   variable_set_id = tfe_variable_set.test.id
 }
+
+resource "tfe_variable" "turnstile_secret_test" {
+  key             = "turnstile_secret"
+  category        = "terraform"
+  description     = "Cloudflare Turnstile secret for test"
+  sensitive       = true
+  variable_set_id = tfe_variable_set.test.id
+}

--- a/terraform/modules/render_service/main.tf
+++ b/terraform/modules/render_service/main.tf
@@ -70,6 +70,7 @@ resource "render_env_group" "backend" {
       POLAR_TAX_PROCESSORS                       = { value = var.backend_config.tax_processors }
       POLAR_TAX_RECORD_PROCESSOR                 = { value = var.backend_config.tax_record_processor }
       POLAR_NUMERAL_API_KEY                      = { value = var.backend_secrets.numeral_api_key }
+      POLAR_TURNSTILE_SECRET                     = { value = var.backend_secrets.turnstile_secret }
       POLAR_CUSTOMER_PORTAL_URL_OVERRIDES        = { value = var.backend_config.customer_portal_url_overrides }
     },
     var.backend_config.plain_default_tier_external_id != "" ? {

--- a/terraform/modules/render_service/variables.tf
+++ b/terraform/modules/render_service/variables.tf
@@ -167,6 +167,7 @@ variable "backend_secrets" {
     chargeback_stop_webhook_secret = optional(string, "")
     numeral_api_key                = optional(string, "")
     firecrawl_api_key              = optional(string, "")
+    turnstile_secret               = string
   })
   sensitive = true
 }

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -332,6 +332,7 @@ module "production" {
     app_review_otp_code            = var.backend_app_review_otp_code
     chargeback_stop_webhook_secret = var.backend_chargebackstop_webhook_secret_production
     numeral_api_key                = var.numeral_api_key_production
+    turnstile_secret               = var.turnstile_secret
   }
 
   aws_s3_config = {

--- a/terraform/production/variables.tf
+++ b/terraform/production/variables.tf
@@ -539,3 +539,9 @@ variable "stripe_app_client_link_id" {
   type        = string
   default     = ""
 }
+
+variable "turnstile_secret" {
+  description = "Cloudflare Turnstile secret"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -212,6 +212,7 @@ module "sandbox" {
     sentry_dsn               = var.backend_sentry_dsn_sandbox
     jwks                     = var.backend_jwks_sandbox
     numeral_api_key          = var.numeral_api_key_sandbox
+    turnstile_secret         = var.turnstile_secret
   }
 
   aws_s3_config = {

--- a/terraform/sandbox/variables.tf
+++ b/terraform/sandbox/variables.tf
@@ -450,3 +450,9 @@ variable "stripe_app_client_link_id" {
   type        = string
   default     = ""
 }
+
+variable "turnstile_secret" {
+  description = "Cloudflare Turnstile secret"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -212,6 +212,7 @@ module "test" {
     sentry_dsn               = var.backend_sentry_dsn
     jwks                     = var.backend_jwks
     numeral_api_key          = var.numeral_api_key
+    turnstile_secret         = var.turnstile_secret
   }
 
   aws_s3_config = {

--- a/terraform/test/variables.tf
+++ b/terraform/test/variables.tf
@@ -434,3 +434,9 @@ variable "stripe_app_client_link_id" {
   type        = string
   default     = ""
 }
+
+variable "turnstile_secret" {
+  description = "Cloudflare Turnstile secret"
+  type        = string
+  sensitive   = true
+}


### PR DESCRIPTION
## Summary

- declare a sensitive `turnstile_secret` Terraform Cloud variable for production, sandbox, and test
- add the secret to the shared Render backend secrets object
- expose it to backend services as `POLAR_TURNSTILE_SECRET`

## Why

The Turnstile secret must be available in every backend environment before email OTP requests begin enforcing Turnstile verification.

## Impact

Populate `turnstile_secret` in the Production, Sandbox, and Test Terraform Cloud variable sets before merging the stacked application PR.

This is the base PR for #13339.

## Validation

- `terraform fmt -check -recursive terraform`
- independent diff scope check: Terraform files only
- ADR compliance review: no violations

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

