### PR TITLE
feat(payment_method): remind customers before their card expires

### DIFF
--- a/clients/apps/web/src/components/Settings/OrganizationCustomerEmailSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationCustomerEmailSettings.tsx
@@ -72,6 +72,11 @@ const customerEmails: {
       'Sent when a canceled subscription permanently ends at the end of the billing cycle',
   },
   {
+    key: 'payment_method_expiration_reminder',
+    title: 'Card expiring',
+    description: 'Sent before a card backing an active subscription expires',
+  },
+  {
     key: 'subscription_past_due',
     title: 'Subscription past due',
     description: 'Sent when a subscription payment fails and becomes overdue',

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -26496,6 +26496,8 @@ export interface components {
     OrganizationCustomerEmailSettings: {
       /** Order Confirmation */
       order_confirmation: boolean
+      /** Payment Method Expiration Reminder */
+      payment_method_expiration_reminder: boolean
       /** Subscription Cancellation */
       subscription_cancellation: boolean
       /** Subscription Confirmation */

--- a/server/emails/src/emails/index.ts
+++ b/server/emails/src/emails/index.ts
@@ -13,6 +13,7 @@ import { OrderConfirmation } from './order_confirmation'
 import { OrganizationAccessTokenLeaked } from './organization_access_token_leaked'
 import { OrganizationInvite } from './organization_invite'
 import { OrganizationOffboarded } from './organization_offboarded'
+import { PaymentMethodExpirationReminder } from './payment_method_expiration_reminder'
 import { PersonalAccessTokenLeaked } from './personal_access_token_leaked'
 import { PolarSelfStartupProgramWelcome } from './polar_self_startup_program_welcome'
 import { PolarSelfSubscriptionCancellation } from './polar_self_subscription_cancellation'
@@ -49,6 +50,7 @@ const TEMPLATES: Record<string, React.FC<never>> = {
   organization_access_token_leaked: OrganizationAccessTokenLeaked,
   organization_invite: OrganizationInvite,
   organization_offboarded: OrganizationOffboarded,
+  payment_method_expiration_reminder: PaymentMethodExpirationReminder,
   personal_access_token_leaked: PersonalAccessTokenLeaked,
   seat_invitation: SeatInvitation,
   subscription_cancellation: SubscriptionCancellation,

--- a/server/emails/src/emails/payment_method_expiration_reminder.tsx
+++ b/server/emails/src/emails/payment_method_expiration_reminder.tsx
@@ -1,0 +1,77 @@
+import {
+  Button,
+  FooterCustomer,
+  Intro,
+  Text,
+  WrapperOrganization,
+} from '../components/foundation'
+import { organization } from '../preview'
+import type { schemas } from '../types'
+
+export function PaymentMethodExpirationReminder({
+  email,
+  organization,
+  payment_method,
+  product_names,
+  expiration_date,
+  url,
+}: schemas['PaymentMethodExpirationReminderProps']) {
+  const { brand, last4 } = payment_method.method_metadata
+  const brandLabel = brand.charAt(0).toUpperCase() + brand.slice(1)
+  const plural = product_names.length > 1
+  const productList = plural
+    ? `${product_names.slice(0, -1).join(', ')} and ${product_names[product_names.length - 1]}`
+    : product_names[0]
+
+  return (
+    <WrapperOrganization
+      organization={organization}
+      preview={`Your card ending in ${last4} will expire soon`}
+    >
+      <Intro headline="Your card expires soon">
+        Your{' '}
+        <Text as="span" weight="medium">
+          {brandLabel}
+        </Text>{' '}
+        card ending in{' '}
+        <Text as="span" weight="medium">
+          {last4}
+        </Text>{' '}
+        that pays for your{' '}
+        <Text as="span" weight="medium">
+          {productList}
+        </Text>{' '}
+        subscription{plural ? 's' : ''} will expire soon (
+        <Text as="span" weight="medium">
+          {expiration_date}
+        </Text>
+        ).
+      </Intro>
+      <Text>
+        To avoid an interruption, add an up-to-date payment method from your
+        customer portal.
+      </Text>
+      <Button href={url}>Update payment method</Button>
+      <FooterCustomer organization={organization} email={email} />
+    </WrapperOrganization>
+  )
+}
+
+PaymentMethodExpirationReminder.PreviewProps = {
+  email: 'john@example.com',
+  organization,
+  payment_method: {
+    id: '12345',
+    method_metadata: {
+      brand: 'visa',
+      last4: '4242',
+      exp_month: 4,
+      exp_year: 2026,
+    },
+  },
+  product_names: ['Premium'],
+  expiration_date: 'April 2026',
+  url: 'https://polar.sh/acme-inc/portal/settings',
+}
+
+export default PaymentMethodExpirationReminder

--- a/server/emails/src/emails/payment_method_expiration_reminder.tsx
+++ b/server/emails/src/emails/payment_method_expiration_reminder.tsx
@@ -20,7 +20,7 @@ export function PaymentMethodExpirationReminder({
   const brandLabel = brand.charAt(0).toUpperCase() + brand.slice(1)
   const plural = product_names.length > 1
   const productList = plural
-    ? `${product_names.slice(0, -1).join(', ')} and ${product_names[product_names.length - 1]}`
+    ? `${product_names.slice(0, -1).join(', ')} and ${product_names.at(-1)}`
     : product_names[0]
 
   return (

--- a/server/emails/src/types/openapi.ts
+++ b/server/emails/src/types/openapi.ts
@@ -1982,6 +1982,8 @@ export interface components {
     OrganizationCustomerEmailSettings: {
       /** Order Confirmation */
       order_confirmation: boolean
+      /** Payment Method Expiration Reminder */
+      payment_method_expiration_reminder: boolean
       /** Subscription Cancellation */
       subscription_cancellation: boolean
       /** Subscription Confirmation */
@@ -2195,6 +2197,82 @@ export interface components {
       /** Allow Customer Updates */
       allow_customer_updates: boolean
     }
+    /** PaymentMethodCard */
+    PaymentMethodCard: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the object.
+       */
+      id: string
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      processor: components['schemas']['PaymentProcessor']
+      /**
+       * Customer Id
+       * Format: uuid4
+       */
+      customer_id: string
+      /**
+       * Type
+       * @constant
+       */
+      type: 'card'
+      method_metadata: components['schemas']['PaymentMethodCardMetadata']
+    }
+    /** PaymentMethodCardMetadata */
+    PaymentMethodCardMetadata: {
+      /** Brand */
+      brand: string
+      /** Last4 */
+      last4: string
+      /** Exp Month */
+      exp_month: number
+      /** Exp Year */
+      exp_year: number
+      /**
+       * Wallet
+       * @default null
+       */
+      wallet: string | null
+    }
+    /** PaymentMethodExpirationReminderEmail */
+    PaymentMethodExpirationReminderEmail: {
+      /**
+       * Template
+       * @default payment_method_expiration_reminder
+       * @constant
+       */
+      template: 'payment_method_expiration_reminder'
+      props: components['schemas']['PaymentMethodExpirationReminderProps']
+    }
+    /** PaymentMethodExpirationReminderProps */
+    PaymentMethodExpirationReminderProps: {
+      /** Email */
+      email: string
+      organization: components['schemas']['Organization']
+      payment_method: components['schemas']['PaymentMethodCard']
+      /** Product Names */
+      product_names: string[]
+      /** Expiration Date */
+      expiration_date: string
+      /** Url */
+      url: string
+    }
+    /**
+     * PaymentProcessor
+     * @enum {string}
+     */
+    PaymentProcessor: 'stripe'
     /** PersonalAccessTokenLeakedEmail */
     PersonalAccessTokenLeakedEmail: {
       /**

--- a/server/polar/email/schemas.py
+++ b/server/polar/email/schemas.py
@@ -21,6 +21,7 @@ from polar.notifications.notification import (
 )
 from polar.order.schemas import OrderBase, OrderItemSchema
 from polar.organization.schemas import Organization
+from polar.payment_method.schemas import PaymentMethodCard
 from polar.product.schemas import BenefitList, ProductBase
 from polar.subscription.schemas import SubscriptionBase
 
@@ -38,6 +39,7 @@ class EmailTemplate(StrEnum):
     organization_invite = "organization_invite"
     organization_offboarded = "organization_offboarded"
     support_case_organization_new_message = "support_case_organization_new_message"
+    payment_method_expiration_reminder = "payment_method_expiration_reminder"
     personal_access_token_leaked = "personal_access_token_leaked"
     seat_invitation = "seat_invitation"
     subscription_cancellation = "subscription_cancellation"
@@ -258,6 +260,21 @@ class SeatInvitationProps(EmailProps):
 class SeatInvitationEmail(BaseModel):
     template: Literal[EmailTemplate.seat_invitation] = EmailTemplate.seat_invitation
     props: SeatInvitationProps
+
+
+class PaymentMethodExpirationReminderProps(EmailProps):
+    organization: Organization
+    payment_method: PaymentMethodCard
+    product_names: list[str]
+    expiration_date: str
+    url: str
+
+
+class PaymentMethodExpirationReminderEmail(BaseModel):
+    template: Literal[EmailTemplate.payment_method_expiration_reminder] = (
+        EmailTemplate.payment_method_expiration_reminder
+    )
+    props: PaymentMethodExpirationReminderProps
 
 
 class SubscriptionPropsBase(EmailProps):
@@ -553,6 +570,7 @@ Email = Annotated[
     | OrganizationInviteEmail
     | OrganizationOffboardedEmail
     | SupportCaseOrganizationNewMessageEmail
+    | PaymentMethodExpirationReminderEmail
     | PersonalAccessTokenLeakedEmail
     | SeatInvitationEmail
     | SubscriptionCancellationEmail

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -112,6 +112,7 @@ def _default_order_settings() -> OrganizationOrderSettings:
 
 class OrganizationCustomerEmailSettings(TypedDict):
     order_confirmation: bool
+    payment_method_expiration_reminder: bool
     subscription_cancellation: bool
     subscription_confirmation: bool
     subscription_cycled: bool
@@ -129,6 +130,7 @@ class OrganizationCustomerEmailSettings(TypedDict):
 def _default_customer_email_settings() -> OrganizationCustomerEmailSettings:
     return {
         "order_confirmation": True,
+        "payment_method_expiration_reminder": True,
         "subscription_cancellation": True,
         "subscription_confirmation": True,
         "subscription_cycled": True,

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -1,6 +1,16 @@
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from enum import IntEnum, StrEnum
-from typing import TYPE_CHECKING, Annotated, Any, Literal, NotRequired, Self, TypedDict
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    Literal,
+    NotRequired,
+    Self,
+    TypedDict,
+    cast,
+)
 from urllib.parse import urlparse
 from uuid import UUID
 
@@ -144,6 +154,20 @@ def _default_customer_email_settings() -> OrganizationCustomerEmailSettings:
         "subscription_uncanceled": True,
         "subscription_updated": True,
     }
+
+
+def resolve_default_customer_email_settings(
+    stored: Mapping[str, Any],
+) -> OrganizationCustomerEmailSettings:
+    """Complete stored settings with defaults so reads tolerate keys added after
+    an organization's settings were last written (lazy materialization)."""
+    defaults = _default_customer_email_settings()
+    # Default payment_method_expiration_reminder to the value of
+    # subscription_cycled for graceful rollout
+    defaults["payment_method_expiration_reminder"] = bool(
+        stored.get("subscription_cycled", defaults["subscription_cycled"])
+    )
+    return cast(OrganizationCustomerEmailSettings, {**defaults, **stored})
 
 
 class CustomerPortalUsageSettings(TypedDict):

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -36,7 +36,7 @@ from polar.models.organization import (
     OrganizationCustomerPortalSettings,
     OrganizationStatus,
     OrganizationSubscriptionSettings,
-    _default_customer_email_settings,
+    resolve_default_customer_email_settings,
 )
 from polar.models.organization_review import OrganizationReview
 from polar.models.support_case import ReviewAppealSupportCase
@@ -329,10 +329,8 @@ class OrganizationSocialLink(Schema):
 
 
 def _merge_customer_email_settings_defaults(value: Any) -> Any:
-    """Complete stored settings with defaults so reads tolerate keys added after
-    an organization's settings were last written (lazy materialization)."""
     if isinstance(value, dict):
-        return {**_default_customer_email_settings(), **value}
+        return resolve_default_customer_email_settings(value)
     return value
 
 

--- a/server/polar/payment_method/repository.py
+++ b/server/polar/payment_method/repository.py
@@ -1,6 +1,8 @@
+from collections.abc import Sequence
+from datetime import UTC, datetime
 from uuid import UUID
 
-from sqlalchemy import Select, update
+from sqlalchemy import Select, String, and_, cast, or_, select, update
 from sqlalchemy.orm import joinedload
 
 from polar.enums import PaymentProcessor
@@ -11,6 +13,22 @@ from polar.kit.repository import (
     RepositorySoftDeletionMixin,
 )
 from polar.models import Customer, PaymentMethod, Subscription
+from polar.models.email_log import EmailLog, EmailLogStatus
+
+
+def _expiration_datetime(year: int, month: int) -> datetime:
+    """Cards stay valid through the end of their expiration month."""
+    return datetime(year + month // 12, month % 12 + 1, 1, tzinfo=UTC)
+
+
+def expiring_periods(now: datetime, window_end: datetime) -> list[tuple[int, int]]:
+    """(year, month) pairs whose expiration falls within (now, window_end]."""
+    periods: list[tuple[int, int]] = []
+    year, month = now.year, now.month
+    while _expiration_datetime(year, month) <= window_end:
+        periods.append((year, month))
+        year, month = (year + 1, 1) if month == 12 else (year, month + 1)
+    return periods
 
 
 class PaymentMethodRepository(
@@ -94,6 +112,67 @@ class PaymentMethodRepository(
         statement = statement.options(*options)
         result = await self.session.execute(statement)
         return list(result.scalars().all())
+
+    async def get_cards_needing_expiration_reminder(
+        self,
+        now: datetime,
+        window_end: datetime,
+        *,
+        options: Options = (),
+    ) -> Sequence[PaymentMethod]:
+        """
+        Find card payment methods expiring within the window that back a billable
+        subscription and have no sent `payment_method_expiration_reminder` email logged for
+        that expiration.
+        """
+        periods = expiring_periods(now, window_end)
+        if not periods:
+            return []
+
+        exp_year = PaymentMethod.method_metadata["exp_year"].as_integer()
+        exp_month = PaymentMethod.method_metadata["exp_month"].as_integer()
+        expiring_condition = or_(
+            *(and_(exp_year == year, exp_month == month) for year, month in periods)
+        )
+
+        billable_subscription_subquery = (
+            select(Subscription.id)
+            .where(
+                Subscription.payment_method_id == PaymentMethod.id,
+                Subscription.billable.is_(True),
+            )
+            .correlate(PaymentMethod)
+            .exists()
+        )
+
+        logged_payment_method = EmailLog.email_props["payment_method"]
+        already_sent_subquery = (
+            select(EmailLog.id)
+            .where(
+                EmailLog.email_template == "payment_method_expiration_reminder",
+                EmailLog.status == EmailLogStatus.sent,
+                logged_payment_method["id"].as_string()
+                == cast(PaymentMethod.id, String),
+                logged_payment_method["method_metadata"]["exp_year"].as_integer()
+                == exp_year,
+                logged_payment_method["method_metadata"]["exp_month"].as_integer()
+                == exp_month,
+            )
+            .correlate(PaymentMethod)
+            .exists()
+        )
+
+        statement = (
+            self.get_base_statement()
+            .where(
+                PaymentMethod.type == "card",
+                expiring_condition,
+                billable_subscription_subquery,
+                ~already_sent_subquery,
+            )
+            .options(*options)
+        )
+        return await self.get_all(statement)
 
     async def soft_delete(
         self, object: PaymentMethod, *, flush: bool = False

--- a/server/polar/payment_method/repository.py
+++ b/server/polar/payment_method/repository.py
@@ -140,6 +140,7 @@ class PaymentMethodRepository(
             .where(
                 Subscription.payment_method_id == PaymentMethod.id,
                 Subscription.billable.is_(True),
+                Subscription.deleted_at.is_(None),
             )
             .correlate(PaymentMethod)
             .exists()

--- a/server/polar/payment_method/service.py
+++ b/server/polar/payment_method/service.py
@@ -1,17 +1,28 @@
 import uuid
+from datetime import date
+from urllib.parse import urlencode
 
 import stripe as stripe_lib
+from babel.dates import format_date
 from sqlalchemy import select
+from sqlalchemy.orm import joinedload
 
+from polar.config import settings
 from polar.customer.repository import CustomerRepository
+from polar.customer.service import customer as customer_service
+from polar.email.schemas import EmailAdapter
+from polar.email.sender import enqueue_email_template
 from polar.enums import PaymentProcessor
 from polar.exceptions import PolarError
 from polar.integrations.stripe.service import stripe as stripe_service
 from polar.integrations.stripe.utils import get_expandable_id
 from polar.models import Checkout, Customer, Order, PaymentMethod, Subscription
+from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncSession
+from polar.subscription.repository import SubscriptionRepository
 
 from .repository import PaymentMethodRepository
+from .schemas import PaymentMethodCard
 
 
 class PaymentMethodError(PolarError): ...
@@ -21,6 +32,13 @@ class NoPaymentMethodOnIntent(PaymentMethodError):
     def __init__(self, intent_id: str) -> None:
         self.intent_id = intent_id
         message = f"No payment method found on Stripe intent with ID {intent_id}."
+        super().__init__(message)
+
+
+class PaymentMethodDoesNotExist(PaymentMethodError):
+    def __init__(self, payment_method_id: uuid.UUID) -> None:
+        self.payment_method_id = payment_method_id
+        message = f"Payment method with ID {payment_method_id} does not exist."
         super().__init__(message)
 
 
@@ -130,6 +148,78 @@ class PaymentMethodService:
             return payment_methods[0]
 
         return None
+
+    async def send_expiration_reminder_email(
+        self, session: AsyncSession, payment_method: PaymentMethod
+    ) -> None:
+        if payment_method.type != "card":
+            return
+
+        card = PaymentMethodCard.model_validate(payment_method, from_attributes=True)
+        expiration_date = format_date(
+            date(card.method_metadata.exp_year, card.method_metadata.exp_month, 1),
+            format="MMMM y",
+            locale="en_US",
+        )
+
+        subscription_repository = SubscriptionRepository.from_session(session)
+        subscriptions = await subscription_repository.list_billable_by_payment_method(
+            payment_method.id, options=(joinedload(Subscription.product),)
+        )
+        product_names = sorted({s.product.name for s in subscriptions})
+        # The card doesn't back anything billable, bail out
+        if not product_names:
+            return
+
+        customer = payment_method.customer
+        organization_repository = OrganizationRepository.from_session(session)
+        organization = await organization_repository.get_by_id(
+            customer.organization_id, include_deleted=True, include_blocked=True
+        )
+        assert organization is not None
+
+        if not organization.customer_email_settings.get(
+            "payment_method_expiration_reminder", True
+        ):
+            return
+
+        recipients = await customer_service.get_email_recipients(session, customer)
+        subject = f"Your card ending in {card.method_metadata.last4} expires soon"
+
+        for recipient_email in recipients:
+            token = await customer_service.create_session_token_for_recipient(
+                session, customer, recipient_email
+            )
+            if token is None:
+                continue
+
+            query_string = urlencode(
+                {"customer_session_token": token, "email": recipient_email}
+            )
+            portal_url = settings.generate_frontend_url(
+                f"/{organization.slug}/portal/settings?{query_string}"
+            )
+
+            email = EmailAdapter.validate_python(
+                {
+                    "template": "payment_method_expiration_reminder",
+                    "props": {
+                        "email": recipient_email,
+                        "organization": organization,
+                        "payment_method": card,
+                        "product_names": product_names,
+                        "expiration_date": expiration_date,
+                        "url": portal_url,
+                    },
+                }
+            )
+
+            enqueue_email_template(
+                email,
+                **organization.email_from_reply,
+                to_email_addr=recipient_email,
+                subject=subject,
+            )
 
     async def _get_billable_subscription_ids(
         self, session: AsyncSession, payment_method: PaymentMethod

--- a/server/polar/payment_method/service.py
+++ b/server/polar/payment_method/service.py
@@ -17,6 +17,7 @@ from polar.exceptions import PolarError
 from polar.integrations.stripe.service import stripe as stripe_service
 from polar.integrations.stripe.utils import get_expandable_id
 from polar.models import Checkout, Customer, Order, PaymentMethod, Subscription
+from polar.models.organization import resolve_default_customer_email_settings
 from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncSession
 from polar.subscription.repository import SubscriptionRepository
@@ -178,9 +179,10 @@ class PaymentMethodService:
         )
         assert organization is not None
 
-        if not organization.customer_email_settings.get(
-            "payment_method_expiration_reminder", True
-        ):
+        email_settings = resolve_default_customer_email_settings(
+            organization.customer_email_settings
+        )
+        if not email_settings["payment_method_expiration_reminder"]:
             return
 
         recipients = await customer_service.get_email_recipients(session, customer)

--- a/server/polar/payment_method/tasks.py
+++ b/server/polar/payment_method/tasks.py
@@ -1,0 +1,52 @@
+import uuid
+from datetime import timedelta
+
+from polar.kit.utils import utc_now
+from polar.worker import (
+    AsyncSessionMaker,
+    CronTrigger,
+    TaskPriority,
+    actor,
+    enqueue_job,
+)
+
+from .repository import PaymentMethodRepository
+from .service import PaymentMethodDoesNotExist
+from .service import payment_method as payment_method_service
+
+EXPIRATION_REMINDER_WINDOW = timedelta(days=30)
+
+
+@actor(
+    actor_name="payment_method.scan_expiration_reminders",
+    cron_trigger=CronTrigger.from_crontab("45 * * * *"),
+    priority=TaskPriority.LOW,
+)
+async def scan_expiration_reminders() -> None:
+    """Scan for soon-to-expire cards needing a reminder and fan out."""
+    now = utc_now()
+    window_end = now + EXPIRATION_REMINDER_WINDOW
+
+    async with AsyncSessionMaker() as session:
+        repository = PaymentMethodRepository.from_session(session)
+        payment_methods = await repository.get_cards_needing_expiration_reminder(
+            now, window_end
+        )
+
+    for payment_method in payment_methods:
+        enqueue_job("payment_method.send_expiration_reminder", payment_method.id)
+
+
+@actor(actor_name="payment_method.send_expiration_reminder", priority=TaskPriority.LOW)
+async def send_expiration_reminder(payment_method_id: uuid.UUID) -> None:
+    async with AsyncSessionMaker() as session:
+        repository = PaymentMethodRepository.from_session(session)
+        payment_method = await repository.get_by_id(
+            payment_method_id, options=repository.get_eager_options()
+        )
+        if payment_method is None:
+            raise PaymentMethodDoesNotExist(payment_method_id)
+
+        await payment_method_service.send_expiration_reminder_email(
+            session, payment_method
+        )

--- a/server/polar/payment_method/tasks.py
+++ b/server/polar/payment_method/tasks.py
@@ -14,7 +14,9 @@ from .repository import PaymentMethodRepository
 from .service import PaymentMethodDoesNotExist
 from .service import payment_method as payment_method_service
 
-EXPIRATION_REMINDER_WINDOW = timedelta(days=30)
+# Cards expire at the end of their month, so a 30 day window would always fire on
+# the 1st — where the reminder competes with everyone's monthly billing emails.
+EXPIRATION_REMINDER_WINDOW = timedelta(days=20)
 
 
 @actor(

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -107,6 +107,20 @@ class SubscriptionRepository(
         )
         return await self.get_all(statement)
 
+    async def list_billable_by_payment_method(
+        self, payment_method_id: UUID, *, options: Options = ()
+    ) -> Sequence[Subscription]:
+        statement = (
+            self.get_base_statement()
+            .where(
+                Subscription.payment_method_id == payment_method_id,
+                Subscription.status.in_(SubscriptionStatus.billable_statuses()),
+                Subscription.ended_at.is_(None),
+            )
+            .options(*options)
+        )
+        return await self.get_all(statement)
+
     def get_billable_by_organization_statement(
         self, organization_id: UUID, *, options: Options = ()
     ) -> Select[tuple[Subscription]]:

--- a/server/polar/tasks.py
+++ b/server/polar/tasks.py
@@ -28,6 +28,7 @@ from polar.order import tasks as order
 from polar.organization import tasks as organization
 from polar.organization_access_token import tasks as organization_access_token
 from polar.organization_review import tasks as organization_review
+from polar.payment_method import tasks as payment_method
 from polar.payout import tasks as payout
 from polar.payout_account import tasks as payout_account
 from polar.personal_access_token import tasks as personal_access_token
@@ -67,6 +68,7 @@ __all__ = [
     "organization",
     "organization_access_token",
     "organization_review",
+    "payment_method",
     "payout",
     "payout_account",
     "personal_access_token",

--- a/server/scripts/seeds_load.py
+++ b/server/scripts/seeds_load.py
@@ -1588,6 +1588,7 @@ async def create_seed_data(
             },
             "customer_email_settings": {
                 "order_confirmation": False,
+                "payment_method_expiration_reminder": False,
                 "subscription_cancellation": False,
                 "subscription_confirmation": False,
                 "subscription_cycled": False,

--- a/server/tests/organization/test_schemas.py
+++ b/server/tests/organization/test_schemas.py
@@ -3,7 +3,10 @@ from pydantic import ValidationError
 
 from polar.enums import SubscriptionProrationBehavior
 from polar.kit.currency import PresentmentCurrency
-from polar.models.organization import OrganizationSubscriptionSettings
+from polar.models.organization import (
+    OrganizationSubscriptionSettings,
+    resolve_default_customer_email_settings,
+)
 from polar.organization.schemas import OrganizationCreate, OrganizationUpdate
 
 
@@ -101,3 +104,43 @@ class TestSlugMaxLength:
         slug = "a" * 65
         with pytest.raises(ValidationError, match="at most 64 characters"):
             OrganizationCreate(name="Clean Name", slug=slug)
+
+
+class TestResolveCustomerEmailSettings:
+    def test_new_email_inherits_a_disabled_subscription_cycle(self) -> None:
+        """Organizations predating the key have it absent; they shouldn't get a
+        new customer email switched on behind their back."""
+        resolved = resolve_default_customer_email_settings(
+            {"order_confirmation": False, "subscription_cycled": False}
+        )
+
+        assert resolved["payment_method_expiration_reminder"] is False
+
+    def test_new_email_inherits_an_enabled_subscription_cycle(self) -> None:
+        resolved = resolve_default_customer_email_settings(
+            {"subscription_cycled": True}
+        )
+
+        assert resolved["payment_method_expiration_reminder"] is True
+
+    def test_stored_value_wins_over_inheritance(self) -> None:
+        resolved = resolve_default_customer_email_settings(
+            {
+                "subscription_cycled": False,
+                "payment_method_expiration_reminder": True,
+            }
+        )
+
+        assert resolved["payment_method_expiration_reminder"] is True
+
+    def test_falls_back_to_enabled_when_nothing_is_stored(self) -> None:
+        resolved = resolve_default_customer_email_settings({})
+
+        assert resolved["payment_method_expiration_reminder"] is True
+
+    def test_other_missing_keys_still_default_to_enabled(self) -> None:
+        resolved = resolve_default_customer_email_settings(
+            {"subscription_cycled": False}
+        )
+
+        assert resolved["order_confirmation"] is True

--- a/server/tests/payment_method/test_repository.py
+++ b/server/tests/payment_method/test_repository.py
@@ -1,0 +1,305 @@
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from pytest_mock import MockerFixture
+
+from polar.email.react import serialize_email_props
+from polar.enums import EmailSender
+from polar.models import Customer, PaymentMethod, Product
+from polar.models.email_log import EmailLog, EmailLogStatus
+from polar.models.subscription import SubscriptionStatus
+from polar.payment_method.repository import (
+    PaymentMethodRepository,
+    expiring_periods,
+)
+from polar.payment_method.service import (
+    payment_method as payment_method_service,
+)
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import (
+    create_active_subscription,
+    create_payment_method,
+    create_subscription,
+)
+
+NOW = datetime(2026, 4, 10, tzinfo=UTC)
+WINDOW_END = NOW + timedelta(days=30)
+
+
+class TestExpiringPeriods:
+    def test_includes_the_current_month(self) -> None:
+        assert expiring_periods(NOW, WINDOW_END) == [(2026, 4)]
+
+    def test_excludes_months_expiring_after_the_window(self) -> None:
+        assert expiring_periods(NOW, NOW + timedelta(days=5)) == []
+
+    def test_rolls_over_to_the_next_year(self) -> None:
+        now = datetime(2026, 12, 5, tzinfo=UTC)
+        assert expiring_periods(now, now + timedelta(days=40)) == [(2026, 12)]
+
+    def test_spans_two_months(self) -> None:
+        now = datetime(2026, 4, 1, tzinfo=UTC)
+        assert expiring_periods(now, now + timedelta(days=62)) == [
+            (2026, 4),
+            (2026, 5),
+        ]
+
+
+async def create_expiring_card(
+    save_fixture: SaveFixture,
+    customer: Customer,
+    product: Product,
+    *,
+    exp_month: int = 4,
+    exp_year: int = 2026,
+    type: str = "card",
+    status: SubscriptionStatus = SubscriptionStatus.active,
+) -> PaymentMethod:
+    payment_method = await create_payment_method(
+        save_fixture,
+        customer,
+        type=type,
+        method_metadata={
+            "brand": "visa",
+            "last4": "4242",
+            "exp_month": exp_month,
+            "exp_year": exp_year,
+        },
+    )
+    if status == SubscriptionStatus.active:
+        await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            payment_method=payment_method,
+        )
+    else:
+        await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            payment_method=payment_method,
+            status=status,
+        )
+    return payment_method
+
+
+async def create_sent_log(
+    save_fixture: SaveFixture,
+    payment_method: PaymentMethod,
+    *,
+    exp_month: int = 4,
+    exp_year: int = 2026,
+    email_template: str = "payment_method_expiration_reminder",
+) -> EmailLog:
+    props: dict[str, Any] = {
+        "payment_method": {
+            "id": str(payment_method.id),
+            "method_metadata": {"exp_month": exp_month, "exp_year": exp_year},
+        }
+    }
+    email_log = EmailLog(
+        status=EmailLogStatus.sent,
+        processor=EmailSender.resend,
+        to_email_addr="customer@example.com",
+        from_email_addr="acme@polar.sh",
+        from_name="Acme",
+        subject="Your card ending in 4242 expires soon",
+        email_template=email_template,
+        email_props=props,
+    )
+    await save_fixture(email_log)
+    return email_log
+
+
+@pytest.mark.asyncio
+class TestGetCardsExpiring:
+    async def test_returns_card_expiring_in_window(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        payment_method = await create_expiring_card(save_fixture, customer, product)
+
+        repository = PaymentMethodRepository.from_session(session)
+        result = await repository.get_cards_needing_expiration_reminder(NOW, WINDOW_END)
+
+        assert [pm.id for pm in result] == [payment_method.id]
+
+    async def test_excludes_card_expiring_after_window(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        await create_expiring_card(
+            save_fixture, customer, product, exp_month=11, exp_year=2026
+        )
+
+        repository = PaymentMethodRepository.from_session(session)
+        result = await repository.get_cards_needing_expiration_reminder(NOW, WINDOW_END)
+
+        assert result == []
+
+    async def test_excludes_already_expired_card(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        await create_expiring_card(
+            save_fixture, customer, product, exp_month=1, exp_year=2026
+        )
+
+        repository = PaymentMethodRepository.from_session(session)
+        result = await repository.get_cards_needing_expiration_reminder(NOW, WINDOW_END)
+
+        assert result == []
+
+    async def test_excludes_card_without_billable_subscription(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        await create_expiring_card(
+            save_fixture, customer, product, status=SubscriptionStatus.canceled
+        )
+
+        repository = PaymentMethodRepository.from_session(session)
+        result = await repository.get_cards_needing_expiration_reminder(NOW, WINDOW_END)
+
+        assert result == []
+
+    async def test_excludes_card_without_any_subscription(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+    ) -> None:
+        await create_payment_method(
+            save_fixture,
+            customer,
+            method_metadata={
+                "brand": "visa",
+                "last4": "4242",
+                "exp_month": 4,
+                "exp_year": 2026,
+            },
+        )
+
+        repository = PaymentMethodRepository.from_session(session)
+        result = await repository.get_cards_needing_expiration_reminder(NOW, WINDOW_END)
+
+        assert result == []
+
+    async def test_excludes_non_card_payment_method(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        await create_expiring_card(save_fixture, customer, product, type="link")
+
+        repository = PaymentMethodRepository.from_session(session)
+        result = await repository.get_cards_needing_expiration_reminder(NOW, WINDOW_END)
+
+        assert result == []
+
+    async def test_excludes_card_already_reminded(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        payment_method = await create_expiring_card(save_fixture, customer, product)
+        await create_sent_log(save_fixture, payment_method)
+
+        repository = PaymentMethodRepository.from_session(session)
+        result = await repository.get_cards_needing_expiration_reminder(NOW, WINDOW_END)
+
+        assert result == []
+
+    async def test_returns_card_reminded_for_a_previous_expiration(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        payment_method = await create_expiring_card(save_fixture, customer, product)
+        await create_sent_log(save_fixture, payment_method, exp_month=4, exp_year=2025)
+
+        repository = PaymentMethodRepository.from_session(session)
+        result = await repository.get_cards_needing_expiration_reminder(NOW, WINDOW_END)
+
+        assert [pm.id for pm in result] == [payment_method.id]
+
+    async def test_ignores_logs_for_other_templates(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        payment_method = await create_expiring_card(save_fixture, customer, product)
+        await create_sent_log(
+            save_fixture, payment_method, email_template="order_confirmation"
+        )
+
+        repository = PaymentMethodRepository.from_session(session)
+        result = await repository.get_cards_needing_expiration_reminder(NOW, WINDOW_END)
+
+        assert [pm.id for pm in result] == [payment_method.id]
+
+
+@pytest.mark.asyncio
+class TestDedupRoundTrip:
+    async def test_real_send_props_suppress_the_next_scan(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+        mocker: MockerFixture,
+    ) -> None:
+        """The dedup query must read the props the sender actually writes."""
+        payment_method = await create_expiring_card(save_fixture, customer, product)
+        enqueue_mock = mocker.patch(
+            "polar.payment_method.service.enqueue_email_template", autospec=True
+        )
+
+        await payment_method_service.send_expiration_reminder_email(
+            session, payment_method
+        )
+
+        # Reproduce exactly what the `email.send` actor persists
+        email = enqueue_mock.call_args.args[0]
+        email_props = json.loads(serialize_email_props(email))
+        email_log = EmailLog(
+            status=EmailLogStatus.sent,
+            processor=EmailSender.resend,
+            to_email_addr=enqueue_mock.call_args.kwargs["to_email_addr"],
+            from_email_addr="acme@polar.sh",
+            from_name="Acme",
+            subject=enqueue_mock.call_args.kwargs["subject"],
+            email_template=email.template,
+            email_props=email_props,
+        )
+        await save_fixture(email_log)
+
+        repository = PaymentMethodRepository.from_session(session)
+        assert (
+            await repository.get_cards_needing_expiration_reminder(NOW, WINDOW_END)
+            == []
+        )

--- a/server/tests/payment_method/test_repository.py
+++ b/server/tests/payment_method/test_repository.py
@@ -4,10 +4,12 @@ from typing import Any
 
 import pytest
 from pytest_mock import MockerFixture
+from sqlalchemy import select
 
 from polar.email.react import serialize_email_props
 from polar.enums import EmailSender
-from polar.models import Customer, PaymentMethod, Product
+from polar.kit.utils import utc_now
+from polar.models import Customer, PaymentMethod, Product, Subscription
 from polar.models.email_log import EmailLog, EmailLogStatus
 from polar.models.subscription import SubscriptionStatus
 from polar.payment_method.repository import (
@@ -173,6 +175,33 @@ class TestGetCardsExpiring:
         await create_expiring_card(
             save_fixture, customer, product, status=SubscriptionStatus.canceled
         )
+
+        repository = PaymentMethodRepository.from_session(session)
+        result = await repository.get_cards_needing_expiration_reminder(NOW, WINDOW_END)
+
+        assert result == []
+
+    async def test_excludes_card_whose_subscription_is_soft_deleted(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        payment_method = await create_expiring_card(save_fixture, customer, product)
+        subscription = (
+            (
+                await session.execute(
+                    select(Subscription).where(
+                        Subscription.payment_method_id == payment_method.id
+                    )
+                )
+            )
+            .scalars()
+            .one()
+        )
+        subscription.deleted_at = utc_now()
+        await save_fixture(subscription)
 
         repository = PaymentMethodRepository.from_session(session)
         result = await repository.get_cards_needing_expiration_reminder(NOW, WINDOW_END)

--- a/server/tests/payment_method/test_repository.py
+++ b/server/tests/payment_method/test_repository.py
@@ -19,6 +19,7 @@ from polar.payment_method.repository import (
 from polar.payment_method.service import (
     payment_method as payment_method_service,
 )
+from polar.payment_method.tasks import EXPIRATION_REMINDER_WINDOW
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
@@ -41,6 +42,16 @@ class TestExpiringPeriods:
     def test_rolls_over_to_the_next_year(self) -> None:
         now = datetime(2026, 12, 5, tzinfo=UTC)
         assert expiring_periods(now, now + timedelta(days=40)) == [(2026, 12)]
+
+    def test_does_not_remind_at_the_start_of_the_month(self) -> None:
+        start = datetime(2026, 4, 1, tzinfo=UTC)
+        assert (2026, 4) not in expiring_periods(
+            start, start + EXPIRATION_REMINDER_WINDOW
+        )
+
+    def test_reminds_well_before_the_card_expires(self) -> None:
+        later = datetime(2026, 4, 16, tzinfo=UTC)
+        assert (2026, 4) in expiring_periods(later, later + EXPIRATION_REMINDER_WINDOW)
 
     def test_spans_two_months(self) -> None:
         now = datetime(2026, 4, 1, tzinfo=UTC)

--- a/server/tests/payment_method/test_service.py
+++ b/server/tests/payment_method/test_service.py
@@ -1,3 +1,4 @@
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -6,6 +7,7 @@ from pytest_mock import MockerFixture
 from polar.enums import PaymentProcessor, SubscriptionRecurringInterval
 from polar.integrations.stripe.service import StripeService
 from polar.models import Customer, Organization, PaymentMethod, Product
+from polar.models.organization import OrganizationCustomerEmailSettings
 from polar.models.subscription import SubscriptionStatus
 from polar.payment_method.service import (
     PaymentMethodInUseByActiveSubscription,
@@ -434,6 +436,41 @@ class TestSendExpiringReminderEmail:
     ) -> None:
         payment_method = await create_payment_method(
             save_fixture, customer, type="link", method_metadata={}
+        )
+
+        await payment_method_service.send_expiration_reminder_email(
+            session, payment_method
+        )
+
+        enqueue_email_template_mock.assert_not_called()
+
+    async def test_skips_when_organization_disabled_the_cycle_email(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+        enqueue_email_template_mock: MagicMock,
+    ) -> None:
+        """An organization predating this template has no stored key, so the
+        setting is inherited from their subscription cycle preference."""
+        stored = {
+            key: value
+            for key, value in organization.customer_email_settings.items()
+            if key != "payment_method_expiration_reminder"
+        } | {"subscription_cycled": False}
+        organization.customer_email_settings = cast(
+            OrganizationCustomerEmailSettings, stored
+        )
+        await save_fixture(organization)
+
+        payment_method = await create_expiring_card(save_fixture, customer)
+        await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            payment_method=payment_method,
         )
 
         await payment_method_service.send_expiration_reminder_email(

--- a/server/tests/payment_method/test_service.py
+++ b/server/tests/payment_method/test_service.py
@@ -3,9 +3,9 @@ from unittest.mock import MagicMock
 import pytest
 from pytest_mock import MockerFixture
 
-from polar.enums import PaymentProcessor
+from polar.enums import PaymentProcessor, SubscriptionRecurringInterval
 from polar.integrations.stripe.service import StripeService
-from polar.models import Customer, PaymentMethod, Product
+from polar.models import Customer, Organization, PaymentMethod, Product
 from polar.models.subscription import SubscriptionStatus
 from polar.payment_method.service import (
     PaymentMethodInUseByActiveSubscription,
@@ -17,6 +17,8 @@ from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_active_subscription,
+    create_payment_method,
+    create_product,
     create_subscription,
 )
 from tests.fixtures.stripe import build_stripe_payment_method
@@ -283,3 +285,188 @@ class TestDelete:
         # Subscription should be reassigned to the default payment method
         await session.refresh(subscription)
         assert subscription.payment_method_id == payment_method_default.id
+
+
+@pytest.fixture
+def enqueue_email_template_mock(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch(
+        "polar.payment_method.service.enqueue_email_template", autospec=True
+    )
+
+
+async def create_expiring_card(
+    save_fixture: SaveFixture, customer: Customer
+) -> PaymentMethod:
+    return await create_payment_method(
+        save_fixture,
+        customer,
+        method_metadata={
+            "brand": "visa",
+            "last4": "4242",
+            "exp_month": 4,
+            "exp_year": 2026,
+        },
+    )
+
+
+@pytest.mark.asyncio
+class TestSendExpiringReminderEmail:
+    async def test_enqueues_email_naming_the_product(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+        enqueue_email_template_mock: MagicMock,
+    ) -> None:
+        payment_method = await create_expiring_card(save_fixture, customer)
+        await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            payment_method=payment_method,
+        )
+
+        await payment_method_service.send_expiration_reminder_email(
+            session, payment_method
+        )
+
+        enqueue_email_template_mock.assert_called_once()
+        email = enqueue_email_template_mock.call_args.args[0]
+        assert email.template == "payment_method_expiration_reminder"
+        assert email.props.product_names == [product.name]
+        assert email.props.expiration_date == "April 2026"
+        assert email.props.payment_method.method_metadata.last4 == "4242"
+        assert (
+            enqueue_email_template_mock.call_args.kwargs["subject"]
+            == "Your card ending in 4242 expires soon"
+        )
+
+    async def test_names_every_billable_product_once(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+        enqueue_email_template_mock: MagicMock,
+    ) -> None:
+        other_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            name="Another Product",
+        )
+        payment_method = await create_expiring_card(save_fixture, customer)
+        for subscribed_product in (product, other_product, product):
+            await create_active_subscription(
+                save_fixture,
+                product=subscribed_product,
+                customer=customer,
+                payment_method=payment_method,
+            )
+
+        await payment_method_service.send_expiration_reminder_email(
+            session, payment_method
+        )
+
+        email = enqueue_email_template_mock.call_args.args[0]
+        assert email.props.product_names == sorted({product.name, "Another Product"})
+
+    async def test_ignores_products_of_non_billable_subscriptions(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+        enqueue_email_template_mock: MagicMock,
+    ) -> None:
+        canceled_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            name="Canceled Product",
+        )
+        payment_method = await create_expiring_card(save_fixture, customer)
+        await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            payment_method=payment_method,
+        )
+        await create_subscription(
+            save_fixture,
+            product=canceled_product,
+            customer=customer,
+            payment_method=payment_method,
+            status=SubscriptionStatus.canceled,
+        )
+
+        await payment_method_service.send_expiration_reminder_email(
+            session, payment_method
+        )
+
+        email = enqueue_email_template_mock.call_args.args[0]
+        assert email.props.product_names == [product.name]
+
+    async def test_skips_when_no_billable_subscription(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        enqueue_email_template_mock: MagicMock,
+    ) -> None:
+        payment_method = await create_expiring_card(save_fixture, customer)
+
+        await payment_method_service.send_expiration_reminder_email(
+            session, payment_method
+        )
+
+        enqueue_email_template_mock.assert_not_called()
+
+    async def test_skips_non_card_payment_method(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        enqueue_email_template_mock: MagicMock,
+    ) -> None:
+        payment_method = await create_payment_method(
+            save_fixture, customer, type="link", method_metadata={}
+        )
+
+        await payment_method_service.send_expiration_reminder_email(
+            session, payment_method
+        )
+
+        enqueue_email_template_mock.assert_not_called()
+
+    async def test_skips_when_organization_disabled_the_email(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        organization: Organization,
+        product: Product,
+        enqueue_email_template_mock: MagicMock,
+    ) -> None:
+        organization.customer_email_settings = {
+            **organization.customer_email_settings,
+            "payment_method_expiration_reminder": False,
+        }
+        await save_fixture(organization)
+
+        payment_method = await create_expiring_card(save_fixture, customer)
+        await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            payment_method=payment_method,
+        )
+
+        await payment_method_service.send_expiration_reminder_email(
+            session, payment_method
+        )
+
+        enqueue_email_template_mock.assert_not_called()


### PR DESCRIPTION
Related issue: https://github.com/polarsource/feedback/issues/225

Example reminder email:
<img width="391" height="607" alt="image" src="https://github.com/user-attachments/assets/81fc3aae-94b9-44b9-9589-6db46fc1fb9a" />


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787910528&installation_model_id=13063&pr_number=13424&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13424&signature=2b3c8ae1d5e835158081979e35b99c3581cbc73d1d8a95b596aa00adf28d9067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send expiring-card reminder emails about 20 days before a card backing an active subscription expires. An hourly scan finds affected cards and emails a portal link; organizations can disable the email, and for existing orgs the default inherits from their subscription cycle setting.

- **New Features**
  - Added `payment_method_expiration_reminder` email (shows brand/last4, expiry, product names) with a secure portal link.
  - Hourly cron `payment_method.scan_expiration_reminders` finds cards expiring within ~20 days and enqueues `payment_method.send_expiration_reminder`; only cards with billable subscriptions are considered. Sends are deduped via `email_logs` by card + expiry month/year. New org setting `payment_method_expiration_reminder` (exposed in Organization Customer Email settings) defaults to the org’s `subscription_cycled` preference for existing orgs; client/OpenAPI types updated.

- **Bug Fixes**
  - Scan now ignores soft-deleted subscriptions to avoid enqueueing reminders for cards with only deleted billable subscriptions.

<sup>Written for commit 7b5a7885ed7aa7dbfca884dc4acaaa8def3d0396. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



