### PR TITLE
lambda: Ensure that app/server comes before polar sdk

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -167,7 +167,7 @@ COPY --from=docker.io/tailscale/tailscale:v1.98.4 /usr/local/bin/tailscale /var/
 
 ENV LAMBDA_TASK_ROOT=/app/server
 ENV PATH="/app/server/.venv/bin:$PATH"
-ENV PYTHONPATH="/app/server/.venv/lib/python3.14/site-packages:/app/server"
+ENV PYTHONPATH="/app/server:/app/server/.venv/lib/python3.14/site-packages"
 ENV POLAR_EMAIL_RENDERER_BINARY_PATH=/app/server/react-email-pkg
 ENV POLAR_IP_GEOLOCATION_DATABASE_DIRECTORY_PATH=/data
 ENV POLAR_IP_GEOLOCATION_DATABASE_NAME=country_asn.mmdb


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787470195&installation_model_id=13063&pr_number=13365&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13365&signature=d36b2add0d22dfd3048ef0e0a488449168c322aaad11174502caabc386fd775e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prioritized /app/server on PYTHONPATH in the Lambda image so app code loads before the Polar SDK, preventing import conflicts and fixing import resolution.

This updates server/Dockerfile to put /app/server before the venv’s site-packages in PYTHONPATH.

<sup>Written for commit 6025120b4a7572f21a23389d37a9e1b749529e7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

