### PR TITLE
feat(organization): enforce dispute_settings not null

### DIFF
--- a/server/migrations/versions/2026-07-31-1152_enforce_organizations_dispute_settings_.py
+++ b/server/migrations/versions/2026-07-31-1152_enforce_organizations_dispute_settings_.py
@@ -1,0 +1,50 @@
+"""enforce organizations dispute_settings not null
+
+Revision ID: 5a95b59f156b
+Revises: 98f971463e5d
+Create Date: 2026-07-31 11:52:34.032752
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "5a95b59f156b"
+down_revision = "98f971463e5d"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+
+def upgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    # `organizations` is a busy table: allow longer to acquire the lock.
+    op.execute("SET LOCAL lock_timeout = '30s'")
+    op.execute(
+        """
+        UPDATE organizations
+        SET dispute_settings = '{"auto_accept_below_amount": null, "auto_accept_currency": null}'
+        WHERE dispute_settings IS NULL
+        """
+    )
+    op.alter_column(
+        "organizations",
+        "dispute_settings",
+        existing_type=postgresql.JSONB(astext_type=sa.Text()),
+        nullable=False,
+    )
+
+
+def downgrade() -> None:
+    # Ensures we don't break app by applying a deadlock-inducing migration
+    # `organizations` is a busy table: allow longer to acquire the lock.
+    op.execute("SET LOCAL lock_timeout = '30s'")
+    op.alter_column(
+        "organizations",
+        "dispute_settings",
+        existing_type=postgresql.JSONB(astext_type=sa.Text()),
+        nullable=True,
+    )

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -674,8 +674,8 @@ class Organization(RateLimitGroupMixin, RecordModel):
         JSONB, nullable=False, default=_default_checkout_settings
     )
 
-    dispute_settings: Mapped[OrganizationDisputeSettings | None] = mapped_column(
-        JSONB, nullable=True, default=_default_dispute_settings
+    dispute_settings: Mapped[OrganizationDisputeSettings] = mapped_column(
+        JSONB, nullable=False, default=_default_dispute_settings
     )
 
     embed_hosts: Mapped[list[str]] = mapped_column(JSONB, nullable=False, default=list)
@@ -903,6 +903,14 @@ class Organization(RateLimitGroupMixin, RecordModel):
     @property
     def checkout_require_3ds(self) -> bool:
         return self.checkout_settings.get("require_3ds", False)
+
+    @property
+    def dispute_auto_accept_below_amount(self) -> int | None:
+        return self.dispute_settings["auto_accept_below_amount"]
+
+    @property
+    def dispute_auto_accept_currency(self) -> str | None:
+        return self.dispute_settings["auto_accept_currency"]
 
     @declared_attr
     def all_products(cls) -> Mapped[list["Product"]]:


### PR DESCRIPTION
## Summary

Don't merge before I run the backfill script from https://github.com/polarsource/polar/pull/13467

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788083815&installation_model_id=13063&pr_number=13482&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13482&signature=ec7d3c538458eaecf486b9eeaad8b89ec3423bba8f1dc3724da6ebd9d520e1ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces `organizations.dispute_settings` to be non-null at the DB and model level to ensure consistent access. Adds simple accessors for dispute auto-accept settings.

- **Migration**
  - Backfills nulls to `{"auto_accept_below_amount": null, "auto_accept_currency": null}` and sets NOT NULL with a 30s lock timeout.
  - Applies Alembic migration to enforce the constraint.

- **New Features**
  - Adds `dispute_auto_accept_below_amount` and `dispute_auto_accept_currency` properties on `Organization`.
  - Makes the model column `nullable=False` with a default.

<sup>Written for commit a75e033e1061993345679b060431e09ce066dcaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

