### PR TITLE
fix(terraform): pass Slack config to the production Lambda worker

### DIFF
--- a/terraform/production/aws.tf
+++ b/terraform/production/aws.tf
@@ -59,6 +59,7 @@ locals {
     POLAR_EMAIL_SENDER                = "resend"
     POLAR_EMAIL_FROM_NAME             = "Polar"
     POLAR_EMAIL_FROM_DOMAIN           = "notifications.polar.sh"
+    POLAR_SLACK_CHANNEL               = var.slo_report_slack_channel
     POLAR_WORKER_SQS_ENABLED          = "true"
     POLAR_WORKER_SQS_QUEUE_PREFIX     = "polar-production-tasks"
   }
@@ -71,6 +72,7 @@ locals {
     POLAR_RESEND_API_KEY  = var.backend_resend_api_key_production
     POLAR_SECRET          = var.backend_secret_production
     POLAR_SENTRY_DSN      = var.backend_sentry_dsn_production
+    POLAR_SLACK_BOT_TOKEN = var.slo_report_slack_bot_token
     TAILSCALE_AUTHKEY     = var.lambda_worker_tailscale_token
   }
 


### PR DESCRIPTION
Invariant checks have run every 15 minutes as expected, but no failure has ever reached Slack.

`InvariantService.check` returns early when `SLACK_BOT_TOKEN` or `SLACK_CHANNEL` is unset (`server/polar/observability/invariants/service.py:96`). Those two settings are only wired into the `slo-report-production` Render env group. The invariant tasks run on the Lambda worker, which builds its environment from `local.lambda_worker_environment` and `local.lambda_worker_secrets` — neither included them.

Logfire confirms it: every `Invariant check failed` record is paired one-to-one with `Slack bot token or channel not configured, cannot send invariant failure notification`, across production, sandbox and test, for the full 14-day retention window.

Currently failing in production and unreported: `SubscriptionsLockedInvariant` (111 in 2 days), `PayoutTransactionsAmountInvariant` (106), `SubscriptionsCurrentPeriodEndInvariant` (5).

Both Terraform variables already exist, so this only forwards them to the Lambda.

Follow-ups, not in this PR:
- The early return should be loud. A `log.warning` firing 96 times a day is how this went unnoticed for weeks.
- Sandbox and test never set `slo_report_config`, so their workers are silent too. Either wire it up or scope those invariants to production via `ENVIRONMENTS`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787925577&installation_model_id=13063&pr_number=13435&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13435&signature=f3d3152b4a4aba28c7c03fb5e781e1fd78ef71ae6e2bc331c4344a9d452999af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

