### PR TITLE
feat(subscription): add partial indexes for scheduler queries

### DIFF
--- a/server/migrations/versions/2026-07-27-1553_add_partial_indexes_for_subscription_.py
+++ b/server/migrations/versions/2026-07-27-1553_add_partial_indexes_for_subscription_.py
@@ -1,0 +1,80 @@
+"""add partial indexes for subscription scheduler queries
+
+Revision ID: 915a09233568
+Revises: 646c76720b00
+Create Date: 2026-07-27 15:53:38.061059
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "915a09233568"
+down_revision = "37f4ba372112"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+CYCLE_INDEX = "ix_subscriptions_cycle_schedule"
+CYCLE_WHERE = (
+    "scheduler_locked_at IS NULL "
+    "AND status IN ('trialing', 'active') "
+    "AND current_period_end IS NOT NULL"
+)
+
+RESUME_INDEX = "ix_subscriptions_resume_schedule"
+RESUME_WHERE = (
+    "scheduler_locked_at IS NULL AND status = 'paused' AND resumes_at IS NOT NULL"
+)
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        # Drop any INVALID leftover from an interrupted concurrent build first.
+        op.drop_index(
+            CYCLE_INDEX,
+            table_name="subscriptions",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            CYCLE_INDEX,
+            "subscriptions",
+            ["current_period_end"],
+            unique=False,
+            postgresql_concurrently=True,
+            postgresql_where=sa.text(CYCLE_WHERE),
+        )
+
+        op.drop_index(
+            RESUME_INDEX,
+            table_name="subscriptions",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            RESUME_INDEX,
+            "subscriptions",
+            ["resumes_at"],
+            unique=False,
+            postgresql_concurrently=True,
+            postgresql_where=sa.text(RESUME_WHERE),
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            CYCLE_INDEX,
+            table_name="subscriptions",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )
+        op.drop_index(
+            RESUME_INDEX,
+            table_name="subscriptions",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )

--- a/server/polar/models/subscription.py
+++ b/server/polar/models/subscription.py
@@ -122,6 +122,24 @@ class Subscription(CustomFieldDataMixin, MetadataMixin, RecordModel):
             "status",
             "current_period_end",
         ),
+        Index(
+            "ix_subscriptions_cycle_schedule",
+            "current_period_end",
+            postgresql_where=(
+                "scheduler_locked_at IS NULL "
+                "AND status IN ('trialing', 'active') "
+                "AND current_period_end IS NOT NULL"
+            ),
+        ),
+        Index(
+            "ix_subscriptions_resume_schedule",
+            "resumes_at",
+            postgresql_where=(
+                "scheduler_locked_at IS NULL "
+                "AND status = 'paused' "
+                "AND resumes_at IS NOT NULL"
+            ),
+        ),
     )
 
     amount: Mapped[int] = mapped_column("amount_v2", BigInteger, nullable=False)


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787756984&installation_model_id=13063&pr_number=13393&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13393&signature=f49d5ff88df6bccf8fce9d80f93fdc0c778285734053bb47cfd1b5e2503536a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add concurrent partial Postgres indexes on `subscriptions` to keep scheduler wakeups fast and avoid heartbeat timeouts. We index `current_period_end` on unlocked `trialing`/`active` rows and `resumes_at` on unlocked `paused` rows, dropping stale indexes before create so queries use index walks instead of full scans + sort.

<sup>Written for commit 0345f973efb0bea74f2acbbd08daeacdeb722d2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

