### PR TITLE
fix(user): handle concurrent creation in get_by_email_or_create

### DIFF
--- a/server/polar/user/service.py
+++ b/server/polar/user/service.py
@@ -5,6 +5,7 @@ from uuid import UUID
 import stripe as stripe_lib
 import structlog
 from sqlalchemy import func, update
+from sqlalchemy.exc import IntegrityError
 
 from polar.exceptions import PolarError
 from polar.integrations.polar.service import polar_self as polar_self_service
@@ -76,14 +77,23 @@ class UserService:
     ) -> tuple[User, bool]:
         repository = UserRepository.from_session(session)
         user = await repository.get_by_email(email)
-        created = False
-        if user is None:
+        if user is not None:
+            return (user, False)
+
+        nested = await session.begin_nested()
+        try:
             user = await self.create_by_email(
                 session, email, signup_attribution=signup_attribution
             )
-            created = True
+        except IntegrityError:
+            await nested.rollback()
+            user = await repository.get_by_email(email)
+            if user is None:
+                raise
+            log.info("user.get_by_email_or_create.concurrent_creation", user_id=user.id)
+            return (user, False)
 
-        return (user, created)
+        return (user, True)
 
     async def create_by_email(
         self,

--- a/server/tests/user/test_service.py
+++ b/server/tests/user/test_service.py
@@ -2,6 +2,7 @@ import pytest
 import stripe as stripe_lib
 from pytest_mock import MockerFixture
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 
 from polar.kit.utils import utc_now
 from polar.models import (
@@ -14,6 +15,7 @@ from polar.models import (
 from polar.models.user import IdentityVerificationStatus, OAuthPlatform
 from polar.models.user_organization import OrganizationRole
 from polar.postgres import AsyncSession
+from polar.user.repository import UserRepository
 from polar.user.schemas import UserDeletionBlockedReason, UserUpdate
 from polar.user.service import (
     IdentityAlreadyVerified,
@@ -27,6 +29,47 @@ from tests.fixtures.random_objects import (
     create_oauth_account,
     create_payout_account,
 )
+
+
+@pytest.mark.asyncio
+class TestGetByEmailOrCreate:
+    async def test_existing_user(self, session: AsyncSession, user: User) -> None:
+        result, created = await user_service.get_by_email_or_create(
+            session, user.email.upper()
+        )
+
+        assert result.id == user.id
+        assert created is False
+
+    async def test_creates_missing_user(self, session: AsyncSession) -> None:
+        result, created = await user_service.get_by_email_or_create(
+            session, "new-user@example.com"
+        )
+
+        assert result.email == "new-user@example.com"
+        assert created is True
+
+    async def test_concurrent_creation_returns_existing_user(
+        self, session: AsyncSession, mocker: MockerFixture, user: User
+    ) -> None:
+        """Both concurrent requests saw no user, so the insert hits the unique
+        index on the email: the loser must recover the row instead of failing."""
+        mocker.patch.object(UserRepository, "get_by_email", side_effect=[None, user])
+
+        result, created = await user_service.get_by_email_or_create(session, user.email)
+
+        assert result.id == user.id
+        assert created is False
+
+    async def test_integrity_error_without_conflicting_user(
+        self, session: AsyncSession, mocker: MockerFixture, user: User
+    ) -> None:
+        """An IntegrityError we can't explain by a concurrent creation must not be
+        swallowed."""
+        mocker.patch.object(UserRepository, "get_by_email", side_effect=[None, None])
+
+        with pytest.raises(IntegrityError):
+            await user_service.get_by_email_or_create(session, user.email)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

**Related Issue**: Fixes polarsource/feedback#302

`user_service.get_by_email_or_create` did a check-then-create with no handling for the duplicate-key error, so two concurrent requests for the same new email could both attempt an insert and the loser got a 500.

## What

- `get_by_email_or_create` now wraps the insert in a savepoint. On `IntegrityError` it rolls back to the savepoint, re-reads the row the winning request created, and returns it with `created=False`. If no row is found, the error is re-raised so unrelated integrity failures still surface.
- Added `TestGetByEmailOrCreate` in `server/tests/user/test_service.py` covering the existing-user path, the create path, the concurrent-creation recovery, and the re-raise path.

## Why

`POST /v1/organizations/{id}/members/invite` calls `get_by_email_or_create` before `organization_service.add_user`. When two admins invite the same new member email simultaneously, both requests can observe `get_by_email() -> None` and both try to create the user. The second insert violates `ix_users_email_case_insensitive` and raises `IntegrityError` during `session.flush()`, which propagated out of the endpoint as a 500 — the request never reached `add_user`.

Both invites should succeed: one creates the user, the other finds it. The same TOCTOU window exists on the other callers of this method (`auth/endpoints.py`, `auth/sso/endpoints.py`, `auth/oauth2/router.py`), so the fix is in the service rather than at the invite call site.

## How

Mirrors the recovery pattern already used elsewhere in the codebase — `EventTypeRepository.get_or_create` (`polar/event_type/repository.py`) and `organization_service.add_user`, which already handled the duplicate-membership half of this same race:

```python
nested = await session.begin_nested()
try:
    user = await self.create_by_email(session, email, signup_attribution=signup_attribution)
except IntegrityError:
    await nested.rollback()
    user = await repository.get_by_email(email)
    if user is None:
        raise
    return (user, False)
return (user, True)
```

Notes on the approach:

- **Savepoint, not `session.rollback()`.** A full rollback would discard the whole request transaction, not just the failed insert. `begin_nested()` scopes the rollback to the `INSERT` and leaves the caller's transaction usable — this is the established convention in this repo.
- **No stale background job.** `create_by_email` enqueues `user.on_after_signup` *after* the flush, so the losing request never enqueues a job for a user it didn't create.
- **The recovery lookup does find the row.** Under READ COMMITTED, the loser's `INSERT` blocks until the winner commits, so the unique violation implies the row is committed and visible to the subsequent statement's snapshot.
- **Re-raise preserves current behaviour** for the case where the conflicting row exists but `get_by_email` filters it out (blocked users are excluded from that query). Returning a blocked user here would change auth behaviour, which is out of scope for this fix.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`) — `ruff format` and `ruff check` pass on the changed files; `lint_types` and `pytest` could not be run in this environment (no Python 3.14 toolchain, no Docker for the test database), so CI is the first full check
- [x] No unrelated changes or drive-by fixes are included

---
_Generated by [Claude Code](https://claude.ai/code/session_01WJrhWohQsPQfvRBwiroRzf)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788021014&installation_model_id=13063&pr_number=13476&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13476&signature=0a2f1b7cdda7a9091f685874ebe966cc98d0f06cd9b5cbdb90957f092e14f99e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

