### PR TITLE
fix: reset posthog identity on logout

### DIFF
--- a/clients/apps/web/src/app/(main)/onboarding/start/page.tsx
+++ b/clients/apps/web/src/app/(main)/onboarding/start/page.tsx
@@ -6,12 +6,14 @@ import { CONFIG } from '@/utils/config'
 import Link from 'next/link'
 import { Box } from '@polar-sh/orbit/Box'
 import { Button } from '@polar-sh/orbit'
+import { useLogout } from '@/hooks/auth'
 import { usePostHog } from '@/hooks/posthog'
 import { redirect, useRouter } from 'next/navigation'
 
 export default function Page() {
   const router = useRouter()
   const posthog = usePostHog()
+  const logout = useLogout()
   const { updateData } = useOnboardingData()
 
   if (CONFIG.IS_SANDBOX) {
@@ -60,12 +62,13 @@ export default function Page() {
         >
           User settings
         </Link>
-        <a
-          href={`${CONFIG.BASE_URL}/v1/auth/logout`}
-          className="dark:hover:text-polar-200 text-sm hover:text-gray-900"
+        <button
+          type="button"
+          onClick={logout}
+          className="dark:hover:text-polar-200 cursor-pointer text-sm hover:text-gray-900"
         >
           Log out
-        </a>
+        </button>
       </Box>
       <Box
         width="100%"

--- a/clients/apps/web/src/components/Layout/Dashboard/DashboardSidebar.tsx
+++ b/clients/apps/web/src/components/Layout/Dashboard/DashboardSidebar.tsx
@@ -1,5 +1,5 @@
 import { SupportButton } from '@/components/Feedback/SupportButton'
-import { useAuth } from '@/hooks/auth'
+import { useAuth, useLogout } from '@/hooks/auth'
 import { NotificationsPopover } from '@/components/Notifications/NotificationsPopover'
 import { OmniSearch } from '@/components/Search/OmniSearch'
 import { CONFIG } from '@/utils/config'
@@ -52,6 +52,7 @@ export const DashboardSidebar = ({
 }) => {
   const router = useRouter()
   const { currentUser } = useAuth()
+  const logout = useLogout()
 
   const [searchOpen, setSearchOpen] = useState(false)
 
@@ -249,13 +250,7 @@ export const DashboardSidebar = ({
                     </DropdownMenuItem>
                   )}
                   <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    onClick={() =>
-                      router.push(`${CONFIG.BASE_URL}/v1/auth/logout`)
-                    }
-                  >
-                    Logout
-                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={logout}>Logout</DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
             </SidebarMenuItem>

--- a/clients/apps/web/src/components/Navigation/PublicProfileDropdown.tsx
+++ b/clients/apps/web/src/components/Navigation/PublicProfileDropdown.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useLogout } from '@/hooks/auth'
 import { useListOrganizations } from '@/hooks/queries'
 import { CONFIG } from '@/utils/config'
 import { useOutsideClick } from '@/utils/useOutsideClick'
@@ -34,6 +35,8 @@ const PublicProfileDropdown = ({
   const loggedUser = authenticatedUser
 
   const organizations = useListOrganizations({}, !!loggedUser)
+
+  const logout = useLogout()
 
   if (!loggedUser) {
     return null
@@ -87,12 +90,18 @@ const PublicProfileDropdown = ({
 
             <Separator className="my-2" />
 
-            <LinkItem
-              href={`${CONFIG.BASE_URL}/v1/auth/logout`}
-              icon={<LogoutOutlined fontSize="small" />}
-            >
-              <span className="mx-2 py-2">Log out</span>
-            </LinkItem>
+            <ListItem current={false} className="rounded-lg px-4">
+              <button
+                type="button"
+                onClick={logout}
+                className="flex w-full cursor-pointer flex-row items-center gap-x-2 text-left text-sm"
+              >
+                <span className="text-lg">
+                  <LogoutOutlined fontSize="small" />
+                </span>
+                <span className="mx-2 py-2">Log out</span>
+              </button>
+            </ListItem>
           </ul>
         </div>
       )}

--- a/clients/apps/web/src/components/Onboarding/OnboardingShell.tsx
+++ b/clients/apps/web/src/components/Onboarding/OnboardingShell.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { useAuth } from '@/hooks'
-import { CONFIG } from '@/utils/config'
+import { useAuth, useLogout } from '@/hooks'
 import { Box } from '@polar-sh/orbit/Box'
 import { motion } from 'motion/react'
 import { ArrowLeft } from 'lucide-react'
@@ -36,6 +35,7 @@ export function OnboardingShell({
 }: OnboardingShellProps) {
   const router = useRouter()
   const { userOrganizations } = useAuth()
+  const logout = useLogout()
   const [hadOrgs] = useState(() => userOrganizations.length > 0)
   const currentIndex = step ? STEPS.indexOf(step) : -1
 
@@ -70,12 +70,13 @@ export function OnboardingShell({
           User settings
         </Link>
 
-        <a
-          href={`${CONFIG.BASE_URL}/v1/auth/logout`}
-          className="dark:hover:text-polar-200 text-sm hover:text-gray-900"
+        <button
+          type="button"
+          onClick={logout}
+          className="dark:hover:text-polar-200 cursor-pointer text-sm hover:text-gray-900"
         >
           Log out
-        </a>
+        </button>
       </Box>
       <Box width="100%" maxWidth="60rem">
         {/* Left: form */}

--- a/clients/apps/web/src/components/Settings/UserDeleteSettings.tsx
+++ b/clients/apps/web/src/components/Settings/UserDeleteSettings.tsx
@@ -1,7 +1,7 @@
 'use client'
 
+import { useLogout } from '@/hooks/auth'
 import { useDeleteUser } from '@/hooks/queries'
-import { CONFIG } from '@/utils/config'
 import { Button } from '@polar-sh/orbit'
 import { useCallback, useState } from 'react'
 import { ConfirmModal } from '../Modal/ConfirmModal'
@@ -12,6 +12,7 @@ const TOAST_LONG_DURATION = 8000
 
 export default function UserDeleteSettings() {
   const deleteUser = useDeleteUser()
+  const logout = useLogout()
   const [showDeleteModal, setShowDeleteModal] = useState(false)
 
   const handleDelete = useCallback(async () => {
@@ -36,7 +37,7 @@ export default function UserDeleteSettings() {
         variant: 'success',
         duration: TOAST_LONG_DURATION,
       })
-      window.location.href = `${CONFIG.BASE_URL}/v1/auth/logout`
+      logout()
     } else {
       const organizations = data.blocking_organizations ?? []
       const orgNames = organizations.map((o) => o.name).join(', ')
@@ -48,7 +49,7 @@ export default function UserDeleteSettings() {
       })
       setShowDeleteModal(false)
     }
-  }, [deleteUser])
+  }, [deleteUser, logout])
 
   return (
     <>

--- a/clients/apps/web/src/hooks/auth.ts
+++ b/clients/apps/web/src/hooks/auth.ts
@@ -1,10 +1,11 @@
 import { usePostHog } from '@/hooks/posthog'
 import { AuthContext } from '@/providers/auth'
 import { api } from '@/utils/client'
+import { CONFIG } from '@/utils/config'
 import { schemas, unwrap } from '@polar-sh/client'
 import * as Sentry from '@sentry/nextjs'
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { useContext, useEffect } from 'react'
+import { useCallback, useContext, useEffect } from 'react'
 
 export const useAuth = (): {
   authenticated: boolean
@@ -55,6 +56,15 @@ export const useAuth = (): {
     userOrganizations,
     setUserOrganizations,
   }
+}
+
+export const useLogout = (): (() => void) => {
+  const posthog = usePostHog()
+
+  return useCallback(() => {
+    posthog.reset()
+    window.location.href = `${CONFIG.BASE_URL}/v1/auth/logout`
+  }, [posthog])
 }
 
 export const useAuthSessionStart = () =>

--- a/clients/apps/web/src/hooks/posthog.ts
+++ b/clients/apps/web/src/hooks/posthog.ts
@@ -1,5 +1,6 @@
 'use client'
 
+import { DISTINCT_ID_COOKIE } from '@/experiments/constants'
 import type { schemas } from '@polar-sh/client'
 import type { JsonType } from '@posthog/core'
 import type { CaptureOptions } from 'posthog-js'
@@ -105,6 +106,7 @@ export const usePostHog = (): PolarHog => {
 
   const reset: PolarHog['reset'] = useCallback(() => {
     posthog.reset()
+    document.cookie = `${DISTINCT_ID_COOKIE}=; max-age=0; path=/; samesite=lax`
   }, [posthog])
 
   const context = useMemo(

--- a/clients/apps/web/src/hooks/posthog.ts
+++ b/clients/apps/web/src/hooks/posthog.ts
@@ -67,6 +67,7 @@ export interface PolarHog {
     options?: CaptureOptions,
   ) => void
   identify: (user: schemas['UserRead']) => void
+  reset: () => void
 }
 
 export const usePostHog = (): PolarHog => {
@@ -102,13 +103,18 @@ export const usePostHog = (): PolarHog => {
     [posthog],
   )
 
+  const reset: PolarHog['reset'] = useCallback(() => {
+    posthog.reset()
+  }, [posthog])
+
   const context = useMemo(
     () => ({
       setPersistence,
       capture,
       identify,
+      reset,
     }),
-    [setPersistence, capture, identify],
+    [setPersistence, capture, identify, reset],
   )
 
   return context


### PR DESCRIPTION
## Summary

Would love an extra pair of eyes on this since it's related to auth.

Related Issue: https://github.com/polarsource/feedback/issues/298

Reset PostHog identity and session data when users log out.

## What
- Restored centralized logout behavior through useLogout.
- Reset PostHog before navigating to the backend logout endpoint.
- Replaced clickable logout anchors with semantic buttons and menu actions.


## Why
PostHog identity data persisted after logout, causing subsequent anonymous events to remain associated with the previous user. This is for those users who accepted the cookies and data is stored localstorage, not in memory.

## How
All logout entry points call useLogout, which resets PostHog and then navigates through the existing backend logout flow.

Checklist
- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [] New functionality is covered by tests
- [x] Linting and type checking pass (uv run task lint && uv run task lint_types)
- [x] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787739559&installation_model_id=13063&pr_number=13384&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13384&signature=e5984937abe72acce502b1d51d3cef1b509329ccfd1f91a884d300be0e1b069b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

