### PR TITLE
feat(checkout): log embeds refused by the allowlist

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -716,6 +716,12 @@ class CheckoutService:
                     str(parsed_embed_origin), organization.embed_hosts
                 )
                 if embed_origin is None:
+                    log.warning(
+                        "Embedded checkout refused: origin is not an allowed embed host",
+                        organization_id=str(organization.id),
+                        embed_origin=str(parsed_embed_origin),
+                        embed_hosts=organization.embed_hosts,
+                    )
                     raise EmbedHostNotAllowed(str(parsed_embed_origin))
             else:
                 embed_origin = str(parsed_embed_origin)


### PR DESCRIPTION
## Summary

**Related Issue**: polarsource/feedback#195

Makes allowlist refusals visible. Follows #13425, which added the enforcement.

## What

A log line when an embed is refused, carrying the organization, the origin it sent, and the hosts it has configured.

## Why

A refused embed raises before the `Checkout` row is written, so the database never learns it happened and Metabase has nothing to query. Adoption is measurable from the database; refusals are not.

That matters most for a merchant who configures partially. Listing one host of three enforces the list immediately and breaks the other two, while the banner disappears and the reminder email skips them, since both key off an empty list. Every signal reads them as done.

## How

Logfire already counts and charts events, so a Prometheus counter would add a metric name and a dashboard panel to maintain for strictly less information: it carries no labels, so it could never say which organization. `embed_hosts` next to the rejected origin usually shows the mistake outright, such as a missing `www`.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included