### PR TITLE
server/order: record the charged tax when a calculation expires

### DIFF
--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -31,7 +31,6 @@ from polar.enums import (
     PaymentMode,
     PaymentProcessor,
     TaxBehavior,
-    TaxProcessor,
 )
 from polar.event.repository import EventRepository
 from polar.event.service import event as event_service
@@ -2078,116 +2077,11 @@ class OrderService:
                 "order.balance", order_id=order.id, charge_id=payment.processor_id
             )
 
-        # Record tax transaction
         if (
             order.tax_calculation_processor_id is not None
             and order.tax_transaction_processor_id is None
         ):
-            tax_processor: TaxProcessor | None = None
-            assert order.tax_processor is not None
-            assert order.tax_behavior is not None
-            assert order.billing_address is not None
-            assert order.product is not None
-            try:
-                transaction_id, tax_processor = await tax_calculation_service.record(
-                    order.tax_processor,
-                    order.tax_calculation_processor_id,
-                    amount=order.net_amount,
-                    tax_amount=order.tax_amount,
-                    currency=order.currency,
-                    address=order.billing_address,
-                    tax_code=order.product.tax_code,
-                    reference=str(order.id),
-                    transaction_date=order.created_at,
-                )
-                update_dict = {
-                    **update_dict,
-                    "tax_processor": tax_processor,
-                    "tax_transaction_processor_id": transaction_id,
-                }
-
-            except CalculationExpiredError:
-                # Recover by recalculating tax
-                # Happens if the order was created a long time ago and the tax calculation result expired before payment was completed
-                product = order.product
-                customer = order.customer
-                tax_exempted = (
-                    order.subscription.tax_exempted if order.subscription else False
-                )
-                assert product is not None
-                (
-                    tax_processor,
-                    tax_behavior,
-                    tax_calculation_processor_id,
-                    tax_amount,
-                    tax_breakdown,
-                ) = await calculate_tax(
-                    reference=str(order.id),
-                    taxable_amount=order.net_amount,
-                    currency=order.currency,
-                    customer=customer,
-                    product=product,
-                    tax_behavior_option=order.tax_behavior.to_option(),
-                    tax_exempted=tax_exempted,
-                )
-
-                # The customer paid the tax we quoted them, so that's what we record
-                # and remit. A fresh calculation that disagrees can't be recorded:
-                # book the charged amounts as a manual transaction instead.
-                if tax_amount != order.tax_amount:
-                    log.warning(
-                        "Tax recalculation differs from the charged tax, "
-                        "recording the charged amount",
-                        order_id=order.id,
-                        charged_tax_amount=order.tax_amount,
-                        recalculated_tax_amount=tax_amount,
-                        recalculated_calculation_id=tax_calculation_processor_id,
-                    )
-                    (
-                        transaction_id,
-                        tax_processor,
-                    ) = await tax_calculation_service.record_amounts(
-                        amount=order.net_amount,
-                        tax_amount=order.tax_amount,
-                        currency=order.currency,
-                        address=order.billing_address,
-                        tax_code=order.product.tax_code,
-                        reference=str(order.id),
-                        transaction_date=order.created_at,
-                    )
-                    update_dict = {
-                        **update_dict,
-                        "tax_processor": tax_processor,
-                        "tax_transaction_processor_id": transaction_id,
-                    }
-                else:
-                    update_dict = {
-                        **update_dict,
-                        "tax_calculation_processor_id": tax_calculation_processor_id,
-                        "tax_behavior": tax_behavior,
-                        "tax_breakdown": tax_breakdown or None,
-                    }
-
-                    if tax_processor and tax_calculation_processor_id:
-                        (
-                            transaction_id,
-                            tax_processor,
-                        ) = await tax_calculation_service.record(
-                            tax_processor,
-                            tax_calculation_processor_id,
-                            amount=order.net_amount,
-                            tax_amount=tax_amount,
-                            currency=order.currency,
-                            address=order.billing_address,
-                            tax_code=order.product.tax_code,
-                            reference=str(order.id),
-                            transaction_date=order.created_at,
-                        )
-                        update_dict = {
-                            **update_dict,
-                            "tax_processor": tax_processor,
-                            "tax_transaction_processor_id": transaction_id,
-                        }
+            update_dict = {**update_dict, **await self._record_tax_transaction(order)}
 
         repository = OrderRepository.from_session(session)
         order = await repository.update(order, update_dict=update_dict)
@@ -2204,6 +2098,120 @@ class OrderService:
             await self._on_order_updated(session, order, previous_status)
 
         return order
+
+    async def _record_tax_transaction(self, order: Order) -> dict[str, Any]:
+        """Book the order's tax with the recording processor.
+
+        Returns the order fields to update.
+        """
+        assert order.tax_calculation_processor_id is not None
+        assert order.tax_processor is not None
+        assert order.billing_address is not None
+        assert order.product is not None
+
+        try:
+            transaction_id, tax_processor = await tax_calculation_service.record(
+                order.tax_processor,
+                order.tax_calculation_processor_id,
+                amount=order.net_amount,
+                tax_amount=order.tax_amount,
+                currency=order.currency,
+                address=order.billing_address,
+                tax_code=order.product.tax_code,
+                reference=str(order.id),
+                transaction_date=order.created_at,
+            )
+        except CalculationExpiredError:
+            # Happens if the order was created a long time ago and the tax
+            # calculation expired before the payment was completed.
+            return await self._record_expired_tax_calculation(order)
+
+        return {
+            "tax_processor": tax_processor,
+            "tax_transaction_processor_id": transaction_id,
+        }
+
+    async def _record_expired_tax_calculation(self, order: Order) -> dict[str, Any]:
+        """Book the tax of an order whose calculation expired before payment.
+
+        Returns the order fields to update.
+        """
+        assert order.tax_behavior is not None
+        assert order.billing_address is not None
+        assert order.product is not None
+
+        (
+            tax_processor,
+            tax_behavior,
+            tax_calculation_processor_id,
+            tax_amount,
+            tax_breakdown,
+        ) = await calculate_tax(
+            reference=str(order.id),
+            taxable_amount=order.net_amount,
+            currency=order.currency,
+            customer=order.customer,
+            product=order.product,
+            tax_behavior_option=order.tax_behavior.to_option(),
+            tax_exempted=order.subscription.tax_exempted
+            if order.subscription
+            else False,
+        )
+
+        # The customer paid the tax we quoted them, so that's what we record and
+        # remit. A fresh calculation that disagrees can't be recorded: book the
+        # charged amounts as a manual transaction instead.
+        if tax_amount != order.tax_amount:
+            log.warning(
+                "Tax recalculation differs from the charged tax, "
+                "recording the charged amount",
+                order_id=order.id,
+                charged_tax_amount=order.tax_amount,
+                recalculated_tax_amount=tax_amount,
+                recalculated_calculation_id=tax_calculation_processor_id,
+            )
+            (
+                transaction_id,
+                tax_processor,
+            ) = await tax_calculation_service.record_amounts(
+                amount=order.net_amount,
+                tax_amount=order.tax_amount,
+                currency=order.currency,
+                address=order.billing_address,
+                tax_code=order.product.tax_code,
+                reference=str(order.id),
+                transaction_date=order.created_at,
+            )
+            return {
+                "tax_processor": tax_processor,
+                "tax_transaction_processor_id": transaction_id,
+            }
+
+        update_dict: dict[str, Any] = {
+            "tax_calculation_processor_id": tax_calculation_processor_id,
+            "tax_behavior": tax_behavior,
+            "tax_breakdown": tax_breakdown or None,
+        }
+
+        if tax_processor and tax_calculation_processor_id:
+            transaction_id, tax_processor = await tax_calculation_service.record(
+                tax_processor,
+                tax_calculation_processor_id,
+                amount=order.net_amount,
+                tax_amount=tax_amount,
+                currency=order.currency,
+                address=order.billing_address,
+                tax_code=order.product.tax_code,
+                reference=str(order.id),
+                transaction_date=order.created_at,
+            )
+            update_dict = {
+                **update_dict,
+                "tax_processor": tax_processor,
+                "tax_transaction_processor_id": transaction_id,
+            }
+
+        return update_dict
 
     async def send_admin_notification(
         self, session: AsyncSession, organization: Organization, order: Order

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -340,17 +340,6 @@ class SubscriptionNotTrialing(OrderError):
         super().__init__(message)
 
 
-class TaxCalculationChangedAfterPayment(OrderError):
-    def __init__(self, order: Order, new_calculation_id: str | None) -> None:
-        self.order = order
-        self.new_calculation_id = new_calculation_id
-        message = (
-            "Tax calculation for order {order.id} has changed after payment was made. "
-            "New calculation ID: {new_calculation_id}."
-        )
-        super().__init__(message)
-
-
 class OrderService:
     @asynccontextmanager
     async def acquire_payment_lock(
@@ -2117,7 +2106,7 @@ class OrderService:
                     "tax_transaction_processor_id": transaction_id,
                 }
 
-            except CalculationExpiredError as e:
+            except CalculationExpiredError:
                 # Recover by recalculating tax
                 # Happens if the order was created a long time ago and the tax calculation result expired before payment was completed
                 product = order.product
@@ -2141,28 +2130,25 @@ class OrderService:
                     tax_behavior_option=order.tax_behavior.to_option(),
                     tax_exempted=tax_exempted,
                 )
-                update_dict = {
-                    **update_dict,
-                    "tax_calculation_processor_id": tax_calculation_processor_id,
-                    "tax_amount": tax_amount,
-                    "tax_behavior": tax_behavior,
-                    "tax_breakdown": tax_breakdown or None,
-                }
 
+                # The customer paid the tax we quoted them, so that's what we record
+                # and remit. A fresh calculation that disagrees can't be recorded:
+                # book the charged amounts as a manual transaction instead.
                 if tax_amount != order.tax_amount:
-                    raise TaxCalculationChangedAfterPayment(
-                        order, tax_calculation_processor_id
+                    log.warning(
+                        "Tax recalculation differs from the charged tax, "
+                        "recording the charged amount",
+                        order_id=order.id,
+                        charged_tax_amount=order.tax_amount,
+                        recalculated_tax_amount=tax_amount,
+                        recalculated_calculation_id=tax_calculation_processor_id,
                     )
-
-                if tax_processor and tax_calculation_processor_id:
                     (
                         transaction_id,
                         tax_processor,
-                    ) = await tax_calculation_service.record(
-                        tax_processor,
-                        tax_calculation_processor_id,
+                    ) = await tax_calculation_service.record_amounts(
                         amount=order.net_amount,
-                        tax_amount=tax_amount,
+                        tax_amount=order.tax_amount,
                         currency=order.currency,
                         address=order.billing_address,
                         tax_code=order.product.tax_code,
@@ -2174,6 +2160,34 @@ class OrderService:
                         "tax_processor": tax_processor,
                         "tax_transaction_processor_id": transaction_id,
                     }
+                else:
+                    update_dict = {
+                        **update_dict,
+                        "tax_calculation_processor_id": tax_calculation_processor_id,
+                        "tax_behavior": tax_behavior,
+                        "tax_breakdown": tax_breakdown or None,
+                    }
+
+                    if tax_processor and tax_calculation_processor_id:
+                        (
+                            transaction_id,
+                            tax_processor,
+                        ) = await tax_calculation_service.record(
+                            tax_processor,
+                            tax_calculation_processor_id,
+                            amount=order.net_amount,
+                            tax_amount=tax_amount,
+                            currency=order.currency,
+                            address=order.billing_address,
+                            tax_code=order.product.tax_code,
+                            reference=str(order.id),
+                            transaction_date=order.created_at,
+                        )
+                        update_dict = {
+                            **update_dict,
+                            "tax_processor": tax_processor,
+                            "tax_transaction_processor_id": transaction_id,
+                        }
 
         repository = OrderRepository.from_session(session)
         order = await repository.update(order, update_dict=update_dict)

--- a/server/polar/tax/calculation/__init__.py
+++ b/server/polar/tax/calculation/__init__.py
@@ -150,24 +150,47 @@ class TaxCalculationService:
                 record_processor=settings.TAX_RECORD_PROCESSOR,
                 calculation_id=processor_id,
             )
-            backfill_reference = await tax_processor_service.backfill(
-                amount,
-                tax_amount,
-                currency,
-                address,
-                tax_code,
-                reference,
-                transaction_date,
-            )
-            return (
-                f"{_BACKFILL_REFERENCE_PREFIX}{backfill_reference}",
-                settings.TAX_RECORD_PROCESSOR,
+            return await self.record_amounts(
+                amount=amount,
+                tax_amount=tax_amount,
+                currency=currency,
+                address=address,
+                tax_code=tax_code,
+                reference=reference,
+                transaction_date=transaction_date,
             )
 
         assert processor_id is not None
         return await tax_processor_service.record(
             processor_id, reference
         ), settings.TAX_RECORD_PROCESSOR
+
+    async def record_amounts(
+        self,
+        *,
+        amount: int,
+        tax_amount: int,
+        currency: str,
+        address: Address,
+        tax_code: TaxCode,
+        reference: str,
+        transaction_date: datetime,
+    ) -> tuple[str, TaxProcessor]:
+        """Record a tax transaction from explicit amounts, without a calculation."""
+        tax_processor_service = _get_tax_service(settings.TAX_RECORD_PROCESSOR)
+        backfill_reference = await tax_processor_service.backfill(
+            amount,
+            tax_amount,
+            currency,
+            address,
+            tax_code,
+            reference,
+            transaction_date,
+        )
+        return (
+            f"{_BACKFILL_REFERENCE_PREFIX}{backfill_reference}",
+            settings.TAX_RECORD_PROCESSOR,
+        )
 
     async def revert(
         self,

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -3124,7 +3124,7 @@ class TestHandlePayment:
             billing_address=Address(country=CountryAlpha2("FR")),
         )
 
-        # Set tax_amount=200 to match the recalculated amount so no TaxCalculationChangedAfterPayment is raised
+        # Set tax_amount=200 to match the recalculated amount
         order = await create_order(
             save_fixture,
             product=product,
@@ -3178,6 +3178,66 @@ class TestHandlePayment:
             )
             == 1
         )
+
+    async def test_charged_tax_recorded_when_recalculation_differs(
+        self,
+        tax_service_mock: MagicMock,
+        calculate_tax_mock: AsyncMock,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        organization: Organization,
+    ) -> None:
+        customer_with_address = await create_customer(
+            save_fixture,
+            organization=organization,
+            billing_address=Address(country=CountryAlpha2("FR")),
+        )
+
+        # The mocked calculate returns 20% of the net amount, i.e. 200 here
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer_with_address,
+            status=OrderStatus.pending,
+            subtotal_amount=1000,
+            tax_amount=150,
+            billing_address=customer_with_address.billing_address,
+        )
+
+        order.tax_processor = TaxProcessor.numeral
+        order.tax_calculation_processor_id = "tax_calc_expired_123"
+        order.tax_behavior = TaxBehavior.exclusive
+        await save_fixture(order)
+
+        payment = await create_payment(
+            save_fixture,
+            organization,
+            processor_id="stripe_payment_789",
+        )
+
+        tax_service_mock.record.side_effect = CalculationExpiredError()
+        tax_service_mock.record_amounts.return_value = (
+            "backfill_MANUAL_LINE_ITEM_ID",
+            TaxProcessor.numeral,
+        )
+
+        updated_order = await order_service.handle_payment(session, order, payment)
+
+        assert updated_order.status == OrderStatus.paid
+
+        # The tax the customer was charged is recorded, not the new calculation
+        calculate_tax_mock.assert_called_once()
+        tax_service_mock.record_amounts.assert_called_once()
+        assert tax_service_mock.record_amounts.call_args.kwargs["tax_amount"] == 150
+        assert tax_service_mock.record_amounts.call_args.kwargs["amount"] == 1000
+
+        assert updated_order.tax_amount == 150
+        assert updated_order.tax_calculation_processor_id == "tax_calc_expired_123"
+        assert (
+            updated_order.tax_transaction_processor_id == "backfill_MANUAL_LINE_ITEM_ID"
+        )
+        assert updated_order.tax_processor == TaxProcessor.numeral
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Record the charged tax when the calculation expired, instead of raising. + 1 refactor commit for readability

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787469551&installation_model_id=13063&pr_number=13364&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13364&signature=310104f525bf13d628aea79cd9fe720b3e8791f2605b6b64740d6b0658dd41fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

