### PR TITLE
feat(checkout): enforce embed hosts on checkout links

### DIFF
--- a/docs/changelog/recent.mdx
+++ b/docs/changelog/recent.mdx
@@ -4,6 +4,16 @@ title: Product Updates
 description: Stay up to date with the latest changes and improvements to Polar.
 ---
 
+<Update label="2026-07-29">
+## Embed hosts
+
+Choose which hosts are allowed to embed your checkout, in Settings → Preferences → Embedding. As soon as you list a host, only the hosts on your list can embed.
+
+Organizations created from 4 August 2026 need a list before they can embed. Existing organizations carry on as before until they add their first host, and we will email you well ahead of the date this applies to everyone.
+
+[Read more](/features/checkout/embed#embed-hosts)
+</Update>
+
 <Update label="2026-07-28">
 ## Per-customer discount limits
 

--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -91,7 +91,7 @@ from polar.observability.checkout_metrics import (
     CHECKOUT_SUCCEEDED_TOTAL,
 )
 from polar.order.service import order as order_service
-from polar.organization.embed_hosts import parse_origin
+from polar.organization.embed_hosts import match_origin, parse_origin
 from polar.postgres import AsyncReadSession, AsyncSession
 from polar.posthog import posthog
 from polar.product.custom_price import validate_custom_price_amount
@@ -261,6 +261,13 @@ class CheckoutCustomerExternalIdMismatch(CheckoutError):
             "but with a different email address."
         )
         super().__init__(message, 422)
+
+
+class EmbedHostNotAllowed(CheckoutError):
+    def __init__(self, embed_origin: str) -> None:
+        self.embed_origin = embed_origin
+        message = f"{embed_origin} is not allowed to embed this checkout."
+        super().__init__(message, 403)
 
 
 CHECKOUT_CLIENT_SECRET_PREFIX = "polar_c_"
@@ -700,10 +707,18 @@ class CheckoutService:
         **query_metadata: str | None,
     ) -> Checkout:
         if embed_origin is not None:
+            organization = checkout_link.organization
             parsed_embed_origin = parse_origin(embed_origin)
-            embed_origin = (
-                str(parsed_embed_origin) if parsed_embed_origin is not None else None
-            )
+            if parsed_embed_origin is None:
+                embed_origin = None
+            elif organization.embed_hosts_enforced:
+                embed_origin = match_origin(
+                    str(parsed_embed_origin), organization.embed_hosts
+                )
+                if embed_origin is None:
+                    raise EmbedHostNotAllowed(str(parsed_embed_origin))
+            else:
+                embed_origin = str(parsed_embed_origin)
 
         products: list[Product] = []
         for product in checkout_link.products:

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -28,6 +28,7 @@ from polar.checkout.service import (
     CheckoutCustomerDeleted,
     CheckoutCustomerExternalIdMismatch,
     DiscountRedemptionLimitReached,
+    EmbedHostNotAllowed,
     ExpiredCheckoutError,
     NotConfirmedCheckout,
     NotOpenCheckout,
@@ -74,7 +75,10 @@ from polar.models.customer_seat import SeatStatus
 from polar.models.discount import DiscountDuration, DiscountType
 from polar.models.member import MemberRole
 from polar.models.order import OrderBillingReasonInternal, OrderStatus
-from polar.models.organization import OrganizationStatus
+from polar.models.organization import (
+    EMBED_HOSTS_ENFORCED_FROM,
+    OrganizationStatus,
+)
 from polar.models.product_price import (
     ProductPriceAmountType,
     ProductPriceCustom,
@@ -2596,6 +2600,82 @@ class TestCheckoutLinkCreate:
         )
 
         assert checkout.embed_origin == "https://example.com"
+
+    async def test_allowed_embed_origin(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product_one_time: Product,
+    ) -> None:
+        organization.embed_hosts = ["*.example.com"]
+        await save_fixture(organization)
+        checkout_link = await create_checkout_link(
+            save_fixture, products=[product_one_time]
+        )
+
+        checkout = await checkout_service.checkout_link_create(
+            session, checkout_link, embed_origin="https://www.example.com/checkout"
+        )
+
+        assert checkout.embed_origin == "https://www.example.com"
+
+    async def test_refused_embed_origin(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product_one_time: Product,
+    ) -> None:
+        organization.embed_hosts = ["example.com"]
+        await save_fixture(organization)
+        checkout_link = await create_checkout_link(
+            save_fixture, products=[product_one_time]
+        )
+
+        with pytest.raises(EmbedHostNotAllowed):
+            await checkout_service.checkout_link_create(
+                session, checkout_link, embed_origin="https://evil.com"
+            )
+
+    async def test_refused_embed_origin_for_new_organization(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product_one_time: Product,
+    ) -> None:
+        """An organization past the cutoff must configure a list before embedding."""
+        organization.created_at = EMBED_HOSTS_ENFORCED_FROM
+        await save_fixture(organization)
+        checkout_link = await create_checkout_link(
+            save_fixture, products=[product_one_time]
+        )
+
+        with pytest.raises(EmbedHostNotAllowed):
+            await checkout_service.checkout_link_create(
+                session, checkout_link, embed_origin="https://example.com"
+            )
+
+    async def test_dropped_embed_origin_when_enforced(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product_one_time: Product,
+    ) -> None:
+        """A value carrying no origin can't embed anyway, so it doesn't 403."""
+        organization.embed_hosts = ["example.com"]
+        await save_fixture(organization)
+        checkout_link = await create_checkout_link(
+            save_fixture, products=[product_one_time]
+        )
+
+        checkout = await checkout_service.checkout_link_create(
+            session, checkout_link, embed_origin="null"
+        )
+
+        assert checkout.embed_origin is None
 
     async def test_valid_custom_price_honors_zero_prefill(
         self,

--- a/server/tests/checkout_link/test_endpoints.py
+++ b/server/tests/checkout_link/test_endpoints.py
@@ -384,6 +384,23 @@ class TestRedirect:
         )
         assert checkouts[0].embed_origin is None
 
+    async def test_refused_embed_origin(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        checkout_link: CheckoutLink,
+    ) -> None:
+        organization.embed_hosts = ["example.com"]
+        await save_fixture(organization)
+
+        response = await client.get(
+            f"/v1/checkout-links/{checkout_link.client_secret}/redirect",
+            params={"embed_origin": "https://evil.com"},
+        )
+
+        assert response.status_code == 403
+
     async def test_allowed_metadata(
         self, session: AsyncSession, client: AsyncClient, checkout_link: CheckoutLink
     ) -> None:


### PR DESCRIPTION
## Summary

**Related Issue**: https://github.com/polarsource/feedback/issues/195

<!-- Brief description of what this PR does -->

Enforce embed hosts for new organizations or organization that have filled the allow list. 

Adds changelog about the enforcement

Tried locally using curl:


<img width="1248" height="172" alt="Screenshot 2026-07-29 at 12 07 50" src="https://github.com/user-attachments/assets/61fc4f50-f47e-434b-8c79-b68d1b16d1ec" />


## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787911743&installation_model_id=13063&pr_number=13425&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13425&signature=dd79af5fac42d4b537204c8e5bb9e0b9806f9a49876cbe29ba1b4d5879483142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

