### PR TITLE
fix: stop orphaning Stripe identity verification sessions

### DIFF
--- a/server/polar/user/service.py
+++ b/server/polar/user/service.py
@@ -47,16 +47,6 @@ class IdentityVerificationProcessing(UserError):
         super().__init__(message, 403)
 
 
-class IdentityVerificationDoesNotExist(UserError):
-    def __init__(self, identity_verification_id: str) -> None:
-        self.identity_verification_id = identity_verification_id
-        message = (
-            f"Received identity verification {identity_verification_id} from Stripe, "
-            "but no associated User exists."
-        )
-        super().__init__(message)
-
-
 class InvalidAccount(UserError):
     def __init__(self, account_id: UUID) -> None:
         self.account_id = account_id
@@ -176,23 +166,55 @@ class UserService:
             id=verification_session.id, client_secret=verification_session.client_secret
         )
 
+    async def _get_verification_session_user(
+        self,
+        repository: UserRepository,
+        verification_session: stripe_lib.identity.VerificationSession,
+    ) -> User | None:
+        # `identity_verification_id` only points to the user's latest session, so an
+        # earlier one is unreachable by id: fall back to the metadata we set on create.
+        user = await repository.get_by_identity_verification_id(
+            verification_session.id, for_update=True
+        )
+        if user is not None:
+            return user
+
+        metadata = verification_session.get("metadata") or {}
+        user_id = metadata.get("user_id")
+        if user_id is None:
+            log.warning(
+                "identity_verification.session_without_user",
+                verification_session_id=verification_session.id,
+            )
+            return None
+
+        user = await repository.get_by_id(UUID(user_id), for_update=True)
+        if user is None:
+            log.warning(
+                "identity_verification.user_not_found",
+                verification_session_id=verification_session.id,
+                user_id=user_id,
+            )
+        return user
+
     async def identity_verification_verified(
         self,
         session: AsyncSession,
         verification_session: stripe_lib.identity.VerificationSession,
-    ) -> User:
+    ) -> User | None:
         repository = UserRepository.from_session(session)
-        user = await repository.get_by_identity_verification_id(
-            verification_session.id, for_update=True
+        user = await self._get_verification_session_user(
+            repository, verification_session
         )
         if user is None:
-            raise IdentityVerificationDoesNotExist(verification_session.id)
+            return None
 
         assert verification_session.status == "verified"
         user = await repository.update(
             user,
             update_dict={
-                "identity_verification_status": IdentityVerificationStatus.verified
+                "identity_verification_status": IdentityVerificationStatus.verified,
+                "identity_verification_id": verification_session.id,
             },
         )
 
@@ -207,13 +229,15 @@ class UserService:
         self,
         session: AsyncSession,
         verification_session: stripe_lib.identity.VerificationSession,
-    ) -> User:
+    ) -> User | None:
         repository = UserRepository.from_session(session)
         user = await repository.get_by_identity_verification_id(
             verification_session.id, for_update=True
         )
+        # No user points at this session anymore: it belongs to an attempt the user
+        # has moved on from, so it says nothing about their current state.
         if user is None:
-            raise IdentityVerificationDoesNotExist(verification_session.id)
+            return None
 
         # Once a user is verified, keep them verified: a late `processing` webhook
         # must not overwrite it. A failed user can retry, so `failed` -> `pending` is fine.
@@ -232,13 +256,15 @@ class UserService:
         self,
         session: AsyncSession,
         verification_session: stripe_lib.identity.VerificationSession,
-    ) -> User:
+    ) -> User | None:
         repository = UserRepository.from_session(session)
         user = await repository.get_by_identity_verification_id(
             verification_session.id, for_update=True
         )
+        # No user points at this session anymore: it belongs to an attempt the user
+        # has moved on from, so it says nothing about their current state.
         if user is None:
-            raise IdentityVerificationDoesNotExist(verification_session.id)
+            return None
 
         # Once a user is verified, keep them verified. An old or repeated webhook
         # from a past attempt must not undo it.

--- a/server/polar/user/service.py
+++ b/server/polar/user/service.py
@@ -140,17 +140,15 @@ class UserService:
         if user.identity_verified:
             raise IdentityAlreadyVerified(user.id)
 
-        if user.identity_verification_status == IdentityVerificationStatus.pending:
-            raise IdentityVerificationProcessing(user.id)
-
         verification_session: stripe_lib.identity.VerificationSession | None = None
         if user.identity_verification_id is not None:
             verification_session = await stripe_service.get_verification_session(
                 user.identity_verification_id
             )
 
-        # Our status lags Stripe's while a webhook is in flight, so trust Stripe here:
-        # replacing a session that's still live orphans the webhooks it has yet to send.
+        # Our status lags Stripe's while a webhook is in flight, so the session Stripe
+        # reports is the only gate: replacing one that's still live orphans the webhooks
+        # it has yet to send, and gating on a stale `pending` locks the user out.
         if verification_session is not None:
             match verification_session.status:
                 case "verified":

--- a/server/polar/user/service.py
+++ b/server/polar/user/service.py
@@ -149,10 +149,20 @@ class UserService:
                 user.identity_verification_id
             )
 
-        if (
-            verification_session is None
-            or verification_session.status != "requires_input"
-        ):
+        # Our status lags Stripe's while a webhook is in flight, so trust Stripe here:
+        # replacing a session that's still live orphans the webhooks it has yet to send.
+        if verification_session is not None:
+            match verification_session.status:
+                case "verified":
+                    raise IdentityAlreadyVerified(user.id)
+                case "processing":
+                    raise IdentityVerificationProcessing(user.id)
+                case "requires_input":
+                    pass
+                case _:
+                    verification_session = None
+
+        if verification_session is None:
             verification_session = await stripe_service.create_verification_session(
                 user
             )

--- a/server/polar/user/service.py
+++ b/server/polar/user/service.py
@@ -47,6 +47,16 @@ class IdentityVerificationProcessing(UserError):
         super().__init__(message, 403)
 
 
+class IdentityVerificationForUnknownUser(UserError):
+    def __init__(self, identity_verification_id: str) -> None:
+        self.identity_verification_id = identity_verification_id
+        message = (
+            f"Received identity verification {identity_verification_id} from Stripe, "
+            "but it can't be attributed to any User."
+        )
+        super().__init__(message)
+
+
 class InvalidAccount(UserError):
     def __init__(self, account_id: UUID) -> None:
         self.account_id = account_id
@@ -146,9 +156,6 @@ class UserService:
                 user.identity_verification_id
             )
 
-        # Our status lags Stripe's while a webhook is in flight, so the session Stripe
-        # reports is the only gate: replacing one that's still live orphans the webhooks
-        # it has yet to send, and gating on a stale `pending` locks the user out.
         if verification_session is not None:
             match verification_session.status:
                 case "verified":
@@ -178,9 +185,7 @@ class UserService:
         self,
         repository: UserRepository,
         verification_session: stripe_lib.identity.VerificationSession,
-    ) -> User | None:
-        # `identity_verification_id` only points to the user's latest session, so an
-        # earlier one is unreachable by id: fall back to the metadata we set on create.
+    ) -> User:
         user = await repository.get_by_identity_verification_id(
             verification_session.id, for_update=True
         )
@@ -189,33 +194,22 @@ class UserService:
 
         metadata = verification_session.get("metadata") or {}
         user_id = metadata.get("user_id")
-        if user_id is None:
-            log.warning(
-                "identity_verification.session_without_user",
-                verification_session_id=verification_session.id,
-            )
-            return None
+        if user_id is not None:
+            user = await repository.get_by_id(UUID(user_id), for_update=True)
+            if user is not None:
+                return user
 
-        user = await repository.get_by_id(UUID(user_id), for_update=True)
-        if user is None:
-            log.warning(
-                "identity_verification.user_not_found",
-                verification_session_id=verification_session.id,
-                user_id=user_id,
-            )
-        return user
+        raise IdentityVerificationForUnknownUser(verification_session.id)
 
     async def identity_verification_verified(
         self,
         session: AsyncSession,
         verification_session: stripe_lib.identity.VerificationSession,
-    ) -> User | None:
+    ) -> User:
         repository = UserRepository.from_session(session)
         user = await self._get_verification_session_user(
             repository, verification_session
         )
-        if user is None:
-            return None
 
         assert verification_session.status == "verified"
         user = await repository.update(
@@ -237,15 +231,14 @@ class UserService:
         self,
         session: AsyncSession,
         verification_session: stripe_lib.identity.VerificationSession,
-    ) -> User | None:
+    ) -> User:
         repository = UserRepository.from_session(session)
-        user = await repository.get_by_identity_verification_id(
-            verification_session.id, for_update=True
+        user = await self._get_verification_session_user(
+            repository, verification_session
         )
-        # No user points at this session anymore: it belongs to an attempt the user
-        # has moved on from, so it says nothing about their current state.
-        if user is None:
-            return None
+
+        if user.identity_verification_id != verification_session.id:
+            return user
 
         # Once a user is verified, keep them verified: a late `processing` webhook
         # must not overwrite it. A failed user can retry, so `failed` -> `pending` is fine.
@@ -264,15 +257,14 @@ class UserService:
         self,
         session: AsyncSession,
         verification_session: stripe_lib.identity.VerificationSession,
-    ) -> User | None:
+    ) -> User:
         repository = UserRepository.from_session(session)
-        user = await repository.get_by_identity_verification_id(
-            verification_session.id, for_update=True
+        user = await self._get_verification_session_user(
+            repository, verification_session
         )
-        # No user points at this session anymore: it belongs to an attempt the user
-        # has moved on from, so it says nothing about their current state.
-        if user is None:
-            return None
+
+        if user.identity_verification_id != verification_session.id:
+            return user
 
         # Once a user is verified, keep them verified. An old or repeated webhook
         # from a past attempt must not undo it.

--- a/server/tests/user/test_service.py
+++ b/server/tests/user/test_service.py
@@ -17,6 +17,7 @@ from polar.postgres import AsyncSession
 from polar.user.schemas import UserDeletionBlockedReason, UserUpdate
 from polar.user.service import (
     IdentityAlreadyVerified,
+    IdentityVerificationForUnknownUser,
     IdentityVerificationProcessing,
 )
 from polar.user.service import user as user_service
@@ -344,9 +345,6 @@ class TestCreateIdentityVerification:
         session: AsyncSession,
         user: User,
     ) -> None:
-        """A user left at `pending` by a lost `requires_input` webhook can still
-        resume: Stripe's status decides, ours doesn't.
-        """
         user.identity_verification_id = "vs_existing"
         user.identity_verification_status = IdentityVerificationStatus.pending
         await save_fixture(user)
@@ -373,9 +371,6 @@ class TestCreateIdentityVerification:
         session: AsyncSession,
         user: User,
     ) -> None:
-        """Our status lags Stripe's until the `processing` webhook lands. Creating a
-        second session in that window orphans the first one's webhooks.
-        """
         user.identity_verification_id = "vs_existing"
         user.identity_verification_status = IdentityVerificationStatus.unverified
         await save_fixture(user)
@@ -500,7 +495,6 @@ class TestIdentityVerificationVerified:
             session, verification_session
         )
 
-        assert updated_user is not None
         assert (
             updated_user.identity_verification_status
             == IdentityVerificationStatus.verified
@@ -519,10 +513,6 @@ class TestIdentityVerificationVerified:
         session: AsyncSession,
         user: User,
     ) -> None:
-        """A user who started a second session is no longer reachable by the first
-        session's id. The `user_id` metadata still resolves them, so a pass from the
-        earlier attempt is applied instead of stranding the webhook unhandled.
-        """
         user.identity_verification_id = "vs_second"
         user.identity_verification_status = IdentityVerificationStatus.unverified
         await save_fixture(user)
@@ -545,14 +535,13 @@ class TestIdentityVerificationVerified:
             session, verification_session
         )
 
-        assert updated_user is not None
         assert (
             updated_user.identity_verification_status
             == IdentityVerificationStatus.verified
         )
         assert updated_user.identity_verification_id == "vs_first"
 
-    async def test_ignores_session_of_unknown_user(
+    async def test_raises_for_unattributable_session(
         self,
         session: AsyncSession,
     ) -> None:
@@ -560,12 +549,10 @@ class TestIdentityVerificationVerified:
             {"id": "vs_unknown", "status": "verified"}, None
         )
 
-        assert (
+        with pytest.raises(IdentityVerificationForUnknownUser):
             await user_service.identity_verification_verified(
                 session, verification_session
             )
-            is None
-        )
 
 
 @pytest.mark.asyncio
@@ -588,7 +575,6 @@ class TestIdentityVerificationPending:
             session, verification_session
         )
 
-        assert updated_user is not None
         assert (
             updated_user.identity_verification_status
             == IdentityVerificationStatus.pending
@@ -618,7 +604,6 @@ class TestIdentityVerificationPending:
             session, verification_session
         )
 
-        assert updated_user is not None
         assert (
             updated_user.identity_verification_status
             == IdentityVerificationStatus.verified
@@ -646,7 +631,6 @@ class TestIdentityVerificationPending:
             session, verification_session
         )
 
-        assert updated_user is not None
         assert (
             updated_user.identity_verification_status
             == IdentityVerificationStatus.pending
@@ -658,9 +642,6 @@ class TestIdentityVerificationPending:
         session: AsyncSession,
         user: User,
     ) -> None:
-        """The user has started another attempt, so a `processing` webhook from the
-        abandoned one says nothing about where they are now.
-        """
         user.identity_verification_id = "vs_second"
         user.identity_verification_status = IdentityVerificationStatus.failed
         await save_fixture(user)
@@ -674,12 +655,8 @@ class TestIdentityVerificationPending:
             None,
         )
 
-        assert (
-            await user_service.identity_verification_pending(
-                session, verification_session
-            )
-            is None
-        )
+        await user_service.identity_verification_pending(session, verification_session)
+
         assert user.identity_verification_status == IdentityVerificationStatus.failed
 
 
@@ -703,7 +680,6 @@ class TestIdentityVerificationFailed:
             session, verification_session
         )
 
-        assert updated_user is not None
         assert (
             updated_user.identity_verification_status
             == IdentityVerificationStatus.failed
@@ -730,7 +706,6 @@ class TestIdentityVerificationFailed:
             session, verification_session
         )
 
-        assert updated_user is not None
         assert (
             updated_user.identity_verification_status
             == IdentityVerificationStatus.verified
@@ -742,9 +717,6 @@ class TestIdentityVerificationFailed:
         session: AsyncSession,
         user: User,
     ) -> None:
-        """A `canceled` webhook from an abandoned attempt must not fail the user's
-        current one.
-        """
         user.identity_verification_id = "vs_second"
         user.identity_verification_status = IdentityVerificationStatus.pending
         await save_fixture(user)
@@ -758,10 +730,6 @@ class TestIdentityVerificationFailed:
             None,
         )
 
-        assert (
-            await user_service.identity_verification_failed(
-                session, verification_session
-            )
-            is None
-        )
+        await user_service.identity_verification_failed(session, verification_session)
+
         assert user.identity_verification_status == IdentityVerificationStatus.pending

--- a/server/tests/user/test_service.py
+++ b/server/tests/user/test_service.py
@@ -330,6 +330,7 @@ class TestIdentityVerificationVerified:
             session, verification_session
         )
 
+        assert updated_user is not None
         assert (
             updated_user.identity_verification_status
             == IdentityVerificationStatus.verified
@@ -340,6 +341,61 @@ class TestIdentityVerificationVerified:
         }
         assert organization.id in activated_org_ids
         assert organization_second.id not in activated_org_ids
+
+    async def test_resolves_user_from_metadata_when_superseded(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        """A user who started a second session is no longer reachable by the first
+        session's id. The `user_id` metadata still resolves them, so a pass from the
+        earlier attempt is applied instead of stranding the webhook unhandled.
+        """
+        user.identity_verification_id = "vs_second"
+        user.identity_verification_status = IdentityVerificationStatus.unverified
+        await save_fixture(user)
+
+        mocker.patch(
+            "polar.user.service.organization_service.maybe_activate",
+            new_callable=mocker.AsyncMock,
+        )
+
+        verification_session = stripe_lib.identity.VerificationSession.construct_from(
+            {
+                "id": "vs_first",
+                "status": "verified",
+                "metadata": {"user_id": str(user.id)},
+            },
+            None,
+        )
+
+        updated_user = await user_service.identity_verification_verified(
+            session, verification_session
+        )
+
+        assert updated_user is not None
+        assert (
+            updated_user.identity_verification_status
+            == IdentityVerificationStatus.verified
+        )
+        assert updated_user.identity_verification_id == "vs_first"
+
+    async def test_ignores_session_of_unknown_user(
+        self,
+        session: AsyncSession,
+    ) -> None:
+        verification_session = stripe_lib.identity.VerificationSession.construct_from(
+            {"id": "vs_unknown", "status": "verified"}, None
+        )
+
+        assert (
+            await user_service.identity_verification_verified(
+                session, verification_session
+            )
+            is None
+        )
 
 
 @pytest.mark.asyncio
@@ -362,6 +418,7 @@ class TestIdentityVerificationPending:
             session, verification_session
         )
 
+        assert updated_user is not None
         assert (
             updated_user.identity_verification_status
             == IdentityVerificationStatus.pending
@@ -391,6 +448,7 @@ class TestIdentityVerificationPending:
             session, verification_session
         )
 
+        assert updated_user is not None
         assert (
             updated_user.identity_verification_status
             == IdentityVerificationStatus.verified
@@ -418,10 +476,41 @@ class TestIdentityVerificationPending:
             session, verification_session
         )
 
+        assert updated_user is not None
         assert (
             updated_user.identity_verification_status
             == IdentityVerificationStatus.pending
         )
+
+    async def test_ignores_superseded_session(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        """The user has started another attempt, so a `processing` webhook from the
+        abandoned one says nothing about where they are now.
+        """
+        user.identity_verification_id = "vs_second"
+        user.identity_verification_status = IdentityVerificationStatus.failed
+        await save_fixture(user)
+
+        verification_session = stripe_lib.identity.VerificationSession.construct_from(
+            {
+                "id": "vs_first",
+                "status": "processing",
+                "metadata": {"user_id": str(user.id)},
+            },
+            None,
+        )
+
+        assert (
+            await user_service.identity_verification_pending(
+                session, verification_session
+            )
+            is None
+        )
+        assert user.identity_verification_status == IdentityVerificationStatus.failed
 
 
 @pytest.mark.asyncio
@@ -444,6 +533,7 @@ class TestIdentityVerificationFailed:
             session, verification_session
         )
 
+        assert updated_user is not None
         assert (
             updated_user.identity_verification_status
             == IdentityVerificationStatus.failed
@@ -470,7 +560,38 @@ class TestIdentityVerificationFailed:
             session, verification_session
         )
 
+        assert updated_user is not None
         assert (
             updated_user.identity_verification_status
             == IdentityVerificationStatus.verified
         )
+
+    async def test_ignores_superseded_session(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        """A `canceled` webhook from an abandoned attempt must not fail the user's
+        current one.
+        """
+        user.identity_verification_id = "vs_second"
+        user.identity_verification_status = IdentityVerificationStatus.pending
+        await save_fixture(user)
+
+        verification_session = stripe_lib.identity.VerificationSession.construct_from(
+            {
+                "id": "vs_first",
+                "status": "canceled",
+                "metadata": {"user_id": str(user.id)},
+            },
+            None,
+        )
+
+        assert (
+            await user_service.identity_verification_failed(
+                session, verification_session
+            )
+            is None
+        )
+        assert user.identity_verification_status == IdentityVerificationStatus.pending

--- a/server/tests/user/test_service.py
+++ b/server/tests/user/test_service.py
@@ -337,6 +337,35 @@ class TestCreateIdentityVerification:
         create_mock.assert_not_awaited()
         assert verification.id == "vs_existing"
 
+    async def test_reuses_session_requiring_input_when_status_is_stale(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        """A user left at `pending` by a lost `requires_input` webhook can still
+        resume: Stripe's status decides, ours doesn't.
+        """
+        user.identity_verification_id = "vs_existing"
+        user.identity_verification_status = IdentityVerificationStatus.pending
+        await save_fixture(user)
+
+        mocker.patch(
+            "polar.user.service.stripe_service.get_verification_session",
+            new_callable=mocker.AsyncMock,
+            return_value=_verification_session("vs_existing", "requires_input"),
+        )
+        create_mock = mocker.patch(
+            "polar.user.service.stripe_service.create_verification_session",
+            new_callable=mocker.AsyncMock,
+        )
+
+        verification = await user_service.create_identity_verification(session, user)
+
+        create_mock.assert_not_awaited()
+        assert verification.id == "vs_existing"
+
     async def test_refuses_while_stripe_is_processing(
         self,
         mocker: MockerFixture,

--- a/server/tests/user/test_service.py
+++ b/server/tests/user/test_service.py
@@ -15,6 +15,10 @@ from polar.models.user import IdentityVerificationStatus, OAuthPlatform
 from polar.models.user_organization import OrganizationRole
 from polar.postgres import AsyncSession
 from polar.user.schemas import UserDeletionBlockedReason, UserUpdate
+from polar.user.service import (
+    IdentityAlreadyVerified,
+    IdentityVerificationProcessing,
+)
 from polar.user.service import user as user_service
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
@@ -278,6 +282,143 @@ class TestRequestDeletion:
         recipients = result.scalars().all()
         assert len(recipients) == 2
         assert all(r.deleted_at is not None for r in recipients)
+
+
+def _verification_session(
+    id: str, status: str
+) -> stripe_lib.identity.VerificationSession:
+    return stripe_lib.identity.VerificationSession.construct_from(
+        {"id": id, "status": status, "client_secret": f"{id}_secret"}, None
+    )
+
+
+@pytest.mark.asyncio
+class TestCreateIdentityVerification:
+    async def test_creates_first_session(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        create_mock = mocker.patch(
+            "polar.user.service.stripe_service.create_verification_session",
+            new_callable=mocker.AsyncMock,
+            return_value=_verification_session("vs_new", "requires_input"),
+        )
+
+        verification = await user_service.create_identity_verification(session, user)
+
+        create_mock.assert_awaited_once()
+        assert verification.id == "vs_new"
+        assert user.identity_verification_id == "vs_new"
+
+    async def test_reuses_session_requiring_input(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        user.identity_verification_id = "vs_existing"
+        await save_fixture(user)
+
+        mocker.patch(
+            "polar.user.service.stripe_service.get_verification_session",
+            new_callable=mocker.AsyncMock,
+            return_value=_verification_session("vs_existing", "requires_input"),
+        )
+        create_mock = mocker.patch(
+            "polar.user.service.stripe_service.create_verification_session",
+            new_callable=mocker.AsyncMock,
+        )
+
+        verification = await user_service.create_identity_verification(session, user)
+
+        create_mock.assert_not_awaited()
+        assert verification.id == "vs_existing"
+
+    async def test_refuses_while_stripe_is_processing(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        """Our status lags Stripe's until the `processing` webhook lands. Creating a
+        second session in that window orphans the first one's webhooks.
+        """
+        user.identity_verification_id = "vs_existing"
+        user.identity_verification_status = IdentityVerificationStatus.unverified
+        await save_fixture(user)
+
+        mocker.patch(
+            "polar.user.service.stripe_service.get_verification_session",
+            new_callable=mocker.AsyncMock,
+            return_value=_verification_session("vs_existing", "processing"),
+        )
+        create_mock = mocker.patch(
+            "polar.user.service.stripe_service.create_verification_session",
+            new_callable=mocker.AsyncMock,
+        )
+
+        with pytest.raises(IdentityVerificationProcessing):
+            await user_service.create_identity_verification(session, user)
+
+        create_mock.assert_not_awaited()
+        assert user.identity_verification_id == "vs_existing"
+
+    async def test_refuses_when_stripe_already_verified(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        user.identity_verification_id = "vs_existing"
+        user.identity_verification_status = IdentityVerificationStatus.unverified
+        await save_fixture(user)
+
+        mocker.patch(
+            "polar.user.service.stripe_service.get_verification_session",
+            new_callable=mocker.AsyncMock,
+            return_value=_verification_session("vs_existing", "verified"),
+        )
+        create_mock = mocker.patch(
+            "polar.user.service.stripe_service.create_verification_session",
+            new_callable=mocker.AsyncMock,
+        )
+
+        with pytest.raises(IdentityAlreadyVerified):
+            await user_service.create_identity_verification(session, user)
+
+        create_mock.assert_not_awaited()
+        assert user.identity_verification_id == "vs_existing"
+
+    async def test_replaces_canceled_session(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        user: User,
+    ) -> None:
+        user.identity_verification_id = "vs_canceled"
+        await save_fixture(user)
+
+        mocker.patch(
+            "polar.user.service.stripe_service.get_verification_session",
+            new_callable=mocker.AsyncMock,
+            return_value=_verification_session("vs_canceled", "canceled"),
+        )
+        mocker.patch(
+            "polar.user.service.stripe_service.create_verification_session",
+            new_callable=mocker.AsyncMock,
+            return_value=_verification_session("vs_new", "requires_input"),
+        )
+
+        verification = await user_service.create_identity_verification(session, user)
+
+        assert verification.id == "vs_new"
+        assert user.identity_verification_id == "vs_new"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Identity verification webhooks are piling up unhandled in `/external-events`.

`user.identity_verification_id` is a one-slot pointer, and it's the only key the webhook handlers use. When a user starts a second verification session the pointer moves, and every webhook still in flight for the first one finds no user
and raises — a 500, so the event never gets marked handled. A `verified` lost this way leaves the user unverified for good.

Two fixes:

- Webhooks resolve the user from the session's `user_id` metadata when the id  lookup misses, so a late `verified` still lands. `processing`, `requires_input` and `canceled` from a session the user has moved on from are now ignored
  instead of raising.
- `create_identity_verification` branches on the status Stripe reports rather than our own, which lags it. It refuses while a session is `processing` or `verified`, reuses one that `requires_input`, and only replaces a `canceled` one.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787729539&installation_model_id=13063&pr_number=13378&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13378&signature=18c9a493fd325ef90267baef933bd9bc8d38205d5a3d9152a335330a247885e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

