### PR TITLE
fix(order): raise PaymentFailed for soft-deleted payment method in sync mode

### DIFF
--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1445,7 +1445,8 @@ class OrderService:
             payment_method = await payment_method_repository.get_by_id(
                 payment_method_id
             )
-            assert payment_method is not None
+            if payment_method is None:
+                raise PaymentFailed(PaymentFailedReason.missing_payment_method)
             await self.trigger_payment(
                 session,
                 order,

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -89,6 +89,7 @@ from polar.order.service import (
     PaymentActionRequired,
     PaymentAlreadyInProgress,
     PaymentFailed,
+    PaymentFailedReason,
     RecurringProduct,
     SubscriptionNotTrialing,
 )
@@ -2221,6 +2222,61 @@ class TestCreateSubscriptionOrder:
         trigger_payment_mock.assert_called_once()
         call_args = trigger_payment_mock.call_args
         assert call_args.args[2].id == default_pm.id
+
+    async def test_sync_mode_soft_deleted_payment_method_raises_payment_failed(
+        self,
+        mocker: MockerFixture,
+        calculate_tax_mock: MagicMock,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        organization: Organization,
+    ) -> None:
+        """When the referenced payment method has been soft-deleted, sync mode
+        should raise PaymentFailed(missing_payment_method) instead of crashing
+        with an AssertionError."""
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            billing_address=Address(country=CountryAlpha2("FR")),
+        )
+        payment_method = await create_payment_method(save_fixture, customer=customer)
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            payment_method=payment_method,
+        )
+
+        payment_method.deleted_at = utc_now()
+        await save_fixture(payment_method)
+
+        price = product.prices[0]
+        assert is_fixed_price(price)
+        await create_billing_entry(
+            save_fixture,
+            type=BillingEntryType.cycle,
+            customer=customer,
+            product_price=price,
+            amount=price.price_amount,
+            currency=price.price_currency,
+            subscription=subscription,
+        )
+
+        trigger_payment_mock = mocker.patch.object(
+            order_service, "trigger_payment", new_callable=AsyncMock
+        )
+
+        with pytest.raises(PaymentFailed) as exc_info:
+            await order_service.create_subscription_order(
+                session,
+                subscription,
+                OrderBillingReasonInternal.subscription_update,
+                payment_mode=PaymentMode.sync,
+            )
+
+        assert exc_info.value.reason == PaymentFailedReason.missing_payment_method
+        trigger_payment_mock.assert_not_called()
 
     async def test_sync_under_minimum_emits_paid_transition_once(
         self,


### PR DESCRIPTION
## Summary

Sync-mode subscription order creation crashed with `AssertionError` (500) when the referenced payment method had been soft-deleted, instead of raising the intended `PaymentFailed(missing_payment_method)`.

## What

In `_create_order` (`server/polar/order/service.py`), the `PaymentMode.sync` branch replaced

```python
assert payment_method is not None
```

with an explicit `None` check that raises `PaymentFailed(PaymentFailedReason.missing_payment_method)`.

Added a regression test, `TestCreateSubscriptionOrder::test_sync_mode_soft_deleted_payment_method_raises_payment_failed`, covering a subscription whose payment method has been soft-deleted.

## Why

`PaymentMethodRepository.get_by_id()` excludes soft-deleted rows (the soft-deletion base statement filters on `deleted_at is None`). So a non-`None` `payment_method_id` can still resolve to `None` when the payment method has been soft-deleted — for example after `payment_method_service.delete(...)` retires an invalid card.

The sync branch already handled `payment_method_id is None` correctly, but assumed a non-`None` id always resolves to a `PaymentMethod`. The assert bypassed the intended `PaymentFailed` flow and surfaced as a 500 during subscription updates requiring immediate payment (prorations), and is reported to Sentry as a hard error rather than a normal payment failure.

## How

Replaced the assert with the `None` check already used by `_resolve_payment_method` in the same service, which raises `PaymentFailed(PaymentFailedReason.missing_payment_method)`. `PaymentFailed` carries a 402 status code, so the caller now gets a graceful payment failure instead of a crash.

The regression test was verified against the pre-fix code: with the assert restored it fails with `AssertionError` at `polar/order/service.py:1448`; with the fix it passes and asserts `trigger_payment` is never called.

Verification:
- `tests/order/` — 247 passed
- `tests/subscription/` — 355 passed
- `uv run task lint` — all checks passed
- `uv run task lint_types` — no issues in 1626 source files

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013d97e4yJa7nVdPvas9wJTu

---
_Generated by [Claude Code](https://claude.ai/code/session_013d97e4yJa7nVdPvas9wJTu)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787735413&installation_model_id=13063&pr_number=13383&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13383&signature=d7ae4ea30097eea9b38b65094f95efe78153a29a962036b7662d2e980c00bdc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13383?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

