### PR TITLE
redesign product overview benefits & discounts, add price to header 

### DIFF
--- a/clients/apps/web/src/components/Products/ProductPage/ProductBenefits.tsx
+++ b/clients/apps/web/src/components/Products/ProductPage/ProductBenefits.tsx
@@ -1,0 +1,117 @@
+'use client'
+
+import {
+  benefitsDisplayNames,
+  resolveBenefitIcon,
+} from '@/components/Benefit/utils'
+import { EmptyState } from '@/components/Shared/EmptyState'
+import { ScrollFade } from '@/components/Shared/ScrollFade'
+import { schemas } from '@polar-sh/client'
+import { Button, List, ListItem, Pill, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { ChevronRight, Gift } from 'lucide-react'
+import Link from 'next/link'
+
+export interface ProductBenefitsProps {
+  organization: schemas['Organization']
+  product: schemas['Product']
+}
+
+export const ProductBenefits = ({
+  organization,
+  product,
+}: ProductBenefitsProps) => {
+  const benefitCount = product.benefits.length
+
+  return (
+    <Box flexDirection="column" gap="xl" minWidth={0}>
+      <Box alignItems="center" justifyContent="between" gap="l">
+        <Box flexDirection="column" gap="xs" minWidth={0}>
+          <Text variant="heading-xxs" as="h2">
+            Automated Benefits
+          </Text>
+          <Text color="muted">
+            {benefitCount} {benefitCount === 1 ? 'benefit' : 'benefits'} granted
+            by {product.name}
+          </Text>
+        </Box>
+        <Link href={`/dashboard/${organization.slug}/products/benefits`}>
+          <Button size="sm">View All</Button>
+        </Link>
+      </Box>
+
+      {benefitCount === 0 ? (
+        <EmptyState
+          icon={<Gift />}
+          title="No benefits"
+          description="This product has no benefits applied"
+        />
+      ) : (
+        <Box
+          display="block"
+          overflow="hidden"
+          borderRadius="l"
+          borderWidth={1}
+          borderStyle="solid"
+          borderColor="border-primary"
+        >
+          <ScrollFade className="max-h-80">
+            <List size="small" className="rounded-none border-0">
+              {product.benefits.map((benefit) => (
+                <Link
+                  key={benefit.id}
+                  href={`/dashboard/${organization.slug}/products/benefits/${benefit.id}`}
+                >
+                  <ListItem size="small">
+                    <Box
+                      minWidth={0}
+                      flexGrow={1}
+                      alignItems="center"
+                      columnGap="m"
+                    >
+                      <Box
+                        width={32}
+                        height={32}
+                        flexShrink={0}
+                        alignItems="center"
+                        justifyContent="center"
+                        borderRadius="s"
+                        backgroundColor="background-secondary"
+                        color="text-secondary"
+                      >
+                        {resolveBenefitIcon(benefit.type, 'h-4 w-4')}
+                      </Box>
+                      <Box flexDirection="column" minWidth={0}>
+                        <Text truncate>{benefit.description}</Text>
+                        <Box alignItems="center" columnGap="s" minWidth={0}>
+                          <Text variant="caption" color="muted" truncate>
+                            {benefitsDisplayNames[benefit.type]}
+                          </Text>
+                          {benefit.visibility !== 'public' ? (
+                            <Pill
+                              color="gray"
+                              className="shrink-0 px-2 py-0.5 text-xs"
+                            >
+                              Hidden from customers
+                            </Pill>
+                          ) : null}
+                        </Box>
+                      </Box>
+                    </Box>
+                    <Box
+                      flexShrink={0}
+                      color="text-tertiary"
+                      alignItems="center"
+                    >
+                      <ChevronRight size={16} />
+                    </Box>
+                  </ListItem>
+                </Link>
+              ))}
+            </List>
+          </ScrollFade>
+        </Box>
+      )}
+    </Box>
+  )
+}

--- a/clients/apps/web/src/components/Products/ProductPage/ProductBenefits.tsx
+++ b/clients/apps/web/src/components/Products/ProductPage/ProductBenefits.tsx
@@ -4,13 +4,16 @@ import {
   benefitsDisplayNames,
   resolveBenefitIcon,
 } from '@/components/Benefit/utils'
+import { Pagination } from '@/components/Products/Benefits/components/Pagination'
 import { EmptyState } from '@/components/Shared/EmptyState'
-import { ScrollFade } from '@/components/Shared/ScrollFade'
 import { schemas } from '@polar-sh/client'
-import { Button, List, ListItem, Pill, Text } from '@polar-sh/orbit'
+import { List, ListItem, Pill, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { ChevronRight, Gift } from 'lucide-react'
 import Link from 'next/link'
+import { useMemo, useState } from 'react'
+
+const PAGE_SIZE = 5
 
 export interface ProductBenefitsProps {
   organization: schemas['Organization']
@@ -21,23 +24,42 @@ export const ProductBenefits = ({
   organization,
   product,
 }: ProductBenefitsProps) => {
+  const [page, setPage] = useState(1)
   const benefitCount = product.benefits.length
+  const totalPages = Math.max(1, Math.ceil(benefitCount / PAGE_SIZE))
+
+  const pageBenefits = useMemo(() => {
+    const start = (page - 1) * PAGE_SIZE
+    return product.benefits.slice(start, start + PAGE_SIZE)
+  }, [page, product.benefits])
 
   return (
     <Box flexDirection="column" gap="xl" minWidth={0}>
-      <Box alignItems="center" justifyContent="between" gap="l">
-        <Box flexDirection="column" gap="xs" minWidth={0}>
-          <Text variant="heading-xxs" as="h2">
-            Automated Benefits
-          </Text>
+      <Box flexDirection="column" gap="xs" minWidth={0}>
+        <Text variant="heading-xxs" as="h2">
+          Automated Benefits
+        </Text>
+        <Box alignItems="center" justifyContent="between" gap="l">
           <Text color="muted">
             {benefitCount} {benefitCount === 1 ? 'benefit' : 'benefits'} granted
             by {product.name}
           </Text>
+          <Link href={`/dashboard/${organization.slug}/products/benefits`}>
+            <Box
+              color={{ base: 'text-secondary', hover: 'text-primary' }}
+              transitionProperty="colors"
+              transitionDuration="fast"
+              alignItems="center"
+              columnGap="xs"
+              flexShrink={0}
+            >
+              <Text variant="caption" color="inherit">
+                View all
+              </Text>
+              <ChevronRight size={14} />
+            </Box>
+          </Link>
         </Box>
-        <Link href={`/dashboard/${organization.slug}/products/benefits`}>
-          <Button size="sm">View All</Button>
-        </Link>
       </Box>
 
       {benefitCount === 0 ? (
@@ -47,69 +69,65 @@ export const ProductBenefits = ({
           description="This product has no benefits applied"
         />
       ) : (
-        <Box
-          display="block"
-          overflow="hidden"
-          borderRadius="l"
-          borderWidth={1}
-          borderStyle="solid"
-          borderColor="border-primary"
-        >
-          <ScrollFade className="max-h-80">
-            <List size="small" className="rounded-none border-0">
-              {product.benefits.map((benefit) => (
-                <Link
-                  key={benefit.id}
-                  href={`/dashboard/${organization.slug}/products/benefits/${benefit.id}`}
-                >
-                  <ListItem size="small">
+        <Box flexDirection="column" gap="l">
+          <List size="small">
+            {pageBenefits.map((benefit) => (
+              <Link
+                key={benefit.id}
+                href={`/dashboard/${organization.slug}/products/benefits/${benefit.id}`}
+              >
+                <ListItem size="small">
+                  <Box
+                    minWidth={0}
+                    flexGrow={1}
+                    alignItems="center"
+                    columnGap="m"
+                  >
                     <Box
-                      minWidth={0}
-                      flexGrow={1}
-                      alignItems="center"
-                      columnGap="m"
-                    >
-                      <Box
-                        width={32}
-                        height={32}
-                        flexShrink={0}
-                        alignItems="center"
-                        justifyContent="center"
-                        borderRadius="s"
-                        backgroundColor="background-secondary"
-                        color="text-secondary"
-                      >
-                        {resolveBenefitIcon(benefit.type, 'h-4 w-4')}
-                      </Box>
-                      <Box flexDirection="column" minWidth={0}>
-                        <Text truncate>{benefit.description}</Text>
-                        <Box alignItems="center" columnGap="s" minWidth={0}>
-                          <Text variant="caption" color="muted" truncate>
-                            {benefitsDisplayNames[benefit.type]}
-                          </Text>
-                          {benefit.visibility !== 'public' ? (
-                            <Pill
-                              color="gray"
-                              className="shrink-0 px-2 py-0.5 text-xs"
-                            >
-                              Hidden from customers
-                            </Pill>
-                          ) : null}
-                        </Box>
-                      </Box>
-                    </Box>
-                    <Box
+                      width={32}
+                      height={32}
                       flexShrink={0}
-                      color="text-tertiary"
                       alignItems="center"
+                      justifyContent="center"
+                      borderRadius="s"
+                      backgroundColor="background-secondary"
+                      color="text-secondary"
                     >
-                      <ChevronRight size={16} />
+                      {resolveBenefitIcon(benefit.type, 'h-4 w-4')}
                     </Box>
-                  </ListItem>
-                </Link>
-              ))}
-            </List>
-          </ScrollFade>
+                    <Box flexDirection="column" minWidth={0}>
+                      <Text truncate>{benefit.description}</Text>
+                      <Box alignItems="center" columnGap="s" minWidth={0}>
+                        <Text variant="caption" color="muted" truncate>
+                          {benefitsDisplayNames[benefit.type]}
+                        </Text>
+                        {benefit.visibility !== 'public' ? (
+                          <Pill
+                            color="gray"
+                            className="shrink-0 px-2 py-0.5 text-xs"
+                          >
+                            Hidden from customers
+                          </Pill>
+                        ) : null}
+                      </Box>
+                    </Box>
+                  </Box>
+                  <Box flexShrink={0} color="text-tertiary" alignItems="center">
+                    <ChevronRight size={16} />
+                  </Box>
+                </ListItem>
+              </Link>
+            ))}
+          </List>
+          {totalPages > 1 && (
+            <Box justifyContent="end">
+              <Pagination
+                page={page}
+                totalPages={totalPages}
+                onPageChange={setPage}
+              />
+            </Box>
+          )}
         </Box>
       )}
     </Box>

--- a/clients/apps/web/src/components/Products/ProductPage/ProductDiscounts.tsx
+++ b/clients/apps/web/src/components/Products/ProductPage/ProductDiscounts.tsx
@@ -2,6 +2,7 @@
 
 import { Pagination } from '@/components/Products/Benefits/components/Pagination'
 import { EmptyState } from '@/components/Shared/EmptyState'
+import { LoadingBox } from '@/components/Shared/LoadingBox'
 import { useDiscounts } from '@/hooks/queries'
 import { getDiscountDisplay } from '@/utils/discount'
 import { schemas } from '@polar-sh/client'
@@ -77,12 +78,7 @@ export const ProductDiscounts = ({
       </Box>
 
       {discountsLoading ? (
-        <Box
-          height={96}
-          borderRadius="l"
-          backgroundColor="background-card"
-          className="animate-pulse"
-        />
+        <LoadingBox height={96} borderRadius="l" />
       ) : discountCount === 0 ? (
         <EmptyState
           icon={<TicketPercent />}
@@ -104,12 +100,7 @@ export const ProductDiscounts = ({
                     <Text truncate>{discount.name}</Text>
                     {discount.code ? (
                       <Box alignItems="center" columnGap="s">
-                        <Text
-                          as="span"
-                          variant="caption"
-                          color="muted"
-                          style={{ lineHeight: 1 }}
-                        >
+                        <Text as="span" variant="caption" color="muted">
                           Code:
                         </Text>
                         <Pill

--- a/clients/apps/web/src/components/Products/ProductPage/ProductDiscounts.tsx
+++ b/clients/apps/web/src/components/Products/ProductPage/ProductDiscounts.tsx
@@ -1,15 +1,17 @@
 'use client'
 
+import { Pagination } from '@/components/Products/Benefits/components/Pagination'
 import { EmptyState } from '@/components/Shared/EmptyState'
-import { ScrollFade } from '@/components/Shared/ScrollFade'
 import { useDiscounts } from '@/hooks/queries'
 import { getDiscountDisplay } from '@/utils/discount'
 import { schemas } from '@polar-sh/client'
-import { Button, List, ListItem, Pill, Text } from '@polar-sh/orbit'
+import { List, ListItem, Pill, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
-import { TicketPercent } from 'lucide-react'
+import { ChevronRight, TicketPercent } from 'lucide-react'
 import Link from 'next/link'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
+
+const PAGE_SIZE = 5
 
 export interface ProductDiscountsProps {
   organization: schemas['Organization']
@@ -20,6 +22,7 @@ export const ProductDiscounts = ({
   organization,
   product,
 }: ProductDiscountsProps) => {
+  const [page, setPage] = useState(1)
   const { data: discountsData, isLoading: discountsLoading } = useDiscounts(
     organization.id,
     { limit: 100 },
@@ -36,23 +39,41 @@ export const ProductDiscounts = ({
   )
 
   const discountCount = applicableDiscounts.length
+  const totalPages = Math.max(1, Math.ceil(discountCount / PAGE_SIZE))
+
+  const pageDiscounts = useMemo(() => {
+    const start = (page - 1) * PAGE_SIZE
+    return applicableDiscounts.slice(start, start + PAGE_SIZE)
+  }, [applicableDiscounts, page])
 
   return (
     <Box flexDirection="column" gap="xl" minWidth={0}>
-      <Box alignItems="center" justifyContent="between" gap="l">
-        <Box flexDirection="column" gap="xs" minWidth={0}>
-          <Text variant="heading-xxs" as="h2">
-            Applicable Discounts
-          </Text>
+      <Box flexDirection="column" gap="xs" minWidth={0}>
+        <Text variant="heading-xxs" as="h2">
+          Applicable Discounts
+        </Text>
+        <Box alignItems="center" justifyContent="between" gap="l">
           <Text color="muted">
             {discountsLoading
               ? `Discounts valid for ${product.name}`
               : `${discountCount} ${discountCount === 1 ? 'discount' : 'discounts'} valid for ${product.name}`}
           </Text>
+          <Link href={`/dashboard/${organization.slug}/products/discounts`}>
+            <Box
+              color={{ base: 'text-secondary', hover: 'text-primary' }}
+              transitionProperty="colors"
+              transitionDuration="fast"
+              alignItems="center"
+              columnGap="xs"
+              flexShrink={0}
+            >
+              <Text variant="caption" color="inherit">
+                View all
+              </Text>
+              <ChevronRight size={14} />
+            </Box>
+          </Link>
         </Box>
-        <Link href={`/dashboard/${organization.slug}/products/discounts`}>
-          <Button size="sm">View All</Button>
-        </Link>
       </Box>
 
       {discountsLoading ? (
@@ -69,53 +90,53 @@ export const ProductDiscounts = ({
           description="No discounts currently apply to this product"
         />
       ) : (
-        <Box
-          display="block"
-          overflow="hidden"
-          borderRadius="l"
-          borderWidth={1}
-          borderStyle="solid"
-          borderColor="border-primary"
-        >
-          <ScrollFade className="max-h-80">
-            <List size="small" className="rounded-none border-0">
-              {applicableDiscounts.map((discount) => (
-                <ListItem key={discount.id} size="small">
-                  <Box
-                    minWidth={0}
-                    flexGrow={1}
-                    alignItems="center"
-                    columnGap="m"
-                  >
-                    <Box flexDirection="column" minWidth={0} rowGap="xs">
-                      <Text truncate>{discount.name}</Text>
-                      {discount.code ? (
-                        <Box alignItems="center" columnGap="s">
-                          <Text
-                            as="span"
-                            variant="caption"
-                            color="muted"
-                            style={{ lineHeight: 1 }}
-                          >
-                            Code:
-                          </Text>
-                          <Pill
-                            color="gray"
-                            className="shrink-0 px-2 py-0.5 font-mono text-xs leading-none"
-                          >
-                            {discount.code}
-                          </Pill>
-                        </Box>
-                      ) : null}
-                    </Box>
+        <Box flexDirection="column" gap="l">
+          <List size="small">
+            {pageDiscounts.map((discount) => (
+              <ListItem key={discount.id} size="small">
+                <Box
+                  minWidth={0}
+                  flexGrow={1}
+                  alignItems="center"
+                  columnGap="m"
+                >
+                  <Box flexDirection="column" minWidth={0} rowGap="xs">
+                    <Text truncate>{discount.name}</Text>
+                    {discount.code ? (
+                      <Box alignItems="center" columnGap="s">
+                        <Text
+                          as="span"
+                          variant="caption"
+                          color="muted"
+                          style={{ lineHeight: 1 }}
+                        >
+                          Code:
+                        </Text>
+                        <Pill
+                          color="gray"
+                          className="shrink-0 px-2 py-0.5 font-mono text-xs leading-none"
+                        >
+                          {discount.code}
+                        </Pill>
+                      </Box>
+                    ) : null}
                   </Box>
-                  <Box flexShrink={0} alignItems="center">
-                    <Text>{getDiscountDisplay(discount)}</Text>
-                  </Box>
-                </ListItem>
-              ))}
-            </List>
-          </ScrollFade>
+                </Box>
+                <Box flexShrink={0} alignItems="center">
+                  <Text>{getDiscountDisplay(discount)}</Text>
+                </Box>
+              </ListItem>
+            ))}
+          </List>
+          {totalPages > 1 && (
+            <Box justifyContent="end">
+              <Pagination
+                page={page}
+                totalPages={totalPages}
+                onPageChange={setPage}
+              />
+            </Box>
+          )}
         </Box>
       )}
     </Box>

--- a/clients/apps/web/src/components/Products/ProductPage/ProductDiscounts.tsx
+++ b/clients/apps/web/src/components/Products/ProductPage/ProductDiscounts.tsx
@@ -1,8 +1,15 @@
+'use client'
+
+import { EmptyState } from '@/components/Shared/EmptyState'
+import { ScrollFade } from '@/components/Shared/ScrollFade'
 import { useDiscounts } from '@/hooks/queries'
 import { getDiscountDisplay } from '@/utils/discount'
 import { schemas } from '@polar-sh/client'
-import { DataTable, DataTableColumnHeader } from '@polar-sh/orbit'
-import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
+import { Button, List, ListItem, Pill, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { TicketPercent } from 'lucide-react'
+import Link from 'next/link'
+import { useMemo } from 'react'
 
 export interface ProductDiscountsProps {
   organization: schemas['Organization']
@@ -15,73 +22,102 @@ export const ProductDiscounts = ({
 }: ProductDiscountsProps) => {
   const { data: discountsData, isLoading: discountsLoading } = useDiscounts(
     organization.id,
-    {
-      limit: 100,
-    },
+    { limit: 100 },
   )
 
-  const applicableDiscounts = discountsData?.items.filter(
-    (discount) =>
-      discount.products.length === 0 ||
-      discount.products.some((p) => p.id === product.id),
+  const applicableDiscounts = useMemo(
+    () =>
+      discountsData?.items.filter(
+        (discount) =>
+          discount.products.length === 0 ||
+          discount.products.some((p) => p.id === product.id),
+      ) ?? [],
+    [discountsData?.items, product.id],
   )
+
+  const discountCount = applicableDiscounts.length
 
   return (
-    <div className="flex flex-col gap-y-6">
-      <div className="flex flex-row items-center justify-between gap-x-6">
-        <div className="flex flex-col gap-y-1">
-          <h2 className="text-lg">Applicable Discounts</h2>
-          <p className="dark:text-polar-500 text-sm text-gray-500">
-            All Discounts valid for {product.name}
-          </p>
-        </div>
-      </div>
-      <DataTable
-        data={applicableDiscounts ?? []}
-        columns={[
-          {
-            accessorKey: 'name',
-            enableSorting: true,
-            header: ({ column }) => (
-              <DataTableColumnHeader column={column} title="Name" />
-            ),
-            cell: (props) => {
-              return props.getValue() as string
-            },
-          },
-          {
-            accessorKey: 'code',
-            enableSorting: true,
-            header: ({ column }) => (
-              <DataTableColumnHeader column={column} title="Code" />
-            ),
-            cell: ({ row: { original: discount } }) => (
-              <span>{discount.code}</span>
-            ),
-          },
-          {
-            accessorKey: 'amount',
-            enableSorting: true,
-            header: ({ column }) => (
-              <DataTableColumnHeader column={column} title="Amount" />
-            ),
-            cell: ({ row: { original: discount } }) => (
-              <span>{getDiscountDisplay(discount)}</span>
-            ),
-          },
-          {
-            accessorKey: 'created_at',
-            enableSorting: true,
-            header: ({ column }) => (
-              <DataTableColumnHeader column={column} title="Date" />
-            ),
-            cell: (props) => (
-              <FormattedDateTime datetime={props.getValue() as string} />
-            ),
-          },
-        ]}
-        isLoading={discountsLoading}
-      />
-    </div>
+    <Box flexDirection="column" gap="xl" minWidth={0}>
+      <Box alignItems="center" justifyContent="between" gap="l">
+        <Box flexDirection="column" gap="xs" minWidth={0}>
+          <Text variant="heading-xxs" as="h2">
+            Applicable Discounts
+          </Text>
+          <Text color="muted">
+            {discountsLoading
+              ? `Discounts valid for ${product.name}`
+              : `${discountCount} ${discountCount === 1 ? 'discount' : 'discounts'} valid for ${product.name}`}
+          </Text>
+        </Box>
+        <Link href={`/dashboard/${organization.slug}/products/discounts`}>
+          <Button size="sm">View All</Button>
+        </Link>
+      </Box>
+
+      {discountsLoading ? (
+        <Box
+          height={96}
+          borderRadius="l"
+          backgroundColor="background-card"
+          className="animate-pulse"
+        />
+      ) : discountCount === 0 ? (
+        <EmptyState
+          icon={<TicketPercent />}
+          title="No discounts"
+          description="No discounts currently apply to this product"
+        />
+      ) : (
+        <Box
+          display="block"
+          overflow="hidden"
+          borderRadius="l"
+          borderWidth={1}
+          borderStyle="solid"
+          borderColor="border-primary"
+        >
+          <ScrollFade className="max-h-80">
+            <List size="small" className="rounded-none border-0">
+              {applicableDiscounts.map((discount) => (
+                <ListItem key={discount.id} size="small">
+                  <Box
+                    minWidth={0}
+                    flexGrow={1}
+                    alignItems="center"
+                    columnGap="m"
+                  >
+                    <Box flexDirection="column" minWidth={0} rowGap="xs">
+                      <Text truncate>{discount.name}</Text>
+                      {discount.code ? (
+                        <Box alignItems="center" columnGap="s">
+                          <Text
+                            as="span"
+                            variant="caption"
+                            color="muted"
+                            style={{ lineHeight: 1 }}
+                          >
+                            Code:
+                          </Text>
+                          <Pill
+                            color="gray"
+                            className="shrink-0 px-2 py-0.5 font-mono text-xs leading-none"
+                          >
+                            {discount.code}
+                          </Pill>
+                        </Box>
+                      ) : null}
+                    </Box>
+                  </Box>
+                  <Box flexShrink={0} alignItems="center">
+                    <Text>{getDiscountDisplay(discount)}</Text>
+                  </Box>
+                </ListItem>
+              ))}
+            </List>
+          </ScrollFade>
+        </Box>
+      )}
+    </Box>
   )
 }

--- a/clients/apps/web/src/components/Products/ProductPage/ProductDiscounts.tsx
+++ b/clients/apps/web/src/components/Products/ProductPage/ProductDiscounts.tsx
@@ -41,11 +41,12 @@ export const ProductDiscounts = ({
 
   const discountCount = applicableDiscounts.length
   const totalPages = Math.max(1, Math.ceil(discountCount / PAGE_SIZE))
+  const currentPage = Math.min(page, totalPages)
 
   const pageDiscounts = useMemo(() => {
-    const start = (page - 1) * PAGE_SIZE
+    const start = (currentPage - 1) * PAGE_SIZE
     return applicableDiscounts.slice(start, start + PAGE_SIZE)
-  }, [applicableDiscounts, page])
+  }, [applicableDiscounts, currentPage])
 
   return (
     <Box flexDirection="column" gap="xl" minWidth={0}>
@@ -122,7 +123,7 @@ export const ProductDiscounts = ({
           {totalPages > 1 && (
             <Box justifyContent="end">
               <Pagination
-                page={page}
+                page={currentPage}
                 totalPages={totalPages}
                 onPageChange={setPage}
               />

--- a/clients/apps/web/src/components/Products/ProductPage/ProductOverview.tsx
+++ b/clients/apps/web/src/components/Products/ProductPage/ProductOverview.tsx
@@ -1,5 +1,7 @@
 import { MiniMetricChartBox } from '@/components/Metrics/MiniMetricChartBox'
 import { schemas } from '@polar-sh/client'
+import { Grid } from '@polar-sh/orbit'
+import { ProductBenefits } from './ProductBenefits'
 import { ProductDiscounts } from './ProductDiscounts'
 import { ProductOrders } from './ProductOrders'
 import { ProductSubscriptions } from './ProductSubscriptions'
@@ -56,8 +58,17 @@ export const ProductOverview = ({
       )}
       <ProductOrders organization={organization} product={product} />
 
-      {!product.is_archived && (
-        <ProductDiscounts organization={organization} product={product} />
+      {product.is_archived ? (
+        <ProductBenefits organization={organization} product={product} />
+      ) : (
+        <Grid
+          templateColumns={{ base: '1fr', md: 'repeat(2, minmax(0, 1fr))' }}
+          columnGap="2xl"
+          rowGap="2xl"
+        >
+          <ProductBenefits organization={organization} product={product} />
+          <ProductDiscounts organization={organization} product={product} />
+        </Grid>
       )}
     </div>
   )

--- a/clients/apps/web/src/components/Products/ProductPage/ProductPage.tsx
+++ b/clients/apps/web/src/components/Products/ProductPage/ProductPage.tsx
@@ -1,9 +1,12 @@
 import { ConfirmModal } from '@/components/Modal/ConfirmModal'
 import { useModal } from '@/components/Modal/useModal'
+import LegacyRecurringProductPrices from '@/components/Products/LegacyRecurringProductPrices'
+import ProductPriceLabel from '@/components/Products/ProductPriceLabel'
 import { toast } from '@/components/Toast/use-toast'
 import { useMetrics, useUpdateProduct } from '@/hooks/queries'
 import { apiErrorToast } from '@/utils/api/errors'
 import { getChartRangeParams } from '@/utils/metrics'
+import { hasLegacyRecurringPrices } from '@/utils/product'
 import MoreVert from '@mui/icons-material/MoreVert'
 import { schemas } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
@@ -134,24 +137,35 @@ export const ProductPage = ({ organization, product }: ProductPageProps) => {
     <Tabs defaultValue="overview" className="h-full">
       <DashboardBody
         title={
-          <div className="flex min-w-0 flex-row items-center gap-4">
+          <div className="flex min-w-0 flex-col gap-1">
             <div className="flex min-w-0 flex-row items-center gap-4">
               <h1 className="truncate text-2xl">{product.name}</h1>
+              <div className="flex shrink-0 flex-row items-center gap-4">
+                <Status
+                  status={
+                    product.is_recurring ? 'Subscription' : 'One-time Product'
+                  }
+                  color={
+                    ProductTypeDisplayColor[
+                      product.is_recurring ? 'subscription' : 'one_time'
+                    ]
+                  }
+                />
+                {product.is_archived && (
+                  <Status status="Archived" color="red" />
+                )}
+              </div>
             </div>
-
-            <div className="flex flex-row items-center gap-4">
-              <Status
-                status={
-                  product.is_recurring ? 'Subscription' : 'One-time Product'
-                }
-                color={
-                  ProductTypeDisplayColor[
-                    product.is_recurring ? 'subscription' : 'one_time'
-                  ]
-                }
-              />
-              {product.is_archived && <Status status="Archived" color="red" />}
-            </div>
+            <span className="dark:text-polar-500 text-xl text-gray-400 [&_*]:!text-current">
+              {hasLegacyRecurringPrices(product) ? (
+                <LegacyRecurringProductPrices product={product} />
+              ) : (
+                <ProductPriceLabel
+                  product={product}
+                  currency={organization.default_presentment_currency}
+                />
+              )}
+            </span>
           </div>
         }
         header={
@@ -236,7 +250,7 @@ export const ProductPage = ({ organization, product }: ProductPageProps) => {
           </div>
         }
       >
-        <TabsList className="pb-8">
+        <TabsList className="pb-4">
           <TabsTrigger value="overview">Overview</TabsTrigger>
           <TabsTrigger value="metrics">Metrics</TabsTrigger>
         </TabsList>


### PR DESCRIPTION
## Summary

After merging: #13359

Adds a benefits section to the product Overview tab, redesigns the applicable discounts section, and surfaces the product's price in the page header.

## What

- New `ProductBenefits` section showing the benefits granted by the product, paginated.
- Rework `ProductDiscounts` from a `DataTable` into a paginated list (5 per page) using Orbit primitives.
- Add the product's price to the page header via `ProductPriceLabel`, with a `LegacyRecurringProductPrices` fallback, stacked under the name alongside the status pills.

## Why

The Overview tab didn't surface a product's benefits at all, and instead of adding yet another table a list component is used to display them.

## How

Builds on the table-extraction refactor in the base branch (`villiam/product-page-tables-refactor`). Adds `ProductBenefits` and rewrites `ProductDiscounts` to render Orbit `List`/`Box`/`Text` with client-side pagination (`PAGE_SIZE = 5`) over the already-loaded data. Header price reuses the existing `ProductPriceLabel` / `LegacyRecurringProductPrices` components.

## Screenshots

| Screenshots |
|---|
| <img width="1806" height="993" alt="Screenshot 2026-07-23 at 19 19 52" src="https://github.com/user-attachments/assets/ce5df15b-5fa3-4459-b7b8-3f5c9fb99007" /> |
| <img width="1473" height="372" alt="Screenshot 2026-07-23 at 19 20 05" src="https://github.com/user-attachments/assets/b6b04c2c-3354-4e55-b7dd-9f35881cafa4" /> |



## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

