### PR TITLE
Fix job queue flushing in reset_organizations_for_review script

### DIFF
--- a/server/scripts/reset_organizations_for_review.py
+++ b/server/scripts/reset_organizations_for_review.py
@@ -16,10 +16,12 @@ Usage:
 
 from uuid import UUID
 
+import dramatiq
 import typer
 from rich.console import Console
 from rich.table import Table
 
+from polar import tasks  # noqa: F401  -- registers dramatiq actors
 from polar.kit.db.postgres import create_async_sessionmaker
 from polar.models import Organization
 from polar.models.organization import OrganizationStatus
@@ -28,6 +30,8 @@ from polar.organization.service import (
     organization as organization_service,
 )
 from polar.postgres import AsyncSession, create_async_engine
+from polar.redis import create_redis
+from polar.worker import JobQueueManager
 from scripts.helper import configure_script_console_logging, typer_async
 
 cli = typer.Typer()
@@ -124,15 +128,20 @@ async def reset_organizations_for_review(
                 console.print("[yellow]Preview only — pass --execute to apply.")
                 return
 
-            for _, organization in targets:
-                assert organization is not None
-                await organization_service.reset_onboarding_for_review(
-                    session,
-                    organization,
-                    reset_by=reset_by,
-                )
+            async with create_redis("script") as redis:
+                async with JobQueueManager.open(dramatiq.get_broker(), redis):
+                    for _, organization in targets:
+                        assert organization is not None
+                        await organization_service.reset_onboarding_for_review(
+                            session,
+                            organization,
+                            reset_by=reset_by,
+                        )
 
-            await session.commit()
+                    await session.commit()
+                    # JobQueueManager.open() flushes on context exit, i.e. after
+                    # the commit above.
+
             console.print(
                 f"[green]Reset {len(targets)} organization(s) for onboarding review."
             )

--- a/server/tests/scripts/test_reset_organizations_for_review.py
+++ b/server/tests/scripts/test_reset_organizations_for_review.py
@@ -1,9 +1,14 @@
-from unittest.mock import AsyncMock, call, patch
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, call, patch
 from uuid import uuid4
 
 import pytest
 
+import scripts.reset_organizations_for_review as script
+from polar.organization.service import organization as organization_service
 from polar.postgres import AsyncSession
+from polar.worker import JobQueueManager, enqueue_job
+from polar.worker._enqueue import _job_queue_manager
 from scripts.reset_organizations_for_review import _load_organizations
 
 
@@ -30,3 +35,70 @@ async def test_load_organizations_locks_targets(session: AsyncSession) -> None:
             for_update=True,
         ),
     ]
+
+
+class _FakeSession:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    async def __aenter__(self) -> "_FakeSession":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None: ...
+
+    async def commit(self) -> None:
+        self.events.append("commit")
+
+
+class _FakeRedis:
+    async def __aenter__(self) -> "_FakeRedis":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None: ...
+
+
+def test_execute_flushes_enqueued_jobs_after_commit() -> None:
+    """The script runs outside the API and worker, so it must open its own
+    JobQueueManager: the reset enqueues ``payout.cancel_held_payouts``, which
+    raises without one. The flush must happen after the commit."""
+    events: list[str] = []
+    session = _FakeSession(events)
+    organization = MagicMock()
+    flushed_actors: list[str] = []
+
+    async def reset_onboarding_for_review(*args: Any, **kwargs: Any) -> Any:
+        enqueue_job("payout.cancel_held_payouts", account_id=None)
+        return organization
+
+    async def flush(self: JobQueueManager, broker: Any, redis: Any) -> None:
+        events.append("flush")
+        flushed_actors.extend(actor for actor, _, _, _ in self._enqueued_jobs)
+        self.reset()
+
+    _job_queue_manager.set(None)
+
+    with (
+        patch.object(
+            script, "create_async_engine", return_value=MagicMock(dispose=AsyncMock())
+        ),
+        patch.object(script, "create_async_sessionmaker", return_value=lambda: session),
+        patch.object(script, "create_redis", return_value=_FakeRedis()),
+        patch.object(
+            script,
+            "_load_organizations",
+            AsyncMock(return_value=[(organization.id, organization)]),
+        ),
+        patch.object(script, "_show_plan", return_value=True),
+        patch.object(
+            organization_service,
+            "reset_onboarding_for_review",
+            reset_onboarding_for_review,
+        ),
+        patch.object(JobQueueManager, "flush", flush),
+    ):
+        script.reset_organizations_for_review(
+            organization_ids=[uuid4()], execute=True, reset_by="test"
+        )
+
+    assert events == ["commit", "flush"]
+    assert flushed_actors == ["payout.cancel_held_payouts"]


### PR DESCRIPTION
## Summary

Fixes a bug in the `reset_organizations_for_review` script where enqueued jobs were not being flushed to the message broker. The script now properly opens a `JobQueueManager` context and ensures jobs are flushed after the database transaction commits.

## What

- Wrapped the organization reset loop in a `JobQueueManager.open()` context that manages the job queue lifecycle
- Moved `session.commit()` inside the `JobQueueManager` context so that job flushing happens after the commit
- Added necessary imports: `dramatiq`, `create_redis`, `JobQueueManager`, and the `polar.tasks` module
- Added comprehensive test coverage to verify the flush happens after commit

## Why

The `reset_onboarding_for_review` method enqueues jobs (e.g., `payout.cancel_held_payouts`) via `enqueue_job()`. Without an active `JobQueueManager`, this raises an error. Additionally, jobs must be flushed to the message broker after the database transaction commits to ensure consistency—if the commit fails, the jobs shouldn't be processed.

## How

- Created a `JobQueueManager` context using the script's own Redis connection and Dramatiq broker
- Positioned the context so that `session.commit()` happens before the context exits, triggering the automatic flush on exit
- Added a test (`test_execute_flushes_enqueued_jobs_after_commit`) that verifies the flush order using fake session and Redis objects, mocking the service layer to enqueue a job

## Checklist

- [x] This PR addresses a single concern (fixing job queue flushing in the reset script)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests (added `test_execute_flushes_enqueued_jobs_after_commit`)
- [x] No unrelated changes or drive-by fixes are included

https://claude.ai/code/session_01NfxeF19MWWVYQjSBdeKis5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788017875&installation_model_id=13063&pr_number=13471&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13471&signature=6826bdbbe4e414b1c429363a27cfda77f4c18345878b57f9e1b53c4d069a5f03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

