### PR TITLE
Prioritize API key warning over unfulfillable checkout link

### DIFF
--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -2018,9 +2018,12 @@ class OrganizationService:
         An access token without a webhook is a non-blocking warning rather
         than a failure: the merchant can still fulfill via success_url +
         API calls, we just can't observe state changes (refunds,
-        cancellations) without webhooks during review. Aggregate checks
-        expose per-component state via `sub_checks`; the parent `status`
-        remains the source of truth for gating.
+        cancellations) without webhooks during review. That warning wins
+        over an unfulfillable checkout link, so a merchant who started the
+        no-code path and then switched to the API isn't gated on a webhook
+        we only recommend. Aggregate checks expose per-component state via
+        `sub_checks`; the parent `status` remains the source of truth for
+        gating.
         """
         key = OrganizationReviewCheckKey.SETUP_READINESS
 
@@ -2108,15 +2111,18 @@ class OrganizationService:
             or api_path_passed
         ):
             parent_status = OrganizationReviewCheckStatus.PASSED
+        elif access_token_sub.status == OrganizationReviewCheckStatus.PASSED:
+            # API path partially configured — token present, webhook missing.
+            # Evaluated before the checkout-link failure so a leftover no-code
+            # link the merchant abandoned can't turn the recommended webhook
+            # into a hard gate on the API path.
+            parent_status = OrganizationReviewCheckStatus.WARNING
         elif checkout_link_sub.status == OrganizationReviewCheckStatus.FAILED:
             # No-code path attempted but the link can't fulfill yet. Treat as
             # in-progress: still blocks submission (PENDING gates like FAILED),
             # but the UI guides the merchant to finish setting up delivery
             # rather than surfacing it as an error.
             parent_status = OrganizationReviewCheckStatus.PENDING
-        elif access_token_sub.status == OrganizationReviewCheckStatus.PASSED:
-            # API path partially configured — token present, webhook missing.
-            parent_status = OrganizationReviewCheckStatus.WARNING
         else:
             parent_status = OrganizationReviewCheckStatus.PENDING
 

--- a/server/tests/organization/test_service.py
+++ b/server/tests/organization/test_service.py
@@ -2764,6 +2764,41 @@ class TestGetReviewState:
         ]
         assert non_setup_failing  # other checks block, not this warning
 
+    async def test_setup_readiness_access_token_warns_despite_unfulfillable_link(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        """A merchant who created a no-code link and then switched to the API
+        path is warned about the missing webhook, not gated by the link."""
+        product = await create_product(
+            save_fixture, organization=organization, recurring_interval=None
+        )
+        await create_checkout_link(save_fixture, products=[product])
+        await save_fixture(
+            OrganizationAccessToken(
+                comment="test",
+                token="hash",
+                organization=organization,
+                scope="openid",
+            )
+        )
+
+        state = await organization_service.get_review_state(session, organization)
+        step = _step(state, OrganizationReviewCheckKey.SETUP_READINESS)
+
+        assert step.status == OrganizationReviewCheckStatus.WARNING
+        assert step.reasons == [
+            OrganizationReviewCheckReason.SETUP_READINESS_WEBHOOK_MISSING
+        ]
+        assert (
+            _sub(
+                step, OrganizationReviewSubCheckKey.SETUP_READINESS_CHECKOUT_LINK
+            ).status
+            == OrganizationReviewCheckStatus.FAILED
+        )
+
     async def test_all_checks_pass_can_submit(
         self,
         save_fixture: SaveFixture,
@@ -2813,6 +2848,32 @@ class TestGetReviewState:
         setup_step = _step(state, OrganizationReviewCheckKey.SETUP_READINESS)
         assert setup_step.status == OrganizationReviewCheckStatus.PENDING
         assert state.can_submit is False
+
+    async def test_api_key_unblocks_submission_despite_unfulfillable_link(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        user: User,
+    ) -> None:
+        """The webhook is recommended, not required: an API key alone clears
+        setup readiness even when an abandoned no-code link can't fulfill."""
+        product = await _setup_passing_org(save_fixture, organization, user)
+        await set_product_benefits(save_fixture, product=product, benefits=[])
+        await save_fixture(
+            OrganizationAccessToken(
+                comment="test",
+                token="hash",
+                organization=organization,
+                scope="openid",
+            )
+        )
+
+        state = await organization_service.get_review_state(session, organization)
+
+        setup_step = _step(state, OrganizationReviewCheckKey.SETUP_READINESS)
+        assert setup_step.status == OrganizationReviewCheckStatus.WARNING
+        assert state.can_submit is True
 
     async def test_submitted_blocks_resubmission(
         self,


### PR DESCRIPTION
## Summary

Fixes the setup readiness check logic to properly handle merchants who started with a no-code checkout link but switched to the API path. The webhook warning should not be gated by an abandoned link that can't fulfill.

## What

- Reordered the status evaluation logic in `_build_setup_readiness_check` to check for a passed access token (with missing webhook warning) before checking for a failed checkout link
- Added two test cases to verify the new behavior:
  - `test_setup_readiness_access_token_warns_despite_unfulfillable_link`: Verifies that a merchant with an API key gets a webhook warning even when they have an unfulfillable checkout link
  - `test_api_key_unblocks_submission_despite_unfulfillable_link`: Verifies that an API key alone allows submission even with an abandoned checkout link

## Why

Previously, if a merchant created a no-code checkout link and then switched to the API path, the unfulfillable link would block submission with a PENDING status. This was incorrect because:

1. The webhook is a recommendation, not a requirement for the API path
2. A merchant who explicitly switched to the API shouldn't be gated by an abandoned no-code link
3. The API key alone is sufficient to pass setup readiness (with a warning about the missing webhook)

## How

The fix reorders the conditional checks in the parent status determination:
1. First check if both paths are configured and passing → PASSED
2. Then check if API path is partially configured (token present, webhook missing) → WARNING
3. Then check if checkout link is unfulfillable → PENDING
4. Finally default to PENDING

This ensures that a merchant's explicit choice to use the API path (evidenced by creating an access token) takes precedence over an abandoned no-code link.

## Checklist

- [x] This PR addresses a single concern (fixing setup readiness check priority)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests (two new test cases added)
- [ ] Linting and type checking pass (assumed)
- [x] No unrelated changes or drive-by fixes are included

https://claude.ai/code/session_011HymHua1CEWL5DPWK3DJat

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787820956&installation_model_id=13063&pr_number=13399&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13399&signature=054e2642af92b1e8caf707ec90194d175e4b0858bc3807e29d53548445043b9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

