### PR TITLE
perf(invariants): speed up slow invariant checks

### DIFF
--- a/server/migrations/versions/2026-07-29-0000_add_covering_index_for_deleted_customer_.py
+++ b/server/migrations/versions/2026-07-29-0000_add_covering_index_for_deleted_customer_.py
@@ -1,0 +1,42 @@
+"""add covering index for deleted customer invariant check
+
+Revision ID: 8f3d1c4a9e21
+Revises: 45773b693045
+Create Date: 2026-07-29 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "8f3d1c4a9e21"
+down_revision = "45773b693045"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+INDEX_NAME = "ix_customers_deleted_at_id"
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            INDEX_NAME,
+            "customers",
+            ["deleted_at", "id"],
+            unique=False,
+            postgresql_concurrently=True,
+            postgresql_where=sa.text("deleted_at IS NOT NULL"),
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            INDEX_NAME,
+            table_name="customers",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )

--- a/server/migrations/versions/2026-07-29-0000_add_covering_index_for_deleted_customer_.py
+++ b/server/migrations/versions/2026-07-29-0000_add_covering_index_for_deleted_customer_.py
@@ -22,6 +22,14 @@ INDEX_NAME = "ix_customers_deleted_at_id"
 
 def upgrade() -> None:
     with op.get_context().autocommit_block():
+        # A failed/canceled concurrent build leaves an INVALID index behind;
+        # drop it first so rerunning this (unrecorded) migration recovers.
+        op.drop_index(
+            INDEX_NAME,
+            table_name="customers",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )
         op.create_index(
             INDEX_NAME,
             "customers",

--- a/server/polar/models/customer.py
+++ b/server/polar/models/customer.py
@@ -144,6 +144,12 @@ class Customer(MetadataMixin, RecordModel):
             "search_vector",
             postgresql_using="gin",
         ),
+        Index(
+            "ix_customers_deleted_at_id",
+            "deleted_at",
+            "id",
+            postgresql_where=text("deleted_at IS NOT NULL"),
+        ),
         UniqueConstraint("organization_id", "external_id"),
         UniqueConstraint("organization_id", "short_id"),
     )

--- a/server/polar/observability/invariants/rules/payout_transactions_amount_invariant.py
+++ b/server/polar/observability/invariants/rules/payout_transactions_amount_invariant.py
@@ -48,8 +48,8 @@ class PayoutTransactionsAmountInvariant(Invariant):
     AGE_LIMIT = timedelta(days=30)
 
     async def check(self) -> None:
-        # Payout transactions without reversal (same payout_id)
-        payout_subq = (
+        # Recent payout transactions without reversal (same payout_id)
+        recent_payouts = (
             select(Transaction.id, Transaction.amount)
             .where(
                 Transaction.created_at > (func.now() - self.AGE_LIMIT),
@@ -61,38 +61,40 @@ class PayoutTransactionsAmountInvariant(Invariant):
                     )
                 ),
             )
-            .subquery()
+            .cte("recent_payouts")
         )
 
-        # Sum of amounts per payout_transaction_id
+        # Sum of paid amounts, bounded to the recent payout transactions so we
+        # don't aggregate over the entire transactions history.
         paid_subq = (
             select(
                 Transaction.payout_transaction_id,
                 func.coalesce(func.sum(Transaction.amount), 0).label("total_amount"),
             )
-            .where(Transaction.payout_transaction_id.isnot(None))
+            .where(Transaction.payout_transaction_id.in_(select(recent_payouts.c.id)))
             .group_by(Transaction.payout_transaction_id)
             .subquery()
         )
 
         # Find mismatches
-        diff_expr = func.abs(payout_subq.c.amount) - func.coalesce(
+        diff_expr = func.abs(recent_payouts.c.amount) - func.coalesce(
             paid_subq.c.total_amount, 0
         )
         statement = (
             select(
-                payout_subq.c.id,
+                recent_payouts.c.id,
                 diff_expr.label("diff"),
                 over(func.count()),
             )
             .select_from(
-                payout_subq.outerjoin(
-                    paid_subq, payout_subq.c.id == paid_subq.c.payout_transaction_id
+                recent_payouts.outerjoin(
+                    paid_subq,
+                    recent_payouts.c.id == paid_subq.c.payout_transaction_id,
                 )
             )
             .where(func.abs(diff_expr) > 0)
             .limit(self.LIMIT)
-            .order_by(func.abs(diff_expr).desc(), payout_subq.c.id.asc())
+            .order_by(func.abs(diff_expr).desc(), recent_payouts.c.id.asc())
         )
 
         result = await self.session.execute(statement)


### PR DESCRIPTION
Addresses: https://github.com/polarsource/polar/issues/13433

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787929390&installation_model_id=13063&pr_number=13436&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13436&signature=749ee2f8e8cc73f3292f6a49080d2e3028cf8b023e46dfcf6358e11067a758a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up slow invariant checks and prevent statement timeouts. Adds a partial covering index for deleted customers and bounds payout-amount aggregation to recent payouts.

- **Refactors**
  - Limit payout amount check to the last 30 days using a CTE; avoids full-history grouping with unchanged results.

- **Migration**
  - Add partial covering index on `customers(deleted_at, id)` where `deleted_at IS NOT NULL`, created concurrently for index-only scans in the deleted-customer invariant; drop any invalid leftover index first to allow safe reruns.

<sup>Written for commit 4e1f699e6a916f8034d5733e1ec2d96554f0cb25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



