### PR TITLE
server/order: always clear payment lock on payment failure

### DIFF
--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -2800,14 +2800,6 @@ class OrderService:
             skip_dunning: If True, skip dunning progression (e.g., for manual retries
                 where the user can try again without advancing the dunning state machine)
         """
-        # Don't process payment failure if the order is already paid
-        if order.status == OrderStatus.paid:
-            log.warning(
-                "Ignoring payment failure for already paid order",
-                order_id=order.id,
-            )
-            return order
-
         # Clear payment lock on failure
         if order.payment_lock_acquired_at is not None:
             log.info(
@@ -2816,6 +2808,14 @@ class OrderService:
             )
             repository = OrderRepository.from_session(session)
             order = await repository.release_payment_lock(order)
+
+        # Don't process payment failure if the order is already paid
+        if order.status == OrderStatus.paid:
+            log.warning(
+                "Ignoring payment failure for already paid order",
+                order_id=order.id,
+            )
+            return order
 
         # Skip dunning for manual retries - user can retry again
         if skip_dunning:

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -3326,6 +3326,7 @@ class TestHandlePaymentFailure:
             customer=customer,
             subscription=subscription,
             status=OrderStatus.paid,  # Order is already paid
+            payment_lock_acquired_at=utc_now(),
         )
         await save_fixture(order)
 
@@ -3339,6 +3340,7 @@ class TestHandlePaymentFailure:
         # Then
         assert result_order.next_payment_attempt_at is None  # No retry scheduled
         assert result_order.status == OrderStatus.paid  # Status unchanged
+        assert result_order.payment_lock_acquired_at is None  # Lock is released
         mock_mark_past_due.assert_not_called()  # Subscription not marked past_due
 
     async def test_non_subscription_order(


### PR DESCRIPTION

In the current state, `handle_failure` is short-circuited if the Order is already paid, not touching at the payment lock. However, we have in the wild some Orders that are both paid and have a payment lock, which is a state that should not exist. This PR makes sure to always clear the payment lock on payment failure, even if the Order is already paid.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

