### PR TITLE
server/order: stop retries on old order.trigger_payment jobs

### DIFF
--- a/server/polar/order/tasks.py
+++ b/server/polar/order/tasks.py
@@ -20,6 +20,7 @@ from polar.worker import (
     actor,
     can_retry,
     enqueue_job,
+    get_retries,
 )
 
 from .repository import OrderRepository
@@ -98,6 +99,18 @@ async def trigger_payment(
     payment_method_id: uuid.UUID,
     payment_trigger: str | None = None,
 ) -> None:
+    if get_retries() > 0:
+        # We have a lot of piled up trigger payment jobs that we shouldn't retry
+        # Exhaust them for now so we don't trigger more dunning processes than necessary
+        log.info(
+            "Dead-lettering payment trigger",
+            order_id=order_id,
+            payment_method_id=payment_method_id,
+            payment_trigger=payment_trigger,
+            retries=get_retries(),
+        )
+        return
+
     async with AsyncSessionMaker() as session:
         repository = OrderRepository.from_session(session)
         order = await repository.get_by_id(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Short-circuit retries for old `order.trigger_payment` jobs to avoid unnecessary dunning and retry storms. Retried jobs now log context and exit without processing.

- **Bug Fixes**
  - Added `get_retries()` check at the start of `trigger_payment`; if > 0, log and return early.
  - Log includes `order_id`, `payment_method_id`, `payment_trigger`, and `retries` to aid monitoring.

<sup>Written for commit 6491e63328de51b93c883c52c4aa13e12bef209e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

