### PR TITLE
feat(orders): filter orders by status in API and sales dashboard

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -15,6 +15,7 @@ import {
   serializeSearchParams,
 } from '@/utils/datatable'
 import { getChartRangeParams } from '@/utils/metrics'
+import type { OrderStatusFilter } from '@/utils/order'
 import FileDownloadOutlined from '@mui/icons-material/FileDownloadOutlined'
 import { schemas } from '@polar-sh/client'
 import { Box } from '@polar-sh/orbit/Box'
@@ -38,7 +39,7 @@ interface ClientPageProps {
   pagination: DataTablePaginationState
   sorting: DataTableSortingState
   productId?: string[]
-  status: string
+  status: OrderStatusFilter
   metadata?: string[]
 }
 
@@ -57,7 +58,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
     pagination: DataTablePaginationState,
     sorting: DataTableSortingState,
     productId?: string[],
-    status?: string,
+    status?: OrderStatusFilter,
   ) => {
     const params = serializeSearchParams(pagination, sorting)
 
@@ -65,7 +66,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
       productId.forEach((id) => params.append('product_id', id))
     }
 
-    if (status && status !== 'all') {
+    if (status && status !== 'any') {
       params.append('status', status)
     }
 
@@ -129,7 +130,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
     )
   }
 
-  const onStatusSelect = (value: string) => {
+  const onStatusSelect = (value: OrderStatusFilter) => {
     router.push(
       `/dashboard/${organization.slug}/sales?${getSearchParams(
         pagination,
@@ -143,7 +144,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
   const ordersHook = useOrders(organization.id, {
     ...getAPIParams(pagination, sorting),
     product_id: productId,
-    ...(status !== 'all' ? { status: [status as schemas['OrderStatus']] } : {}),
+    status: status === 'any' ? undefined : [status],
   })
 
   const orders = ordersHook.data?.items || []

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -3,6 +3,7 @@
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import { MiniMetricChartBox } from '@/components/Metrics/MiniMetricChartBox'
 import { OrderStatus } from '@/components/Orders/OrderStatus'
+import OrderStatusSelect from '@/components/Orders/OrderStatusSelect'
 import ProductSelect from '@/components/Products/ProductSelect'
 import { useMetrics } from '@/hooks/queries/metrics'
 import { useOrders } from '@/hooks/queries/orders'
@@ -16,6 +17,7 @@ import {
 import { getChartRangeParams } from '@/utils/metrics'
 import FileDownloadOutlined from '@mui/icons-material/FileDownloadOutlined'
 import { schemas } from '@polar-sh/client'
+import { Box } from '@polar-sh/orbit/Box'
 import { formatCurrency } from '@polar-sh/currency'
 import { Truncated } from '@polar-sh/orbit'
 import { Avatar } from '@polar-sh/orbit'
@@ -36,6 +38,7 @@ interface ClientPageProps {
   pagination: DataTablePaginationState
   sorting: DataTableSortingState
   productId?: string[]
+  status: string
   metadata?: string[]
 }
 
@@ -44,6 +47,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
   pagination,
   sorting,
   productId,
+  status,
   metadata,
 }) => {
   const [selectedOrderState, setSelectedOrderState] =
@@ -53,11 +57,16 @@ const ClientPage: React.FC<ClientPageProps> = ({
     pagination: DataTablePaginationState,
     sorting: DataTableSortingState,
     productId?: string[],
+    status?: string,
   ) => {
     const params = serializeSearchParams(pagination, sorting)
 
     if (productId) {
       productId.forEach((id) => params.append('product_id', id))
+    }
+
+    if (status && status !== 'any') {
+      params.append('status', status)
     }
 
     if (metadata) {
@@ -84,6 +93,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
         updatedPagination,
         sorting,
         productId,
+        status,
       )}`,
     )
   }
@@ -103,6 +113,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
         pagination,
         updatedSorting,
         productId,
+        status,
       )}`,
     )
   }
@@ -113,6 +124,18 @@ const ClientPage: React.FC<ClientPageProps> = ({
         pagination,
         sorting,
         value,
+        status,
+      )}`,
+    )
+  }
+
+  const onStatusSelect = (value: string) => {
+    router.push(
+      `/dashboard/${organization.slug}/sales?${getSearchParams(
+        pagination,
+        sorting,
+        productId,
+        value,
       )}`,
     )
   }
@@ -120,6 +143,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
   const ordersHook = useOrders(organization.id, {
     ...getAPIParams(pagination, sorting),
     product_id: productId,
+    ...(status !== 'any' ? { status: [status as schemas['OrderStatus']] } : {}),
   })
 
   const orders = ordersHook.data?.items || []
@@ -282,7 +306,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
     <DashboardBody wide>
       <div className="flex flex-col gap-8">
         <div className="flex items-center justify-between gap-2">
-          <div className="w-auto">
+          <Box alignItems="center" columnGap="m">
             <ProductSelect
               organization={organization}
               value={productId || []}
@@ -290,7 +314,10 @@ const ClientPage: React.FC<ClientPageProps> = ({
               className="w-[300px]"
               includeArchived
             />
-          </div>
+            <Box width={200}>
+              <OrderStatusSelect value={status} onChange={onStatusSelect} />
+            </Box>
+          </Box>
           <Button
             onClick={onExport}
             className="flex flex-row items-center"

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -65,7 +65,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
       productId.forEach((id) => params.append('product_id', id))
     }
 
-    if (status && status !== 'any') {
+    if (status && status !== 'all') {
       params.append('status', status)
     }
 
@@ -143,7 +143,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
   const ordersHook = useOrders(organization.id, {
     ...getAPIParams(pagination, sorting),
     product_id: productId,
-    ...(status !== 'any' ? { status: [status as schemas['OrderStatus']] } : {}),
+    ...(status !== 'all' ? { status: [status as schemas['OrderStatus']] } : {}),
   })
 
   const orders = ordersHook.data?.items || []

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/page.tsx
@@ -52,7 +52,7 @@ export default async function Page(props: {
       pagination={pagination}
       sorting={sorting}
       productId={productId}
-      status={searchParams.status ?? 'any'}
+      status={searchParams.status ?? 'all'}
       metadata={metadata}
     />
   )

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/page.tsx
@@ -15,6 +15,7 @@ export default async function Page(props: {
   searchParams: Promise<
     DataTableSearchParams & {
       product_id?: string[] | string
+      status?: string
       metadata?: string[]
     }
   >
@@ -51,6 +52,7 @@ export default async function Page(props: {
       pagination={pagination}
       sorting={sorting}
       productId={productId}
+      status={searchParams.status ?? 'any'}
       metadata={metadata}
     />
   )

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/page.tsx
@@ -1,5 +1,6 @@
 import { getServerSideAPI } from '@/utils/client/serverside'
 import { DataTableSearchParams, parseSearchParams } from '@/utils/datatable'
+import { isOrderStatus } from '@/utils/order'
 import { getOrganizationBySlugOrNotFound } from '@/utils/organization'
 import { Metadata } from 'next'
 import SalesPage from './SalesPage'
@@ -15,7 +16,7 @@ export default async function Page(props: {
   searchParams: Promise<
     DataTableSearchParams & {
       product_id?: string[] | string
-      status?: string
+      status?: string | string[]
       metadata?: string[]
     }
   >
@@ -40,6 +41,11 @@ export default async function Page(props: {
       : [searchParams.product_id]
     : undefined
 
+  const rawStatus = Array.isArray(searchParams.status)
+    ? searchParams.status[0]
+    : searchParams.status
+  const status = rawStatus && isOrderStatus(rawStatus) ? rawStatus : 'any'
+
   const metadata = searchParams.metadata
     ? Array.isArray(searchParams.metadata)
       ? searchParams.metadata
@@ -52,7 +58,7 @@ export default async function Page(props: {
       pagination={pagination}
       sorting={sorting}
       productId={productId}
-      status={searchParams.status ?? 'all'}
+      status={status}
       metadata={metadata}
     />
   )

--- a/clients/apps/web/src/components/Orders/OrderStatus.tsx
+++ b/clients/apps/web/src/components/Orders/OrderStatus.tsx
@@ -1,7 +1,10 @@
 import { schemas } from '@polar-sh/client'
 import { Status, type StatusColor } from '@polar-sh/orbit'
 
-const OrderStatusDisplayTitle: Record<schemas['Order']['status'], string> = {
+export const OrderStatusDisplayTitle: Record<
+  schemas['Order']['status'],
+  string
+> = {
   draft: 'Draft',
   paid: 'Paid',
   pending: 'Pending',

--- a/clients/apps/web/src/components/Orders/OrderStatusSelect.tsx
+++ b/clients/apps/web/src/components/Orders/OrderStatusSelect.tsx
@@ -1,0 +1,40 @@
+import { enums } from '@polar-sh/client'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from '@polar-sh/orbit'
+import React from 'react'
+import { OrderStatusDisplayTitle } from './OrderStatus'
+
+interface OrderStatusSelectProps {
+  value: string
+  onChange: (value: string) => void
+}
+
+const OrderStatusSelect: React.FC<OrderStatusSelectProps> = ({
+  value,
+  onChange,
+}) => {
+  return (
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger>
+        <SelectValue placeholder="Select a status" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="any">Any status</SelectItem>
+        <SelectSeparator />
+        {enums.orderStatusValues.map((status) => (
+          <SelectItem key={status} value={status}>
+            {OrderStatusDisplayTitle[status]}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  )
+}
+
+export default OrderStatusSelect

--- a/clients/apps/web/src/components/Orders/OrderStatusSelect.tsx
+++ b/clients/apps/web/src/components/Orders/OrderStatusSelect.tsx
@@ -25,7 +25,7 @@ const OrderStatusSelect: React.FC<OrderStatusSelectProps> = ({
         <SelectValue placeholder="Select a status" />
       </SelectTrigger>
       <SelectContent>
-        <SelectItem value="any">Any status</SelectItem>
+        <SelectItem value="all">All statuses</SelectItem>
         <SelectSeparator />
         {enums.orderStatusValues.map((status) => (
           <SelectItem key={status} value={status}>

--- a/clients/apps/web/src/components/Orders/OrderStatusSelect.tsx
+++ b/clients/apps/web/src/components/Orders/OrderStatusSelect.tsx
@@ -1,3 +1,4 @@
+import type { OrderStatusFilter } from '@/utils/order'
 import { enums } from '@polar-sh/client'
 import {
   Select,
@@ -11,8 +12,8 @@ import React from 'react'
 import { OrderStatusDisplayTitle } from './OrderStatus'
 
 interface OrderStatusSelectProps {
-  value: string
-  onChange: (value: string) => void
+  value: OrderStatusFilter
+  onChange: (value: OrderStatusFilter) => void
 }
 
 const OrderStatusSelect: React.FC<OrderStatusSelectProps> = ({
@@ -20,12 +21,17 @@ const OrderStatusSelect: React.FC<OrderStatusSelectProps> = ({
   onChange,
 }) => {
   return (
-    <Select value={value} onValueChange={onChange}>
+    <Select
+      value={value}
+      onValueChange={(value) => onChange(value as OrderStatusFilter)}
+    >
       <SelectTrigger>
         <SelectValue placeholder="Select a status" />
       </SelectTrigger>
       <SelectContent>
-        <SelectItem value="all">All statuses</SelectItem>
+        <SelectItem value="any">
+          <span className="whitespace-nowrap">Any status</span>
+        </SelectItem>
         <SelectSeparator />
         {enums.orderStatusValues.map((status) => (
           <SelectItem key={status} value={status}>

--- a/clients/apps/web/src/utils/order.ts
+++ b/clients/apps/web/src/utils/order.ts
@@ -1,4 +1,4 @@
-import { Client, schemas, unwrap } from '@polar-sh/client'
+import { Client, enums, schemas, unwrap } from '@polar-sh/client'
 import { parseISO } from 'date-fns'
 import { notFound } from 'next/navigation'
 import { cache } from 'react'
@@ -24,6 +24,11 @@ const _getOrderById = async (
 
 // Tell React to memoize it for the duration of the request
 export const getOrderById = cache(_getOrderById)
+
+export type OrderStatusFilter = schemas['OrderStatus'] | 'any'
+
+export const isOrderStatus = (value: string): value is schemas['OrderStatus'] =>
+  (enums.orderStatusValues as readonly string[]).includes(value)
 
 /**
  * Determines if an order is eligible for payment retry

--- a/clients/packages/client/src/enums.ts
+++ b/clients/packages/client/src/enums.ts
@@ -7,6 +7,7 @@ export {
   countAggregationFuncValues,
   customFieldTypeValues,
   meterUnitValues,
+  orderStatusValues,
   presentmentCurrencyValues,
   propertyAggregationFuncValues,
   refundReasonValues,

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -42175,6 +42175,11 @@ export interface operations {
         checkout_id?: string | string[] | null
         /** @description Filter by subscription ID. */
         subscription_id?: string | string[] | null
+        /** @description Filter by order status. */
+        status?:
+          | components['schemas']['OrderStatus']
+          | components['schemas']['OrderStatus'][]
+          | null
         /** @description Only include orders created after this date */
         created_after?: string | null
         /** @description Only include orders created before this date */

--- a/server/polar/order/endpoints.py
+++ b/server/polar/order/endpoints.py
@@ -17,6 +17,7 @@ from polar.kit.metadata import MetadataQuery, get_metadata_query_openapi_schema
 from polar.kit.pagination import ListResource, PaginationParams, PaginationParamsQuery
 from polar.kit.schemas import MultipleQueryFilter
 from polar.models import Order
+from polar.models.order import OrderStatus
 from polar.models.product import ProductBillingType
 from polar.openapi import APITag
 from polar.organization.resolver import get_payload_organization
@@ -126,6 +127,9 @@ async def list(
     subscription_id: MultipleQueryFilter[SubscriptionID] | None = Query(
         None, title="SubscriptionID Filter", description="Filter by subscription ID."
     ),
+    status: MultipleQueryFilter[OrderStatus] | None = Query(
+        None, title="Status Filter", description="Filter by order status."
+    ),
     created_after: datetime | None = Query(
         None,
         description="Only include orders created after this date",
@@ -148,6 +152,7 @@ async def list(
         external_customer_id=external_customer_id,
         checkout_id=checkout_id,
         subscription_id=subscription_id,
+        status=status,
         created_after=created_after,
         created_before=created_before,
         metadata=metadata,

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -378,6 +378,7 @@ class OrderService:
         external_customer_id: Sequence[str] | None = None,
         checkout_id: Sequence[uuid.UUID] | None = None,
         subscription_id: Sequence[uuid.UUID] | None = None,
+        status: Sequence[OrderStatus] | None = None,
         created_after: datetime | None = None,
         created_before: datetime | None = None,
         metadata: MetadataQuery | None = None,
@@ -437,6 +438,9 @@ class OrderService:
 
         if subscription_id is not None:
             statement = statement.where(Order.subscription_id.in_(subscription_id))
+
+        if status is not None:
+            statement = statement.where(Order.status.in_(status))
 
         if created_after is not None:
             statement = statement.where(Order.created_at > created_after)

--- a/server/tests/order/test_endpoints.py
+++ b/server/tests/order/test_endpoints.py
@@ -146,6 +146,67 @@ class TestListOrders:
         json = response.json()
         assert json["pagination"]["total_count"] == 2
 
+    @pytest.mark.auth
+    async def test_status_filter(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        paid_order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.paid,
+        )
+        await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.refunded,
+        )
+
+        response = await client.get(
+            "/v1/orders/", params={"status": OrderStatus.paid.value}
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+        assert json["pagination"]["total_count"] == 1
+        assert json["items"][0]["id"] == str(paid_order.id)
+
+    @pytest.mark.auth
+    async def test_status_filter_multiple(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        for status in (OrderStatus.paid, OrderStatus.refunded, OrderStatus.pending):
+            await create_order(
+                save_fixture,
+                product=product,
+                customer=customer,
+                status=status,
+            )
+
+        response = await client.get(
+            "/v1/orders/",
+            params={"status": [OrderStatus.paid.value, OrderStatus.refunded.value]},
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+        assert json["pagination"]["total_count"] == 2
+        assert {item["status"] for item in json["items"]} == {
+            OrderStatus.paid.value,
+            OrderStatus.refunded.value,
+        }
+
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.orders_read}))
     async def test_organization_scoped_session(
         self,

--- a/server/tests/order/test_endpoints.py
+++ b/server/tests/order/test_endpoints.py
@@ -155,37 +155,6 @@ class TestListOrders:
         product: Product,
         customer: Customer,
     ) -> None:
-        paid_order = await create_order(
-            save_fixture,
-            product=product,
-            customer=customer,
-            status=OrderStatus.paid,
-        )
-        await create_order(
-            save_fixture,
-            product=product,
-            customer=customer,
-            status=OrderStatus.refunded,
-        )
-
-        response = await client.get(
-            "/v1/orders/", params={"status": OrderStatus.paid.value}
-        )
-
-        assert response.status_code == 200
-        json = response.json()
-        assert json["pagination"]["total_count"] == 1
-        assert json["items"][0]["id"] == str(paid_order.id)
-
-    @pytest.mark.auth
-    async def test_status_filter_multiple(
-        self,
-        save_fixture: SaveFixture,
-        client: AsyncClient,
-        user_organization: UserOrganization,
-        product: Product,
-        customer: Customer,
-    ) -> None:
         for status in (OrderStatus.paid, OrderStatus.refunded, OrderStatus.pending):
             await create_order(
                 save_fixture,


### PR DESCRIPTION
## Summary

**Related Issue**: https://github.com/polarsource/feedback/issues/28

Adds a `status` filter to the orders list endpoint and surfaces it as a dropdown on the
dashboard Sales page.

## What

**Backend**

- `GET /v1/orders/` accepts a repeatable `status` query param
  (`MultipleQueryFilter[OrderStatus]`), forwarded to `OrderService.list`.

**Frontend**

- New `OrderStatusSelect` component listing every `OrderStatus` plus an "Any status" option.

## Why

The Sales page listed every order with no way to narrow it down. Finding e.g. all refunded
or all pending orders meant paging through the full list. The API had filters for customer,
product, checkout and subscription, but not status.

## How

Followed the existing filter pattern in `OrderService.list`: an optional
`Sequence[OrderStatus]` translated to `Order.status.in_(status)`, exposed via
`MultipleQueryFilter` on the endpoint so repeated params OR together.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787900304&installation_model_id=13063&pr_number=13420&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13420&signature=b1593284f4f7ba21007581dac010ce74053289f17a1c38b9936d12c8539b7f20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

