### PR TITLE
clients/auth: render Turnstile after modal remount

### DIFF
--- a/clients/apps/web/src/components/Auth/EmailOTPForm.test.tsx
+++ b/clients/apps/web/src/components/Auth/EmailOTPForm.test.tsx
@@ -1,0 +1,125 @@
+import { act, render } from '@testing-library/react'
+import type { InputHTMLAttributes, PropsWithChildren, ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const scriptState = vi.hoisted(() => ({
+  onLoad: undefined as (() => void) | undefined,
+  onReady: undefined as (() => void) | undefined,
+  src: '',
+}))
+
+vi.mock('next/script', () => ({
+  default: ({
+    onLoad,
+    onReady,
+    src,
+  }: {
+    onLoad?: () => void
+    onReady?: () => void
+    src: string
+  }) => {
+    scriptState.onLoad = onLoad
+    scriptState.onReady = onReady
+    scriptState.src = src
+    return null
+  },
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('@/hooks', () => ({
+  useAuthSessionStart: () => ({ mutateAsync: vi.fn() }),
+  useEmailOTPRequest: () => ({ mutateAsync: vi.fn() }),
+}))
+
+vi.mock('@/hooks/posthog', () => ({
+  usePostHog: () => ({ capture: vi.fn() }),
+}))
+
+vi.mock('@/utils/api/errors', () => ({
+  setValidationErrors: vi.fn(),
+}))
+
+vi.mock('@polar-sh/client', () => ({
+  isValidationError: () => false,
+}))
+
+vi.mock('@polar-sh/orbit', () => ({
+  Button: ({ children }: PropsWithChildren) => <button>{children}</button>,
+  Input: (props: InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}))
+
+vi.mock('@polar-sh/ui/components/ui/form', () => {
+  const Passthrough = ({ children }: PropsWithChildren) => children
+
+  return {
+    Form: Passthrough,
+    FormControl: Passthrough,
+    FormField: ({
+      render: renderField,
+    }: {
+      render: (args: { field: object }) => ReactNode
+    }) => renderField({ field: {} }),
+    FormItem: Passthrough,
+    FormMessage: () => null,
+  }
+})
+
+import EmailOTPForm from './EmailOTPForm'
+
+const turnstile = {
+  remove: vi.fn(),
+  render: vi.fn(),
+  reset: vi.fn(),
+}
+
+describe('EmailOTPForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    scriptState.onLoad = undefined
+    scriptState.onReady = undefined
+    scriptState.src = ''
+    turnstile.render
+      .mockReturnValueOnce('first-widget')
+      .mockReturnValueOnce('second-widget')
+    Object.assign(window, { turnstile: undefined })
+  })
+
+  it('renders a fresh widget on remount without another script callback', () => {
+    const firstRender = render(<EmailOTPForm authenticationSession={null} />)
+
+    expect(scriptState.src).toContain('render=explicit')
+    expect(turnstile.render).not.toHaveBeenCalled()
+
+    Object.assign(window, { turnstile })
+    act(() => scriptState.onReady?.())
+    expect(turnstile.render).toHaveBeenCalledTimes(1)
+    expect(turnstile.render.mock.calls[0]?.[1]).toMatchObject({
+      action: 'turnstile-spin-v2',
+      sitekey: '0x4AAAAAAD7cBrbpX3kX8K9g',
+    })
+
+    firstRender.unmount()
+    expect(turnstile.remove).toHaveBeenCalledWith('first-widget')
+
+    render(<EmailOTPForm authenticationSession={null} />)
+
+    expect(turnstile.render).toHaveBeenCalledTimes(2)
+    expect(turnstile.render.mock.calls[1]?.[0]).not.toBe(
+      turnstile.render.mock.calls[0]?.[0],
+    )
+  })
+
+  it('renders after remounting while the script is still loading', () => {
+    const firstRender = render(<EmailOTPForm authenticationSession={null} />)
+    firstRender.unmount()
+
+    render(<EmailOTPForm authenticationSession={null} />)
+    Object.assign(window, { turnstile })
+    act(() => scriptState.onLoad?.())
+
+    expect(turnstile.render).toHaveBeenCalledTimes(1)
+  })
+})

--- a/clients/apps/web/src/components/Auth/EmailOTPForm.tsx
+++ b/clients/apps/web/src/components/Auth/EmailOTPForm.tsx
@@ -15,7 +15,7 @@ import {
 } from '@polar-sh/ui/components/ui/form'
 import { useRouter } from 'next/navigation'
 import Script from 'next/script'
-import { useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 
 interface EmailOTPFormProps {
@@ -26,9 +26,17 @@ interface EmailOTPFormProps {
 
 interface TurnstileWindow extends Window {
   turnstile?: {
-    reset: () => void
+    remove: (widgetId: string) => void
+    render: (
+      container: HTMLElement,
+      options: { sitekey: string; action: string },
+    ) => string
+    reset: (widgetId: string) => void
   }
 }
+
+const TURNSTILE_SITE_KEY = '0x4AAAAAAD7cBrbpX3kX8K9g'
+const TURNSTILE_ACTION = 'turnstile-spin-v2'
 
 const EmailOTPForm = ({
   authenticationSession,
@@ -42,10 +50,38 @@ const EmailOTPForm = ({
   })
   const { control, handleSubmit, setError } = form
   const [loading, setLoading] = useState(false)
+  const turnstileContainerRef = useRef<HTMLDivElement>(null)
+  const turnstileWidgetIdRef = useRef<string | null>(null)
   const authSessionStart = useAuthSessionStart()
   const emailOTPRequest = useEmailOTPRequest()
   const posthog = usePostHog()
   const router = useRouter()
+
+  const renderTurnstile = useCallback(() => {
+    const turnstile = (window as TurnstileWindow).turnstile
+    const container = turnstileContainerRef.current
+    if (!turnstile || !container || turnstileWidgetIdRef.current) {
+      return
+    }
+
+    turnstileWidgetIdRef.current = turnstile.render(container, {
+      sitekey: TURNSTILE_SITE_KEY,
+      action: TURNSTILE_ACTION,
+    })
+  }, [])
+
+  useEffect(() => {
+    renderTurnstile()
+
+    return () => {
+      const turnstile = (window as TurnstileWindow).turnstile
+      const widgetId = turnstileWidgetIdRef.current
+      if (turnstile && widgetId) {
+        turnstile.remove(widgetId)
+      }
+      turnstileWidgetIdRef.current = null
+    }
+  }, [renderTurnstile])
 
   const onSubmit: SubmitHandler<{ email: string }> = async (
     { email },
@@ -102,7 +138,10 @@ const EmailOTPForm = ({
       })
     } finally {
       const turnstileWindow = window as TurnstileWindow
-      turnstileWindow.turnstile?.reset()
+      const widgetId = turnstileWidgetIdRef.current
+      if (widgetId) {
+        turnstileWindow.turnstile?.reset(widgetId)
+      }
       setLoading(false)
     }
   }
@@ -110,8 +149,10 @@ const EmailOTPForm = ({
   return (
     <>
       <Script
-        src="https://challenges.cloudflare.com/turnstile/v0/api.js"
+        src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"
         strategy="afterInteractive"
+        onLoad={renderTurnstile}
+        onReady={renderTurnstile}
       />
       <Form {...form}>
         <form
@@ -135,9 +176,10 @@ const EmailOTPForm = ({
                         {...field}
                       />
                       <div
+                        ref={turnstileContainerRef}
                         className="cf-turnstile"
-                        data-sitekey="0x4AAAAAAD7cBrbpX3kX8K9g"
-                        data-action="turnstile-spin-v2"
+                        data-sitekey={TURNSTILE_SITE_KEY}
+                        data-action={TURNSTILE_ACTION}
                       />
                       <Button
                         type="submit"


### PR DESCRIPTION
## What changed

- switch the email OTP Turnstile widget to explicit rendering
- render the widget when the form mounts, when the script loads, and when the script is ready
- scope widget reset and cleanup to the rendered widget ID
- add regressions for modal remounts after the script has loaded and while it is still loading

## Why

Closing the authentication modal unmounts the Turnstile container. Reopening it creates a new container, but the cached script does not reliably trigger another implicit scan, leaving the form without a token and causing submissions to fail the missing-token check.

## Validation

- full web formatting and ESLint pass
- web TypeScript check
- `EmailOTPForm` Vitest regression tests (2 passing)
- correctness, security, simplification, Polar conventions, and ADR reviews

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

