### PR TITLE
Fix tax calculation for refunds with applied balance

### DIFF
--- a/server/polar/models/order.py
+++ b/server/polar/models/order.py
@@ -463,9 +463,12 @@ class Order(CustomFieldDataMixin, MetadataMixin, RecordModel):
         if refund_amount == self.refundable_amount:
             return self.refundable_tax_amount
 
+        if not self.taxed:
+            return 0
+
         ratio = self.tax_amount / self.net_amount
         tax_amount = round(refund_amount * ratio)
-        return tax_amount
+        return min(tax_amount, self.refundable_tax_amount)
 
 
 orders_search_vector_update_function = PGFunction(

--- a/server/tests/models/test_order.py
+++ b/server/tests/models/test_order.py
@@ -147,6 +147,24 @@ async def test_calculate_refunded_tax_from_total(
             id="exclusive sub amount with applied balance",
         ),
         pytest.param(
+            TaxBehavior.exclusive,
+            1000,
+            250,
+            1000,
+            1500,
+            250,
+            id="exclusive sub amount exceeding net with applied balance is capped",
+        ),
+        pytest.param(
+            TaxBehavior.exclusive,
+            1000,
+            0,
+            1000,
+            1500,
+            0,
+            id="exclusive untaxed with applied balance",
+        ),
+        pytest.param(
             TaxBehavior.inclusive, 1000, 200, 0, 800, 200, id="inclusive full amount"
         ),
         pytest.param(


### PR DESCRIPTION
## Summary

Fixes tax refund calculation to properly handle cases where a balance is applied to an order, ensuring the refundable tax amount is never exceeded.

## What

Modified `calculate_refunded_tax_from_subtotal` in `server/polar/models/order.py` to:
1. Return 0 tax for untaxed orders (when `self.taxed` is False)
2. Cap the calculated tax amount to not exceed `self.refundable_tax_amount`

Added test cases to verify the fix handles:
- Exclusive tax with applied balance where refund amount exceeds net (capped correctly)
- Exclusive tax with applied balance and zero tax amount

## Why

When a balance is applied to an order, the refundable amount and refundable tax amount are reduced accordingly. The previous implementation could calculate a tax refund that exceeds the actual refundable tax amount, leading to incorrect refund calculations. This fix ensures the refunded tax never exceeds what's actually refundable.

## How

- Added early return for untaxed orders to avoid division issues
- Added `min()` cap to ensure calculated tax doesn't exceed `refundable_tax_amount`
- Added two new test cases to `test_calculate_refunded_tax_from_total` covering the edge cases

## Checklist

- [x] This PR addresses a single concern (one bug fix)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests (two new test cases added)
- [x] No unrelated changes or drive-by fixes are included

https://claude.ai/code/session_01HM1rjsVVX5W6C3b2XcUBHE

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787734215&installation_model_id=13063&pr_number=13381&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13381&signature=46637f5791792646fb638ff082b020b9abd80a07b8cbdf82a692874fd30d2b39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

