### PR TITLE
Add backoffice order unvoid flow

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -25156,6 +25156,90 @@ export interface components {
       customer_cancellation_comment: string | null
     }
     /**
+     * OrderUnvoidedEvent
+     * @description An event created by Polar when an order is unvoided.
+     */
+    OrderUnvoidedEvent: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the object.
+       */
+      id: string
+      /**
+       * Timestamp
+       * Format: date-time
+       * @description The timestamp of the event.
+       */
+      timestamp: string
+      /**
+       * Organization Id
+       * Format: uuid4
+       * @description The ID of the organization owning the event.
+       * @example 1dbfc517-0bbf-4301-9ba8-555ca42b9737
+       */
+      organization_id: string
+      /**
+       * Customer Id
+       * @description ID of the customer in your Polar organization associated with the event.
+       */
+      customer_id: string | null
+      /** @description The customer associated with the event. */
+      customer: components['schemas']['Customer'] | null
+      /**
+       * External Customer Id
+       * @description ID of the customer in your system associated with the event.
+       */
+      external_customer_id: string | null
+      /**
+       * Member Id
+       * @description ID of the member within the customer's organization who performed the action inside B2B.
+       */
+      member_id?: string | null
+      /**
+       * External Member Id
+       * @description ID of the member in your system within the customer's organization who performed the action inside B2B.
+       */
+      external_member_id?: string | null
+      /**
+       * Child Count
+       * @description Number of direct child events linked to this event.
+       * @default 0
+       */
+      child_count: number
+      /**
+       * Parent Id
+       * @description The ID of the parent event.
+       */
+      parent_id?: string | null
+      /**
+       * Label
+       * @description Human readable label of the event type.
+       */
+      label: string
+      /**
+       * Source
+       * @description The source of the event. `system` events are created by Polar. `user` events are the one you create through our ingestion API.
+       * @constant
+       */
+      source: 'system'
+      /**
+       * @description The name of the event. (enum property replaced by openapi-typescript)
+       * @enum {string}
+       */
+      name: 'order.unvoided'
+      metadata: components['schemas']['OrderUnvoidedMetadata']
+    }
+    /** OrderUnvoidedMetadata */
+    OrderUnvoidedMetadata: {
+      /** Order Id */
+      order_id: string
+      /** Amount */
+      amount: number
+      /** Currency */
+      currency: string
+    }
+    /**
      * OrderUpdate
      * @description Schema to update an order.
      */
@@ -33846,6 +33930,7 @@ export interface components {
       | components['schemas']['OrderPaidEvent']
       | components['schemas']['OrderRefundedEvent']
       | components['schemas']['OrderVoidedEvent']
+      | components['schemas']['OrderUnvoidedEvent']
       | components['schemas']['CheckoutCreatedEvent']
       | components['schemas']['CustomerCreatedEvent']
       | components['schemas']['CustomerUpdatedEvent']
@@ -63301,6 +63386,9 @@ export const orderSortPropertyValues: ReadonlyArray<
 export const orderStatusValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['OrderStatus']
 > = ['draft', 'pending', 'paid', 'refunded', 'partially_refunded', 'void']
+export const orderUnvoidedEventNameValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['OrderUnvoidedEvent']['name']
+> = ['order.unvoided']
 export const orderVoidedEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['OrderVoidedEvent']['name']
 > = ['order.voided']

--- a/server/polar/backoffice/orders/endpoints.py
+++ b/server/polar/backoffice/orders/endpoints.py
@@ -340,6 +340,12 @@ async def get(
                             hx_target="#modal",
                         ):
                             text("Void")
+                    elif order.status == OrderStatus.void:
+                        with button(
+                            hx_get=str(request.url_for("orders:unvoid", id=order.id)),
+                            hx_target="#modal",
+                        ):
+                            text("Unvoid")
 
             with tag.div(classes="grid grid-cols-1 lg:grid-cols-2 gap-4"):
                 # Order Details
@@ -966,7 +972,8 @@ async def void(
         with tag.div(classes="flex flex-col gap-4"):
             with tag.p():
                 text(
-                    "Are you sure you want to void this order? This action cannot be undone."
+                    "Are you sure you want to void this order? "
+                    "Only Polar support can undo this action."
                 )
             with tag.div(classes="modal-action"):
                 with tag.form(method="dialog"):
@@ -978,3 +985,65 @@ async def void(
                     variant="error",
                 ):
                     text("Void Order")
+
+
+@router.api_route("/{id}/unvoid", name="orders:unvoid", methods=["GET", "POST"])
+async def unvoid(
+    request: Request,
+    id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+) -> Any:
+    order_repository = OrderRepository.from_session(session)
+    if request.method == "POST":
+        order = await order_repository.get_by_id(
+            id,
+            options=order_repository.get_eager_options(),
+            for_update=True,
+        )
+    else:
+        order = await order_repository.get_by_id(
+            id,
+            options=order_repository.get_eager_options(),
+        )
+
+    if order is None:
+        raise HTTPException(status_code=404)
+
+    if order.status != OrderStatus.void:
+        await add_toast(request, "Only void orders can be unvoided.", "error")
+        return HXRedirectResponse(
+            request, str(request.url_for("orders:get", id=id)), 303
+        )
+
+    if request.method == "POST":
+        try:
+            await order_service.unvoid(session, order)
+            await add_toast(request, "Order unvoided successfully.", "success")
+            return HXRedirectResponse(
+                request, str(request.url_for("orders:get", id=id)), 303
+            )
+        except Exception as e:
+            await add_toast(request, f"Failed to unvoid order: {e}", "error")
+
+    with modal("Unvoid order", open=True):
+        with tag.div(classes="flex flex-col gap-4"):
+            with tag.p():
+                text(
+                    "This will return the order to pending. It will not retry payment, "
+                    "resume dunning, or change the linked subscription."
+                )
+            if order.subscription is not None:
+                with tag.p(classes="text-warning"):
+                    text(
+                        f"Linked subscription status: {order.subscription.status.value}."
+                    )
+            with tag.div(classes="modal-action"):
+                with tag.form(method="dialog"):
+                    with button(ghost=True):
+                        text("Cancel")
+                with button(
+                    hx_post=str(request.url_for("orders:unvoid", id=id)),
+                    hx_target="#modal",
+                    variant="primary",
+                ):
+                    text("Unvoid Order")

--- a/server/polar/event/schemas.py
+++ b/server/polar/event/schemas.py
@@ -29,6 +29,7 @@ from polar.event.system import (
     MeterResetMetadata,
     OrderPaidMetadata,
     OrderRefundedMetadata,
+    OrderUnvoidedMetadata,
     OrderVoidedMetadata,
     SubscriptionBillingPeriodUpdatedMetadata,
     SubscriptionCanceledMetadata,
@@ -532,6 +533,15 @@ class OrderVoidedEvent(SystemEventBase):
     )
 
 
+class OrderUnvoidedEvent(SystemEventBase):
+    """An event created by Polar when an order is unvoided."""
+
+    name: Literal[SystemEventEnum.order_unvoided] = Field(description=_NAME_DESCRIPTION)
+    metadata: OrderUnvoidedMetadata = Field(
+        validation_alias=AliasChoices("user_metadata", "metadata")
+    )
+
+
 class CheckoutCreatedEvent(SystemEventBase):
     """An event created by Polar when a checkout is created."""
 
@@ -652,6 +662,7 @@ SystemEvent = Annotated[
     | OrderPaidEvent
     | OrderRefundedEvent
     | OrderVoidedEvent
+    | OrderUnvoidedEvent
     | CheckoutCreatedEvent
     | CustomerCreatedEvent
     | CustomerUpdatedEvent

--- a/server/polar/event/system.py
+++ b/server/polar/event/system.py
@@ -37,6 +37,7 @@ class SystemEvent(StrEnum):
     order_paid = "order.paid"
     order_refunded = "order.refunded"
     order_voided = "order.voided"
+    order_unvoided = "order.unvoided"
     checkout_created = "checkout.created"
     customer_created = "customer.created"
     customer_updated = "customer.updated"
@@ -69,6 +70,7 @@ SYSTEM_EVENT_LABELS: dict[str, str] = {
     "order.paid": "Order Paid",
     "order.refunded": "Order Refunded",
     "order.voided": "Order Voided",
+    "order.unvoided": "Order Unvoided",
     "checkout.created": "Checkout Created",
     "subscription.seats_updated": "Subscription Seats Updated",
     "subscription.billing_period_updated": "Subscription Billing Period Updated",
@@ -488,6 +490,19 @@ class OrderVoidedEvent(Event):
         user_metadata: Mapped[OrderVoidedMetadata]  # type: ignore[assignment]
 
 
+class OrderUnvoidedMetadata(TypedDict):
+    order_id: str
+    amount: int
+    currency: str
+
+
+class OrderUnvoidedEvent(Event):
+    if TYPE_CHECKING:
+        source: Mapped[Literal[EventSource.system]]
+        name: Mapped[Literal[SystemEvent.order_unvoided]]
+        user_metadata: Mapped[OrderUnvoidedMetadata]  # type: ignore[assignment]
+
+
 class CheckoutCreatedMetadata(TypedDict):
     checkout_id: str
     checkout_status: str
@@ -854,6 +869,15 @@ def build_system_event(
     customer: Customer,
     organization: Organization,
     metadata: OrderVoidedMetadata,
+) -> Event: ...
+
+
+@overload
+def build_system_event(
+    name: Literal[SystemEvent.order_unvoided],
+    customer: Customer,
+    organization: Organization,
+    metadata: OrderUnvoidedMetadata,
 ) -> Event: ...
 
 

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -236,6 +236,13 @@ class OrderNotPending(OrderError):
         super().__init__(message)
 
 
+class OrderNotVoid(OrderError):
+    def __init__(self, order: Order) -> None:
+        self.order = order
+        message = f"Order {order.id} is not void"
+        super().__init__(message)
+
+
 class PaymentAlreadyInProgress(OrderError):
     def __init__(self, order: Order) -> None:
         self.order = order
@@ -2631,6 +2638,39 @@ class OrderService:
             session,
             build_system_event(
                 SystemEvent.order_voided,
+                customer=order.customer,
+                organization=order.organization,
+                metadata={
+                    "order_id": str(order.id),
+                    "amount": order.total_amount,
+                    "currency": order.currency,
+                },
+            ),
+        )
+        await self._on_order_updated(session, order, previous_status=previous_status)
+
+        return order
+
+    async def unvoid(self, session: AsyncSession, order: Order) -> Order:
+        """Return a void order to pending without scheduling a payment retry."""
+        if order.status != OrderStatus.void:
+            raise OrderNotVoid(order)
+
+        previous_status = order.status
+
+        repository = OrderRepository.from_session(session)
+        order = await repository.update(
+            order,
+            update_dict={
+                "status": OrderStatus.pending,
+                "next_payment_attempt_at": None,
+            },
+        )
+
+        await event_service.create_event(
+            session,
+            build_system_event(
+                SystemEvent.order_unvoided,
                 customer=order.customer,
                 organization=order.organization,
                 metadata={

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -84,6 +84,7 @@ from polar.order.service import (
     OrderNotEligibleForInvoice,
     OrderNotEligibleForRetry,
     OrderNotPending,
+    OrderNotVoid,
     OrganizationNotReadyForPayments,
     PaymentActionRequired,
     PaymentAlreadyInProgress,
@@ -5570,6 +5571,60 @@ class TestVoidOrder:
             session, customer, order.currency
         )
         assert new_balance == 200
+
+
+class TestUnvoidOrder:
+    @pytest.mark.asyncio
+    async def test_unvoid_order(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        next_attempt_at = utc_now() + timedelta(hours=24)
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.void,
+            next_payment_attempt_at=next_attempt_at,
+        )
+        send_webhook_mock = mocker.patch.object(order_service, "send_webhook")
+
+        result_order = await order_service.unvoid(session, order)
+
+        assert result_order.status == OrderStatus.pending
+        assert result_order.next_payment_attempt_at is None
+        events = await get_all_by_name(session, SystemEvent.order_unvoided)
+        assert len(events) == 1
+        assert events[0].user_metadata == {
+            "order_id": str(order.id),
+            "amount": order.total_amount,
+            "currency": order.currency,
+        }
+        send_webhook_mock.assert_awaited_once_with(
+            session, order, WebhookEventType.order_updated
+        )
+
+    @pytest.mark.asyncio
+    async def test_unvoid_non_void_order(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.pending,
+        )
+
+        with pytest.raises(OrderNotVoid):
+            await order_service.unvoid(session, order)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

**Related Issue**: N/A

Adds a backoffice-only flow for returning a void order to pending without retrying payment or resuming dunning.

## What

- Add an `OrderService.unvoid` transition from void to pending.
- Add a backoffice confirmation action for void orders.
- Emit a typed `order.unvoided` system event and regenerate the TypeScript API client.
- Cover the service transition and invalid-status guard with focused tests.

## Why

Polar support occasionally needs to correct an order that was voided by mistake. The existing flow treated voiding as irreversible, forcing direct database intervention.

## How

The backoffice POST locks the order row, validates that it is void, and delegates to the order service. The service restores pending status, keeps the automatic retry timestamp empty, appends `order.unvoided`, and sends the existing `order.updated` webhook. It does not change customer balance, subscription state, or enqueue payment work.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

## Validation

- `uv run pytest tests/order/test_service.py -k TestUnvoidOrder -q` — 2 passed
- `uv run task lint`
- `uv run task lint_types` — 1,625 files checked
- `pnpm run generate` — generated client build passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

