### PR TITLE
fix(scheduler): keep heartbeat fresh during idle waits

### DIFF
--- a/server/polar/worker/scheduler.py
+++ b/server/polar/worker/scheduler.py
@@ -23,16 +23,25 @@ configure_logfire("worker")
 configure_logging(logfire=True)
 
 HEARTBEAT_STALENESS_SECONDS = 60
+# Cap the idle sleep below the staleness threshold so an idle scheduler keeps
+# refreshing its heartbeat instead of reading as unhealthy.
+HEARTBEAT_INTERVAL_SECONDS = 30
 _last_heartbeat: float = 0.0
+
+
+def _bounded_wait_seconds(wait_seconds: float | None) -> float:
+    if wait_seconds is None:
+        return HEARTBEAT_INTERVAL_SECONDS
+    return min(wait_seconds, HEARTBEAT_INTERVAL_SECONDS)
 
 
 class LogfireBlockingScheduler(BlockingScheduler):
     def _main_loop(self) -> None:
         global _last_heartbeat
-        wait_seconds = 1
+        wait_seconds: float | None = 1
         while self.state != STATE_STOPPED:
             with logfire.span("Scheduler wakeup"):
-                self._event.wait(wait_seconds)
+                self._event.wait(_bounded_wait_seconds(wait_seconds))
                 self._event.clear()
                 wait_seconds = self._process_jobs()
                 _last_heartbeat = time.monotonic()

--- a/server/tests/worker/test_health.py
+++ b/server/tests/worker/test_health.py
@@ -173,6 +173,31 @@ class TestIsSchedulerHealthy:
             scheduler_module._last_heartbeat = original
 
 
+class TestBoundedWaitSeconds:
+    def test_caps_long_wait_to_heartbeat_interval(self) -> None:
+        from polar.worker.scheduler import (
+            HEARTBEAT_INTERVAL_SECONDS,
+            HEARTBEAT_STALENESS_SECONDS,
+            _bounded_wait_seconds,
+        )
+
+        assert _bounded_wait_seconds(900) == HEARTBEAT_INTERVAL_SECONDS
+        assert HEARTBEAT_INTERVAL_SECONDS < HEARTBEAT_STALENESS_SECONDS
+
+    def test_caps_none_wait_to_heartbeat_interval(self) -> None:
+        from polar.worker.scheduler import (
+            HEARTBEAT_INTERVAL_SECONDS,
+            _bounded_wait_seconds,
+        )
+
+        assert _bounded_wait_seconds(None) == HEARTBEAT_INTERVAL_SECONDS
+
+    def test_keeps_short_wait_unchanged(self) -> None:
+        from polar.worker.scheduler import _bounded_wait_seconds
+
+        assert _bounded_wait_seconds(5) == 5
+
+
 def _create_test_app() -> Starlette:
     mock_redis = AsyncMock()
     mock_redis.ping = AsyncMock()


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787829240&installation_model_id=13063&pr_number=13403&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13403&signature=bddb1314f8601f78fe28c6d7dd9b7c68cececb9cb5bcd3b9b65eaf22be45df2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents false unhealthy status and restarts by keeping the scheduler heartbeat fresh during idle waits. Caps idle sleep to 30s so the heartbeat updates well within the staleness window.

- **Bug Fixes**
  - In `polar.worker.scheduler`, added `HEARTBEAT_INTERVAL_SECONDS` (30s) and `_bounded_wait_seconds`, and used it in the main loop to limit idle waits.
  - Added tests to verify wait capping and that the interval is below `HEARTBEAT_STALENESS_SECONDS`.

<sup>Written for commit b95697a6499b3f0b45fa9e843303b7032b1bc26b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

