### PR TITLE
test(organization): pin embed host tests to the unenforced cohort

### DIFF
--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -2589,8 +2589,11 @@ class TestCheckoutLinkCreate:
         self,
         save_fixture: SaveFixture,
         session: AsyncSession,
+        organization: Organization,
         product_one_time: Product,
     ) -> None:
+        organization.created_at = EMBED_HOSTS_ENFORCED_FROM - timedelta(days=1)
+        await save_fixture(organization)
         checkout_link = await create_checkout_link(
             save_fixture, products=[product_one_time]
         )

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from httpx import AsyncClient
@@ -40,6 +40,10 @@ from tests.fixtures.random_objects import (
     create_subscription,
     create_user,
 )
+
+# The organization fixture is created now, which is past the cutoff from
+# 4 August 2026 onwards. Tests that assert the unenforced behaviour pin it.
+BEFORE_EMBED_CUTOFF = EMBED_HOSTS_ENFORCED_FROM - timedelta(days=1)
 
 
 @pytest.mark.asyncio
@@ -859,9 +863,13 @@ class TestGetEmbedStatus:
     async def test_never_embedded(
         self,
         client: AsyncClient,
+        save_fixture: SaveFixture,
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
+        organization.created_at = BEFORE_EMBED_CUTOFF
+        await save_fixture(organization)
+
         response = await client.get(f"/v1/organizations/{organization.id}/embed-status")
 
         assert response.status_code == 200
@@ -879,6 +887,8 @@ class TestGetEmbedStatus:
         product: Product,
         user_organization: UserOrganization,
     ) -> None:
+        organization.created_at = BEFORE_EMBED_CUTOFF
+        await save_fixture(organization)
         checkout = await create_checkout(save_fixture, products=[product])
         checkout.embed_origin = "https://example.com"
         await save_fixture(checkout)
@@ -939,6 +949,7 @@ class TestGetEmbedStatus:
         organization: Organization,
         user_organization: UserOrganization,
     ) -> None:
+        organization.created_at = BEFORE_EMBED_CUTOFF
         organization.embed_hosts = ["example.com"]
         await save_fixture(organization)
 


### PR DESCRIPTION
## Summary

The organization fixture is created at the current time, so from 4 August 2026 it falls past the cutoff and enforcement switches on under four tests that assert the opposite.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787993950&installation_model_id=13063&pr_number=13451&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13451&signature=a9f3905c585af690a2bc2a8d9aac37106fab7e42782bc2b31e31e806ba3a7c9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13451?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

