### PR TITLE
Surface SSO-required orgs in the dashboard org switcher

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/layout.tsx
@@ -60,6 +60,7 @@ export default async function Layout(props: {
     <OrganizationContextProvider
       organization={organization}
       organizations={organizations}
+      memberOrganizations={memberOrganizations}
     >
       <AccountSetupProvider>{children}</AccountSetupProvider>
     </OrganizationContextProvider>

--- a/clients/apps/web/src/components/Layout/Dashboard/DashboardSidebar.tsx
+++ b/clients/apps/web/src/components/Layout/Dashboard/DashboardSidebar.tsx
@@ -6,6 +6,7 @@ import { CONFIG } from '@/utils/config'
 import { isImpersonating } from '@/utils/impersonation'
 import ArrowOutwardOutlined from '@mui/icons-material/ArrowOutwardOutlined'
 import KeyboardArrowDown from '@mui/icons-material/KeyboardArrowDown'
+import LockOutlined from '@mui/icons-material/LockOutlined'
 import Search from '@mui/icons-material/Search'
 import { schemas } from '@polar-sh/client'
 import { Avatar, Button } from '@polar-sh/orbit'
@@ -215,8 +216,9 @@ export const DashboardSidebar = ({
                         className="h-6 w-6"
                       />
                       <span className="min-w-0 truncate">{org.name}</span>
-                      <span className="dark:bg-polar-700 ml-auto shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-500 dark:text-gray-400">
-                        SSO required
+                      <span className="dark:bg-polar-700 ml-auto flex shrink-0 items-center gap-x-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-500 dark:text-gray-400">
+                        <LockOutlined fontSize="inherit" />
+                        SSO
                       </span>
                     </DropdownMenuItem>
                   ))}

--- a/clients/apps/web/src/components/Layout/Dashboard/DashboardSidebar.tsx
+++ b/clients/apps/web/src/components/Layout/Dashboard/DashboardSidebar.tsx
@@ -42,10 +42,12 @@ export const DashboardSidebar = ({
   type = 'organization',
   organization,
   organizations,
+  memberOrganizations,
 }: {
   type?: 'organization' | 'account'
   organization?: schemas['Organization']
   organizations: schemas['Organization'][]
+  memberOrganizations: schemas['MemberOrganization'][]
 }) => {
   const router = useRouter()
   const { currentUser } = useAuth()
@@ -58,6 +60,11 @@ export const DashboardSidebar = ({
   const navigateToOrganization = (org: schemas['Organization']) => {
     router.push(`/dashboard/${org.slug}`)
   }
+
+  const accessibleOrganizationIds = new Set(organizations.map((org) => org.id))
+  const ssoRequiredOrganizations = memberOrganizations.filter(
+    (org) => org.requires_sso && !accessibleOrganizationIds.has(org.id),
+  )
 
   const [_isImpersonating, setIsImpersonating] = useState(false)
   useEffect(() => {
@@ -194,6 +201,23 @@ export const DashboardSidebar = ({
                         className="h-6 w-6"
                       />
                       <span className="min-w-0 truncate">{org.name}</span>
+                    </DropdownMenuItem>
+                  ))}
+                  {ssoRequiredOrganizations.map((org) => (
+                    <DropdownMenuItem
+                      key={org.id}
+                      className="flex flex-row items-center gap-x-2"
+                      onClick={() => router.push(`/auth/sso/${org.slug}`)}
+                    >
+                      <Avatar
+                        name={org.name}
+                        avatar_url={org.avatar_url}
+                        className="h-6 w-6"
+                      />
+                      <span className="min-w-0 truncate">{org.name}</span>
+                      <span className="dark:bg-polar-700 ml-auto shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-500 dark:text-gray-400">
+                        SSO required
+                      </span>
                     </DropdownMenuItem>
                   ))}
                   <DropdownMenuSeparator />

--- a/clients/apps/web/src/components/Layout/DashboardLayout.tsx
+++ b/clients/apps/web/src/components/Layout/DashboardLayout.tsx
@@ -32,7 +32,8 @@ const DashboardLayout = (
     className?: string
   }>,
 ) => {
-  const { organization, organizations } = useContext(OrganizationContext)
+  const { organization, organizations, memberOrganizations } =
+    useContext(OrganizationContext)
 
   useEffect(() => {
     setLastVisitedEnv(CONFIG.IS_SANDBOX ? 'sandbox' : 'production')
@@ -52,6 +53,7 @@ const DashboardLayout = (
           <DashboardSidebar
             organization={organization}
             organizations={organizations ?? []}
+            memberOrganizations={memberOrganizations ?? []}
             type={props.type}
           />
         </div>

--- a/clients/apps/web/src/providers/maintainerOrganization.tsx
+++ b/clients/apps/web/src/providers/maintainerOrganization.tsx
@@ -12,6 +12,7 @@ const stub = (): never => {
 interface OrganizationContextType {
   organization: schemas['Organization']
   organizations: schemas['Organization'][]
+  memberOrganizations: schemas['MemberOrganization'][]
 }
 
 export const OrganizationContext =
@@ -21,10 +22,12 @@ export const OrganizationContext =
 export const OrganizationContextProvider = ({
   organization,
   organizations,
+  memberOrganizations,
   children,
 }: {
   organization: schemas['Organization']
   organizations: schemas['Organization'][]
+  memberOrganizations: schemas['MemberOrganization'][]
   children: React.ReactNode
 }) => {
   return (
@@ -32,6 +35,7 @@ export const OrganizationContextProvider = ({
       value={{
         organization,
         organizations,
+        memberOrganizations,
       }}
     >
       {children}

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -22748,6 +22748,10 @@ export interface components {
       id: string
       /** Slug */
       slug: string
+      /** Name */
+      name: string
+      /** Avatar Url */
+      avatar_url: string | null
       /**
        * Requires Sso
        * @description Whether this organization enforces SSO.

--- a/server/polar/user/endpoints.py
+++ b/server/polar/user/endpoints.py
@@ -90,7 +90,11 @@ async def get_authenticated(
             ],
             "member_organizations": [
                 MemberOrganization(
-                    id=org.id, slug=org.slug, requires_sso=org.sso_enforced
+                    id=org.id,
+                    slug=org.slug,
+                    name=org.name,
+                    avatar_url=org.avatar_url,
+                    requires_sso=org.sso_enforced,
                 )
                 for org, _ in org_with_roles
             ],

--- a/server/polar/user/schemas.py
+++ b/server/polar/user/schemas.py
@@ -32,6 +32,8 @@ class OAuthAccountRead(TimestampedSchema):
 class MemberOrganization(Schema):
     id: UUID4
     slug: str
+    name: str
+    avatar_url: str | None
     requires_sso: bool = Field(
         description="Whether this organization enforces SSO.",
     )

--- a/server/tests/user/test_endpoints.py
+++ b/server/tests/user/test_endpoints.py
@@ -112,6 +112,8 @@ async def test_get_users_me_excludes_sso_enforced_org_for_global_session(
         {
             "id": str(organization.id),
             "slug": organization.slug,
+            "name": organization.name,
+            "avatar_url": organization.avatar_url,
             "requires_sso": True,
         }
     ]
@@ -142,6 +144,8 @@ async def test_get_users_me_includes_sso_enforced_org_for_sso_session(
         {
             "id": str(organization.id),
             "slug": organization.slug,
+            "name": organization.name,
+            "avatar_url": organization.avatar_url,
             "requires_sso": True,
         }
     ]


### PR DESCRIPTION
## Summary


<img width="301" height="531" alt="Screenshot 2026-07-23 at 12 33 46" src="https://github.com/user-attachments/assets/b6ec22a5-13ee-4b9e-adfb-e538980400bd" />



## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaced SSO‑required organizations in the dashboard org switcher and linked them to the SSO sign‑in flow. The server now includes org name and avatar for `member_organizations` to power this UI.

- **New Features**
  - Org switcher shows SSO‑required orgs (not yet accessible) with an “SSO” lock badge; clicking routes to `/auth/sso/:slug`.
  - `OrganizationContext` now provides `memberOrganizations`; wired through `DashboardLayout` and `DashboardSidebar`.
  - `/users/me` returns `MemberOrganization` with `name` and `avatar_url`; client types updated to consume these fields.
  - Tests updated to assert the new response shape.

<sup>Written for commit ef45b38f64cdc03ac455c453235740b6e465c37f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

