### PR TITLE
fix(subscriptions): display bugs found migrating the customer portal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,9 @@ dev snap --branch my-feature        # test a specific branch
 dev snap --detect                   # auto-detect URLs from git diff
 ```
 
+The customer portal authenticates with a session token rather than the dashboard login, so
+`dev snap` can't reach it on its own. Get its URLs from `dev portal-urls --snap` first.
+
 See `server/AGENTS.md` for backend command and testing specifics.
 
 ## Conventions

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -402,7 +402,22 @@ The tool:
 2. Checks out the base branch and screenshots again
 3. Generates a visual diff report with pixel-level comparison
 
-Results are saved to `dev/snap-runs/<timestamp>/result/` with an HTML report for side-by-side comparison.
+Results are saved to `screenshots/runs/<timestamp>/result/` with an HTML report for side-by-side comparison.
+
+### Snapping the customer portal
+
+`dev snap` logs into the dashboard, but the customer portal authenticates with a
+`?customer_session_token=` query parameter instead. `dev portal-urls` mints a session over
+the seeded data so a portal run needs no interaction:
+
+```sh
+dev portal-urls                     # Print every portal URL with a fresh token
+dev portal-urls --snap              # Print them as a ready-to-run `dev snap` command
+dev portal-urls --org my-org        # Pick a customer from another seeded org
+```
+
+The session lasts 24 hours by default (`--ttl-hours`), because `dev snap` captures both
+branches against one set of URLs and the token has to outlive the whole run.
 
 ## Login using email
 

--- a/clients/apps/web/src/components/CustomerPortal/OrderPaymentRetry.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/OrderPaymentRetry.tsx
@@ -5,6 +5,7 @@ import {
   useCustomerOrderPaymentStatus,
 } from '@/hooks/queries/customerPortal'
 import { type Client, schemas } from '@polar-sh/client'
+import { formatCurrency } from '@polar-sh/currency'
 import { Button } from '@polar-sh/orbit'
 import { PaymentElement } from '@stripe/react-stripe-js'
 import {
@@ -383,8 +384,7 @@ export const OrderPaymentRetry = ({
           <div className="flex justify-between">
             <span>Amount:</span>
             <span>
-              ${(order.total_amount / 100).toFixed(2)}{' '}
-              {order.currency.toUpperCase()}
+              {formatCurrency('accounting')(order.total_amount, order.currency)}
             </span>
           </div>
         </div>

--- a/clients/apps/web/src/components/Subscriptions/SubscriptionActionsMenu.tsx
+++ b/clients/apps/web/src/components/Subscriptions/SubscriptionActionsMenu.tsx
@@ -124,7 +124,7 @@ const SubscriptionActionsMenu = ({
                 Cancel Subscription
               </DropdownMenuItem>
             ))}
-          {subscription.status === 'paused' ? (
+          {subscription.ended_at ? null : subscription.status === 'paused' ? (
             <DropdownMenuItem
               onClick={handleResume}
               disabled={resumeSubscription.isPending}

--- a/clients/apps/web/src/components/Subscriptions/SubscriptionDetailsGrid.tsx
+++ b/clients/apps/web/src/components/Subscriptions/SubscriptionDetailsGrid.tsx
@@ -56,6 +56,9 @@ export const SubscriptionDetailsGrid = ({
 }) => {
   const productName = product?.name ?? subscription.product.name
 
+  const trialEndDatetime =
+    subscription.status === 'trialing' ? subscription.trial_end : null
+
   let nextEventDatetime: string | undefined
   let cancellationDate: string | undefined
   if (subscription.ended_at) {
@@ -68,6 +71,12 @@ export const SubscriptionDetailsGrid = ({
     subscription.current_period_end
   ) {
     nextEventDatetime = subscription.current_period_end
+  }
+
+  // While trialing the API holds `trial_end` and the next event on the same
+  // date, so the cell below would repeat the trial cell under another label.
+  if (nextEventDatetime === trialEndDatetime) {
+    nextEventDatetime = undefined
   }
 
   const cancellationReason = subscription.customer_cancellation_reason
@@ -117,12 +126,12 @@ export const SubscriptionDetailsGrid = ({
             </Text>
           }
         />
-        {subscription.status === 'trialing' && subscription.trial_end && (
+        {trialEndDatetime && (
           <DetailCell
             label="Trial ends"
             value={
               <Text variant="body" as="span">
-                <FormattedDateTime datetime={subscription.trial_end} />
+                <FormattedDateTime datetime={trialEndDatetime} />
               </Text>
             }
           />

--- a/clients/apps/web/src/components/Subscriptions/SubscriptionInvoicePreview.tsx
+++ b/clients/apps/web/src/components/Subscriptions/SubscriptionInvoicePreview.tsx
@@ -23,14 +23,22 @@ const SubscriptionInvoicePreview = ({
   const isActive = subscription.status === 'active'
   const isPaused = subscription.status === 'paused'
 
+  const isCancelingAtPeriodEnd =
+    subscription.cancel_at_period_end && !subscription.ended_at
+
+  const isPausing = subscription.pause_at_period_end || isPaused
+  const isResumingCharge =
+    isPausing && subscription.resumes_at !== null && !isCancelingAtPeriodEnd
+  const isPausingIndefinitely = isPausing && !subscription.resumes_at
+
+  // The query and the render below share one gate: a narrower `enabled` leaves
+  // states that render the preview without ever fetching it.
+  const showsCharge =
+    (isActive || isTrialing || isResumingCharge) && !isPausingIndefinitely
+
   const { data: chargePreview } = useSubscriptionChargePreview(
     subscription.id,
-    {
-      enabled:
-        isActive ||
-        isTrialing ||
-        (isPaused && subscription.resumes_at !== null),
-    },
+    { enabled: showsCharge },
   )
 
   const productId = useMemo(
@@ -44,26 +52,11 @@ const SubscriptionInvoicePreview = ({
     [subscription],
   )
 
-  const isCancelingAtPeriodEnd =
-    subscription.cancel_at_period_end && !subscription.ended_at
-
   const isFreeProduct = subscription.prices.some(isFreePrice)
   const hasMeters = subscription.meters.length > 0
   const hasNextInvoice = !isFreeProduct || hasMeters
 
-  const isResumingCharge =
-    (subscription.pause_at_period_end || isPaused) &&
-    subscription.resumes_at !== null &&
-    !isCancelingAtPeriodEnd
-  const isPausingIndefinitely =
-    (subscription.pause_at_period_end || isPaused) && !subscription.resumes_at
-
-  if (
-    (!isActive && !isTrialing && !isResumingCharge) ||
-    isPausingIndefinitely ||
-    !hasNextInvoice ||
-    !chargePreview
-  ) {
+  if (!showsCharge || !hasNextInvoice || !chargePreview) {
     return null
   }
 

--- a/dev/cli/commands/portal_urls.py
+++ b/dev/cli/commands/portal_urls.py
@@ -1,0 +1,98 @@
+"""Print authenticated customer portal URLs, ready to paste into `dev snap`.
+
+The portal sits behind `?customer_session_token=`, and `dev snap` only knows how to
+log into `/dashboard`. This mints a session against the seeded data instead, so a
+snap run needs no interaction.
+"""
+
+from typing import Annotated
+
+import typer
+
+from shared import DEFAULT_WEB_PORT, SERVER_DIR, console, run_command
+
+WEB_BASE_URL = f"http://127.0.0.1:{DEFAULT_WEB_PORT}"
+
+
+def _portal_paths(seed: dict[str, str]) -> list[str]:
+    """Every portal route, in navigation order. Routes behind an id are skipped
+    when the seed has nothing to point them at."""
+    subscription_id = seed.get("SUBSCRIPTION_ID")
+    order_id = seed.get("ORDER_ID")
+    return [
+        "/portal/overview",
+        *([f"/portal/subscriptions/{subscription_id}"] if subscription_id else []),
+        "/portal/orders",
+        *([f"/portal/orders/{order_id}"] if order_id else []),
+        "/portal/settings",
+        "/portal/usage",
+        "/portal/wallet",
+    ]
+
+
+def register(app: typer.Typer, prompt_setup: callable) -> None:
+    @app.command(name="portal-urls")
+    def portal_urls(
+        org: Annotated[
+            str,
+            typer.Option("--org", help="Organization slug to pick a customer from"),
+        ] = "acme-corp",
+        ttl_hours: Annotated[
+            int,
+            typer.Option("--ttl-hours", help="Session lifetime", min=1),
+        ] = 24,
+        snap: Annotated[
+            bool,
+            typer.Option("--snap", help="Print a ready-to-run `dev snap` command"),
+        ] = False,
+    ) -> None:
+        """Print customer portal URLs with a fresh session token."""
+        result = run_command(
+            [
+                "uv",
+                "run",
+                "python",
+                "-m",
+                "scripts.seeds_load",
+                "customer-portal-session",
+                "--org",
+                org,
+                "--ttl-hours",
+                str(ttl_hours),
+            ],
+            cwd=SERVER_DIR,
+            capture=True,
+        )
+        if not result or result.returncode != 0:
+            console.print("[red]Could not mint a customer session.[/red]")
+            output = (
+                getattr(result, "stderr", "") or getattr(result, "stdout", "") or ""
+            ).strip()
+            if output:
+                console.print(f"[dim]{output}[/dim]")
+            raise typer.Exit(1)
+
+        seed = dict(
+            line.strip().split("=", 1)
+            for line in result.stdout.split("\n")
+            if "=" in line
+        )
+        token = seed.get("CUSTOMER_SESSION_TOKEN")
+        slug = seed.get("ORGANIZATION_SLUG")
+        if not token or not slug:
+            console.print("[red]Seed output missing a session token.[/red]")
+            raise typer.Exit(1)
+
+        urls = [
+            f"{WEB_BASE_URL}/{slug}{path}?customer_session_token={token}"
+            for path in _portal_paths(seed)
+        ]
+
+        console.print()
+        if snap:
+            command = f"dev snap --url '{','.join(urls)}' --viewport desktop,mobile"
+            console.print(command, soft_wrap=True)
+        else:
+            for url in urls:
+                console.print(url, soft_wrap=True)
+        console.print()

--- a/server/scripts/seeds_load.py
+++ b/server/scripts/seeds_load.py
@@ -33,6 +33,7 @@ from polar.customer.schemas.customer import (
     CustomerTeamCreate,
 )
 from polar.customer.service import customer as customer_service
+from polar.customer_session.service import CUSTOMER_SESSION_TOKEN_PREFIX
 from polar.discount.schemas import DiscountPercentageCreate
 from polar.discount.service import discount as discount_service
 from polar.dispute.dispute_case import dispute_case as dispute_case_service
@@ -63,10 +64,12 @@ from polar.models.checkout import Checkout, CheckoutStatus
 from polar.models.checkout_product import CheckoutProduct
 from polar.models.customer import Customer
 from polar.models.customer_seat import CustomerSeat, SeatStatus
+from polar.models.customer_session import CustomerSession
 from polar.models.discount import DiscountDuration, DiscountType
 from polar.models.event import Event as EventModel
 from polar.models.file import File, FileServiceTypes
 from polar.models.member import Member, MemberRole
+from polar.models.order import Order
 from polar.models.organization import (
     Organization,
     OrganizationCustomerEmailSettings,
@@ -2843,6 +2846,99 @@ def polar_self_env() -> None:
             print(f"POLAR_POLAR_ACCESS_TOKEN={token}")
             print(f"{WEBHOOK_SECRET_ENV_KEY}={webhook_secret}")
             print("POLAR_POLAR_API_URL=http://127.0.0.1:8000")
+
+        await engine.dispose()
+
+    asyncio.run(run())
+
+
+@cli.command(name="customer-portal-session")
+def customer_portal_session(
+    org_slug: str = typer.Option(
+        "acme-corp",
+        "--org",
+        help="Organization slug to pick a customer from. The seed only gives "
+        "acme-corp real subscriptions.",
+    ),
+    ttl_hours: int = typer.Option(
+        24,
+        "--ttl-hours",
+        help="Session lifetime. The default outlives a `dev snap` run, "
+        "which captures both branches against one set of URLs.",
+        min=1,
+    ),
+) -> None:
+    """Mint a customer session over seeded data and output it for dev tooling."""
+
+    async def run() -> None:
+        engine = create_async_engine("script")
+        sessionmaker = create_async_sessionmaker(engine)
+        async with sessionmaker() as session:
+            subscription = (
+                await session.execute(
+                    select(Subscription)
+                    .join(Organization, Subscription.organization_id == Organization.id)
+                    .where(
+                        Organization.slug == org_slug,
+                        Subscription.status == SubscriptionStatus.active,
+                    )
+                    .options(joinedload(Subscription.customer))
+                    .order_by(Subscription.created_at)
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+            if subscription is None:
+                available = (
+                    (
+                        await session.execute(
+                            select(Organization.slug)
+                            .join(
+                                Subscription,
+                                Subscription.organization_id == Organization.id,
+                            )
+                            .where(Subscription.status == SubscriptionStatus.active)
+                            .distinct()
+                            .order_by(Organization.slug)
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+                print(f"No active subscription in '{org_slug}'.")
+                if available:
+                    print(f"Try --org {' or --org '.join(available)}.")
+                else:
+                    print("No organization has one. Run `dev seed` first.")
+                raise typer.Exit(1)
+
+            customer = subscription.customer
+
+            order_id = (
+                await session.execute(
+                    select(Order.id)
+                    .where(Order.customer_id == customer.id)
+                    .order_by(Order.created_at.desc())
+                    .limit(1)
+                )
+            ).scalar_one_or_none()
+
+            token, token_hash = generate_token_hash_pair(
+                secret=settings.SECRET, prefix=CUSTOMER_SESSION_TOKEN_PREFIX
+            )
+            session.add(
+                CustomerSession(
+                    token=token_hash,
+                    customer_id=customer.id,
+                    expires_at=utc_now() + timedelta(hours=ttl_hours),
+                )
+            )
+            await session.commit()
+
+            print(f"ORGANIZATION_SLUG={org_slug}")
+            print(f"CUSTOMER_SESSION_TOKEN={token}")
+            print(f"SUBSCRIPTION_ID={subscription.id}")
+            if order_id:
+                print(f"ORDER_ID={order_id}")
 
         await engine.dispose()
 


### PR DESCRIPTION
## Summary

Extracted from #13371, which I'm closing. The Orbit migration there grew past what it was worth, and Pieter is right that the portal and the dashboard shouldn't share components. These four bugs and the snap tooling stand on their own.

## Bugs

- **Retried order shows the wrong currency.** `OrderPaymentRetry` hardcoded a dollar  sign, so a 50 EUR order read `$50.00 EUR`. Now `formatCurrency`.
- **Pause actions on an ended subscription.** Cancelling immediately sets `ended_at` without clearing `pause_at_period_end` (`subscription/service.py:2190`), so the merchant menu still offered "Cancel Scheduled Pause".
- **Charge preview renders nothing.** The query gate was narrower than the render gate.  A `past_due` subscription with a scheduled resume passed the render check, never fetched, and drew an empty section. Both now read one flag.
- **One date under two labels.** The API sets `trial_end` and `current_period_end` to the same value while trialing (`subscription/service.py:700`), so the merchant grid showed "Trial ends" and "Renewal date" on the same day.

## Dev tooling

`dev portal-urls` mints a customer session over the seeded data and prints the portal URLs. `dev snap` only knows how to log into `/dashboard`, so it could not reach the portal at all. `--snap` prints a ready-to-run command.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787819750&installation_model_id=13063&pr_number=13397&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13397&signature=3acc2a30d8330a2d5838936f7b45a617a031f19a3f67d5788f852342c6336e95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

