### PR TITLE
fix: display "Free" for zero-amount subscriptions in webhooks

### DIFF
--- a/server/polar/subscription/schemas.py
+++ b/server/polar/subscription/schemas.py
@@ -172,7 +172,7 @@ class SubscriptionBase(IDSchema, TimestampedSchema):
     )
 
     def get_amount_display(self) -> str:
-        if self.amount is None or self.currency is None:
+        if self.amount == 0:
             return "Free"
         return (
             f"{format_currency(self.amount, self.currency)}/{self.recurring_interval}"


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- issue number -->

Free subscriptions render as `$0.00/month` instead of `Free` in webhook notifications (Discord/Slack) for subscription created and updated events.

## What

Update `SubscriptionBase.get_amount_display()` to return `"Free"` when `amount == 0` instead of checking `amount is None`.

```python
def get_amount_display(self) -> str:
    if self.amount == 0:
        return "Free"
    return f"{format_currency(self.amount, self.currency)}/{self.recurring_interval}"
```

## Why

The method was written when `amount`/`currency` were optional and free subscriptions had `amount=None`. Commit `0ab3d7030` (Mar 2025) made both fields non-nullable — free subscriptions are now represented as `amount=0` with a currency set. The `if self.amount is None or self.currency is None` check became unreachable dead code, so the `"Free"` branch never triggered and free subscriptions formatted as `$0.00/<interval>`.

This mirrors the intended display already used by the notification payload, which returns `"free"` for absent-price subscriptions (`polar/notifications/notification.py`).

## How

Changed the guard from a `None` check to `self.amount == 0`, so a zero amount is treated as free while paid subscriptions (including trials with a set amount) continue to format normally.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016uw33xFtRydGrvoNrY98Sw

---
_Generated by [Claude Code](https://claude.ai/code/session_016uw33xFtRydGrvoNrY98Sw)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787734521&installation_model_id=13063&pr_number=13382&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13382&signature=6e6d819ebb2bec21557bd3b7f293efffe79526e6afed3077b921babfc92b1dc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

