### PR TITLE
feat(organization): add nullable dispute_settings column

### DIFF
--- a/server/migrations/versions/2026-07-30-1539_add_dispute_settings_to_organizations.py
+++ b/server/migrations/versions/2026-07-30-1539_add_dispute_settings_to_organizations.py
@@ -1,0 +1,38 @@
+"""add dispute_settings to organizations
+
+Revision ID: 98f971463e5d
+Revises: 72c8a2d0ea56
+Create Date: 2026-07-30 15:39:20.081950
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "98f971463e5d"
+down_revision = "72c8a2d0ea56"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    # `organizations` is a busy table: allow longer to acquire the lock.
+    op.execute("SET LOCAL lock_timeout = '30s'")
+    op.add_column(
+        "organizations",
+        sa.Column(
+            "dispute_settings", postgresql.JSONB(astext_type=sa.Text()), nullable=True
+        ),
+    )
+
+
+def downgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    # `organizations` is a busy table: allow longer to acquire the lock.
+    op.execute("SET LOCAL lock_timeout = '30s'")
+    op.drop_column("organizations", "dispute_settings")

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -222,6 +222,18 @@ def _default_checkout_settings() -> OrganizationCheckoutSettings:
     }
 
 
+class OrganizationDisputeSettings(TypedDict):
+    auto_accept_below_amount: int | None
+    auto_accept_currency: str | None
+
+
+def _default_dispute_settings() -> OrganizationDisputeSettings:
+    return {
+        "auto_accept_below_amount": None,
+        "auto_accept_currency": None,
+    }
+
+
 class OrganizationIndividualLegalEntity(TypedDict):
     type: Literal["individual"]
 
@@ -660,6 +672,10 @@ class Organization(RateLimitGroupMixin, RecordModel):
 
     checkout_settings: Mapped[OrganizationCheckoutSettings] = mapped_column(
         JSONB, nullable=False, default=_default_checkout_settings
+    )
+
+    dispute_settings: Mapped[OrganizationDisputeSettings | None] = mapped_column(
+        JSONB, nullable=True, default=_default_dispute_settings
     )
 
     embed_hosts: Mapped[list[str]] = mapped_column(JSONB, nullable=False, default=list)

--- a/server/scripts/backfill_organization_dispute_settings.py
+++ b/server/scripts/backfill_organization_dispute_settings.py
@@ -48,7 +48,9 @@ async def backfill(
     execute: bool = typer.Option(
         False, help="Actually run the backfill (default: dry-run)"
     ),
-    batch_size: int = typer.Option(5000, help="Number of rows to process per batch"),
+    batch_size: int = typer.Option(
+        5000, min=1, help="Number of rows to process per batch"
+    ),
     sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
 ) -> None:
     engine = create_async_engine("script")

--- a/server/scripts/backfill_organization_dispute_settings.py
+++ b/server/scripts/backfill_organization_dispute_settings.py
@@ -1,0 +1,107 @@
+"""
+Backfill organizations.dispute_settings to the default settings.
+
+The column was added as nullable to avoid a locking migration on the hot
+`organizations` table. New rows get the defaults from the model, but rows that
+existed before the column was added are still NULL. This script fills them so a
+later migration can safely enforce NOT NULL.
+
+Every physical row must be filled — including soft-deleted ones — since the
+future NOT NULL constraint applies to the whole table, so we intentionally do
+not filter on `deleted_at`.
+
+Usage:
+    cd server
+
+    # Dry-run (default) — show how many rows would be backfilled:
+    uv run python -m scripts.backfill_organization_dispute_settings
+
+    # Execute the backfill (batched):
+    uv run python -m scripts.backfill_organization_dispute_settings --execute
+"""
+
+import structlog
+import typer
+from rich.console import Console
+from sqlalchemy import func, select, update
+
+from polar.kit.db.postgres import create_async_sessionmaker
+from polar.models import Organization
+from polar.postgres import create_async_engine
+from scripts.helper import (
+    configure_script_console_logging,
+    limit_bindparam,
+    run_batched_update,
+    typer_async,
+)
+
+cli = typer.Typer()
+console = Console()
+log = structlog.get_logger()
+
+configure_script_console_logging()
+
+
+@cli.command()
+@typer_async
+async def backfill(
+    execute: bool = typer.Option(
+        False, help="Actually run the backfill (default: dry-run)"
+    ),
+    batch_size: int = typer.Option(5000, help="Number of rows to process per batch"),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+) -> None:
+    engine = create_async_engine("script")
+    sessionmaker = create_async_sessionmaker(engine)
+
+    try:
+        async with sessionmaker() as session:
+            result = await session.execute(
+                select(func.count()).where(Organization.dispute_settings.is_(None))
+            )
+            total = result.scalar_one()
+
+        if total == 0:
+            console.print("[green]No organizations with a NULL dispute_settings.")
+            return
+
+        if not execute:
+            console.print(
+                f"[yellow]Dry-run — use --execute to backfill {total} "
+                "organization(s) to the default dispute settings."
+            )
+            return
+
+        console.rule("[bold]Executing backfill")
+        subquery = (
+            select(Organization.id)
+            .where(Organization.dispute_settings.is_(None))
+            .order_by(Organization.id)
+            .limit(limit_bindparam())
+            .scalar_subquery()
+        )
+        stmt = (
+            update(Organization)
+            .where(Organization.id.in_(subquery))
+            .values(
+                dispute_settings={
+                    "auto_accept_below_amount": None,
+                    "auto_accept_currency": None,
+                }
+            )
+        )
+        rows_updated = await run_batched_update(
+            stmt, batch_size=batch_size, sleep_seconds=sleep_seconds
+        )
+        log.info("backfill.complete", rowcount=rows_updated)
+        console.print(
+            f"\n[green]Backfilled {rows_updated} organization(s) to the default "
+            "dispute settings."
+        )
+
+    finally:
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Summary

Dispute auto approval feature, requested here: https://polar-sh.slack.com/archives/C0BCZLJ06RM/p1785415313773999?thread_ts=1785396275.524209&cid=C0BCZLJ06RM

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788015347&installation_model_id=13063&pr_number=13467&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13467&signature=716e1c0d493d324582cb39702bb2d725a26f80585c20bdd7a16185637121d358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

