### PR TITLE
feat(organization): embed hosts allowlist

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -25605,6 +25605,16 @@ export interface components {
       customer_email_settings: components['schemas']['OrganizationCustomerEmailSettings']
       /** @description Settings related to the customer portal */
       customer_portal_settings: components['schemas']['OrganizationCustomerPortalSettings']
+      /**
+       * Embed Hosts
+       * @description Hosts allowed to embed this organization's checkout. An entry is a host, optionally prefixed by a scheme and suffixed by a port. `*.example.com` matches any subdomain, but not `example.com` itself. Without a scheme, HTTPS is implied.
+       */
+      embed_hosts: string[]
+      /**
+       * Embed Hosts Enforced
+       * @description Whether an embedding page's origin must match `embed_hosts`. Organizations that have not configured a list yet embed unchecked until the allowlist is enforced for everyone.
+       */
+      embed_hosts_enforced: boolean
       /** @description Two-letter country code (ISO 3166-1 alpha-2). */
       country?:
         | (
@@ -26845,6 +26855,16 @@ export interface components {
       customer_email_settings: components['schemas']['OrganizationCustomerEmailSettings']
       /** @description Settings related to the customer portal */
       customer_portal_settings: components['schemas']['OrganizationCustomerPortalSettings']
+      /**
+       * Embed Hosts
+       * @description Hosts allowed to embed this organization's checkout. An entry is a host, optionally prefixed by a scheme and suffixed by a port. `*.example.com` matches any subdomain, but not `example.com` itself. Without a scheme, HTTPS is implied.
+       */
+      embed_hosts: string[]
+      /**
+       * Embed Hosts Enforced
+       * @description Whether an embedding page's origin must match `embed_hosts`. Organizations that have not configured a list yet embed unchecked until the allowlist is enforced for everyone.
+       */
+      embed_hosts_enforced: boolean
       /** @description Two-letter country code (ISO 3166-1 alpha-2). */
       country?:
         | (
@@ -28117,6 +28137,8 @@ export interface components {
       customer_portal_settings?:
         | components['schemas']['OrganizationCustomerPortalSettings']
         | null
+      /** Embed Hosts */
+      embed_hosts?: string[] | null
       /** @description Default presentment currency for the organization */
       default_presentment_currency?:
         | components['schemas']['PresentmentCurrency']
@@ -28250,6 +28272,16 @@ export interface components {
       customer_email_settings: components['schemas']['OrganizationCustomerEmailSettings']
       /** @description Settings related to the customer portal */
       customer_portal_settings: components['schemas']['OrganizationCustomerPortalSettings']
+      /**
+       * Embed Hosts
+       * @description Hosts allowed to embed this organization's checkout. An entry is a host, optionally prefixed by a scheme and suffixed by a port. `*.example.com` matches any subdomain, but not `example.com` itself. Without a scheme, HTTPS is implied.
+       */
+      embed_hosts: string[]
+      /**
+       * Embed Hosts Enforced
+       * @description Whether an embedding page's origin must match `embed_hosts`. Organizations that have not configured a list yet embed unchecked until the allowlist is enforced for everyone.
+       */
+      embed_hosts_enforced: boolean
       /** @description Two-letter country code (ISO 3166-1 alpha-2). */
       country?:
         | (

--- a/server/emails/src/types/openapi.ts
+++ b/server/emails/src/types/openapi.ts
@@ -1655,6 +1655,16 @@ export interface components {
       /** @description Settings related to the customer portal */
       customer_portal_settings: components['schemas']['OrganizationCustomerPortalSettings']
       /**
+       * Embed Hosts
+       * @description Hosts allowed to embed this organization's checkout. An entry is a host, optionally prefixed by a scheme and suffixed by a port. `*.example.com` matches any subdomain, but not `example.com` itself. Without a scheme, HTTPS is implied.
+       */
+      embed_hosts: string[]
+      /**
+       * Embed Hosts Enforced
+       * @description Whether an embedding page's origin must match `embed_hosts`. Organizations that have not configured a list yet embed unchecked until the allowlist is enforced for everyone.
+       */
+      embed_hosts_enforced: boolean
+      /**
        * @description Two-letter country code (ISO 3166-1 alpha-2).
        * @default null
        */

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -91,6 +91,7 @@ from polar.observability.checkout_metrics import (
     CHECKOUT_SUCCEEDED_TOTAL,
 )
 from polar.order.service import order as order_service
+from polar.organization.embed_hosts import parse_origin
 from polar.postgres import AsyncReadSession, AsyncSession
 from polar.posthog import posthog
 from polar.product.custom_price import validate_custom_price_amount
@@ -698,6 +699,12 @@ class CheckoutService:
         query_prefill: dict[str, str | UUID4 | dict[str, str] | None] | None = None,
         **query_metadata: str | None,
     ) -> Checkout:
+        if embed_origin is not None:
+            parsed_embed_origin = parse_origin(embed_origin)
+            embed_origin = (
+                str(parsed_embed_origin) if parsed_embed_origin is not None else None
+            )
+
         products: list[Product] = []
         for product in checkout_link.products:
             if not product.is_archived and product.visibility != Visibility.draft:

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -181,6 +181,10 @@ class OrganizationCheckoutSettings(TypedDict):
     require_3ds: bool
 
 
+# Organizations created from this point must list their embed hosts.
+EMBED_HOSTS_ENFORCED_FROM = datetime(2026, 8, 4, tzinfo=UTC)
+
+
 def _default_checkout_settings() -> OrganizationCheckoutSettings:
     return {
         "require_3ds": True,
@@ -630,6 +634,13 @@ class Organization(RateLimitGroupMixin, RecordModel):
     embed_hosts: Mapped[list[str] | None] = mapped_column(
         JSONB, nullable=True, default=list
     )
+
+    @property
+    def embed_hosts_enforced(self) -> bool:
+        """Filling the list in opts an older organization in: nothing but a
+        merchant ever writes to the column, so a non-empty list is a deliberate
+        choice."""
+        return bool(self.embed_hosts) or self.created_at >= EMBED_HOSTS_ENFORCED_FROM
 
     legal_entity: Mapped[OrganizationLegalEntity | None] = mapped_column(
         JSONB, nullable=True, default=None

--- a/server/polar/organization/embed_hosts.py
+++ b/server/polar/organization/embed_hosts.py
@@ -1,0 +1,138 @@
+from dataclasses import dataclass
+
+from pydantic import AnyUrl, TypeAdapter, ValidationError
+
+DEFAULT_PORTS = {"http": 80, "https": 443}
+DEFAULT_SCHEME = "https"
+
+MAX_HOST_LENGTH = 253
+
+WILDCARD_PREFIX = "*."
+# Stands in for the wildcard so an entry can go through the origin parser.
+_WILDCARD_LABEL = "wildcard"
+
+_url_adapter = TypeAdapter(AnyUrl)
+
+
+class InvalidEmbedHost(ValueError):
+    def __init__(self, value: str, reason: str) -> None:
+        self.value = value
+        super().__init__(f"{value!r} is not a valid embed host: {reason}")
+
+
+@dataclass(frozen=True, slots=True)
+class ParsedOrigin:
+    scheme: str
+    host: str
+    port: int | None
+
+    def __str__(self) -> str:
+        if self.port is None or self.port == DEFAULT_PORTS.get(self.scheme):
+            return f"{self.scheme}://{self.host}"
+        return f"{self.scheme}://{self.host}:{self.port}"
+
+
+@dataclass(frozen=True, slots=True)
+class HostPattern:
+    scheme: str
+    host: str
+    port: int | None
+    wildcard: bool
+
+    def __str__(self) -> str:
+        scheme = f"{self.scheme}://" if self.scheme != DEFAULT_SCHEME else ""
+        host = f"{WILDCARD_PREFIX}{self.host}" if self.wildcard else self.host
+        port = (
+            f":{self.port}"
+            if self.port is not None and self.port != DEFAULT_PORTS.get(self.scheme)
+            else ""
+        )
+        return f"{scheme}{host}{port}"
+
+    def matches(self, origin: ParsedOrigin) -> bool:
+        if origin.scheme != self.scheme or origin.port != self.port:
+            return False
+        if self.wildcard:
+            return origin.host.endswith(f".{self.host}")
+        return origin.host == self.host
+
+
+def _parse_url(value: str) -> AnyUrl | None:
+    try:
+        return _url_adapter.validate_python(value)
+    except ValidationError:
+        return None
+
+
+def parse_origin(value: str) -> ParsedOrigin | None:
+    """Path, query, fragment and credentials are dropped: `postMessage` compares
+    the origin of `targetOrigin` and ignores the rest. `null` and `file://`
+    carry no origin at all."""
+    url = _parse_url(value)
+    if url is None or url.host is None or "*" in url.host:
+        return None
+
+    return ParsedOrigin(url.scheme, url.host, url.port)
+
+
+def parse_host_pattern(value: str) -> HostPattern | None:
+    """An entry is a host with an optional scheme and port — `example.com`,
+    `*.example.com`, `localhost:3000`, `http://192.168.1.43:5500` — and HTTPS
+    when no scheme is given. It shares the URL parser with `parse_origin` so an
+    entry and the origin it must match normalize alike, punycode included."""
+    entry = value.strip()
+    scheme, separator, remainder = entry.partition("://")
+    if not separator:
+        scheme, remainder = DEFAULT_SCHEME, entry
+
+    wildcard = remainder.startswith(WILDCARD_PREFIX)
+    host = remainder.removeprefix(WILDCARD_PREFIX) if wildcard else remainder
+    if not host or "*" in host:
+        return None
+
+    probe = f"{scheme}://{_WILDCARD_LABEL}.{host}" if wildcard else f"{scheme}://{host}"
+    url = _parse_url(probe)
+    if url is None or url.host is None:
+        return None
+
+    # An origin may carry these and lose them; an entry has to be a host alone.
+    if url.path not in (None, "", "/") or url.query is not None:
+        return None
+    if url.fragment is not None or url.username is not None:
+        return None
+
+    parsed_host = url.host.removeprefix(f"{_WILDCARD_LABEL}.") if wildcard else url.host
+    if len(parsed_host) > MAX_HOST_LENGTH:
+        return None
+
+    return HostPattern(url.scheme, parsed_host, url.port, wildcard)
+
+
+def validate_host_pattern(value: str) -> str:
+    if not value.strip():
+        raise InvalidEmbedHost(value, "it is empty")
+
+    if value.strip().removeprefix(WILDCARD_PREFIX).strip() in ("", "*"):
+        raise InvalidEmbedHost(value, "a bare wildcard would let any page embed")
+
+    pattern = parse_host_pattern(value)
+    if pattern is None:
+        raise InvalidEmbedHost(
+            value, "write a host, with an optional scheme and port, and no path"
+        )
+
+    return str(pattern)
+
+
+def match_origin(origin: str, hosts: list[str]) -> str | None:
+    """Return the normalized origin when the allowlist admits it."""
+    parsed = parse_origin(origin)
+    if parsed is None:
+        return None
+
+    for entry in hosts:
+        pattern = parse_host_pattern(entry)
+        if pattern is not None and pattern.matches(parsed):
+            return str(parsed)
+
+    return None

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -44,6 +44,7 @@ from polar.models.user_organization import (
     OrganizationNotificationSettings,
     OrganizationRole,
 )
+from polar.organization.embed_hosts import InvalidEmbedHost, validate_host_pattern
 
 OrganizationID = Annotated[
     UUID4,
@@ -68,6 +69,35 @@ NameInput = Annotated[
     str,
     StringConstraints(min_length=3),
     AfterValidator(validate_blocked_words),
+]
+
+
+def validate_embed_hosts(value: list[str]) -> list[str]:
+    hosts: list[str] = []
+    for entry in value:
+        try:
+            host = validate_host_pattern(entry)
+        except InvalidEmbedHost as e:
+            raise ValueError(str(e)) from e
+        if host not in hosts:
+            hosts.append(host)
+    return hosts
+
+
+_embed_hosts_description = (
+    "Hosts allowed to embed this organization's checkout. "
+    "An entry is a host, optionally prefixed by a scheme and suffixed by a port. "
+    "`*.example.com` matches any subdomain, but not `example.com` itself. "
+    "Without a scheme, HTTPS is implied."
+)
+
+EmbedHostsInput = Annotated[
+    list[str],
+    AfterValidator(validate_embed_hosts),
+    Field(
+        description=_embed_hosts_description,
+        examples=[["example.com", "*.example.com", "http://localhost:3000"]],
+    ),
 ]
 
 
@@ -476,6 +506,14 @@ class Organization(OrganizationBase):
     customer_portal_settings: OrganizationCustomerPortalSettings = Field(
         description="Settings related to the customer portal",
     )
+    embed_hosts: list[str] = Field(description=_embed_hosts_description)
+    embed_hosts_enforced: bool = Field(
+        description=(
+            "Whether an embedding page's origin must match `embed_hosts`. "
+            "Organizations that have not configured a list yet embed unchecked "
+            "until the allowlist is enforced for everyone."
+        ),
+    )
     country: CountryAlpha2 | None = Field(
         None, description="Two-letter country code (ISO 3166-1 alpha-2)."
     )
@@ -614,6 +652,7 @@ class OrganizationUpdate(Schema):
     subscription_settings: OrganizationSubscriptionSettings | None = None
     customer_email_settings: OrganizationCustomerEmailSettings | None = None
     customer_portal_settings: OrganizationCustomerPortalSettings | None = None
+    embed_hosts: EmbedHostsInput | None = None
     default_presentment_currency: PresentmentCurrency | None = Field(
         None, description="Default presentment currency for the organization"
     )

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -2565,6 +2565,38 @@ class TestCheckoutLinkCreate:
         assert checkout.success_url == "https://example.com/success"
         assert checkout.user_metadata == {"key": "value"}
 
+    async def test_dropped_embed_origin(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product_one_time: Product,
+    ) -> None:
+        checkout_link = await create_checkout_link(
+            save_fixture, products=[product_one_time]
+        )
+
+        checkout = await checkout_service.checkout_link_create(
+            session, checkout_link, embed_origin="*"
+        )
+
+        assert checkout.embed_origin is None
+
+    async def test_normalized_embed_origin(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product_one_time: Product,
+    ) -> None:
+        checkout_link = await create_checkout_link(
+            save_fixture, products=[product_one_time]
+        )
+
+        checkout = await checkout_service.checkout_link_create(
+            session, checkout_link, embed_origin="https://Example.com:443/"
+        )
+
+        assert checkout.embed_origin == "https://example.com"
+
     async def test_valid_custom_price_honors_zero_prefill(
         self,
         save_fixture: SaveFixture,

--- a/server/tests/checkout_link/test_endpoints.py
+++ b/server/tests/checkout_link/test_endpoints.py
@@ -366,6 +366,24 @@ class TestRedirect:
         assert response.status_code == 307
         assert CHECKOUT_CLIENT_SECRET_PREFIX in response.headers["location"]
 
+    async def test_wildcard_embed_origin(
+        self, session: AsyncSession, client: AsyncClient, checkout_link: CheckoutLink
+    ) -> None:
+        response = await client.get(
+            f"/v1/checkout-links/{checkout_link.client_secret}/redirect",
+            params={"embed_origin": "*"},
+        )
+
+        assert response.status_code == 307
+
+        checkout_repository = CheckoutRepository.from_session(session)
+        checkouts = await checkout_repository.get_all(
+            checkout_repository.get_base_statement().order_by(
+                Checkout.created_at.desc()
+            )
+        )
+        assert checkouts[0].embed_origin is None
+
     async def test_allowed_metadata(
         self, session: AsyncSession, client: AsyncClient, checkout_link: CheckoutLink
     ) -> None:

--- a/server/tests/organization/test_embed_hosts.py
+++ b/server/tests/organization/test_embed_hosts.py
@@ -1,0 +1,162 @@
+import pytest
+
+from polar.organization.embed_hosts import (
+    InvalidEmbedHost,
+    match_origin,
+    parse_origin,
+    validate_host_pattern,
+)
+
+
+class TestParseOrigin:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("https://example.com", "https://example.com"),
+            ("https://a.b.example.com", "https://a.b.example.com"),
+            ("https://example.com/", "https://example.com"),
+            ("HTTPS://Example.COM", "https://example.com"),
+            ("https://example.com:443", "https://example.com"),
+            ("https://example.com:8443", "https://example.com:8443"),
+            ("http://localhost:3000", "http://localhost:3000"),
+            ("http://127.0.0.1:3000", "http://127.0.0.1:3000"),
+            ("https://exämple.com", "https://xn--exmple-cua.com"),
+        ],
+    )
+    def test_origin(self, value: str, expected: str) -> None:
+        parsed = parse_origin(value)
+
+        assert parsed is not None
+        assert str(parsed) == expected
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("https://example.com/laserHinge", "https://example.com"),
+            ("https://example.com/?verified=true", "https://example.com"),
+            ("https://example.com/#/", "https://example.com"),
+            ("https://example.com/sales?status=cancelled", "https://example.com"),
+            ("https://evil.com@good.com", "https://good.com"),
+            ("https://example.com\n", "https://example.com"),
+        ],
+    )
+    def test_reduced_to_origin(self, value: str, expected: str) -> None:
+        """`postMessage` compares origins and ignores the rest, so we do too."""
+        parsed = parse_origin(value)
+
+        assert parsed is not None
+        assert str(parsed) == expected
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("http://example.com", "http://example.com"),
+            ("http://192.168.1.43:5500", "http://192.168.1.43:5500"),
+            ("http://tauri.localhost", "http://tauri.localhost"),
+            ("chrome-extension://abcdef", "chrome-extension://abcdef"),
+        ],
+    )
+    def test_non_https_origin(self, value: str, expected: str) -> None:
+        """Which schemes may embed is the allowlist's call, not the parser's."""
+        parsed = parse_origin(value)
+
+        assert parsed is not None
+        assert str(parsed) == expected
+
+    def test_wildcard_host(self) -> None:
+        """A wildcard is an allowlist entry, never an origin a browser sends."""
+        assert parse_origin("https://*.example.com") is None
+        assert parse_origin("https://*") is None
+
+    @pytest.mark.parametrize(
+        "value", ["", "*", "null", "file://", "ips-platform-x:3000"]
+    )
+    def test_no_origin(self, value: str) -> None:
+        assert parse_origin(value) is None
+
+
+class TestValidateHostPattern:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            ("example.com", "example.com"),
+            ("*.example.com", "*.example.com"),
+            ("EXAMPLE.com", "example.com"),
+            ("  example.com  ", "example.com"),
+            ("https://example.com", "example.com"),
+            ("example.com:443", "example.com"),
+            ("example.com:8443", "example.com:8443"),
+            ("localhost:3000", "localhost:3000"),
+            ("http://localhost:3000", "http://localhost:3000"),
+            ("http://192.168.1.43:5500", "http://192.168.1.43:5500"),
+            ("chrome-extension://abcdef", "chrome-extension://abcdef"),
+            ("*.exämple.com", "*.xn--exmple-cua.com"),
+        ],
+    )
+    def test_normalized(self, value: str, expected: str) -> None:
+        assert validate_host_pattern(value) == expected
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "   ",
+            "*",
+            "*.",
+            "https://*",
+            "*example.com",
+            "a.*.com",
+            "example.com/path",
+            "example.com?a=1",
+            "example.com#fragment",
+            "example.com\\evil.com",
+            "user@example.com",
+            "https://evil.com@good.com",
+            "exa mple.com",
+            "x" * 260,
+        ],
+    )
+    def test_rejected(self, value: str) -> None:
+        with pytest.raises(InvalidEmbedHost):
+            validate_host_pattern(value)
+
+
+class TestMatchOrigin:
+    @pytest.mark.parametrize(
+        ("origin", "entry"),
+        [
+            ("https://example.com", "example.com"),
+            ("https://a.example.com", "*.example.com"),
+            ("https://a.b.example.com", "*.example.com"),
+            ("https://example.com:8443", "example.com:8443"),
+            ("http://localhost:3000", "http://localhost:3000"),
+            ("https://a.xn--exmple-cua.com", "*.exämple.com"),
+            ("chrome-extension://abcdef", "chrome-extension://abcdef"),
+        ],
+    )
+    def test_allowed(self, origin: str, entry: str) -> None:
+        assert match_origin(origin, [entry]) == origin
+
+    @pytest.mark.parametrize(
+        ("origin", "entry"),
+        [
+            ("https://evil.com", "example.com"),
+            ("https://www.example.com", "example.com"),
+            ("https://example.com", "*.example.com"),
+            ("https://notexample.com", "*.example.com"),
+            ("https://example.com:8443", "example.com"),
+            ("http://example.com", "example.com"),
+            ("http://localhost:3000", "localhost:3000"),
+        ],
+    )
+    def test_refused(self, origin: str, entry: str) -> None:
+        assert match_origin(origin, [entry]) is None
+
+    def test_reduced_to_origin(self) -> None:
+        assert (
+            match_origin("https://www.makercase.com/laserHinge", ["*.makercase.com"])
+            == "https://www.makercase.com"
+        )
+
+    def test_empty_allowlist(self) -> None:
+        assert match_origin("https://example.com", []) is None


### PR DESCRIPTION
Related Issue: polarsource/feedback#195

Adds an organization-level allowlist of hosts permitted to embed checkout. Nothing is enforced yet.

## What

Organization.embed_hosts readable and writable over the API, under org-write scope. Entries are hosts with an optional scheme and port: example.com, *.example.com, localhost:3000, http://192.168.1.43:5500. HTTPS is implied, and *.example.com matches any subdomain but not the apex.

Organization.embed_hosts_enforced computed from the list being non-empty, or the organization being created on or after EMBED_HOSTS_ENFORCED_FROM.

embed_origin reduced to its origin on the checkout-link redirect instead of stored verbatim.

## Why

embed_origin arrives from a query parameter and becomes the postMessage targetOrigin carrying a customer session token. The allowlist is what will let merchants constrain it. This PR is the API and the matching; enforcement follows separately so merchants can populate their list before anything breaks.

## How

Entries and origins share one URL parser, so both normalise identically — *.exämple.com is stored as *.xn--exmple-cua.com and matches https://a.xn--exmple-cua.com.

parse_origin reduces a URL to its origin and never errors. 90 days of production shows a strict check would have refused something from 122 of 1,379 embedding organizations, mostly full page URLs like https://www.makercase.com/laserHinge, plus plain HTTP and chrome-extension://. All of those embed correctly, because postMessage compares only the origin. Values with no origin (null, file://) store nothing rather than raising.

No cap on list length: one organization runs 92 distinct apex domains. Wildcards inside a label are not supported, so Vercel previews like website-<hash>-tabler-io.vercel.app can only be covered by *.vercel.app — worth deciding before enforcement.

Merges after #13408.

Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (uv run task lint && uv run task lint_types)
- [x] No unrelated changes or drive-by fixes are included