### PR TITLE
add date filtering to orders table and fix responsiveness

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -260,20 +260,38 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
   return (
     <DashboardBody wide>
       <div className="flex flex-col gap-8">
-        <div className="flex items-center justify-between gap-2">
-          <Box alignItems="center" columnGap="m">
-            <ProductSelect
-              organization={organization}
-              value={productId || []}
-              onChange={onProductSelect}
-              className="w-[300px]"
-              includeArchived
-            />
-            <Box width={200}>
+        <Box
+          flexDirection={{ base: 'column', md: 'row' }}
+          alignItems={{ base: 'stretch', md: 'center' }}
+          justifyContent="between"
+          gap="l"
+        >
+          <Box
+            flexDirection={{ base: 'column', sm: 'row' }}
+            flexWrap="wrap"
+            alignItems={{ base: 'stretch', sm: 'center' }}
+            gap="m"
+            width={{ base: '100%', md: 'auto' }}
+          >
+            <Box width={{ base: '100%', md: 300 }} flexGrow={{ sm: 1, md: 0 }}>
+              <ProductSelect
+                organization={organization}
+                value={productId || []}
+                onChange={onProductSelect}
+                className="w-full"
+                includeArchived
+              />
+            </Box>
+            <Box
+              width={{ base: '100%', sm: 'auto' }}
+              minWidth={{ sm: 160 }}
+              maxWidth={{ md: 200 }}
+              flexGrow={{ sm: 1, md: 0 }}
+            >
               <OrderStatusSelect value={status} onChange={onStatusSelect} />
             </Box>
             <DateRangePicker
-              className="w-52 shrink-0 [&>button:last-child]:text-left"
+              className="w-full shrink-0 sm:w-52 [&>button:last-child]:text-left"
               date={{ from: startDate, to: endDate }}
               onDateChange={onDateChange}
               minDate={startOfDay(new Date(organization.created_at))}
@@ -281,14 +299,14 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
           </Box>
           <Button
             onClick={onExport}
-            className="flex flex-row items-center"
+            className="flex w-full flex-row items-center md:w-auto"
             variant={'secondary'}
             wrapperClassNames="gap-x-2"
           >
             <FileDownloadOutlined fontSize="inherit" />
             <span>Export</span>
           </Button>
-        </div>
+        </Box>
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
           <MiniMetricChartBox
             title="Orders"

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -1,6 +1,9 @@
 'use client'
 
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
+import DateRangePicker, {
+  DateRange,
+} from '@/components/Metrics/DateRangePicker'
 import { MiniMetricChartBox } from '@/components/Metrics/MiniMetricChartBox'
 import { OrderStatus } from '@/components/Orders/OrderStatus'
 import OrderStatusSelect from '@/components/Orders/OrderStatusSelect'
@@ -9,8 +12,9 @@ import { useMetrics } from '@/hooks/queries/metrics'
 import { useOrders } from '@/hooks/queries/orders'
 import { useDataTableQueryState } from '@/hooks/useDataTableQueryState'
 import { getServerURL } from '@/utils/api'
+import { useDateRange } from '@/utils/date'
 import { getAPIParams } from '@/utils/datatable'
-import { getChartRangeParams } from '@/utils/metrics'
+import { dateRangeToInterval } from '@/utils/metrics'
 import FileDownloadOutlined from '@mui/icons-material/FileDownloadOutlined'
 import { enums, schemas } from '@polar-sh/client'
 import { Box } from '@polar-sh/orbit/Box'
@@ -27,6 +31,7 @@ import {
 import { Status } from '@polar-sh/orbit'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import { RowSelectionState } from '@tanstack/react-table'
+import { startOfDay } from 'date-fns'
 import { useRouter } from 'next/navigation'
 import {
   parseAsArrayOf,
@@ -61,6 +66,8 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
   const [{ product_id: productId, status, metadata }, setFilters] =
     useQueryStates(filterParsers)
 
+  const { startDate, endDate, setStartDate, setEndDate } = useDateRange()
+
   const onProductSelect = (value: string[]) => {
     setFilters({ product_id: value.length > 0 ? value : null })
     resetPage()
@@ -71,10 +78,18 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
     resetPage()
   }
 
+  const onDateChange = (range: DateRange) => {
+    setStartDate(range.from)
+    setEndDate(range.to)
+    resetPage()
+  }
+
   const ordersHook = useOrders(organization.id, {
     ...getAPIParams(pagination, sorting),
     product_id: productId ?? undefined,
     status: status ? [status] : undefined,
+    created_after: startDate.toISOString(),
+    created_before: endDate.toISOString(),
   })
 
   const orders = ordersHook.data?.items || []
@@ -223,15 +238,11 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
     }
   }, [selectedOrder, router, organization])
 
-  const [allTimeStart, allTimeEnd, allTimeInterval] = getChartRangeParams(
-    'all_time',
-    organization.created_at,
-  )
   const { data: metricsData } = useMetrics({
     organization_id: organization.id,
-    startDate: allTimeStart,
-    endDate: allTimeEnd,
-    interval: allTimeInterval,
+    startDate,
+    endDate,
+    interval: dateRangeToInterval(startDate, endDate),
     product_id: productId ?? undefined,
     metrics: ['orders', 'revenue', 'average_order_value'],
   })
@@ -261,6 +272,12 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
             <Box width={200}>
               <OrderStatusSelect value={status} onChange={onStatusSelect} />
             </Box>
+            <DateRangePicker
+              className="w-52 shrink-0 [&>button:last-child]:text-left"
+              date={{ from: startDate, to: endDate }}
+              onDateChange={onDateChange}
+              minDate={startOfDay(new Date(organization.created_at))}
+            />
           </Box>
           <Button
             onClick={onExport}

--- a/clients/apps/web/src/components/Metrics/DateRangePicker.tsx
+++ b/clients/apps/web/src/components/Metrics/DateRangePicker.tsx
@@ -26,6 +26,7 @@ import FormattedInterval from '@polar-sh/ui/components/atoms/FormattedInterval'
 import { Calendar } from '@polar-sh/ui/components/ui/calendar'
 import {
   Popover,
+  PopoverClose,
   PopoverContent,
   PopoverTrigger,
 } from '@polar-sh/ui/components/ui/popover'
@@ -226,18 +227,19 @@ const DateRangeIntervals = ({
   return (
     <div className="flex w-full flex-col gap-1">
       {allIntervals.map((int) => (
-        <div
-          key={int.slug}
-          onClick={() => onIntervalChange(int)}
-          role="button"
-          className={twMerge(
-            'dark:hover:bg-polar-800 dark:text-polar-500 flex w-full items-center justify-between rounded-sm border border-transparent px-3 py-2 text-sm text-gray-500 select-none hover:bg-gray-100',
-            interval?.slug === int.slug &&
-              'dark:bg-polar-800 dark:border-polar-700 bg-gray-100 text-black dark:text-white',
-          )}
-        >
-          {int.label}
-        </div>
+        <PopoverClose asChild key={int.slug}>
+          <div
+            onClick={() => onIntervalChange(int)}
+            role="button"
+            className={twMerge(
+              'dark:hover:bg-polar-800 dark:text-polar-500 flex w-full items-center justify-between rounded-sm border border-transparent px-3 py-2 text-sm text-gray-500 select-none hover:bg-gray-100',
+              interval?.slug === int.slug &&
+                'dark:bg-polar-800 dark:border-polar-700 bg-gray-100 text-black dark:text-white',
+            )}
+          >
+            {int.label}
+          </div>
+        </PopoverClose>
       ))}
     </div>
   )

--- a/clients/packages/ui/src/components/ui/popover.tsx
+++ b/clients/packages/ui/src/components/ui/popover.tsx
@@ -9,6 +9,8 @@ const Popover = PopoverPrimitive.Root
 
 const PopoverTrigger = PopoverPrimitive.Trigger
 
+const PopoverClose = PopoverPrimitive.Close
+
 const PopoverContent = ({
   ref,
   className,
@@ -31,4 +33,4 @@ const PopoverContent = ({
 )
 PopoverContent.displayName = PopoverPrimitive.Content.displayName
 
-export { Popover, PopoverContent, PopoverTrigger }
+export { Popover, PopoverClose, PopoverContent, PopoverTrigger }


### PR DESCRIPTION
## Summary
- Add date range filtering to the Orders page, wiring `created_after` / `created_before` into the orders list and scoping the metric cards (Orders, Revenue, Average Order Value) to the same range.
- Make the filter bar mobile responsive so product, status, date, and Export stack/wrap instead of overflowing on small screens.
- Fix date range preset selection so choosing an interval closes the popover (`PopoverClose`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787980226&installation_model_id=13063&pr_number=13447&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13447&signature=7e8ec06fe1b27263f386b935be6626e6d94996b2dc4854e51b31e8118c19ffda"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

