### PR TITLE
server/meter: bound billing entry backlog processing

### DIFF
--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -13,7 +13,6 @@ from sqlalchemy import (
     String,
     and_,
     cast,
-    exists,
     func,
     literal,
     or_,
@@ -308,7 +307,7 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         after_ingested_at: datetime | None,
         after_event_id: UUID | None,
         limit: int,
-    ) -> Sequence[tuple[Event, Customer]]:
+    ) -> Sequence[tuple[Event, Customer | None]]:
         page_statement = (
             select(
                 MeterEvent.event_id,
@@ -317,21 +316,7 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
                 MeterEvent.organization_id,
                 MeterEvent.ingested_at,
             )
-            .where(
-                MeterEvent.meter_id == meter_id,
-                or_(
-                    MeterEvent.customer_id.is_not(None),
-                    and_(
-                        MeterEvent.external_customer_id.is_not(None),
-                        exists(
-                            select(1).where(
-                                Customer.external_id == MeterEvent.external_customer_id,
-                                Customer.organization_id == MeterEvent.organization_id,
-                            )
-                        ),
-                    ),
-                ),
-            )
+            .where(MeterEvent.meter_id == meter_id)
             .order_by(MeterEvent.ingested_at.asc(), MeterEvent.event_id.asc())
             .limit(limit)
         )
@@ -374,11 +359,17 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         )
         statement = (
             select(Event, Customer)
-            .join(resolved_customers, resolved_customers.c.event_id == Event.id)
-            .join(Customer, Customer.id == resolved_customers.c.resolved_customer_id)
+            .join(event_page, event_page.c.event_id == Event.id)
+            .outerjoin(
+                resolved_customers,
+                resolved_customers.c.event_id == event_page.c.event_id,
+            )
+            .outerjoin(
+                Customer, Customer.id == resolved_customers.c.resolved_customer_id
+            )
             .order_by(
-                resolved_customers.c.ingested_at.asc(),
-                resolved_customers.c.event_id.asc(),
+                event_page.c.ingested_at.asc(),
+                event_page.c.event_id.asc(),
             )
         )
         result = await self.session.execute(statement)

--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     String,
     and_,
     cast,
+    exists,
     func,
     literal,
     or_,
@@ -32,6 +33,7 @@ from polar.models import (
     Customer,
     Event,
     Meter,
+    MeterEvent,
 )
 from polar.models.event import EventSource
 from polar.models.product_price import ProductPriceMeteredUnit
@@ -298,6 +300,89 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
             Event.organization_id == meter.organization_id,
             self.get_meter_clause(meter),
         )
+
+    async def get_meter_billing_page(
+        self,
+        meter_id: UUID,
+        *,
+        after_ingested_at: datetime | None,
+        after_event_id: UUID | None,
+        limit: int,
+    ) -> Sequence[tuple[Event, Customer]]:
+        page_statement = (
+            select(
+                MeterEvent.event_id,
+                MeterEvent.customer_id,
+                MeterEvent.external_customer_id,
+                MeterEvent.organization_id,
+                MeterEvent.ingested_at,
+            )
+            .where(
+                MeterEvent.meter_id == meter_id,
+                or_(
+                    MeterEvent.customer_id.is_not(None),
+                    and_(
+                        MeterEvent.external_customer_id.is_not(None),
+                        exists(
+                            select(1).where(
+                                Customer.external_id == MeterEvent.external_customer_id,
+                                Customer.organization_id == MeterEvent.organization_id,
+                            )
+                        ),
+                    ),
+                ),
+            )
+            .order_by(MeterEvent.ingested_at.asc(), MeterEvent.event_id.asc())
+            .limit(limit)
+        )
+        if after_ingested_at is not None:
+            assert after_event_id is not None
+            page_statement = page_statement.where(
+                or_(
+                    MeterEvent.ingested_at > after_ingested_at,
+                    and_(
+                        MeterEvent.ingested_at == after_ingested_at,
+                        MeterEvent.event_id > after_event_id,
+                    ),
+                )
+            )
+
+        event_page = page_statement.cte("meter_billing_event_page")
+        resolved_customers = (
+            select(
+                event_page.c.event_id,
+                event_page.c.ingested_at,
+                event_page.c.customer_id.label("resolved_customer_id"),
+            )
+            .where(event_page.c.customer_id.is_not(None))
+            .union_all(
+                select(
+                    event_page.c.event_id,
+                    event_page.c.ingested_at,
+                    Customer.id.label("resolved_customer_id"),
+                )
+                .join(
+                    Customer,
+                    and_(
+                        Customer.external_id == event_page.c.external_customer_id,
+                        Customer.organization_id == event_page.c.organization_id,
+                    ),
+                )
+                .where(event_page.c.customer_id.is_(None))
+            )
+            .cte("meter_billing_resolved_customers")
+        )
+        statement = (
+            select(Event, Customer)
+            .join(resolved_customers, resolved_customers.c.event_id == Event.id)
+            .join(Customer, Customer.id == resolved_customers.c.resolved_customer_id)
+            .order_by(
+                resolved_customers.c.ingested_at.asc(),
+                resolved_customers.c.event_id.asc(),
+            )
+        )
+        result = await self.session.execute(statement)
+        return [(event, customer) for event, customer in result.all()]
 
     def get_by_pending_entries_statement(
         self, subscription: UUID, price: UUID

--- a/server/polar/meter/service.py
+++ b/server/polar/meter/service.py
@@ -13,7 +13,6 @@ from sqlalchemy import (
     asc,
     cte,
     desc,
-    exists,
     func,
     or_,
     select,
@@ -45,7 +44,6 @@ from polar.models import (
     Customer,
     Event,
     Meter,
-    MeterEvent,
     Product,
     ProductPriceMeteredUnit,
     SubscriptionProductPrice,
@@ -59,9 +57,7 @@ from .repository import MeterRepository
 from .schemas import MeterCreate, MeterQuantities, MeterQuantity, MeterUpdate
 from .sorting import MeterSortProperty
 
-# Number of events processed per billing batch. Bounds the per-query cost of the
-# subscription price lookup so it stays proportional to the batch, not to the
-# meter's whole unprocessed backlog (which could be spiked and unbounded).
+# Maximum number of events processed by one billing task invocation.
 _BILLING_ENTRY_BATCH_SIZE = 500
 
 
@@ -511,162 +507,72 @@ class MeterService:
         self, session: AsyncSession, meter: Meter
     ) -> Sequence[BillingEntry]:
         event_repository = EventRepository.from_session(session)
-        statement = (
-            event_repository.get_base_statement()
-            .join(MeterEvent, MeterEvent.event_id == Event.id)
-            .where(
-                MeterEvent.meter_id == meter.id,
-                or_(
-                    MeterEvent.customer_id.is_not(None),
-                    and_(
-                        MeterEvent.external_customer_id.is_not(None),
-                        exists(
-                            select(1).where(
-                                Customer.external_id == MeterEvent.external_customer_id,
-                                Customer.organization_id == MeterEvent.organization_id,
-                            )
-                        ),
-                    ),
-                ),
-            )
-        )
         last_billed_event = meter.last_billed_event
-        if last_billed_event is not None:
-            statement = statement.where(
-                or_(
-                    MeterEvent.ingested_at > last_billed_event.ingested_at,
-                    and_(
-                        MeterEvent.ingested_at == last_billed_event.ingested_at,
-                        MeterEvent.event_id > last_billed_event.id,
-                    ),
-                )
-            )
+        page = await event_repository.get_meter_billing_page(
+            meter.id,
+            after_ingested_at=(
+                last_billed_event.ingested_at if last_billed_event is not None else None
+            ),
+            after_event_id=(
+                last_billed_event.id if last_billed_event is not None else None
+            ),
+            limit=_BILLING_ENTRY_BATCH_SIZE,
+        )
 
         subscription_product_price_repository = (
             SubscriptionProductPriceRepository.from_session(session)
         )
 
-        statement = statement.order_by(
-            MeterEvent.ingested_at.asc(), MeterEvent.event_id.asc()
-        ).options(joinedload(Event.customer))
-
         entries: list[BillingEntry] = []
         updated_subscriptions: set[uuid.UUID] = set()
-        last_event: Event | None = None
-
-        # Stream events in the billing order and process them in bounded batches.
-        # The subscription price lookup is done once per batch (from the batch's
-        # own customers), so its cost stays proportional to the batch size rather
-        # than to the meter's entire unprocessed backlog.
-        batch: list[Event] = []
-        async for event in event_repository.stream(statement):
-            batch.append(event)
-            if len(batch) >= _BILLING_ENTRY_BATCH_SIZE:
-                (
-                    last_event,
-                    batch_entries,
-                    batch_subscriptions,
-                ) = await self._process_billing_entries_batch(
-                    session,
-                    meter,
-                    subscription_product_price_repository,
-                    batch,
+        if page:
+            customer_ids = {customer.id for _, customer in page}
+            customer_price_map = (
+                await subscription_product_price_repository.get_by_customers_and_meter(
+                    list(customer_ids), meter.id
                 )
-                entries.extend(batch_entries)
-                updated_subscriptions.update(batch_subscriptions)
-                batch = []
-
-        if batch:
-            (
-                last_event,
-                batch_entries,
-                batch_subscriptions,
-            ) = await self._process_billing_entries_batch(
-                session,
-                meter,
-                subscription_product_price_repository,
-                batch,
             )
-            entries.extend(batch_entries)
-            updated_subscriptions.update(batch_subscriptions)
 
-        meter.last_billed_event = (
-            last_event if last_event is not None else last_billed_event
-        )
-        session.add(meter)
+            for event, customer in page:
+                try:
+                    customer_price = customer_price_map[customer.id]
+                except KeyError:
+                    concurrent_customer_prices = await subscription_product_price_repository.get_by_customers_and_meter(
+                        [customer.id], meter.id
+                    )
+                    customer_price = concurrent_customer_prices[customer.id]
+                    customer_price_map[customer.id] = customer_price
+
+                if customer_price is None:
+                    continue
+
+                subscription = customer_price.subscription_product_price.subscription
+                if (
+                    subscription.trial_end is not None
+                    and event.ingested_at < subscription.trial_end
+                ):
+                    continue
+
+                entry = await self._create_subscription_holder_billing_entry(
+                    session,
+                    event,
+                    subscription.customer,
+                    customer_price.subscription_product_price,
+                )
+                entries.append(entry)
+                if entry.subscription is not None:
+                    updated_subscriptions.add(entry.subscription.id)
+
+            meter.last_billed_event = page[-1][0]
+            session.add(meter)
 
         for subscription_id in updated_subscriptions:
             enqueue_job("subscription.update_meters", subscription_id)
 
+        if len(page) == _BILLING_ENTRY_BATCH_SIZE:
+            enqueue_job("meter.billing_entries", meter.id)
+
         return entries
-
-    async def _process_billing_entries_batch(
-        self,
-        session: AsyncSession,
-        meter: Meter,
-        subscription_product_price_repository: SubscriptionProductPriceRepository,
-        batch: Sequence[Event],
-    ) -> tuple[Event, Sequence[BillingEntry], set[uuid.UUID]]:
-        # Collect the distinct paying customers appearing in this batch (in
-        # Python, from the already-fetched events) and look up their prices in a
-        # single call — no extra SQL round trip for the customer-id collection.
-        batch_customer_ids = {
-            customer.id for event in batch if (customer := event.customer) is not None
-        }
-        customer_price_map = (
-            await subscription_product_price_repository.get_by_customers_and_meter(
-                list(batch_customer_ids), meter.id
-            )
-        )
-
-        entries: list[BillingEntry] = []
-        updated_subscriptions: set[uuid.UUID] = set()
-        for event in batch:
-            customer = event.customer
-            assert customer is not None
-
-            # Retrieve the paying customer and subscription product price
-            try:
-                customer_price = customer_price_map[customer.id]
-            except KeyError:
-                # The customer may become visible after the batch lookup under
-                # READ COMMITTED.
-                concurrent_customer_prices = await subscription_product_price_repository.get_by_customers_and_meter(
-                    [customer.id], meter.id
-                )
-                customer_price = concurrent_customer_prices[customer.id]
-                customer_price_map[customer.id] = customer_price
-
-            if customer_price is None:
-                continue
-
-            # Polar never charges during a trial: skip trial events so no
-            # billable BillingEntry rows exist. The watermark still advances,
-            # so these events aren't retried once the trial converts.
-            subscription = customer_price.subscription_product_price.subscription
-            if (
-                subscription.trial_end is not None
-                and event.ingested_at < subscription.trial_end
-            ):
-                continue
-
-            # Get the paying customer (billing manager) from the subscription
-            paying_customer = subscription.customer
-
-            entry = await self._create_subscription_holder_billing_entry(
-                session,
-                event,
-                paying_customer,
-                customer_price.subscription_product_price,
-            )
-            entries.append(entry)
-            if entry.subscription is not None:
-                updated_subscriptions.add(entry.subscription.id)
-
-        # The watermark advances to the last event in billing order, regardless
-        # of whether it produced a billable entry (trial/no-subscription events
-        # must not be retried).
-        return batch[-1], entries, updated_subscriptions
 
     async def get_quantity(
         self,

--- a/server/polar/meter/service.py
+++ b/server/polar/meter/service.py
@@ -526,7 +526,7 @@ class MeterService:
         entries: list[BillingEntry] = []
         updated_subscriptions: set[uuid.UUID] = set()
         if page:
-            customer_ids = {customer.id for _, customer in page}
+            customer_ids = {customer.id for _, customer in page if customer is not None}
             customer_price_map = (
                 await subscription_product_price_repository.get_by_customers_and_meter(
                     list(customer_ids), meter.id
@@ -534,6 +534,9 @@ class MeterService:
             )
 
             for event, customer in page:
+                if customer is None:
+                    continue
+
                 try:
                     customer_price = customer_price_map[customer.id]
                 except KeyError:

--- a/server/polar/meter/tasks.py
+++ b/server/polar/meter/tasks.py
@@ -43,7 +43,9 @@ async def meter_billing_entries(meter_id: uuid.UUID) -> None:
     async with AsyncSessionMaker() as session:
         repository = MeterRepository.from_session(session)
         meter = await repository.get_by_id(
-            meter_id, options=(joinedload(Meter.last_billed_event),)
+            meter_id,
+            options=(joinedload(Meter.last_billed_event),),
+            for_update=True,
         )
         if meter is None:
             raise MeterDoesNotExist(meter_id)

--- a/server/tests/meter/test_service.py
+++ b/server/tests/meter/test_service.py
@@ -9,8 +9,6 @@ import pytest
 import pytest_asyncio
 from pydantic import ValidationError
 from pytest_mock import MockerFixture
-from sqlalchemy.dialects import postgresql
-from sqlalchemy.sql import visitors
 
 from polar.auth.models import AuthSubject
 from polar.enums import SubscriptionRecurringInterval
@@ -1436,7 +1434,6 @@ class TestCreateBillingEntries:
         organization: Organization,
     ) -> None:
         mocker.patch("polar.meter.service._BILLING_ENTRY_BATCH_SIZE", 2)
-        execute_spy = mocker.spy(session, "execute")
         price_lookup_spy = mocker.spy(
             SubscriptionProductPriceRepository, "get_by_customers_and_meter"
         )
@@ -1517,26 +1514,12 @@ class TestCreateBillingEntries:
             for call in enqueue_job_mock.call_args_list
             if call.args[0] == "subscription.update_meters"
         ]
-        assert {call.args[1] for call in subscription_jobs} == {
-            subscription.id for subscription in subscriptions
-        }
-
-        event_fetch_statements = [
-            call.args[0]
-            for call in execute_spy.call_args_list
-            if any(
-                getattr(element, "name", None) == "meter_billing_event_page"
-                for element in visitors.iterate(call.args[0])
-            )
+        assert [call.args[1] for call in subscription_jobs] == [
+            subscriptions[0].id,
+            subscriptions[1].id,
+            subscriptions[2].id,
+            subscriptions[0].id,
         ]
-        assert len(event_fetch_statements) == 3
-        for statement in event_fetch_statements:
-            compiled_statement = statement.compile(dialect=postgresql.dialect())
-            sql = str(compiled_statement)
-            assert " LIMIT " in sql
-            assert "UNION ALL" in sql
-            assert "events.customer_id = customers.id OR" not in sql
-            assert 2 in compiled_statement.params.values()
 
 
 @pytest.mark.asyncio

--- a/server/tests/meter/test_service.py
+++ b/server/tests/meter/test_service.py
@@ -9,6 +9,8 @@ import pytest
 import pytest_asyncio
 from pydantic import ValidationError
 from pytest_mock import MockerFixture
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import visitors
 
 from polar.auth.models import AuthSubject
 from polar.enums import SubscriptionRecurringInterval
@@ -30,6 +32,7 @@ from polar.meter.service import meter as meter_service
 from polar.meter.unit import MeterUnit
 from polar.models import (
     Account,
+    BillingEntry,
     Customer,
     Event,
     Meter,
@@ -1423,7 +1426,7 @@ class TestCreateBillingEntries:
         assert entries[0].customer == customer
         assert entries[0].subscription == subscription
 
-    async def test_multiple_batches(
+    async def test_backlog_across_reenqueued_pages(
         self,
         enqueue_job_mock: AsyncMock,
         mocker: MockerFixture,
@@ -1433,6 +1436,7 @@ class TestCreateBillingEntries:
         organization: Organization,
     ) -> None:
         mocker.patch("polar.meter.service._BILLING_ENTRY_BATCH_SIZE", 2)
+        execute_spy = mocker.spy(session, "execute")
         price_lookup_spy = mocker.spy(
             SubscriptionProductPriceRepository, "get_by_customers_and_meter"
         )
@@ -1462,10 +1466,11 @@ class TestCreateBillingEntries:
             save_fixture, organization=organization, email="batch-none@example.com"
         )
 
-        # 6 events across 3 batches of 2. The last event has no subscription and
-        # must not produce an entry, but must still advance the watermark.
+        # Five events across three task invocations. The last event has no
+        # subscription and must not produce an entry, but must still advance the
+        # watermark.
         events: list[Event] = []
-        for i in range(5):
+        for i in range(4):
             events.append(
                 await create_event(
                     save_fixture,
@@ -1484,25 +1489,54 @@ class TestCreateBillingEntries:
         )
         await event_service._create_meter_events(session, events)
 
-        entries = await meter_service.create_billing_entries(session, meter)
+        entries: list[BillingEntry] = []
+        for expected_watermark in (events[1], events[3], events[4]):
+            entries.extend(await meter_service.create_billing_entries(session, meter))
+            assert meter.last_billed_event == expected_watermark
 
         assert [
             (entry.event, entry.customer, entry.subscription) for entry in entries
-        ] == [(events[i], customers[i % 3], subscriptions[i % 3]) for i in range(5)]
+        ] == [(events[i], customers[i % 3], subscriptions[i % 3]) for i in range(4)]
 
-        # Watermark advances to the last streamed event across all batches, even
-        # though it produced no billable entry.
         assert meter.last_billed_event == events[-1]
 
-        # 6 events, batch size 2 -> ceil(6 / 2) == 3 per-batch lookups: bounded,
-        # not one per event and not one for the whole backlog.
         assert price_lookup_spy.call_count == 3
 
-        assert enqueue_job_mock.call_count == 3
-        for subscription in subscriptions:
-            enqueue_job_mock.assert_any_call(
-                "subscription.update_meters", subscription.id
+        continuation_jobs = [
+            call
+            for call in enqueue_job_mock.call_args_list
+            if call.args[0] == "meter.billing_entries"
+        ]
+        assert [call.args for call in continuation_jobs] == [
+            ("meter.billing_entries", meter.id),
+            ("meter.billing_entries", meter.id),
+        ]
+
+        subscription_jobs = [
+            call
+            for call in enqueue_job_mock.call_args_list
+            if call.args[0] == "subscription.update_meters"
+        ]
+        assert {call.args[1] for call in subscription_jobs} == {
+            subscription.id for subscription in subscriptions
+        }
+
+        event_fetch_statements = [
+            call.args[0]
+            for call in execute_spy.call_args_list
+            if any(
+                getattr(element, "name", None) == "meter_billing_event_page"
+                for element in visitors.iterate(call.args[0])
             )
+        ]
+        assert len(event_fetch_statements) == 3
+        for statement in event_fetch_statements:
+            compiled_statement = statement.compile(dialect=postgresql.dialect())
+            sql = str(compiled_statement)
+            assert " LIMIT " in sql
+            assert "UNION ALL" in sql
+            assert "events.customer_id = customers.id OR" not in sql
+            assert 2 in compiled_statement.params.values()
 
 
 @pytest.mark.asyncio
@@ -1819,7 +1853,7 @@ class TestCreateBillingEntriesWithSeats:
             "subscription.update_meters", billing_manager_subscription.id
         )
 
-    async def test_seat_holders_across_multiple_batches(
+    async def test_seat_holders_across_reenqueued_pages(
         self,
         enqueue_job_mock: AsyncMock,
         mocker: MockerFixture,
@@ -1909,7 +1943,9 @@ class TestCreateBillingEntriesWithSeats:
             )
         await event_service._create_meter_events(session, events)
 
-        entries = await meter_service.create_billing_entries(session, meter)
+        entries: list[BillingEntry] = []
+        for _ in range(3):
+            entries.extend(await meter_service.create_billing_entries(session, meter))
 
         assert len(entries) == 5
         for entry in entries:
@@ -1920,11 +1956,22 @@ class TestCreateBillingEntriesWithSeats:
 
         assert meter.last_billed_event == events[-1]
 
-        # 5 events, batch size 2 -> ceil(5 / 2) == 3 per-batch lookups.
         assert price_lookup_spy.call_count == 3
 
-        enqueue_job_mock.assert_called_once_with(
-            "subscription.update_meters", billing_manager_subscription.id
+        assert (
+            sum(
+                call.args == ("meter.billing_entries", meter.id)
+                for call in enqueue_job_mock.call_args_list
+            )
+            == 2
+        )
+        assert (
+            sum(
+                call.args
+                == ("subscription.update_meters", billing_manager_subscription.id)
+                for call in enqueue_job_mock.call_args_list
+            )
+            == 3
         )
 
     async def test_billing_manager_is_seat_holder(

--- a/server/tests/meter/test_service.py
+++ b/server/tests/meter/test_service.py
@@ -1,4 +1,5 @@
 import uuid
+from collections import Counter
 from datetime import timedelta
 from decimal import Decimal
 from typing import Literal
@@ -1424,6 +1425,51 @@ class TestCreateBillingEntries:
         assert entries[0].customer == customer
         assert entries[0].subscription == subscription
 
+    async def test_unresolved_external_customers_do_not_expand_page(
+        self,
+        enqueue_job_mock: AsyncMock,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        meter: Meter,
+        metered_subscription: Subscription,
+    ) -> None:
+        mocker.patch("polar.meter.service._BILLING_ENTRY_BATCH_SIZE", 2)
+        events = [
+            await create_event(
+                save_fixture,
+                organization=customer.organization,
+                external_customer_id=f"unresolved-{index}",
+                metadata={"tokens": 10, "model": "lite"},
+            )
+            for index in range(2)
+        ]
+        events.append(
+            await create_event(
+                save_fixture,
+                organization=customer.organization,
+                customer=customer,
+                metadata={"tokens": 10, "model": "lite"},
+            )
+        )
+        await event_service._create_meter_events(session, events)
+
+        first_page_entries = await meter_service.create_billing_entries(session, meter)
+
+        assert first_page_entries == []
+        assert meter.last_billed_event == events[1]
+        enqueue_job_mock.assert_called_once_with("meter.billing_entries", meter.id)
+
+        enqueue_job_mock.reset_mock()
+        second_page_entries = await meter_service.create_billing_entries(session, meter)
+
+        assert [entry.event for entry in second_page_entries] == [events[2]]
+        assert meter.last_billed_event == events[2]
+        enqueue_job_mock.assert_called_once_with(
+            "subscription.update_meters", metered_subscription.id
+        )
+
     async def test_backlog_across_reenqueued_pages(
         self,
         enqueue_job_mock: AsyncMock,
@@ -1514,12 +1560,14 @@ class TestCreateBillingEntries:
             for call in enqueue_job_mock.call_args_list
             if call.args[0] == "subscription.update_meters"
         ]
-        assert [call.args[1] for call in subscription_jobs] == [
-            subscriptions[0].id,
-            subscriptions[1].id,
-            subscriptions[2].id,
-            subscriptions[0].id,
-        ]
+        assert Counter(call.args[1] for call in subscription_jobs) == Counter(
+            (
+                subscriptions[0].id,
+                subscriptions[1].id,
+                subscriptions[2].id,
+                subscriptions[0].id,
+            )
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

**Related Issue**: N/A

Bounds each `meter.billing_entries` invocation to one fixed event page and re-enqueues continuation work, preventing large meter backlogs from exhausting the actor time limit.

## What

- Fetch at most 500 meter events per invocation using keyset pagination on `(ingested_at, event_id)`.
- Replace the non-sargable `Event.customer` joinedload predicate with sargable direct-ID and `(organization_id, external_id)` resolution branches combined with `UNION ALL`.
- Advance `last_billed_event` after one page and enqueue `meter.billing_entries` again when the page is full.
- Lock the meter row for the task transaction so scheduled and continuation jobs cannot process the same page concurrently.
- Preserve trial skipping, direct-over-seat price priority, no-price watermark advancement, and `subscription.update_meters` enqueueing.

## Why

PRs #13361 and #13362 bounded subscription price lookups, but the actor still opened an unbounded event cursor over the meter's full backlog. Fetching that cursor through the non-sargable customer join could exceed the 30-second worker limit before price batching ran. Timed-out attempts never advanced the watermark, so the backlog and retry storm continued growing.

Operationally, meter `b7f3e925-d6c8-4bc8-b40a-291f2793512e` should still be paused or drained independently until this fix is deployed.

## How

The repository first materializes an ordered, limited meter-event page. Customer resolution runs only against that page through indexed lookup branches. The service processes the page in one transaction, updates the watermark to its final event even when that event has no price, and queues a continuation only when another page may exist. The worker's existing transaction boundary commits progress before buffered jobs are published.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

Validation:

- `uv run pytest tests/meter/ -q` — 127 passed, 3 skipped
- `uv run pytest tests/event/ -q` — 109 passed, 24 skipped
- `uv run pytest tests/subscription/ -q` — 355 passed
- `uv run task lint`
- `uv run task lint_types`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787469249&installation_model_id=13063&pr_number=13363&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13363&signature=c44cff5baec193aefb30e7f106a38125e730d79bfd6565909dd859fcefc52a1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

