### PR TITLE
feat(organization): embed hosts hard cutoff

### DIFF
--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -44,6 +44,7 @@ from polar.exceptions import PolarError
 from polar.kit.currency import PresentmentCurrency
 from polar.kit.db.models import RateLimitGroupMixin, RecordModel
 from polar.kit.extensions.sqlalchemy import StringEnum
+from polar.kit.utils import utc_now
 
 from .account import Account
 
@@ -209,6 +210,9 @@ class OrganizationCheckoutSettings(TypedDict):
 
 # Organizations created from this point must list their embed hosts.
 EMBED_HOSTS_ENFORCED_FROM = datetime(2026, 8, 4, tzinfo=UTC)
+
+# From this point every organization must, whenever it was created.
+EMBED_HOSTS_ENFORCED_FOR_ALL = datetime(2026, 8, 17, tzinfo=UTC)
 
 
 def _default_checkout_settings() -> OrganizationCheckoutSettings:
@@ -661,10 +665,14 @@ class Organization(RateLimitGroupMixin, RecordModel):
 
     @property
     def embed_hosts_enforced(self) -> bool:
-        """Configuring a list does not enforce it. Existing organizations keep
-        embedding unchecked until the allowlist is enforced for everyone, so a
-        list that misses a host they use costs them nothing until then."""
-        return self.created_at >= EMBED_HOSTS_ENFORCED_FROM
+        """Configuring a list does not enforce it. Merchants were emailed ahead
+        of the date it starts applying to everyone; until then, only
+        organizations young enough to have never embedded unchecked are held to
+        their list."""
+        return (
+            utc_now() >= EMBED_HOSTS_ENFORCED_FOR_ALL
+            or self.created_at >= EMBED_HOSTS_ENFORCED_FROM
+        )
 
     legal_entity: Mapped[OrganizationLegalEntity | None] = mapped_column(
         JSONB, nullable=True, default=None

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -211,8 +211,9 @@ class OrganizationCheckoutSettings(TypedDict):
 # Organizations created from this point must list their embed hosts.
 EMBED_HOSTS_ENFORCED_FROM = datetime(2026, 8, 4, tzinfo=UTC)
 
-# From this point every organization must, whenever it was created.
-EMBED_HOSTS_ENFORCED_FOR_ALL = datetime(2026, 8, 17, tzinfo=UTC)
+# From this point every organization must, whenever it was created. Noon rather
+# than midnight so it lands on 17 August across most of the world.
+EMBED_HOSTS_ENFORCED_FOR_ALL = datetime(2026, 8, 17, 12, tzinfo=UTC)
 
 
 def _default_checkout_settings() -> OrganizationCheckoutSettings:

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -106,6 +106,7 @@ from polar.tax.tax_id import TaxIDFormat
 from polar.trial_redemption.repository import TrialRedemptionRepository
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
+from tests.fixtures.embed_hosts import BEFORE_EMBED_CUTOFF
 from tests.fixtures.events import get_all_by_name
 from tests.fixtures.random_objects import (
     create_active_subscription,
@@ -2587,12 +2588,13 @@ class TestCheckoutLinkCreate:
 
     async def test_normalized_embed_origin(
         self,
+        embed_hosts_not_enforced: None,
         save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
         product_one_time: Product,
     ) -> None:
-        organization.created_at = EMBED_HOSTS_ENFORCED_FROM - timedelta(days=1)
+        organization.created_at = BEFORE_EMBED_CUTOFF
         await save_fixture(organization)
         checkout_link = await create_checkout_link(
             save_fixture, products=[product_one_time]
@@ -2645,6 +2647,7 @@ class TestCheckoutLinkCreate:
 
     async def test_unlisted_embed_origin_before_the_cutoff(
         self,
+        embed_hosts_not_enforced: None,
         save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
@@ -2652,7 +2655,7 @@ class TestCheckoutLinkCreate:
     ) -> None:
         """Listing hosts doesn't enforce them: older organizations embed
         unchecked until the cutoff applies to everyone."""
-        organization.created_at = EMBED_HOSTS_ENFORCED_FROM - timedelta(days=1)
+        organization.created_at = BEFORE_EMBED_CUTOFF
         organization.embed_hosts = ["example.com"]
         await save_fixture(organization)
         checkout_link = await create_checkout_link(

--- a/server/tests/fixtures/__init__.py
+++ b/server/tests/fixtures/__init__.py
@@ -3,6 +3,7 @@ import logging
 from tests.fixtures.auth import *  # noqa: F403
 from tests.fixtures.base import *  # noqa: F403
 from tests.fixtures.database import *  # noqa: F403
+from tests.fixtures.embed_hosts import *  # noqa: F403
 from tests.fixtures.file import *  # noqa: F403
 from tests.fixtures.locker import *  # noqa: F403
 from tests.fixtures.random_objects import *  # noqa: F403

--- a/server/tests/fixtures/embed_hosts.py
+++ b/server/tests/fixtures/embed_hosts.py
@@ -1,0 +1,20 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pytest_mock import MockerFixture
+
+from polar.models.organization import EMBED_HOSTS_ENFORCED_FROM
+
+# The organization fixture is created now, which falls past the cohort cutoff
+# from 4 August 2026 onwards. Tests covering an unenforced organization pin it.
+BEFORE_EMBED_CUTOFF = EMBED_HOSTS_ENFORCED_FROM - timedelta(days=1)
+
+
+@pytest.fixture
+def embed_hosts_not_enforced(mocker: MockerFixture) -> None:
+    """Hold the global cutoff in the future: these tests cover the behaviour
+    before every organization is held to its list."""
+    mocker.patch(
+        "polar.models.organization.EMBED_HOSTS_ENFORCED_FOR_ALL",
+        datetime(2100, 1, 1, tzinfo=UTC),
+    )

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 
 import pytest
 from httpx import AsyncClient
@@ -29,6 +29,7 @@ from polar.user_organization.service import (
 )
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
+from tests.fixtures.embed_hosts import BEFORE_EMBED_CUTOFF
 from tests.fixtures.random_objects import (
     create_account,
     create_appeal_case,
@@ -43,7 +44,6 @@ from tests.fixtures.random_objects import (
 
 # The organization fixture is created now, which is past the cutoff from
 # 4 August 2026 onwards. Tests that assert the unenforced behaviour pin it.
-BEFORE_EMBED_CUTOFF = EMBED_HOSTS_ENFORCED_FROM - timedelta(days=1)
 
 
 @pytest.mark.asyncio
@@ -862,6 +862,7 @@ class TestGetEmbedStatus:
     @pytest.mark.auth
     async def test_never_embedded(
         self,
+        embed_hosts_not_enforced: None,
         client: AsyncClient,
         save_fixture: SaveFixture,
         organization: Organization,
@@ -881,6 +882,7 @@ class TestGetEmbedStatus:
     @pytest.mark.auth
     async def test_embedded_without_hosts(
         self,
+        embed_hosts_not_enforced: None,
         client: AsyncClient,
         save_fixture: SaveFixture,
         organization: Organization,
@@ -944,6 +946,7 @@ class TestGetEmbedStatus:
     @pytest.mark.auth
     async def test_hosts_configured(
         self,
+        embed_hosts_not_enforced: None,
         client: AsyncClient,
         save_fixture: SaveFixture,
         organization: Organization,


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- issue number -->

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->

## Why

<!-- Explain why this change is needed -->

## How

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787998780&installation_model_id=13063&pr_number=13454&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13454&signature=cff360bdd53929ede5114c2b35ae2b441180f99b22451d43cc160a88032dc227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces embed host allowlists for all organizations starting 17 Aug 2026 at 12:00 UTC, while keeping cohort-based enforcement for orgs created on or after 4 Aug 2026.

- **New Features**
  - Added `EMBED_HOSTS_ENFORCED_FOR_ALL` (2026-08-17 12:00 UTC); `embed_hosts_enforced` is true when `utc_now()` ≥ the global cutoff or `created_at` ≥ `EMBED_HOSTS_ENFORCED_FROM` (2026-08-04).
  - Added test fixtures `BEFORE_EMBED_CUTOFF` and `embed_hosts_not_enforced`; updated checkout and organization tests to pin pre-cutoff behavior.

- **Migration**
  - Ensure each organization’s `embed_hosts` lists all allowed domains before 17 Aug 2026 12:00 UTC.

<sup>Written for commit 7ba24288952b3704f6eb823daf2ca1eb7a280276. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

