### PR TITLE
feat(dashboard): add embed hosts settings

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/SettingsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/SettingsPage.tsx
@@ -6,6 +6,7 @@ import FeatureSettings from '@/components/Settings/FeatureSettings'
 import OrganizationAccessTokensSettings from '@/components/Settings/OrganizationAccessTokensSettings'
 import OrganizationCustomerEmailSettings from '@/components/Settings/OrganizationCustomerEmailSettings'
 import OrganizationCustomerPortalSettings from '@/components/Settings/OrganizationCustomerPortalSettings'
+import OrganizationEmbedSettings from '@/components/Settings/OrganizationEmbedSettings'
 import OrganizationDeleteSettings from '@/components/Settings/OrganizationDeleteSettings'
 import OrganizationNotificationSettings from '@/components/Settings/OrganizationNotificationSettings'
 import OrganizationPaymentSettings from '@/components/Settings/OrganizationPaymentSettings'
@@ -61,6 +62,17 @@ export default function ClientPage({
         <Section id="customer_portal">
           <SectionDescription title="Customer portal" />
           <OrganizationCustomerPortalSettings
+            organization={org}
+            readOnly={!canManageOrganization}
+          />
+        </Section>
+
+        <Section id="embedding">
+          <SectionDescription
+            title="Embedding"
+            description="Hosts allowed to embed your checkout"
+          />
+          <OrganizationEmbedSettings
             organization={org}
             readOnly={!canManageOrganization}
           />

--- a/clients/apps/web/src/components/Settings/OrganizationEmbedSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationEmbedSettings.tsx
@@ -1,0 +1,155 @@
+import { useUpdateOrganization } from '@/hooks/queries'
+import { extractApiErrorMessage } from '@/utils/api/errors'
+import { schemas } from '@polar-sh/client'
+import { Box } from '@polar-sh/orbit/Box'
+import { Button } from '@polar-sh/orbit/Button'
+import { Input } from '@polar-sh/orbit/Input'
+import { Text } from '@polar-sh/orbit/Text'
+import { X } from 'lucide-react'
+import React, { useCallback, useState } from 'react'
+import { toast } from '../Toast/use-toast'
+import { SettingsGroup, SettingsGroupItem } from './SettingsGroup'
+
+interface OrganizationEmbedSettingsProps {
+  organization: schemas['Organization']
+  readOnly: boolean
+}
+
+const OrganizationEmbedSettings: React.FC<OrganizationEmbedSettingsProps> = ({
+  organization,
+  readOnly,
+}) => {
+  const [hosts, setHosts] = useState<string[]>(organization.embed_hosts)
+  const [draft, setDraft] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const updateOrganization = useUpdateOrganization()
+
+  const save = useCallback(
+    async (embed_hosts: string[]) => {
+      setError(null)
+      const { data, error } = await updateOrganization.mutateAsync({
+        id: organization.id,
+        body: { embed_hosts },
+      })
+
+      if (error) {
+        const message = extractApiErrorMessage(error)
+        setError(message)
+        toast({
+          title: 'Embedding settings update failed',
+          description: message,
+        })
+        return false
+      }
+
+      setHosts(data.embed_hosts)
+      return true
+    },
+    [organization.id, updateOrganization],
+  )
+
+  const add = useCallback(async () => {
+    const entry = draft.trim()
+    if (!entry) {
+      return
+    }
+    if (await save([...hosts, entry])) {
+      setDraft('')
+    }
+  }, [draft, hosts, save])
+
+  const remove = useCallback(
+    (entry: string) => save(hosts.filter((host) => host !== entry)),
+    [hosts, save],
+  )
+
+  return (
+    <SettingsGroup>
+      <SettingsGroupItem
+        title="Embed hosts"
+        description={
+          organization.embed_hosts_enforced
+            ? 'Only these hosts can embed your checkout.'
+            : 'Listing a host starts restricting your checkout to it right away.'
+        }
+        vertical
+      >
+        <Box flexDirection="column" gap="m" width="100%">
+          {hosts.length > 0 ? (
+            <Box as="ul" flexDirection="column" gap="xs">
+              {hosts.map((host) => (
+                <Box
+                  as="li"
+                  key={host}
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="between"
+                  gap="m"
+                  paddingVertical="s"
+                  paddingHorizontal="m"
+                  backgroundColor="background-card"
+                  borderRadius="s"
+                >
+                  <Text variant="body">{host}</Text>
+                  {readOnly ? null : (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      type="button"
+                      aria-label={`Remove ${host}`}
+                      onClick={() => remove(host)}
+                      loading={updateOrganization.isPending}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  )}
+                </Box>
+              ))}
+            </Box>
+          ) : null}
+
+          {readOnly ? null : (
+            <Box gap="s" alignItems="start">
+              <Input
+                value={draft}
+                aria-label="Embed host"
+                placeholder="example.com"
+                onChange={(e) => setDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    add()
+                  }
+                }}
+              />
+              <Button
+                type="button"
+                onClick={add}
+                disabled={draft.trim().length === 0}
+                loading={updateOrganization.isPending}
+              >
+                Add
+              </Button>
+            </Box>
+          )}
+
+          {error === null ? null : (
+            <Text variant="caption" color="danger">
+              {error}
+            </Text>
+          )}
+
+          <Text variant="caption" color="muted">
+            Write a host on its own, without a scheme: example.com,
+            *.example.com for any subdomain, or localhost:3000 with a port.
+            HTTPS is always allowed, and HTTP too on localhost and private
+            addresses.
+          </Text>
+        </Box>
+      </SettingsGroupItem>
+    </SettingsGroup>
+  )
+}
+
+export default OrganizationEmbedSettings

--- a/clients/apps/web/src/components/Settings/OrganizationEmbedSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationEmbedSettings.tsx
@@ -50,11 +50,11 @@ const OrganizationEmbedSettings: React.FC<OrganizationEmbedSettingsProps> = ({
   )
 
   const add = useCallback(async () => {
-    const entry = draft.trim()
-    if (!entry) {
+    const entries = draft.split(/[\s,]+/).filter(Boolean)
+    if (entries.length === 0) {
       return
     }
-    if (await save([...hosts, entry])) {
+    if (await save([...hosts, ...entries])) {
       setDraft('')
     }
   }, [draft, hosts, save])
@@ -113,8 +113,8 @@ const OrganizationEmbedSettings: React.FC<OrganizationEmbedSettingsProps> = ({
             <Box gap="s" alignItems="start">
               <Input
                 value={draft}
-                aria-label="Embed host"
-                placeholder="example.com"
+                aria-label="Embed hosts"
+                placeholder="example.com, *.example.com"
                 onChange={(e) => setDraft(e.target.value)}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') {
@@ -141,10 +141,11 @@ const OrganizationEmbedSettings: React.FC<OrganizationEmbedSettingsProps> = ({
           )}
 
           <Text variant="caption" color="muted">
-            Write a host on its own, without a scheme: example.com,
-            *.example.com for any subdomain, or localhost:3000 with a port.
-            HTTPS is always allowed, and HTTP too on localhost and private
-            addresses.
+            Add every host at once, separated by commas or spaces — the list
+            takes effect as soon as you save. Write each host on its own,
+            without a scheme: example.com, *.example.com for any subdomain, or
+            localhost:3000 with a port. HTTPS is always allowed, and HTTP too on
+            localhost and private addresses.
           </Text>
         </Box>
       </SettingsGroupItem>

--- a/clients/apps/web/src/components/Settings/OrganizationEmbedSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationEmbedSettings.tsx
@@ -117,7 +117,7 @@ const OrganizationEmbedSettings: React.FC<OrganizationEmbedSettingsProps> = ({
                 placeholder="example.com, *.example.com"
                 onChange={(e) => setDraft(e.target.value)}
                 onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
+                  if (e.key === 'Enter' && !updateOrganization.isPending) {
                     e.preventDefault()
                     add()
                   }


### PR DESCRIPTION
## Summary

**Related Issue**: polarsource/feedback#195

Adds an Embedding section to Settings → Preferences so merchants can manage `embed_hosts`.


https://github.com/user-attachments/assets/a65c70ee-8177-4dda-979e-9453e3ac51d7



## What

A list of the organization's embed hosts, with add and remove. The section description reflects `embed_hosts_enforced`: once a list exists, it reads "Only these hosts can embed your checkout".

## Why

The allowlist has been writable over the API since #13405 with no way to reach it from the dashboard. Enforcement lands next, so merchants need somewhere to configure before it does.

## How

No validation in the client. The list is posted and the server's 422 is surfaced, so the grammar lives in one place and the UI can't drift from it. Rows render the value the server returns, not what was typed, which makes normalisation visible — `EXAMPLE.com` comes back as `example.com`, `exämple.com` as `xn--exmple-cua.com`.

Members without organization management see the list read-only.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787908596&installation_model_id=13063&pr_number=13422&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13422&signature=4cdbdf0179bbc8c4a30a38cd60a9b45e4fcfc7382d42554f9e7f791aaaad17f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

