### PR TITLE
server/meter: fix N+1 billing price lookups

### DIFF
--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -20,7 +20,7 @@ from sqlalchemy import (
     update,
 )
 from sqlalchemy.dialects.postgresql import aggregate_order_by, insert
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import aliased, joinedload
 
 from polar.authz.types import AccessibleOrganizationID
 from polar.kit.repository import RepositoryBase, RepositoryIDMixin
@@ -256,6 +256,19 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
             .limit(1)
         )
         return await self.get_one_or_none(statement)
+
+    async def get_distinct_customer_ids(
+        self, statement: Select[tuple[Event]]
+    ) -> Sequence[UUID]:
+        resolved_customer = aliased(Customer)
+        customer_ids_statement = (
+            statement.with_only_columns(resolved_customer.id)
+            .join(resolved_customer, Event.customer.of_type(resolved_customer))
+            .distinct()
+            .order_by(None)
+        )
+        result = await self.session.scalars(customer_ids_statement)
+        return result.all()
 
     def get_customer_id_filter_clause(
         self, customer_id: Sequence[UUID]

--- a/server/polar/meter/service.py
+++ b/server/polar/meter/service.py
@@ -52,10 +52,7 @@ from polar.models import (
 )
 from polar.organization.resolver import get_payload_organization
 from polar.postgres import AsyncReadSession, AsyncSession
-from polar.subscription.repository import (
-    CustomerSubscriptionProductPrice,
-    SubscriptionProductPriceRepository,
-)
+from polar.subscription.repository import SubscriptionProductPriceRepository
 from polar.worker import enqueue_job, make_bulk_job_delay_calculator
 
 from .repository import MeterRepository
@@ -527,8 +524,6 @@ class MeterService:
                     ),
                 ),
             )
-            .order_by(MeterEvent.ingested_at.asc(), MeterEvent.event_id.asc())
-            .options(joinedload(Event.customer))
         )
         last_billed_event = meter.last_billed_event
         if last_billed_event is not None:
@@ -542,12 +537,19 @@ class MeterService:
                 )
             )
 
+        customer_ids = await event_repository.get_distinct_customer_ids(statement)
         subscription_product_price_repository = (
             SubscriptionProductPriceRepository.from_session(session)
         )
-        customer_price_map: dict[
-            uuid.UUID, CustomerSubscriptionProductPrice | None
-        ] = {}
+        customer_price_map = (
+            await subscription_product_price_repository.get_by_customers_and_meter(
+                customer_ids, meter.id
+            )
+        )
+
+        statement = statement.order_by(
+            MeterEvent.ingested_at.asc(), MeterEvent.event_id.asc()
+        ).options(joinedload(Event.customer))
 
         entries: list[BillingEntry] = []
         updated_subscriptions: set[uuid.UUID] = set()
@@ -561,9 +563,11 @@ class MeterService:
             try:
                 customer_price = customer_price_map[customer.id]
             except KeyError:
-                customer_price = await subscription_product_price_repository.get_by_customer_and_meter(
-                    customer.id, meter.id
+                # The customer may become visible after the prefetch under READ COMMITTED.
+                concurrent_customer_prices = await subscription_product_price_repository.get_by_customers_and_meter(
+                    [customer.id], meter.id
                 )
+                customer_price = concurrent_customer_prices[customer.id]
                 customer_price_map[customer.id] = customer_price
 
             if customer_price is None:

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -7,7 +7,7 @@ from uuid import UUID
 import sqlalchemy as sa
 from sqlalchemy import ColumnElement, Select, and_, case, cast, func, or_, select
 from sqlalchemy.orm import contains_eager
-from sqlalchemy.orm.strategy_options import joinedload, selectinload
+from sqlalchemy.orm.strategy_options import joinedload, raiseload, selectinload
 
 from polar.auth.models import (
     AuthSubject,
@@ -566,9 +566,43 @@ class SubscriptionProductPriceRepository(
 
         return await self._get_seat_subscription_price(customer_id, meter_id)
 
+    async def get_by_customers_and_meter(
+        self, customer_ids: Sequence[UUID], meter_id: UUID
+    ) -> dict[UUID, CustomerSubscriptionProductPrice | None]:
+        """
+        Get prices for multiple customers in two queries.
+
+        Direct subscriptions take priority over seat-derived subscriptions.
+        """
+        unique_customer_ids = list(dict.fromkeys(customer_ids))
+        if not unique_customer_ids:
+            return {}
+
+        direct_prices = await self._get_direct_subscription_prices(
+            unique_customer_ids, meter_id
+        )
+        seat_prices = await self._get_seat_subscription_prices(
+            unique_customer_ids, meter_id
+        )
+
+        return {
+            customer_id: direct_prices.get(customer_id, seat_prices.get(customer_id))
+            for customer_id in unique_customer_ids
+        }
+
     async def _get_direct_subscription_price(
         self, customer_id: UUID, meter_id: UUID
     ) -> CustomerSubscriptionProductPrice | None:
+        return (
+            await self._get_direct_subscription_prices([customer_id], meter_id)
+        ).get(customer_id)
+
+    async def _get_direct_subscription_prices(
+        self, customer_ids: Sequence[UUID], meter_id: UUID
+    ) -> dict[UUID, CustomerSubscriptionProductPrice]:
+        customer_ids_parameter = sa.bindparam(
+            "customer_ids", customer_ids, type_=sa.ARRAY(sa.Uuid())
+        )
         statement = (
             self.get_base_statement()
             .join(
@@ -583,78 +617,86 @@ class SubscriptionProductPriceRepository(
                 ProductPrice.is_metered.is_(True),
                 ProductPriceMeteredUnit.meter_id == meter_id,
                 Subscription.billable.is_(True),
-                Subscription.customer_id == customer_id,
+                Subscription.customer_id == sa.any_(customer_ids_parameter),
             )
             # In case customer has several subscriptions, take the earliest one
-            .order_by(Subscription.started_at.asc())
-            .limit(1)
+            .distinct(Subscription.customer_id)
+            .order_by(Subscription.customer_id, Subscription.started_at.asc())
             .options(
                 contains_eager(SubscriptionProductPrice.product_price),
-                contains_eager(SubscriptionProductPrice.subscription).joinedload(
-                    Subscription.customer
+                contains_eager(SubscriptionProductPrice.subscription).options(
+                    joinedload(Subscription.customer).raiseload(Customer.owner),
+                    raiseload(Subscription.subscription_product_prices),
+                    raiseload(Subscription.meters),
                 ),
             )
         )
 
-        subscription_product_price = await self.get_one_or_none(statement)
-        if subscription_product_price is None:
-            return None
-
-        return CustomerSubscriptionProductPrice(
-            customer_id=subscription_product_price.subscription.customer_id,
-            subscription_product_price=subscription_product_price,
-        )
+        subscription_product_prices = await self.get_all(statement)
+        return {
+            subscription_product_price.subscription.customer_id: CustomerSubscriptionProductPrice(
+                customer_id=subscription_product_price.subscription.customer_id,
+                subscription_product_price=subscription_product_price,
+            )
+            for subscription_product_price in subscription_product_prices
+        }
 
     async def _get_seat_subscription_price(
         self, customer_id: UUID, meter_id: UUID
     ) -> CustomerSubscriptionProductPrice | None:
-        """
-        Get subscription product price for a customer who is a seat holder.
-
-        Returns the billing manager's subscription if the seat holder has access
-        to a metered price for the specified meter.
-        """
-        seat = await self._get_active_seat_for_customer(customer_id)
-        if seat is None or seat.subscription is None:
-            return None
-
-        # Find matching metered price in billing manager's subscription
-        assert seat.subscription is not None
-        metered_price = self._find_metered_price_in_subscription(
-            seat.subscription, meter_id
-        )
-        if metered_price is None:
-            return None
-
-        return CustomerSubscriptionProductPrice(
-            customer_id=seat.subscription.customer_id,
-            subscription_product_price=metered_price,
+        return (await self._get_seat_subscription_prices([customer_id], meter_id)).get(
+            customer_id
         )
 
-    async def _get_active_seat_for_customer(
-        self, customer_id: UUID
-    ) -> CustomerSeat | None:
-        """Get the active seat for a customer, with subscription data eagerly loaded."""
+    async def _get_seat_subscription_prices(
+        self, customer_ids: Sequence[UUID], meter_id: UUID
+    ) -> dict[UUID, CustomerSubscriptionProductPrice]:
+        seats = await self._get_active_seats_for_customers(customer_ids)
+        customer_prices: dict[UUID, CustomerSubscriptionProductPrice] = {}
+        for seat in seats:
+            if seat.customer_id is None or seat.subscription is None:
+                continue
+
+            metered_price = self._find_metered_price_in_subscription(
+                seat.subscription, meter_id
+            )
+            if metered_price is None:
+                continue
+
+            customer_prices[seat.customer_id] = CustomerSubscriptionProductPrice(
+                customer_id=seat.subscription.customer_id,
+                subscription_product_price=metered_price,
+            )
+
+        return customer_prices
+
+    async def _get_active_seats_for_customers(
+        self, customer_ids: Sequence[UUID]
+    ) -> Sequence[CustomerSeat]:
+        """Get active seats for customers, with subscription data eagerly loaded."""
+        customer_ids_parameter = sa.bindparam(
+            "customer_ids", customer_ids, type_=sa.ARRAY(sa.Uuid())
+        )
         statement = (
             select(CustomerSeat)
             .where(
-                CustomerSeat.customer_id == customer_id,
+                CustomerSeat.customer_id == sa.any_(customer_ids_parameter),
                 CustomerSeat.status == SeatStatus.claimed,
             )
+            .distinct(CustomerSeat.customer_id)
+            .order_by(CustomerSeat.customer_id)
             .options(
                 joinedload(CustomerSeat.subscription).options(
-                    joinedload(Subscription.customer),
+                    joinedload(Subscription.customer).raiseload(Customer.owner),
                     joinedload(Subscription.subscription_product_prices).options(
                         joinedload(SubscriptionProductPrice.product_price),
-                        # Load the back-reference to satisfy lazy='raise_on_sql'
-                        # This points to the same Subscription already being loaded above
-                        joinedload(SubscriptionProductPrice.subscription),
                     ),
+                    raiseload(Subscription.meters),
                 )
             )
-            .limit(1)
         )
-        return await self.session.scalar(statement)
+        result = await self.session.execute(statement)
+        return result.scalars().unique().all()
 
     def _find_metered_price_in_subscription(
         self, subscription: Subscription, meter_id: UUID

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -7,6 +7,7 @@ from uuid import UUID
 import sqlalchemy as sa
 from sqlalchemy import ColumnElement, Select, and_, case, cast, func, or_, select
 from sqlalchemy.orm import contains_eager
+from sqlalchemy.orm.attributes import set_committed_value
 from sqlalchemy.orm.strategy_options import joinedload, raiseload, selectinload
 
 from polar.auth.models import (
@@ -663,6 +664,7 @@ class SubscriptionProductPriceRepository(
             if metered_price is None:
                 continue
 
+            set_committed_value(metered_price, "subscription", seat.subscription)
             customer_prices[seat.customer_id] = CustomerSubscriptionProductPrice(
                 customer_id=seat.subscription.customer_id,
                 subscription_product_price=metered_price,

--- a/server/tests/meter/test_service.py
+++ b/server/tests/meter/test_service.py
@@ -1258,6 +1258,74 @@ class TestCreateBillingEntries:
             "subscription.update_meters", metered_subscription.id
         )
 
+    async def test_multiple_customers(
+        self,
+        enqueue_job_mock: AsyncMock,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        meter: Meter,
+        organization: Organization,
+    ) -> None:
+        customer_1 = await create_customer(
+            save_fixture, organization=organization, email="customer-1@example.com"
+        )
+        customer_2 = await create_customer(
+            save_fixture, organization=organization, email="customer-2@example.com"
+        )
+        customer_without_subscription = await create_customer(
+            save_fixture, organization=organization, email="none@example.com"
+        )
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(meter, Decimal(100), None, "usd")],
+        )
+        subscription_1 = await create_active_subscription(
+            save_fixture, customer=customer_1, product=product
+        )
+        subscription_2 = await create_active_subscription(
+            save_fixture, customer=customer_2, product=product
+        )
+        events = [
+            await create_event(
+                save_fixture,
+                organization=organization,
+                customer=customer_1,
+                metadata={"tokens": 20, "model": "lite"},
+            ),
+            await create_event(
+                save_fixture,
+                organization=organization,
+                customer=customer_2,
+                metadata={"tokens": 10, "model": "lite"},
+            ),
+            await create_event(
+                save_fixture,
+                organization=organization,
+                customer=customer_without_subscription,
+                metadata={"tokens": 5, "model": "lite"},
+            ),
+        ]
+        await event_service._create_meter_events(session, events)
+
+        entries = await meter_service.create_billing_entries(session, meter)
+
+        assert [
+            (entry.event, entry.customer, entry.subscription) for entry in entries
+        ] == [
+            (events[0], customer_1, subscription_1),
+            (events[1], customer_2, subscription_2),
+        ]
+        assert meter.last_billed_event == events[-1]
+        assert enqueue_job_mock.call_count == 2
+        enqueue_job_mock.assert_any_call(
+            "subscription.update_meters", subscription_1.id
+        )
+        enqueue_job_mock.assert_any_call(
+            "subscription.update_meters", subscription_2.id
+        )
+
     async def test_last_billed_event(
         self,
         enqueue_job_mock: AsyncMock,

--- a/server/tests/subscription/test_repository.py
+++ b/server/tests/subscription/test_repository.py
@@ -94,6 +94,8 @@ class TestSubscriptionProductPriceRepository:
             customer=seat_holder,
             status=SeatStatus.claimed,
         )
+        subscription_id = subscription.id
+        session.expunge_all()
 
         repository = SubscriptionProductPriceRepository.from_session(session)
         result = await repository.get_by_customers_and_meter([seat_holder.id], meter.id)
@@ -102,9 +104,11 @@ class TestSubscriptionProductPriceRepository:
         assert customer_price is not None
         assert customer_price.customer_id == billing_manager.id
         assert (
-            customer_price.subscription_product_price.subscription_id == subscription.id
+            customer_price.subscription_product_price.subscription_id == subscription_id
         )
-        assert customer_price.subscription_product_price.subscription == subscription
+        assert (
+            customer_price.subscription_product_price.subscription.id == subscription_id
+        )
 
     async def test_get_by_customers_and_meter_no_subscription(
         self,

--- a/server/tests/subscription/test_repository.py
+++ b/server/tests/subscription/test_repository.py
@@ -1,0 +1,196 @@
+from datetime import timedelta
+from decimal import Decimal
+
+import pytest
+
+from polar.enums import SubscriptionRecurringInterval
+from polar.kit.utils import utc_now
+from polar.models import Customer, Meter, Organization
+from polar.models.customer_seat import SeatStatus
+from polar.postgres import AsyncSession
+from polar.subscription.repository import SubscriptionProductPriceRepository
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import (
+    create_active_subscription,
+    create_customer,
+    create_customer_seat,
+    create_product,
+)
+
+
+@pytest.mark.asyncio
+class TestSubscriptionProductPriceRepository:
+    async def test_get_by_customers_and_meter_direct_subscription(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        meter: Meter,
+        organization: Organization,
+    ) -> None:
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(meter, Decimal(100), None, "usd")],
+        )
+        later_subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            started_at=utc_now(),
+        )
+        earlier_subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            started_at=utc_now() - timedelta(days=1),
+        )
+
+        repository = SubscriptionProductPriceRepository.from_session(session)
+        result = await repository.get_by_customers_and_meter([customer.id], meter.id)
+
+        customer_price = result[customer.id]
+        assert customer_price is not None
+        assert customer_price.customer_id == customer.id
+        assert (
+            customer_price.subscription_product_price.subscription_id
+            == earlier_subscription.id
+        )
+        assert (
+            customer_price.subscription_product_price.subscription_id
+            != later_subscription.id
+        )
+
+    async def test_get_by_customers_and_meter_seat_subscription(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        meter: Meter,
+        organization: Organization,
+    ) -> None:
+        billing_manager = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="billing-manager@example.com",
+        )
+        seat_holder = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="seat-holder@example.com",
+        )
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(meter, Decimal(100), None, "usd")],
+        )
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=billing_manager
+        )
+        await create_customer_seat(
+            save_fixture,
+            subscription=subscription,
+            customer=seat_holder,
+            status=SeatStatus.claimed,
+        )
+
+        repository = SubscriptionProductPriceRepository.from_session(session)
+        result = await repository.get_by_customers_and_meter([seat_holder.id], meter.id)
+
+        customer_price = result[seat_holder.id]
+        assert customer_price is not None
+        assert customer_price.customer_id == billing_manager.id
+        assert (
+            customer_price.subscription_product_price.subscription_id == subscription.id
+        )
+        assert customer_price.subscription_product_price.subscription == subscription
+
+    async def test_get_by_customers_and_meter_no_subscription(
+        self,
+        session: AsyncSession,
+        customer: Customer,
+        meter: Meter,
+    ) -> None:
+        repository = SubscriptionProductPriceRepository.from_session(session)
+
+        result = await repository.get_by_customers_and_meter([customer.id], meter.id)
+
+        assert result == {customer.id: None}
+
+    async def test_get_by_customers_and_meter_mixed_batch(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        meter: Meter,
+        organization: Organization,
+    ) -> None:
+        direct_customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="direct@example.com",
+        )
+        seat_holder = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="seat-holder@example.com",
+        )
+        customer_without_subscription = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="none@example.com",
+        )
+        billing_manager = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="billing-manager@example.com",
+        )
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(meter, Decimal(100), None, "usd")],
+        )
+        direct_subscription = await create_active_subscription(
+            save_fixture, product=product, customer=direct_customer
+        )
+        seat_subscription = await create_active_subscription(
+            save_fixture, product=product, customer=billing_manager
+        )
+        await create_customer_seat(
+            save_fixture,
+            subscription=seat_subscription,
+            customer=seat_holder,
+            status=SeatStatus.claimed,
+        )
+        await create_customer_seat(
+            save_fixture,
+            subscription=seat_subscription,
+            customer=direct_customer,
+            status=SeatStatus.claimed,
+        )
+
+        repository = SubscriptionProductPriceRepository.from_session(session)
+        result = await repository.get_by_customers_and_meter(
+            [
+                direct_customer.id,
+                seat_holder.id,
+                customer_without_subscription.id,
+            ],
+            meter.id,
+        )
+
+        direct_customer_price = result[direct_customer.id]
+        assert direct_customer_price is not None
+        assert (
+            direct_customer_price.subscription_product_price.subscription_id
+            == direct_subscription.id
+        )
+        seat_holder_price = result[seat_holder.id]
+        assert seat_holder_price is not None
+        assert seat_holder_price.customer_id == billing_manager.id
+        assert (
+            seat_holder_price.subscription_product_price.subscription_id
+            == seat_subscription.id
+        )
+        assert result[customer_without_subscription.id] is None


### PR DESCRIPTION
## Summary

**Related Issue**: N/A

Batch subscription price resolution for `meter.billing_entries` so billing large sets of distinct customers no longer performs sequential per-customer database lookups and times out workers.

## What

- Prefetch distinct customer IDs for the exact pending meter-event query before streaming events.
- Resolve direct subscription prices for all customers in one query, choosing the earliest billable subscription per customer.
- Resolve claimed seat subscriptions for all customers in one query, with direct subscriptions taking priority.
- Remove the redundant subscription back-reference eager-load tree from the seat query.
- Use typed UUID-array `ANY` predicates so large batches do not exceed PostgreSQL bind limits.
- Keep a race-only fallback for customers that become visible between the prefetch and stream under `READ COMMITTED`.
- Add repository coverage for direct, seat-derived, missing, and mixed/direct-priority results, plus multi-customer billing-entry coverage.

## Why

The actor cached lookups per customer but still performed up to two sequential database round-trips for every distinct customer. Production runs touching hundreds of customers spent most of the actor lifetime resolving subscriptions, exceeded the worker time limit, and entered timeout/restart storms.

## How

`SubscriptionProductPriceRepository.get_by_customers_and_meter` executes batched direct and seat lookups and merges them with the existing direct-over-seat semantics. `MeterService.create_billing_entries` builds the full lookup map before streaming, so normal event processing uses dictionary lookups only. Existing behavior for customers without a resolvable price and billing watermark advancement is preserved.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

## Validation

- `uv run task lint`
- `uv run task lint_types`
- `uv run pytest tests/subscription/test_repository.py tests/meter/test_service.py::TestCreateBillingEntries tests/meter/test_service.py::TestCreateBillingEntriesWithSeats -q` (13 passed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787456436&installation_model_id=13063&pr_number=13361&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13361&signature=568b7a0d708f77dca3ab500f126e697eab73c724e993f373a156f35f72c22a16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

