### PR TITLE
Always check for `deleted_at`, drop redundant index

### DIFF
--- a/server/migrations/versions/2026-07-31-0954_drop_redundant_billing_entry_index.py
+++ b/server/migrations/versions/2026-07-31-0954_drop_redundant_billing_entry_index.py
@@ -1,0 +1,46 @@
+"""drop redundant billing entry index
+
+Revision ID: 5a1b80eeae48
+Revises: 72c8a2d0ea56
+Create Date: 2026-07-31 09:54:49.326543
+
+"""
+
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "5a1b80eeae48"
+down_revision = "72c8a2d0ea56"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+INDEX_NAME = "ix_billing_entries_s_oi_pp"
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            INDEX_NAME,
+            table_name="billing_entry",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            INDEX_NAME,
+            table_name="billing_entry",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            INDEX_NAME,
+            "billing_entry",
+            ["subscription_id", "order_item_id", "product_price_id"],
+            unique=False,
+            postgresql_concurrently=True,
+        )

--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -383,6 +383,7 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
             .join(BillingEntry, Event.id == BillingEntry.event_id)
             .where(
                 BillingEntry.subscription_id == subscription,
+                BillingEntry.deleted_at.is_(None),
                 BillingEntry.order_item_id.is_(None),
                 BillingEntry.product_price_id == price,
             )
@@ -406,6 +407,7 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
             )
             .where(
                 BillingEntry.subscription_id == subscription,
+                BillingEntry.deleted_at.is_(None),
                 BillingEntry.order_item_id.is_(None),
                 ProductPriceMeteredUnit.meter_id == meter,
             )

--- a/server/polar/models/billing_entry.py
+++ b/server/polar/models/billing_entry.py
@@ -38,12 +38,6 @@ class BillingEntry(RecordModel):
     __tablename__ = "billing_entry"
     __table_args__ = (
         Index(
-            "ix_billing_entries_s_oi_pp",
-            "subscription_id",
-            "order_item_id",
-            "product_price_id",
-        ),
-        Index(
             "ix_billing_entries_s_d_oi_pp",
             "subscription_id",
             "deleted_at",

--- a/server/tests/billing_entry/test_service.py
+++ b/server/tests/billing_entry/test_service.py
@@ -6,6 +6,7 @@ import pytest_asyncio
 from polar.billing_entry.service import billing_entry as billing_entry_service
 from polar.enums import SubscriptionProrationBehavior, SubscriptionRecurringInterval
 from polar.event.system import SystemEvent
+from polar.kit.utils import utc_now
 from polar.meter.aggregation import AggregationFunction, PropertyAggregation
 from polar.meter.filter import Filter, FilterConjunction
 from polar.models import (
@@ -330,6 +331,15 @@ class TestCreateOrderItemsFromPending:
                 tokens=30,
             ),
         ]
+        deleted_entry = await create_metered_event_billing_entry(
+            save_fixture,
+            customer=customer,
+            price=price,
+            subscription=metered_subscription,
+            tokens=40,
+        )
+        deleted_entry.deleted_at = utc_now()
+        await save_fixture(deleted_entry)
 
         async with billing_entry_service.create_order_items_from_pending(
             session, metered_subscription
@@ -700,6 +710,16 @@ class TestCreateOrderItemsFromPending:
                 metadata_key="servers",
             ),
         ]
+        deleted_entry = await create_metered_event_billing_entry(
+            save_fixture,
+            customer=customer,
+            price=price_a,
+            subscription=subscription,
+            tokens=100,
+            metadata_key="servers",
+        )
+        deleted_entry.deleted_at = utc_now()
+        await save_fixture(deleted_entry)
 
         # Simulate product change: create new price for same meter but different product
         product_b = await create_product(


### PR DESCRIPTION
I do believe this also fixes a potential bug where we could have billed for deleted entries.