### PR TITLE
Match human friendly formatting from `@polar-sh/currency`

### DIFF
--- a/clients/apps/web/src/utils/formatters.test.ts
+++ b/clients/apps/web/src/utils/formatters.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { formatHumanFriendlyScalar } from './formatters'
+
+describe('formatHumanFriendlyScalar', () => {
+  it('uses the statistics abbreviation thresholds and precision', () => {
+    expect(formatHumanFriendlyScalar(0.01)).toEqual('0.01')
+    expect(formatHumanFriendlyScalar(12)).toEqual('12')
+    expect(formatHumanFriendlyScalar(12.3)).toEqual('12.30')
+    expect(formatHumanFriendlyScalar(1_234)).toEqual('1,234')
+    expect(formatHumanFriendlyScalar(1_234.56)).toEqual('1,234.56')
+    expect(formatHumanFriendlyScalar(12_345.67)).toEqual('12,345')
+    expect(formatHumanFriendlyScalar(123_456.78)).toEqual('123,456')
+    expect(formatHumanFriendlyScalar(1_234_567)).toEqual('1.235M')
+    expect(formatHumanFriendlyScalar(12_345_678)).toEqual('12.346M')
+    expect(formatHumanFriendlyScalar(123_456_789)).toEqual('123.46M')
+  })
+
+  it('applies the same rules to negative values', () => {
+    expect(formatHumanFriendlyScalar(-12_345.67)).toEqual('-12,345')
+    expect(formatHumanFriendlyScalar(-1_234_567)).toEqual('-1.235M')
+    expect(formatHumanFriendlyScalar(-123_456_789)).toEqual('-123.46M')
+  })
+})

--- a/clients/apps/web/src/utils/formatters.ts
+++ b/clients/apps/web/src/utils/formatters.ts
@@ -12,13 +12,32 @@ export const formatScalar = (() => {
 })()
 
 export const formatHumanFriendlyScalar = (() => {
-  const formatter = new Intl.NumberFormat('en-US', {
-    maximumFractionDigits: 2,
+  const compactFormatter = new Intl.NumberFormat('en-US', {
     notation: 'compact',
     compactDisplay: 'short',
+    maximumSignificantDigits: 5,
+    maximumFractionDigits: 3,
+    roundingPriority: 'lessPrecision',
+  })
+  const integerFormatter = new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: 0,
+  })
+  const standardFormatter = new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
   })
 
-  return (value: number): string => stripTrailingZeros(formatter.format(value))
+  return (value: number): string => {
+    if (Math.abs(value) >= 1_000_000) {
+      return compactFormatter.format(value)
+    }
+
+    if (Math.abs(value) >= 10_000) {
+      return integerFormatter.format(Math.trunc(value))
+    }
+
+    return stripTrailingZeros(standardFormatter.format(value))
+  }
 })()
 
 export const formatPercentage = (() => {


### PR DESCRIPTION
I'm a pedantic asshole

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787994789&installation_model_id=13063&pr_number=13452&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13452&signature=c139fb201b2b41c72302ad13976c3e6a3b92ad0a2dee7bd25585919f45b80639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns human-friendly scalar formatting with `@polar-sh/currency` to ensure consistent thresholds, rounding, and negative value handling across the app.

- **Bug Fixes**
  - Updated `formatHumanFriendlyScalar` rules:
    - >= 1,000,000: compact short (e.g., 1.235M).
    - 10,000–999,999: integer, no decimals.
    - < 10,000: two decimals with separators.
  - Added tests in `clients/apps/web/src/utils/formatters.test.ts` covering thresholds and negative values.

<sup>Written for commit 48efe063eb88dea0588119c85bf823be15a2476a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

