### PR TITLE
fix(ui): always use 24-hour clock in FormattedDateTime

### DIFF
--- a/clients/packages/ui/src/components/atoms/FormattedDateTime.tsx
+++ b/clients/packages/ui/src/components/atoms/FormattedDateTime.tsx
@@ -27,7 +27,11 @@ const FormattedDateTime: React.FC<FormattedDateTimeProps> = ({
       }
 
       if (resolution === 'time') {
-        return parsedDate.toLocaleString(locale, { dateStyle, timeStyle })
+        return parsedDate.toLocaleString(locale, {
+          dateStyle,
+          timeStyle,
+          hourCycle: 'h23',
+        })
       }
 
       if (resolution === 'month') {


### PR DESCRIPTION
## Summary

Always render times from `FormattedDateTime` in 24-hour format, instead of locale-default AM/PM (e.g. `en-US`).

## What

When `resolution="time"`, pass `hourCycle: 'h23'` into `toLocaleString` so times always use a 24-hour clock.

## Why

`FormattedDateTime` defaults to `en-US`, which formats times as AM/PM (`5:30 PM`). Dashboard surfaces that show precise timestamps are easier to scan and compare in 24-hour form (`17:30`), and that matches how we already format times elsewhere (e.g. metrics charts, orders widget with `hour12: false`). Also being more similar as common accounting software.

## How

Add `hourCycle: 'h23'` to the existing `toLocaleString` options for the `time` resolution path. Date-only and month resolutions are unchanged.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787988653&installation_model_id=13063&pr_number=13449&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13449&signature=07a2e51cc9a71c5350d851491a8ed77ed8b0d2211fda544cc32fe4992bfa3bec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

