### PR TITLE
docs(adr): make the enforce migration's backfill unconditional

### DIFF
--- a/handbook/engineering/decisions/0006-migration-and-backfill-safety.mdx
+++ b/handbook/engineering/decisions/0006-migration-and-backfill-safety.mdx
@@ -23,46 +23,39 @@ Two things make migrations risky during a deploy:
 ## Decision
 
 - Generate migrations with `alembic revision --autogenerate`. Every migration inherits
-  `SET LOCAL lock_timeout = '5s'` from the template.
+  `SET LOCAL lock_timeout = '5s'` from the template. Raise it for a busy table.
 - Add a NOT NULL column across separate PRs: add it nullable, backfill with a batched script
   (`run_batched_update`), then enforce NOT NULL.
-- The enforce migration's inline `UPDATE ... WHERE col IS NULL` is guarded by
-  `settings.is_development()`, so it runs only against a local database. Deployed environments
-  (testing, sandbox, production) run the batched backfill script first, verified before deploy,
-  so they skip the inline `UPDATE` and never rewrite a hot table under lock. The following
-  `SET NOT NULL` then doubles as a check that the backfill completed.
+- The enforce migration runs an unconditional `UPDATE ... WHERE col IS NULL` immediately before
+  `SET NOT NULL`. The batched script does the real work first, so by the time the migration runs
+  this `UPDATE` matches nothing and rewrites nothing.
 - Keep migration PRs isolated from application code.
 
-The local-only guard is a plain inline check. Import `settings` in the migration (from
-`polar.config`, the same module `migrations/env.py` already imports); `is_development()` is
-true only when `POLAR_ENV=development`, which is local:
-
 ```python
-from polar.config import settings
-
 def upgrade() -> None:
-    # Local dev only: deployed environments run the batched backfill first.
-    if settings.is_development():
-        op.execute("UPDATE organizations SET sso_enforced = false WHERE sso_enforced IS NULL")
+    op.execute("UPDATE organizations SET sso_enforced = false WHERE sso_enforced IS NULL")
     op.alter_column("organizations", "sso_enforced", nullable=False)
 ```
 
+The `UPDATE` stays because the script misses two things: environments where nobody ran it, and
+rows written NULL between the backfill and the deploy. Either one fails `SET NOT NULL` and
+strands the schema on the previous revision.
+
 ## Consequences
 
-- A lock-holding migration fails fast at the 5s timeout instead of taking the database down.
+- A lock-holding migration fails fast at the lock timeout instead of taking the database down.
 - Large backfills run outside the deploy path, in controlled batches.
 - Code never ships ahead of the schema it needs.
 - CI enforces this: a "Migration Isolation Check" gates which files travel together, and
   `alembic check` catches model-versus-migration drift.
-- `settings.is_development()` is the single decision for what counts as local. A deployed
-  enforce migration cannot rewrite the table; if the backfill was skipped, `SET NOT NULL` fails
-  the deploy instead.
+- The batched script stays mandatory. The migration's `UPDATE` is only cheap because the script
+  has already left it nothing to do.
 
 ## Alternatives considered
 
 - **Add NOT NULL in one step and let the migration's `UPDATE` backfill every row**: rewrites the
-  table under lock during deploy. The inline `UPDATE` runs in local development only; the batched
-  script does the real backfill everywhere else.
+  table under lock during deploy. The batched script runs first precisely so the migration's
+  `UPDATE` has nothing left to do.
 - **Ship a migration in the same PR as the code that depends on it**: breaks the
   API-before-workers ordering.
 


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- issue number -->

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->

## Why

<!-- Explain why this change is needed -->

## How

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787843790&installation_model_id=13063&pr_number=13410&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13410&signature=48752b54dc08e431107b86f0af6786695aa5f3d6d68f2d6340a8b1eae96506e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made ADR 0006’s enforce migration backfill unconditional: the migration always runs UPDATE ... WHERE col IS NULL before SET NOT NULL, acting as a cheap safety net after the batched backfill. Also clarified lock timeout guidance (5s default; raise for busy tables) and updated consequences/alternatives.

<sup>Written for commit 3a52039ba2e20cbb80f30a1500a4154fc33970b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

