### PR TITLE
feat(discount): per-customer redemption limits

### DIFF
--- a/clients/packages/checkout/src/providers/CheckoutFormProvider.tsx
+++ b/clients/packages/checkout/src/providers/CheckoutFormProvider.tsx
@@ -88,6 +88,9 @@ export const CheckoutFormProvider = ({
             case 'RequestValidationError':
               setValidationErrors(error.detail, setError)
               break
+            case 'DiscountRedemptionLimitReached':
+              setError('discount_code', { message: error.detail })
+              break
             case 'AlreadyActiveSubscriptionError':
             case 'NotOpenCheckout':
             case 'PaymentNotReady':
@@ -125,6 +128,9 @@ export const CheckoutFormProvider = ({
           case 'NotOpenCheckout':
           case 'PaymentNotReady':
             setError('root', { message: error.detail })
+            break
+          case 'DiscountRedemptionLimitReached':
+            setError('discount_code', { message: error.detail })
             break
           case 'TrialAlreadyRedeemed':
             setTrialUnavailable(true)

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -12487,6 +12487,7 @@ export interface components {
       | components['schemas']['NotOpenCheckout']
       | components['schemas']['PaymentNotReady']
       | components['schemas']['TrialAlreadyRedeemed']
+      | components['schemas']['DiscountRedemptionLimitReached']
     /**
      * CheckoutLink
      * @description Checkout link data.
@@ -20258,6 +20259,17 @@ export interface components {
        * @description The ID of the organization owning the product.
        */
       organization_id: string
+    }
+    /** DiscountRedemptionLimitReached */
+    DiscountRedemptionLimitReached: {
+      /**
+       * Error
+       * @example DiscountRedemptionLimitReached
+       * @constant
+       */
+      error: 'DiscountRedemptionLimitReached'
+      /** Detail */
+      detail: string
     }
     /**
      * DiscountSortProperty

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -19391,6 +19391,11 @@ export interface components {
        * @description Optional maximum number of times the discount can be redeemed.
        */
       max_redemptions?: number | null
+      /**
+       * Max Redemptions Per Customer
+       * @description Optional maximum number of times the discount can be redeemed by a single customer.
+       */
+      max_redemptions_per_customer?: number | null
       /** Products */
       products?: string[] | null
       /**
@@ -19504,6 +19509,11 @@ export interface components {
        */
       max_redemptions: number | null
       /**
+       * Max Redemptions Per Customer
+       * @description Maximum number of times the discount can be redeemed by a single customer.
+       */
+      max_redemptions_per_customer: number | null
+      /**
        * Redemptions Count
        * @description Number of times the discount has been redeemed.
        */
@@ -19588,6 +19598,11 @@ export interface components {
        * @description Maximum number of times the discount can be redeemed.
        */
       max_redemptions: number | null
+      /**
+       * Max Redemptions Per Customer
+       * @description Maximum number of times the discount can be redeemed by a single customer.
+       */
+      max_redemptions_per_customer: number | null
       /**
        * Redemptions Count
        * @description Number of times the discount has been redeemed.
@@ -19678,6 +19693,11 @@ export interface components {
        */
       max_redemptions: number | null
       /**
+       * Max Redemptions Per Customer
+       * @description Maximum number of times the discount can be redeemed by a single customer.
+       */
+      max_redemptions_per_customer: number | null
+      /**
        * Redemptions Count
        * @description Number of times the discount has been redeemed.
        */
@@ -19765,6 +19785,11 @@ export interface components {
        */
       max_redemptions: number | null
       /**
+       * Max Redemptions Per Customer
+       * @description Maximum number of times the discount can be redeemed by a single customer.
+       */
+      max_redemptions_per_customer: number | null
+      /**
        * Redemptions Count
        * @description Number of times the discount has been redeemed.
        */
@@ -19824,6 +19849,11 @@ export interface components {
        * @description Optional maximum number of times the discount can be redeemed.
        */
       max_redemptions?: number | null
+      /**
+       * Max Redemptions Per Customer
+       * @description Optional maximum number of times the discount can be redeemed by a single customer.
+       */
+      max_redemptions_per_customer?: number | null
       /** Products */
       products?: string[] | null
       /**
@@ -19914,6 +19944,11 @@ export interface components {
        */
       max_redemptions: number | null
       /**
+       * Max Redemptions Per Customer
+       * @description Maximum number of times the discount can be redeemed by a single customer.
+       */
+      max_redemptions_per_customer: number | null
+      /**
        * Redemptions Count
        * @description Number of times the discount has been redeemed.
        */
@@ -19981,6 +20016,11 @@ export interface components {
        * @description Maximum number of times the discount can be redeemed.
        */
       max_redemptions: number | null
+      /**
+       * Max Redemptions Per Customer
+       * @description Maximum number of times the discount can be redeemed by a single customer.
+       */
+      max_redemptions_per_customer: number | null
       /**
        * Redemptions Count
        * @description Number of times the discount has been redeemed.
@@ -20054,6 +20094,11 @@ export interface components {
        */
       max_redemptions: number | null
       /**
+       * Max Redemptions Per Customer
+       * @description Maximum number of times the discount can be redeemed by a single customer.
+       */
+      max_redemptions_per_customer: number | null
+      /**
        * Redemptions Count
        * @description Number of times the discount has been redeemed.
        */
@@ -20123,6 +20168,11 @@ export interface components {
        * @description Maximum number of times the discount can be redeemed.
        */
       max_redemptions: number | null
+      /**
+       * Max Redemptions Per Customer
+       * @description Maximum number of times the discount can be redeemed by a single customer.
+       */
+      max_redemptions_per_customer: number | null
       /**
        * Redemptions Count
        * @description Number of times the discount has been redeemed.
@@ -20273,6 +20323,11 @@ export interface components {
        * @description Optional maximum number of times the discount can be redeemed.
        */
       max_redemptions?: number | null
+      /**
+       * Max Redemptions Per Customer
+       * @description Optional maximum number of times the discount can be redeemed by a single customer.
+       */
+      max_redemptions_per_customer?: number | null
       duration?: components['schemas']['DiscountDuration'] | null
       /** Duration In Months */
       duration_in_months?: number | null

--- a/server/polar/checkout/endpoints.py
+++ b/server/polar/checkout/endpoints.py
@@ -42,6 +42,7 @@ from .schemas import (
 )
 from .service import (
     AlreadyActiveSubscriptionError,
+    DiscountRedemptionLimitReached,
     ExpiredCheckoutError,
     NotOpenCheckout,
     PaymentError,
@@ -74,7 +75,8 @@ CheckoutForbiddenError = {
         AlreadyActiveSubscriptionError.schema()
         | NotOpenCheckout.schema()
         | PaymentNotReady.schema()
-        | TrialAlreadyRedeemed.schema(),
+        | TrialAlreadyRedeemed.schema()
+        | DiscountRedemptionLimitReached.schema(),
         SetSchemaReference("CheckoutForbiddenError"),
     ],
 }

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -1034,8 +1034,7 @@ class CheckoutService:
             if checkout.is_payment_setup_required:
                 raise PaymentNotReady()
 
-        # For wallet payments (Apple Pay, Google Pay, Link), we hide the customer name
-        # field for better UX and instead extract the name from Stripe's confirmation token.
+        confirmation_token: stripe_lib.ConfirmationToken | None = None
         if (
             checkout.payment_processor == PaymentProcessor.stripe
             and checkout_confirm.confirmation_token_id is not None
@@ -1045,19 +1044,21 @@ class CheckoutService:
                 confirmation_token = await stripe_service.get_confirmation_token(
                     checkout_confirm.confirmation_token_id
                 )
-                if (
-                    confirmation_token.payment_method_preview is not None
-                    and confirmation_token.payment_method_preview.billing_details
-                    is not None
-                ):
-                    wallet_name = (
-                        confirmation_token.payment_method_preview.billing_details.name
-                    )
-                    if wallet_name:
-                        checkout.customer_name = wallet_name
-                        session.add(checkout)
             except stripe_lib.StripeError:
-                pass
+                confirmation_token = None
+
+        # For wallet payments (Apple Pay, Google Pay, Link), we hide the customer name
+        # field for better UX and instead extract the name from Stripe's confirmation token.
+        if confirmation_token is not None and checkout.customer_name is None:
+            payment_method_preview = confirmation_token.payment_method_preview
+            if (
+                payment_method_preview is not None
+                and payment_method_preview.billing_details is not None
+            ):
+                wallet_name = payment_method_preview.billing_details.name
+                if wallet_name:
+                    checkout.customer_name = wallet_name
+                    session.add(checkout)
 
         required_fields = self._get_required_confirm_fields(checkout)
         for required_field in required_fields:

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -19,6 +19,7 @@ from polar.authz.service import assert_resource_permission, get_accessible_org_i
 from polar.checkout.guard import has_product_checkout
 from polar.checkout.schemas import (
     CheckoutConfirm,
+    CheckoutConfirmBase,
     CheckoutConfirmStripe,
     CheckoutCreate,
     CheckoutPriceCreate,
@@ -210,6 +211,16 @@ class TrialAlreadyRedeemed(CheckoutError):
         message = (
             "You have already used a trial for this product. "
             "Trials can only be used once per customer."
+        )
+        super().__init__(message, 403)
+
+
+class DiscountRedemptionLimitReached(CheckoutError):
+    def __init__(self, checkout: Checkout) -> None:
+        self.checkout = checkout
+        message = (
+            "You have already redeemed this discount the maximum number of "
+            "times allowed per customer."
         )
         super().__init__(message, 403)
 
@@ -1038,7 +1049,13 @@ class CheckoutService:
         if (
             checkout.payment_processor == PaymentProcessor.stripe
             and checkout_confirm.confirmation_token_id is not None
-            and checkout.customer_name is None
+            and (
+                checkout.customer_name is None
+                or (
+                    checkout.discount is not None
+                    and checkout.discount.max_redemptions_per_customer is not None
+                )
+            )
         ):
             try:
                 confirmation_token = await stripe_service.get_confirmation_token(
@@ -1116,6 +1133,39 @@ class CheckoutService:
                     **checkout.payment_processor_metadata,
                     "customer_id": stripe_customer_id,
                 }
+
+                # Enforce the per-customer discount redemption limit *before* creating
+                # any payment intent, so we never charge a customer we're about to
+                # reject. The card fingerprint is read from the confirmation token's
+                # payment method preview (no intent/charge required yet).
+                if (
+                    checkout.discount is not None
+                    and checkout.discount.max_redemptions_per_customer is not None
+                ):
+                    # Serialize concurrent confirmations of the same buyer, so two
+                    # checkouts can't both read the count before either redeems.
+                    customer_repository = CustomerRepository.from_session(session)
+                    await customer_repository.get_by_id(customer.id, for_update=True)
+
+                    payment_method_fingerprint: str | None = None
+                    if (
+                        confirmation_token is not None
+                        and confirmation_token.payment_method_preview is not None
+                    ):
+                        payment_method_fingerprint = get_fingerprint(
+                            typing.cast(
+                                stripe_lib.PaymentMethod,
+                                confirmation_token.payment_method_preview,
+                            )
+                        )
+                    if await discount_service.check_per_customer_limit_reached(
+                        session,
+                        checkout.discount,
+                        checkout=checkout,
+                        customer=customer,
+                        payment_method_fingerprint=payment_method_fingerprint,
+                    ):
+                        raise DiscountRedemptionLimitReached(checkout)
 
                 intent: stripe_lib.PaymentIntent | stripe_lib.SetupIntent | None = None
                 if checkout.is_payment_form_required:
@@ -2239,6 +2289,19 @@ class CheckoutService:
         checkout = await self._update_trial_end(checkout)
 
         session.add(checkout)
+
+        # Tell the buyer as soon as they apply the code, instead of letting them fill in
+        # the payment form first. Confirmation re-checks with the card fingerprint, which
+        # isn't available yet, so it stays the authoritative gate.
+        if (
+            isinstance(checkout_update, CheckoutUpdatePublic)
+            and not isinstance(checkout_update, CheckoutConfirmBase)
+            and checkout.discount is not None
+            and await discount_service.check_per_customer_limit_reached(
+                session, checkout.discount, checkout=checkout
+            )
+        ):
+            raise DiscountRedemptionLimitReached(checkout)
 
         await self._validate_subscription_uniqueness(session, checkout)
 

--- a/server/polar/discount/repository.py
+++ b/server/polar/discount/repository.py
@@ -1,10 +1,30 @@
 from uuid import UUID
 
-from sqlalchemy import func, select, update
-from sqlalchemy.orm import raiseload
+from sqlalchemy import (
+    ColumnElement,
+    ColumnExpressionArgument,
+    distinct,
+    func,
+    or_,
+    select,
+    update,
+)
+from sqlalchemy.orm import InstrumentedAttribute, raiseload
 
 from polar.kit.repository import RepositoryBase, RepositoryIDMixin
-from polar.models import Discount, DiscountRedemption
+from polar.models import (
+    Checkout,
+    Customer,
+    Discount,
+    DiscountRedemption,
+    Order,
+    Payment,
+    Refund,
+    Subscription,
+)
+from polar.models.order import OrderStatus
+from polar.models.payment import PaymentStatus
+from polar.models.refund import RefundReason, RefundStatus
 
 
 class DiscountRepository(RepositoryBase[Discount], RepositoryIDMixin[Discount, UUID]):
@@ -45,3 +65,108 @@ class DiscountRedemptionRepository(
             .where(DiscountRedemption.checkout_id == checkout_id)
         )
         await self.session.execute(statement)
+
+    async def count_redemptions_by_customer(
+        self,
+        discount_id: UUID,
+        *,
+        exclude_checkout_id: UUID,
+        customer_id: UUID | None = None,
+        customer_email: str | None = None,
+        payment_method_fingerprint: str | None = None,
+    ) -> int:
+        """
+        Count past redemptions of a discount attributable to a given customer.
+
+        The customer is identified by any of the provided hints (OR logic), mirroring
+        the trial-abuse feature: customer ID, unaliased email, or payment method
+        fingerprint. Identity is derived by joining the redemption's linked checkout
+        (customer ID + email), its subscription (customer ID + email, for discounts
+        applied to an existing subscription) and payment (card fingerprint, only
+        present when a charge occurred).
+
+        A redemption whose orders are all fully refunded doesn't count, unless the
+        refund was issued to head off a chargeback. The global ``max_redemptions``
+        budget is unaffected.
+
+        The current, in-progress redemption is excluded via ``exclude_checkout_id``.
+        """
+
+        def unalias(column: InstrumentedAttribute[str | None]) -> ColumnElement[str]:
+            # Strip the `+alias` suffix from the local part in SQL, mirroring
+            # `polar.kit.email.unalias_email`. The provided `customer_email` is
+            # expected to be already unaliased and lowercased.
+            return func.regexp_replace(func.lower(column), r"\+[^@]*", "")
+
+        clauses: list[ColumnExpressionArgument[bool]] = []
+
+        if customer_id is not None:
+            clauses.append(Checkout.customer_id == customer_id)
+            clauses.append(Subscription.customer_id == customer_id)
+
+        if customer_email is not None:
+            clauses.append(unalias(Checkout.customer_email) == customer_email)
+            clauses.append(unalias(Customer.email) == customer_email)
+
+        if payment_method_fingerprint is not None:
+            clauses.append(
+                Payment.method_metadata["fingerprint"].astext
+                == payment_method_fingerprint
+            )
+
+        # No hints to match against: nothing can be attributed to the customer.
+        if not clauses:
+            return 0
+
+        # NULL-safe: a checkout-less redemption never matches a checkout-less order.
+        redemption_orders = select(Order.id).where(
+            or_(
+                Order.checkout_id == DiscountRedemption.checkout_id,
+                Order.subscription_id == DiscountRedemption.subscription_id,
+            )
+        )
+        chargeback_prevented = (
+            select(Refund.id)
+            .where(
+                Refund.order_id == Order.id,
+                Refund.status == RefundStatus.succeeded,
+                Refund.reason == RefundReason.dispute_prevention,
+            )
+            .exists()
+        )
+
+        statement = (
+            select(func.count(distinct(DiscountRedemption.id)))
+            .join(Checkout, Checkout.id == DiscountRedemption.checkout_id, isouter=True)
+            .join(
+                Subscription,
+                Subscription.id == DiscountRedemption.subscription_id,
+                isouter=True,
+            )
+            .join(Customer, Customer.id == Subscription.customer_id, isouter=True)
+            .where(
+                DiscountRedemption.discount_id == discount_id,
+                # NULL-safe: subscription-only redemptions have no checkout.
+                DiscountRedemption.checkout_id.is_distinct_from(exclude_checkout_id),
+                or_(*clauses),
+                or_(
+                    ~redemption_orders.exists(),
+                    redemption_orders.where(
+                        Order.status.in_(OrderStatus.paid_statuses())
+                    ).exists(),
+                    redemption_orders.where(chargeback_prevented).exists(),
+                ),
+            )
+        )
+
+        if payment_method_fingerprint is not None:
+            statement = statement.join(
+                Payment,
+                (Payment.checkout_id == DiscountRedemption.checkout_id)
+                # A retried checkout keeps its declined attempts.
+                & (Payment.status == PaymentStatus.succeeded),
+                isouter=True,
+            )
+
+        result = await self.session.execute(statement)
+        return result.scalar_one()

--- a/server/polar/discount/schemas.py
+++ b/server/polar/discount/schemas.py
@@ -97,6 +97,16 @@ MaxRedemptions = Annotated[
     ),
     Ge(1),
 ]
+MaxRedemptionsPerCustomer = Annotated[
+    Int32 | None,
+    Field(
+        description=(
+            "Optional maximum number of times the discount can be redeemed "
+            "by a single customer."
+        ),
+    ),
+    Ge(1),
+]
 DurationInMonths = Annotated[
     Int32,
     Field(
@@ -159,6 +169,7 @@ class DiscountCreateBase(MetadataInputMixin, Schema):
     starts_at: StartsAt = None
     ends_at: EndsAt = None
     max_redemptions: MaxRedemptions = None
+    max_redemptions_per_customer: MaxRedemptionsPerCustomer = None
 
     products: ProductsList | None = None
 
@@ -272,6 +283,7 @@ class DiscountUpdate(MetadataInputMixin, Schema):
     starts_at: StartsAt = None
     ends_at: EndsAt = None
     max_redemptions: MaxRedemptions = None
+    max_redemptions_per_customer: MaxRedemptionsPerCustomer = None
 
     duration: DiscountDuration | None = None
     duration_in_months: DurationInMonths | None = None
@@ -329,6 +341,11 @@ class DiscountBase(MetadataOutputMixin, IDSchema, TimestampedSchema):
     )
     max_redemptions: int | None = Field(
         description="Maximum number of times the discount can be redeemed."
+    )
+    max_redemptions_per_customer: int | None = Field(
+        description=(
+            "Maximum number of times the discount can be redeemed by a single customer."
+        )
     )
 
     redemptions_count: int = Field(

--- a/server/polar/discount/service.py
+++ b/server/polar/discount/service.py
@@ -440,20 +440,19 @@ class DiscountService(ResourceServiceReader[Discount]):
         self, session: AsyncSession, discount: Discount
     ) -> AsyncIterator[DiscountRedemption]:
         """
-        Redeem a discount with FOR UPDATE lock to prevent concurrent redemptions.
-
-        Uses PostgreSQL row-level locking instead of Redis distributed locks.
-        The lock is held until the parent transaction commits.
+        Redeem a discount, locking its row when globally capped so the count can't be
+        read stale. Without that cap the lock would make concurrent buyers of the same
+        code fail each other.
         """
         repository = DiscountRepository.from_session(session)
 
-        # Acquire FOR UPDATE lock (we're already inside checkout's transaction)
-        try:
-            await repository.get_by_id(discount.id, for_update=True, nowait=True)
-        except DBAPIError as e:
-            if is_lock_not_available_error(e):
-                raise DiscountNotRedeemableError(discount) from e
-            raise
+        if discount.max_redemptions is not None:
+            try:
+                await repository.get_by_id(discount.id, for_update=True, nowait=True)
+            except DBAPIError as e:
+                if is_lock_not_available_error(e):
+                    raise DiscountNotRedeemableError(discount) from e
+                raise
 
         if not await self.is_redeemable_discount(session, discount):
             raise DiscountNotRedeemableError(discount)

--- a/server/polar/discount/service.py
+++ b/server/polar/discount/service.py
@@ -486,7 +486,7 @@ class DiscountService(ResourceServiceReader[Discount]):
         """
         Redeem a discount, locking its row when globally capped so the count can't be
         read stale. Without that cap the lock would make concurrent buyers of the same
-        code fail each other.
+        code fail each other; the per-customer limit serializes on the customer instead.
         """
         repository = DiscountRepository.from_session(session)
 

--- a/server/polar/discount/service.py
+++ b/server/polar/discount/service.py
@@ -486,7 +486,10 @@ class DiscountService(ResourceServiceReader[Discount]):
         """
         Redeem a discount, locking its row when globally capped so the count can't be
         read stale. Without that cap the lock would make concurrent buyers of the same
-        code fail each other; the per-customer limit serializes on the customer instead.
+        code fail each other.
+
+        A per-customer cap serializes on the customer row instead, which the caller
+        must lock before it checks the count.
         """
         repository = DiscountRepository.from_session(session)
 

--- a/server/polar/discount/service.py
+++ b/server/polar/discount/service.py
@@ -14,14 +14,19 @@ from polar.authz.service import (
     assert_organization_permission,
     assert_resource_permission,
 )
-from polar.discount.repository import DiscountRepository
+from polar.discount.repository import (
+    DiscountRedemptionRepository,
+    DiscountRepository,
+)
 from polar.exceptions import PolarError, PolarRequestValidationError
 from polar.kit.db.locking import is_lock_not_available_error
+from polar.kit.email import unalias_email
 from polar.kit.pagination import PaginationParams, paginate
 from polar.kit.services import ResourceServiceReader
 from polar.kit.sorting import Sorting
 from polar.kit.utils import utc_now
 from polar.models import (
+    Customer,
     Discount,
     DiscountProduct,
     Organization,
@@ -434,6 +439,45 @@ class DiscountService(ResourceServiceReader[Discount]):
             return discount.redemptions_count < discount.max_redemptions
 
         return True
+
+    async def check_per_customer_limit_reached(
+        self,
+        session: AsyncSession,
+        discount: Discount,
+        *,
+        checkout: Checkout,
+        customer: Customer | None = None,
+        payment_method_fingerprint: str | None = None,
+    ) -> bool:
+        """
+        Check whether a customer has reached the discount's per-customer redemption limit.
+
+        The customer is identified using the same signals as the trial-abuse feature:
+        customer ID, unaliased email, and payment method fingerprint (OR logic), scoped
+        to this specific discount. Returns ``False`` when no per-customer limit is set.
+
+        Before confirmation there is no customer yet, so the checkout's own fields are
+        used instead.
+        """
+        if discount.max_redemptions_per_customer is None:
+            return False
+
+        customer_id = customer.id if customer is not None else checkout.customer_id
+        email = (
+            customer.email
+            if customer is not None and customer.email
+            else checkout.customer_email
+        )
+
+        repository = DiscountRedemptionRepository.from_session(session)
+        count = await repository.count_redemptions_by_customer(
+            discount.id,
+            exclude_checkout_id=checkout.id,
+            customer_id=customer_id,
+            customer_email=unalias_email(email).lower() if email else None,
+            payment_method_fingerprint=payment_method_fingerprint,
+        )
+        return count >= discount.max_redemptions_per_customer
 
     @contextlib.asynccontextmanager
     async def redeem_discount(

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -27,6 +27,7 @@ from polar.checkout.service import (
     AlreadyActiveSubscriptionError,
     CheckoutCustomerDeleted,
     CheckoutCustomerExternalIdMismatch,
+    DiscountRedemptionLimitReached,
     ExpiredCheckoutError,
     NotConfirmedCheckout,
     NotOpenCheckout,
@@ -110,8 +111,10 @@ from tests.fixtures.random_objects import (
     create_customer,
     create_customer_seat,
     create_discount,
+    create_discount_redemption,
     create_member,
     create_order,
+    create_payment,
     create_product,
     create_product_fixed_and_seat,
     create_product_price_fixed,
@@ -3080,6 +3083,48 @@ class TestUpdate:
                 ),
             )
 
+    async def test_discount_code_per_customer_limit_reached(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+        checkout_one_time_fixed: Checkout,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.percentage,
+            basis_points=1000,
+            duration=DiscountDuration.once,
+            organization=organization,
+            code="LIMITEDPERCUSTOMER",
+            max_redemptions_per_customer=1,
+        )
+        prior_customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        prior_checkout = await create_checkout(
+            save_fixture,
+            products=[product],
+            customer=prior_customer,
+            discount=discount,
+        )
+        prior_checkout.customer_email = "customer@example.com"
+        await save_fixture(prior_checkout)
+        await create_discount_redemption(
+            save_fixture, discount=discount, checkout=prior_checkout
+        )
+
+        with pytest.raises(DiscountRedemptionLimitReached):
+            await checkout_service.update(
+                session,
+                checkout_one_time_fixed,
+                CheckoutUpdatePublic(
+                    discount_code=discount.code,
+                    customer_email="customer@example.com",
+                ),
+            )
+
     async def test_invalid_discount_id_not_applicable(
         self,
         session: AsyncSession,
@@ -5431,6 +5476,158 @@ class TestConfirm:
                         "confirmation_token_id": "CONFIRMATION_TOKEN_ID",
                         "customer_name": "Customer Name",
                         "customer_email": email,
+                        "customer_billing_address": {"country": "FR"},
+                    }
+                ),
+            )
+
+    async def test_discount_per_customer_limit_reached(
+        self,
+        save_fixture: SaveFixture,
+        stripe_service_mock: MagicMock,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Anonymous],
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            code="LIMITEDPERCUSTOMER",
+            max_redemptions_per_customer=1,
+        )
+
+        # The same customer already redeemed this discount once.
+        existing_customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        prior_checkout = await create_checkout(
+            save_fixture,
+            products=[product],
+            customer=existing_customer,
+            discount=discount,
+        )
+        prior_checkout.customer_email = "customer@example.com"
+        await save_fixture(prior_checkout)
+        await create_discount_redemption(
+            save_fixture, discount=discount, checkout=prior_checkout
+        )
+
+        checkout = await create_checkout(
+            save_fixture, products=[product], discount=discount
+        )
+
+        confirmation_token = MagicMock(spec=stripe_lib.ConfirmationToken)
+        confirmation_token.payment_method_preview = MagicMock()
+        confirmation_token.payment_method_preview.billing_details = MagicMock()
+        confirmation_token.payment_method_preview.billing_details.name = "Customer Name"
+        confirmation_token.payment_method_preview.card = SimpleNamespace(
+            fingerprint="FINGERPRINT"
+        )
+        stripe_service_mock.get_confirmation_token.return_value = confirmation_token
+        stripe_service_mock.create_customer.return_value = SimpleNamespace(
+            id="STRIPE_CUSTOMER_ID"
+        )
+        stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
+            client_secret="CLIENT_SECRET", status="succeeded"
+        )
+        stripe_service_mock.create_setup_intent.return_value = SimpleNamespace(
+            client_secret="CLIENT_SECRET", status="succeeded"
+        )
+
+        with pytest.raises(DiscountRedemptionLimitReached):
+            await checkout_service.confirm(
+                session,
+                auth_subject,
+                checkout,
+                CheckoutConfirmStripe.model_validate(
+                    {
+                        "confirmation_token_id": "CONFIRMATION_TOKEN_ID",
+                        "customer_name": "Customer Name",
+                        "customer_email": "customer@example.com",
+                        "customer_billing_address": {"country": "FR"},
+                    }
+                ),
+            )
+
+    async def test_discount_per_customer_limit_reached_by_fingerprint(
+        self,
+        save_fixture: SaveFixture,
+        stripe_service_mock: MagicMock,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Anonymous],
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            code="LIMITEDPERCUSTOMER",
+            max_redemptions_per_customer=1,
+        )
+
+        # Different email, but the same card fingerprint as the prior redemption.
+        prior_customer = await create_customer(
+            save_fixture, organization=organization, email="other@example.com"
+        )
+        prior_checkout = await create_checkout(
+            save_fixture,
+            products=[product],
+            customer=prior_customer,
+            discount=discount,
+        )
+        prior_checkout.customer_email = "other@example.com"
+        await save_fixture(prior_checkout)
+        await create_payment(
+            save_fixture,
+            organization,
+            checkout=prior_checkout,
+            method_metadata={"fingerprint": "FINGERPRINT"},
+        )
+        await create_discount_redemption(
+            save_fixture, discount=discount, checkout=prior_checkout
+        )
+
+        checkout = await create_checkout(
+            save_fixture, products=[product], discount=discount
+        )
+
+        confirmation_token = MagicMock(spec=stripe_lib.ConfirmationToken)
+        confirmation_token.payment_method_preview = MagicMock()
+        confirmation_token.payment_method_preview.billing_details = MagicMock()
+        confirmation_token.payment_method_preview.billing_details.name = "Customer Name"
+        confirmation_token.payment_method_preview.card = SimpleNamespace(
+            fingerprint="FINGERPRINT"
+        )
+        stripe_service_mock.get_confirmation_token.return_value = confirmation_token
+        stripe_service_mock.create_customer.return_value = SimpleNamespace(
+            id="STRIPE_CUSTOMER_ID"
+        )
+        stripe_service_mock.create_payment_intent.return_value = SimpleNamespace(
+            client_secret="CLIENT_SECRET", status="succeeded"
+        )
+        stripe_service_mock.create_setup_intent.return_value = SimpleNamespace(
+            client_secret="CLIENT_SECRET", status="succeeded"
+        )
+
+        # `customer_name` is set, so the token is only fetched because the discount
+        # carries a per-customer limit.
+        with pytest.raises(DiscountRedemptionLimitReached):
+            await checkout_service.confirm(
+                session,
+                auth_subject,
+                checkout,
+                CheckoutConfirmStripe.model_validate(
+                    {
+                        "confirmation_token_id": "CONFIRMATION_TOKEN_ID",
+                        "customer_name": "Customer Name",
+                        "customer_email": "unrelated@example.com",
                         "customer_billing_address": {"country": "FR"},
                     }
                 ),

--- a/server/tests/discount/test_endpoints.py
+++ b/server/tests/discount/test_endpoints.py
@@ -205,6 +205,58 @@ class TestCreateDiscount:
 
         assert response.status_code == 201
 
+    @pytest.mark.auth
+    async def test_valid_max_redemptions_per_customer(
+        self,
+        session: AsyncSession,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.post(
+            "/v1/discounts/",
+            json={
+                "name": "Discount",
+                "type": "percentage",
+                "code": "DISCOUNT",
+                "duration": "once",
+                "basis_points": 1000,
+                "max_redemptions_per_customer": 3,
+                "organization_id": str(organization.id),
+            },
+        )
+
+        assert response.status_code == 201
+        json = response.json()
+        assert json["max_redemptions_per_customer"] == 3
+
+        repository = DiscountRepository.from_session(session)
+        discount = await repository.get_by_id(json["id"])
+        assert discount is not None
+        assert discount.max_redemptions_per_customer == 3
+
+    @pytest.mark.auth
+    async def test_max_redemptions_per_customer_zero_rejected(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.post(
+            "/v1/discounts/",
+            json={
+                "name": "Discount",
+                "type": "percentage",
+                "code": "DISCOUNT",
+                "duration": "once",
+                "basis_points": 1000,
+                "max_redemptions_per_customer": 0,
+                "organization_id": str(organization.id),
+            },
+        )
+
+        assert response.status_code == 422
+
     @pytest.mark.parametrize(
         "payload",
         [
@@ -376,6 +428,28 @@ class TestUpdateDiscount:
         )
 
         assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_update_max_redemptions_per_customer(
+        self,
+        session: AsyncSession,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        discount_fixed_once: Discount,
+    ) -> None:
+        response = await client.patch(
+            f"/v1/discounts/{discount_fixed_once.id}",
+            json={"max_redemptions_per_customer": 5},
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+        assert json["max_redemptions_per_customer"] == 5
+
+        repository = DiscountRepository.from_session(session)
+        updated = await repository.get_by_id(discount_fixed_once.id)
+        assert updated is not None
+        assert updated.max_redemptions_per_customer == 5
 
 
 @pytest.mark.asyncio

--- a/server/tests/discount/test_service.py
+++ b/server/tests/discount/test_service.py
@@ -1334,12 +1334,20 @@ class TestRedeemDiscount:
             ),
         )
 
+    @pytest.mark.parametrize(
+        "max_redemptions_per_customer",
+        [
+            pytest.param(None, id="uncapped"),
+            pytest.param(1, id="per_customer"),
+        ],
+    )
     async def test_discount_without_global_cap_ignores_contention(
         self,
         save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
         contended_lock: None,
+        max_redemptions_per_customer: int | None,
     ) -> None:
         discount = await create_discount(
             save_fixture,
@@ -1347,6 +1355,7 @@ class TestRedeemDiscount:
             basis_points=1000,
             duration=DiscountDuration.once,
             organization=organization,
+            max_redemptions_per_customer=max_redemptions_per_customer,
         )
 
         async with discount_service.redeem_discount(session, discount) as redemption:

--- a/server/tests/discount/test_service.py
+++ b/server/tests/discount/test_service.py
@@ -20,9 +20,7 @@ from polar.exceptions import PolarRequestValidationError
 from polar.kit.currency import PresentmentCurrency
 from polar.kit.utils import utc_now
 from polar.models import (
-    Checkout,
     Discount,
-    DiscountRedemption,
     Organization,
     Product,
     UserOrganization,
@@ -33,18 +31,22 @@ from polar.models.discount import (
     DiscountPercentage,
     DiscountType,
 )
+from polar.models.order import OrderStatus
+from polar.models.payment import PaymentStatus
+from polar.models.refund import RefundReason
 from polar.models.webhook_endpoint import WebhookEventType
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_checkout, create_discount
-
-
-async def create_discount_redemption(
-    save_fixture: SaveFixture, *, discount: Discount, checkout: Checkout
-) -> DiscountRedemption:
-    discount_redemption = DiscountRedemption(discount=discount, checkout=checkout)
-    await save_fixture(discount_redemption)
-    return discount_redemption
+from tests.fixtures.random_objects import (
+    create_checkout,
+    create_customer,
+    create_discount,
+    create_discount_redemption,
+    create_order,
+    create_payment,
+    create_refund,
+    create_subscription,
+)
 
 
 @pytest.fixture
@@ -806,6 +808,518 @@ class TestIsRepetitionExpired:
         assert discount.is_repetition_expired(now, within_duration) is False
         # Should expire after duration
         assert discount.is_repetition_expired(now, after_duration) is True
+
+
+@pytest.mark.asyncio
+class TestCheckPerCustomerLimitReached:
+    async def test_no_limit_set(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            max_redemptions_per_customer=None,
+        )
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        checkout = await create_checkout(
+            save_fixture, products=[product], customer=customer
+        )
+
+        assert (
+            await discount_service.check_per_customer_limit_reached(
+                session, discount, checkout=checkout, customer=customer
+            )
+            is False
+        )
+
+    async def test_under_limit(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            max_redemptions_per_customer=2,
+        )
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        prior_checkout = await create_checkout(
+            save_fixture, products=[product], customer=customer
+        )
+        await create_discount_redemption(
+            save_fixture, discount=discount, checkout=prior_checkout
+        )
+        current_checkout = await create_checkout(
+            save_fixture, products=[product], customer=customer
+        )
+
+        assert (
+            await discount_service.check_per_customer_limit_reached(
+                session, discount, checkout=current_checkout, customer=customer
+            )
+            is False
+        )
+
+    async def test_limit_reached_by_customer_id(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            max_redemptions_per_customer=1,
+        )
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        prior_checkout = await create_checkout(
+            save_fixture, products=[product], customer=customer
+        )
+        await create_discount_redemption(
+            save_fixture, discount=discount, checkout=prior_checkout
+        )
+        current_checkout = await create_checkout(
+            save_fixture, products=[product], customer=customer
+        )
+
+        assert (
+            await discount_service.check_per_customer_limit_reached(
+                session, discount, checkout=current_checkout, customer=customer
+            )
+            is True
+        )
+
+    async def test_limit_reached_by_email_alias(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            max_redemptions_per_customer=1,
+        )
+        # A *different* customer previously redeemed, but with the same base email.
+        prior_customer = await create_customer(
+            save_fixture, organization=organization, email="someone-else@example.com"
+        )
+        prior_checkout = await create_checkout(
+            save_fixture, products=[product], customer=prior_customer
+        )
+        prior_checkout.customer_email = "customer@example.com"
+        await save_fixture(prior_checkout)
+        await create_discount_redemption(
+            save_fixture, discount=discount, checkout=prior_checkout
+        )
+
+        # Current customer uses a `+alias` variant of the same email.
+        current_customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="customer+alias@example.com",
+        )
+        current_checkout = await create_checkout(
+            save_fixture, products=[product], customer=current_customer
+        )
+
+        assert (
+            await discount_service.check_per_customer_limit_reached(
+                session,
+                discount,
+                checkout=current_checkout,
+                customer=current_customer,
+            )
+            is True
+        )
+
+    async def test_limit_reached_by_fingerprint(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            max_redemptions_per_customer=1,
+        )
+        # Different customer and email, but the same card fingerprint.
+        prior_customer = await create_customer(
+            save_fixture, organization=organization, email="other@example.com"
+        )
+        prior_checkout = await create_checkout(
+            save_fixture, products=[product], customer=prior_customer
+        )
+        prior_checkout.customer_email = "other@example.com"
+        await save_fixture(prior_checkout)
+        await create_payment(
+            save_fixture,
+            organization,
+            checkout=prior_checkout,
+            method_metadata={"fingerprint": "FINGERPRINT"},
+        )
+        await create_discount_redemption(
+            save_fixture, discount=discount, checkout=prior_checkout
+        )
+
+        current_customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        current_checkout = await create_checkout(
+            save_fixture, products=[product], customer=current_customer
+        )
+
+        assert (
+            await discount_service.check_per_customer_limit_reached(
+                session,
+                discount,
+                checkout=current_checkout,
+                customer=current_customer,
+                payment_method_fingerprint="FINGERPRINT",
+            )
+            is True
+        )
+
+    async def test_declined_card_fingerprint_does_not_count(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            max_redemptions_per_customer=1,
+        )
+        prior_customer = await create_customer(
+            save_fixture, organization=organization, email="other@example.com"
+        )
+        prior_checkout = await create_checkout(
+            save_fixture, products=[product], customer=prior_customer
+        )
+        prior_checkout.customer_email = "other@example.com"
+        await save_fixture(prior_checkout)
+        # Declined once, then retried with another card.
+        await create_payment(
+            save_fixture,
+            organization,
+            status=PaymentStatus.failed,
+            checkout=prior_checkout,
+            method_metadata={"fingerprint": "DECLINED_CARD"},
+        )
+        await create_payment(
+            save_fixture,
+            organization,
+            checkout=prior_checkout,
+            method_metadata={"fingerprint": "SETTLED_CARD"},
+        )
+        await create_discount_redemption(
+            save_fixture, discount=discount, checkout=prior_checkout
+        )
+
+        current_customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        current_checkout = await create_checkout(
+            save_fixture, products=[product], customer=current_customer
+        )
+
+        assert (
+            await discount_service.check_per_customer_limit_reached(
+                session,
+                discount,
+                checkout=current_checkout,
+                customer=current_customer,
+                payment_method_fingerprint="DECLINED_CARD",
+            )
+            is False
+        )
+
+    async def test_limit_reached_by_subscription_redemption(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            max_redemptions_per_customer=1,
+        )
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        # Applying a discount to an existing subscription redeems it without a checkout.
+        subscription = await create_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        await create_discount_redemption(
+            save_fixture, discount=discount, subscription=subscription
+        )
+        current_checkout = await create_checkout(
+            save_fixture, products=[product], customer=customer
+        )
+
+        assert (
+            await discount_service.check_per_customer_limit_reached(
+                session, discount, checkout=current_checkout, customer=customer
+            )
+            is True
+        )
+
+    async def test_refunded_order_frees_the_slot(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            max_redemptions_per_customer=1,
+        )
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        prior_checkout = await create_checkout(
+            save_fixture, products=[product], customer=customer
+        )
+        await create_discount_redemption(
+            save_fixture, discount=discount, checkout=prior_checkout
+        )
+        await create_order(
+            save_fixture,
+            customer=customer,
+            product=product,
+            checkout=prior_checkout,
+            status=OrderStatus.refunded,
+        )
+        current_checkout = await create_checkout(
+            save_fixture, products=[product], customer=customer
+        )
+
+        assert (
+            await discount_service.check_per_customer_limit_reached(
+                session, discount, checkout=current_checkout, customer=customer
+            )
+            is False
+        )
+
+    async def test_chargeback_prevention_refund_keeps_the_slot(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            max_redemptions_per_customer=1,
+        )
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        prior_checkout = await create_checkout(
+            save_fixture, products=[product], customer=customer
+        )
+        await create_discount_redemption(
+            save_fixture, discount=discount, checkout=prior_checkout
+        )
+        order = await create_order(
+            save_fixture,
+            customer=customer,
+            product=product,
+            checkout=prior_checkout,
+            status=OrderStatus.refunded,
+        )
+        payment = await create_payment(save_fixture, organization, order=order)
+        await create_refund(
+            save_fixture,
+            order,
+            payment,
+            reason=RefundReason.dispute_prevention,
+        )
+        current_checkout = await create_checkout(
+            save_fixture, products=[product], customer=customer
+        )
+
+        assert (
+            await discount_service.check_per_customer_limit_reached(
+                session, discount, checkout=current_checkout, customer=customer
+            )
+            is True
+        )
+
+    async def test_partially_refunded_order_keeps_the_slot(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            max_redemptions_per_customer=1,
+        )
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        prior_checkout = await create_checkout(
+            save_fixture, products=[product], customer=customer
+        )
+        await create_discount_redemption(
+            save_fixture, discount=discount, checkout=prior_checkout
+        )
+        await create_order(
+            save_fixture,
+            customer=customer,
+            product=product,
+            checkout=prior_checkout,
+            status=OrderStatus.partially_refunded,
+        )
+        current_checkout = await create_checkout(
+            save_fixture, products=[product], customer=customer
+        )
+
+        assert (
+            await discount_service.check_per_customer_limit_reached(
+                session, discount, checkout=current_checkout, customer=customer
+            )
+            is True
+        )
+
+    async def test_subscription_keeps_the_slot_while_a_cycle_is_paid(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            max_redemptions_per_customer=1,
+        )
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        subscription = await create_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        await create_discount_redemption(
+            save_fixture, discount=discount, subscription=subscription
+        )
+        await create_order(
+            save_fixture,
+            customer=customer,
+            product=product,
+            subscription=subscription,
+            status=OrderStatus.refunded,
+        )
+        await create_order(
+            save_fixture,
+            customer=customer,
+            product=product,
+            subscription=subscription,
+            status=OrderStatus.paid,
+        )
+        current_checkout = await create_checkout(
+            save_fixture, products=[product], customer=customer
+        )
+
+        assert (
+            await discount_service.check_per_customer_limit_reached(
+                session, discount, checkout=current_checkout, customer=customer
+            )
+            is True
+        )
+
+    async def test_excludes_current_checkout(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            max_redemptions_per_customer=1,
+        )
+        customer = await create_customer(
+            save_fixture, organization=organization, email="customer@example.com"
+        )
+        current_checkout = await create_checkout(
+            save_fixture, products=[product], customer=customer
+        )
+        # The only redemption belongs to the in-progress checkout, so it must not count.
+        await create_discount_redemption(
+            save_fixture, discount=discount, checkout=current_checkout
+        )
+
+        assert (
+            await discount_service.check_per_customer_limit_reached(
+                session, discount, checkout=current_checkout, customer=customer
+            )
+            is False
+        )
 
 
 @pytest.mark.asyncio

--- a/server/tests/discount/test_service.py
+++ b/server/tests/discount/test_service.py
@@ -4,14 +4,17 @@ from unittest.mock import AsyncMock
 
 import pytest
 from pytest_mock import MockerFixture
+from sqlalchemy.exc import DBAPIError
 
 from polar.auth.models import AuthSubject, User
 from polar.checkout.schemas import CheckoutUpdatePublic
 from polar.checkout.service import checkout as checkout_service
+from polar.discount.repository import DiscountRepository
 from polar.discount.schemas import (
     DiscountFixedCreate,
     DiscountUpdate,
 )
+from polar.discount.service import DiscountNotRedeemableError
 from polar.discount.service import discount as discount_service
 from polar.exceptions import PolarRequestValidationError
 from polar.kit.currency import PresentmentCurrency
@@ -803,3 +806,54 @@ class TestIsRepetitionExpired:
         assert discount.is_repetition_expired(now, within_duration) is False
         # Should expire after duration
         assert discount.is_repetition_expired(now, after_duration) is True
+
+
+@pytest.mark.asyncio
+class TestRedeemDiscount:
+    @pytest.fixture
+    def contended_lock(self, mocker: MockerFixture) -> None:
+        mocker.patch.object(
+            DiscountRepository,
+            "get_by_id",
+            side_effect=DBAPIError(
+                "SELECT", {}, Exception("could not obtain lock on row")
+            ),
+        )
+
+    async def test_discount_without_global_cap_ignores_contention(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        contended_lock: None,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.percentage,
+            basis_points=1000,
+            duration=DiscountDuration.once,
+            organization=organization,
+        )
+
+        async with discount_service.redeem_discount(session, discount) as redemption:
+            assert redemption.discount == discount
+
+    async def test_capped_discount_rejects_contention(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        contended_lock: None,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.percentage,
+            basis_points=1000,
+            duration=DiscountDuration.once,
+            organization=organization,
+            max_redemptions=10,
+        )
+
+        with pytest.raises(DiscountNotRedeemableError):
+            async with discount_service.redeem_discount(session, discount):
+                pass

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -38,6 +38,7 @@ from polar.models import (
     CustomField,
     Discount,
     DiscountProduct,
+    DiscountRedemption,
     Dispute,
     Event,
     EventType,
@@ -786,6 +787,7 @@ async def create_discount(
     starts_at: datetime | None = None,
     ends_at: datetime | None = None,
     max_redemptions: int | None = None,
+    max_redemptions_per_customer: int | None = None,
     products: list[Product] | None = None,
 ) -> DiscountFixed: ...
 @typing.overload
@@ -802,6 +804,7 @@ async def create_discount(
     starts_at: datetime | None = None,
     ends_at: datetime | None = None,
     max_redemptions: int | None = None,
+    max_redemptions_per_customer: int | None = None,
     products: list[Product] | None = None,
 ) -> DiscountPercentage: ...
 async def create_discount(
@@ -818,6 +821,7 @@ async def create_discount(
     starts_at: datetime | None = None,
     ends_at: datetime | None = None,
     max_redemptions: int | None = None,
+    max_redemptions_per_customer: int | None = None,
     products: list[Product] | None = None,
 ) -> Discount:
     model = type.get_model()
@@ -832,6 +836,7 @@ async def create_discount(
         ends_at=ends_at,
         discount_products=[],
         max_redemptions=max_redemptions,
+        max_redemptions_per_customer=max_redemptions_per_customer,
         redemptions_count=0,
     )
     if isinstance(custom_field, DiscountFixed):
@@ -847,6 +852,22 @@ async def create_discount(
 
     await save_fixture(custom_field)
     return custom_field
+
+
+async def create_discount_redemption(
+    save_fixture: SaveFixture,
+    *,
+    discount: Discount,
+    checkout: Checkout | None = None,
+    subscription: Subscription | None = None,
+) -> DiscountRedemption:
+    discount_redemption = DiscountRedemption(
+        discount=discount,
+        checkout=checkout,
+        subscription=subscription,
+    )
+    await save_fixture(discount_redemption)
+    return discount_redemption
 
 
 @pytest_asyncio.fixture


### PR DESCRIPTION
## Summary

Adds `max_redemptions_per_customer`, so a code can be shared publicly with unlimited total uses but capped per buyer.

Dashboard field and docs follow in the next PR; until then the limit is API-only.

Closes polarsource/feedback#86. Replaces #13328, rebuilt on main with a clean history.

Builds on @pieterbeulque's #11993 — the schemas, service logic, error class and most tests come from there. The column shipped in #13322.

## How it works

Identity reuses the trial-abuse signals: customer ID, unaliased email, card fingerprint, OR-matched. The check runs before the Stripe intent is created, so a rejected buyer is never charged. Applying an exhausted code is rejected at apply time too, rather than after the payment form.

The card fingerprint is an extra signal, not a requirement. Free products and 100%-forever subscriptions never produce a confirmation token, so the check falls back to customer ID and email.

A redemption stops counting once all its orders are fully refunded, so a refunded buyer gets their slot back. Refunds issued to head off a chargeback are the exception: they keep the slot, since buy-refund-repeat is the loop this limit exists to close. A lost dispute never marks the order refunded, so it was never in scope. The global `max_redemptions` budget is unaffected either way: the code was still handed out.

Redemptions from a discount applied to an existing subscription count toward the limit, but merchants applying one are not blocked.

## Commits

1. `refactor(checkout): fetch the confirmation token once` — no behavior change.
2. `fix(discount): only lock the discount row when it has a global cap` — predates this work. An uncapped code made concurrent buyers fail each other.
3. `feat(discount): add max_redemptions_per_customer to the API`
4. `feat(discount): count redemptions per customer` — including the refund and chargeback rules.
5. `feat(checkout): enforce the per-customer discount limit` — takes a customer-row lock, so a per-customer code serializes per buyer instead of per code.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included
