### PR TITLE
chore(email): make dedup-key backfill dry-run by default

### DIFF
--- a/server/scripts/backfill_email_log_deduplication_key.py
+++ b/server/scripts/backfill_email_log_deduplication_key.py
@@ -6,8 +6,9 @@ from sqlalchemy import ColumnElement, and_, func, or_, select, update
 from sqlalchemy.orm import aliased
 
 from polar.email.schemas import EmailTemplate
-from polar.kit.db.postgres import AsyncSession
+from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
 from polar.models.email_log import EmailLog, EmailLogStatus
+from polar.postgres import create_async_engine
 from scripts.helper import (
     configure_script_logging,
     limit_bindparam,
@@ -88,9 +89,10 @@ async def run_backfill(
     *,
     batch_size: int = 5000,
     sleep_seconds: float = 0.1,
+    dry_run: bool = True,
     session: AsyncSession | None = None,
 ) -> int:
-    updated = 0
+    total = 0
     for template, key, valid in CONFIGS:
         src = aliased(EmailLog)
         other = aliased(EmailLog)
@@ -120,36 +122,64 @@ async def run_backfill(
             .exists()
         )
 
-        id_subquery = (
-            select(src.id)
-            .where(
-                src.status == EmailLogStatus.sent,
-                src.email_template == template,
-                src.deduplication_key.is_(None),
-                valid(src),
-                is_canonical,
-            )
-            .limit(limit_bindparam())
+        candidate_statement = select(src.id).where(
+            src.status == EmailLogStatus.sent,
+            src.email_template == template,
+            src.deduplication_key.is_(None),
+            valid(src),
+            is_canonical,
         )
 
-        updated += await run_batched_update(
+        if dry_run:
+            count = await _count(
+                select(func.count()).select_from(candidate_statement.subquery()),
+                session,
+            )
+            typer.echo(f"[dry-run] {template}: {count} rows would be updated")
+            total += count
+            continue
+
+        total += await run_batched_update(
             update(EmailLog)
             .values(deduplication_key=key(EmailLog))
-            .where(EmailLog.id.in_(id_subquery)),
+            .where(EmailLog.id.in_(candidate_statement.limit(limit_bindparam()))),
             batch_size=batch_size,
             sleep_seconds=sleep_seconds,
             session=session,
         )
-    return updated
+
+    if dry_run:
+        typer.echo(
+            f"[dry-run] {total} rows would be updated in total. "
+            "Re-run with --execute to apply."
+        )
+    return total
+
+
+async def _count(statement: Any, session: AsyncSession | None) -> int:
+    if session is not None:
+        return (await session.execute(statement)).scalar_one()
+    engine = create_async_engine("script")
+    try:
+        sessionmaker = create_async_sessionmaker(engine)
+        async with sessionmaker() as read_session:
+            return (await read_session.execute(statement)).scalar_one()
+    finally:
+        await engine.dispose()
 
 
 @cli.command()
 @typer_async
 async def backfill_email_log_deduplication_key(
+    execute: bool = typer.Option(
+        False, "--execute", help="Apply changes. Without it, runs as a dry run."
+    ),
     batch_size: int = typer.Option(5000, help="Number of rows to process per batch"),
     sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
 ) -> None:
-    await run_backfill(batch_size=batch_size, sleep_seconds=sleep_seconds)
+    await run_backfill(
+        batch_size=batch_size, sleep_seconds=sleep_seconds, dry_run=not execute
+    )
 
 
 if __name__ == "__main__":

--- a/server/tests/scripts/test_backfill_email_log_deduplication_key.py
+++ b/server/tests/scripts/test_backfill_email_log_deduplication_key.py
@@ -67,7 +67,7 @@ class TestBackfillEmailLogDeduplicationKey:
             email_props=_card_props(payment_method_id),
         )
 
-        updated = await run_backfill(session=session)
+        updated = await run_backfill(dry_run=False, session=session)
 
         assert updated == 1
         assert (
@@ -96,7 +96,7 @@ class TestBackfillEmailLogDeduplicationKey:
             },
         )
 
-        await run_backfill(session=session)
+        await run_backfill(dry_run=False, session=session)
 
         assert (
             await _get_key(session, renewal)
@@ -128,7 +128,7 @@ class TestBackfillEmailLogDeduplicationKey:
             deduplication_key="preexisting",
         )
 
-        updated = await run_backfill(session=session)
+        updated = await run_backfill(dry_run=False, session=session)
 
         assert updated == 0
         assert await _get_key(session, failed) is None
@@ -159,7 +159,7 @@ class TestBackfillEmailLogDeduplicationKey:
             created_at=datetime(2026, 1, 3, tzinfo=UTC),
         )
 
-        await run_backfill(session=session)
+        await run_backfill(dry_run=False, session=session)
 
         expected = f"payment_method_expiration_reminder:{payment_method_id}:2026-4"
         assert await _get_key(session, earliest) == expected
@@ -190,11 +190,25 @@ class TestBackfillEmailLogDeduplicationKey:
             created_at=datetime(2026, 1, 2, tzinfo=UTC),
         )
 
-        updated = await run_backfill(session=session)
+        updated = await run_backfill(dry_run=False, session=session)
 
         assert updated == 0
         assert await _get_key(session, older_null) is None
         assert await _get_key(session, newer_keyed) == expected
+
+    async def test_dry_run_is_the_default_and_writes_nothing(
+        self, save_fixture: SaveFixture, session: AsyncSession
+    ) -> None:
+        email_log = await _create_email_log(
+            save_fixture,
+            template="payment_method_expiration_reminder",
+            email_props=_card_props(str(uuid4())),
+        )
+
+        would_update = await run_backfill(session=session)
+
+        assert would_update == 1
+        assert await _get_key(session, email_log) is None
 
     async def test_is_idempotent(
         self, save_fixture: SaveFixture, session: AsyncSession
@@ -205,8 +219,8 @@ class TestBackfillEmailLogDeduplicationKey:
             email_props=_card_props(str(uuid4())),
         )
 
-        first = await run_backfill(session=session)
-        second = await run_backfill(session=session)
+        first = await run_backfill(dry_run=False, session=session)
+        second = await run_backfill(dry_run=False, session=session)
 
         assert first == 1
         assert second == 0


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788009347&installation_model_id=13063&pr_number=13463&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13463&signature=75897b173f3eb472db9644d428fe61963983923c07f9d38cbe148d8e2e2e3b33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the email log deduplication-key backfill a dry run by default. The script now reports how many rows would be updated and does not write unless run with `--execute`.

- **New Features**
  - Prints per-template counts and a final total of rows that would be updated.
  - Returns the total count (dry run) or updated rows (execute mode).
  - Adds safe counting when no session is provided via `create_async_engine` and `create_async_sessionmaker`.
  - Keeps batching controls; `--batch-size` and `--sleep-seconds` behave the same, with clearer help text.

- **Migration**
  - Update any jobs or scripts that previously ran this backfill to pass `--execute` to apply changes.

<sup>Written for commit e72f3e71ef3e21907f18e3096ed298056594fb97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

