### PR TITLE
Add date range filtering to subscriptions list

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
@@ -18,6 +18,7 @@ import { DataTableSortingState, getAPIParams } from '@/utils/datatable'
 import { useDateRange } from '@/utils/date'
 import FileDownloadOutlined from '@mui/icons-material/FileDownloadOutlined'
 import { schemas } from '@polar-sh/client'
+import { Box } from '@polar-sh/orbit/Box'
 import { Avatar } from '@polar-sh/orbit'
 import { Button } from '@polar-sh/orbit'
 import {
@@ -27,6 +28,7 @@ import {
 } from '@polar-sh/orbit'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import { Status } from '@polar-sh/orbit'
+import { Text } from '@polar-sh/orbit'
 import {
   functionalUpdate,
   OnChangeFn,
@@ -41,6 +43,7 @@ import {
   useQueryStates,
 } from 'nuqs'
 import React, { useEffect, useState } from 'react'
+import { startOfDay } from 'date-fns'
 
 const filterParsers = {
   product_id: parseAsString,
@@ -182,9 +185,11 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
             <div className="overflow-hidden text-ellipsis">
               {customer.name || customer.email || '—'}
               {showBillingName && (
-                <span className="dark:text-polar-500 ml-2 text-gray-500">
-                  {customer.billing_name}
-                </span>
+                <Box as="span" ml="s">
+                  <Text as="span" color="muted">
+                    {customer.billing_name}
+                  </Text>
+                </Box>
               )}
             </div>
           </div>
@@ -261,7 +266,9 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
             <DataTableColumnHeader column={column} title={key} />
           ),
           cell: (props) => (
-            <span className="font-mono">{props.getValue() as string}</span>
+            <Text as="span" monospace>
+              {props.getValue() as string}
+            </Text>
           ),
         }))
       : []),
@@ -305,6 +312,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
               date={{ from: startDate, to: endDate }}
               onDateChange={onDateChange}
               className="[&>button:last-child]:text-left"
+              minDate={startOfDay(new Date(organization.created_at))}
             />
           </div>
           <Button

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
@@ -1,6 +1,9 @@
 'use client'
 
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
+import DateRangePicker, {
+  DateRange,
+} from '@/components/Metrics/DateRangePicker'
 import SubscriptionCancellationSelect from '@/components/Subscriptions/SubscriptionCancellationSelect'
 import { SubscriptionStatus as SubscriptionStatusComponent } from '@/components/Subscriptions/SubscriptionStatus'
 import SubscriptionStatusSelect, {
@@ -12,6 +15,7 @@ import { useProducts, useSubscriptions } from '@/hooks/queries'
 import { useDataTableQueryState } from '@/hooks/useDataTableQueryState'
 import { getServerURL } from '@/utils/api'
 import { DataTableSortingState, getAPIParams } from '@/utils/datatable'
+import { useDateRange } from '@/utils/date'
 import FileDownloadOutlined from '@mui/icons-material/FileDownloadOutlined'
 import { schemas } from '@polar-sh/client'
 import { Avatar } from '@polar-sh/orbit'
@@ -98,6 +102,8 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
     setFilters,
   ] = useQueryStates(filterParsers)
 
+  const { startDate, endDate, setStartDate, setEndDate } = useDateRange()
+
   const setSorting: OnChangeFn<DataTableSortingState> = (updater) => {
     setSortingState((old) =>
       withEndsAtSecondarySort(functionalUpdate(updater, old)),
@@ -122,11 +128,19 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
     resetPage()
   }
 
+  const onDateChange = (range: DateRange) => {
+    setStartDate(range.from)
+    setEndDate(range.to)
+    resetPage()
+  }
+
   const subscriptionsHook = useSubscriptions(organization.id, {
     ...getAPIParams(pagination, sorting),
     product_id: productId ?? undefined,
     status: status === 'any' ? undefined : [status],
     cancel_at_period_end: cancelAtPeriodEnd ?? undefined,
+    started_at_after: startDate.toISOString(),
+    started_at_before: endDate.toISOString(),
   })
 
   const subscriptions = subscriptionsHook.data?.items || []
@@ -287,6 +301,11 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
                 onChange={onProductSelect}
               />
             </div>
+            <DateRangePicker
+              date={{ from: startDate, to: endDate }}
+              onDateChange={onDateChange}
+              className="[&>button:last-child]:text-left"
+            />
           </div>
           <Button
             onClick={onExport}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
@@ -142,8 +142,8 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
     product_id: productId ?? undefined,
     status: status === 'any' ? undefined : [status],
     cancel_at_period_end: cancelAtPeriodEnd ?? undefined,
-    started_at_after: startDate.toISOString(),
-    started_at_before: endDate.toISOString(),
+    started_after: startDate.toISOString(),
+    started_before: endDate.toISOString(),
   })
 
   const subscriptions = subscriptionsHook.data?.items || []

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -40018,10 +40018,10 @@ export interface operations {
         canceled_at_after?: string | null
         /** @description Filter by cancellation date (before or equal to). */
         canceled_at_before?: string | null
-        /** @description Filter by start date (after or equal to). */
-        started_at_after?: string | null
-        /** @description Filter by start date (before or equal to). */
-        started_at_before?: string | null
+        /** @description Only include subscriptions started after this date. */
+        started_after?: string | null
+        /** @description Only include subscriptions started before this date. */
+        started_before?: string | null
         /** @description Page number, defaults to 1. */
         page?: number
         /** @description Size of a page, defaults to 10. Maximum is 100. */

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -40018,6 +40018,10 @@ export interface operations {
         canceled_at_after?: string | null
         /** @description Filter by cancellation date (before or equal to). */
         canceled_at_before?: string | null
+        /** @description Filter by start date (after or equal to). */
+        started_at_after?: string | null
+        /** @description Filter by start date (before or equal to). */
+        started_at_before?: string | null
         /** @description Page number, defaults to 1. */
         page?: number
         /** @description Size of a page, defaults to 10. Maximum is 100. */

--- a/server/polar/subscription/endpoints.py
+++ b/server/polar/subscription/endpoints.py
@@ -109,13 +109,13 @@ async def list(
         None,
         description="Filter by cancellation date (before or equal to).",
     ),
-    started_at_after: datetime | None = Query(
+    started_after: datetime | None = Query(
         None,
-        description="Filter by start date (after or equal to).",
+        description="Only include subscriptions started after this date.",
     ),
-    started_at_before: datetime | None = Query(
+    started_before: datetime | None = Query(
         None,
-        description="Filter by start date (before or equal to).",
+        description="Only include subscriptions started before this date.",
     ),
     session: AsyncReadSession = Depends(get_db_read_session),
 ) -> ListResource[SubscriptionSchema]:
@@ -134,8 +134,8 @@ async def list(
         customer_cancellation_reason=customer_cancellation_reason,
         canceled_at_after=canceled_at_after,
         canceled_at_before=canceled_at_before,
-        started_at_after=started_at_after,
-        started_at_before=started_at_before,
+        started_after=started_after,
+        started_before=started_before,
         metadata=metadata,
         pagination=pagination,
         sorting=sorting,

--- a/server/polar/subscription/endpoints.py
+++ b/server/polar/subscription/endpoints.py
@@ -109,6 +109,14 @@ async def list(
         None,
         description="Filter by cancellation date (before or equal to).",
     ),
+    started_at_after: datetime | None = Query(
+        None,
+        description="Filter by start date (after or equal to).",
+    ),
+    started_at_before: datetime | None = Query(
+        None,
+        description="Filter by start date (before or equal to).",
+    ),
     session: AsyncReadSession = Depends(get_db_read_session),
 ) -> ListResource[SubscriptionSchema]:
     """List subscriptions."""
@@ -126,6 +134,8 @@ async def list(
         customer_cancellation_reason=customer_cancellation_reason,
         canceled_at_after=canceled_at_after,
         canceled_at_before=canceled_at_before,
+        started_at_after=started_at_after,
+        started_at_before=started_at_before,
         metadata=metadata,
         pagination=pagination,
         sorting=sorting,

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -374,6 +374,8 @@ class SubscriptionService:
         | None = None,
         canceled_at_after: datetime | None = None,
         canceled_at_before: datetime | None = None,
+        started_at_after: datetime | None = None,
+        started_at_before: datetime | None = None,
         metadata: MetadataQuery | None = None,
         pagination: PaginationParams,
         sorting: list[Sorting[SubscriptionSortProperty]] = [
@@ -432,6 +434,12 @@ class SubscriptionService:
 
         if canceled_at_before is not None:
             statement = statement.where(Subscription.canceled_at <= canceled_at_before)
+
+        if started_at_after is not None:
+            statement = statement.where(Subscription.started_at >= started_at_after)
+
+        if started_at_before is not None:
+            statement = statement.where(Subscription.started_at <= started_at_before)
 
         if metadata is not None:
             statement = apply_metadata_clause(Subscription, statement, metadata)

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -374,8 +374,8 @@ class SubscriptionService:
         | None = None,
         canceled_at_after: datetime | None = None,
         canceled_at_before: datetime | None = None,
-        started_at_after: datetime | None = None,
-        started_at_before: datetime | None = None,
+        started_after: datetime | None = None,
+        started_before: datetime | None = None,
         metadata: MetadataQuery | None = None,
         pagination: PaginationParams,
         sorting: list[Sorting[SubscriptionSortProperty]] = [
@@ -435,11 +435,11 @@ class SubscriptionService:
         if canceled_at_before is not None:
             statement = statement.where(Subscription.canceled_at <= canceled_at_before)
 
-        if started_at_after is not None:
-            statement = statement.where(Subscription.started_at >= started_at_after)
+        if started_after is not None:
+            statement = statement.where(Subscription.started_at > started_after)
 
-        if started_at_before is not None:
-            statement = statement.where(Subscription.started_at <= started_at_before)
+        if started_before is not None:
+            statement = statement.where(Subscription.started_at < started_before)
 
         if metadata is not None:
             statement = apply_metadata_clause(Subscription, statement, metadata)

--- a/server/tests/subscription/test_endpoints.py
+++ b/server/tests/subscription/test_endpoints.py
@@ -219,7 +219,7 @@ class TestListSubscriptions:
         assert json["pagination"]["total_count"] == 2
 
     @pytest.mark.auth
-    async def test_started_at_date_range(
+    async def test_started_date_range(
         self,
         save_fixture: SaveFixture,
         client: AsyncClient,
@@ -242,8 +242,8 @@ class TestListSubscriptions:
         response = await client.get(
             "/v1/subscriptions/",
             params={
-                "started_at_after": "2024-03-01T00:00:00Z",
-                "started_at_before": "2024-07-01T00:00:00Z",
+                "started_after": "2024-03-01T00:00:00Z",
+                "started_before": "2024-07-01T00:00:00Z",
             },
         )
         assert response.status_code == 200

--- a/server/tests/subscription/test_endpoints.py
+++ b/server/tests/subscription/test_endpoints.py
@@ -219,6 +219,38 @@ class TestListSubscriptions:
         assert json["pagination"]["total_count"] == 2
 
     @pytest.mark.auth
+    async def test_started_at_date_range(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        user_organization: UserOrganization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        for started_at in (
+            datetime(2024, 3, 15, tzinfo=UTC),
+            datetime(2024, 6, 15, tzinfo=UTC),
+            datetime(2024, 9, 15, tzinfo=UTC),
+        ):
+            await create_active_subscription(
+                save_fixture,
+                product=product,
+                customer=customer,
+                started_at=started_at,
+            )
+
+        response = await client.get(
+            "/v1/subscriptions/",
+            params={
+                "started_at_after": "2024-03-01T00:00:00Z",
+                "started_at_before": "2024-07-01T00:00:00Z",
+            },
+        )
+        assert response.status_code == 200
+        json = response.json()
+        assert json["pagination"]["total_count"] == 2
+
+    @pytest.mark.auth
     async def test_cancellation_reason_with_date_range(
         self,
         save_fixture: SaveFixture,


### PR DESCRIPTION
## Summary


Add start-date filtering to the subscriptions list API and dashboard table.

## What

- Add `started_at` / `started_at` query params to the subscriptions list endpoint and service
- Add a date range picker to the dashboard subscriptions page

## Why

Merchants need to filter subscriptions by when they started, not only by product, status, or cancellation date.

## How

Expose start-date bounds on the list endpoint (mirroring existing `canceled_at_*` filters), then wire the existing `DateRangePicker` / `useDateRange` pattern into the subscriptions table and pass those values through to the API.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787982635&installation_model_id=13063&pr_number=13448&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13448&signature=0eb189c791dfb57a832e7518535a833ef186d59759c8c952b8f9caa95d353e0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

