### PR TITLE
Fix session state after concurrent member creation race

### DIFF
--- a/server/polar/member/service.py
+++ b/server/polar/member/service.py
@@ -368,29 +368,16 @@ class MemberService:
             created_at=customer.created_at,
         )
 
-        nested = await session.begin_nested()
+        # Scope the flush in a savepoint: on an IntegrityError the context manager
+        # rolls it back, so a concurrent insert that trips the partial unique index
+        # doesn't leave the session in an aborted state (which would make the
+        # re-query below raise PendingRollbackError). The savepoint is released on
+        # success, so callers that loop (e.g. the organization backfill) don't
+        # accumulate open savepoints.
         try:
-            created_member = await repository.create(member, flush=True)
-            customer.owner = created_member
-            log.info(
-                "member.create_owner_member.success",
-                customer_id=customer.id,
-                member_id=created_member.id,
-                organization_id=organization.id,
-            )
-            if send_webhook:
-                await webhook_service.send(
-                    session,
-                    organization,
-                    WebhookEventType.member_created,
-                    created_member,
-                )
-            return created_member
+            async with session.begin_nested():
+                created_member = await repository.create(member, flush=True)
         except IntegrityError as e:
-            # Roll back to the savepoint before re-querying: a failed flush leaves
-            # the session in an aborted state, so the follow-up query would raise
-            # PendingRollbackError instead of returning the concurrently-created owner.
-            await nested.rollback()
             log.info(
                 "member.create_owner_member.constraint_violation",
                 customer_id=customer.id,
@@ -417,6 +404,22 @@ class MemberService:
                 error=str(e),
             )
             raise
+        else:
+            customer.owner = created_member
+            log.info(
+                "member.create_owner_member.success",
+                customer_id=customer.id,
+                member_id=created_member.id,
+                organization_id=organization.id,
+            )
+            if send_webhook:
+                await webhook_service.send(
+                    session,
+                    organization,
+                    WebhookEventType.member_created,
+                    created_member,
+                )
+            return created_member
 
     async def get_or_create_seat_member(
         self,
@@ -484,23 +487,17 @@ class MemberService:
             role=role,
         )
 
-        nested = await session.begin_nested()
+        # Scope the flush in a savepoint: on an IntegrityError the context manager
+        # rolls it back, so a concurrent insert that trips the partial unique index
+        # doesn't leave the session in an aborted state (which would make the
+        # re-query below raise PendingRollbackError). The savepoint is released on
+        # success, so callers that create several members in one session don't
+        # accumulate open savepoints.
         try:
-            created = await repository.create(member, flush=True)
-            log.info(
-                "member.get_or_create_by_email.created",
-                member_id=created.id,
-                customer_id=customer_id,
-                organization_id=organization_id,
-                email=email,
-            )
-            return created
+            async with session.begin_nested():
+                created = await repository.create(member, flush=True)
         except IntegrityError:
             # Race condition: another transaction created the member concurrently.
-            # Roll back to the savepoint before re-querying: a failed flush leaves
-            # the session in an aborted state, so the follow-up query would raise
-            # PendingRollbackError instead of returning the existing member.
-            await nested.rollback()
             log.info(
                 "member.get_or_create_by_email.integrity_error_retry",
                 customer_id=customer_id,
@@ -510,6 +507,15 @@ class MemberService:
             if existing:
                 return existing
             raise
+        else:
+            log.info(
+                "member.get_or_create_by_email.created",
+                member_id=created.id,
+                customer_id=customer_id,
+                organization_id=organization_id,
+                email=email,
+            )
+            return created
 
     async def list_by_customer(
         self,

--- a/server/polar/member/service.py
+++ b/server/polar/member/service.py
@@ -368,6 +368,7 @@ class MemberService:
             created_at=customer.created_at,
         )
 
+        nested = await session.begin_nested()
         try:
             created_member = await repository.create(member, flush=True)
             customer.owner = created_member
@@ -386,6 +387,10 @@ class MemberService:
                 )
             return created_member
         except IntegrityError as e:
+            # Roll back to the savepoint before re-querying: a failed flush leaves
+            # the session in an aborted state, so the follow-up query would raise
+            # PendingRollbackError instead of returning the concurrently-created owner.
+            await nested.rollback()
             log.info(
                 "member.create_owner_member.constraint_violation",
                 customer_id=customer.id,
@@ -479,6 +484,7 @@ class MemberService:
             role=role,
         )
 
+        nested = await session.begin_nested()
         try:
             created = await repository.create(member, flush=True)
             log.info(
@@ -490,7 +496,11 @@ class MemberService:
             )
             return created
         except IntegrityError:
-            # 4. Race condition: another transaction created the member concurrently
+            # Race condition: another transaction created the member concurrently.
+            # Roll back to the savepoint before re-querying: a failed flush leaves
+            # the session in an aborted state, so the follow-up query would raise
+            # PendingRollbackError instead of returning the existing member.
+            await nested.rollback()
             log.info(
                 "member.get_or_create_by_email.integrity_error_retry",
                 customer_id=customer_id,

--- a/server/polar/member/service.py
+++ b/server/polar/member/service.py
@@ -368,12 +368,6 @@ class MemberService:
             created_at=customer.created_at,
         )
 
-        # Scope the flush in a savepoint: on an IntegrityError the context manager
-        # rolls it back, so a concurrent insert that trips the partial unique index
-        # doesn't leave the session in an aborted state (which would make the
-        # re-query below raise PendingRollbackError). The savepoint is released on
-        # success, so callers that loop (e.g. the organization backfill) don't
-        # accumulate open savepoints.
         try:
             async with session.begin_nested():
                 created_member = await repository.create(member, flush=True)
@@ -487,12 +481,6 @@ class MemberService:
             role=role,
         )
 
-        # Scope the flush in a savepoint: on an IntegrityError the context manager
-        # rolls it back, so a concurrent insert that trips the partial unique index
-        # doesn't leave the session in an aborted state (which would make the
-        # re-query below raise PendingRollbackError). The savepoint is released on
-        # success, so callers that create several members in one session don't
-        # accumulate open savepoints.
         try:
             async with session.begin_nested():
                 created = await repository.create(member, flush=True)

--- a/server/tests/member/test_service.py
+++ b/server/tests/member/test_service.py
@@ -435,6 +435,64 @@ class TestCreateOwnerMember:
         members = await repository.list_by_customer(customer.id)
         assert len([m for m in members if m.role == MemberRole.owner]) == 1
 
+    async def test_concurrent_duplicate_returns_existing_without_pending_rollback(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        """Regression: a concurrent insert that trips a partial unique index during
+        flush must not leave the session in an aborted state. The savepoint
+        rollback lets the re-query return the existing owner instead of raising
+        PendingRollbackError."""
+        organization.feature_settings = {"member_model_enabled": True}
+        await save_fixture(organization)
+
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="owner@example.com",
+        )
+        # The owner a concurrent request already committed.
+        existing = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="owner@example.com",
+            role=MemberRole.owner,
+        )
+        await save_fixture(existing)
+
+        # Force the code past the initial owner lookup (as if no owner existed yet
+        # at check time) so the real flush hits the unique index and would poison
+        # the session without the savepoint rollback.
+        original_get = MemberRepository.get_owner_by_customer_id
+        call_count = 0
+
+        async def mock_get(
+            self: Any, customer_id: Any, *, include_deleted: bool = False
+        ) -> Member | None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return None
+            return await original_get(
+                self, customer_id, include_deleted=include_deleted
+            )
+
+        mocker.patch.object(MemberRepository, "get_owner_by_customer_id", mock_get)
+
+        member = await member_service.create_owner_member(
+            session, customer, organization
+        )
+
+        assert member is not None
+        assert member.id == existing.id
+        assert call_count == 2  # initial lookup + re-query after rollback
+
+        # The session recovered from the failed flush and is still usable.
+        await session.flush()
+
 
 @pytest.mark.asyncio
 class TestCreate:
@@ -1409,6 +1467,60 @@ class TestGetOrCreateByEmail:
 
         assert member.id == existing.id
         assert call_count == 1  # create was attempted
+
+    async def test_concurrent_duplicate_returns_existing_without_pending_rollback(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        """Regression: a concurrent insert that trips the partial unique index
+        during flush must not leave the session in an aborted state. The savepoint
+        rollback lets the re-query return the existing member instead of raising
+        PendingRollbackError."""
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="customer@example.com",
+        )
+        # The member a concurrent request already committed.
+        existing = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="race@example.com",
+            name="Existing",
+            role=MemberRole.member,
+        )
+        await save_fixture(existing)
+
+        # Force the code past the initial lookup (as if the row didn't exist yet at
+        # check time) so the real flush hits the unique index and would poison the
+        # session without the savepoint rollback.
+        original_get = MemberRepository.get_by_customer_id_and_email
+        call_count = 0
+
+        async def mock_get(self: Any, customer_id: Any, email: Any) -> Member | None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return None
+            return await original_get(self, customer_id, email)
+
+        mocker.patch.object(MemberRepository, "get_by_customer_id_and_email", mock_get)
+
+        member = await member_service.get_or_create_by_email(
+            session,
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="race@example.com",
+        )
+
+        assert member.id == existing.id
+        assert call_count == 2  # initial lookup + re-query after rollback
+
+        # The session recovered from the failed flush and is still usable.
+        await session.flush()
 
     async def test_sets_external_id_on_creation(
         self,


### PR DESCRIPTION
## Summary

**Related Issue**: N/A

Fixes a regression where concurrent member creation attempts would leave the database session in an aborted state, causing `PendingRollbackError` instead of returning the existing member.

## What

Added savepoint rollback handling in two member service methods:
- `create_owner_member()`: When a concurrent owner creation fails the unique index constraint
- `get_or_create_by_email()`: When a concurrent member creation fails the unique index constraint

Both methods now use `session.begin_nested()` to create a savepoint before attempting the flush. If an `IntegrityError` occurs (indicating a concurrent insert), the savepoint is rolled back before re-querying for the existing member.

## Why

When a flush operation fails due to an `IntegrityError`, SQLAlchemy leaves the session in an aborted state. Attempting to execute queries in this state raises `PendingRollbackError`. The code was catching the `IntegrityError` and trying to re-query for the existing member, but this would fail with `PendingRollbackError` instead of returning the concurrent insert.

By rolling back to a savepoint before the failed flush, the session is restored to a valid state, allowing the re-query to succeed and return the existing member.

## How

- Created a nested transaction (savepoint) before each flush attempt
- On `IntegrityError`, explicitly rollback the savepoint to restore session state
- The re-query then executes successfully and returns the concurrently-created member
- Added regression tests for both methods that simulate concurrent inserts by mocking the initial lookup to return `None`, forcing the flush to hit the unique constraint

## Checklist

- [x] This PR addresses a single concern (fixing session state after concurrent member creation)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests (added regression tests for both methods)
- [x] No unrelated changes or drive-by fixes are included

https://claude.ai/code/session_01UTjQv3Lpfh4g36cH7auZ84

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787734110&installation_model_id=13063&pr_number=13380&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13380&signature=2d496dfdce5e6c683538e6731d9fe4554b9af0eea7c2e5820aec57aeec4d4db6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

