### PR TITLE
fix(transaction): attribute payout reversals to the payout they reverse

### DIFF
--- a/server/polar/transaction/service/payout.py
+++ b/server/polar/transaction/service/payout.py
@@ -69,6 +69,12 @@ class PayoutTransactionService(BaseTransactionService):
         transaction: Transaction,
         payout: Payout,
     ) -> Transaction:
+        # Reset first: it clears every row pointing at the payout, reversal included.
+        balance_transaction_repository = BalanceTransactionRepository.from_session(
+            session
+        )
+        await balance_transaction_repository.reset_payout_transaction_id(transaction.id)
+
         reversed_transaction = Transaction(
             id=generate_uuid(),
             type=TransactionType.payout_reversal,
@@ -86,17 +92,12 @@ class PayoutTransactionService(BaseTransactionService):
             incurred_transactions=[],
             account_incurred_transactions=[],
             payout=payout,
+            # The reversal belongs to the payout it reverses, never to a later one.
+            payout_transaction=transaction,
         )
 
         repository = PayoutReversalTransactionRepository.from_session(session)
-        reversed_transaction = await repository.create(reversed_transaction, flush=True)
-
-        balance_transaction_repository = BalanceTransactionRepository.from_session(
-            session
-        )
-        await balance_transaction_repository.reset_payout_transaction_id(transaction.id)
-
-        return reversed_transaction
+        return await repository.create(reversed_transaction, flush=True)
 
 
 payout_transaction = PayoutTransactionService(Transaction)

--- a/server/scripts/backfill_payout_reversal_unpaid.py
+++ b/server/scripts/backfill_payout_reversal_unpaid.py
@@ -22,21 +22,26 @@ Usage:
 
 from collections.abc import Sequence
 from datetime import datetime
-from typing import Any, cast
+from typing import Any
 from uuid import UUID
 
 import structlog
 import typer
 from rich.console import Console
 from rich.table import Table
-from sqlalchemy import CursorResult, Row, Select, or_, select, update
+from sqlalchemy import Row, Select, Update, func, or_, select, update
 from sqlalchemy.orm import aliased
 
 from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
 from polar.models import Transaction
 from polar.models.transaction import TransactionType
 from polar.postgres import create_async_engine
-from scripts.helper import configure_script_console_logging, typer_async
+from scripts.helper import (
+    configure_script_console_logging,
+    limit_bindparam,
+    run_batched_update,
+    typer_async,
+)
 
 cli = typer.Typer()
 console = Console()
@@ -50,10 +55,19 @@ _MISATTRIBUTED = or_(
     reversal.payout_transaction_id.is_(None),
     reversal.payout_transaction_id != reversed_payout_transaction.id,
 )
+_PREVIEW_LIMIT = 50
 
 
-def _candidates_statement() -> Select[tuple[UUID, datetime, int, UUID | None, UUID]]:
-    return (
+def _candidates[SelectT: Select[Any]](statement: SelectT) -> SelectT:
+    return statement.join(
+        reversed_payout_transaction,
+        (reversed_payout_transaction.payout_id == reversal.payout_id)
+        & (reversed_payout_transaction.type == TransactionType.payout),
+    ).where(reversal.type == TransactionType.payout_reversal, _MISATTRIBUTED)
+
+
+def _preview_statement() -> Select[tuple[UUID, datetime, int, UUID | None, UUID]]:
+    return _candidates(
         select(
             reversal.id,
             reversal.created_at,
@@ -61,20 +75,39 @@ def _candidates_statement() -> Select[tuple[UUID, datetime, int, UUID | None, UU
             reversal.payout_transaction_id,
             reversed_payout_transaction.id,
         )
-        .join(
-            reversed_payout_transaction,
-            (reversed_payout_transaction.payout_id == reversal.payout_id)
-            & (reversed_payout_transaction.type == TransactionType.payout),
+    ).order_by(reversal.created_at)
+
+
+def _count_statement() -> Select[tuple[int]]:
+    return select(func.count()).select_from(_candidates(select(reversal.id)).subquery())
+
+
+def _attribution_statement() -> Update:
+    batch = _candidates(select(reversal.id)).limit(limit_bindparam())
+    target = (
+        select(reversed_payout_transaction.id)
+        .where(
+            reversed_payout_transaction.payout_id == Transaction.payout_id,
+            reversed_payout_transaction.type == TransactionType.payout,
         )
-        .where(reversal.type == TransactionType.payout_reversal, _MISATTRIBUTED)
-        .order_by(reversal.created_at)
+        .correlate(Transaction)
+        .scalar_subquery()
+    )
+    return (
+        update(Transaction)
+        .where(Transaction.id.in_(batch))
+        .values(payout_transaction_id=target)
+        .execution_options(synchronize_session=False)
     )
 
 
 def _render(
-    rows: Sequence[Row[tuple[UUID, datetime, int, UUID | None, UUID]]],
+    rows: Sequence[Row[tuple[UUID, datetime, int, UUID | None, UUID]]], total: int
 ) -> None:
-    table = Table(title=f"Misattributed payout reversals ({len(rows)})")
+    title = f"Misattributed payout reversals ({total})"
+    if len(rows) < total:
+        title += f" — first {len(rows)}"
+    table = Table(title=title)
     table.add_column("Reversal ID", style="dim")
     table.add_column("Created")
     table.add_column("Amount", justify="right")
@@ -91,38 +124,32 @@ def _render(
     console.print(table)
 
 
-async def run_backfill(session: AsyncSession, *, execute: bool) -> int:
-    rows = (await session.execute(_candidates_statement())).all()
-    _render(rows)
+async def run_backfill(
+    session: AsyncSession,
+    *,
+    execute: bool,
+    batch_size: int = 5000,
+    sleep_seconds: float = 0.1,
+) -> int:
+    total = (await session.execute(_count_statement())).scalar_one()
+    rows = (await session.execute(_preview_statement().limit(_PREVIEW_LIMIT))).all()
+    _render(rows, total)
 
-    if not rows:
+    if total == 0:
         log.info("Nothing to do — every reversal points at the payout it reverses")
         return 0
     if not execute:
-        log.info("Dry-run only — re-run with --execute to attribute", total=len(rows))
+        log.info("Dry-run only — re-run with --execute to attribute", total=total)
         return 0
 
-    target = (
-        select(reversed_payout_transaction.id)
-        .where(
-            reversed_payout_transaction.payout_id == Transaction.payout_id,
-            reversed_payout_transaction.type == TransactionType.payout,
-        )
-        .scalar_subquery()
+    attributed = await run_batched_update(
+        _attribution_statement(),
+        batch_size=batch_size,
+        sleep_seconds=sleep_seconds,
+        session=session,
     )
-    result = cast(
-        CursorResult[Any],
-        await session.execute(
-            update(Transaction)
-            .where(
-                Transaction.type == TransactionType.payout_reversal,
-                Transaction.id.in_([row[0] for row in rows]),
-            )
-            .values(payout_transaction_id=target)
-        ),
-    )
-    log.info("Attributed payout reversals", attributed=result.rowcount)
-    return result.rowcount
+    log.info("Attributed payout reversals", attributed=attributed)
+    return attributed
 
 
 @cli.command()
@@ -131,6 +158,8 @@ async def backfill_payout_reversal_unpaid(
     execute: bool = typer.Option(
         False, help="Actually re-point the reversals (default: dry-run)"
     ),
+    batch_size: int = typer.Option(5000, help="Number of rows to process per batch"),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
 ) -> None:
     engine = create_async_engine("script")
     sessionmaker = create_async_sessionmaker(engine)
@@ -141,8 +170,12 @@ async def backfill_payout_reversal_unpaid(
 
     try:
         async with sessionmaker() as session:
-            await run_backfill(session, execute=execute)
-            await session.commit()
+            await run_backfill(
+                session,
+                execute=execute,
+                batch_size=batch_size,
+                sleep_seconds=sleep_seconds,
+            )
     finally:
         await engine.dispose()
 

--- a/server/scripts/backfill_payout_reversal_unpaid.py
+++ b/server/scripts/backfill_payout_reversal_unpaid.py
@@ -1,0 +1,151 @@
+"""Attribute ``payout_reversal`` transactions to the payout they reverse.
+
+Reversals used to be left unattributed, then claimed by whichever payout came
+next — counting the released funds twice, since the reset balance transactions
+already carry them. That breaks the check in ``create_payout_invoice``, so the
+affected payouts cannot produce an invoice, and their CSV export lists a row
+that doesn't reconcile to the payout total.
+
+Pointing each reversal at the payout transaction it reverses restores
+``sum(paid_transactions) == payout.amount`` and leaves no reversal
+unattributed. Idempotent: repaired rows drop out of the candidate set.
+
+Usage:
+    cd server
+
+    # Dry-run (default) — list the reversals and where they point today:
+    uv run python -m scripts.backfill_payout_reversal_unpaid
+
+    # Apply:
+    uv run python -m scripts.backfill_payout_reversal_unpaid --execute
+"""
+
+from collections.abc import Sequence
+from datetime import datetime
+from typing import Any, cast
+from uuid import UUID
+
+import structlog
+import typer
+from rich.console import Console
+from rich.table import Table
+from sqlalchemy import CursorResult, Row, Select, or_, select, update
+from sqlalchemy.orm import aliased
+
+from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
+from polar.models import Transaction
+from polar.models.transaction import TransactionType
+from polar.postgres import create_async_engine
+from scripts.helper import configure_script_console_logging, typer_async
+
+cli = typer.Typer()
+console = Console()
+configure_script_console_logging()
+log = structlog.get_logger()
+
+reversal = aliased(Transaction, name="reversal")
+reversed_payout_transaction = aliased(Transaction, name="reversed_payout_transaction")
+
+_MISATTRIBUTED = or_(
+    reversal.payout_transaction_id.is_(None),
+    reversal.payout_transaction_id != reversed_payout_transaction.id,
+)
+
+
+def _candidates_statement() -> Select[tuple[UUID, datetime, int, UUID | None, UUID]]:
+    return (
+        select(
+            reversal.id,
+            reversal.created_at,
+            reversal.amount,
+            reversal.payout_transaction_id,
+            reversed_payout_transaction.id,
+        )
+        .join(
+            reversed_payout_transaction,
+            (reversed_payout_transaction.payout_id == reversal.payout_id)
+            & (reversed_payout_transaction.type == TransactionType.payout),
+        )
+        .where(reversal.type == TransactionType.payout_reversal, _MISATTRIBUTED)
+        .order_by(reversal.created_at)
+    )
+
+
+def _render(
+    rows: Sequence[Row[tuple[UUID, datetime, int, UUID | None, UUID]]],
+) -> None:
+    table = Table(title=f"Misattributed payout reversals ({len(rows)})")
+    table.add_column("Reversal ID", style="dim")
+    table.add_column("Created")
+    table.add_column("Amount", justify="right")
+    table.add_column("Points at today", style="yellow")
+    table.add_column("Should point at", style="green")
+    for reversal_id, created_at, amount, current, target in rows:
+        table.add_row(
+            str(reversal_id),
+            created_at.date().isoformat(),
+            str(amount),
+            str(current) if current else "nothing",
+            str(target),
+        )
+    console.print(table)
+
+
+async def run_backfill(session: AsyncSession, *, execute: bool) -> int:
+    rows = (await session.execute(_candidates_statement())).all()
+    _render(rows)
+
+    if not rows:
+        log.info("Nothing to do — every reversal points at the payout it reverses")
+        return 0
+    if not execute:
+        log.info("Dry-run only — re-run with --execute to attribute", total=len(rows))
+        return 0
+
+    target = (
+        select(reversed_payout_transaction.id)
+        .where(
+            reversed_payout_transaction.payout_id == Transaction.payout_id,
+            reversed_payout_transaction.type == TransactionType.payout,
+        )
+        .scalar_subquery()
+    )
+    result = cast(
+        CursorResult[Any],
+        await session.execute(
+            update(Transaction)
+            .where(
+                Transaction.type == TransactionType.payout_reversal,
+                Transaction.id.in_([row[0] for row in rows]),
+            )
+            .values(payout_transaction_id=target)
+        ),
+    )
+    log.info("Attributed payout reversals", attributed=result.rowcount)
+    return result.rowcount
+
+
+@cli.command()
+@typer_async
+async def backfill_payout_reversal_unpaid(
+    execute: bool = typer.Option(
+        False, help="Actually re-point the reversals (default: dry-run)"
+    ),
+) -> None:
+    engine = create_async_engine("script")
+    sessionmaker = create_async_sessionmaker(engine)
+    mode = "EXECUTE" if execute else "DRY-RUN"
+    console.rule(
+        f"[bold]Attribute payout reversals to the payout they reverse — {mode}"
+    )
+
+    try:
+        async with sessionmaker() as session:
+            await run_backfill(session, execute=execute)
+            await session.commit()
+    finally:
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/tests/payout/test_service_ledger.py
+++ b/server/tests/payout/test_service_ledger.py
@@ -19,6 +19,7 @@ from polar.models.organization import OrganizationStatus
 from polar.models.payout import PayoutStatus
 from polar.payout.service import payout as payout_service
 from polar.postgres import AsyncSession
+from polar.transaction.repository import TransactionRepository
 from polar.transaction.service.transaction import transaction as transaction_service
 from tests.fixtures import random_objects as ro
 from tests.fixtures.database import SaveFixture
@@ -144,3 +145,34 @@ class TestHeldPayoutLedger:
 
         summary_after = await transaction_service.get_summary(session, account)
         assert summary_after.available_balance.amount == 0
+
+    async def test_new_payout_paid_transactions_match_amount(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        locker: Locker,
+        organization: Organization,
+        account: Account,
+        user: User,
+    ) -> None:
+        # The payout it replaces released its funds through both a
+        # payout_reversal and a reset of the balance transactions. Only the
+        # balance transactions belong to the new payout: counting the reversal
+        # too would inflate the gross and break invoice generation.
+        await create_payout_account(save_fixture, organization, user)
+
+        payment_transaction = await create_payment_transaction(save_fixture)
+        await create_balance_transaction(
+            save_fixture, account=account, payment_transaction=payment_transaction
+        )
+
+        first_payout = await payout_service.create(session, locker, organization)
+        await payout_service.cancel(session, first_payout)
+
+        second_payout = await payout_service.create(session, locker, organization)
+
+        repository = TransactionRepository.from_session(session)
+        paid_transactions = await repository.get_all_paid_transactions_by_payout(
+            second_payout.transaction.id
+        )
+        assert second_payout.amount == sum(t.amount for t in paid_transactions)

--- a/server/tests/scripts/test_backfill_payout_reversal_unpaid.py
+++ b/server/tests/scripts/test_backfill_payout_reversal_unpaid.py
@@ -1,0 +1,144 @@
+from datetime import timedelta
+from functools import partial
+
+import pytest
+
+from polar.kit.utils import utc_now
+from polar.locker import Locker
+from polar.models import Account, Organization, Transaction, User
+from polar.payout.service import payout as payout_service
+from polar.postgres import AsyncSession
+from polar.transaction.repository import (
+    PayoutReversalTransactionRepository,
+    TransactionRepository,
+)
+from scripts.backfill_payout_reversal_unpaid import run_backfill
+from tests.fixtures import random_objects as ro
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_payout_account
+
+ten_days_ago = utc_now() - timedelta(days=10)
+create_payment_transaction = partial(
+    ro.create_payment_transaction, amount=10000, created_at=ten_days_ago
+)
+create_balance_transaction = partial(
+    ro.create_balance_transaction, amount=10000, created_at=ten_days_ago
+)
+
+
+@pytest.mark.asyncio
+class TestRunBackfill:
+    async def _cancel_then_repay(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        locker: Locker,
+        organization: Organization,
+        account: Account,
+        user: User,
+    ) -> tuple[Transaction, Transaction, Transaction]:
+        await create_payout_account(save_fixture, organization, user)
+        payment_transaction = await create_payment_transaction(save_fixture)
+        await create_balance_transaction(
+            save_fixture, account=account, payment_transaction=payment_transaction
+        )
+
+        first_payout = await payout_service.create(session, locker, organization)
+        first_transaction = first_payout.transaction
+        await payout_service.cancel(session, first_payout)
+        second_payout = await payout_service.create(session, locker, organization)
+
+        reversal_repository = PayoutReversalTransactionRepository.from_session(session)
+        reversal = await reversal_repository.get_by_payout_id(first_payout.id)
+        assert reversal is not None
+        return reversal, first_transaction, second_payout.transaction
+
+    async def test_dry_run_leaves_the_reversal_where_it_is(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        locker: Locker,
+        organization: Organization,
+        account: Account,
+        user: User,
+    ) -> None:
+        reversal, _, second_transaction = await self._cancel_then_repay(
+            save_fixture, session, locker, organization, account, user
+        )
+        reversal_repository = PayoutReversalTransactionRepository.from_session(session)
+        await reversal_repository.update(
+            reversal, update_dict={"payout_transaction_id": second_transaction.id}
+        )
+
+        attributed = await run_backfill(session, execute=False)
+
+        assert attributed == 0
+        assert reversal.payout_transaction_id == second_transaction.id
+
+    async def test_execute_repoints_and_restores_the_sum(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        locker: Locker,
+        organization: Organization,
+        account: Account,
+        user: User,
+    ) -> None:
+        reversal, first_transaction, second_transaction = await self._cancel_then_repay(
+            save_fixture, session, locker, organization, account, user
+        )
+        reversal_repository = PayoutReversalTransactionRepository.from_session(session)
+        await reversal_repository.update(
+            reversal, update_dict={"payout_transaction_id": second_transaction.id}
+        )
+
+        attributed = await run_backfill(session, execute=True)
+
+        assert attributed == 1
+        await session.refresh(reversal)
+        assert reversal.payout_transaction_id == first_transaction.id
+
+        repository = TransactionRepository.from_session(session)
+        paid_transactions = await repository.get_all_paid_transactions_by_payout(
+            second_transaction.id
+        )
+        assert -second_transaction.amount == sum(t.amount for t in paid_transactions)
+
+    async def test_attributes_a_reversal_left_unattributed(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        locker: Locker,
+        organization: Organization,
+        account: Account,
+        user: User,
+    ) -> None:
+        reversal, first_transaction, _ = await self._cancel_then_repay(
+            save_fixture, session, locker, organization, account, user
+        )
+        reversal_repository = PayoutReversalTransactionRepository.from_session(session)
+        await reversal_repository.update(
+            reversal, update_dict={"payout_transaction_id": None}
+        )
+
+        attributed = await run_backfill(session, execute=True)
+
+        assert attributed == 1
+        await session.refresh(reversal)
+        assert reversal.payout_transaction_id == first_transaction.id
+
+    async def test_leaves_a_correctly_attributed_reversal_alone(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        locker: Locker,
+        organization: Organization,
+        account: Account,
+        user: User,
+    ) -> None:
+        reversal, first_transaction, _ = await self._cancel_then_repay(
+            save_fixture, session, locker, organization, account, user
+        )
+        assert reversal.payout_transaction_id == first_transaction.id
+
+        assert await run_backfill(session, execute=True) == 0

--- a/server/tests/scripts/test_backfill_payout_reversal_unpaid.py
+++ b/server/tests/scripts/test_backfill_payout_reversal_unpaid.py
@@ -127,6 +127,41 @@ class TestRunBackfill:
         await session.refresh(reversal)
         assert reversal.payout_transaction_id == first_transaction.id
 
+    async def test_attributes_every_reversal_across_batches(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        locker: Locker,
+        organization: Organization,
+        account: Account,
+        user: User,
+    ) -> None:
+        await create_payout_account(save_fixture, organization, user)
+        reversal_repository = PayoutReversalTransactionRepository.from_session(session)
+        pairs: list[tuple[Transaction, Transaction]] = []
+        for index in range(3):
+            payment_transaction = await create_payment_transaction(
+                save_fixture, charge_id=f"STRIPE_CHARGE_ID_{index}"
+            )
+            await create_balance_transaction(
+                save_fixture, account=account, payment_transaction=payment_transaction
+            )
+            payout = await payout_service.create(session, locker, organization)
+            await payout_service.cancel(session, payout)
+            reversal = await reversal_repository.get_by_payout_id(payout.id)
+            assert reversal is not None
+            await reversal_repository.update(
+                reversal, update_dict={"payout_transaction_id": None}
+            )
+            pairs.append((reversal, payout.transaction))
+
+        attributed = await run_backfill(session, execute=True, batch_size=1)
+
+        assert attributed == 3
+        for reversal, payout_transaction in pairs:
+            await session.refresh(reversal)
+            assert reversal.payout_transaction_id == payout_transaction.id
+
     async def test_leaves_a_correctly_attributed_reversal_alone(
         self,
         save_fixture: SaveFixture,

--- a/server/tests/transaction/service/test_payout.py
+++ b/server/tests/transaction/service/test_payout.py
@@ -221,6 +221,7 @@ class TestReverse:
         assert transaction.account_currency == payout.account_currency
         assert transaction.account_amount == -payout.account_amount
         assert transaction.transfer_reversal_id is None
+        assert transaction.payout_transaction_id == payout_transaction.id
 
         assert payout_transaction.payout == payout
 


### PR DESCRIPTION
## Summary

**Related Issue**: polarsource/feedback#291

Cancel a payout, request a new one, and the new payout's `paid_transactions` sum to roughly twice its amount. Invoice generation then fails and the CSV export doesn't reconcile.

## What

- `reverse()` stamps the reversal's `payout_transaction_id` with the payout  transaction it reverses, instead of leaving it unattributed.
- `scripts/backfill_payout_reversal_unpaid.py` re-points existing reversals.

## Why

Canceling a payout releases its funds twice over: `reverse()` writes a `payout_reversal` that nets out the `payout`, and `reset_payout_transaction_id()` clears `payout_transaction_id` on the balance transactions. Those balance
transactions are the funds. Both matched `payout_transaction_id IS NULL`, so the next payout claimed both and counted the same money twice.

That breaks `sum(paid_transactions) == payout.amount`, which `create_payout_invoice` asserts and `PayoutTransactionsAmountInvariant` checks. The affected payouts cannot produce an invoice, and their CSV lists a row that doesn't add up to the payout total. No wrong invoice went out — the check runs before the PDF.

## How

The reversal belongs to the payout it reverses, so it is attributed there at cancel time. It no longer has a NULL `payout_transaction_id` for a later payout to claim, which keeps #13107 intact — reversals are still attributed, and now
immediately rather than only if the merchant happens to request another payout.
No summing site needs an exception and the invariant stays as strict as it is.

The reset must run before the reversal is created: it clears every row pointing at the payout, which would otherwise include the reversal itself.

Red/green. The first commit adds a ledger test that cancels a payout, requests a new one, and asserts `payout.amount == sum(paid_transactions)`; it fails on the reported numbers.

Run the backfill after this deploys, not before — a cancel in the window would recreate the rows.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787826830&installation_model_id=13063&pr_number=13401&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13401&signature=882ba493efd5fcadecb09b4298a80054f878eab144656e1b9265dfc93918e73e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13401?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

