### PR TITLE
server/order: don't retry trigger_payment when payment lock is held

### DIFF
--- a/server/polar/order/tasks.py
+++ b/server/polar/order/tasks.py
@@ -133,6 +133,15 @@ async def trigger_payment(
                 order_id=order_id,
             )
             return
+        except PaymentAlreadyInProgress:
+            # Retrying would pile up behind the lock and, once released, burst
+            # real attempts that exhaust dunning. Stale locks are recovered by
+            # the order.process_stale_payment_lock cron.
+            log.info(
+                "Payment already in progress, not retrying",
+                order_id=order_id,
+            )
+            return
         except (
             stripe_lib.APIConnectionError,
             stripe_lib.APIError,

--- a/server/tests/order/test_tasks.py
+++ b/server/tests/order/test_tasks.py
@@ -562,6 +562,34 @@ class TestTriggerPayment:
         mock_create_payment_intent.assert_called_once()
         # Task should complete without raising exception (no retry)
 
+    async def test_trigger_payment_already_in_progress_no_retry(
+        self,
+        save_fixture: SaveFixture,
+        product: Product,
+        organization: Organization,
+        mocker: MockerFixture,
+    ) -> None:
+        # Given an order that already holds a payment lock
+        customer = await create_customer(save_fixture, organization=organization)
+        payment_method = await create_payment_method(save_fixture, customer=customer)
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.pending,
+            payment_lock_acquired_at=utc_now(),
+        )
+
+        mock_create_payment_intent = mocker.patch(
+            "polar.order.service.stripe_service.create_payment_intent",
+        )
+
+        # When
+        await trigger_payment(order.id, payment_method.id)
+
+        # Then the task returns without charging or raising (no retry)
+        mock_create_payment_intent.assert_not_called()
+
     async def test_trigger_payment_api_error_with_retry(
         self,
         save_fixture: SaveFixture,


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- issue number -->

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->

## Why

<!-- Explain why this change is needed -->

## How

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop retrying `trigger_payment` when a payment lock is already held. This prevents retry pile-ups and dunning exhaustion; stale locks are recovered by `order.process_stale_payment_lock`.

- **Bug Fixes**
  - Catch `PaymentAlreadyInProgress` and return without retrying or attempting a charge.
  - Added test to ensure no charge attempt and no retry when a lock is present.

<sup>Written for commit 2b59eec20d8ffac4bfacf8bed6a86ee91eb76464. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

