### PR TITLE
chore(rfc): multi products checkout

### DIFF
--- a/handbook/docs.json
+++ b/handbook/docs.json
@@ -90,7 +90,8 @@
               "engineering/design-documents/api-versioning",
               "engineering/design-documents/payout-reviews",
               "engineering/design-documents/secrets-encryption",
-              "engineering/design-documents/merchant-migrations"
+              "engineering/design-documents/merchant-migrations",
+              "engineering/design-documents/multi-product-checkout"
             ]
           },
           {

--- a/handbook/engineering/design-documents/multi-product-checkout.mdx
+++ b/handbook/engineering/design-documents/multi-product-checkout.mdx
@@ -249,6 +249,11 @@ The last rule follows from `Subscription.meter_interval`, which is snapshotted f
 creation. An add-on metered on a different cadence has nowhere to store it, so validation rejects it
 rather than silently rebasing it.
 
+An add-on matching none of the bases on the link is a mistake, and creation returns a 422. Say the link
+offers a monthly base and the merchant lists `<analytics_yearly>` beside it. No buyer can ever see that
+add-on: there is one base, it is monthly, and the intervals never match. Better to reject the link than
+to hand back one that quietly drops an add-on the merchant configured.
+
 ## API
 
 ### Merchant: offering the menu
@@ -261,11 +266,27 @@ POST /v1/checkout-links
 {
   "products": ["<base_monthly>", "<base_yearly>"],
   "addons": [
-    { "product_id": "<analytics>", "max_quantity": 1 },
-    { "product_id": "<extra_credits>", "min_quantity": 0, "max_quantity": 10 }
+    { "product_id": "<analytics_monthly>", "max_quantity": 1 },
+    { "product_id": "<analytics_yearly>", "max_quantity": 1 },
+    { "product_id": "<extra_credits_monthly>", "min_quantity": 0, "max_quantity": 10 },
+    { "product_id": "<extra_credits_yearly>", "min_quantity": 0, "max_quantity": 10 }
   ]
 }
 ```
+
+`addons` is one flat pool for the link, not a per-base mapping. A product carries a single interval
+(`Product.recurring_interval` and `recurring_interval_count`, `server/polar/models/product.py:73-81`),
+so monthly and yearly analytics are two products — exactly as the two bases are two products. The
+interval match **is** the mapping: the checkout offers only the add-ons eligible for the base the buyer
+has selected through `product_id` (`server/polar/checkout/schemas.py:356-361`), and the read schema
+returns that subset rather than the whole pool. Nothing declares which add-on belongs to which base, so
+no configuration can contradict the interval.
+
+Two costs come with that. Each add-on is duplicated per interval offered. And switching the base drops
+the selection instead of carrying it across: `<analytics_monthly>` and `<analytics_yearly>` are
+unrelated rows, and nothing in the model says they are one offer at two cadences. The buyer re-picks.
+Carrying the selection over needs a notion of product equivalence that does not exist today, and it is
+out of scope here.
 
 `PATCH /v1/checkout-links/{id}` takes `addons` as a full replacement set, matching how it already
 handles `products`. `POST /v1/checkouts` takes the same field. The dashboard's checkout-link editor

--- a/handbook/engineering/design-documents/multi-product-checkout.mdx
+++ b/handbook/engineering/design-documents/multi-product-checkout.mdx
@@ -1,0 +1,361 @@
+<Info>
+**Status**: Draft
+**Created**: July 2026
+**Last Updated**: July 27, 2026
+</Info>
+
+## Summary
+
+Let a buyer pick a base product and add optional **add-ons** before paying. An add-on is an ordinary
+product with its own benefits and its own price, and carries a **quantity**. Everything lands on one
+checkout, one subscription and one invoice. After purchase the customer can add an add-on, drop one, or
+change a quantity, prorated like any other subscription change.
+
+This comes from [feedback#110](https://github.com/polarsource/feedback/issues/110), where ten comments
+split two ways: add-ons on a subscription (a $20/mo base plus advanced analytics at $10/mo), and an
+e-commerce cart with quantities. Pieter settled the split — the add-ons carry quantities.
+
+## Goals
+
+- A checkout offers a base product plus a menu of add-ons; the buyer selects any subset, each with a
+  quantity the merchant bounds.
+- One subscription covers the base and its add-ons. One renewal, one invoice, one payment.
+- Benefits from every selected product are granted; dropping an add-on revokes only that add-on's
+  benefits.
+- Add, remove and re-quantify add-ons after purchase, through the merchant API and the customer portal,
+  with proration.
+- The merchant configures the add-on menu on a checkout link or on a checkout session.
+
+## Non-Goals
+
+- Mixed billing intervals in one subscription. An add-on bills on the base product's interval.
+- An arbitrary cart of unrelated one-time products. A base is always required. One-time add-ons on a
+  one-time base are a plausible follow-up, not v1.
+- Reworking seats. `seats` stays a separate concept on the base product.
+- Add-on-specific trials, or an add-on on its own metered cadence.
+
+## The finding that shapes everything
+
+A checkout and a subscription each resolve to exactly one product today. `Checkout.product_id` is the
+selected product, and `checkout_products` is a *switcher* — a list the buyer picks one from, not a cart.
+`Subscription.product_id` is `NOT NULL`.
+
+Below that boundary, the billing engine is already price-set-driven rather than product-driven:
+
+| Component | Grain today |
+| --- | --- |
+| `Subscription.subscription_product_prices` | N prices; `amount` is already their sum (`server/polar/models/subscription.py:528-531`) |
+| `billing_entry` | keyed by `product_price_id`, never by product (`server/polar/models/billing_entry.py:77`) |
+| `order_items` | per price; `OrderItem.product` is an association proxy through it (`server/polar/models/order_item.py:47`) |
+| `orders` | `product_id` already nullable (`server/polar/models/order.py:229`) |
+| `compute_pending_subscription_line_items` | iterates entries, agnostic of product (`server/polar/billing_entry/service.py:83`) |
+
+Renewal, proration, metering and invoicing therefore need no structural change. Four boundaries do:
+checkout selection, the subscription's product set, benefit grants, and a new quantity concept. Pricing
+and tax on the checkout itself are a fifth, and they are the largest piece — see
+[What breaks above the boundary](#what-breaks-above-the-boundary).
+
+## Data model
+
+### Where add-ons are declared
+
+Reuse the existing join tables. A product is an add-on **in a given checkout**, not globally. Merchants
+build add-ons the way they build anything else: create a product, then offer it as an add-on on a
+checkout link or a checkout session.
+
+```python
+class CheckoutProductRole(StrEnum):
+    option = "option"   # today's mutually-exclusive switcher
+    addon = "addon"     # independently selectable, carries a quantity
+
+
+class CheckoutProduct(RecordModel):
+    # Existing: checkout_id, product_id, order, ad_hoc_prices
+    # Existing: UniqueConstraint("checkout_id", "product_id")
+
+    role: Mapped[CheckoutProductRole | None] = mapped_column(
+        StringEnum(CheckoutProductRole), nullable=True, default=None
+    )
+    """NULL means `option` — every row written before add-ons existed."""
+
+    min_quantity: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
+    max_quantity: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
+    """Merchant's bounds on the offer. NULL/NULL means optional and boolean: 0 or 1."""
+
+    quantity: Mapped[int | None] = mapped_column(Integer, nullable=True, default=None)
+    """Buyer's selection. NULL means not selected. CHECK (quantity IS NULL OR quantity >= 1)."""
+```
+
+`CheckoutLinkProduct` gains `role`, `min_quantity` and `max_quantity`, so the merchant configures the
+menu on the link and the checkout copies it. `CheckoutProduct.ad_hoc_prices` needs no change — it
+already hangs off this row and works for add-ons.
+
+Both tables already carry `UniqueConstraint(checkout_id, product_id)`
+(`server/polar/models/checkout_product.py:16`), so one product cannot appear twice in a menu and the
+selection cannot be duplicated.
+
+**Boolean or quantitative is `max_quantity`.** An add-on you either buy or don't has `max_quantity = 1`.
+An add-on you buy 0 to N of sets `max_quantity = N`. An add-on the buyer cannot decline sets
+`min_quantity = 1`. A selection outside `[min_quantity or 0, max_quantity or 1]` is rejected, and a
+selected row always holds `quantity >= 1` — unselected is `NULL`, never `0`.
+
+We rejected a product-level `product_addons` table. It forces merchants to model add-on relationships
+globally, and the checkout would still need per-session selection state, so it buys nothing.
+
+### The base is a list
+
+`CheckoutProductsCreate` takes `products: list[UUID4]`, and the single-product `CheckoutProductCreate`
+is deprecated (`server/polar/checkout/schemas.py:295-343`). Checkout links are the same
+(`server/polar/checkout_link/schemas.py:123-129`). So the base is a switcher the buyer picks from, and
+the add-on menu sits beside it.
+
+Eligibility is therefore evaluated against the **selected** base, not against the whole switcher. A
+merchant offering a monthly and a yearly base has to offer an add-on valid for each. Switching the base
+re-validates the selection and drops every add-on that no longer qualifies, reporting which ones went.
+
+### What the subscription holds
+
+`Subscription.product_id` stays, and means the **base** product. That keeps every existing reference
+working unchanged — 33 across the backend, 19 to `Subscription.product_id` and 14 to
+`Subscription.product` — along with the webhook payloads and the API's `subscription.product` field.
+
+The product set gets its own table:
+
+```python
+class SubscriptionProductRole(StrEnum):
+    base = "base"
+    addon = "addon"
+
+
+class SubscriptionProduct(RecordModel):
+    __tablename__ = "subscription_products"
+    __table_args__ = (UniqueConstraint("subscription_id", "product_id"),)
+
+    subscription_id: Mapped[UUID] = mapped_column(
+        Uuid, ForeignKey("subscriptions.id", ondelete="cascade"), nullable=False
+    )
+    product_id: Mapped[UUID] = mapped_column(
+        Uuid, ForeignKey("products.id", ondelete="restrict"), nullable=False
+    )
+    role: Mapped[SubscriptionProductRole] = mapped_column(
+        StringEnum(SubscriptionProductRole), nullable=False
+    )
+    quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+```
+
+An earlier draft had no such table and derived the product set through
+`subscription_product_prices → product_price.product`. That derivation is wrong for this feature, for
+three reasons.
+
+**Quantity is a property of the add-on, not of its prices.** An add-on with a static and a metered price
+occupies two `subscription_product_prices` rows. Putting `quantity` there stores the same number twice
+with nothing keeping the pair equal.
+
+**Everything else about add-ons is already product-grained.** The API takes `{product_id, quantity}`.
+The pending-change set is keyed by product. Benefit grants come from `ProductBenefit`. Only the
+persisted state would have been price-grained, so every read would group a join by
+`product_price.product_id` and every write would translate back. That translation is where drift starts.
+
+**A subscription's product membership should not depend on which prices happen to be attached.**
+Deriving it means "which products is this subscription for" has no column to index and no row to point
+at.
+
+`subscription_product_prices` is untouched and stays the source of truth for **amounts**. Its `amount`
+column already holds the extended amount, so `Subscription.update_amount_and_currency`'s
+`sum(price.amount for price in prices)` keeps working with no change.
+`SubscriptionProductPrice.from_price` takes the quantity from the `subscription_products` row and
+multiplies.
+
+`Subscription.product_id` becomes a denormalized pointer at the `role = base` row. One writer sets both.
+
+### Cost of the new table
+
+Every existing subscription needs one `role = base` row. The table is large enough that this is a real
+rollout, in three steps, rather than the single no-backfill revision the earlier draft claimed:
+
+1. Create the table. Nothing reads it.
+2. Deploy the write path, so every new and updated subscription gets its rows.
+3. Run a batched backfill script for the historical rows (`scripts/backfill_*.py`, `run_batched_update`),
+   then deploy the read path.
+
+The columns are `NOT NULL` from the start, because the table is created empty and every row is written
+with a value. No `server_default`, per the repo convention.
+
+### Quantity
+
+Quantity is new and separate from `seats`. Seats drags in the whole `customer_seat` claiming feature;
+quantity is a multiplier and nothing more. Three columns:
+
+- `subscription_products.quantity` — the live selection, `NOT NULL`
+- `order_items.quantity` — nullable
+- `billing_entry.quantity` — nullable
+
+**Snapshot quantity on the billing entry**, rather than reading it live off the subscription. Today
+`_get_static_price_line_item` takes `seats=subscription.seats` (`server/polar/billing_entry/service.py:93`) —
+live state. That is already slightly wrong for a mid-cycle seat change, and would be plainly wrong for
+add-on quantity.
+
+The columns added to existing tables are nullable, `role` included, and that is the honest model rather
+than a way around the migration convention. `NULL` on `quantity` means "not a quantity-priced line" and
+`NULL` on `role` means `option`; every pre-existing row genuinely is both. There is no value we would
+have to invent. It also matters operationally: `order_items`, `billing_entry` and `checkout_products`
+grow with traffic rather than with the customer base, so a `nullable → UPDATE → NOT NULL` rollout across
+them would be three PRs of work for no gain.
+
+### The duplicate-price hole
+
+`SubscriptionProductPrice` declares `subscription_id` and `product_price_id` as `primary_key=True`, but
+`RecordModel` also contributes `id`, so the real primary key is the three-column
+`(subscription_id, product_price_id, id)` and the pair is **not** unique. A duplicate row silently
+doubles the subscription's amount, because `update_amount_and_currency` sums every row. Quantity makes
+it worse: two rows of quantity 2 bill as 4. Production has no duplicates, so the schema PR adds a unique
+constraint on `(subscription_id, product_price_id)` and closes it. That fix stands on its own merit,
+whether or not add-ons ship.
+
+### Pending changes
+
+`SubscriptionUpdate` already carries a pending product change and its proration behavior. It gains a
+child table for the replacement add-on set:
+
+```python
+class SubscriptionUpdateAddon(RecordModel):
+    __tablename__ = "subscription_update_addons"
+    __table_args__ = (UniqueConstraint("subscription_update_id", "product_id"),)
+
+    subscription_update_id: Mapped[UUID] = mapped_column(
+        Uuid, ForeignKey("subscription_updates.id", ondelete="cascade"), nullable=False
+    )
+    product_id: Mapped[UUID] = mapped_column(
+        Uuid, ForeignKey("products.id", ondelete="restrict"), nullable=False
+    )
+    quantity: Mapped[int] = mapped_column(Integer, nullable=False)
+```
+
+A child table rather than JSONB, so the product reference keeps its foreign key. `ondelete="restrict"`
+matches `subscription_products`: a product referenced by live billing state is not deletable.
+
+## Eligibility
+
+An add-on must:
+
+- belong to the same organization as the selected base product;
+- be recurring, with the **same** `recurring_interval` and `recurring_interval_count` as the base;
+- have a price in the checkout's currency;
+- carry no seat-based price;
+- carry no trial of its own — the trial belongs to the base product;
+- carry no metered price on a cadence other than the base product's.
+
+The last rule follows from `Subscription.meter_interval`, which is snapshotted from the base product at
+creation. An add-on metered on a different cadence has nowhere to store it, so validation rejects it
+rather than silently rebasing it.
+
+## API
+
+### Merchant: offering the menu
+
+Add-ons are ordinary products. The merchant offers one by naming it in an `addons` list beside
+`products`, on a checkout link or on a checkout session.
+
+```http
+POST /v1/checkout-links
+{
+  "products": ["<base_monthly>", "<base_yearly>"],
+  "addons": [
+    { "product_id": "<analytics>", "max_quantity": 1 },
+    { "product_id": "<extra_credits>", "min_quantity": 0, "max_quantity": 10 }
+  ]
+}
+```
+
+`PATCH /v1/checkout-links/{id}` takes `addons` as a full replacement set, matching how it already
+handles `products`. `POST /v1/checkouts` takes the same field. The dashboard's checkout-link editor
+gains an add-on picker with the two bounds.
+
+### Buyer: selecting
+
+```http
+PATCH /v1/checkouts/client/{client_secret}
+{
+  "addons": [{ "product_id": "<extra_credits>", "quantity": 3 }]
+}
+```
+
+The buyer-facing update replaces the whole selection, so dropping an add-on is an omission rather than a
+separate call. The read schema returns every offered add-on with its bounds and its selection state.
+These are additive fields on existing public endpoints, not new endpoints.
+
+### After purchase
+
+`PATCH /v1/subscriptions/{id}` gains the same `addons` field, again as a full replacement set, honouring
+the existing `proration_behavior`. The customer portal exposes it behind
+`customer_portal_settings.subscription.update_addons`, beside the existing `update_plan` and
+`update_seats` (`server/polar/models/organization.py:817-828`).
+
+## What breaks above the boundary
+
+The billing engine needs no structural change. The checkout does. These are the parts that break
+quietly, and each one is designed here rather than left as a finding.
+
+### A free base with a paid add-on would skip payment
+
+`Checkout.product_prices` is `self.prices[self.product_id]` — the selected base alone
+(`server/polar/models/checkout.py:478`). Four properties read it: `is_free_product_price`,
+`has_metered_prices`, `is_discount_applicable`, and `is_payment_setup_required` through `self.product`
+(`server/polar/models/checkout.py:323-366`).
+
+Fixing those four is not enough. `checkout.amount` is computed by
+`calculate_upfront_amount(price_set.get_static_prices(), ...)` over the base product's price set
+(`server/polar/checkout/service.py:2260`), and `is_payment_required` is `total_amount > 0`. A free base
+with a paid add-on would price at zero and take no payment.
+
+The design:
+
+- `Checkout.product_prices` returns the selected base's prices plus the prices of every selected add-on.
+  `Checkout.prices` is already a dict keyed by product across all `checkout_products`, so this is a
+  slice change, not a new query.
+- `calculate_upfront_amount` (`server/polar/product/price_set.py:121`) takes `(price, quantity)` pairs
+  instead of a bare sequence. It already special-cases `seats`; quantity joins it.
+- `checkout.amount` sums over base plus selection. `net_amount` and the discount base follow from it
+  unchanged.
+
+### Tax is per product, and this makes it per line
+
+`_update_checkout_tax` reads `checkout.product.is_tax_applicable` and
+`checkout.product_price.tax_behavior` — the base product only
+(`server/polar/checkout/service.py:2266-2276`). Two products on one checkout can carry different tax
+codes and different tax behavior, so one call over one code is wrong as soon as add-ons ship.
+
+This is the largest piece of the feature and it is not a footnote. Checkout tax calculation moves to
+line items, one per selected product, each with its own tax code and behavior, and `checkout.tax_amount`
+becomes their sum. Scope it as its own PR, before the checkout selection PR reaches merchants.
+
+### Revoking an add-on could debit the customer's meter
+
+`list_outdated_grants(product, **scope)` (`server/polar/benefit/grant/repository.py:267`) revokes every
+granted benefit that is not on *that* product. Called once per product on a multi-product subscription,
+the base product's pass revokes the add-on's benefits and vice versa.
+
+For meter credits that is not a silent no-op, it is a debit. `MeterCreditBenefitStrategy.revoke` writes
+an event of `-last_credited_units` against the meter
+(`server/polar/benefit/strategies/meter_credit/service.py:129`). Pieter's case — a base carrying "1,000
+credits" and an add-on carrying "500 extra credits" — would take 1,000 credits off the customer when the
+add-on's revocation pass ran over the base product.
+
+`list_outdated_grants` takes the product **set** and diffs against the union of their benefits. It runs
+once for the subscription, not once per product. A benefit carried by both base and add-on falls out of
+the same change: grants are unique per `(subscription_id, member_id, benefit_id)`, with no product in
+the key (`server/polar/models/benefit_grant.py:93-98`), so there is one grant and it survives as long as any
+product in the set still carries the benefit.
+
+Dropping an add-on mid-cycle revokes its grants, which debits the credits that add-on issued this cycle,
+including any the customer already spent. That is today's behavior for a product downgrade, and this
+design does not change it.
+
+## Open questions
+
+**Restricted discounts.** A discount limited through `discount_products` — does it apply to the whole
+cart, or only to matching line items? Recommendation: matching items only, computed on the item
+subtotal, mirroring the existing `OrderItem.discountable` split.
+
+**Per-line tax sequencing.** Whether line-item tax calculation ships as a standalone change ahead of
+add-ons, or lands with them. Standalone is safer, and testable on today's single-product checkouts.


### PR DESCRIPTION
## Summary

feedback#110 asks for add-ons: a base product plus extras, bought together.

That looks expensive. A checkout and a subscription each point at one product today, so selling several at once looks like a change to the billing engine.

It isn't. A renewal never asks which product a subscription is for. It reads the subscription's price list, writes one billing entry per price, turns each entry into an order item, and sums them. Every step keys on product_price_id. product_id appears in no filter, no join condition and no group-by along that path. The query selects it with the row and never reads it.

So a subscription holding prices from two products would already bill both onto one invoice. Nothing in the engine depends on those prices coming from one product. That limit sits at the entry point: checkout lets you pick one product, and create_or_update_from_checkout fills the list from checkout.product alone.

That changes what this feature costs.

The doc names two silent failures. A free base with a paid add-on skips payment, because four Checkout properties resolve to the base product alone. And removing an add-on can revoke the base product's benefits, because list_outdated_grants takes one product and revokes everything not on it.

One decision before the first migration: whether the new quantity columns are nullable. Every existing row has no quantity. The alternative is a three-PR backfill across the highest-volume tables.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

