### PR TITLE
fix(organization): enforce embed hosts by cohort only

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/EmbedHostsBanner.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/EmbedHostsBanner.tsx
@@ -35,7 +35,7 @@ export const EmbedHostsBanner = ({ organization }: EmbedHostsBannerProps) => {
         <>
           {data.embed_hosts_enforced
             ? 'Your checkout is embedded on at least one site, and no hosts are listed, so those checkouts are not opening.'
-            : 'Your checkout is embedded on at least one site. List the hosts allowed to embed it, or those checkouts will stop opening.'}{' '}
+            : 'Your checkout is embedded on at least one site. Nothing breaks today, but a host you leave out will stop opening your checkout once we enforce the list.'}{' '}
           <a
             href="https://polar.sh/docs/features/checkout/embed#embed-hosts"
             target="_blank"

--- a/clients/apps/web/src/components/Settings/OrganizationEmbedSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationEmbedSettings.tsx
@@ -71,7 +71,7 @@ const OrganizationEmbedSettings: React.FC<OrganizationEmbedSettingsProps> = ({
         description={
           organization.embed_hosts_enforced
             ? 'Only these hosts can embed your checkout.'
-            : 'Listing a host starts restricting your checkout to it right away.'
+            : 'Only these hosts will be able to embed your checkout once we enforce the list. Nothing changes until then.'
         }
         vertical
       >
@@ -141,11 +141,10 @@ const OrganizationEmbedSettings: React.FC<OrganizationEmbedSettingsProps> = ({
           )}
 
           <Text variant="caption" color="muted">
-            Add every host at once, separated by commas or spaces — the list
-            takes effect as soon as you save. Write each host on its own,
-            without a scheme: example.com, *.example.com for any subdomain, or
-            localhost:3000 with a port. HTTPS is always allowed, and HTTP too on
-            localhost and private addresses.
+            Add every host at once, separated by commas or spaces. Write each
+            host on its own, without a scheme: example.com, *.example.com for
+            any subdomain, or localhost:3000 with a port. HTTPS is always
+            allowed, and HTTP too on localhost and private addresses.
           </Text>
         </Box>
       </SettingsGroupItem>

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -635,10 +635,10 @@ class Organization(RateLimitGroupMixin, RecordModel):
 
     @property
     def embed_hosts_enforced(self) -> bool:
-        """Filling the list in opts an older organization in: nothing but a
-        merchant ever writes to the column, so a non-empty list is a deliberate
-        choice."""
-        return bool(self.embed_hosts) or self.created_at >= EMBED_HOSTS_ENFORCED_FROM
+        """Configuring a list does not enforce it. Existing organizations keep
+        embedding unchecked until the allowlist is enforced for everyone, so a
+        list that misses a host they use costs them nothing until then."""
+        return self.created_at >= EMBED_HOSTS_ENFORCED_FROM
 
     legal_entity: Mapped[OrganizationLegalEntity | None] = mapped_column(
         JSONB, nullable=True, default=None

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -2608,6 +2608,7 @@ class TestCheckoutLinkCreate:
         organization: Organization,
         product_one_time: Product,
     ) -> None:
+        organization.created_at = EMBED_HOSTS_ENFORCED_FROM
         organization.embed_hosts = ["*.example.com"]
         await save_fixture(organization)
         checkout_link = await create_checkout_link(
@@ -2627,6 +2628,7 @@ class TestCheckoutLinkCreate:
         organization: Organization,
         product_one_time: Product,
     ) -> None:
+        organization.created_at = EMBED_HOSTS_ENFORCED_FROM
         organization.embed_hosts = ["example.com"]
         await save_fixture(organization)
         checkout_link = await create_checkout_link(
@@ -2637,6 +2639,28 @@ class TestCheckoutLinkCreate:
             await checkout_service.checkout_link_create(
                 session, checkout_link, embed_origin="https://evil.com"
             )
+
+    async def test_unlisted_embed_origin_before_the_cutoff(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product_one_time: Product,
+    ) -> None:
+        """Listing hosts doesn't enforce them: older organizations embed
+        unchecked until the cutoff applies to everyone."""
+        organization.created_at = EMBED_HOSTS_ENFORCED_FROM - timedelta(days=1)
+        organization.embed_hosts = ["example.com"]
+        await save_fixture(organization)
+        checkout_link = await create_checkout_link(
+            save_fixture, products=[product_one_time]
+        )
+
+        checkout = await checkout_service.checkout_link_create(
+            session, checkout_link, embed_origin="https://other.com"
+        )
+
+        assert checkout.embed_origin == "https://other.com"
 
     async def test_refused_embed_origin_for_new_organization(
         self,
@@ -2665,6 +2689,7 @@ class TestCheckoutLinkCreate:
         product_one_time: Product,
     ) -> None:
         """A value carrying no origin can't embed anyway, so it doesn't 403."""
+        organization.created_at = EMBED_HOSTS_ENFORCED_FROM
         organization.embed_hosts = ["example.com"]
         await save_fixture(organization)
         checkout_link = await create_checkout_link(

--- a/server/tests/checkout_link/test_endpoints.py
+++ b/server/tests/checkout_link/test_endpoints.py
@@ -17,7 +17,7 @@ from polar.models import (
     User,
     UserOrganization,
 )
-from polar.models.organization import OrganizationStatus
+from polar.models.organization import EMBED_HOSTS_ENFORCED_FROM, OrganizationStatus
 from polar.postgres import AsyncSession
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
@@ -391,6 +391,7 @@ class TestRedirect:
         organization: Organization,
         checkout_link: CheckoutLink,
     ) -> None:
+        organization.created_at = EMBED_HOSTS_ENFORCED_FROM
         organization.embed_hosts = ["example.com"]
         await save_fixture(organization)
 

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -10,7 +10,11 @@ from polar.config import settings
 from polar.integrations.polar.service import PolarSelfService
 from polar.models import OrganizationSSOConnection, Product, User
 from polar.models.account import Account
-from polar.models.organization import Organization, OrganizationStatus
+from polar.models.organization import (
+    EMBED_HOSTS_ENFORCED_FROM,
+    Organization,
+    OrganizationStatus,
+)
 from polar.models.organization_sso_connection import (
     OIDCAuthMethod,
     OIDCConfiguration,
@@ -902,6 +906,23 @@ class TestGetEmbedStatus:
         assert response.status_code == 200
         json = response.json()
         assert json["embed_hosts"] == ["example.com"]
+        assert json["embed_hosts_enforced"] is False
+
+    @pytest.mark.auth
+    async def test_organization_past_the_cutoff(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        organization.created_at = EMBED_HOSTS_ENFORCED_FROM
+        await save_fixture(organization)
+
+        response = await client.get(f"/v1/organizations/{organization.id}/embed-status")
+
+        assert response.status_code == 200
+        json = response.json()
         assert json["embed_hosts_enforced"] is True
 
 


### PR DESCRIPTION
## Summary

People rushed on the feature and sometimes made mistake configuring the allow list. I'm loosening the rule so nothing is enforced appart for orgs created after the first cutoff (August 4th). Also removing the sense of urgency in the banner + settings.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787943358&installation_model_id=13063&pr_number=13443&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13443&signature=09b713b701639511863d7c7b68240d24b05fda47ba637fb151a37eee221b7ed2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

