### PR TITLE
feat(dashboard): warn when embed hosts are missing from the list

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/EmbedHostsBanner.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/EmbedHostsBanner.tsx
@@ -1,13 +1,28 @@
 'use client'
 
-import { useOrganizationEmbedStatus } from '@/hooks/queries'
 import { useHasPermission } from '@/hooks/permissions'
+import { useOrganizationEmbedStatus } from '@/hooks/queries'
+import { useDismissed } from '@/hooks/useDismissed'
 import { schemas } from '@polar-sh/client'
 import { Alert } from '@polar-sh/orbit'
 import { useRouter } from 'next/navigation'
 
 interface EmbedHostsBannerProps {
   organization: schemas['Organization']
+}
+
+const NO_HOSTS: schemas['OrganizationUncoveredHost'][] = []
+
+// Identifies the set of hosts, so a dismissal covers the ones seen at the time
+// and a host discovered later brings the banner back.
+const fingerprint = (hosts: string[]): string => {
+  const joined = [...hosts].sort().join(',')
+  let hash = 2166136261
+  for (let i = 0; i < joined.length; i++) {
+    hash ^= joined.charCodeAt(i)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0).toString(36)
 }
 
 export const EmbedHostsBanner = ({ organization }: EmbedHostsBannerProps) => {
@@ -23,36 +38,64 @@ export const EmbedHostsBanner = ({ organization }: EmbedHostsBannerProps) => {
     canManageOrganization,
   )
 
-  if (!data?.has_embedded || data.embed_hosts.length > 0) {
+  const uncovered = data?.uncovered_hosts ?? NO_HOSTS
+  const { isDismissed, dismiss } = useDismissed(
+    `embed_hosts_uncovered:${organization.id}:${fingerprint(
+      uncovered.map((host) => host.host),
+    )}`,
+  )
+
+  const openSettings = () =>
+    router.push(`/dashboard/${organization.slug}/settings#embedding`)
+
+  if (!data?.has_embedded) {
+    return null
+  }
+
+  if (data.embed_hosts.length === 0) {
+    return (
+      <Alert
+        variant="warning"
+        title="Add your embed hosts"
+        description={
+          <>
+            {data.embed_hosts_enforced
+              ? 'Your checkout is embedded on at least one site, and no hosts are listed, so those checkouts are not opening.'
+              : 'Your checkout is embedded on at least one site. Nothing breaks today, but a host you leave out will stop opening your checkout once we enforce the list.'}{' '}
+            <a
+              href="https://polar.sh/docs/features/checkout/embed#embed-hosts"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium underline hover:no-underline"
+            >
+              How to write a host
+            </a>
+          </>
+        }
+        actions={[{ text: 'Open settings', onClick: openSettings }]}
+      />
+    )
+  }
+
+  if (uncovered.length === 0 || isDismissed) {
     return null
   }
 
   return (
     <Alert
       variant="warning"
-      title="Add your embed hosts"
-      description={
-        <>
-          {data.embed_hosts_enforced
-            ? 'Your checkout is embedded on at least one site, and no hosts are listed, so those checkouts are not opening.'
-            : 'Your checkout is embedded on at least one site. Nothing breaks today, but a host you leave out will stop opening your checkout once we enforce the list.'}{' '}
-          <a
-            href="https://polar.sh/docs/features/checkout/embed#embed-hosts"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="font-medium underline hover:no-underline"
-          >
-            How to write a host
-          </a>
-        </>
+      title={
+        uncovered.length === 1
+          ? '1 host is missing from your embed hosts'
+          : `${uncovered.length} hosts are missing from your embed hosts`
       }
-      actions={[
-        {
-          text: 'Open settings',
-          onClick: () =>
-            router.push(`/dashboard/${organization.slug}/settings#embedding`),
-        },
-      ]}
+      description={
+        data.embed_hosts_enforced
+          ? 'Your checkout has been embedded from hosts your list does not allow, so those checkouts are not opening.'
+          : 'Your checkout has been embedded from hosts your list does not allow. Those checkouts will stop opening once we enforce the list.'
+      }
+      onDismiss={dismiss}
+      actions={[{ text: 'Review hosts', onClick: openSettings }]}
     />
   )
 }


### PR DESCRIPTION
## Summary

<img width="1327" height="541" alt="Screenshot 2026-07-30 at 13 17 34" src="https://github.com/user-attachments/assets/17930de3-b08e-4db6-9750-cdc5ce6b6000" />


<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13455"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788002271&installation_model_id=13063&pr_number=13455&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13455&signature=7d1b7526b59dcf4cd1ed3cde86df95010267e8e76794efc2c711d2e994f3eb20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a dismissible banner in the dashboard when checkout is embedded from hosts not in the allowed list, and when the list is empty, so admins can fix broken or soon-to-break embeds.

- **New Features**
  - Warn when uncovered embed hosts are detected, with a count-based title and copy that reflects enforcement state.
  - Persist dismissal per organization and current host set; new hosts bring the banner back.
  - Keep the “add hosts” warning when the list is empty, with a docs link and an action to open settings.

<sup>Written for commit b05308fa6ead669450b692aa42e551f5c63eb0d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

