### PR TITLE
Add "Preview access" to seed script

### DIFF
--- a/server/scripts/seed_polar_for_polar.py
+++ b/server/scripts/seed_polar_for_polar.py
@@ -96,6 +96,12 @@ BENEFITS: list[dict[str, object]] = [
         },
     },
     {
+        "description": "Preview access to new features",
+        "metadata": {
+            "type": "preview_access",
+        },
+    },
+    {
         "description": "Single Sign-On",
         "metadata": {
             "type": "sso",
@@ -112,9 +118,13 @@ PRODUCTS: list[dict[str, object]] = [
             "custom": False,
             "order": 2,
             "description": "For entrepreneurs & early teams.",
-            "features": "All features on Free, Prioritized Support",
+            "features": "All features on Free, Preview access to new features, Prioritized Support",
         },
-        "benefits": ["Transaction Fee (Tier 2)", "Support (Tier 2)"],
+        "benefits": [
+            "Transaction Fee (Tier 2)",
+            "Support (Tier 2)",
+            "Preview access to new features",
+        ],
     },
     {
         "name": "Growth",
@@ -127,7 +137,11 @@ PRODUCTS: list[dict[str, object]] = [
             "description": "For scaling startups.",
             "features": "All features on Pro, Prioritized Support",
         },
-        "benefits": ["Transaction Fee (Tier 3)", "Support (Tier 3)"],
+        "benefits": [
+            "Transaction Fee (Tier 3)",
+            "Support (Tier 3)",
+            "Preview access to new features",
+        ],
     },
     {
         "name": "Scale",
@@ -142,6 +156,7 @@ PRODUCTS: list[dict[str, object]] = [
         "benefits": [
             "Transaction Fee (Tier 4)",
             "Support (Tier 4)",
+            "Preview access to new features",
             "Single Sign-On",
         ],
     },


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787816405&installation_model_id=13063&pr_number=13396&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13396&signature=5f2fa8e59791973dbdf3bde1955da3aa64deabcf316f9f0a8b648b36dcff2fe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add “Preview access to new features” to the seed data so paid plans show early access benefits. Adds a new feature entry with metadata type "preview_access" and includes it in Pro, Growth, and Scale features/benefits.

<sup>Written for commit addb19d93e384153c7ee550eb97e6f03295edbd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

