### PR TITLE
Allow backoffice to force re-review on organization

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OnboardingChecklistCard/OnboardingChecklistCard.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OnboardingChecklistCard/OnboardingChecklistCard.tsx
@@ -49,6 +49,8 @@ export const OnboardingChecklistCard = ({ organization }: Props) => {
   }
 
   const accountHref = `/dashboard/${organization.slug}/finance/account`
+  const isResubmission =
+    organization.onboarding_resubmission_requested_at !== null
 
   if (isLoading) {
     return null
@@ -58,7 +60,7 @@ export const OnboardingChecklistCard = ({ organization }: Props) => {
   const requiredSteps = steps.filter(isRequiredStep)
   const total = requiredSteps.length
 
-  if (canManageOrganization && total === 0) {
+  if (canManageOrganization && total === 0 && !isResubmission) {
     return null
   }
 
@@ -75,40 +77,42 @@ export const OnboardingChecklistCard = ({ organization }: Props) => {
 
   return (
     <>
-      <Box position="relative" marginTop="xl">
-        <button
-          type="button"
-          onClick={openAiSetup}
-          className="flex cursor-pointer focus:outline-none"
-        >
-          <Box
-            position="absolute"
-            top={-38}
-            left={12}
-            right={12}
-            display="flex"
-            paddingVertical="m"
-            paddingHorizontal="l"
-            borderTopLeftRadius="l"
-            borderTopRightRadius="l"
-            backgroundColor="background-card"
+      <Box position="relative" marginTop={isResubmission ? 'none' : 'xl'}>
+        {!isResubmission ? (
+          <button
+            type="button"
+            onClick={openAiSetup}
+            className="flex cursor-pointer focus:outline-none"
           >
             <Box
-              flexDirection="row"
-              alignItems="center"
-              columnGap="xs"
-              color={{ base: 'text-secondary', hover: 'text-primary' }}
-              transitionProperty="colors"
-              transitionDuration="fast"
+              position="absolute"
+              top={-38}
+              left={12}
+              right={12}
+              display="flex"
+              paddingVertical="m"
+              paddingHorizontal="l"
+              borderTopLeftRadius="l"
+              borderTopRightRadius="l"
+              backgroundColor="background-card"
             >
-              <SparklesIcon size={14} />
-              <Text variant="caption" color="inherit">
-                Set up Polar with your coding agent
-              </Text>
-              <ChevronRight size={14} />
+              <Box
+                flexDirection="row"
+                alignItems="center"
+                columnGap="xs"
+                color={{ base: 'text-secondary', hover: 'text-primary' }}
+                transitionProperty="colors"
+                transitionDuration="fast"
+              >
+                <SparklesIcon size={14} />
+                <Text variant="caption" color="inherit">
+                  Set up Polar with your coding agent
+                </Text>
+                <ChevronRight size={14} />
+              </Box>
             </Box>
-          </Box>
-        </button>
+          </button>
+        ) : null}
         <Box
           position="relative"
           display="grid"
@@ -131,19 +135,25 @@ export const OnboardingChecklistCard = ({ organization }: Props) => {
               <Box alignItems="center" columnGap="m">
                 <RocketIcon className="h-4 w-4 shrink-0" />
                 <Text variant="title">
-                  {canManageOrganization
-                    ? 'Finish setting up your account'
-                    : 'Account setup in progress'}
+                  {isResubmission
+                    ? canManageOrganization
+                      ? 'Review your organization information'
+                      : 'Onboarding requirements changed'
+                    : canManageOrganization
+                      ? 'Finish setting up your account'
+                      : 'Account setup in progress'}
                 </Text>
               </Box>
               <Text color="muted">
-                Set up your products and integrate into your app. Test the full
-                flow with 100% discount codes. When you&rsquo;re ready, go live
-                to start accepting payments from your customers.
+                {isResubmission
+                  ? canManageOrganization
+                    ? 'Since your last visit, our onboarding requirements have changed. Please review and resubmit your organization information to continue using Polar.'
+                    : 'Since your last visit, our onboarding requirements have changed. An admin needs to review and resubmit the organization information.'
+                  : 'Set up your products and integrate into your app. Test the full flow with 100% discount codes. When you’re ready, go live to start accepting payments from your customers.'}
               </Text>
             </Box>
 
-            {canManageOrganization ? (
+            {canManageOrganization && total > 0 ? (
               <Box flexDirection="column" rowGap="s">
                 <Text color="muted">
                   {completed} of {total} required steps complete
@@ -182,11 +192,14 @@ export const OnboardingChecklistCard = ({ organization }: Props) => {
               {!canManageOrganization ? (
                 <>
                   <Text variant="title">
-                    Payments aren&rsquo;t enabled for your organization yet
+                    {isResubmission
+                      ? 'Organization review required'
+                      : 'Payments aren’t enabled for your organization yet'}
                   </Text>
                   <Text color="muted">
-                    An owner or admin needs to finish account setup before you
-                    can accept payments.
+                    {isResubmission
+                      ? 'An admin needs to review and resubmit the organization information before payments can be accepted.'
+                      : 'An admin needs to finish account setup before payments can be accepted.'}
                   </Text>
                 </>
               ) : nextLabel ? (
@@ -216,7 +229,13 @@ export const OnboardingChecklistCard = ({ organization }: Props) => {
                 }}
               >
                 <Button>
-                  {canSubmit ? 'Review & submit' : 'Continue setup'}
+                  {isResubmission
+                    ? canSubmit
+                      ? 'Review & resubmit'
+                      : 'Review requirements'
+                    : canSubmit
+                      ? 'Review & submit'
+                      : 'Continue setup'}
                 </Button>
               </Link>
             ) : null}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OnboardingChecklistCard/OnboardingChecklistCard.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OnboardingChecklistCard/OnboardingChecklistCard.tsx
@@ -49,8 +49,6 @@ export const OnboardingChecklistCard = ({ organization }: Props) => {
   }
 
   const accountHref = `/dashboard/${organization.slug}/finance/account`
-  const isResubmission =
-    organization.onboarding_resubmission_requested_at !== null
 
   if (isLoading) {
     return null
@@ -60,7 +58,7 @@ export const OnboardingChecklistCard = ({ organization }: Props) => {
   const requiredSteps = steps.filter(isRequiredStep)
   const total = requiredSteps.length
 
-  if (canManageOrganization && total === 0 && !isResubmission) {
+  if (canManageOrganization && total === 0) {
     return null
   }
 
@@ -77,42 +75,40 @@ export const OnboardingChecklistCard = ({ organization }: Props) => {
 
   return (
     <>
-      <Box position="relative" marginTop={isResubmission ? 'none' : 'xl'}>
-        {!isResubmission ? (
-          <button
-            type="button"
-            onClick={openAiSetup}
-            className="flex cursor-pointer focus:outline-none"
+      <Box position="relative" marginTop="xl">
+        <button
+          type="button"
+          onClick={openAiSetup}
+          className="flex cursor-pointer focus:outline-none"
+        >
+          <Box
+            position="absolute"
+            top={-38}
+            left={12}
+            right={12}
+            display="flex"
+            paddingVertical="m"
+            paddingHorizontal="l"
+            borderTopLeftRadius="l"
+            borderTopRightRadius="l"
+            backgroundColor="background-card"
           >
             <Box
-              position="absolute"
-              top={-38}
-              left={12}
-              right={12}
-              display="flex"
-              paddingVertical="m"
-              paddingHorizontal="l"
-              borderTopLeftRadius="l"
-              borderTopRightRadius="l"
-              backgroundColor="background-card"
+              flexDirection="row"
+              alignItems="center"
+              columnGap="xs"
+              color={{ base: 'text-secondary', hover: 'text-primary' }}
+              transitionProperty="colors"
+              transitionDuration="fast"
             >
-              <Box
-                flexDirection="row"
-                alignItems="center"
-                columnGap="xs"
-                color={{ base: 'text-secondary', hover: 'text-primary' }}
-                transitionProperty="colors"
-                transitionDuration="fast"
-              >
-                <SparklesIcon size={14} />
-                <Text variant="caption" color="inherit">
-                  Set up Polar with your coding agent
-                </Text>
-                <ChevronRight size={14} />
-              </Box>
+              <SparklesIcon size={14} />
+              <Text variant="caption" color="inherit">
+                Set up Polar with your coding agent
+              </Text>
+              <ChevronRight size={14} />
             </Box>
-          </button>
-        ) : null}
+          </Box>
+        </button>
         <Box
           position="relative"
           display="grid"
@@ -135,25 +131,19 @@ export const OnboardingChecklistCard = ({ organization }: Props) => {
               <Box alignItems="center" columnGap="m">
                 <RocketIcon className="h-4 w-4 shrink-0" />
                 <Text variant="title">
-                  {isResubmission
-                    ? canManageOrganization
-                      ? 'Review your organization information'
-                      : 'Onboarding requirements changed'
-                    : canManageOrganization
-                      ? 'Finish setting up your account'
-                      : 'Account setup in progress'}
+                  {canManageOrganization
+                    ? 'Finish setting up your account'
+                    : 'Account setup in progress'}
                 </Text>
               </Box>
               <Text color="muted">
-                {isResubmission
-                  ? canManageOrganization
-                    ? 'Since your last visit, our onboarding requirements have changed. Please review and resubmit your organization information to continue using Polar.'
-                    : 'Since your last visit, our onboarding requirements have changed. An admin needs to review and resubmit the organization information.'
-                  : 'Set up your products and integrate into your app. Test the full flow with 100% discount codes. When you’re ready, go live to start accepting payments from your customers.'}
+                Set up your products and integrate into your app. Test the full
+                flow with 100% discount codes. When you&rsquo;re ready, go live
+                to start accepting payments from your customers.
               </Text>
             </Box>
 
-            {canManageOrganization && total > 0 ? (
+            {canManageOrganization ? (
               <Box flexDirection="column" rowGap="s">
                 <Text color="muted">
                   {completed} of {total} required steps complete
@@ -192,14 +182,11 @@ export const OnboardingChecklistCard = ({ organization }: Props) => {
               {!canManageOrganization ? (
                 <>
                   <Text variant="title">
-                    {isResubmission
-                      ? 'Organization review required'
-                      : 'Payments aren’t enabled for your organization yet'}
+                    Payments aren&rsquo;t enabled for your organization yet
                   </Text>
                   <Text color="muted">
-                    {isResubmission
-                      ? 'An admin needs to review and resubmit the organization information before payments can be accepted.'
-                      : 'An admin needs to finish account setup before payments can be accepted.'}
+                    An owner or admin needs to finish account setup before you
+                    can accept payments.
                   </Text>
                 </>
               ) : nextLabel ? (
@@ -229,13 +216,7 @@ export const OnboardingChecklistCard = ({ organization }: Props) => {
                 }}
               >
                 <Button>
-                  {isResubmission
-                    ? canSubmit
-                      ? 'Review & resubmit'
-                      : 'Review requirements'
-                    : canSubmit
-                      ? 'Review & submit'
-                      : 'Continue setup'}
+                  {canSubmit ? 'Review & submit' : 'Continue setup'}
                 </Button>
               </Link>
             ) : null}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OrganizationStatusBanner.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/OrganizationStatusBanner.tsx
@@ -5,6 +5,7 @@ import { DeniedBanner } from './DeniedBanner'
 import { OffboardedBanner } from './OffboardedBanner'
 import { OffboardingBanner } from './OffboardingBanner'
 import { OnboardingChecklistCard } from './OnboardingChecklistCard/OnboardingChecklistCard'
+import { ResubmissionBanner } from './ResubmissionBanner'
 
 interface OrganizationStatusBannerProps {
   organization: schemas['Organization']
@@ -34,6 +35,10 @@ export const OrganizationStatusBanner = ({
   }
 
   if (paymentStatus?.organization_status === 'created') {
+    if (organization.onboarding_resubmission_requested_at) {
+      return <ResubmissionBanner organization={organization} />
+    }
+
     return <OnboardingChecklistCard organization={organization} />
   }
 

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/ResubmissionBanner.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/ResubmissionBanner.tsx
@@ -1,0 +1,53 @@
+import { useHasPermission } from '@/hooks/permissions'
+import { schemas } from '@polar-sh/client'
+import { Button, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { ClipboardCheckIcon } from 'lucide-react'
+import Link from 'next/link'
+
+interface ResubmissionBannerProps {
+  organization: schemas['Organization']
+}
+
+export const ResubmissionBanner = ({
+  organization,
+}: ResubmissionBannerProps) => {
+  const canManageOrganization = useHasPermission(
+    organization.id,
+    'organization:manage',
+  )
+
+  return (
+    <Box
+      flexDirection={{ base: 'column', md: 'row' }}
+      justifyContent="between"
+      gap="l"
+      borderRadius="l"
+      backgroundColor="background-card"
+      padding={{ base: 'l', md: 'xl' }}
+    >
+      <Box flexDirection="column" rowGap="s">
+        <Box alignItems="center" columnGap="s">
+          <ClipboardCheckIcon className="h-4 w-4 shrink-0" />
+          <Text variant="title">Review your organization information</Text>
+        </Box>
+        <Box maxWidth={720} flexDirection="column" rowGap="xs">
+          <Text color="muted">
+            Since your last visit, our onboarding requirements have changed.
+            {canManageOrganization
+              ? ' Please review and resubmit your organization information to continue using Polar.'
+              : ' An admin needs to review and resubmit the organization information to continue using Polar.'}
+          </Text>
+          <Text color="muted">
+            Payments are unavailable until your organization is approved again.
+          </Text>
+        </Box>
+      </Box>
+      {canManageOrganization ? (
+        <Link href={`/dashboard/${organization.slug}/finance/account`}>
+          <Button>Review &amp; resubmit</Button>
+        </Link>
+      ) : null}
+    </Box>
+  )
+}

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -25579,6 +25579,11 @@ export interface components {
        */
       details_submitted_at: string | null
       /**
+       * Onboarding Resubmission Requested At
+       * @description When Polar requested that the organization review and resubmit its onboarding information, if applicable.
+       */
+      onboarding_resubmission_requested_at: string | null
+      /**
        * Sso Enforced
        * @description Whether members must access this organization through its SSO connection.
        */
@@ -26813,6 +26818,11 @@ export interface components {
        * @description When the business details were submitted for review.
        */
       details_submitted_at: string | null
+      /**
+       * Onboarding Resubmission Requested At
+       * @description When Polar requested that the organization review and resubmit its onboarding information, if applicable.
+       */
+      onboarding_resubmission_requested_at: string | null
       /**
        * Sso Enforced
        * @description Whether members must access this organization through its SSO connection.
@@ -28213,6 +28223,11 @@ export interface components {
        * @description When the business details were submitted for review.
        */
       details_submitted_at: string | null
+      /**
+       * Onboarding Resubmission Requested At
+       * @description When Polar requested that the organization review and resubmit its onboarding information, if applicable.
+       */
+      onboarding_resubmission_requested_at: string | null
       /**
        * Sso Enforced
        * @description Whether members must access this organization through its SSO connection.

--- a/server/emails/src/types/openapi.ts
+++ b/server/emails/src/types/openapi.ts
@@ -1628,6 +1628,11 @@ export interface components {
        */
       details_submitted_at: string | null
       /**
+       * Onboarding Resubmission Requested At
+       * @description When Polar requested that the organization review and resubmit its onboarding information, if applicable.
+       */
+      onboarding_resubmission_requested_at: string | null
+      /**
        * Sso Enforced
        * @description Whether members must access this organization through its SSO connection.
        */

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -2381,6 +2381,11 @@ async def reset_onboarding_dialog(
                             "the organization is approved again"
                         )
                     with tag.li():
+                        text(
+                            "Cancel pending-review payouts and return their reserved "
+                            "funds to the organization's balance"
+                        )
+                    with tag.li():
                         text("Retire the current review so the AI review runs again")
                     with tag.li():
                         text(

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -2327,6 +2327,91 @@ async def block_dialog(
 
 
 @router.api_route(
+    "/{organization_id}/reset-onboarding-dialog",
+    name="organizations:reset_onboarding_dialog",
+    methods=["GET", "POST"],
+    response_model=None,
+)
+async def reset_onboarding_dialog(
+    request: Request,
+    organization_id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+    user_session: UserSession = Depends(get_admin),
+) -> HXRedirectResponse | None:
+    repository = OrganizationRepository.from_session(session)
+    organization = await repository.get_by_id(organization_id, include_blocked=True)
+    if organization is None:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    if request.method == "POST":
+        await organization_service.reset_onboarding_for_review(
+            session,
+            organization,
+            reset_by=user_session.user.email,
+        )
+        await add_toast(
+            request,
+            "Organization onboarding reset. They must review and resubmit their information.",
+            "success",
+        )
+        return HXRedirectResponse(
+            request,
+            str(
+                request.url_for("organizations:detail", organization_id=organization_id)
+            ),
+            303,
+        )
+
+    with modal("Reset Onboarding", open=True):
+        with tag.div(classes="flex flex-col gap-4"):
+            with tag.p(classes="font-semibold text-warning"):
+                text("Require a new onboarding review")
+
+            with tag.div(
+                classes="bg-warning/10 border border-warning/20 p-4 rounded-lg"
+            ):
+                with tag.p(classes="font-semibold mb-2"):
+                    text("This action will:")
+                with tag.ul(classes="list-disc list-inside space-y-1 text-sm"):
+                    with tag.li():
+                        text("Change the organization status to Created")
+                    with tag.li():
+                        text(
+                            "Disable payments, renewals, payouts, and refunds until "
+                            "the organization is approved again"
+                        )
+                    with tag.li():
+                        text("Retire the current review so the AI review runs again")
+                    with tag.li():
+                        text(
+                            "Keep the existing organization information available "
+                            "for the owner or admin to review and resubmit"
+                        )
+                    with tag.li():
+                        text(
+                            "Show the organization an onboarding requirements "
+                            "changed notice in the dashboard"
+                        )
+
+            with tag.div(classes="modal-action pt-6 border-t border-base-200"):
+                with tag.form(method="dialog"):
+                    with button(ghost=True):
+                        text("Cancel")
+                with tag.form(
+                    hx_post=str(
+                        request.url_for(
+                            "organizations:reset_onboarding_dialog",
+                            organization_id=organization_id,
+                        )
+                    ),
+                ):
+                    with button(variant="warning", type="submit"):
+                        text("Reset Onboarding")
+
+    return None
+
+
+@router.api_route(
     "/{organization_id}/under-review-dialog",
     name="organizations:under_review_dialog",
     methods=["GET", "POST"],

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -2344,11 +2344,15 @@ async def reset_onboarding_dialog(
         raise HTTPException(status_code=404, detail="Organization not found")
 
     if request.method == "POST":
-        await organization_service.reset_onboarding_for_review(
-            session,
-            organization,
-            reset_by=user_session.user.email,
-        )
+        try:
+            await organization_service.reset_onboarding_for_review(
+                session,
+                organization,
+                reset_by=user_session.user.email,
+            )
+        except OrganizationError as e:
+            await add_toast(request, e.message, "error")
+            return None
         await add_toast(
             request,
             "Organization onboarding reset. They must review and resubmit their information.",

--- a/server/polar/backoffice/organizations_v2/views/detail_view.py
+++ b/server/polar/backoffice/organizations_v2/views/detail_view.py
@@ -765,6 +765,26 @@ class OrganizationDetailView:
                                     "withdraw their remaining balance."
                                 )
 
+                    if self.org.status in {
+                        OrganizationStatus.ACTIVE,
+                        OrganizationStatus.REVIEW,
+                        OrganizationStatus.SNOOZED,
+                    }:
+                        with tag.div(classes="w-full"):
+                            with button(
+                                variant="warning",
+                                size="sm",
+                                outline=True,
+                                hx_get=str(
+                                    request.url_for(
+                                        "organizations:reset_onboarding_dialog",
+                                        organization_id=self.org.id,
+                                    )
+                                ),
+                                hx_target="#modal",
+                            ):
+                                text("Reset Onboarding")
+
                     # Always available actions
                     with tag.div(classes="divider my-2"):
                         pass

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -442,6 +442,12 @@ class Organization(OrganizationBase):
     details_submitted_at: datetime | None = Field(
         description="When the business details were submitted for review.",
     )
+    onboarding_resubmission_requested_at: datetime | None = Field(
+        description=(
+            "When Polar requested that the organization review and resubmit "
+            "its onboarding information, if applicable."
+        ),
+    )
     sso_enforced: bool = Field(
         description=(
             "Whether members must access this organization through its SSO connection."

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -621,12 +621,13 @@ class OrganizationService:
         *,
         reset_by: str,
     ) -> Organization:
-        resettable_statuses = {
+        await session.refresh(organization, with_for_update=True)
+
+        if organization.status not in {
             OrganizationStatus.ACTIVE,
             OrganizationStatus.REVIEW,
             OrganizationStatus.SNOOZED,
-        }
-        if organization.status not in resettable_statuses:
+        }:
             raise OrganizationError(
                 "Only active, review, or snoozed organizations can be reset "
                 "for onboarding review.",

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -641,6 +641,11 @@ class OrganizationService:
         organization.snooze_type = None
         organization.onboarding_resubmission_requested_at = datetime.now(UTC)
 
+        enqueue_job(
+            "payout.cancel_held_payouts",
+            account_id=organization.account_id,
+        )
+
         review_repository = OrganizationReviewRepository.from_session(session)
         review = await review_repository.get_by_organization(organization.id)
         if review is not None:

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -602,6 +602,7 @@ class OrganizationService:
 
         if organization.details_submitted_at is None:
             organization.details_submitted_at = datetime.now(UTC)
+            organization.onboarding_resubmission_requested_at = None
             enqueue_job(
                 "organization_review.run_agent",
                 organization_id=organization.id,
@@ -611,6 +612,57 @@ class OrganizationService:
         session.add(organization)
 
         await self._after_update(session, organization)
+        return organization
+
+    async def reset_onboarding_for_review(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+        *,
+        reset_by: str,
+    ) -> Organization:
+        resettable_statuses = {
+            OrganizationStatus.ACTIVE,
+            OrganizationStatus.REVIEW,
+            OrganizationStatus.SNOOZED,
+        }
+        if organization.status not in resettable_statuses:
+            raise OrganizationError(
+                "Only active, review, or snoozed organizations can be reset "
+                "for onboarding review.",
+                409,
+            )
+
+        previous_status = organization.status
+        organization.set_status(OrganizationStatus.CREATED)
+        organization.details_submitted_at = None
+        organization.snoozed_until = None
+        organization.snooze_type = None
+        organization.onboarding_resubmission_requested_at = datetime.now(UTC)
+
+        review_repository = OrganizationReviewRepository.from_session(session)
+        review = await review_repository.get_by_organization(organization.id)
+        if review is not None:
+            await AgentReviewRepository.from_session(session).soft_delete(review)
+
+        await AgentReviewRepository.from_session(session).deactivate_current_decisions(
+            organization.id
+        )
+
+        _append_internal_note(
+            organization,
+            "Onboarding reset from "
+            f"{previous_status.get_display_name()} to Created by {reset_by}. "
+            "The organization must review and resubmit its information.",
+        )
+        session.add(organization)
+        log.info(
+            "organization.onboarding_reset",
+            organization_id=str(organization.id),
+            slug=organization.slug,
+            previous_status=previous_status.value,
+            reset_by=reset_by,
+        )
         return organization
 
     async def check_can_delete(

--- a/server/polar/organization_review/tasks.py
+++ b/server/polar/organization_review/tasks.py
@@ -161,6 +161,11 @@ async def run_review_agent(
             )
             return
 
+        submission_generation = (
+            organization.details_submitted_at,
+            organization.onboarding_resubmission_requested_at,
+        )
+
         # A product-change review only makes sense for active orgs: it exists
         # to pull them back into review. Status may have changed between enqueue
         # and execution (debounce delay), so re-check here before spending an
@@ -180,6 +185,20 @@ async def run_review_agent(
         result = await run_organization_review(
             session, organization, context=review_context
         )
+
+        if review_context == ReviewContext.SUBMISSION:
+            await session.refresh(organization, with_for_update=True)
+            current_submission_generation = (
+                organization.details_submitted_at,
+                organization.onboarding_resubmission_requested_at,
+            )
+            if current_submission_generation != submission_generation:
+                log.info(
+                    "organization_review.submission.skip_stale",
+                    organization_id=str(organization_id),
+                    slug=organization.slug,
+                )
+                return
 
         report = result.report
         agent_review_id = await _persist_agent_result(

--- a/server/polar/payout/tasks.py
+++ b/server/polar/payout/tasks.py
@@ -128,15 +128,15 @@ async def cancel_account_payouts(account_id: uuid.UUID) -> None:
 
 @actor(actor_name="payout.cancel_held_payouts", priority=TaskPriority.LOW)
 async def cancel_held_payouts(
-    account_id: uuid.UUID, payout_account_id: uuid.UUID
+    account_id: uuid.UUID, payout_account_id: uuid.UUID | None = None
 ) -> None:
-    """Cancel only held payouts for an account when its payout account changes.
+    """Cancel only held payouts for an account.
 
-    Enqueued by ``set_payout_account`` on a swap: a held payout pins the payout
-    account it was created against, so releasing it later would transfer to the
-    stale account. Scoped to ``payout_account_id`` (the previous account) so a
-    held payout already created against the new account isn't canceled. Pending
-    payouts are left alone (their transfer may already be in flight).
+    On an onboarding reset, every held payout is canceled because the
+    organization leaves the review flow. On a payout-account swap, the cancel
+    is scoped to the previous payout account so a hold against the new account
+    is preserved. Pending payouts are always left alone because their transfer
+    may already be in flight.
     """
     async with AsyncSessionMaker() as session:
         await payout_service.cancel_account_payouts(

--- a/server/scripts/reset_organizations_for_review.py
+++ b/server/scripts/reset_organizations_for_review.py
@@ -2,7 +2,8 @@
 
 The organizations keep their existing information, but return to CREATED with
 payment capabilities disabled. Their current review is retired, and submitting
-the onboarding form starts a fresh AI review.
+the onboarding form starts a fresh AI review. Held payouts are canceled and
+their reserved funds are returned to the organization's balance.
 
 Usage:
     cd server

--- a/server/scripts/reset_organizations_for_review.py
+++ b/server/scripts/reset_organizations_for_review.py
@@ -23,7 +23,9 @@ from polar.kit.db.postgres import create_async_sessionmaker
 from polar.models import Organization
 from polar.models.organization import OrganizationStatus
 from polar.organization.repository import OrganizationRepository
-from polar.organization.service import organization as organization_service
+from polar.organization.service import (
+    organization as organization_service,
+)
 from polar.postgres import AsyncSession, create_async_engine
 from scripts.helper import configure_script_console_logging, typer_async
 
@@ -31,12 +33,6 @@ cli = typer.Typer()
 console = Console()
 
 configure_script_console_logging()
-
-_ELIGIBLE_STATUSES = {
-    OrganizationStatus.ACTIVE,
-    OrganizationStatus.REVIEW,
-    OrganizationStatus.SNOOZED,
-}
 
 
 async def _load_organizations(
@@ -46,7 +42,11 @@ async def _load_organizations(
     return [
         (
             organization_id,
-            await repository.get_by_id(organization_id, include_blocked=True),
+            await repository.get_by_id(
+                organization_id,
+                include_blocked=True,
+                for_update=True,
+            ),
         )
         for organization_id in organization_ids
     ]
@@ -66,7 +66,11 @@ def _show_plan(targets: list[tuple[UUID, Organization | None]]) -> bool:
             table.add_row(str(organization_id), "—", "—", "[red]Not found")
             continue
 
-        if organization.status not in _ELIGIBLE_STATUSES:
+        if organization.status not in {
+            OrganizationStatus.ACTIVE,
+            OrganizationStatus.REVIEW,
+            OrganizationStatus.SNOOZED,
+        }:
             is_valid = False
             table.add_row(
                 str(organization.id),

--- a/server/scripts/reset_organizations_for_review.py
+++ b/server/scripts/reset_organizations_for_review.py
@@ -1,0 +1,139 @@
+"""Reset explicitly selected organizations so they must complete onboarding again.
+
+The organizations keep their existing information, but return to CREATED with
+payment capabilities disabled. Their current review is retired, and submitting
+the onboarding form starts a fresh AI review.
+
+Usage:
+    cd server
+    uv run python -m scripts.reset_organizations_for_review \
+        <organization-id> [<organization-id> ...]
+    uv run python -m scripts.reset_organizations_for_review \
+        <organization-id> [<organization-id> ...] \
+        --reset-by operator@polar.sh --execute
+"""
+
+from uuid import UUID
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from polar.kit.db.postgres import create_async_sessionmaker
+from polar.models import Organization
+from polar.models.organization import OrganizationStatus
+from polar.organization.repository import OrganizationRepository
+from polar.organization.service import organization as organization_service
+from polar.postgres import AsyncSession, create_async_engine
+from scripts.helper import configure_script_console_logging, typer_async
+
+cli = typer.Typer()
+console = Console()
+
+configure_script_console_logging()
+
+_ELIGIBLE_STATUSES = {
+    OrganizationStatus.ACTIVE,
+    OrganizationStatus.REVIEW,
+    OrganizationStatus.SNOOZED,
+}
+
+
+async def _load_organizations(
+    session: AsyncSession, organization_ids: list[UUID]
+) -> list[tuple[UUID, Organization | None]]:
+    repository = OrganizationRepository.from_session(session)
+    return [
+        (
+            organization_id,
+            await repository.get_by_id(organization_id, include_blocked=True),
+        )
+        for organization_id in organization_ids
+    ]
+
+
+def _show_plan(targets: list[tuple[UUID, Organization | None]]) -> bool:
+    table = Table(title="Organizations to reset for onboarding review")
+    table.add_column("ID", style="dim")
+    table.add_column("Slug")
+    table.add_column("Current status", style="cyan")
+    table.add_column("Result")
+
+    is_valid = True
+    for organization_id, organization in targets:
+        if organization is None:
+            is_valid = False
+            table.add_row(str(organization_id), "—", "—", "[red]Not found")
+            continue
+
+        if organization.status not in _ELIGIBLE_STATUSES:
+            is_valid = False
+            table.add_row(
+                str(organization.id),
+                organization.slug,
+                organization.status.get_display_name(),
+                "[red]Ineligible status",
+            )
+            continue
+
+        table.add_row(
+            str(organization.id),
+            organization.slug,
+            organization.status.get_display_name(),
+            "[green]Reset to Created",
+        )
+
+    console.print(table)
+    return is_valid
+
+
+@cli.command()
+@typer_async
+async def reset_organizations_for_review(
+    organization_ids: list[UUID] = typer.Argument(
+        ..., help="Organization IDs to reset"
+    ),
+    execute: bool = typer.Option(
+        False, "--execute", help="Apply the reset (default: preview only)"
+    ),
+    reset_by: str = typer.Option(
+        "bulk reset script",
+        "--reset-by",
+        help="Operator recorded in each organization's internal notes",
+    ),
+) -> None:
+    unique_ids = list(dict.fromkeys(organization_ids))
+    engine = create_async_engine("script")
+    sessionmaker = create_async_sessionmaker(engine)
+
+    try:
+        async with sessionmaker() as session:
+            targets = await _load_organizations(session, unique_ids)
+            if not _show_plan(targets):
+                console.print(
+                    "[red]No changes made. Fix missing or ineligible organizations first."
+                )
+                raise typer.Exit(code=1)
+
+            if not execute:
+                console.print("[yellow]Preview only — pass --execute to apply.")
+                return
+
+            for _, organization in targets:
+                assert organization is not None
+                await organization_service.reset_onboarding_for_review(
+                    session,
+                    organization,
+                    reset_by=reset_by,
+                )
+
+            await session.commit()
+            console.print(
+                f"[green]Reset {len(targets)} organization(s) for onboarding review."
+            )
+    finally:
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/tests/backoffice/organizations_v2/test_endpoints.py
+++ b/server/tests/backoffice/organizations_v2/test_endpoints.py
@@ -249,6 +249,19 @@ class TestBlockDialog:
 
 @pytest.mark.asyncio
 class TestResetOnboardingDialog:
+    async def test_warns_that_held_payouts_are_canceled(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        organization: Organization,
+    ) -> None:
+        response = await backoffice_client.get(
+            f"/organizations/{organization.id}/reset-onboarding-dialog"
+        )
+
+        assert response.status_code == 200
+        assert "Cancel pending-review payouts" in response.text
+        assert "return their reserved funds" in response.text
+
     async def test_resets_organization(
         self,
         backoffice_client: httpx.AsyncClient,

--- a/server/tests/backoffice/organizations_v2/test_endpoints.py
+++ b/server/tests/backoffice/organizations_v2/test_endpoints.py
@@ -284,6 +284,25 @@ class TestResetOnboardingDialog:
         assert organization.internal_notes is not None
         assert user.email in organization.internal_notes
 
+    async def test_shows_error_when_organization_was_already_reset(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.status = OrganizationStatus.CREATED
+        await session.flush()
+
+        response = await backoffice_client.post(
+            f"/organizations/{organization.id}/reset-onboarding-dialog"
+        )
+
+        assert response.status_code == 200
+        assert (
+            "Only active, review, or snoozed organizations can be reset "
+            "for onboarding review."
+        ) in response.text
+
 
 @pytest.mark.asyncio
 class TestOffboardDialog:

--- a/server/tests/backoffice/organizations_v2/test_endpoints.py
+++ b/server/tests/backoffice/organizations_v2/test_endpoints.py
@@ -248,6 +248,31 @@ class TestBlockDialog:
 
 
 @pytest.mark.asyncio
+class TestResetOnboardingDialog:
+    async def test_resets_organization(
+        self,
+        backoffice_client: httpx.AsyncClient,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        organization.status = OrganizationStatus.ACTIVE
+        organization.details_submitted_at = datetime.now(UTC)
+        await session.flush()
+
+        response = await backoffice_client.post(
+            f"/organizations/{organization.id}/reset-onboarding-dialog"
+        )
+
+        assert response.status_code == 303
+        assert organization.status == OrganizationStatus.CREATED
+        assert organization.details_submitted_at is None
+        assert organization.onboarding_resubmission_requested_at is not None
+        assert organization.internal_notes is not None
+        assert user.email in organization.internal_notes
+
+
+@pytest.mark.asyncio
 class TestOffboardDialog:
     async def test_missing_aup_section_does_not_offboard(
         self,

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1427,6 +1427,7 @@ class TestResetOnboardingForReview:
         status: OrganizationStatus,
     ) -> None:
         organization.status = status
+        await session.flush()
 
         with pytest.raises(OrganizationError) as exc_info:
             await organization_service.reset_onboarding_for_review(

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -414,6 +414,29 @@ class TestUpdateReviewSubmission:
         )
 
     @pytest.mark.auth
+    async def test_submit_clears_resubmission_requirement(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        mocker.patch("polar.organization.service.enqueue_job")
+        organization.status = OrganizationStatus.CREATED
+        organization.website = "https://example.com"
+        organization.email = "support@example.com"
+        organization.details = {
+            "product_description": "Subscription SaaS for software teams and agencies.",
+            "selling_categories": ["Software / SaaS"],
+            "pricing_models": ["Subscription"],
+            "switching": False,
+        }
+        organization.onboarding_resubmission_requested_at = datetime.now(UTC)
+
+        await organization_service.submit_for_review(session, organization)
+
+        assert organization.onboarding_resubmission_requested_at is None
+
+    @pytest.mark.auth
     async def test_update_with_submit_for_review_requires_relevant_fields(
         self,
         session: AsyncSession,
@@ -1333,6 +1356,87 @@ class TestBlockOrganization:
             payout_account_id=stripe_payout_account.id,
             reason="fraud",
         )
+
+
+@pytest.mark.asyncio
+class TestResetOnboardingForReview:
+    @pytest.mark.parametrize(
+        "status",
+        [
+            OrganizationStatus.ACTIVE,
+            OrganizationStatus.REVIEW,
+            OrganizationStatus.SNOOZED,
+        ],
+    )
+    async def test_resets_eligible_organization(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+        status: OrganizationStatus,
+    ) -> None:
+        organization.status = status
+        organization.capabilities = {**STATUS_CAPABILITIES[status]}
+        organization.details_submitted_at = datetime.now(UTC)
+        organization.snoozed_until = datetime.now(UTC) + timedelta(days=1)
+        organization.snooze_type = SnoozeType.NEXT_SALE
+        review = OrganizationReview(
+            organization_id=organization.id,
+            verdict=OrganizationReview.Verdict.PASS,
+            risk_score=10.0,
+            violated_sections=[],
+            reason="Previously approved",
+            model_used="test",
+        )
+        session.add(review)
+        await session.flush()
+
+        result = await organization_service.reset_onboarding_for_review(
+            session,
+            organization,
+            reset_by="admin@example.com",
+        )
+
+        assert result.status == OrganizationStatus.CREATED
+        assert result.capabilities == STATUS_CAPABILITIES[OrganizationStatus.CREATED]
+        assert result.details_submitted_at is None
+        assert result.snoozed_until is None
+        assert result.snooze_type is None
+        assert result.onboarding_resubmission_requested_at is not None
+        assert review.deleted_at is not None
+        assert result.internal_notes is not None
+        assert (
+            f"reset from {status.get_display_name()} to Created"
+            in result.internal_notes
+        )
+        assert "admin@example.com" in result.internal_notes
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            OrganizationStatus.CREATED,
+            OrganizationStatus.DENIED,
+            OrganizationStatus.BLOCKED,
+            OrganizationStatus.OFFBOARDING,
+            OrganizationStatus.OFFBOARDED,
+        ],
+    )
+    async def test_rejects_ineligible_status(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+        status: OrganizationStatus,
+    ) -> None:
+        organization.status = status
+
+        with pytest.raises(OrganizationError) as exc_info:
+            await organization_service.reset_onboarding_for_review(
+                session,
+                organization,
+                reset_by="admin@example.com",
+            )
+
+        assert exc_info.value.status_code == 409
+        assert organization.status == status
 
 
 @pytest.mark.asyncio

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -1370,10 +1370,12 @@ class TestResetOnboardingForReview:
     )
     async def test_resets_eligible_organization(
         self,
+        mocker: MockerFixture,
         session: AsyncSession,
         organization: Organization,
         status: OrganizationStatus,
     ) -> None:
+        enqueue_job_mock = mocker.patch("polar.organization.service.enqueue_job")
         organization.status = status
         organization.capabilities = {**STATUS_CAPABILITIES[status]}
         organization.details_submitted_at = datetime.now(UTC)
@@ -1409,6 +1411,10 @@ class TestResetOnboardingForReview:
             in result.internal_notes
         )
         assert "admin@example.com" in result.internal_notes
+        enqueue_job_mock.assert_called_once_with(
+            "payout.cancel_held_payouts",
+            account_id=organization.account_id,
+        )
 
     @pytest.mark.parametrize(
         "status",

--- a/server/tests/organization_review/test_tasks.py
+++ b/server/tests/organization_review/test_tasks.py
@@ -8,8 +8,13 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from sqlalchemy import update
 
-from polar.models.organization import Organization, OrganizationStatus
+from polar.models.organization import (
+    STATUS_CAPABILITIES,
+    Organization,
+    OrganizationStatus,
+)
 from polar.models.organization_review import OrganizationReview
 from polar.organization.repository import (
     OrganizationReviewRepository as OrgReviewRepository,
@@ -164,6 +169,74 @@ class TestRunReviewAgentSubmission:
         assert updated.violated_sections == []
         assert updated.timed_out is False
         assert updated.organization_details_snapshot["name"] == organization.name
+
+    async def test_reset_while_agent_is_running_discards_stale_result(
+        self,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        submitted_at = datetime(2026, 7, 28, 10, 0, tzinfo=UTC)
+        reset_requested_at = datetime(2026, 7, 28, 10, 1, tzinfo=UTC)
+        organization.status = OrganizationStatus.ACTIVE
+        organization.capabilities = {**STATUS_CAPABILITIES[OrganizationStatus.ACTIVE]}
+        organization.details_submitted_at = submitted_at
+        await session.flush()
+
+        agent_result = _make_agent_result(
+            verdict=ReviewVerdict.DENY,
+            risk_level=RiskLevel.HIGH,
+        )
+
+        async def reset_organization_during_review(
+            *_args: object, **_kwargs: object
+        ) -> AgentReviewResult:
+            await session.execute(
+                update(Organization)
+                .where(Organization.id == organization.id)
+                .values(
+                    status=OrganizationStatus.CREATED,
+                    capabilities=STATUS_CAPABILITIES[OrganizationStatus.CREATED],
+                    details_submitted_at=None,
+                    onboarding_resubmission_requested_at=reset_requested_at,
+                )
+                .execution_options(synchronize_session=False)
+            )
+            return agent_result
+
+        with (
+            patch(
+                "polar.organization_review.tasks.AsyncSessionMaker",
+                return_value=_mock_session_maker(session),
+            ),
+            patch(
+                "polar.organization_review.tasks.run_organization_review",
+                side_effect=reset_organization_during_review,
+            ),
+        ):
+            await _run_review_agent(
+                organization.id,
+                context=ReviewContext.SUBMISSION,
+            )
+
+        await session.flush()
+        session.expire_all()
+
+        await session.refresh(organization)
+        assert organization.status == OrganizationStatus.CREATED
+        assert organization.details_submitted_at is None
+        assert organization.onboarding_resubmission_requested_at == reset_requested_at
+
+        organization_review_repository = OrgReviewRepository.from_session(session)
+        assert (
+            await organization_review_repository.get_by_organization(organization.id)
+            is None
+        )
+
+        agent_review_repository = AgentReviewRepository.from_session(session)
+        assert (
+            await agent_review_repository.get_latest_agent_review(organization.id)
+            is None
+        )
 
     async def test_non_grandfathered_existing_review_is_overwritten(
         self,

--- a/server/tests/scripts/test_reset_organizations_for_review.py
+++ b/server/tests/scripts/test_reset_organizations_for_review.py
@@ -1,0 +1,32 @@
+from unittest.mock import AsyncMock, call, patch
+from uuid import uuid4
+
+import pytest
+
+from polar.postgres import AsyncSession
+from scripts.reset_organizations_for_review import _load_organizations
+
+
+@pytest.mark.asyncio
+async def test_load_organizations_locks_targets(session: AsyncSession) -> None:
+    organization_ids = [uuid4(), uuid4()]
+    get_by_id = AsyncMock(side_effect=[None, None])
+
+    with patch(
+        "scripts.reset_organizations_for_review.OrganizationRepository.from_session"
+    ) as from_session:
+        from_session.return_value.get_by_id = get_by_id
+        await _load_organizations(session, organization_ids)
+
+    assert get_by_id.await_args_list == [
+        call(
+            organization_ids[0],
+            include_blocked=True,
+            for_update=True,
+        ),
+        call(
+            organization_ids[1],
+            include_blocked=True,
+            for_update=True,
+        ),
+    ]


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787820524&installation_model_id=13063&pr_number=13398&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13398&signature=02289d7b83ea9bf700fe92a6fc54e4097e5d0e1b16206092694323199d246c20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a backoffice “Reset Onboarding” action that moves an org back to Created and requires a fresh review. Held payouts are canceled and funds returned; payments, renewals, payouts, and refunds are paused until re‑approval. A dashboard banner guides admins to resubmit.

- **New Features**
  - Backoffice: “Reset Onboarding” modal for Active/Review/Snoozed orgs; sets status to Created, clears submitted/snooze fields, timestamps `onboarding_resubmission_requested_at`, retires the current AI review/decisions, adds an internal note, shows success/error toasts, and warns that held payouts will be canceled.
  - Dashboard: show a Resubmission banner when status is Created and `onboarding_resubmission_requested_at` is set; managers get a “Review & resubmit” button to `finance/account`.
  - API: added `onboarding_resubmission_requested_at` to `schemas.Organization`; updated `@polar-sh/client` v1 and generated email OpenAPI types to include it.
  - Review Agent: discard stale submission results if the org is reset while the agent is running.
  - Payouts: cancel held payouts on reset and return reserved funds; pending payouts are left alone.

- **Migration**
  - Trigger via the backoffice action or run `server/scripts/reset_organizations_for_review.py` (preview by default; use `--execute` to apply and `--reset-by` to attribute). No breaking changes.

<sup>Written for commit 78a5a14857fe36df5e6e9538b3b6e0b6acbe1462. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

