### PR TITLE
docs: clarify default-currency price is required for products

### DIFF
--- a/docs/features/products.mdx
+++ b/docs/features/products.mdx
@@ -33,7 +33,7 @@ Whether the amount you enter includes tax or has tax added on top depends on you
 
 ### Multiple payment currencies
 
-Products can be priced in several currencies at once so customers pay in their local currency. Your organization has a default payment currency that acts as the fallback, and you can add more on top. The price structure (price type, metered prices, etc.) must match across every currency you enable.
+Products can be priced in several currencies at once so customers pay in their local currency. Your organization has a default payment currency that acts as the fallback, and you can add more on top. A price in the default currency is **required** — if you leave it empty, the product is treated as free. To price a product only in another currency, change your organization's default payment currency under **Settings** first. The price structure (price type, metered prices, etc.) must match across every currency you enable.
 
 Polar picks the currency based on the customer's geolocation at checkout. If their currency isn't enabled on the product, it falls back to your organization's default.
 


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VonJk35dcfVhHPaqN7CqLA

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified multi-currency product pricing: a price in the organization's default currency is required; leaving it empty makes the product free. Added guidance to change the default currency in Settings if you want to price a product only in another currency.

<sup>Written for commit f6bb8363c5677fc82e8c84f90a0fde4a014c9b24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

