### PR TITLE
fix(backoffice): stop Cancel submitting the action form in modals

### DIFF
--- a/server/polar/backoffice/AGENTS.md
+++ b/server/polar/backoffice/AGENTS.md
@@ -119,6 +119,28 @@ with modal_content("modal-id", title="Confirm Action"):
             text("Confirm")
 ```
 
+**Never nest a `<form>` inside another `<form>`.** HTML5 forbids it: the parser drops
+the inner start tag and reparents its buttons onto the outer form, so a "Cancel" wrapped
+in `tag.form(method="dialog")` inside an `hx-post` form submits that form and performs the
+action it was meant to abort. Use `modal_close_button` for dismiss buttons — it is a
+`type="button"` that closes the surrounding `<dialog>`, so it is safe anywhere:
+
+```python
+from polar.backoffice.components import button, modal, modal_close_button
+
+with modal("Confirm Action", open=True):
+    with tag.form(method="post", hx_post=action_url, hx_target="#modal"):
+        with tag.textarea(name="reason", required=True):
+            pass
+        with tag.div(classes="modal-action"):
+            with modal_close_button(ghost=True):
+                text("Cancel")
+            with button(variant="error", type="submit"):
+                text("Confirm")
+```
+
+`uv run task lint_nested_form` (part of `uv run task lint`) fails on nested forms.
+
 ### Accordions
 
 ```python

--- a/server/polar/backoffice/DEVELOPMENT_GUIDE.md
+++ b/server/polar/backoffice/DEVELOPMENT_GUIDE.md
@@ -225,9 +225,8 @@ async def delete_confirmation(
             text(f"Are you sure you want to delete '{entity.name}'? This action cannot be undone.")
 
         with tag.div(classes="modal-action"):
-            with tag.form(method="dialog"):
-                with button(variant="neutral"):
-                    text("Cancel")
+            with modal_close_button(variant="neutral"):
+                text("Cancel")
 
             with tag.form(
                 method="POST",
@@ -385,9 +384,8 @@ async def action_confirmation(request: Request, id: UUID4) -> None:
             text("Confirmation message")
 
         with tag.div(classes="modal-action"):
-            with tag.form(method="dialog"):
-                with button(variant="neutral"):
-                    text("Cancel")
+            with modal_close_button(variant="neutral"):
+                text("Cancel")
 
             with tag.form(method="POST", hx_post=confirm_url):
                 with button(variant="error", type="submit"):
@@ -400,6 +398,14 @@ async def action_confirm(request: Request, id: UUID4) -> Any:
     # Redirect
     pass
 ```
+
+Dismiss buttons must use `modal_close_button`, never a `tag.form(method="dialog")`
+wrapper. HTML5 forbids nested `<form>` elements: when the modal's action form wraps the
+whole body (reason textarea, inputs, action row), a nested dismiss form is dropped by the
+parser and its button is reparented onto the action form — clicking "Cancel" then submits
+the action. `modal_close_button` renders a `type="button"` that closes the surrounding
+`<dialog>`, so it is safe wherever it is placed. `uv run task lint_nested_form` enforces
+this.
 
 ## Components Reference
 
@@ -487,6 +493,17 @@ with modal("Dialog Title", open=True):
     with tag.div(classes="modal-action"):
         with button(variant="primary"):
             text("OK")
+```
+
+#### `modal_close_button()`
+
+Dismiss button for a modal. Takes the same styling arguments as `button()`, renders a
+`type="button"` and closes the enclosing `<dialog>`, so it never submits a form it happens
+to sit inside.
+
+```python
+with modal_close_button(ghost=True):
+    text("Cancel")
 ```
 
 ## Forms and Validation

--- a/server/polar/backoffice/components/__init__.py
+++ b/server/polar/backoffice/components/__init__.py
@@ -11,7 +11,7 @@ from ._dispute_status_badge import dispute_status_badge
 from ._evidence_due_label import evidence_due_label
 from ._layout import layout
 from ._metric_card import metric_card
-from ._modal import modal
+from ._modal import modal, modal_close_button
 from ._state import card, empty_state, loading_state
 from ._status_badge import status_badge
 from ._support_tier_badge import support_tier_badge
@@ -35,6 +35,7 @@ __all__ = [
     "loading_state",
     "metric_card",
     "modal",
+    "modal_close_button",
     "navigation",
     "status_badge",
     "support_tier_badge",

--- a/server/polar/backoffice/components/_modal.py
+++ b/server/polar/backoffice/components/_modal.py
@@ -2,6 +2,11 @@ import contextlib
 from collections.abc import Generator
 
 from tagflow import attr, tag, text
+from tagflow.tagflow import AttrValue
+
+from ._button import Size, Variant, button
+
+CLOSE_MODAL_SCRIPT = "on click call me.closest('dialog').close()"
 
 
 @contextlib.contextmanager
@@ -57,4 +62,56 @@ def modal(title: str, *, open: bool = False) -> Generator[None]:
                 pass
 
 
-__all__ = ["modal"]
+@contextlib.contextmanager
+def modal_close_button(
+    *,
+    variant: Variant | None = None,
+    size: Size | None = None,
+    ghost: bool = False,
+    link: bool = False,
+    soft: bool = False,
+    outline: bool = False,
+    **kwargs: AttrValue,
+) -> Generator[None]:
+    """Create a button that closes the enclosing modal without submitting anything.
+
+    Use this for "Cancel" and other dismiss actions instead of wrapping the
+    button in a `<form method="dialog">`. HTML5 forbids nested `<form>` elements:
+    when a dismiss form sits inside an action form, the parser drops it and the
+    button becomes a submit button of the action form, so clicking "Cancel"
+    performs the action it was meant to abort.
+
+    The button is a `type="button"`, so it never submits any form regardless of
+    where it is rendered, and closes the surrounding `<dialog>` via hyperscript.
+
+    Args:
+        variant: The button color variant, as in `button`.
+        size: The button size, as in `button`.
+        ghost: If True, applies ghost styling.
+        link: If True, styles the button to look like a link.
+        soft: If True, applies soft styling modifier.
+        outline: If True, applies outline styling.
+        **kwargs: Additional HTML attributes for the button element.
+
+    Yields:
+        None: Context manager yields control for button content.
+
+    Example:
+        >>> with modal_close_button(ghost=True):
+        ...     text("Cancel")
+    """
+    with button(
+        variant=variant,
+        size=size,
+        ghost=ghost,
+        link=link,
+        soft=soft,
+        outline=outline,
+        type="button",
+        _=CLOSE_MODAL_SCRIPT,
+        **kwargs,
+    ):
+        yield
+
+
+__all__ = ["CLOSE_MODAL_SCRIPT", "modal", "modal_close_button"]

--- a/server/polar/backoffice/customers/endpoints.py
+++ b/server/polar/backoffice/customers/endpoints.py
@@ -53,7 +53,13 @@ from polar.wallet.repository import WalletRepository, WalletTransactionRepositor
 from polar.wallet.service import wallet as wallet_service
 from polar.worker import enqueue_job
 
-from ..components import button, datatable, description_list, modal
+from ..components import (
+    button,
+    datatable,
+    description_list,
+    modal,
+    modal_close_button,
+)
 from ..formatters import currency
 from ..layout import layout
 from ..responses import HXRedirectResponse
@@ -710,9 +716,8 @@ async def create_balance_transaction(
                     hx_target="#modal",
                 ):
                     with tag.div(classes="modal-action"):
-                        with tag.form(method="dialog"):
-                            with button(ghost=True):
-                                text("Cancel")
+                        with modal_close_button(ghost=True):
+                            text("Cancel")
                         with button(type="submit", variant="primary"):
                             text("Create Transaction")
 
@@ -1053,9 +1058,8 @@ async def edit_email(
                     hx_target="#modal",
                 ):
                     with tag.div(classes="modal-action"):
-                        with tag.form(method="dialog"):
-                            with button(ghost=True):
-                                text("Cancel")
+                        with modal_close_button(ghost=True):
+                            text("Cancel")
                         with button(type="submit", variant="primary"):
                             text("Update Email")
 

--- a/server/polar/backoffice/orders/endpoints.py
+++ b/server/polar/backoffice/orders/endpoints.py
@@ -28,7 +28,14 @@ from polar.tax.calculation.base import TaxabilityReason
 from polar.worker import enqueue_job
 
 from .. import formatters
-from ..components import button, datatable, description_list, input, modal
+from ..components import (
+    button,
+    datatable,
+    description_list,
+    input,
+    modal,
+    modal_close_button,
+)
 from ..layout import layout
 from ..responses import HXRedirectResponse
 from ..toast import add_toast
@@ -814,9 +821,8 @@ async def refund(
                 validation_error=validation_error,
             ):
                 with tag.div(classes="modal-action"):
-                    with tag.form(method="dialog"):
-                        with button(ghost=True):
-                            text("Cancel")
+                    with modal_close_button(ghost=True):
+                        text("Cancel")
                     with button(type="submit", variant="primary"):
                         text("Submit")
 

--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -110,7 +110,7 @@ from polar.support_case.schemas import ReviewAppealSupportCaseMessageCreate
 from polar.transaction.service.transaction import transaction as transaction_service
 from polar.worker import enqueue_job
 
-from ..components import button, input, modal
+from ..components import button, input, modal, modal_close_button
 from ..dependencies import get_admin
 from ..layout import layout
 from ..responses import HXRedirectResponse
@@ -1356,9 +1356,8 @@ async def approve_dialog(
                     pass
 
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(variant="primary", type="submit"):
                     text("Approve Organization")
 
@@ -1538,9 +1537,8 @@ async def deny_dialog(
             )
 
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(variant="error", type="submit"):
                     text("Deny Organization")
 
@@ -1697,9 +1695,8 @@ async def approve_denied_dialog(
                     pass
 
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(variant="primary", type="submit"):
                     text("Approve Organization")
 
@@ -1830,9 +1827,8 @@ async def deny_appeal_dialog(
                         pass
 
                 with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                    with tag.form(method="dialog"):
-                        with button(ghost=True):
-                            text("Cancel")
+                    with modal_close_button(ghost=True):
+                        text("Cancel")
                     with button(variant="error", type="submit"):
                         text("Deny Appeal")
 
@@ -1989,9 +1985,8 @@ async def appeal_case_approve_dialog(
                 ):
                     pass
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(variant="primary", type="submit"):
                     text("Approve Appeal")
 
@@ -2094,9 +2089,8 @@ async def appeal_case_deny_dialog(
                 ):
                     pass
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(variant="error", type="submit"):
                     text("Deny Appeal")
 
@@ -2239,9 +2233,8 @@ async def unblock_approve_dialog(
                     pass
 
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(variant="primary", type="submit"):
                     text("Unblock & Approve")
 
@@ -2317,9 +2310,8 @@ async def block_dialog(
             )
 
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(variant="error", type="submit"):
                     text("Block Organization")
 
@@ -2643,9 +2635,8 @@ async def snooze_dialog(
                     pass
 
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(variant="warning", type="submit"):
                     text("Snooze")
 
@@ -2887,9 +2878,8 @@ async def create_review_ticket(
                     pass
 
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(variant="primary", type="submit"):
                     text("Create")
 
@@ -2995,9 +2985,8 @@ async def offboard_dialog(
                     pass
 
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(variant="warning", type="submit"):
                     text("Set Offboarding")
 
@@ -3126,9 +3115,8 @@ async def offboarded_dialog(
                             )
 
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(variant="warning", type="submit"):
                     text("Complete Offboarding")
 
@@ -3222,9 +3210,8 @@ async def edit_organization(
         ):
             # Action buttons
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(
                     type="submit",
                     variant="primary",
@@ -3303,9 +3290,8 @@ async def edit_details(
         ):
             # Action buttons
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(
                     type="submit",
                     variant="primary",
@@ -3394,9 +3380,8 @@ async def edit_order_settings(
                                 text(desc)
 
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(type="submit", variant="primary"):
                     text("Save Changes")
 
@@ -3461,9 +3446,8 @@ async def edit_rate_limit_group(
             classes="flex flex-col",
         ):
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(type="submit", variant="primary"):
                     text("Save Changes")
 
@@ -3619,9 +3603,8 @@ async def edit_socials(
         ):
             # Action buttons
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(
                     type="submit",
                     variant="primary",
@@ -3749,9 +3732,8 @@ async def edit_features(
 
             # Action buttons
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(
                     type="submit",
                     variant="primary",
@@ -3841,9 +3823,8 @@ async def edit_checkout_settings(
 
             # Action buttons
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(
                     type="submit",
                     variant="primary",
@@ -3919,9 +3900,8 @@ async def edit_account_settings(
             classes="flex flex-col",
         ):
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(type="submit", variant="primary"):
                     text("Save Changes")
 
@@ -3986,9 +3966,8 @@ async def add_note(
         ):
             # Action buttons
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(
                     type="submit",
                     variant="primary",
@@ -4056,9 +4035,8 @@ async def edit_note(
         ):
             # Action buttons
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(
                     type="submit",
                     variant="primary",
@@ -4286,9 +4264,8 @@ async def setup_account(
                     pass
 
             with tag.div(classes="modal-action pt-6 border-t border-base-200"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(variant="primary", type="submit"):
                     text("Create Manual Account")
 
@@ -4588,9 +4565,8 @@ async def grant_credit(
 
             # Action buttons
             with tag.div(classes="modal-action"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(variant="primary", type="submit"):
                     text("Grant Credit")
 
@@ -4736,9 +4712,8 @@ async def import_orders(
             with tag.div(id="import-progress"):
                 pass
             with tag.div(classes="modal-action"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(
                     type="submit",
                     variant="primary",
@@ -4809,9 +4784,8 @@ async def add_payment_method_domain(
             validation_error=validation_error,
         ):
             with tag.div(classes="modal-action"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(
                     type="submit",
                     variant="primary",

--- a/server/polar/backoffice/organizations_v2/views/modals/delete_payout_account_modal.py
+++ b/server/polar/backoffice/organizations_v2/views/modals/delete_payout_account_modal.py
@@ -6,7 +6,7 @@ from collections.abc import Generator
 from pydantic import ValidationError
 from tagflow import tag, text
 
-from polar.backoffice.components import button, modal
+from polar.backoffice.components import button, modal, modal_close_button
 from polar.enums import PayoutAccountType
 from polar.models import PayoutAccount
 
@@ -100,9 +100,8 @@ class DeletePayoutAccountModal:
                     with tag.div(classes="mr-auto"):
                         pass  # spacer
 
-                    with tag.form(method="dialog"):
-                        with button(ghost=True, type="submit"):
-                            text("Cancel")
+                    with modal_close_button(ghost=True):
+                        text("Cancel")
 
                     with button(variant="error", type="submit"):
                         text("Delete Payout Account")

--- a/server/polar/backoffice/organizations_v2/views/modals/set_capability_modal.py
+++ b/server/polar/backoffice/organizations_v2/views/modals/set_capability_modal.py
@@ -6,7 +6,7 @@ from collections.abc import Generator
 from pydantic import ValidationError
 from tagflow import tag, text
 
-from polar.backoffice.components import button, modal
+from polar.backoffice.components import button, modal, modal_close_button
 from polar.models import Organization
 from polar.models.organization import STATUS_CAPABILITIES, CapabilityName
 
@@ -102,9 +102,8 @@ class SetCapabilityModal:
                         "flex justify-end gap-2"
                     )
                 ):
-                    with tag.form(method="dialog"):
-                        with button(ghost=True, type="submit"):
-                            text("Cancel")
+                    with modal_close_button(ghost=True):
+                        text("Cancel")
 
                     with button(variant="primary", outline=True, type="submit"):
                         text(f"{action_word} capability")

--- a/server/polar/backoffice/payouts/endpoints.py
+++ b/server/polar/backoffice/payouts/endpoints.py
@@ -30,7 +30,14 @@ from polar.postgres import AsyncSession, get_db_session
 from polar.worker import enqueue_job
 
 from .. import formatters
-from ..components import button, datatable, description_list, input, modal
+from ..components import (
+    button,
+    datatable,
+    description_list,
+    input,
+    modal,
+    modal_close_button,
+)
 from ..layout import layout
 from ..toast import add_toast
 from .forms import RetryPayoutForm
@@ -525,9 +532,8 @@ async def retry(
                 data={"account_amount": remaining_amount},
             ):
                 with tag.div(classes="modal-action"):
-                    with tag.form(method="dialog"):
-                        with button(ghost=True):
-                            text("Cancel")
+                    with modal_close_button(ghost=True):
+                        text("Cancel")
                     with button(
                         type="submit",
                         variant="primary",

--- a/server/polar/backoffice/subscriptions/endpoints.py
+++ b/server/polar/backoffice/subscriptions/endpoints.py
@@ -35,6 +35,7 @@ from ..components import (
     description_list,
     input,
     modal,
+    modal_close_button,
 )
 from ..layout import layout
 from ..orders.components import orders_datatable
@@ -481,9 +482,8 @@ async def cancel(
             validation_error=validation_error,
         ):
             with tag.div(classes="modal-action"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(type="submit", variant="primary"):
                     text("Submit")
 
@@ -653,8 +653,7 @@ async def update_billing_period_end(
             validation_error=validation_error,
         ):
             with tag.div(classes="modal-action"):
-                with tag.form(method="dialog"):
-                    with button(ghost=True):
-                        text("Cancel")
+                with modal_close_button(ghost=True):
+                    text("Cancel")
                 with button(type="submit", variant="primary"):
                     text("Submit")

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -118,6 +118,7 @@ lint_check = { cmd = "ruff format --check . && ruff check . && task lint_ast", h
 lint_ast = { cmd = "python -m scripts.linters", help = "run all custom AST lint rules" }
 lint_subquery = { cmd = "python -m scripts.linters --only subquery", help = "flag .subquery() calls that don't narrow columns" }
 lint_org_scope = { cmd = "python -m scripts.linters --only org-scope", help = "flag inline UserOrganization filters that bypass select_user_org_ids" }
+lint_nested_form = { cmd = "python -m scripts.linters --only nested-form", help = "flag nested <form> elements in backoffice views" }
 lint_types = { cmd = "mypy --num-workers 2 polar scripts tests", help = "run mypy type verify" }
 db_migrate = { cmd = "python -m scripts.db upgrade", help = "run alembic upgrade" }
 db_recreate = { cmd = "python -m scripts.db recreate", help = "drop and recreate database" }

--- a/server/scripts/linters/__main__.py
+++ b/server/scripts/linters/__main__.py
@@ -13,10 +13,15 @@ import ast
 import sys
 from pathlib import Path
 
-from . import frontend_url, org_scope, subquery
+from . import frontend_url, nested_form, org_scope, subquery
 from .base import Rule, line_has_skip
 
-RULES: tuple[Rule, ...] = (subquery.RULE, org_scope.RULE, frontend_url.RULE)
+RULES: tuple[Rule, ...] = (
+    subquery.RULE,
+    org_scope.RULE,
+    frontend_url.RULE,
+    nested_form.RULE,
+)
 
 
 def main() -> int:

--- a/server/scripts/linters/nested_form.py
+++ b/server/scripts/linters/nested_form.py
@@ -1,0 +1,89 @@
+"""Flag backoffice `tag.form(...)` blocks nested inside another form.
+
+HTML5 forbids nested `<form>` elements. The parser drops the inner start tag and
+reparents its children onto the outer form, so a "Cancel" button wrapped in
+`<form method="dialog">` inside an `hx-post` form becomes a submit button of that
+outer form: clicking Cancel performs the very action it was meant to abort.
+
+A form is opened by `tag.form(...)` or by rendering a `forms.BaseForm` subclass
+(`SomeForm.render(...)`, which emits the `<form>` element itself). Nesting is
+detected lexically within a single function, which is how these views are
+written.
+
+Use `modal_close_button()` from `polar.backoffice.components` for dismiss
+buttons, or move the inner form out so the two are siblings.
+"""
+
+from __future__ import annotations
+
+import ast
+
+from .base import Rule, Violation
+
+MESSAGE = (
+    "nested <form> element: HTML5 drops the inner form and reparents its "
+    "buttons onto the outer one, so a Cancel button here submits the outer "
+    "form. Use modal_close_button() from polar.backoffice.components, or make "
+    "the two forms siblings. Escape with `# lint-skip: nested-form` if the "
+    "nesting is intentional."
+)
+
+
+def _opens_form(item: ast.withitem) -> bool:
+    """Return True if the `with` item renders a `<form>` element."""
+    call = item.context_expr
+    if not isinstance(call, ast.Call):
+        return False
+    func = call.func
+    if not isinstance(func, ast.Attribute):
+        return False
+    if (
+        func.attr == "form"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "tag"
+    ):
+        return True
+    # `SomeForm.render(...)` renders the <form> element itself.
+    return func.attr == "render" and "Form" in ast.dump(func.value)
+
+
+class _Visitor(ast.NodeVisitor):
+    """Track the lexical form nesting depth, resetting at each function body."""
+
+    def __init__(self) -> None:
+        self.depth = 0
+        self.violations: list[Violation] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        outer_depth = self.depth
+        self.depth = 0
+        self.generic_visit(node)
+        self.depth = outer_depth
+
+    visit_AsyncFunctionDef = visit_FunctionDef  # type: ignore[assignment]
+
+    def visit_With(self, node: ast.With) -> None:
+        if any(_opens_form(item) for item in node.items):
+            if self.depth > 0:
+                self.violations.append((node.lineno, MESSAGE))
+            self.depth += 1
+            self.generic_visit(node)
+            self.depth -= 1
+        else:
+            self.generic_visit(node)
+
+    visit_AsyncWith = visit_With  # type: ignore[assignment]
+
+
+def check(tree: ast.Module) -> list[Violation]:
+    visitor = _Visitor()
+    visitor.visit(tree)
+    return visitor.violations
+
+
+RULE = Rule(
+    name="nested-form",
+    skip_code="nested-form",
+    summary="flag nested <form> elements in backoffice views",
+    check=check,
+)


### PR DESCRIPTION
## Summary

**Related Issue**: Fixes polarsource/feedback#278

Backoffice modal "Cancel" buttons were wrapped in a `<form method="dialog">` nested inside the modal's `hx-post` action form. HTML5 forbids nested `<form>` elements, so the browser drops the inner one and Cancel becomes a submit button of the action form — clicking it performs the very admin action it was meant to abort. This affects **34 dismiss buttons across 7 files**, not just `SetCapabilityModal`.

## What

- New `modal_close_button()` component (`polar/backoffice/components/_modal.py`), exported from `polar.backoffice.components`.
- All 34 nested dismiss buttons switched to it:

  | File | Sites |
  | --- | --- |
  | `organizations_v2/endpoints.py` | 26 |
  | `customers/endpoints.py` | 2 |
  | `subscriptions/endpoints.py` | 2 |
  | `orders/endpoints.py` | 1 |
  | `payouts/endpoints.py` | 1 |
  | `organizations_v2/views/modals/set_capability_modal.py` | 1 |
  | `organizations_v2/views/modals/delete_payout_account_modal.py` | 1 |

- New `nested-form` AST lint rule (`scripts/linters/nested_form.py`), wired into `task lint_ast` and exposed as `task lint_nested_form`.
- `AGENTS.md` / `DEVELOPMENT_GUIDE.md` updated — their modal examples used the old wrapper.

## Why

The original report named `set_capability_modal.py`. A lexical AST sweep of `polar/backoffice/` found 34 occurrences: 23 where the outer form is a literal `tag.form(...)`, and **11 where the outer `<form>` comes from `BaseForm.render(...)`** (`forms.py:624`) — that second group is invisible to a grep for `tag.form` inside `tag.form` and includes the refund, payout-retry, cancel-subscription and edit-customer-email modals.

Confirmed in Chromium against the buggy markup:

```
nested forms inside outer form: 0      # parser dropped the inner <form>
Cancel button .form               → outer1   # form owner is the POST form
click Cancel  → submit events on  ["outer1"] # HTMX would fire the hx-post
              → dialog still open
```

Not every dismiss button was affected — the sibling-form pattern in `support_case_section.py`, `_confirmation_dialog.py` and the modal's own ✕ button are valid HTML and are left alone.

## How

Three options were considered:

1. **Sibling forms** (the report's suggestion). Works only when the action form contains just a button. For these modals the action form wraps the whole body (reason textarea, inputs, action row), so a sibling Cancel would have to leave `modal-action`, breaking the layout, or every input would need a `form=` attribute. Rejected.
2. **`<button type="submit" form="…">`** pointing at a sibling `method="dialog"` form. Verified to work (form owner correctly resolves to the dialog form, no submit on the action form), but needs a unique id per modal, and the existing `on every htmx:beforeSend … toggle @disabled on <button[type='submit']/>` hyperscript would disable Cancel during requests.
3. **`type="button"` + close the `<dialog>` from script** — chosen. Safe regardless of where it is rendered, no ids, unaffected by the submit-disabling behaviour.

CSP is `script-src 'self'` with no `'unsafe-inline'`, so inline `onclick` is not an option. The close is done with hyperscript, which is already bundled in `scripts.mjs` and already used for element scripts elsewhere in the backoffice (e.g. `support_case_section.py:512`) — no build change needed.

```python
with modal_close_button(ghost=True):
    text("Cancel")
```

renders `<button class="btn btn-ghost" type="button" _="on click call me.closest('dialog').close()">Cancel</button>`.

Verified end to end in Chromium, driving the real component output through the real htmx + hyperscript bundle with the modal swapped in over HTMX (so hyperscript processes the fragment the same way it does in production):

```
nested forms inside the action form: 0
click Cancel             → requests: []          dialog open: false
click "Enable capability" → requests: ["post /apply"]
```

The lint rule flags `tag.form(...)` lexically inside another form-opening block, understands `SomeForm.render(...)`, ignores the valid sibling pattern, and supports `# lint-skip: nested-form`.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests — there is no backoffice render-test suite and no existing tests for `scripts/linters`; the regression guard is the new `nested-form` lint rule, which I verified against both the old buggy shape and the valid sibling shape
- [x] Linting passes: `ruff format --check`, `ruff check` and all four AST rules are clean. **`lint_types` was not run** — this container has no Python 3.14, so the `uv` env could not be created; please let CI confirm mypy
- [x] No unrelated changes or drive-by fixes are included

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7ykEi38GYDB75r622JmBr)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788021824&installation_model_id=13063&pr_number=13477&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13477&signature=265cc7cda90b1fcf6d6433348d794b0af4aaf0b853afa340eb976508a5b20548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

