### PR TITLE
feat(files): allow downloading benefit files from the dashboard

### DIFF
--- a/clients/apps/web/src/components/Benefit/Downloadables/DownloadablesSection.tsx
+++ b/clients/apps/web/src/components/Benefit/Downloadables/DownloadablesSection.tsx
@@ -1,10 +1,54 @@
 'use client'
 
 import { OrderSection } from '@/components/Orders/OrderSection'
-import { useFiles } from '@/hooks/queries'
+import { toast } from '@/components/Toast/use-toast'
+import { useDownloadFile, useFiles } from '@/hooks/queries'
+import { extractApiErrorMessage } from '@/utils/api/errors'
+import ArrowDownward from '@mui/icons-material/ArrowDownward'
 import { schemas } from '@polar-sh/client'
-import { List, ListItem, Text } from '@polar-sh/orbit'
+import { Button, List, ListItem, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
+import { useCallback } from 'react'
+
+const DownloadableFileItem = ({ file }: { file: schemas['FileRead'] }) => {
+  const downloadFile = useDownloadFile(file.id, (fileDownload) => {
+    window.location.href = fileDownload.download.url
+  })
+
+  const onDownload = useCallback(() => {
+    downloadFile.mutateAsync().then((response) => {
+      if (response.error) {
+        toast({
+          title: 'File Download Failed',
+          description: `Error downloading file ${file.name}: ${extractApiErrorMessage(response.error)}`,
+        })
+      }
+    })
+  }, [downloadFile, file.name])
+
+  return (
+    <ListItem>
+      <Box minWidth={0} flexGrow={1}>
+        <Text truncate>{file.name}</Text>
+      </Box>
+      <Box flexShrink={0} alignItems="center" columnGap="m">
+        <Text color="muted" tabularNums>
+          {file.size_readable}
+        </Text>
+        <Button
+          size="icon"
+          variant="secondary"
+          className="h-8 w-8"
+          onClick={onDownload}
+          loading={downloadFile.isPending}
+          aria-label={`Download ${file.name}`}
+        >
+          <ArrowDownward fontSize="inherit" />
+        </Button>
+      </Box>
+    </ListItem>
+  )
+}
 
 export const DownloadablesSection = ({
   benefit,
@@ -35,16 +79,7 @@ export const DownloadablesSection = ({
       ) : (
         <List size="small">
           {(data?.items ?? []).map((file) => (
-            <ListItem key={file.id}>
-              <Box minWidth={0} flexGrow={1}>
-                <Text truncate>{file.name}</Text>
-              </Box>
-              <Box flexShrink={0}>
-                <Text color="muted" tabularNums>
-                  {file.size_readable}
-                </Text>
-              </Box>
-            </ListItem>
+            <DownloadableFileItem key={file.id} file={file} />
           ))}
         </List>
       )}

--- a/clients/apps/web/src/components/Benefit/Downloadables/DownloadablesSection.tsx
+++ b/clients/apps/web/src/components/Benefit/Downloadables/DownloadablesSection.tsx
@@ -16,14 +16,22 @@ const DownloadableFileItem = ({ file }: { file: schemas['FileRead'] }) => {
   })
 
   const onDownload = useCallback(() => {
-    downloadFile.mutateAsync().then((response) => {
-      if (response.error) {
-        toast({
-          title: 'File Download Failed',
-          description: `Error downloading file ${file.name}: ${extractApiErrorMessage(response.error)}`,
-        })
-      }
-    })
+    const showFailure = (reason: string) =>
+      toast({
+        title: 'File Download Failed',
+        description: `Error downloading file ${file.name}: ${reason}`,
+      })
+
+    downloadFile
+      .mutateAsync()
+      .then((response) => {
+        if (response.error) {
+          showFailure(extractApiErrorMessage(response.error))
+        }
+      })
+      .catch(() => {
+        showFailure('Please try again later')
+      })
   }, [downloadFile, file.name])
 
   return (

--- a/clients/apps/web/src/components/Benefit/Downloadables/FileList/FileListItem.tsx
+++ b/clients/apps/web/src/components/Benefit/Downloadables/FileList/FileListItem.tsx
@@ -1,4 +1,4 @@
-import { useDeleteFile } from '@/hooks/queries'
+import { useDeleteFile, useDownloadFile } from '@/hooks/queries'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import AudioFileOutlined from '@mui/icons-material/AudioFileOutlined'
@@ -225,6 +225,21 @@ export const FileListItem = ({
     removeFile()
   })
 
+  const downloadFile = useDownloadFile(file.id, (fileDownload) => {
+    window.location.href = fileDownload.download.url
+  })
+
+  const onDownload = useCallback(() => {
+    downloadFile.mutateAsync().then((response) => {
+      if (response.error) {
+        toast({
+          title: 'File Download Failed',
+          description: `Error downloading file ${file.name}: ${extractApiErrorMessage(response.error)}`,
+        })
+      }
+    })
+  }, [downloadFile, file])
+
   const onToggleEnabled = useCallback(
     (enabled: boolean) => {
       setArchivedFile(file.id, !enabled)
@@ -317,6 +332,11 @@ export const FileListItem = ({
               align="end"
               className="dark:bg-polar-800 bg-gray-50 shadow-lg"
             >
+              {file.is_uploaded && (
+                <DropdownMenuItem onClick={onDownload}>
+                  Download
+                </DropdownMenuItem>
+              )}
               {file.checksum_sha256_hex && (
                 <DropdownMenuItem onClick={onCopySHA}>
                   Copy SHA256 Checksum

--- a/clients/apps/web/src/components/Benefit/Downloadables/FileList/FileListItem.tsx
+++ b/clients/apps/web/src/components/Benefit/Downloadables/FileList/FileListItem.tsx
@@ -230,15 +230,23 @@ export const FileListItem = ({
   })
 
   const onDownload = useCallback(() => {
-    downloadFile.mutateAsync().then((response) => {
-      if (response.error) {
-        toast({
-          title: 'File Download Failed',
-          description: `Error downloading file ${file.name}: ${extractApiErrorMessage(response.error)}`,
-        })
-      }
-    })
-  }, [downloadFile, file])
+    const showFailure = (reason: string) =>
+      toast({
+        title: 'File Download Failed',
+        description: `Error downloading file ${file.name}: ${reason}`,
+      })
+
+    downloadFile
+      .mutateAsync()
+      .then((response) => {
+        if (response.error) {
+          showFailure(extractApiErrorMessage(response.error))
+        }
+      })
+      .catch(() => {
+        showFailure('Please try again later')
+      })
+  }, [downloadFile, file.name])
 
   const onToggleEnabled = useCallback(
     (enabled: boolean) => {

--- a/clients/apps/web/src/hooks/queries/files.ts
+++ b/clients/apps/web/src/hooks/queries/files.ts
@@ -47,6 +47,28 @@ export const useFiles = (
     enabled: fileIds.length > 0,
   })
 
+export const useDownloadFile = (
+  id: string,
+  onSuccessCallback?: (res: schemas['FileDownload']) => void,
+) =>
+  useMutation({
+    mutationFn: () =>
+      api.GET('/v1/files/{id}/download', {
+        params: {
+          path: { id },
+        },
+      }),
+    onSuccess: (response) => {
+      if (response.error) {
+        return
+      }
+
+      if (onSuccessCallback) {
+        onSuccessCallback(response.data)
+      }
+    },
+  })
+
 export const usePatchFile = (
   id: string,
   onSuccessCallback?: (res: FileRead) => void,

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -2937,6 +2937,28 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/files/{id}/download': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get File Download
+     * @description Get a presigned URL to download a file.
+     *
+     *     **Scopes**: `files:read` `files:write`
+     */
+    get: operations['files:download']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/files/{id}/uploaded': {
     parameters: {
       query?: never
@@ -43495,6 +43517,56 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['FileUpload']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'files:download': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description The file ID. */
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['FileDownload']
+        }
+      }
+      /** @description You don't have the permission to download this file. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['NotPermitted']
+        }
+      }
+      /** @description File not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
         }
       }
       /** @description Validation Error */

--- a/server/polar/file/endpoints.py
+++ b/server/polar/file/endpoints.py
@@ -82,6 +82,7 @@ async def list(
 @router.get(
     "/{id}/download",
     summary="Get File Download",
+    tags=[APITag.private],
     response_model=FileDownload,
     responses={
         403: {

--- a/server/polar/file/endpoints.py
+++ b/server/polar/file/endpoints.py
@@ -94,7 +94,7 @@ async def list(
 async def download(
     id: FileID,
     auth_subject: auth.FileRead,
-    session: AsyncReadSession = Depends(get_db_read_session),
+    session: AsyncSession = Depends(get_db_session),
 ) -> FileDownload:
     """Get a presigned URL to download a file."""
     file = await file_service.get(session, auth_subject, id)

--- a/server/polar/file/endpoints.py
+++ b/server/polar/file/endpoints.py
@@ -95,7 +95,7 @@ async def list(
 async def download(
     id: FileID,
     auth_subject: auth.FileRead,
-    session: AsyncSession = Depends(get_db_session),
+    session: AsyncReadSession = Depends(get_db_read_session),
 ) -> FileDownload:
     """Get a presigned URL to download a file."""
     file = await file_service.get(session, auth_subject, id)

--- a/server/polar/file/endpoints.py
+++ b/server/polar/file/endpoints.py
@@ -27,6 +27,7 @@ from polar.routing import APIRouter
 from . import auth
 from .schemas import (
     FileCreate,
+    FileDownload,
     FilePatch,
     FileRead,
     FileReadAdapter,
@@ -76,6 +77,36 @@ async def list(
         count,
         pagination,
     )
+
+
+@router.get(
+    "/{id}/download",
+    summary="Get File Download",
+    response_model=FileDownload,
+    responses={
+        403: {
+            "description": "You don't have the permission to download this file.",
+            "model": NotPermitted.schema(),
+        },
+        404: FileNotFound,
+    },
+)
+async def download(
+    id: FileID,
+    auth_subject: auth.FileRead,
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> FileDownload:
+    """Get a presigned URL to download a file."""
+    file = await file_service.get(session, auth_subject, id)
+    if file is None or not file.is_uploaded:
+        raise ResourceNotFound()
+
+    if file.service == FileServiceTypes.support_case_attachment:
+        raise NotPermitted(
+            "Support case attachments cannot be downloaded through the files API."
+        )
+
+    return file_service.generate_downloadable_schema(file)
 
 
 @router.post(

--- a/server/polar/file/service.py
+++ b/server/polar/file/service.py
@@ -59,7 +59,7 @@ class FileService:
 
     async def get(
         self,
-        session: AsyncSession,
+        session: AsyncReadSession,
         auth_subject: AuthSubject[User | Organization],
         id: uuid.UUID,
     ) -> File | None:

--- a/server/polar/file/service.py
+++ b/server/polar/file/service.py
@@ -59,7 +59,7 @@ class FileService:
 
     async def get(
         self,
-        session: AsyncReadSession,
+        session: AsyncSession,
         auth_subject: AuthSubject[User | Organization],
         id: uuid.UUID,
     ) -> File | None:

--- a/server/tests/file/test_endpoints.py
+++ b/server/tests/file/test_endpoints.py
@@ -1,3 +1,4 @@
+import uuid
 from urllib.parse import parse_qs, urlencode, urlparse
 
 import pytest
@@ -174,6 +175,81 @@ class TestList:
         assert response.status_code == 200
         json = response.json()
         assert [item["id"] for item in json["items"]] == [str(visible.id)]
+
+
+@pytest.mark.asyncio
+class TestDownload:
+    async def test_anonymous(self, client: AsyncClient) -> None:
+        response = await client.get(f"/v1/files/{uuid.uuid4()}/download")
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_not_existing(self, client: AsyncClient) -> None:
+        response = await client.get(f"/v1/files/{uuid.uuid4()}/download")
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_not_uploaded(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        file = await create_support_case_attachment_file(
+            save_fixture,
+            organization,
+            name="release.zip",
+            service=FileServiceTypes.downloadable,
+            is_uploaded=False,
+        )
+
+        response = await client.get(f"/v1/files/{file.id}/download")
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_support_case_attachment_not_permitted(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        file = await create_support_case_attachment_file(save_fixture, organization)
+
+        response = await client.get(f"/v1/files/{file.id}/download")
+
+        assert response.status_code == 403
+
+    @pytest.mark.auth(
+        AuthSubjectFixture(subject="user"),
+        AuthSubjectFixture(subject="organization"),
+    )
+    async def test_valid(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        file = await create_support_case_attachment_file(
+            save_fixture,
+            organization,
+            name="release.zip",
+            service=FileServiceTypes.downloadable,
+        )
+
+        response = await client.get(f"/v1/files/{file.id}/download")
+
+        assert response.status_code == 200
+        json = response.json()
+        assert json["id"] == str(file.id)
+        assert json["service"] == "downloadable"
+        assert json["download"]["url"]
+        assert json["download"]["expires_at"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

**Related Issue**: #

Allow merchants to download benefit files from the dashboard via a new files download endpoint and UI actions.

## What

- Add `GET /v1/files/{id}/download` returning a presigned download URL
- Add Download in the benefit file list menu and a download button on the benefit Files section

## Why

Dashboard users could manage downloadable benefit files but had no way to download them for inspection without going through the customer portal flow.

## How

Reuse existing file auth and S3 download helpers for the new endpoint, then wire dashboard actions through a `useDownloadFile` mutation that opens the presigned URL.

|Screenshot|
|---|
| <img width="1428" height="251" alt="Screenshot 2026-07-29 at 13 32 22" src="https://github.com/user-attachments/assets/a972afb7-dce6-4958-bef9-eb94dbb37d16" /> |

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787916814&installation_model_id=13063&pr_number=13432&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13432&signature=0003c8515a3f164b604c87ecdb8321690912d05916b396e1579c8c823ef1e6af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

