### PR TITLE
fix(tax): accept post-2023 Taiwanese unified business numbers

### DIFF
--- a/server/polar/tax/tax_id.py
+++ b/server/polar/tax/tax_id.py
@@ -13,6 +13,7 @@ import stdnum.il.idnr
 import stdnum.in_.gstin
 import stdnum.mk.edb
 import stdnum.tr.vkn
+import stdnum.tw.ubn
 import stdnum.vn.mst
 from pydantic import Field
 from sqlalchemy.dialects.postgresql import JSONB
@@ -352,6 +353,23 @@ class TRTINValidator(ValidatorProtocol):
             raise InvalidTaxID(number, country) from e
 
 
+class TWVATValidator(ValidatorProtocol):
+    # Since April 2023, Taiwan also issues UBN whose weighted digit sum is
+    # divisible by 5; stdnum only implements the original divisible-by-10 rule.
+    # The seventh digit "7" alternative applies to both rules.
+    def validate(self, number: str, country: str) -> str:
+        number = stdnum.tw.ubn.compact(number)
+        try:
+            return stdnum.tw.ubn.validate(number)
+        except stdnum.exceptions.InvalidChecksum as e:
+            checksum = stdnum.tw.ubn.calc_checksum(number)
+            if checksum % 5 == 0 or (number[6] == "7" and (checksum + 1) % 5 == 0):
+                return number
+            raise InvalidTaxID(number, country) from e
+        except stdnum.exceptions.ValidationError as e:
+            raise InvalidTaxID(number, country) from e
+
+
 class INGSTValidator(ValidatorProtocol):
     def validate(self, number: str, country: str) -> str:
         number = stdnum.in_.gstin.compact(number)
@@ -443,6 +461,8 @@ def _get_validator(tax_id_type: TaxIDFormat) -> ValidatorProtocol:
             return MKVATValidator()
         case TaxIDFormat.tr_tin:
             return TRTINValidator()
+        case TaxIDFormat.tw_vat:
+            return TWVATValidator()
         case TaxIDFormat.in_gst:
             return INGSTValidator()
         case TaxIDFormat.vn_tin:

--- a/server/tests/tax/test_tax_id.py
+++ b/server/tests/tax/test_tax_id.py
@@ -68,6 +68,14 @@ from polar.tax.tax_id import InvalidTaxID, TaxID, TaxIDFormat, validate_tax_id
         ("12345678901", "GE", ("12345678901", TaxIDFormat.ge_vat)),
         ("GE12345678901", "GE", ("12345678901", TaxIDFormat.ge_vat)),
         ("28392339", "MU", ("28392339", TaxIDFormat.mu_tan)),
+        # TW UBN: original rule, weighted digit sum divisible by 10
+        ("22099131", "TW", ("22099131", TaxIDFormat.tw_vat)),
+        ("04541302", "TW", ("04541302", TaxIDFormat.tw_vat)),
+        ("89398777", "TW", ("89398777", TaxIDFormat.tw_vat)),  # 7th digit "7"
+        # TW UBN: since April 2023, divisible by 5 is enough
+        ("62140097", "TW", ("62140097", TaxIDFormat.tw_vat)),
+        ("6214-0097", "TW", ("62140097", TaxIDFormat.tw_vat)),
+        ("90000075", "TW", ("90000075", TaxIDFormat.tw_vat)),  # 7th digit "7"
         # CR TIN: cédula jurídica (business)
         ("3-101-356876", "CR", ("3101356876", TaxIDFormat.cr_tin)),
         ("3101356876", "CR", ("3101356876", TaxIDFormat.cr_tin)),
@@ -104,6 +112,7 @@ def test_validate_tax_id_valid(number: str, country: str, expected: TaxID) -> No
         ("123456789012", "GE"),  # Too long
         ("12345678A", "GE"),  # Non-digit
         ("88392339", "MU"),  # Wrong leading digit
+        ("62140098", "TW"),  # Wrong check digit under both rules
         ("9999999999", "CR"),  # Invalid CR TIN
         ("1-1000-0001", "CR"),  # cédula física (individual), not accepted
     ],


### PR DESCRIPTION
## Summary

**Related Issue**: N/A — reported directly, reproduced with UBN `62140097`.

Taiwanese customers whose unified business number (UBN, 統一編號) was issued under the post-2023 rules were rejected at checkout with an "invalid tax ID" error. This makes us accept them, while keeping the pre-2023 numbers working.

## What

- New `TWVATValidator` in `server/polar/tax/tax_id.py`, wired into `_get_validator` for `TaxIDFormat.tw_vat`. Previously `tw_vat` fell through to the generic `StdNumValidator`.
- Test coverage in `server/tests/tax/test_tax_id.py` for both checksum rules, separator handling, and the seventh-digit-`7` special case.

## Why

Taiwan's Ministry of Finance relaxed the UBN check rule in April 2023: the weighted digit sum now only needs to be divisible by **5** rather than **10**, roughly doubling the available number space as the old one ran out. `python-stdnum` (2.2, current pin) still implements only the original divisible-by-10 rule, so it raises `InvalidChecksum` for numbers issued under the new scheme.

Our checkout path (`checkout/service.py:473` and `:2253`) turns that into a 422 on `body.customer_tax_id`, so the customer sees a validation error on a number that is genuinely valid and registered.

Concretely, for `62140097` the weights `(1,2,1,2,1,2,4,1)` give a weighted digit sum of 35 — `35 % 10 == 5` (rejected today), `35 % 5 == 0` (valid under the current rule). This affects roughly half of all UBN issued since April 2023, so it will keep recurring for TW customers.

## How

`TWVATValidator` still calls `stdnum.tw.ubn.validate` first, so length, digit-format and the pre-2023 checksum behave exactly as before. Only on `InvalidChecksum` does it retry with the relaxed rule — and since stdnum raises that error only after the length and format checks have passed, the fallback cannot loosen anything except the checksum.

The seventh-digit-`7` alternative (where the `7 × 4 = 28` carry may be counted either way) is preserved for both rules: `(checksum + 1) % 5 == 0`, mirroring stdnum's `checksum == 9` case for the mod-10 rule.

This follows the existing `ECRUCValidator` pattern, which already works around a stdnum checksum gap the same way.

### Verification

- All 73 cases in `tests/tax/test_tax_id.py` pass, including the 7 new TW cases.
- `uv run task lint` and `uv run task lint_types` both clean.

One caveat on how the tests were run locally: the dev container had no Docker daemon, so the session-scoped conftest fixtures (Minio/Postgres) couldn't start and `uv run pytest` errors during setup for that file — on `main` as much as on this branch. The file was therefore run against the real `polar.tax.tax_id` and the real installed `stdnum` with the repo conftest bypassed. It's a pure function with no DB or S3 involvement, so nothing under test was stubbed, and CI will run it normally.

### Follow-ups (not in this PR)

- **Stripe**: we now accept numbers Stripe may still reject under its own `tw_vat` validation. If it does, the failure moves from our checkout validation to the Stripe customer call — worth a sandbox check with `62140097` before this hits production.
- **Existing customers**: anyone who previously worked around this with an incorrect number, or gave up, still has bad or missing tax data. `server/scripts/invalid_tax_id_customers.py` looks like the right tool for a sweep.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AQ7f417zVgSetMTj5UEy9D

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQ7f417zVgSetMTj5UEy9D)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787946870&installation_model_id=13063&pr_number=13445&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13445&signature=f1e10f3e8bddd2a4dc6df7263f3951ca0e1eabc6c1c6c3fa0669650f559f2330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

