### PR TITLE
refactor(dashboard): move sales and subscriptions table state to nuqs

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -11,9 +11,8 @@ import { useDataTableQueryState } from '@/hooks/useDataTableQueryState'
 import { getServerURL } from '@/utils/api'
 import { getAPIParams } from '@/utils/datatable'
 import { getChartRangeParams } from '@/utils/metrics'
-import { orderStatusFilterValues, type OrderStatusFilter } from '@/utils/order'
 import FileDownloadOutlined from '@mui/icons-material/FileDownloadOutlined'
-import { schemas } from '@polar-sh/client'
+import { enums, schemas } from '@polar-sh/client'
 import { Box } from '@polar-sh/orbit/Box'
 import { formatCurrency } from '@polar-sh/currency'
 import { Truncated } from '@polar-sh/orbit'
@@ -38,7 +37,7 @@ import React, { useEffect, useState } from 'react'
 
 const filterParsers = {
   product_id: parseAsArrayOf(parseAsString),
-  status: parseAsStringLiteral(orderStatusFilterValues).withDefault('any'),
+  status: parseAsStringLiteral(enums.orderStatusValues),
   metadata: parseAsArrayOf(parseAsString),
 }
 
@@ -66,7 +65,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
     resetPage()
   }
 
-  const onStatusSelect = (value: OrderStatusFilter) => {
+  const onStatusSelect = (value: schemas['OrderStatus'] | null) => {
     setFilters({ status: value })
     resetPage()
   }
@@ -74,7 +73,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
   const ordersHook = useOrders(organization.id, {
     ...getAPIParams(pagination, sorting),
     product_id: productId ?? undefined,
-    status: status === 'any' ? undefined : [status],
+    status: status ? [status] : undefined,
   })
 
   const orders = ordersHook.data?.items || []

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -7,15 +7,11 @@ import OrderStatusSelect from '@/components/Orders/OrderStatusSelect'
 import ProductSelect from '@/components/Products/ProductSelect'
 import { useMetrics } from '@/hooks/queries/metrics'
 import { useOrders } from '@/hooks/queries/orders'
+import { useDataTableQueryState } from '@/hooks/useDataTableQueryState'
 import { getServerURL } from '@/utils/api'
-import {
-  DataTablePaginationState,
-  DataTableSortingState,
-  getAPIParams,
-  serializeSearchParams,
-} from '@/utils/datatable'
+import { getAPIParams } from '@/utils/datatable'
 import { getChartRangeParams } from '@/utils/metrics'
-import type { OrderStatusFilter } from '@/utils/order'
+import { orderStatusFilterValues, type OrderStatusFilter } from '@/utils/order'
 import FileDownloadOutlined from '@mui/icons-material/FileDownloadOutlined'
 import { schemas } from '@polar-sh/client'
 import { Box } from '@polar-sh/orbit/Box'
@@ -32,118 +28,52 @@ import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import { Status } from '@polar-sh/orbit'
 import { RowSelectionState } from '@tanstack/react-table'
 import { useRouter } from 'next/navigation'
+import {
+  parseAsArrayOf,
+  parseAsString,
+  parseAsStringLiteral,
+  useQueryStates,
+} from 'nuqs'
 import React, { useEffect, useState } from 'react'
+
+const filterParsers = {
+  product_id: parseAsArrayOf(parseAsString),
+  status: parseAsStringLiteral(orderStatusFilterValues).withDefault('any'),
+  metadata: parseAsArrayOf(parseAsString),
+}
 
 interface ClientPageProps {
   organization: schemas['Organization']
-  pagination: DataTablePaginationState
-  sorting: DataTableSortingState
-  productId?: string[]
-  status: OrderStatusFilter
-  metadata?: string[]
 }
 
-const ClientPage: React.FC<ClientPageProps> = ({
-  organization,
-  pagination,
-  sorting,
-  productId,
-  status,
-  metadata,
-}) => {
+const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
   const [selectedOrderState, setSelectedOrderState] =
     useState<RowSelectionState>({})
 
-  const getSearchParams = (
-    pagination: DataTablePaginationState,
-    sorting: DataTableSortingState,
-    productId?: string[],
-    status?: OrderStatusFilter,
-  ) => {
-    const params = serializeSearchParams(pagination, sorting)
-
-    if (productId) {
-      productId.forEach((id) => params.append('product_id', id))
-    }
-
-    if (status && status !== 'any') {
-      params.append('status', status)
-    }
-
-    if (metadata) {
-      metadata.forEach((key) => params.append('metadata', key))
-    }
-
-    return params
-  }
-
   const router = useRouter()
 
-  const setPagination = (
-    updaterOrValue:
-      | DataTablePaginationState
-      | ((old: DataTablePaginationState) => DataTablePaginationState),
-  ) => {
-    const updatedPagination =
-      typeof updaterOrValue === 'function'
-        ? updaterOrValue(pagination)
-        : updaterOrValue
+  const { pagination, setPagination, sorting, setSorting, resetPage } =
+    useDataTableQueryState({
+      defaultSorting: [{ id: 'created_at', desc: true }],
+      defaultPageSize: 50,
+    })
 
-    router.push(
-      `/dashboard/${organization.slug}/sales?${getSearchParams(
-        updatedPagination,
-        sorting,
-        productId,
-        status,
-      )}`,
-    )
-  }
-
-  const setSorting = (
-    updaterOrValue:
-      | DataTableSortingState
-      | ((old: DataTableSortingState) => DataTableSortingState),
-  ) => {
-    const updatedSorting =
-      typeof updaterOrValue === 'function'
-        ? updaterOrValue(sorting)
-        : updaterOrValue
-
-    router.push(
-      `/dashboard/${organization.slug}/sales?${getSearchParams(
-        pagination,
-        updatedSorting,
-        productId,
-        status,
-      )}`,
-    )
-  }
+  const [{ product_id: productId, status, metadata }, setFilters] =
+    useQueryStates(filterParsers)
 
   const onProductSelect = (value: string[]) => {
-    router.push(
-      `/dashboard/${organization.slug}/sales?${getSearchParams(
-        pagination,
-        sorting,
-        value,
-        status,
-      )}`,
-    )
+    setFilters({ product_id: value.length > 0 ? value : null })
+    resetPage()
   }
 
   const onStatusSelect = (value: OrderStatusFilter) => {
-    router.push(
-      `/dashboard/${organization.slug}/sales?${getSearchParams(
-        pagination,
-        sorting,
-        productId,
-        value,
-      )}`,
-    )
+    setFilters({ status: value })
+    resetPage()
   }
 
   const ordersHook = useOrders(organization.id, {
     ...getAPIParams(pagination, sorting),
-    product_id: productId,
+    product_id: productId ?? undefined,
     status: status === 'any' ? undefined : [status],
   })
 
@@ -281,7 +211,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
     startDate: allTimeStart,
     endDate: allTimeEnd,
     interval: allTimeInterval,
-    product_id: productId,
+    product_id: productId ?? undefined,
     metrics: ['orders', 'revenue', 'cumulative_revenue'],
   })
   const { data: todayMetricsData } = useMetrics({
@@ -289,7 +219,7 @@ const ClientPage: React.FC<ClientPageProps> = ({
     startDate: new Date(),
     endDate: new Date(),
     interval: 'day',
-    product_id: productId,
+    product_id: productId ?? undefined,
     metrics: ['revenue'],
   })
 

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/page.tsx
@@ -1,6 +1,4 @@
 import { getServerSideAPI } from '@/utils/client/serverside'
-import { DataTableSearchParams, parseSearchParams } from '@/utils/datatable'
-import { isOrderStatus } from '@/utils/order'
 import { getOrganizationBySlugOrNotFound } from '@/utils/organization'
 import { Metadata } from 'next'
 import SalesPage from './SalesPage'
@@ -13,15 +11,7 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function Page(props: {
   params: Promise<{ organization: string }>
-  searchParams: Promise<
-    DataTableSearchParams & {
-      product_id?: string[] | string
-      status?: string | string[]
-      metadata?: string[]
-    }
-  >
 }) {
-  const searchParams = await props.searchParams
   const params = await props.params
   const api = await getServerSideAPI()
   const organization = await getOrganizationBySlugOrNotFound(
@@ -29,37 +19,5 @@ export default async function Page(props: {
     params.organization,
   )
 
-  const { pagination, sorting } = parseSearchParams(
-    searchParams,
-    [{ id: 'created_at', desc: true }],
-    50,
-  )
-
-  const productId = searchParams.product_id
-    ? Array.isArray(searchParams.product_id)
-      ? searchParams.product_id
-      : [searchParams.product_id]
-    : undefined
-
-  const rawStatus = Array.isArray(searchParams.status)
-    ? searchParams.status[0]
-    : searchParams.status
-  const status = rawStatus && isOrderStatus(rawStatus) ? rawStatus : 'any'
-
-  const metadata = searchParams.metadata
-    ? Array.isArray(searchParams.metadata)
-      ? searchParams.metadata
-      : [searchParams.metadata]
-    : undefined
-
-  return (
-    <SalesPage
-      organization={organization}
-      pagination={pagination}
-      sorting={sorting}
-      productId={productId}
-      status={status}
-      metadata={metadata}
-    />
-  )
+  return <SalesPage organization={organization} />
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
@@ -3,16 +3,15 @@
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import SubscriptionCancellationSelect from '@/components/Subscriptions/SubscriptionCancellationSelect'
 import { SubscriptionStatus as SubscriptionStatusComponent } from '@/components/Subscriptions/SubscriptionStatus'
-import SubscriptionStatusSelect from '@/components/Subscriptions/SubscriptionStatusSelect'
+import SubscriptionStatusSelect, {
+  subscriptionStatusFilterValues,
+  type SubscriptionStatusFilter,
+} from '@/components/Subscriptions/SubscriptionStatusSelect'
 import SubscriptionTiersSelect from '@/components/Subscriptions/SubscriptionTiersSelect'
 import { useProducts, useSubscriptions } from '@/hooks/queries'
+import { useDataTableQueryState } from '@/hooks/useDataTableQueryState'
 import { getServerURL } from '@/utils/api'
-import {
-  DataTablePaginationState,
-  DataTableSortingState,
-  getAPIParams,
-  serializeSearchParams,
-} from '@/utils/datatable'
+import { DataTableSortingState, getAPIParams } from '@/utils/datatable'
 import FileDownloadOutlined from '@mui/icons-material/FileDownloadOutlined'
 import { schemas } from '@polar-sh/client'
 import { Avatar } from '@polar-sh/orbit'
@@ -24,171 +23,110 @@ import {
 } from '@polar-sh/orbit'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import { Status } from '@polar-sh/orbit'
-import { RowSelectionState } from '@tanstack/react-table'
+import {
+  functionalUpdate,
+  OnChangeFn,
+  RowSelectionState,
+} from '@tanstack/react-table'
 import { useRouter } from 'next/navigation'
+import {
+  parseAsArrayOf,
+  parseAsBoolean,
+  parseAsString,
+  parseAsStringLiteral,
+  useQueryStates,
+} from 'nuqs'
 import React, { useEffect, useState } from 'react'
+
+const filterParsers = {
+  product_id: parseAsString,
+  status: parseAsStringLiteral(subscriptionStatusFilterValues).withDefault(
+    'active',
+  ),
+  cancel_at_period_end: parseAsBoolean,
+  metadata: parseAsArrayOf(parseAsString),
+}
+
+// Secondary sort on ends_at when sorting by status
+const withEndsAtSecondarySort = (
+  sorting: DataTableSortingState,
+): DataTableSortingState => {
+  const statusSort = sorting.find((s) => s.id === 'status')
+  if (!statusSort || sorting.some((s) => s.id === 'ends_at')) {
+    return sorting
+  }
+  return [
+    statusSort,
+    { id: 'ends_at', desc: statusSort.desc },
+    ...sorting.filter((s) => s.id !== 'status'),
+  ]
+}
 
 interface ClientPageProps {
   organization: schemas['Organization']
-  pagination: DataTablePaginationState
-  sorting: DataTableSortingState
-  productId?: string
-  subscriptionStatus?: schemas['SubscriptionStatus'] | 'any'
-  cancelAtPeriodEnd?: 'all' | 'true' | 'false'
-  metadata?: string[]
 }
 
-const ClientPage: React.FC<ClientPageProps> = ({
-  organization,
-  pagination,
-  sorting,
-  productId,
-  subscriptionStatus,
-  cancelAtPeriodEnd,
-  metadata,
-}) => {
+const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
   const [selectedSubscriptionState, setSelectedSubscriptionState] =
     useState<RowSelectionState>({})
+
+  const router = useRouter()
 
   const subscriptionTiers = useProducts(organization.id, {
     is_recurring: true,
     limit: 100,
   })
 
-  const filter = productId || 'all'
-  const status = subscriptionStatus || 'active'
-  const cancelAtPeriodEndFilter = cancelAtPeriodEnd || 'all'
-  const getSearchParams = (
-    pagination: DataTablePaginationState,
-    sorting: DataTableSortingState,
-    filter: string,
-    status: string,
-    cancelAtPeriodEndFilter: string,
-  ) => {
-    const params = serializeSearchParams(pagination, sorting)
-    if (filter !== 'all') {
-      params.append('product_id', filter)
-    }
+  const {
+    pagination,
+    setPagination,
+    sorting,
+    setSorting: setSortingState,
+    resetPage,
+  } = useDataTableQueryState({
+    defaultSorting: [{ id: 'started_at', desc: true }],
+    defaultPageSize: 50,
+  })
 
-    params.append('status', status)
+  const [
+    {
+      product_id: productId,
+      status,
+      cancel_at_period_end: cancelAtPeriodEnd,
+      metadata,
+    },
+    setFilters,
+  ] = useQueryStates(filterParsers)
 
-    if (cancelAtPeriodEndFilter !== 'all') {
-      params.append('cancel_at_period_end', cancelAtPeriodEndFilter)
-    }
-
-    if (metadata) {
-      metadata.forEach((key) => params.append('metadata', key))
-    }
-
-    return params
-  }
-
-  const router = useRouter()
-
-  const setPagination = (
-    updaterOrValue:
-      | DataTablePaginationState
-      | ((old: DataTablePaginationState) => DataTablePaginationState),
-  ) => {
-    const updatedPagination =
-      typeof updaterOrValue === 'function'
-        ? updaterOrValue(pagination)
-        : updaterOrValue
-
-    router.push(
-      `/dashboard/${organization.slug}/sales/subscriptions?${getSearchParams(
-        updatedPagination,
-        sorting,
-        filter,
-        status,
-        cancelAtPeriodEndFilter,
-      )}`,
+  const setSorting: OnChangeFn<DataTableSortingState> = (updater) => {
+    setSortingState((old) =>
+      withEndsAtSecondarySort(functionalUpdate(updater, old)),
     )
   }
 
-  const setSorting = (
-    updaterOrValue:
-      | DataTableSortingState
-      | ((old: DataTableSortingState) => DataTableSortingState),
-  ) => {
-    let updatedSorting =
-      typeof updaterOrValue === 'function'
-        ? updaterOrValue(sorting)
-        : updaterOrValue
-
-    // Add secondary sort on ends_at when sorting by status
-    const statusSort = updatedSorting.find((s) => s.id === 'status')
-    if (statusSort) {
-      const hasSecondarySortOnEndsAt = updatedSorting.some(
-        (s) => s.id === 'ends_at',
-      )
-      if (!hasSecondarySortOnEndsAt) {
-        updatedSorting = [
-          statusSort,
-          { id: 'ends_at', desc: statusSort.desc },
-          ...updatedSorting.filter((s) => s.id !== 'status'),
-        ]
-      }
-    }
-
-    router.push(
-      `/dashboard/${organization.slug}/sales/subscriptions?${getSearchParams(
-        pagination,
-        updatedSorting,
-        filter,
-        status,
-        cancelAtPeriodEndFilter,
-      )}`,
-    )
+  const onProductSelect = (value: string | null) => {
+    setFilters({ product_id: value })
+    resetPage()
   }
 
-  const setFilter = (filter: string) => {
-    router.push(
-      `/dashboard/${organization.slug}/sales/subscriptions?${getSearchParams(
-        pagination,
-        sorting,
-        filter,
-        status,
-        cancelAtPeriodEndFilter,
-      )}`,
-    )
+  const onStatusSelect = (value: SubscriptionStatusFilter) => {
+    setFilters({
+      status: value,
+      cancel_at_period_end: value === 'active' ? cancelAtPeriodEnd : null,
+    })
+    resetPage()
   }
 
-  const setStatus = (status: string) => {
-    const newCancelAtPeriodEnd =
-      status === 'active' ? cancelAtPeriodEndFilter : 'all'
-    router.push(
-      `/dashboard/${organization.slug}/sales/subscriptions?${getSearchParams(
-        pagination,
-        sorting,
-        filter,
-        status,
-        newCancelAtPeriodEnd,
-      )}`,
-    )
-  }
-
-  const setCancelAtPeriodEnd = (cancelAtPeriodEnd: string) => {
-    router.push(
-      `/dashboard/${organization.slug}/sales/subscriptions?${getSearchParams(
-        pagination,
-        sorting,
-        filter,
-        status,
-        cancelAtPeriodEnd,
-      )}`,
-    )
+  const onCancelAtPeriodEndSelect = (value: boolean | null) => {
+    setFilters({ cancel_at_period_end: value })
+    resetPage()
   }
 
   const subscriptionsHook = useSubscriptions(organization.id, {
     ...getAPIParams(pagination, sorting),
-    ...(productId ? { product_id: productId } : {}),
-    ...(status !== 'any' ? { status: [status] } : {}),
-    ...(cancelAtPeriodEndFilter === 'false'
-      ? { cancel_at_period_end: false }
-      : cancelAtPeriodEndFilter === 'true'
-        ? { cancel_at_period_end: true }
-        : {}),
+    product_id: productId ?? undefined,
+    status: status === 'any' ? undefined : [status],
+    cancel_at_period_end: cancelAtPeriodEnd ?? undefined,
   })
 
   const subscriptions = subscriptionsHook.data?.items || []
@@ -330,31 +268,23 @@ const ClientPage: React.FC<ClientPageProps> = ({
           <div className="flex shrink-0 items-center gap-4">
             <div className="w-auto">
               <SubscriptionStatusSelect
-                statuses={[
-                  'active',
-                  'trialing',
-                  'paused',
-                  'past_due',
-                  'canceled',
-                  'unpaid',
-                ]}
-                value={subscriptionStatus || 'any'}
-                onChange={setStatus}
+                value={status}
+                onChange={onStatusSelect}
               />
             </div>
             {status === 'active' && (
               <div className="w-auto">
                 <SubscriptionCancellationSelect
-                  value={cancelAtPeriodEnd || 'all'}
-                  onChange={setCancelAtPeriodEnd}
+                  value={cancelAtPeriodEnd}
+                  onChange={onCancelAtPeriodEndSelect}
                 />
               </div>
             )}
             <div className="w-auto">
               <SubscriptionTiersSelect
                 products={subscriptionTiers.data?.items || []}
-                value={productId || 'all'}
-                onChange={setFilter}
+                value={productId}
+                onChange={onProductSelect}
               />
             </div>
           </div>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
@@ -298,7 +298,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
             <span>Export</span>
           </Button>
         </div>
-        {subscriptions && pageCount !== undefined && (
+        {subscriptions && pageCount !== undefined ? (
           <DataTable
             columns={columns}
             data={subscriptions}
@@ -316,7 +316,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
             getRowId={(row) => row.id.toString()}
             enableRowSelection
           />
-        )}
+        ) : null}
       </div>
     </DashboardBody>
   )

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/page.tsx
@@ -1,7 +1,5 @@
 import { getServerSideAPI } from '@/utils/client/serverside'
-import { DataTableSearchParams, parseSearchParams } from '@/utils/datatable'
 import { getOrganizationBySlugOrNotFound } from '@/utils/organization'
-import { schemas } from '@polar-sh/client'
 import { Metadata } from 'next'
 import SubscriptionsPage from './SubscriptionsPage'
 
@@ -13,16 +11,7 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function Page(props: {
   params: Promise<{ organization: string }>
-  searchParams: Promise<
-    DataTableSearchParams & {
-      product_id?: string
-      status?: schemas['SubscriptionStatus'] | 'any'
-      cancel_at_period_end?: 'all' | 'true' | 'false'
-      metadata?: string[]
-    }
-  >
 }) {
-  const searchParams = await props.searchParams
   const params = await props.params
   const api = await getServerSideAPI()
   const organization = await getOrganizationBySlugOrNotFound(
@@ -30,27 +19,5 @@ export default async function Page(props: {
     params.organization,
   )
 
-  const { pagination, sorting } = parseSearchParams(
-    searchParams,
-    [{ id: 'started_at', desc: true }],
-    50,
-  )
-
-  const metadata = searchParams.metadata
-    ? Array.isArray(searchParams.metadata)
-      ? searchParams.metadata
-      : [searchParams.metadata]
-    : undefined
-
-  return (
-    <SubscriptionsPage
-      organization={organization}
-      pagination={pagination}
-      sorting={sorting}
-      productId={searchParams.product_id}
-      subscriptionStatus={searchParams.status ?? 'active'}
-      cancelAtPeriodEnd={searchParams.cancel_at_period_end ?? 'all'}
-      metadata={metadata}
-    />
-  )
+  return <SubscriptionsPage organization={organization} />
 }

--- a/clients/apps/web/src/components/Orders/OrderStatusSelect.tsx
+++ b/clients/apps/web/src/components/Orders/OrderStatusSelect.tsx
@@ -1,5 +1,4 @@
-import type { OrderStatusFilter } from '@/utils/order'
-import { enums } from '@polar-sh/client'
+import { enums, schemas } from '@polar-sh/client'
 import {
   Select,
   SelectContent,
@@ -12,8 +11,8 @@ import React from 'react'
 import { OrderStatusDisplayTitle } from './OrderStatus'
 
 interface OrderStatusSelectProps {
-  value: OrderStatusFilter
-  onChange: (value: OrderStatusFilter) => void
+  value: schemas['OrderStatus'] | null
+  onChange: (value: schemas['OrderStatus'] | null) => void
 }
 
 const OrderStatusSelect: React.FC<OrderStatusSelectProps> = ({
@@ -22,8 +21,10 @@ const OrderStatusSelect: React.FC<OrderStatusSelectProps> = ({
 }) => {
   return (
     <Select
-      value={value}
-      onValueChange={(value) => onChange(value as OrderStatusFilter)}
+      value={value ?? 'any'}
+      onValueChange={(value) =>
+        onChange(value === 'any' ? null : (value as schemas['OrderStatus']))
+      }
     >
       <SelectTrigger>
         <SelectValue placeholder="Select a status" />

--- a/clients/apps/web/src/components/Subscriptions/SubscriptionCancellationSelect.tsx
+++ b/clients/apps/web/src/components/Subscriptions/SubscriptionCancellationSelect.tsx
@@ -8,15 +8,20 @@ import {
 import React from 'react'
 
 interface SubscriptionCancellationSelectProps {
-  value: string
-  onChange: (value: string) => void
+  value: boolean | null
+  onChange: (value: boolean | null) => void
 }
 
 const SubscriptionCancellationSelect: React.FC<
   SubscriptionCancellationSelectProps
 > = ({ value, onChange }) => {
   return (
-    <Select value={value} onValueChange={onChange}>
+    <Select
+      value={value === null ? 'all' : String(value)}
+      onValueChange={(value) =>
+        onChange(value === 'all' ? null : value === 'true')
+      }
+    >
       <SelectTrigger>
         <SelectValue placeholder="Select cancellation status" />
       </SelectTrigger>

--- a/clients/apps/web/src/components/Subscriptions/SubscriptionStatusSelect.tsx
+++ b/clients/apps/web/src/components/Subscriptions/SubscriptionStatusSelect.tsx
@@ -11,19 +11,37 @@ import {
 import React from 'react'
 import { subscriptionStatusDisplayNames } from './utils'
 
+const SELECTABLE_STATUSES = [
+  'active',
+  'trialing',
+  'paused',
+  'past_due',
+  'canceled',
+  'unpaid',
+] as const satisfies readonly schemas['SubscriptionStatus'][]
+
+export const subscriptionStatusFilterValues = [
+  'any',
+  ...SELECTABLE_STATUSES,
+] as const
+
+export type SubscriptionStatusFilter =
+  (typeof subscriptionStatusFilterValues)[number]
+
 interface SubscriptionStatusSelectProps {
-  statuses: schemas['SubscriptionStatus'][]
-  value: string
-  onChange: (value: string) => void
+  value: SubscriptionStatusFilter
+  onChange: (value: SubscriptionStatusFilter) => void
 }
 
 const SubscriptionStatusSelect: React.FC<SubscriptionStatusSelectProps> = ({
-  statuses,
   value,
   onChange,
 }) => {
   return (
-    <Select value={value} onValueChange={onChange}>
+    <Select
+      value={value}
+      onValueChange={(value) => onChange(value as SubscriptionStatusFilter)}
+    >
       <SelectTrigger>
         <SelectValue placeholder="Select a status" />
       </SelectTrigger>
@@ -32,7 +50,7 @@ const SubscriptionStatusSelect: React.FC<SubscriptionStatusSelectProps> = ({
           <span className="whitespace-nowrap">Any status</span>
         </SelectItem>
         <SelectSeparator />
-        {statuses.map((status) => (
+        {SELECTABLE_STATUSES.map((status) => (
           <React.Fragment key={status}>
             <SelectGroup>
               <SelectItem value={status}>

--- a/clients/apps/web/src/components/Subscriptions/SubscriptionTiersSelect.tsx
+++ b/clients/apps/web/src/components/Subscriptions/SubscriptionTiersSelect.tsx
@@ -11,8 +11,8 @@ import React from 'react'
 
 interface SubscriptionTiersSelectProps {
   products: schemas['Product'][]
-  value: string
-  onChange: (value: string) => void
+  value: string | null
+  onChange: (value: string | null) => void
 }
 
 const SubscriptionTiersSelect: React.FC<SubscriptionTiersSelectProps> = ({
@@ -21,7 +21,10 @@ const SubscriptionTiersSelect: React.FC<SubscriptionTiersSelectProps> = ({
   onChange,
 }) => {
   return (
-    <Select value={value} onValueChange={onChange}>
+    <Select
+      value={value ?? 'all'}
+      onValueChange={(value) => onChange(value === 'all' ? null : value)}
+    >
       <SelectTrigger>
         <SelectValue placeholder="Select a product" />
       </SelectTrigger>

--- a/clients/apps/web/src/hooks/useDataTableQueryState.ts
+++ b/clients/apps/web/src/hooks/useDataTableQueryState.ts
@@ -1,0 +1,88 @@
+'use client'
+
+import {
+  DataTablePaginationState,
+  DataTableSortingState,
+  sortingQueryParamToState,
+  sortingStateToQueryParam,
+} from '@/utils/datatable'
+import { functionalUpdate, OnChangeFn } from '@tanstack/react-table'
+import {
+  parseAsArrayOf,
+  parseAsInteger,
+  parseAsString,
+  useQueryStates,
+} from 'nuqs'
+import { useCallback, useMemo } from 'react'
+
+interface UseDataTableQueryStateProps {
+  defaultSorting?: DataTableSortingState
+  defaultPageSize?: number
+}
+
+interface DataTableQueryState {
+  pagination: DataTablePaginationState
+  setPagination: OnChangeFn<DataTablePaginationState>
+  sorting: DataTableSortingState
+  setSorting: OnChangeFn<DataTableSortingState>
+  resetPage: () => void
+}
+
+/**
+ * Binds a DataTable's pagination and sorting to the URL query string.
+ * Filters owned by the page should live in their own `useQueryStates` call and
+ * call `resetPage` when they change and nuqs batches both into a single URL
+ * update.
+ */
+export const useDataTableQueryState = ({
+  defaultSorting = [],
+  defaultPageSize = 20,
+}: UseDataTableQueryStateProps = {}): DataTableQueryState => {
+  const defaultSortingParam = sortingStateToQueryParam(defaultSorting).join(',')
+
+  const parsers = useMemo(
+    () => ({
+      page: parseAsInteger.withDefault(1),
+      limit: parseAsInteger.withDefault(defaultPageSize),
+      sorting: parseAsArrayOf(parseAsString).withDefault(
+        defaultSortingParam ? defaultSortingParam.split(',') : [],
+      ),
+    }),
+    [defaultPageSize, defaultSortingParam],
+  )
+
+  const [{ page, limit, sorting: sortingParam }, setQueryState] =
+    useQueryStates(parsers)
+
+  const pagination = useMemo(
+    () => ({ pageIndex: page - 1, pageSize: limit }),
+    [page, limit],
+  )
+
+  const sorting = useMemo(
+    () => sortingQueryParamToState(sortingParam),
+    [sortingParam],
+  )
+
+  const setPagination = useCallback<OnChangeFn<DataTablePaginationState>>(
+    (updater) => {
+      const updated = functionalUpdate(updater, pagination)
+      setQueryState({ page: updated.pageIndex + 1, limit: updated.pageSize })
+    },
+    [pagination, setQueryState],
+  )
+
+  const setSorting = useCallback<OnChangeFn<DataTableSortingState>>(
+    (updater) => {
+      const updated = functionalUpdate(updater, sorting)
+      setQueryState({ sorting: sortingStateToQueryParam(updated), page: 1 })
+    },
+    [sorting, setQueryState],
+  )
+
+  const resetPage = useCallback(() => {
+    setQueryState({ page: 1 })
+  }, [setQueryState])
+
+  return { pagination, setPagination, sorting, setSorting, resetPage }
+}

--- a/clients/apps/web/src/utils/order.ts
+++ b/clients/apps/web/src/utils/order.ts
@@ -25,10 +25,12 @@ const _getOrderById = async (
 // Tell React to memoize it for the duration of the request
 export const getOrderById = cache(_getOrderById)
 
-export type OrderStatusFilter = schemas['OrderStatus'] | 'any'
+export const orderStatusFilterValues = [
+  'any',
+  ...enums.orderStatusValues,
+] as const
 
-export const isOrderStatus = (value: string): value is schemas['OrderStatus'] =>
-  (enums.orderStatusValues as readonly string[]).includes(value)
+export type OrderStatusFilter = (typeof orderStatusFilterValues)[number]
 
 /**
  * Determines if an order is eligible for payment retry

--- a/clients/apps/web/src/utils/order.ts
+++ b/clients/apps/web/src/utils/order.ts
@@ -1,4 +1,4 @@
-import { Client, enums, schemas, unwrap } from '@polar-sh/client'
+import { Client, schemas, unwrap } from '@polar-sh/client'
 import { parseISO } from 'date-fns'
 import { notFound } from 'next/navigation'
 import { cache } from 'react'
@@ -24,13 +24,6 @@ const _getOrderById = async (
 
 // Tell React to memoize it for the duration of the request
 export const getOrderById = cache(_getOrderById)
-
-export const orderStatusFilterValues = [
-  'any',
-  ...enums.orderStatusValues,
-] as const
-
-export type OrderStatusFilter = (typeof orderStatusFilterValues)[number]
 
 /**
  * Determines if an order is eligible for payment retry


### PR DESCRIPTION
## Summary

Moves the Sales and Subscriptions tables into nuqs for URL state, behind a shared hook.
Mostly a refactor, but also reduces the non needed parsing on the server.

## What

- New `useDataTableQueryState` hook keeps pagination and sorting in the URL.
- Both pages lose their search-param serialisation helper and the four or five `router.push`
  callbacks that went with it.
- Both server components stop reading search params entirely.
- The other nine table pages are untouched and still use the old helpers, migrating in follow up.

## Why

Every paginate, sort and filter click did a full server round trip: push the URL, re-render the
page on the server, ship a new payload down the wire.

None of which did anything really if I'm correct. The server parsed the params and passed them straight into a client
component, it never used them to fetch or render. The rows come from TanStack Query in the
browser, so nothing was ever server-rendered off those params. nuqs updates the URL
client-side and if we want ssr prefetching later it's easy to incorporate parsers with nuqs

Also improves some pagination issues when filtering.

## How

The hook owns page, limit and sorting. Each page keeps its own filters alongside it and resets the
page when one changes, nuqs batches both into a single URL update.


## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests — none added; the three behaviour changes above are untested
- [x] Linting and type checking pass — typecheck, lint and build all pass (frontend-only, so the
      backend commands don't apply)
- [x] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787913611&installation_model_id=13063&pr_number=13431&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13431&signature=ee3c17df2ea8cb46e959b628c52ceb610baa32bfe679e9a3ac8c0a226be3150c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13431?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

