### PR TITLE
ci: unbreak dev CLI lint and the OTP test

### DIFF
--- a/clients/apps/web/src/components/Auth/EmailOTPForm.test.tsx
+++ b/clients/apps/web/src/components/Auth/EmailOTPForm.test.tsx
@@ -51,6 +51,14 @@ vi.mock('@polar-sh/orbit', () => ({
   Input: (props: InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
 }))
 
+vi.mock('@/utils/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/config')>()
+  return {
+    ...actual,
+    CONFIG: { ...actual.CONFIG, ENVIRONMENT: 'testing' },
+  }
+})
+
 vi.mock('@polar-sh/ui/components/ui/form', () => {
   const Passthrough = ({ children }: PropsWithChildren) => children
 

--- a/dev/cli/pyproject.toml
+++ b/dev/cli/pyproject.toml
@@ -2,7 +2,9 @@
 target-version = "py312"
 
 [tool.ruff.lint]
-extend-select = ["I", "UP", "T20"]
+# Pinned explicitly: `extend-select` builds on ruff's default set, which widened
+# from 4 rule families to 37 in ruff 0.16 and failed CI on untouched files.
+select = ["E4", "E7", "E9", "F", "I", "UP", "T20"]
 
 [tool.ruff.lint.per-file-ignores]
 "cli.py" = ["E402"]


### PR DESCRIPTION
## Summary

**Dev CLI lint.** `extend-select` builds on ruff's default rule set, which widened from 4 families to 37 in ruff 0.16. The unpinned `uv run --with ruff` picked that up, so an unchanged config started demanding 419 rules and failed on 34 pre-existing findings across 9 untouched files. `select` now states the intended set explicitly: 419 rules → 108, 34 errors → 0, no code changed.

**OTP test.** `EmailOTPForm.test.tsx` asserts a hardcoded production Turnstile sitekey, but the component branches on `CONFIG.ENVIRONMENT`, which falls back to `development` when unset. CI sets `VERCEL_ENV: testing` so it passes there; it fails on every developer machine. The test now mocks the config like it already mocks everything else.


## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

