### PR TITLE
Improve sales orders table layout, timestamps, and metric cards

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -65,7 +65,7 @@ const formatOrderDate = (value: string) => {
     year: 'numeric',
     hour: '2-digit',
     minute: '2-digit',
-    hour12: false
+    hour12: false,
   })
 }
 
@@ -142,7 +142,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
         const showBillingName =
           !!customer.billing_name &&
           customer.name?.toLocaleLowerCase() !==
-          customer.billing_name.toLocaleLowerCase()
+            customer.billing_name.toLocaleLowerCase()
         return (
           <div className="flex flex-row items-center gap-2">
             <Avatar
@@ -208,7 +208,6 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
       ),
       cell: ({ row: { original: order } }) => (
         <OrderStatus status={order.status} />
-
       ),
     },
     {
@@ -224,7 +223,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
       ),
       cell: ({ row: { original: order } }) => (
         <Box display="block" textAlign="right">
-          <Text variant='body' tabularNums>
+          <Text variant="body" tabularNums>
             {formatCurrency('accounting')(order.net_amount, order.currency)}
           </Text>
         </Box>
@@ -232,17 +231,17 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
     },
     ...(metadata
       ? metadata.map<DataTableColumnDef<schemas['Order']>>((key) => ({
-        accessorKey: `metadata.${key}`,
-        enableSorting: false,
-        header: ({ column }) => (
-          <DataTableColumnHeader
-            column={column}
-            title={key}
-            className="text-black dark:text-white"
-          />
-        ),
-        cell: (props) => <Text monospace>{props.getValue() as string}</Text>,
-      }))
+          accessorKey: `metadata.${key}`,
+          enableSorting: false,
+          header: ({ column }) => (
+            <DataTableColumnHeader
+              column={column}
+              title={key}
+              className="text-black dark:text-white"
+            />
+          ),
+          cell: (props) => <Text monospace>{props.getValue() as string}</Text>,
+        }))
       : []),
   ]
 

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -41,6 +41,34 @@ const filterParsers = {
   metadata: parseAsArrayOf(parseAsString),
 }
 
+/**
+ * Invoice numbers are `{orgPrefix}-{seq}` or `{orgPrefix}-{customerShortId}-{seq}`.
+ * Org prefix defaults to `slug.upper()` (may include hyphens, e.g. ACME-CORP).
+ */
+const formatInvoiceNumber = (
+  invoiceNumber: string | null,
+  organizationSlug: string,
+) => {
+  if (!invoiceNumber) return null
+  const prefix = `${organizationSlug.toUpperCase()}-`
+  if (invoiceNumber.startsWith(prefix)) {
+    return invoiceNumber.slice(prefix.length)
+  }
+  return invoiceNumber
+}
+
+const formatOrderDate = (value: string) => {
+  const date = new Date(value)
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false
+  })
+}
+
 interface ClientPageProps {
   organization: schemas['Organization']
 }
@@ -82,6 +110,27 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
 
   const columns: DataTableColumnDef<schemas['Order']>[] = [
     {
+      accessorKey: 'created_at',
+      enableSorting: true,
+      size: 120,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Invoice" />
+      ),
+      cell: ({ row: { original: order } }) => (
+        <Box flexDirection="column" rowGap="xs" minWidth={0}>
+          <Text>
+            <time dateTime={order.created_at}>
+              {formatOrderDate(order.created_at)}
+            </time>
+          </Text>
+          <Text color="muted" monospace tabularNums>
+            {formatInvoiceNumber(order.invoice_number, organization.slug) ??
+              '—'}
+          </Text>
+        </Box>
+      ),
+    },
+    {
       accessorKey: 'customer',
       enableSorting: true,
       size: 200,
@@ -93,7 +142,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
         const showBillingName =
           !!customer.billing_name &&
           customer.name?.toLocaleLowerCase() !==
-            customer.billing_name.toLocaleLowerCase()
+          customer.billing_name.toLocaleLowerCase()
         return (
           <div className="flex flex-row items-center gap-2">
             <Avatar
@@ -112,29 +161,6 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
               </Text>
             </Truncated>
           </div>
-        )
-      },
-    },
-    {
-      accessorKey: 'created_at',
-      enableSorting: true,
-      size: 160,
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="Date" />
-      ),
-      cell: (props) => {
-        const date = new Date(props.getValue() as string)
-        return (
-          <time dateTime={date.toISOString()}>
-            {date.toLocaleString('en-US', {
-              month: 'short',
-              day: 'numeric',
-              year: 'numeric',
-              hour: '2-digit',
-              minute: '2-digit',
-              hour12: false,
-            })}
-          </time>
         )
       },
     },
@@ -176,14 +202,20 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
     {
       accessorKey: 'net_amount',
       enableSorting: true,
-      size: 100,
+      size: 80,
       header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="Amount" />
+        <DataTableColumnHeader
+          column={column}
+          title="Amount"
+          className="flex justify-end"
+        />
       ),
       cell: ({ row: { original: order } }) => (
-        <Text>
-          {formatCurrency('standard')(order.net_amount, order.currency)}
-        </Text>
+        <Box display="block" textAlign="right">
+          <Text variant='default' tabularNums>
+            {formatCurrency('accounting')(order.net_amount, order.currency)}
+          </Text>
+        </Box>
       ),
     },
     {
@@ -191,33 +223,30 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
       enableSorting: true,
       size: 140,
       header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="Status" />
+        <div className="flex justify-end">
+          <DataTableColumnHeader column={column} title="Status" />
+        </div>
       ),
       cell: ({ row: { original: order } }) => (
-        <OrderStatus status={order.status} />
-      ),
-    },
-    {
-      accessorKey: 'invoice_number',
-      enableSorting: true,
-      size: 180,
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="Invoice number" />
+        <div className="flex justify-end">
+          <OrderStatus status={order.status} />
+        </div>
+
       ),
     },
     ...(metadata
       ? metadata.map<DataTableColumnDef<schemas['Order']>>((key) => ({
-          accessorKey: `metadata.${key}`,
-          enableSorting: false,
-          header: ({ column }) => (
-            <DataTableColumnHeader
-              column={column}
-              title={key}
-              className="text-black dark:text-white"
-            />
-          ),
-          cell: (props) => <Text monospace>{props.getValue() as string}</Text>,
-        }))
+        accessorKey: `metadata.${key}`,
+        enableSorting: false,
+        header: ({ column }) => (
+          <DataTableColumnHeader
+            column={column}
+            title={key}
+            className="text-black dark:text-white"
+          />
+        ),
+        cell: (props) => <Text monospace>{props.getValue() as string}</Text>,
+      }))
       : []),
   ]
 

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -23,7 +23,6 @@ import {
   DataTableColumnDef,
   DataTableColumnHeader,
 } from '@polar-sh/orbit'
-import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import { Status } from '@polar-sh/orbit'
 import { RowSelectionState } from '@tanstack/react-table'
 import { useRouter } from 'next/navigation'
@@ -118,16 +117,25 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
     {
       accessorKey: 'created_at',
       enableSorting: true,
-      size: 180,
+      size: 160,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Date" />
       ),
-      cell: (props) => (
-        <FormattedDateTime
-          datetime={props.getValue() as string}
-          resolution="time"
-        />
-      ),
+      cell: (props) => {
+        const date = new Date(props.getValue() as string)
+        return (
+          <time dateTime={date.toISOString()} >
+            {date.toLocaleString('en-US', {
+              month: 'short',
+              day: 'numeric',
+              year: 'numeric',
+              hour: '2-digit',
+              minute: '2-digit',
+              hour12: false,
+            })}
+          </time>
+        )
+      },
     },
     {
       accessorKey: 'product',
@@ -237,15 +245,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
     endDate: allTimeEnd,
     interval: allTimeInterval,
     product_id: productId ?? undefined,
-    metrics: ['orders', 'revenue', 'cumulative_revenue'],
-  })
-  const { data: todayMetricsData } = useMetrics({
-    organization_id: organization.id,
-    startDate: new Date(),
-    endDate: new Date(),
-    interval: 'day',
-    product_id: productId ?? undefined,
-    metrics: ['revenue'],
+    metrics: ['orders', 'revenue', 'average_order_value'],
   })
 
   const onExport = () => {
@@ -291,14 +291,14 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
             metric={metricsData?.metrics.orders}
           />
           <MiniMetricChartBox
-            title="Today's Revenue"
-            value={todayMetricsData?.totals.revenue}
-            metric={todayMetricsData?.metrics.revenue}
+            title="Revenue"
+            value={metricsData?.totals.revenue}
+            metric={metricsData?.metrics.revenue}
           />
           <MiniMetricChartBox
-            title="Cumulative Revenue"
-            value={metricsData?.totals.revenue}
-            metric={metricsData?.metrics.cumulative_revenue}
+            title="Average Order Value"
+            value={metricsData?.totals.average_order_value}
+            metric={metricsData?.metrics.average_order_value}
           />
         </div>
         {orders && pageCount !== undefined && (

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -92,10 +92,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
       cell: ({ row: { original: order } }) => (
         <Box flexDirection="column" rowGap="xs" minWidth={0}>
           <Text tabularNums>
-            <FormattedDateTime
-              datetime={order.created_at}
-              resolution="time"
-            />
+            <FormattedDateTime datetime={order.created_at} resolution="time" />
           </Text>
           <Text color="muted" monospace tabularNums>
             {order.invoice_number ?? '—'}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -114,7 +114,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
       enableSorting: true,
       size: 120,
       header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="Invoice" />
+        <DataTableColumnHeader column={column} title="Date" />
       ),
       cell: ({ row: { original: order } }) => (
         <Box flexDirection="column" rowGap="xs" minWidth={0}>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -102,7 +102,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
               name={customer.email ?? customer.name ?? '—'}
             />
             <Truncated>
-              <Text>
+              <Text as="span">
                 {customer.name || customer.email || '—'}
                 {showBillingName && (
                   <span className="dark:text-polar-500 ml-2 text-gray-500">
@@ -157,14 +157,14 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
         if (!product) {
           return (
             <Truncated>
-              <Text>{description}</Text>
+              <Text as="span">{description}</Text>
             </Truncated>
           )
         }
         return (
           <div className="flex flex-row items-center gap-2">
             <Truncated>
-              <Text>{product.name}</Text>
+              <Text as="span">{product.name}</Text>
             </Truncated>
             {product.is_archived && (
               <Status status="Archived" color="red" size="small" />

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -200,6 +200,18 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
       },
     },
     {
+      accessorKey: 'status',
+      enableSorting: true,
+      size: 140,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Status" />
+      ),
+      cell: ({ row: { original: order } }) => (
+        <OrderStatus status={order.status} />
+
+      ),
+    },
+    {
       accessorKey: 'net_amount',
       enableSorting: true,
       size: 80,
@@ -212,26 +224,10 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
       ),
       cell: ({ row: { original: order } }) => (
         <Box display="block" textAlign="right">
-          <Text variant='default' tabularNums>
+          <Text variant='body' tabularNums>
             {formatCurrency('accounting')(order.net_amount, order.currency)}
           </Text>
         </Box>
-      ),
-    },
-    {
-      accessorKey: 'status',
-      enableSorting: true,
-      size: 140,
-      header: ({ column }) => (
-        <div className="flex justify-end">
-          <DataTableColumnHeader column={column} title="Status" />
-        </div>
-      ),
-      cell: ({ row: { original: order } }) => (
-        <div className="flex justify-end">
-          <OrderStatus status={order.status} />
-        </div>
-
       ),
     },
     ...(metadata

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -115,18 +115,6 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
       },
     },
     {
-      accessorKey: 'net_amount',
-      enableSorting: true,
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="Amount" />
-      ),
-      cell: ({ row: { original: order } }) => (
-        <span>
-          {formatCurrency('standard')(order.net_amount, order.currency)}
-        </span>
-      ),
-    },
-    {
       accessorKey: 'product',
       enableSorting: false,
       header: ({ column }) => (
@@ -151,6 +139,18 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
       },
     },
     {
+      accessorKey: 'net_amount',
+      enableSorting: true,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Amount" />
+      ),
+      cell: ({ row: { original: order } }) => (
+        <span>
+          {formatCurrency('standard')(order.net_amount, order.currency)}
+        </span>
+      ),
+    },
+    {
       accessorKey: 'status',
       enableSorting: true,
       header: ({ column }) => (
@@ -163,13 +163,6 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
       ),
     },
     {
-      accessorKey: 'invoice_number',
-      enableSorting: true,
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="Invoice number" />
-      ),
-    },
-    {
       accessorKey: 'created_at',
       enableSorting: true,
       header: ({ column }) => (
@@ -177,6 +170,13 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
       ),
       cell: (props) => (
         <FormattedDateTime datetime={props.getValue() as string} />
+      ),
+    },
+    {
+      accessorKey: 'invoice_number',
+      enableSorting: true,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Invoice number" />
       ),
     },
     ...(metadata

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -25,6 +25,7 @@ import {
   DataTableColumnHeader,
 } from '@polar-sh/orbit'
 import { Status } from '@polar-sh/orbit'
+import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import { RowSelectionState } from '@tanstack/react-table'
 import { useRouter } from 'next/navigation'
 import {
@@ -39,18 +40,6 @@ const filterParsers = {
   product_id: parseAsArrayOf(parseAsString),
   status: parseAsStringLiteral(enums.orderStatusValues),
   metadata: parseAsArrayOf(parseAsString),
-}
-
-const formatOrderDate = (value: string) => {
-  const date = new Date(value)
-  return date.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  })
 }
 
 interface ClientPageProps {
@@ -103,9 +92,10 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
       cell: ({ row: { original: order } }) => (
         <Box flexDirection="column" rowGap="xs" minWidth={0}>
           <Text tabularNums>
-            <time dateTime={order.created_at}>
-              {formatOrderDate(order.created_at)}
-            </time>
+            <FormattedDateTime
+              datetime={order.created_at}
+              resolution="time"
+            />
           </Text>
           <Text color="muted" monospace tabularNums>
             {order.invoice_number ?? '—'}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -14,6 +14,7 @@ import { getChartRangeParams } from '@/utils/metrics'
 import FileDownloadOutlined from '@mui/icons-material/FileDownloadOutlined'
 import { enums, schemas } from '@polar-sh/client'
 import { Box } from '@polar-sh/orbit/Box'
+import { Text } from '@polar-sh/orbit'
 import { formatCurrency } from '@polar-sh/currency'
 import { Truncated } from '@polar-sh/orbit'
 import { Avatar } from '@polar-sh/orbit'
@@ -101,14 +102,14 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
               name={customer.email ?? customer.name ?? '—'}
             />
             <Truncated>
-              <span>
+              <Text>
                 {customer.name || customer.email || '—'}
                 {showBillingName && (
                   <span className="dark:text-polar-500 ml-2 text-gray-500">
                     {customer.billing_name}
                   </span>
                 )}
-              </span>
+              </Text>
             </Truncated>
           </div>
         )
@@ -124,7 +125,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
       cell: (props) => {
         const date = new Date(props.getValue() as string)
         return (
-          <time dateTime={date.toISOString()} >
+          <time dateTime={date.toISOString()}>
             {date.toLocaleString('en-US', {
               month: 'short',
               day: 'numeric',
@@ -145,7 +146,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
         <DataTableColumnHeader
           column={column}
           title="Product"
-          className="text-black font-[550] dark:text-white"
+          className="font-[550] text-black dark:text-white"
         />
       ),
       cell: ({
@@ -156,14 +157,14 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
         if (!product) {
           return (
             <Truncated>
-              <span>{description}</span>
+              <Text>{description}</Text>
             </Truncated>
           )
         }
         return (
           <div className="flex flex-row items-center gap-2">
             <Truncated>
-              <span>{product.name}</span>
+              <Text>{product.name}</Text>
             </Truncated>
             {product.is_archived && (
               <Status status="Archived" color="red" size="small" />
@@ -177,15 +178,12 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
       enableSorting: true,
       size: 100,
       header: ({ column }) => (
-        <DataTableColumnHeader
-          column={column}
-          title="Amount"
-        />
+        <DataTableColumnHeader column={column} title="Amount" />
       ),
       cell: ({ row: { original: order } }) => (
-        <div className="">
+        <Text>
           {formatCurrency('standard')(order.net_amount, order.currency)}
-        </div>
+        </Text>
       ),
     },
     {
@@ -196,9 +194,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
         <DataTableColumnHeader column={column} title="Status" />
       ),
       cell: ({ row: { original: order } }) => (
-        <span className="flex shrink">
-          <OrderStatus status={order.status} />
-        </span>
+        <OrderStatus status={order.status} />
       ),
     },
     {
@@ -220,9 +216,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
               className="text-black dark:text-white"
             />
           ),
-          cell: (props) => (
-            <span className="font-mono">{props.getValue() as string}</span>
-          ),
+          cell: (props) => <Text monospace>{props.getValue() as string}</Text>,
         }))
       : []),
   ]

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -41,22 +41,6 @@ const filterParsers = {
   metadata: parseAsArrayOf(parseAsString),
 }
 
-/**
- * Invoice numbers are `{orgPrefix}-{seq}` or `{orgPrefix}-{customerShortId}-{seq}`.
- * Org prefix defaults to `slug.upper()` (may include hyphens, e.g. ACME-CORP).
- */
-const formatInvoiceNumber = (
-  invoiceNumber: string | null,
-  organizationSlug: string,
-) => {
-  if (!invoiceNumber) return null
-  const prefix = `${organizationSlug.toUpperCase()}-`
-  if (invoiceNumber.startsWith(prefix)) {
-    return invoiceNumber.slice(prefix.length)
-  }
-  return invoiceNumber
-}
-
 const formatOrderDate = (value: string) => {
   const date = new Date(value)
   return date.toLocaleDateString('en-US', {
@@ -118,14 +102,13 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
       ),
       cell: ({ row: { original: order } }) => (
         <Box flexDirection="column" rowGap="xs" minWidth={0}>
-          <Text>
+          <Text tabularNums>
             <time dateTime={order.created_at}>
               {formatOrderDate(order.created_at)}
             </time>
           </Text>
           <Text color="muted" monospace tabularNums>
-            {formatInvoiceNumber(order.invoice_number, organization.slug) ??
-              '—'}
+            {order.invoice_number ?? '—'}
           </Text>
         </Box>
       ),

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -84,6 +84,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
     {
       accessorKey: 'customer',
       enableSorting: true,
+      size: 200,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Customer" />
       ),
@@ -115,10 +116,29 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
       },
     },
     {
+      accessorKey: 'created_at',
+      enableSorting: true,
+      size: 180,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Date" />
+      ),
+      cell: (props) => (
+        <FormattedDateTime
+          datetime={props.getValue() as string}
+          resolution="time"
+        />
+      ),
+    },
+    {
       accessorKey: 'product',
       enableSorting: false,
+      size: 200,
       header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="Description" />
+        <DataTableColumnHeader
+          column={column}
+          title="Product"
+          className="text-black font-[550] dark:text-white"
+        />
       ),
       cell: ({
         row: {
@@ -126,11 +146,17 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
         },
       }) => {
         if (!product) {
-          return <span>{description}</span>
+          return (
+            <Truncated>
+              <span>{description}</span>
+            </Truncated>
+          )
         }
         return (
-          <div className="flex flex-row items-center gap-4">
-            {product.name}
+          <div className="flex flex-row items-center gap-2">
+            <Truncated>
+              <span>{product.name}</span>
+            </Truncated>
             {product.is_archived && (
               <Status status="Archived" color="red" size="small" />
             )}
@@ -141,18 +167,23 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
     {
       accessorKey: 'net_amount',
       enableSorting: true,
+      size: 100,
       header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="Amount" />
+        <DataTableColumnHeader
+          column={column}
+          title="Amount"
+        />
       ),
       cell: ({ row: { original: order } }) => (
-        <span>
+        <div className="">
           {formatCurrency('standard')(order.net_amount, order.currency)}
-        </span>
+        </div>
       ),
     },
     {
       accessorKey: 'status',
       enableSorting: true,
+      size: 140,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Status" />
       ),
@@ -163,18 +194,9 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
       ),
     },
     {
-      accessorKey: 'created_at',
-      enableSorting: true,
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column} title="Date" />
-      ),
-      cell: (props) => (
-        <FormattedDateTime datetime={props.getValue() as string} />
-      ),
-    },
-    {
       accessorKey: 'invoice_number',
       enableSorting: true,
+      size: 180,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Invoice number" />
       ),
@@ -184,7 +206,11 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
           accessorKey: `metadata.${key}`,
           enableSorting: false,
           header: ({ column }) => (
-            <DataTableColumnHeader column={column} title={key} />
+            <DataTableColumnHeader
+              column={column}
+              title={key}
+              className="text-black dark:text-white"
+            />
           ),
           cell: (props) => (
             <span className="font-mono">{props.getValue() as string}</span>


### PR DESCRIPTION
## Summary

| Screenshot |
|---|
| <img width="2880" height="1220" alt="image" src="https://github.com/user-attachments/assets/f2108a00-0ffb-4dfe-b8bc-6af3fd8426c7" />|


Improve the sales orders table layout and timestamps, and align the page metric cards to a coherent all-time set.

## What

- Refine orders table column order and sizing for a clearer scan path  
  - New: Date (+ Invoice) → Customer  → Product → Status → Amount
- Show order timestamps with date + time in 24-hour local format (`hour12: false`), instead of day-only `FormattedDateTime`
- Replace metric cards **Today’s Revenue** / **Cumulative Revenue** with all-time **Revenue** and **Average Order Value** (alongside **Orders**). The _today_ view can be accomplished with picking the date filter in follow up PR.

## Why

- The previous column layout didn’t prioritize the fields you actually scan first when reviewing sales. Having invoice and date in same column it feels more like a ledger, and easier to scan. Sorting didn't make sense with the invoice column anyway since introduction of customer-prefixes.
- For transactions, time of day is useful signal, not just the calendar day; AM/PM from `FormattedDateTime` is noisy in a dense table, and 24h is shorter and unambiguous
- Metric cards mixed timeframes (today vs all-time), and “cumulative” doesn’t add meaning for a single all-time number. **Orders · Revenue · AOV** shares one timeframe and closes the loop (`orders × AOV ≈ revenue`). _Today_ view can be accomplished by filtering on date, in upcoming PR.

## How

- Column order/sizing updates on the orders DataTable
- Single all-time `useMetrics` call for `orders`, `revenue`, `average_order_value` (drop the separate “today” request)

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787978020&installation_model_id=13063&pr_number=13446&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13446&signature=b6174fe3fb9738ef66e6570b662bd40e2191203cee6af6542308a007c350d93a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

