### PR TITLE
feat(organization): enforce embed_hosts not null

### DIFF
--- a/server/migrations/versions/2026-07-28-1633_enforce_organizations_embed_hosts_not_.py
+++ b/server/migrations/versions/2026-07-28-1633_enforce_organizations_embed_hosts_not_.py
@@ -11,7 +11,6 @@ from alembic import op
 from sqlalchemy.dialects import postgresql
 
 # Polar Custom Imports
-from polar.config import settings
 
 # revision identifiers, used by Alembic.
 revision = "45773b693045"
@@ -24,13 +23,7 @@ def upgrade() -> None:
     # Ensures we don't break app by applying a deadlock-inducing migration
     # `organizations` is a busy table: allow longer to acquire the lock.
     op.execute("SET LOCAL lock_timeout = '30s'")
-    # Local dev only, so a fresh database doesn't need the backfill script.
-    # Deployed environments run scripts.backfill_organization_embed_hosts first,
-    # and never rewrite the table under lock.
-    if settings.is_development():
-        op.execute(
-            "UPDATE organizations SET embed_hosts = '[]' WHERE embed_hosts IS NULL"
-        )
+    op.execute("UPDATE organizations SET embed_hosts = '[]' WHERE embed_hosts IS NULL")
     op.alter_column(
         "organizations",
         "embed_hosts",

--- a/server/migrations/versions/2026-07-28-1633_enforce_organizations_embed_hosts_not_.py
+++ b/server/migrations/versions/2026-07-28-1633_enforce_organizations_embed_hosts_not_.py
@@ -1,0 +1,51 @@
+"""enforce organizations embed_hosts not null
+
+Revision ID: 45773b693045
+Revises: b493ccc15e3f
+Create Date: 2026-07-28 16:33:09.615815
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# Polar Custom Imports
+from polar.config import settings
+
+# revision identifiers, used by Alembic.
+revision = "45773b693045"
+down_revision = "b493ccc15e3f"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    # `organizations` is a busy table: allow longer to acquire the lock.
+    op.execute("SET LOCAL lock_timeout = '30s'")
+    # Local dev only, so a fresh database doesn't need the backfill script.
+    # Deployed environments run scripts.backfill_organization_embed_hosts first,
+    # and never rewrite the table under lock.
+    if settings.is_development():
+        op.execute(
+            "UPDATE organizations SET embed_hosts = '[]' WHERE embed_hosts IS NULL"
+        )
+    op.alter_column(
+        "organizations",
+        "embed_hosts",
+        existing_type=postgresql.JSONB(astext_type=sa.Text()),
+        nullable=False,
+    )
+
+
+def downgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    # `organizations` is a busy table: allow longer to acquire the lock.
+    op.execute("SET LOCAL lock_timeout = '30s'")
+    op.alter_column(
+        "organizations",
+        "embed_hosts",
+        existing_type=postgresql.JSONB(astext_type=sa.Text()),
+        nullable=True,
+    )

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -627,9 +627,7 @@ class Organization(RateLimitGroupMixin, RecordModel):
         JSONB, nullable=False, default=_default_checkout_settings
     )
 
-    embed_hosts: Mapped[list[str] | None] = mapped_column(
-        JSONB, nullable=True, default=list
-    )
+    embed_hosts: Mapped[list[str]] = mapped_column(JSONB, nullable=False, default=list)
 
     legal_entity: Mapped[OrganizationLegalEntity | None] = mapped_column(
         JSONB, nullable=True, default=None


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- issue number -->

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->

## Why

<!-- Explain why this change is needed -->

## How

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787841585&installation_model_id=13063&pr_number=13408&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13408&signature=b88ea718774c1321a54902000e0e495401d78d038fc261e7bcb41a7a068fb8fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `organizations.embed_hosts` non-null with a default empty array to standardize storage and simplify reads. Removes `None` cases and prevents null writes.

- **Migration**
  - Backfills all NULL `embed_hosts` to `[]` in the migration, then sets NOT NULL with a 30s lock timeout.
  - Updates the ORM: `embed_hosts` is `list[str]` with default `[]` (no `None`).

<sup>Written for commit f62b2e40e83467035b7edae23aa5874915ee9938. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13408?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

