### PR TITLE
Tweak Finance → Income a bit

### DIFF
--- a/clients/apps/web/src/components/Transactions/TransactionsList.tsx
+++ b/clients/apps/web/src/components/Transactions/TransactionsList.tsx
@@ -114,8 +114,8 @@ const TransactionsList = ({
 
         return (
           <div className="flex flex-row justify-end">
-            {paymentTransaction.presentment_currency !==
-            transaction.currency ? (
+            {amount !== 0 &&
+            paymentTransaction.presentment_currency !== transaction.currency ? (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <span className="dark:decoration-polar-500 underline decoration-gray-400 decoration-dashed decoration-1 underline-offset-4">
@@ -210,8 +210,8 @@ const TransactionsList = ({
 
         return (
           <div className="flex justify-end">
-            {paymentTransaction.presentment_currency !==
-            transaction.currency ? (
+            {paymentTransaction.tax_amount !== 0 &&
+            paymentTransaction.presentment_currency !== transaction.currency ? (
               <Tooltip>
                 <TooltipTrigger asChild>
                   <span className="dark:decoration-polar-500 underline decoration-gray-400 decoration-dashed decoration-1 underline-offset-4">

--- a/clients/apps/web/src/components/Transactions/TransactionsList.tsx
+++ b/clients/apps/web/src/components/Transactions/TransactionsList.tsx
@@ -60,18 +60,7 @@ const TransactionsList = ({
         if (isSameDayAsParent) {
           return null
         }
-        return (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div className="truncate whitespace-nowrap">
-                <FormattedDateTime datetime={datetime} resolution="day" />
-              </div>
-            </TooltipTrigger>
-            <TooltipContent>
-              <FormattedDateTime datetime={datetime} resolution="time" />
-            </TooltipContent>
-          </Tooltip>
-        )
+        return <FormattedDateTime datetime={datetime} resolution="time" />
       },
     },
     {

--- a/clients/apps/web/src/components/Transactions/TransactionsList.tsx
+++ b/clients/apps/web/src/components/Transactions/TransactionsList.tsx
@@ -118,7 +118,7 @@ const TransactionsList = ({
             transaction.currency ? (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <span className="underline decoration-dotted">
+                  <span className="dark:decoration-polar-500 underline decoration-gray-400 decoration-dashed decoration-1 underline-offset-4">
                     {formatCurrency('accounting')(amount, transaction.currency)}
                   </span>
                 </TooltipTrigger>
@@ -214,7 +214,7 @@ const TransactionsList = ({
             transaction.currency ? (
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <span className="underline decoration-dotted">
+                  <span className="dark:decoration-polar-500 underline decoration-gray-400 decoration-dashed decoration-1 underline-offset-4">
                     {formatCurrency('accounting')(
                       -paymentTransaction.tax_amount,
                       transaction.currency,


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787993573&installation_model_id=13063&pr_number=13450&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13450&signature=a1910e8a216a753f7942a02dbb43ddf01f44cfd8d063f7fe14eff6677e97bd20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show transaction time inline in the Transactions list (removed the date tooltip) and refine FX display for clarity.
FX tooltips now appear only when the amount or tax is non‑zero and the currency differs, with a clearer dashed, theme-aware underline style.

<sup>Written for commit 4b69024ca0b8a3fab626cfb1546eb8cb78a9cb30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

