### PR TITLE
fix: mobile invoice editing on the order detail page

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/[id]/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/[id]/SalesPage.tsx
@@ -12,7 +12,10 @@ import { OrderRefundsSection } from '@/components/Orders/OrderRefundsSection'
 import { OrderSeatsSection } from '@/components/Orders/OrderSeatsSection'
 import { OrderSection } from '@/components/Orders/OrderSection'
 import { OrderStatus } from '@/components/Orders/OrderStatus'
-import { DownloadInvoiceDashboard } from '@/components/Orders/DownloadInvoice'
+import {
+  DownloadInvoiceDashboard,
+  type EditInvoiceHandle,
+} from '@/components/Orders/DownloadInvoice'
 import { DownloadReceiptDashboard } from '@/components/Orders/DownloadReceipt'
 import { InvoicePreview } from '@/components/Orders/InvoicePreview'
 import { toast } from '@/components/Toast/use-toast'
@@ -36,7 +39,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@polar-sh/ui/components/ui/dropdown-menu'
-import React from 'react'
+import { useIsMobile } from '@polar-sh/ui/hooks/use-mobile'
+import React, { useRef } from 'react'
 
 interface ClientPageProps {
   organization: schemas['Organization']
@@ -55,6 +59,8 @@ const ClientPage: React.FC<ClientPageProps> = ({
     { order_id: _order.id },
   )
   const { data: refunds } = useRefunds(_order.id)
+  const isMobile = useIsMobile()
+  const editInvoiceRef = useRef<EditInvoiceHandle | null>(null)
 
   const orderPayments = payments?.items ?? []
   const inDunningLifecycle =
@@ -98,6 +104,8 @@ const ClientPage: React.FC<ClientPageProps> = ({
                 order={order}
                 organization={organization}
                 onInvoiceGenerated={refetchOrder}
+                hideEditButton={isMobile}
+                editInvoiceRef={editInvoiceRef}
               />
               {order.receipt_number != null && (
                 <DownloadReceiptDashboard
@@ -116,6 +124,13 @@ const ClientPage: React.FC<ClientPageProps> = ({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
+              {isMobile && order.paid && order.is_invoice_generated && (
+                <DropdownMenuItem
+                  onClick={() => editInvoiceRef.current?.show()}
+                >
+                  Edit Invoice
+                </DropdownMenuItem>
+              )}
               <DropdownMenuItem
                 onClick={() => {
                   navigator.clipboard

--- a/clients/apps/web/src/components/Customer/CustomerContextView.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerContextView.tsx
@@ -89,7 +89,7 @@ export const CustomerContextView = ({
         </Link>
       </ContextCard>
       <ContextCard>
-        <div className="flex flex-col">
+        <div className="flex flex-col gap-3 sm:gap-0">
           {!customer.deleted_at && (
             <DetailRow
               labelClassName="flex-none md:basis-24"

--- a/clients/apps/web/src/components/Customer/CustomerContextView.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerContextView.tsx
@@ -89,7 +89,7 @@ export const CustomerContextView = ({
         </Link>
       </ContextCard>
       <ContextCard>
-        <div className="flex flex-col gap-3 sm:gap-0">
+        <div className="flex flex-col gap-3 md:gap-0">
           {!customer.deleted_at && (
             <DetailRow
               labelClassName="flex-none md:basis-24"

--- a/clients/apps/web/src/components/Orders/DownloadInvoice.tsx
+++ b/clients/apps/web/src/components/Orders/DownloadInvoice.tsx
@@ -516,7 +516,9 @@ const DownloadInvoice = ({
                   disabled={loading}
                   className={className}
                 >
-                  Generate invoice
+                  {order.is_invoice_generated
+                    ? 'Update invoice'
+                    : 'Generate invoice'}
                 </Button>
                 {errors.root && (
                   <p className="text-destructive-foreground text-sm">

--- a/clients/apps/web/src/components/Orders/DownloadInvoice.tsx
+++ b/clients/apps/web/src/components/Orders/DownloadInvoice.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { InlineModal } from '@polar-sh/orbit'
+import { InlineModal, InlineModalHeader } from '@polar-sh/orbit'
 import { useModal } from '@/components/Modal/useModal'
 import { useOrganizationSSE } from '@/hooks/sse'
 import { setValidationErrors } from '@/utils/api/errors'
@@ -341,11 +341,19 @@ const DownloadInvoice = ({
         isShown={isShown}
         hide={hide}
         modalContent={
-          <Form {...form}>
-            <form
-              onSubmit={handleSubmit(onModalSubmit)}
-              className="flex flex-col gap-y-6 px-8 py-10"
-            >
+          <div className="flex h-full flex-col overflow-y-auto">
+            <InlineModalHeader hide={hide}>
+              <h2 className="text-xl">
+                {order.is_invoice_generated
+                  ? 'Edit Invoice'
+                  : 'Generate Invoice'}
+              </h2>
+            </InlineModalHeader>
+            <Form {...form}>
+              <form
+                onSubmit={handleSubmit(onModalSubmit)}
+                className="flex flex-col gap-y-6 px-8 pb-10"
+              >
               <FormField
                 control={control}
                 name="billing_name"
@@ -515,6 +523,7 @@ const DownloadInvoice = ({
               )}
             </form>
           </Form>
+          </div>
         }
       />
     </>

--- a/clients/apps/web/src/components/Orders/DownloadInvoice.tsx
+++ b/clients/apps/web/src/components/Orders/DownloadInvoice.tsx
@@ -32,13 +32,24 @@ import {
   FormMessage,
 } from '@polar-sh/ui/components/ui/form'
 import type EventEmitter from 'eventemitter3'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { useForm } from 'react-hook-form'
 import { twMerge } from 'tailwind-merge'
 import { useCustomerPortalContext } from '../CustomerPortal/CustomerPortalProvider'
 
 type Variant = NonNullable<Parameters<typeof buttonVariants>[0]>['variant']
 type Size = NonNullable<Parameters<typeof buttonVariants>[0]>['size']
+
+export type EditInvoiceHandle = {
+  show: () => void
+}
 
 const INVOICE_GENERATED_EVENT = 'order.invoice_generated'
 const INVOICE_GENERATION_TIMEOUT_MS = 30_000
@@ -83,6 +94,8 @@ const DownloadInvoice = ({
   invoiceURL,
   orderURL,
   dropdown = false,
+  hideEditButton = false,
+  editInvoiceRef,
   variant,
   size,
   className,
@@ -99,10 +112,20 @@ const DownloadInvoice = ({
   size?: Size
   className?: string
   dropdown?: boolean
+  hideEditButton?: boolean
+  editInvoiceRef?: RefObject<EditInvoiceHandle | null>
 }) => {
   const [loading, setLoading] = useState(false)
   const inFlightRef = useRef(false)
   const { isShown, hide, show } = useModal()
+
+  useEffect(() => {
+    if (!editInvoiceRef) return
+    editInvoiceRef.current = { show }
+    return () => {
+      editInvoiceRef.current = null
+    }
+  }, [editInvoiceRef, show])
   const form = useForm<schemas['OrderUpdate'] | schemas['CustomerOrderUpdate']>(
     {
       defaultValues: {
@@ -283,7 +306,7 @@ const DownloadInvoice = ({
           >
             Download Invoice
           </Button>
-          {order.is_invoice_generated && (
+          {order.is_invoice_generated && !hideEditButton && (
             <Button
               type="button"
               loading={loading}
@@ -298,7 +321,17 @@ const DownloadInvoice = ({
           )}
         </div>
       ),
-    [dropdown, order, loading, size, className, variant, onDownload, show],
+    [
+      dropdown,
+      order,
+      loading,
+      size,
+      className,
+      variant,
+      onDownload,
+      show,
+      hideEditButton,
+    ],
   )
 
   return (
@@ -496,6 +529,8 @@ export const DownloadInvoiceDashboard = ({
   size,
   className,
   dropdown = false,
+  hideEditButton = false,
+  editInvoiceRef,
 }: {
   organization: schemas['Organization']
   order: schemas['Order']
@@ -504,6 +539,8 @@ export const DownloadInvoiceDashboard = ({
   size?: Size
   className?: string
   dropdown?: boolean
+  hideEditButton?: boolean
+  editInvoiceRef?: RefObject<EditInvoiceHandle | null>
 }) => {
   const eventEmitter = useOrganizationSSE(organization.id)
   return (
@@ -518,6 +555,8 @@ export const DownloadInvoiceDashboard = ({
       size={size}
       className={className}
       dropdown={dropdown}
+      hideEditButton={hideEditButton}
+      editInvoiceRef={editInvoiceRef}
     />
   )
 }

--- a/clients/apps/web/src/components/Orders/DownloadInvoice.tsx
+++ b/clients/apps/web/src/components/Orders/DownloadInvoice.tsx
@@ -354,175 +354,177 @@ const DownloadInvoice = ({
                 onSubmit={handleSubmit(onModalSubmit)}
                 className="flex flex-col gap-y-6 px-8 pb-10"
               >
-              <FormField
-                control={control}
-                name="billing_name"
-                rules={{
-                  required: 'This field is required',
-                }}
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Billing name</FormLabel>
+                <FormField
+                  control={control}
+                  name="billing_name"
+                  rules={{
+                    required: 'This field is required',
+                  }}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Billing name</FormLabel>
+                      <FormControl>
+                        <Input {...field} value={field.value || ''} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormItem>
+                  <FormLabel>Billing address</FormLabel>
+                  <FormControl>
+                    <FormField
+                      control={control}
+                      name="billing_address.line1"
+                      rules={{
+                        required: 'This field is required',
+                      }}
+                      render={({ field }) => (
+                        <>
+                          <Input
+                            type="text"
+                            autoComplete="billing address-line1"
+                            placeholder="Line 1"
+                            {...field}
+                            value={field.value || ''}
+                          />
+                          <FormMessage />
+                        </>
+                      )}
+                    />
+                  </FormControl>
+                  <FormControl>
+                    <FormField
+                      control={control}
+                      name="billing_address.line2"
+                      render={({ field }) => (
+                        <>
+                          <Input
+                            type="text"
+                            autoComplete="billing address-line2"
+                            placeholder="Line 2"
+                            {...field}
+                            value={field.value || ''}
+                          />
+                          <FormMessage />
+                        </>
+                      )}
+                    />
+                  </FormControl>
+                  <div className="grid grid-cols-2 gap-x-2">
                     <FormControl>
-                      <Input {...field} value={field.value || ''} />
+                      <FormField
+                        control={control}
+                        name="billing_address.postal_code"
+                        rules={{
+                          required: 'This field is required',
+                        }}
+                        render={({ field }) => (
+                          <div>
+                            <Input
+                              type="text"
+                              autoComplete="billing postal-code"
+                              placeholder="Postal code"
+                              {...field}
+                              value={field.value || ''}
+                            />
+                            <FormMessage />
+                          </div>
+                        )}
+                      />
                     </FormControl>
-                    <FormMessage />
-                  </FormItem>
+                    <FormControl>
+                      <FormField
+                        control={control}
+                        name="billing_address.city"
+                        rules={{
+                          required: 'This field is required',
+                        }}
+                        render={({ field }) => (
+                          <div>
+                            <Input
+                              type="text"
+                              autoComplete="billing address-level2"
+                              placeholder="City"
+                              {...field}
+                              value={field.value || ''}
+                            />
+                            <FormMessage />
+                          </div>
+                        )}
+                      />
+                    </FormControl>
+                  </div>
+                  <FormControl>
+                    <FormField
+                      control={control}
+                      name="billing_address.state"
+                      rules={{
+                        required:
+                          country === 'US' || country === 'CA'
+                            ? 'This field is required'
+                            : false,
+                      }}
+                      render={({ field }) => (
+                        <>
+                          <CountryStatePicker
+                            disabled={
+                              !!order.billing_address?.state ||
+                              order.is_invoice_generated
+                            }
+                            autoComplete="billing address-level1"
+                            country={country}
+                            value={field.value || ''}
+                            onChange={field.onChange}
+                            placeholder={
+                              country === 'US' ? 'State' : 'Province'
+                            }
+                          />
+                          <FormMessage />
+                        </>
+                      )}
+                    />
+                  </FormControl>
+                  <FormControl>
+                    <FormField
+                      control={control}
+                      name="billing_address.country"
+                      rules={{
+                        required: 'This field is required',
+                      }}
+                      render={({ field }) => (
+                        <>
+                          <CountryPicker
+                            disabled={
+                              !!order.billing_address?.country ||
+                              order.is_invoice_generated
+                            }
+                            autoComplete="billing country"
+                            value={field.value || undefined}
+                            onChange={field.onChange}
+                            allowedCountries={enums.addressInputCountryValues}
+                          />
+                          <FormMessage />
+                        </>
+                      )}
+                    />
+                  </FormControl>
+                </FormItem>
+                <Button
+                  type="submit"
+                  loading={loading}
+                  disabled={loading}
+                  className={className}
+                >
+                  Generate invoice
+                </Button>
+                {errors.root && (
+                  <p className="text-destructive-foreground text-sm">
+                    {errors.root.message}
+                  </p>
                 )}
-              />
-              <FormItem>
-                <FormLabel>Billing address</FormLabel>
-                <FormControl>
-                  <FormField
-                    control={control}
-                    name="billing_address.line1"
-                    rules={{
-                      required: 'This field is required',
-                    }}
-                    render={({ field }) => (
-                      <>
-                        <Input
-                          type="text"
-                          autoComplete="billing address-line1"
-                          placeholder="Line 1"
-                          {...field}
-                          value={field.value || ''}
-                        />
-                        <FormMessage />
-                      </>
-                    )}
-                  />
-                </FormControl>
-                <FormControl>
-                  <FormField
-                    control={control}
-                    name="billing_address.line2"
-                    render={({ field }) => (
-                      <>
-                        <Input
-                          type="text"
-                          autoComplete="billing address-line2"
-                          placeholder="Line 2"
-                          {...field}
-                          value={field.value || ''}
-                        />
-                        <FormMessage />
-                      </>
-                    )}
-                  />
-                </FormControl>
-                <div className="grid grid-cols-2 gap-x-2">
-                  <FormControl>
-                    <FormField
-                      control={control}
-                      name="billing_address.postal_code"
-                      rules={{
-                        required: 'This field is required',
-                      }}
-                      render={({ field }) => (
-                        <div>
-                          <Input
-                            type="text"
-                            autoComplete="billing postal-code"
-                            placeholder="Postal code"
-                            {...field}
-                            value={field.value || ''}
-                          />
-                          <FormMessage />
-                        </div>
-                      )}
-                    />
-                  </FormControl>
-                  <FormControl>
-                    <FormField
-                      control={control}
-                      name="billing_address.city"
-                      rules={{
-                        required: 'This field is required',
-                      }}
-                      render={({ field }) => (
-                        <div>
-                          <Input
-                            type="text"
-                            autoComplete="billing address-level2"
-                            placeholder="City"
-                            {...field}
-                            value={field.value || ''}
-                          />
-                          <FormMessage />
-                        </div>
-                      )}
-                    />
-                  </FormControl>
-                </div>
-                <FormControl>
-                  <FormField
-                    control={control}
-                    name="billing_address.state"
-                    rules={{
-                      required:
-                        country === 'US' || country === 'CA'
-                          ? 'This field is required'
-                          : false,
-                    }}
-                    render={({ field }) => (
-                      <>
-                        <CountryStatePicker
-                          disabled={
-                            !!order.billing_address?.state ||
-                            order.is_invoice_generated
-                          }
-                          autoComplete="billing address-level1"
-                          country={country}
-                          value={field.value || ''}
-                          onChange={field.onChange}
-                          placeholder={country === 'US' ? 'State' : 'Province'}
-                        />
-                        <FormMessage />
-                      </>
-                    )}
-                  />
-                </FormControl>
-                <FormControl>
-                  <FormField
-                    control={control}
-                    name="billing_address.country"
-                    rules={{
-                      required: 'This field is required',
-                    }}
-                    render={({ field }) => (
-                      <>
-                        <CountryPicker
-                          disabled={
-                            !!order.billing_address?.country ||
-                            order.is_invoice_generated
-                          }
-                          autoComplete="billing country"
-                          value={field.value || undefined}
-                          onChange={field.onChange}
-                          allowedCountries={enums.addressInputCountryValues}
-                        />
-                        <FormMessage />
-                      </>
-                    )}
-                  />
-                </FormControl>
-              </FormItem>
-              <Button
-                type="submit"
-                loading={loading}
-                disabled={loading}
-                className={className}
-              >
-                Generate invoice
-              </Button>
-              {errors.root && (
-                <p className="text-destructive-foreground text-sm">
-                  {errors.root.message}
-                </p>
-              )}
-            </form>
-          </Form>
+              </form>
+            </Form>
           </div>
         }
       />

--- a/clients/apps/web/src/components/Shared/DetailRow.tsx
+++ b/clients/apps/web/src/components/Shared/DetailRow.tsx
@@ -16,10 +16,10 @@ export const DetailRow = ({
   action,
 }: DetailRowProps) => {
   return (
-    <div className="flex flex-col gap-0.5 py-2 text-sm md:flex-row md:items-baseline md:justify-between md:gap-4 md:py-0">
+    <div className="flex flex-col text-sm md:flex-row md:items-baseline md:justify-between md:gap-4">
       <h3
         className={twMerge(
-          'dark:text-polar-500 flex-1 truncate text-gray-500',
+          'dark:text-polar-500 flex-1 text-gray-500 truncate',
           labelClassName,
         )}
       >

--- a/clients/apps/web/src/components/Shared/DetailRow.tsx
+++ b/clients/apps/web/src/components/Shared/DetailRow.tsx
@@ -16,10 +16,10 @@ export const DetailRow = ({
   action,
 }: DetailRowProps) => {
   return (
-    <div className="flex flex-col text-sm md:flex-row md:items-baseline md:justify-between md:gap-4">
+    <div className="flex flex-col gap-0.5 py-2 text-sm md:flex-row md:items-baseline md:justify-between md:gap-4 md:py-0">
       <h3
         className={twMerge(
-          'dark:text-polar-500 flex-1 text-gray-500 truncate',
+          'dark:text-polar-500 flex-1 truncate text-gray-500',
           labelClassName,
         )}
       >


### PR DESCRIPTION
## Summary:

Minor mobile responsiveness fixes for the order page.

## What

Fixes the invoice editing experience on the order/sales detail page for mobile.

- **Adds a header to the invoice modal** (`InlineModalHeader`) with a title and
  close button, so the slide-over reads correctly on small screens where the
  inline actions are cramped.
- **Moves "Edit Invoice" into the `⋮` menu on mobile.** On desktop the inline
  "Edit Invoice" button is unchanged; on mobile it's hidden (`hideEditButton`)
  and surfaced as a dropdown item instead. `DownloadInvoice` exposes an
  imperative `editInvoiceRef` handle so the page-level menu can open the modal.
- **Fixes a label mismatch**: the modal's submit button now reads "Update
  invoice" when editing an existing invoice and "Generate invoice" otherwise,
  matching the new header ("Edit Invoice" / "Generate Invoice").
  
| Before | After |
|---|---|
| <img width="577" height="250" alt="Screenshot 2026-07-24 at 14 48 32" src="https://github.com/user-attachments/assets/33bf028a-af9a-4287-ac8a-943842286594" /> | <img width="540" height="341" alt="Screenshot 2026-07-24 at 14 48 21" src="https://github.com/user-attachments/assets/62f35f34-d86d-4913-a5f4-3bacaf4255ab" /> | 
| <img width="534" height="634" alt="Screenshot 2026-07-24 at 14 48 42" src="https://github.com/user-attachments/assets/c2d61ea7-edb1-4776-9f82-7f1762ec5d29" /> | <img width="566" height="671" alt="Screenshot 2026-07-24 at 14 48 53" src="https://github.com/user-attachments/assets/595358b6-9d61-4cbb-bcf4-69d43bec7bdf" /> |




## Notes

- No changes to invoice generation, SSE, or download logic — the large diff in
  `DownloadInvoice.tsx` is mostly re-indentation from wrapping the form in the
  new header container.
- Desktop behavior is unchanged; the two "Edit Invoice" entry points (inline
  button vs. menu item) are exact complements and never both render.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787489437&installation_model_id=13063&pr_number=13370&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13370&signature=b2baddc15b659b5ddc0822d6cabb2e81b51ddd5228fdca144397a538340502b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

