### PR TITLE
server/meter: load billing watermark after row lock

### DIFF
--- a/server/polar/meter/tasks.py
+++ b/server/polar/meter/tasks.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from apscheduler.triggers.cron import CronTrigger
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy.orm import joinedload
+from sqlalchemy.orm import selectinload
 
 from polar.event.service import event as event_service
 from polar.exceptions import PolarTaskError
@@ -42,9 +42,11 @@ async def meter_enqueue_billing() -> None:
 async def meter_billing_entries(meter_id: uuid.UUID) -> None:
     async with AsyncSessionMaker() as session:
         repository = MeterRepository.from_session(session)
+        # Load the watermark after acquiring the meter lock. A joinedload can return
+        # the updated meter row with a stale event from the pre-lock snapshot.
         meter = await repository.get_by_id(
             meter_id,
-            options=(joinedload(Meter.last_billed_event),),
+            options=(selectinload(Meter.last_billed_event),),
             for_update=True,
         )
         if meter is None:


### PR DESCRIPTION
## Summary

Follow-up to #13363 that prevents concurrent `meter.billing_entries` continuations from loading a stale billing watermark after waiting on the meter row lock.

## Root cause

The actor used `joinedload(Meter.last_billed_event)` in the same `SELECT ... FOR UPDATE OF meters` statement that acquired the meter lock. Under PostgreSQL `READ COMMITTED`, a waiter can receive the concurrently updated `meters` row while the joined `events` row still reflects the statement's pre-lock snapshot.

That leaves SQLAlchemy with a fresh `last_billed_event_id` but a stale `last_billed_event` relationship. The actor then replays the preceding full 500-event page, sees a full page, and enqueues another continuation without changing the watermark. Logfire showed concrete multi-generation chains that fetched pages and re-enqueued while issuing no meter `UPDATE`.

## Change

Use `selectinload(Meter.last_billed_event)` instead of `joinedload` for the locked meter lookup. SQLAlchemy now:

1. locks and returns the fresh meter row;
2. loads `last_billed_event` in a second query after the lock is held.

A nearby comment documents why the separate loader query is required.

## Impact

Concurrent continuation tasks retain the existing meter-level serialization while using a coherent keyset cursor. This stops stale-page replay and no-progress re-enqueue loops without changing actor retry/time-limit configuration or billing semantics.

## Validation

- `uv run task lint`
- `uv run task lint_types` — 1,626 source files
- `uv run pytest tests/meter -q` — 129 passed, 3 skipped
- `uv run pytest tests/event tests/subscription -q` — 464 passed, 24 skipped

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787487334&installation_model_id=13063&pr_number=13369&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13369&signature=fa87c9f4f003fd0469b031bb45253b47f076bca021918c6f7c0d0d20a2bfeec1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

