### PR TITLE
Restore consumed balance when voiding orders

### DIFF
--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -2670,6 +2670,18 @@ class OrderService:
                 order=order,
             )
 
+        # Give back the balance the order consumed: it'll never be collected.
+        # Applied after the reduction above, which is computed on the balance as it
+        # stands while the order is still due.
+        if order.applied_balance_amount < 0:
+            await wallet_service.create_balance_transaction(
+                session,
+                order.customer,
+                -order.applied_balance_amount,
+                order.currency,
+                order=order,
+            )
+
         await event_service.create_event(
             session,
             build_system_event(
@@ -2702,6 +2714,17 @@ class OrderService:
                 "next_payment_attempt_at": None,
             },
         )
+
+        # Consume again the balance restored on void: the order is due once more,
+        # and `applied_balance_amount` still counts it against `due_amount`.
+        if order.applied_balance_amount < 0:
+            await wallet_service.create_balance_transaction(
+                session,
+                order.customer,
+                order.applied_balance_amount,
+                order.currency,
+                order=order,
+            )
 
         await event_service.create_event(
             session,

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -5688,6 +5688,116 @@ class TestVoidOrder:
         )
         assert new_balance == 200
 
+    @pytest.mark.asyncio
+    async def test_void_restores_balance_consumed_by_order(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        # Given
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.pending,
+            subtotal_amount=3000,
+            applied_balance_amount=-1000,
+        )
+
+        # The customer had 1000, consumed by the order at creation
+        wallet = await create_wallet_billing(
+            save_fixture,
+            customer=customer,
+            initial_balance=1000,
+        )
+        await create_wallet_transaction(save_fixture, wallet=wallet, amount=-1000)
+
+        # When
+        result_order = await order_service.void(session, order)
+
+        # Then
+        assert result_order.status == OrderStatus.void
+
+        new_balance = await wallet_service.get_billing_wallet_balance(
+            session, customer, order.currency
+        )
+        assert new_balance == 1000
+
+    @pytest.mark.asyncio
+    async def test_void_restores_consumed_balance_and_reduces_credit(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        # Given
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.pending,
+            subtotal_amount=3000,
+            applied_balance_amount=-1000,
+        )
+
+        # The customer had 1000, consumed by the order at creation, then got a
+        # 1500 credit from another order
+        wallet = await create_wallet_billing(
+            save_fixture,
+            customer=customer,
+            initial_balance=1000,
+        )
+        await create_wallet_transaction(save_fixture, wallet=wallet, amount=-1000)
+        await create_wallet_transaction(save_fixture, wallet=wallet, amount=1500)
+
+        # When
+        result_order = await order_service.void(session, order)
+
+        # Then
+        assert result_order.status == OrderStatus.void
+
+        # The 1500 credit is reduced by the 2000 due, the 1000 consumed is restored
+        new_balance = await wallet_service.get_billing_wallet_balance(
+            session, customer, order.currency
+        )
+        assert new_balance == 1000
+
+    @pytest.mark.asyncio
+    async def test_void_leaves_negative_balance_untouched(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        # Given
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.pending,
+            subtotal_amount=800,
+        )
+
+        # The customer owes 500 and the order consumed nothing
+        await create_wallet_billing(
+            save_fixture,
+            customer=customer,
+            initial_balance=-500,
+        )
+
+        # When
+        await order_service.void(session, order)
+
+        # Then
+        new_balance = await wallet_service.get_billing_wallet_balance(
+            session, customer, order.currency
+        )
+        assert new_balance == -500
+
 
 class TestUnvoidOrder:
     @pytest.mark.asyncio
@@ -5741,6 +5851,77 @@ class TestUnvoidOrder:
 
         with pytest.raises(OrderNotVoid):
             await order_service.unvoid(session, order)
+
+    @pytest.mark.asyncio
+    async def test_unvoid_reconsumes_restored_balance(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        # Given
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.void,
+            subtotal_amount=3000,
+            applied_balance_amount=-1000,
+        )
+
+        # The 1000 consumed by the order was restored when it was voided
+        await create_wallet_billing(
+            save_fixture,
+            customer=customer,
+            initial_balance=1000,
+        )
+
+        # When
+        result_order = await order_service.unvoid(session, order)
+
+        # Then
+        assert result_order.status == OrderStatus.pending
+
+        new_balance = await wallet_service.get_billing_wallet_balance(
+            session, customer, order.currency
+        )
+        assert new_balance == 0
+
+    @pytest.mark.asyncio
+    async def test_void_unvoid_round_trip_leaves_balance_unchanged(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        # Given
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.pending,
+            subtotal_amount=3000,
+            applied_balance_amount=-1000,
+        )
+        wallet = await create_wallet_billing(
+            save_fixture,
+            customer=customer,
+            initial_balance=1000,
+        )
+        await create_wallet_transaction(save_fixture, wallet=wallet, amount=-1000)
+
+        # When
+        order = await order_service.void(session, order)
+        order = await order_service.unvoid(session, order)
+        order = await order_service.void(session, order)
+
+        # Then
+        new_balance = await wallet_service.get_billing_wallet_balance(
+            session, customer, order.currency
+        )
+        assert new_balance == 1000
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

**Related Issue**: Fixes polarsource/feedback/issues/304

This PR fixes the order void/unvoid logic to properly handle customer wallet balance restoration. When an order is voided, any balance that was consumed by the order should be restored to the customer's wallet. When an order is unvoided, that balance should be consumed again.

## What

- Modified `order_service.void()` to restore the balance amount consumed by the order (`applied_balance_amount`) after reducing the customer's balance for the order's due amount
- Modified `order_service.unvoid()` to re-consume the balance amount when an order is unvoided
- Added comprehensive test coverage for void/unvoid balance restoration scenarios:
  - `test_void_restores_balance_consumed_by_order`: Basic restoration of consumed balance
  - `test_void_restores_consumed_balance_and_reduces_credit`: Restoration with subsequent credits
  - `test_void_leaves_negative_balance_untouched`: Negative balances (customer debt) are not affected
  - `test_unvoid_reconsumes_restored_balance`: Balance is re-consumed on unvoid
  - `test_void_unvoid_round_trip_leaves_balance_unchanged`: Round-trip void/unvoid maintains consistency

## Why

When an order is created with an applied balance amount (customer's wallet balance used to pay for the order), that balance is consumed. If the order is later voided, the balance should be restored since the order will never be collected. The previous implementation was missing this restoration logic, leaving customers' balances incorrectly depleted after voiding orders.

## How

The fix adds balance transaction creation in both `void()` and `unvoid()` methods:
- In `void()`: After reducing the balance for the order's due amount, create a transaction to restore the consumed balance (`-applied_balance_amount`)
- In `unvoid()`: Create a transaction to re-consume the balance (`applied_balance_amount`)

This ensures the wallet balance correctly reflects the order's status throughout its lifecycle.

## Checklist

- [x] This PR addresses a single concern (balance restoration on void/unvoid)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests (5 new test cases added)
- [x] No unrelated changes or drive-by fixes are included

https://claude.ai/code/session_0188wy2s86VMndeaBisaTsYd

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788020635&installation_model_id=13063&pr_number=13475&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13475&signature=b7d3f8281174483f609ff8672e1f93bf78d606a7161cef11c47b9985ac7978e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

