### PR TITLE
observability: alert on unbilled cycle billing entries

### DIFF
--- a/server/polar/observability/invariants/rules/__init__.py
+++ b/server/polar/observability/invariants/rules/__init__.py
@@ -8,6 +8,7 @@ from .subscriptions_canceled_deleted_customer import (
 from .subscriptions_current_period_end import SubscriptionsCurrentPeriodEndInvariant
 from .subscriptions_future_period_start import SubscriptionsFuturePeriodStartInvariant
 from .subscriptions_locked_invariant import SubscriptionsLockedInvariant
+from .unbilled_cycle_billing_entries import UnbilledCycleBillingEntriesInvariant
 
 INVARIANTS: set[type[Invariant]] = {
     NoRecentOrdersInvariant,
@@ -17,6 +18,7 @@ INVARIANTS: set[type[Invariant]] = {
     SubscriptionsCurrentPeriodEndInvariant,
     SubscriptionsFuturePeriodStartInvariant,
     SubscriptionsLockedInvariant,
+    UnbilledCycleBillingEntriesInvariant,
 }
 
 __all__ = ["INVARIANTS", "Invariant", "InvariantError"]

--- a/server/polar/observability/invariants/rules/unbilled_cycle_billing_entries.py
+++ b/server/polar/observability/invariants/rules/unbilled_cycle_billing_entries.py
@@ -1,0 +1,71 @@
+import uuid
+from datetime import timedelta
+
+from sqlalchemy import func, over, select
+
+from polar.models import BillingEntry, Organization, Subscription
+from polar.models.billing_entry import BillingEntryType
+from polar.models.subscription import SubscriptionStatus
+
+from .base import Invariant, InvariantError
+
+
+class UnbilledCycleBillingEntriesInvariantError(InvariantError):
+    """Exception raised when the UnbilledCycleBillingEntriesInvariant check fails."""
+
+    def __init__(self, count: int, subscriptions: list[uuid.UUID]) -> None:
+        message = (
+            f"Found {count} cycle billing entries not attached to an order item. "
+            "The subscription cycled but its order was never created."
+        )
+        super().__init__(
+            UnbilledCycleBillingEntriesInvariant,
+            message,
+            {
+                "count": count,
+                "subscriptions": {
+                    "ids": subscriptions,
+                    "has_more": count > len(subscriptions),
+                },
+            },
+        )
+
+
+class UnbilledCycleBillingEntriesInvariant(Invariant):
+    """
+    Invariant that checks if there are any cycle billing entries never attached to an order item.
+
+    Failure of this invariant indicate there is an issue with the subscription cycle process.
+    """
+
+    LEEWAY = timedelta(hours=6)
+    LIMIT = 10
+
+    async def check(self) -> None:
+        statement = (
+            select(BillingEntry.subscription_id, over(func.count()))
+            .join(BillingEntry.subscription)
+            .join(Subscription.organization)
+            .where(
+                BillingEntry.deleted_at.is_(None),
+                BillingEntry.type == BillingEntryType.cycle,
+                BillingEntry.order_item_id.is_(None),
+                BillingEntry.created_at < (func.now() - self.LEEWAY),
+                Subscription.deleted_at.is_(None),
+                Subscription.status != SubscriptionStatus.canceled,
+                Organization.deleted_at.is_(None),
+            )
+            .limit(self.LIMIT)
+            .order_by(BillingEntry.created_at.asc(), BillingEntry.subscription_id.asc())
+        )
+
+        result = await self.session.execute(statement)
+        results = result.fetchall()
+        if len(results) > 0:
+            count = results[0][1]
+        else:
+            count = 0
+
+        if count > 0:
+            subscriptions = [row[0] for row in results]
+            raise UnbilledCycleBillingEntriesInvariantError(count, subscriptions)

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -2367,6 +2367,7 @@ async def create_billing_entry(
     currency: str | None = None,
     subscription: Subscription | None = None,
     order_item: OrderItem | None = None,
+    created_at: datetime | None = None,
 ) -> BillingEntry:
     if event is None:
         event = await create_event(
@@ -2383,6 +2384,7 @@ async def create_billing_entry(
         end_timestamp = event.timestamp
 
     billing_entry = BillingEntry(
+        created_at=created_at or utc_now(),
         start_timestamp=start_timestamp,
         end_timestamp=end_timestamp,
         type=type,

--- a/server/tests/observability/invariants/rules/test_unbilled_cycle_billing_entries.py
+++ b/server/tests/observability/invariants/rules/test_unbilled_cycle_billing_entries.py
@@ -1,0 +1,182 @@
+from datetime import timedelta
+
+import pytest
+import pytest_asyncio
+
+from polar.kit.utils import utc_now
+from polar.models import Customer, Product
+from polar.models.billing_entry import BillingEntryType
+from polar.models.order_item import OrderItem
+from polar.models.subscription import SubscriptionStatus
+from polar.observability.invariants.rules.unbilled_cycle_billing_entries import (
+    UnbilledCycleBillingEntriesInvariant,
+    UnbilledCycleBillingEntriesInvariantError,
+)
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import (
+    create_billing_entry,
+    create_order,
+    create_subscription,
+)
+
+
+@pytest_asyncio.fixture
+async def invariant(session: AsyncSession) -> UnbilledCycleBillingEntriesInvariant:
+    return UnbilledCycleBillingEntriesInvariant(session)
+
+
+@pytest.mark.asyncio
+async def test_failure(
+    invariant: UnbilledCycleBillingEntriesInvariant,
+    save_fixture: SaveFixture,
+    product: Product,
+    customer: Customer,
+) -> None:
+    subscription = await create_subscription(
+        save_fixture,
+        status=SubscriptionStatus.active,
+        product=product,
+        customer=customer,
+    )
+    await create_billing_entry(
+        save_fixture,
+        type=BillingEntryType.cycle,
+        customer=customer,
+        product_price=product.prices[0],
+        subscription=subscription,
+        created_at=utc_now() - timedelta(hours=7),
+    )
+
+    with pytest.raises(UnbilledCycleBillingEntriesInvariantError) as exc_info:
+        await invariant.check()
+    assert exc_info.value.context == {
+        "count": 1,
+        "subscriptions": {"ids": [subscription.id], "has_more": False},
+    }
+
+
+@pytest.mark.asyncio
+async def test_failure_over_limit(
+    invariant: UnbilledCycleBillingEntriesInvariant,
+    save_fixture: SaveFixture,
+    product: Product,
+    customer: Customer,
+) -> None:
+    for _ in range(15):
+        subscription = await create_subscription(
+            save_fixture,
+            status=SubscriptionStatus.active,
+            product=product,
+            customer=customer,
+        )
+        await create_billing_entry(
+            save_fixture,
+            type=BillingEntryType.cycle,
+            customer=customer,
+            product_price=product.prices[0],
+            subscription=subscription,
+            created_at=utc_now() - timedelta(hours=7),
+        )
+
+    with pytest.raises(UnbilledCycleBillingEntriesInvariantError) as exc_info:
+        await invariant.check()
+    assert exc_info.value.context["count"] == 15
+    assert len(exc_info.value.context["subscriptions"]["ids"]) == 10
+    assert exc_info.value.context["subscriptions"]["has_more"] is True
+
+
+@pytest.mark.asyncio
+async def test_success(
+    invariant: UnbilledCycleBillingEntriesInvariant,
+    save_fixture: SaveFixture,
+    product: Product,
+    customer: Customer,
+) -> None:
+    subscription = await create_subscription(
+        save_fixture,
+        status=SubscriptionStatus.active,
+        product=product,
+        customer=customer,
+    )
+
+    # Billed: attached to an order item
+    order_item = OrderItem(
+        label="",
+        amount=1000,
+        net_amount=1000,
+        tax_amount=0,
+        proration=False,
+    )
+    await create_order(
+        save_fixture,
+        customer=customer,
+        product=product,
+        subscription=subscription,
+        order_items=[order_item],
+    )
+    await create_billing_entry(
+        save_fixture,
+        type=BillingEntryType.cycle,
+        customer=customer,
+        product_price=product.prices[0],
+        subscription=subscription,
+        order_item=order_item,
+        created_at=utc_now() - timedelta(hours=7),
+    )
+
+    # Pending, but the order creation job may still be retrying
+    await create_billing_entry(
+        save_fixture,
+        type=BillingEntryType.cycle,
+        customer=customer,
+        product_price=product.prices[0],
+        subscription=subscription,
+        created_at=utc_now() - timedelta(hours=2),
+    )
+
+    # Metered entries are legitimately pending for the whole period
+    await create_billing_entry(
+        save_fixture,
+        type=BillingEntryType.metered,
+        customer=customer,
+        product_price=product.prices[0],
+        subscription=subscription,
+        created_at=utc_now() - timedelta(hours=7),
+    )
+
+    # Entries of a deleted subscription are never going to be billed
+    deleted_subscription = await create_subscription(
+        save_fixture,
+        status=SubscriptionStatus.active,
+        product=product,
+        customer=customer,
+    )
+    deleted_subscription.set_deleted_at()
+    await save_fixture(deleted_subscription)
+    await create_billing_entry(
+        save_fixture,
+        type=BillingEntryType.cycle,
+        customer=customer,
+        product_price=product.prices[0],
+        subscription=deleted_subscription,
+        created_at=utc_now() - timedelta(hours=7),
+    )
+
+    # Canceled subscriptions are excluded
+    canceled_subscription = await create_subscription(
+        save_fixture,
+        status=SubscriptionStatus.canceled,
+        product=product,
+        customer=customer,
+    )
+    await create_billing_entry(
+        save_fixture,
+        type=BillingEntryType.cycle,
+        customer=customer,
+        product_price=product.prices[0],
+        subscription=canceled_subscription,
+        created_at=utc_now() - timedelta(hours=7),
+    )
+
+    await invariant.check()


### PR DESCRIPTION
## Summary

Add an invariant that alerts when cycle billing entries stay unattached to an order past a leeway (cycle ran, order never created).

I'm not 100% sure but I think this invariant check won't catch pure usage-based subscriptions without a static price, since it checks only 'cycle' entries.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788080102&installation_model_id=13063&pr_number=13480&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13480&signature=e7c69526126cf57a9ded088aeb93db43e2c89e12e34b29717e26e9c01b252197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

