### PR TITLE
fix(checkout): reset payment form fields on confirm

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -940,13 +940,7 @@ class CheckoutService:
         except TaxCalculationLogicalError:
             pass
 
-        # Reset payment form fields if it's no longer required
-        # This handles the case where a 100% discount is applied and the
-        # payment and billing address sections disappear from the frontend
-        if not checkout.is_payment_form_required:
-            checkout.payment_method_type = None
-            if not checkout.require_billing_address:
-                checkout.is_business_customer = False
+        self._reset_payment_form_fields(checkout)
 
         await self._after_checkout_updated(session, checkout)
         return checkout
@@ -1015,6 +1009,8 @@ class CheckoutService:
                     "input": None,
                 }
             )
+
+        self._reset_payment_form_fields(checkout)
 
         # Case where the price was archived after the checkout was created
         if has_product_checkout(checkout) and checkout.product_price.is_archived:
@@ -2242,6 +2238,15 @@ class CheckoutService:
         await self._validate_subscription_uniqueness(session, checkout)
 
         return checkout
+
+    def _reset_payment_form_fields(self, checkout: Checkout) -> None:
+        # Reset payment form fields if it's no longer required
+        # This handles the case where a 100% discount is applied and the
+        # payment and billing address sections disappear from the frontend
+        if not checkout.is_payment_form_required:
+            checkout.payment_method_type = None
+            if not checkout.require_billing_address:
+                checkout.is_business_customer = False
 
     async def _update_price(
         self,

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -940,7 +940,7 @@ class CheckoutService:
         except TaxCalculationLogicalError:
             pass
 
-        self._reset_payment_form_fields(checkout)
+        self._reset_payment_form_fields_if_needed(checkout)
 
         await self._after_checkout_updated(session, checkout)
         return checkout
@@ -1010,7 +1010,7 @@ class CheckoutService:
                 }
             )
 
-        self._reset_payment_form_fields(checkout)
+        self._reset_payment_form_fields_if_needed(checkout)
 
         # Case where the price was archived after the checkout was created
         if has_product_checkout(checkout) and checkout.product_price.is_archived:
@@ -2239,7 +2239,7 @@ class CheckoutService:
 
         return checkout
 
-    def _reset_payment_form_fields(self, checkout: Checkout) -> None:
+    def _reset_payment_form_fields_if_needed(self, checkout: Checkout) -> None:
         # Reset payment form fields if it's no longer required
         # This handles the case where a 100% discount is applied and the
         # payment and billing address sections disappear from the frontend

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -4933,6 +4933,86 @@ class TestConfirm:
         assert len(updated_discount.discount_redemptions) == 1
         assert updated_discount.discount_redemptions[0].checkout_id == checkout.id
 
+    async def test_full_discount_resets_payment_method(
+        self,
+        save_fixture: SaveFixture,
+        stripe_service_mock: MagicMock,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Anonymous],
+        checkout_one_time_fixed: Checkout,
+        discount_percentage_100: Discount,
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.checkout.service.enqueue_job")
+
+        checkout_one_time_fixed.payment_method_type = "upi"
+        await save_fixture(checkout_one_time_fixed)
+
+        assert checkout_one_time_fixed.is_billing_address_required is True
+
+        stripe_service_mock.create_customer.return_value = SimpleNamespace(
+            id="STRIPE_CUSTOMER_ID"
+        )
+
+        checkout = await checkout_service.confirm(
+            session,
+            auth_subject,
+            checkout_one_time_fixed,
+            CheckoutConfirmStripe.model_validate(
+                {
+                    "customer_name": "Customer Name",
+                    "customer_email": "customer@example.com",
+                    "customer_billing_address": {"country": "IN"},
+                    "discount_code": discount_percentage_100.code,
+                }
+            ),
+        )
+
+        assert checkout.status == CheckoutStatus.confirmed
+        assert checkout.is_payment_form_required is False
+        assert checkout.payment_method_type is None
+        assert checkout.is_billing_address_required is False
+
+        stripe_service_mock.create_payment_intent.assert_not_called()
+        enqueue_job_mock.assert_called_once_with(
+            "checkout.handle_free_success", checkout_id=checkout.id
+        )
+
+    async def test_full_discount_resets_is_business_customer(
+        self,
+        save_fixture: SaveFixture,
+        stripe_service_mock: MagicMock,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        auth_subject: AuthSubject[Anonymous],
+        checkout_one_time_fixed: Checkout,
+        discount_percentage_100: Discount,
+    ) -> None:
+        mocker.patch("polar.checkout.service.enqueue_job")
+
+        checkout_one_time_fixed.is_business_customer = True
+        await save_fixture(checkout_one_time_fixed)
+
+        stripe_service_mock.create_customer.return_value = SimpleNamespace(
+            id="STRIPE_CUSTOMER_ID"
+        )
+
+        checkout = await checkout_service.confirm(
+            session,
+            auth_subject,
+            checkout_one_time_fixed,
+            CheckoutConfirmStripe.model_validate(
+                {
+                    "customer_name": "Customer Name",
+                    "customer_email": "customer@example.com",
+                    "discount_code": discount_percentage_100.code,
+                }
+            ),
+        )
+
+        assert checkout.status == CheckoutStatus.confirmed
+        assert checkout.is_business_customer is False
+
     async def test_valid_custom_pricing_discount(
         self,
         stripe_service_mock: MagicMock,


### PR DESCRIPTION
## Summary

**Related Issue**: https://github.com/polarsource/feedback/issues/312

A checkout that becomes free during confirmation was still validated as if it needed a payment form, blocking the customer with a "Full billing address is required." error. This rarely would happen since applying a discount in checkout uses the _update_. Still worth fixing.

## What

Extract the payment-form reset that `update()` already performed into a shared helper and run it on confirm too. Adds two confirm tests.

## Why

When a 100% discount makes a checkout free, the payment and billing address sections drop out of the form. `update()` handled that; `confirm()` didn't. So when the discount is applied for the first time in the confirm request, confirm validates against a payment method and business-customer flag the customer can no longer see or change, and rejects a checkout that needs neither.

## How

The reset runs after the tax pass on both paths, so the discount is applied and the checkout's final state is what confirm validates against. Both new tests fail on `main` and pass here.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787758428&installation_model_id=13063&pr_number=13395&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13395&signature=72354b751ffe11506bc9d60659db5d6cfd7801e5cd157875e796129fdf37d4dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

