### PR TITLE
Use subscription cycle date for usage billing cut-off & meter reset

### DIFF
--- a/server/polar/billing_entry/repository.py
+++ b/server/polar/billing_entry/repository.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from itertools import batched
 from uuid import UUID
 
-from sqlalchemy import Select, func, select, update
+from sqlalchemy import Select, and_, func, or_, select, update
 from sqlalchemy.orm.strategy_options import contains_eager, joinedload
 
 from polar.config import settings
@@ -14,6 +14,7 @@ from polar.kit.repository import (
     RepositorySoftDeletionMixin,
 )
 from polar.models import BillingEntry
+from polar.models.billing_entry import BillingEntryType
 from polar.models.product_price import ProductPrice, ProductPriceMeteredUnit
 
 
@@ -47,18 +48,22 @@ class BillingEntryRepository(
         return await self.get_all(statement)
 
     async def get_pending_by_subscription(
-        self, subscription_id: UUID, *, options: Options = ()
+        self,
+        subscription_id: UUID,
+        *,
+        cutoff: datetime | None = None,
+        options: Options = (),
     ) -> Sequence[BillingEntry]:
         statement = self.get_pending_by_subscription_statement(
-            subscription_id, options=options
+            subscription_id, cutoff=cutoff, options=options
         )
         return await self.get_all(statement)
 
     async def get_static_pending_by_subscription(
-        self, subscription_id: UUID
+        self, subscription_id: UUID, *, cutoff: datetime | None = None
     ) -> AsyncGenerator[BillingEntry]:
         statement = (
-            self.get_pending_by_subscription_statement(subscription_id)
+            self.get_pending_by_subscription_statement(subscription_id, cutoff=cutoff)
             .join(BillingEntry.product_price)
             .where(ProductPrice.is_static.is_(True))
             .options(
@@ -70,7 +75,7 @@ class BillingEntryRepository(
             yield result
 
     async def get_pending_metered_by_subscription_tuples(
-        self, subscription_id: UUID
+        self, subscription_id: UUID, *, cutoff: datetime | None = None
     ) -> AsyncGenerator[tuple[UUID, UUID, datetime, datetime]]:
         """
         Get pending metered billing entries grouped by (product_price_id, meter_id).
@@ -84,7 +89,7 @@ class BillingEntryRepository(
         subscription.subscription_product_prices, not from these tuples.
         """
         statement = (
-            self.get_pending_by_subscription_statement(subscription_id)
+            self.get_pending_by_subscription_statement(subscription_id, cutoff=cutoff)
             .join(
                 ProductPriceMeteredUnit,
                 BillingEntry.product_price_id == ProductPriceMeteredUnit.id,
@@ -110,10 +115,14 @@ class BillingEntryRepository(
             await results.close()
 
     async def get_pending_ids_by_subscription_and_price(
-        self, subscription_id: UUID, product_price_id: UUID
+        self,
+        subscription_id: UUID,
+        product_price_id: UUID,
+        *,
+        cutoff: datetime | None = None,
     ) -> Sequence[UUID]:
         statement = (
-            self.get_pending_by_subscription_statement(subscription_id)
+            self.get_pending_by_subscription_statement(subscription_id, cutoff=cutoff)
             .with_only_columns(BillingEntry.id)
             .where(BillingEntry.product_price_id == product_price_id)
         )
@@ -121,13 +130,17 @@ class BillingEntryRepository(
         return results.scalars().unique().all()
 
     async def get_pending_ids_by_subscription_and_meter(
-        self, subscription_id: UUID, meter_id: UUID
+        self,
+        subscription_id: UUID,
+        meter_id: UUID,
+        *,
+        cutoff: datetime | None = None,
     ) -> Sequence[UUID]:
         """
         Get all pending billing entry IDs for a subscription and meter across all prices.
         """
         statement = (
-            self.get_pending_by_subscription_statement(subscription_id)
+            self.get_pending_by_subscription_statement(subscription_id, cutoff=cutoff)
             .join(
                 ProductPriceMeteredUnit,
                 BillingEntry.product_price_id == ProductPriceMeteredUnit.id,
@@ -138,7 +151,9 @@ class BillingEntryRepository(
         results = await self.session.execute(statement)
         return results.scalars().unique().all()
 
-    async def lock_pending_by_subscription(self, subscription_id: UUID) -> None:
+    async def lock_pending_by_subscription(
+        self, subscription_id: UUID, *, cutoff: datetime | None = None
+    ) -> None:
         """
         Acquire FOR UPDATE locks on all pending billing entries for a subscription.
 
@@ -148,16 +163,20 @@ class BillingEntryRepository(
         the entries are no longer pending.
         """
         statement = (
-            self.get_pending_by_subscription_statement(subscription_id)
+            self.get_pending_by_subscription_statement(subscription_id, cutoff=cutoff)
             .with_only_columns(BillingEntry.id)
             .with_for_update()
         )
         await self.session.execute(statement)
 
     def get_pending_by_subscription_statement(
-        self, subscription_id: UUID, *, options: Options = ()
+        self,
+        subscription_id: UUID,
+        *,
+        cutoff: datetime | None = None,
+        options: Options = (),
     ) -> Select[tuple["BillingEntry"]]:
-        return (
+        statement = (
             self.get_base_statement()
             .where(
                 BillingEntry.order_item_id.is_(None),
@@ -166,3 +185,16 @@ class BillingEntryRepository(
             .order_by(BillingEntry.product_price_id.asc())
             .options(*options)
         )
+        if cutoff is not None:
+            # Usage at the boundary belongs to the next meter window, while
+            # static entries created there are the new period's recurring charge.
+            statement = statement.where(
+                or_(
+                    BillingEntry.start_timestamp < cutoff,
+                    and_(
+                        BillingEntry.start_timestamp == cutoff,
+                        BillingEntry.type != BillingEntryType.metered,
+                    ),
+                )
+            )
+        return statement

--- a/server/polar/billing_entry/service.py
+++ b/server/polar/billing_entry/service.py
@@ -54,14 +54,18 @@ class MeteredLineItem:
 class BillingEntryService:
     @contextlib.asynccontextmanager
     async def create_order_items_from_pending(
-        self, session: AsyncSession, subscription: Subscription
+        self,
+        session: AsyncSession,
+        subscription: Subscription,
+        *,
+        cutoff: datetime | None = None,
     ) -> AsyncGenerator[Sequence[OrderItem]]:
         repository = BillingEntryRepository.from_session(session)
-        await repository.lock_pending_by_subscription(subscription.id)
+        await repository.lock_pending_by_subscription(subscription.id, cutoff=cutoff)
 
         item_entries_map: dict[OrderItem, Sequence[uuid.UUID]] = {}
         async for line_item, entries in self.compute_pending_subscription_line_items(
-            session, subscription
+            session, subscription, cutoff=cutoff
         ):
             order_item = OrderItem(
                 id=uuid.uuid4(),
@@ -81,12 +85,16 @@ class BillingEntryService:
             await repository.update_order_item_id(entries, order_item.id)
 
     async def compute_pending_subscription_line_items(
-        self, session: AsyncSession, subscription: Subscription
+        self,
+        session: AsyncSession,
+        subscription: Subscription,
+        *,
+        cutoff: datetime | None = None,
     ) -> AsyncGenerator[tuple[StaticLineItem | MeteredLineItem, Sequence[uuid.UUID]]]:
         repository = BillingEntryRepository.from_session(session)
 
         async for entry in repository.get_static_pending_by_subscription(
-            subscription.id
+            subscription.id, cutoff=cutoff
         ):
             static_price = cast(StaticPrice, entry.product_price)
             static_line_item = await self._get_static_price_line_item(
@@ -113,7 +121,9 @@ class BillingEntryService:
             meter_id,
             start_timestamp,
             end_timestamp,
-        ) in repository.get_pending_metered_by_subscription_tuples(subscription.id):
+        ) in repository.get_pending_metered_by_subscription_tuples(
+            subscription.id, cutoff=cutoff
+        ):
             metered_price = cast(
                 MeteredPrice, await product_price_repository.get_by_id(product_price_id)
             )
@@ -147,11 +157,16 @@ class BillingEntryService:
                     continue
 
                 metered_line_item = await self._get_metered_line_item_by_meter(
-                    session, active_price, subscription, start_timestamp, end_timestamp
+                    session,
+                    active_price,
+                    subscription,
+                    start_timestamp,
+                    end_timestamp,
+                    cutoff=cutoff,
                 )
                 pending_entries_ids = (
                     await repository.get_pending_ids_by_subscription_and_meter(
-                        subscription.id, meter_id
+                        subscription.id, meter_id, cutoff=cutoff
                     )
                 )
             else:
@@ -171,11 +186,16 @@ class BillingEntryService:
                     continue
 
                 metered_line_item = await self._get_metered_line_item(
-                    session, metered_price, subscription, start_timestamp, end_timestamp
+                    session,
+                    metered_price,
+                    subscription,
+                    start_timestamp,
+                    end_timestamp,
+                    cutoff=cutoff,
                 )
                 pending_entries_ids = (
                     await repository.get_pending_ids_by_subscription_and_price(
-                        subscription.id, product_price_id
+                        subscription.id, product_price_id, cutoff=cutoff
                     )
                 )
 
@@ -247,6 +267,8 @@ class BillingEntryService:
         subscription: Subscription,
         start_timestamp: datetime,
         end_timestamp: datetime,
+        *,
+        cutoff: datetime | None,
     ) -> MeteredLineItem:
         """
         Compute a metered line item for a specific price.
@@ -254,7 +276,7 @@ class BillingEntryService:
         """
         event_repository = EventRepository.from_session(session)
         events_statement = event_repository.get_by_pending_entries_statement(
-            subscription.id, price.id
+            subscription.id, price.id, cutoff=cutoff
         )
         meter = price.meter
         units = await meter_service.get_quantity(
@@ -294,6 +316,8 @@ class BillingEntryService:
         subscription: Subscription,
         start_timestamp: datetime,
         end_timestamp: datetime,
+        *,
+        cutoff: datetime | None,
     ) -> MeteredLineItem:
         """
         Compute a metered line item grouped by meter.
@@ -306,7 +330,7 @@ class BillingEntryService:
 
         # Get events across ALL prices for this meter
         events_statement = event_repository.get_by_pending_entries_for_meter_statement(
-            subscription.id, meter.id
+            subscription.id, meter.id, cutoff=cutoff
         )
         units = await meter_service.get_quantity(
             session,

--- a/server/polar/customer_meter/service.py
+++ b/server/polar/customer_meter/service.py
@@ -245,10 +245,15 @@ class CustomerMeterService:
         return await repository.update(customer_meter), True
 
     async def get_rollover_units(
-        self, session: AsyncSession, customer: Customer, meter: Meter
+        self,
+        session: AsyncSession,
+        customer: Customer,
+        meter: Meter,
+        *,
+        cutoff: datetime | None = None,
     ) -> int:
         last_event = await self._get_latest_current_window_event(
-            session, customer, meter
+            session, customer, meter, cutoff=cutoff
         )
 
         if last_event is None:
@@ -256,9 +261,13 @@ class CustomerMeterService:
 
         event_repository = EventRepository.from_session(session)
 
-        usage_units = await self._get_usage_quantity(session, customer, meter)
+        usage_units = await self._get_usage_quantity(
+            session, customer, meter, cutoff=cutoff
+        )
 
-        credit_events = await self._get_credit_events(customer, meter, event_repository)
+        credit_events = await self._get_credit_events(
+            customer, meter, event_repository, cutoff=cutoff
+        )
         non_rollover_units = non_negative_running_sum(
             event.user_metadata["units"]
             for event in credit_events
@@ -279,13 +288,15 @@ class CustomerMeterService:
         customer: Customer,
         meter: Meter,
         ingested_at_lower_bound: datetime | None = None,
+        *,
+        cutoff: datetime | None = None,
     ) -> Event | None:
         """
         Get the most recent event in the current meter window.
         """
         event_repository = EventRepository.from_session(session)
         meter_reset_event = await event_repository.get_latest_meter_reset(
-            customer, meter.id
+            customer, meter.id, cutoff=cutoff
         )
 
         by_customer_id = self._build_latest_event_statement(
@@ -295,6 +306,7 @@ class CustomerMeterService:
             meter_reset_event,
             by_external_id=False,
             ingested_at_lower_bound=ingested_at_lower_bound,
+            cutoff=cutoff,
         )
 
         # No union required when no external_id
@@ -311,6 +323,7 @@ class CustomerMeterService:
             meter_reset_event,
             by_external_id=True,
             ingested_at_lower_bound=ingested_at_lower_bound,
+            cutoff=cutoff,
         )
         union_statement = union_all(by_customer_id, by_external_id)
         union_statement = union_statement.order_by(Event.ingested_at.desc()).limit(1)
@@ -322,8 +335,8 @@ class CustomerMeterService:
             external_customer_id=customer.external_id,
             meter_id=str(meter.id),
             meter_filter=meter.filter.model_dump_json() if meter.filter else None,
-            meter_reset_event_ingested_at=(
-                meter_reset_event.ingested_at.isoformat() if meter_reset_event else None
+            meter_reset_event_timestamp=(
+                meter_reset_event.timestamp.isoformat() if meter_reset_event else None
             ),
             ingested_at_lower_bound=ingested_at_lower_bound,
         ):
@@ -363,7 +376,7 @@ class CustomerMeterService:
 
         if meter_reset_event is not None:
             statement = statement.where(
-                MeterEvent.ingested_at >= meter_reset_event.ingested_at
+                MeterEvent.ingested_at >= meter_reset_event.timestamp
             )
 
         if ingested_at_lower_bound is not None:
@@ -424,6 +437,7 @@ class CustomerMeterService:
         meter: Meter,
         meter_reset_event: Event | None,
         by_external_id: bool = False,
+        cutoff: datetime | None = None,
     ) -> Select[tuple[Event]]:
         """Build statement for events by customer_id or external_id (no LIMIT)."""
         statement = event_repository.get_base_statement().where(
@@ -439,8 +453,11 @@ class CustomerMeterService:
 
         if meter_reset_event is not None:
             statement = statement.where(
-                Event.ingested_at >= meter_reset_event.ingested_at
+                Event.ingested_at >= meter_reset_event.timestamp
             )
+
+        if cutoff is not None:
+            statement = statement.where(Event.timestamp < cutoff)
 
         if by_external_id:
             statement = statement.where(event_repository.get_meter_clause(meter))
@@ -462,17 +479,28 @@ class CustomerMeterService:
         meter_reset_event: Event | None,
         by_external_id: bool = False,
         ingested_at_lower_bound: datetime | None = None,
+        cutoff: datetime | None = None,
     ) -> Select[tuple[Event]]:
         """Build a LIMIT 1 statement for getting the latest event."""
         statement = self._build_events_statement(
-            event_repository, customer, meter, meter_reset_event, by_external_id
+            event_repository,
+            customer,
+            meter,
+            meter_reset_event,
+            by_external_id,
+            cutoff,
         )
         if ingested_at_lower_bound is not None:
             statement = statement.where(Event.ingested_at >= ingested_at_lower_bound)
         return statement.order_by(Event.ingested_at.desc()).limit(1)
 
     async def _get_usage_quantity(
-        self, session: AsyncSession, customer: Customer, meter: Meter
+        self,
+        session: AsyncSession,
+        customer: Customer,
+        meter: Meter,
+        *,
+        cutoff: datetime | None = None,
     ) -> float:
         """
         Get the aggregated usage quantity for a customer's meter.
@@ -485,13 +513,18 @@ class CustomerMeterService:
         """
         event_repository = EventRepository.from_session(session)
         meter_reset_event = await event_repository.get_latest_meter_reset(
-            customer, meter.id
+            customer, meter.id, cutoff=cutoff
         )
 
         agg_column = func.coalesce(meter.aggregation.get_sql_column(Event), 0)
 
         by_customer_id = self._build_events_statement(
-            event_repository, customer, meter, meter_reset_event, by_external_id=False
+            event_repository,
+            customer,
+            meter,
+            meter_reset_event,
+            by_external_id=False,
+            cutoff=cutoff,
         ).where(Event.source == EventSource.user)
 
         if customer.external_id is None:
@@ -499,7 +532,12 @@ class CustomerMeterService:
             return result or 0.0
 
         by_external_id = self._build_events_statement(
-            event_repository, customer, meter, meter_reset_event, by_external_id=True
+            event_repository,
+            customer,
+            meter,
+            meter_reset_event,
+            by_external_id=True,
+            cutoff=cutoff,
         ).where(Event.source == EventSource.user)
 
         if meter.aggregation.is_summable():
@@ -556,6 +594,8 @@ class CustomerMeterService:
         customer: Customer,
         meter: Meter,
         event_repository: EventRepository,
+        *,
+        cutoff: datetime | None = None,
     ) -> Sequence[Event]:
         """
         Get credit events for a customer's meter.
@@ -564,7 +604,7 @@ class CustomerMeterService:
         customer_id, never external_customer_id, so no UNION is needed.
         """
         meter_reset_event = await event_repository.get_latest_meter_reset(
-            customer, meter.id
+            customer, meter.id, cutoff=cutoff
         )
 
         statement = (
@@ -574,6 +614,7 @@ class CustomerMeterService:
                 meter,
                 meter_reset_event,
                 by_external_id=False,
+                cutoff=cutoff,
             )
             .where(Event.is_meter_credit.is_(True))
             .order_by(Event.timestamp.asc())
@@ -614,7 +655,7 @@ class CustomerMeterService:
 
         if meter_reset_event is not None:
             statement = statement.where(
-                MeterEvent.ingested_at >= meter_reset_event.ingested_at
+                MeterEvent.ingested_at >= meter_reset_event.timestamp
             )
 
         result = await session.scalar(statement)
@@ -644,7 +685,7 @@ class CustomerMeterService:
 
         if meter_reset_event is not None:
             statement = statement.where(
-                MeterEvent.ingested_at >= meter_reset_event.ingested_at
+                MeterEvent.ingested_at >= meter_reset_event.timestamp
             )
 
         statement = statement.order_by(Event.timestamp.asc())

--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -243,7 +243,11 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         return result.scalar_one_or_none()
 
     async def get_latest_meter_reset(
-        self, customer: Customer, meter_id: UUID
+        self,
+        customer: Customer,
+        meter_id: UUID,
+        *,
+        cutoff: datetime | None = None,
     ) -> Event | None:
         statement = (
             self.get_base_statement()
@@ -256,6 +260,8 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
             .order_by(Event.timestamp.desc())
             .limit(1)
         )
+        if cutoff is not None:
+            statement = statement.where(Event.timestamp < cutoff)
         return await self.get_one_or_none(statement)
 
     def get_customer_id_filter_clause(
@@ -376,9 +382,13 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         return [(event, customer) for event, customer in result.all()]
 
     def get_by_pending_entries_statement(
-        self, subscription: UUID, price: UUID
+        self,
+        subscription: UUID,
+        price: UUID,
+        *,
+        cutoff: datetime | None = None,
     ) -> Select[tuple[Event]]:
-        return (
+        statement = (
             self.get_base_statement()
             .join(BillingEntry, Event.id == BillingEntry.event_id)
             .where(
@@ -388,16 +398,23 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
             )
             .order_by(Event.ingested_at.asc())
         )
+        if cutoff is not None:
+            statement = statement.where(BillingEntry.start_timestamp < cutoff)
+        return statement
 
     def get_by_pending_entries_for_meter_statement(
-        self, subscription: UUID, meter: UUID
+        self,
+        subscription: UUID,
+        meter: UUID,
+        *,
+        cutoff: datetime | None = None,
     ) -> Select[tuple[Event]]:
         """
         Get events for pending billing entries grouped by meter.
         Used for non-summable aggregations where we need to compute across all events
         in the period, regardless of which price was active when the event occurred.
         """
-        return (
+        statement = (
             self.get_base_statement()
             .join(BillingEntry, Event.id == BillingEntry.event_id)
             .join(
@@ -411,6 +428,9 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
             )
             .order_by(Event.ingested_at.asc())
         )
+        if cutoff is not None:
+            statement = statement.where(BillingEntry.start_timestamp < cutoff)
+        return statement
 
     def get_eager_options(self) -> Options:
         return (joinedload(Event.customer), joinedload(Event.event_types))

--- a/server/polar/event/system.py
+++ b/server/polar/event/system.py
@@ -631,6 +631,8 @@ def build_system_event(
     customer: Customer,
     organization: Organization,
     metadata: MeterCreditedMetadata,
+    *,
+    timestamp: datetime | None = None,
 ) -> Event: ...
 
 
@@ -640,6 +642,8 @@ def build_system_event(
     customer: Customer,
     organization: Organization,
     metadata: MeterResetMetadata,
+    *,
+    timestamp: datetime | None = None,
 ) -> Event: ...
 
 

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1303,8 +1303,14 @@ class OrderService:
         Returns:
             The created Order object.
         """
+        cutoff = None
+        if billing_reason in {
+            OrderBillingReasonInternal.subscription_cycle,
+            OrderBillingReasonInternal.subscription_cycle_after_trial,
+        }:
+            cutoff = subscription.current_period_start
         async with billing_entry_service.create_order_items_from_pending(
-            session, subscription
+            session, subscription, cutoff=cutoff
         ) as items:
             if len(items) == 0:
                 raise NoPendingBillingEntries(subscription)
@@ -1420,17 +1426,6 @@ class OrderService:
                 subscription.currency,
                 order=order,
             )
-
-        # Reset the associated meters, if any
-        # Note: subscription_update is intentionally excluded - meter credits from
-        # benefit grants should persist within a billing cycle. Subscription updates
-        # are for prorations, not new billing periods.
-        if billing_reason in {
-            OrderBillingReasonInternal.subscription_cycle,
-            OrderBillingReasonInternal.subscription_cycle_after_trial,
-            OrderBillingReasonInternal.subscription_cancel,
-        }:
-            await subscription_service.reset_meters(session, subscription)
 
         # Emit creation events before settling payment, so `order.created` always
         # precedes `order.paid` and the settling branches below own the paid

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1284,6 +1284,7 @@ class OrderService:
         subscription: Subscription,
         billing_reason: OrderBillingReasonInternal,
         *,
+        cutoff: datetime | None = None,
         payment_mode: PaymentMode = PaymentMode.background,
     ) -> Order:
         """
@@ -1293,6 +1294,7 @@ class OrderService:
             session: Database session to use for the operation.
             subscription: The subscription for which to create the order.
             billing_reason: The reason for billing the subscription.
+            cutoff: The exclusive usage billing cutoff for the order.
             payment_mode: The mode of payment, either "sync" or "background".
                 In "background" mode, the order will be created with pending status
                 and payment will be triggered asynchronously.
@@ -1303,12 +1305,6 @@ class OrderService:
         Returns:
             The created Order object.
         """
-        cutoff = None
-        if billing_reason in {
-            OrderBillingReasonInternal.subscription_cycle,
-            OrderBillingReasonInternal.subscription_cycle_after_trial,
-        }:
-            cutoff = subscription.current_period_start
         async with billing_entry_service.create_order_items_from_pending(
             session, subscription, cutoff=cutoff
         ) as items:

--- a/server/polar/order/tasks.py
+++ b/server/polar/order/tasks.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime
 
 import stripe as stripe_lib
 import structlog
@@ -73,7 +74,9 @@ async def order_created(order_id: uuid.UUID) -> None:
 
 @actor(actor_name="order.create_subscription_order", priority=TaskPriority.LOW)
 async def create_subscription_order(
-    subscription_id: uuid.UUID, order_reason: OrderBillingReasonInternal
+    subscription_id: uuid.UUID,
+    order_reason: OrderBillingReasonInternal,
+    cutoff: str | None = None,
 ) -> None:
     async with AsyncSessionMaker() as session:
         repository = SubscriptionRepository.from_session(session)
@@ -83,9 +86,20 @@ async def create_subscription_order(
         if subscription is None:
             raise SubscriptionDoesNotExist(subscription_id)
 
+        billing_cutoff = None
+        if order_reason in {
+            OrderBillingReasonInternal.subscription_cycle,
+            OrderBillingReasonInternal.subscription_cycle_after_trial,
+        }:
+            billing_cutoff = (
+                datetime.fromisoformat(cutoff)
+                if cutoff is not None
+                else subscription.current_period_start
+            )
+
         try:
             await order_service.create_subscription_order(
-                session, subscription, order_reason
+                session, subscription, order_reason, cutoff=billing_cutoff
             )
         except NoPendingBillingEntries:
             # Skip creating an order if there are no pending billing entries.

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -952,7 +952,8 @@ class SubscriptionService:
             subscription, update_dict={"scheduler_locked_at": None}
         )
 
-        await self.reset_meters(session, subscription, reset_at=cycle_at)
+        reset_at = min(cycle_at, utc_now())
+        await self.reset_meters(session, subscription, reset_at=reset_at)
 
         if not revoke:
             await self._send_webhook(

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -2093,6 +2093,7 @@ class SubscriptionService:
         )
         subscription.initialize_meter_period(now)
 
+        await self.reset_meters(session, subscription, reset_at=now)
         await self.enqueue_benefits_grants(session, subscription)
         await self._create_cycle_billing_entries(session, subscription)
 

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -825,6 +825,7 @@ class SubscriptionService:
             )
             return subscription
 
+        cycle_at = subscription.current_period_end
         revoke = subscription.cancel_at_period_end
 
         # Subscription is due to pause: it enters the paused state at the end of
@@ -947,6 +948,8 @@ class SubscriptionService:
             subscription, update_dict={"scheduler_locked_at": None}
         )
 
+        await self.reset_meters(session, subscription, reset_at=cycle_at)
+
         if not revoke:
             await self._send_webhook(
                 session, subscription, WebhookEventType.subscription_cycled
@@ -1015,7 +1018,11 @@ class SubscriptionService:
                 )
 
     async def reset_meters(
-        self, session: AsyncSession, subscription: Subscription
+        self,
+        session: AsyncSession,
+        subscription: Subscription,
+        *,
+        reset_at: datetime | None = None,
     ) -> None:
         """
         Resets all the subscription meters to start fresh, optionally reporting
@@ -1025,17 +1032,21 @@ class SubscriptionService:
         existing one.
         """
         for subscription_meter in subscription.meters:
-            await self.reset_meter(session, subscription, subscription_meter)
+            await self.reset_meter(
+                session, subscription, subscription_meter, reset_at=reset_at
+            )
 
     async def reset_meter(
         self,
         session: AsyncSession,
         subscription: Subscription,
         subscription_meter: SubscriptionMeter,
+        *,
+        reset_at: datetime | None = None,
     ) -> None:
         customer = subscription.customer
         rollover_units = await customer_meter_service.get_rollover_units(
-            session, customer, subscription_meter.meter
+            session, customer, subscription_meter.meter, cutoff=reset_at
         )
         await event_service.create_event(
             session,
@@ -1044,6 +1055,7 @@ class SubscriptionService:
                 customer=customer,
                 organization=subscription.organization,
                 metadata={"meter_id": str(subscription_meter.meter_id)},
+                timestamp=reset_at,
             ),
         )
         if rollover_units > 0:
@@ -1058,6 +1070,7 @@ class SubscriptionService:
                         "units": rollover_units,
                         "rollover": True,
                     },
+                    timestamp=reset_at,
                 ),
             )
 

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -855,7 +855,7 @@ class SubscriptionService:
             # Apply any pending subscription update (product change, seats change)
             # scheduled for the beginning of this new cycle
             pending_update = subscription.pending_update
-            pending_update_changed_interval = False
+            pending_update_resets_cycle = False
             if pending_update is not None:
                 pending_update.subscription = subscription
                 if pending_update.product_id is not None:
@@ -877,7 +877,11 @@ class SubscriptionService:
                     SubscriptionUpdateRepository.from_session(session)
                 )
                 # Check before apply_update() changes subscription.product
-                pending_update_changed_interval = pending_update.is_interval_changed()
+                pending_update_resets_cycle = (
+                    pending_update.is_interval_changed()
+                    or pending_update.proration_behavior
+                    == SubscriptionProrationBehavior.reset
+                )
                 try:
                     pending_update.apply_update()
                 except NoPricesForCurrencies:
@@ -893,7 +897,7 @@ class SubscriptionService:
                         product_id=pending_update.product_id,
                         currency=subscription.currency,
                     )
-                    pending_update_changed_interval = False
+                    pending_update_resets_cycle = False
                     await subscription_update_repository.soft_delete(pending_update)
                 else:
                     await subscription_update_repository.update(pending_update)
@@ -902,7 +906,7 @@ class SubscriptionService:
                         await self.enqueue_benefits_grants(session, subscription)
                 subscription.pending_update = None
 
-            if update_cycle_dates and not pending_update_changed_interval:
+            if update_cycle_dates and not pending_update_resets_cycle:
                 current_period_end = subscription.current_period_end
                 subscription.current_period_start = current_period_end
                 if previous_status == SubscriptionStatus.trialing:
@@ -966,6 +970,7 @@ class SubscriptionService:
             "order.create_subscription_order",
             subscription.id,
             billing_reason,
+            cutoff=cycle_at.isoformat(),
         )
 
         return subscription
@@ -2104,6 +2109,7 @@ class SubscriptionService:
             "order.create_subscription_order",
             subscription.id,
             OrderBillingReasonInternal.subscription_cycle,
+            cutoff=now.isoformat(),
         )
 
         log.info(

--- a/server/tests/billing_entry/test_service.py
+++ b/server/tests/billing_entry/test_service.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 
 import pytest
@@ -349,6 +350,56 @@ class TestCreateOrderItemsFromPending:
         for entry in entries[1:]:
             await session.refresh(entry)
             assert entry.order_item_id == order_item.id
+
+    async def test_metered_entries_respect_cutoff(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        meter: Meter,
+        product_metered_unit: Product,
+        metered_subscription: Subscription,
+    ) -> None:
+        price = product_metered_unit.prices[0]
+        assert is_metered_price(price)
+        cutoff = datetime(2025, 7, 1, tzinfo=UTC)
+        current_entry = await create_metered_event_billing_entry(
+            save_fixture,
+            customer=customer,
+            price=price,
+            subscription=metered_subscription,
+            tokens=20,
+        )
+        current_entry.start_timestamp = cutoff - timedelta(seconds=1)
+        current_entry.end_timestamp = cutoff - timedelta(seconds=1)
+        await save_fixture(current_entry)
+        future_entry = await create_metered_event_billing_entry(
+            save_fixture,
+            customer=customer,
+            price=price,
+            subscription=metered_subscription,
+            tokens=100,
+        )
+        future_entry.start_timestamp = cutoff
+        future_entry.end_timestamp = cutoff
+        await save_fixture(future_entry)
+
+        async with billing_entry_service.create_order_items_from_pending(
+            session, metered_subscription, cutoff=cutoff
+        ) as order_items:
+            assert len(order_items) == 1
+            order_item = order_items[0]
+            assert order_item.amount == 20_00
+            await create_order(
+                save_fixture,
+                customer=customer,
+                order_items=list(order_items),
+            )
+
+        await session.refresh(current_entry)
+        await session.refresh(future_entry)
+        assert current_entry.order_item_id == order_item.id
+        assert future_entry.order_item_id is None
 
     async def test_several_metered_prices(
         self,

--- a/server/tests/customer_meter/test_service.py
+++ b/server/tests/customer_meter/test_service.py
@@ -77,6 +77,7 @@ async def events(
         await create_event(
             save_fixture,
             timestamp=timestamp + timedelta(seconds=1),
+            ingested_at=timestamp + timedelta(seconds=1),
             organization=customer.organization,
             customer=customer,
             metadata={"tokens": 20, "model": "lite"},
@@ -84,6 +85,7 @@ async def events(
         await create_event(
             save_fixture,
             timestamp=timestamp + timedelta(seconds=2),
+            ingested_at=timestamp + timedelta(seconds=2),
             organization=customer.organization,
             customer=customer,
             source=EventSource.system,
@@ -93,6 +95,7 @@ async def events(
         await create_event(
             save_fixture,
             timestamp=timestamp + timedelta(seconds=3),
+            ingested_at=timestamp + timedelta(seconds=3),
             organization=customer.organization,
             customer=customer,
             metadata={"tokens": 10, "model": "lite"},
@@ -100,6 +103,7 @@ async def events(
         await create_event(
             save_fixture,
             timestamp=timestamp + timedelta(seconds=4),
+            ingested_at=timestamp + timedelta(seconds=4),
             organization=customer.organization,
             customer=customer,
             metadata={"tokens": 10, "model": "lite"},
@@ -107,6 +111,7 @@ async def events(
         await create_event(
             save_fixture,
             timestamp=timestamp + timedelta(seconds=5),
+            ingested_at=timestamp + timedelta(seconds=5),
             organization=customer.organization,
             customer=customer,
             metadata={"tokens": 0, "model": "lite"},
@@ -114,6 +119,7 @@ async def events(
         await create_event(
             save_fixture,
             timestamp=timestamp + timedelta(seconds=6),
+            ingested_at=timestamp + timedelta(seconds=6),
             organization=customer.organization,
             customer=customer,
             source=EventSource.system,
@@ -124,6 +130,7 @@ async def events(
         await create_event(
             save_fixture,
             timestamp=timestamp + timedelta(seconds=7),
+            ingested_at=timestamp + timedelta(seconds=7),
             organization=customer.organization,
             customer=customer,
             metadata={"tokens": 100, "model": "pro"},
@@ -131,6 +138,7 @@ async def events(
         await create_event(
             save_fixture,
             timestamp=timestamp + timedelta(seconds=8),
+            ingested_at=timestamp + timedelta(seconds=8),
             organization=customer.organization,
             customer=customer,
             source=EventSource.system,
@@ -240,6 +248,41 @@ class TestUpdateCustomerMeter:
 
         assert updated is True
 
+    async def test_historical_usage_ingested_after_reset_timestamp_is_included(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        meter: Meter,
+    ) -> None:
+        reset_timestamp = utc_now()
+        await create_event(
+            save_fixture,
+            timestamp=reset_timestamp - timedelta(days=1),
+            ingested_at=reset_timestamp + timedelta(seconds=1),
+            organization=customer.organization,
+            customer=customer,
+            metadata={"tokens": 20, "model": "lite"},
+        )
+        await create_event(
+            save_fixture,
+            timestamp=reset_timestamp,
+            ingested_at=reset_timestamp + timedelta(seconds=2),
+            organization=customer.organization,
+            customer=customer,
+            source=EventSource.system,
+            name=SystemEvent.meter_reset,
+            metadata={"meter_id": str(meter.id)},
+        )
+
+        customer_meter, updated = await customer_meter_service.update_customer_meter(
+            session, customer, meter
+        )
+
+        assert customer_meter is not None
+        assert customer_meter.consumed_units == Decimal(20)
+        assert updated is True
+
     async def test_existing_customer_meter_new_event(
         self,
         save_fixture: SaveFixture,
@@ -315,6 +358,7 @@ class TestUpdateCustomerMeter:
             await create_event(
                 save_fixture,
                 timestamp=timestamp + timedelta(seconds=1),
+                ingested_at=timestamp + timedelta(seconds=1),
                 organization=customer.organization,
                 customer=customer,
                 metadata={"tokens": 20, "model": "lite"},
@@ -322,6 +366,7 @@ class TestUpdateCustomerMeter:
             await create_event(
                 save_fixture,
                 timestamp=timestamp + timedelta(seconds=2),
+                ingested_at=timestamp + timedelta(seconds=2),
                 organization=customer.organization,
                 customer=customer,
                 source=EventSource.system,
@@ -581,6 +626,7 @@ class TestUpdateCustomerMeter:
         await create_event(
             save_fixture,
             timestamp=timestamp + timedelta(seconds=1),
+            ingested_at=timestamp + timedelta(seconds=1),
             organization=customer.organization,
             customer=customer,
             metadata={"tokens": 100, "model": "lite"},
@@ -588,6 +634,7 @@ class TestUpdateCustomerMeter:
         await create_event(
             save_fixture,
             timestamp=timestamp + timedelta(seconds=2),
+            ingested_at=timestamp + timedelta(seconds=2),
             organization=customer.organization,
             customer=customer,
             source=EventSource.system,
@@ -598,6 +645,7 @@ class TestUpdateCustomerMeter:
         await create_event(
             save_fixture,
             timestamp=timestamp + timedelta(seconds=3),
+            ingested_at=timestamp + timedelta(seconds=3),
             organization=customer.organization,
             customer=customer,
             metadata={"tokens": 50, "model": "lite"},
@@ -605,6 +653,7 @@ class TestUpdateCustomerMeter:
         await create_event(
             save_fixture,
             timestamp=timestamp + timedelta(seconds=4),
+            ingested_at=timestamp + timedelta(seconds=4),
             organization=customer.organization,
             customer=customer,
             source=EventSource.system,
@@ -615,6 +664,7 @@ class TestUpdateCustomerMeter:
         await create_event(
             save_fixture,
             timestamp=timestamp + timedelta(seconds=5),
+            ingested_at=timestamp + timedelta(seconds=5),
             organization=customer.organization,
             customer=customer,
             metadata={"tokens": 20, "model": "lite"},
@@ -622,6 +672,7 @@ class TestUpdateCustomerMeter:
         await create_event(
             save_fixture,
             timestamp=timestamp + timedelta(seconds=6),
+            ingested_at=timestamp + timedelta(seconds=6),
             organization=customer.organization,
             customer=customer,
             source=EventSource.system,
@@ -770,6 +821,44 @@ class TestUpdateCustomerMeter:
 
 @pytest.mark.asyncio
 class TestGetRolloverUnits:
+    async def test_excludes_usage_at_or_after_cutoff(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        meter: Meter,
+    ) -> None:
+        cutoff = utc_now()
+        await create_event(
+            save_fixture,
+            timestamp=cutoff - timedelta(seconds=2),
+            organization=customer.organization,
+            customer=customer,
+            source=EventSource.system,
+            name=SystemEvent.meter_credited,
+            metadata={"units": 100, "meter_id": str(meter.id), "rollover": True},
+        )
+        await create_event(
+            save_fixture,
+            timestamp=cutoff - timedelta(seconds=1),
+            organization=customer.organization,
+            customer=customer,
+            metadata={"tokens": 20, "model": "lite"},
+        )
+        await create_event(
+            save_fixture,
+            timestamp=cutoff,
+            organization=customer.organization,
+            customer=customer,
+            metadata={"tokens": 30, "model": "lite"},
+        )
+
+        rollover_units = await customer_meter_service.get_rollover_units(
+            session, customer, meter, cutoff=cutoff
+        )
+
+        assert rollover_units == 80
+
     @pytest.mark.parametrize(
         ("credits", "usage_tokens", "expected_rollover"),
         [
@@ -913,6 +1002,7 @@ class TestGetRolloverUnits:
         await create_event(
             save_fixture,
             timestamp=timestamp + timedelta(seconds=1),
+            ingested_at=timestamp + timedelta(seconds=1),
             organization=customer.organization,
             customer=customer,
             source=EventSource.system,
@@ -923,6 +1013,7 @@ class TestGetRolloverUnits:
         await create_event(
             save_fixture,
             timestamp=timestamp + timedelta(seconds=2),
+            ingested_at=timestamp + timedelta(seconds=2),
             organization=customer.organization,
             customer=customer,
             source=EventSource.system,
@@ -933,6 +1024,7 @@ class TestGetRolloverUnits:
         await create_event(
             save_fixture,
             timestamp=timestamp + timedelta(seconds=3),
+            ingested_at=timestamp + timedelta(seconds=3),
             organization=customer.organization,
             customer=customer,
             source=EventSource.system,

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -2108,6 +2108,7 @@ async def create_event(
     source: EventSource = EventSource.user,
     name: str = METER_TEST_EVENT,
     timestamp: datetime | None = None,
+    ingested_at: datetime | None = None,
     customer: Customer | None = None,
     external_customer_id: str | None = None,
     external_id: str | None = None,
@@ -2122,6 +2123,7 @@ async def create_event(
     event = Event(
         id=event_id,
         timestamp=timestamp or utc_now(),
+        ingested_at=ingested_at or utc_now(),
         source=source,
         name=name,
         customer_id=customer.id if customer else None,
@@ -2376,11 +2378,12 @@ async def create_billing_entry(
             customer=customer,
         )
 
-    if start_timestamp is None:
-        start_timestamp = event.timestamp
-
-    if end_timestamp is None:
-        end_timestamp = event.timestamp
+    if type == BillingEntryType.cycle and subscription is not None:
+        start_timestamp = start_timestamp or subscription.current_period_start
+        end_timestamp = end_timestamp or subscription.current_period_end
+    else:
+        start_timestamp = start_timestamp or event.timestamp
+        end_timestamp = end_timestamp or event.timestamp
 
     billing_entry = BillingEntry(
         start_timestamp=start_timestamp,

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -1165,6 +1165,75 @@ class TestCreateSubscriptionOrder:
             payment_trigger="subscription_cycle",
         )
 
+    @pytest.mark.parametrize(
+        "billing_reason",
+        [
+            OrderBillingReasonInternal.subscription_cycle,
+            OrderBillingReasonInternal.subscription_cycle_after_trial,
+        ],
+    )
+    async def test_cycle_excludes_billing_entries_after_current_period(
+        self,
+        billing_reason: OrderBillingReasonInternal,
+        calculate_tax_mock: MagicMock,
+        enqueue_job_mock: MagicMock,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        organization: Organization,
+        payment_method: PaymentMethod,
+    ) -> None:
+        current_period_start = datetime(2025, 7, 1, tzinfo=UTC)
+        current_period_end = datetime(2025, 8, 1, tzinfo=UTC)
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            billing_address=Address(country=CountryAlpha2("FR")),
+        )
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            payment_method=payment_method,
+            current_period_start=current_period_start,
+            current_period_end=current_period_end,
+        )
+        price = product.prices[0]
+        assert is_fixed_price(price)
+        current_entry = await create_billing_entry(
+            save_fixture,
+            type=BillingEntryType.cycle,
+            start_timestamp=current_period_start,
+            end_timestamp=current_period_end,
+            customer=customer,
+            product_price=price,
+            amount=price.price_amount,
+            currency=price.price_currency,
+            subscription=subscription,
+        )
+        future_entry = await create_billing_entry(
+            save_fixture,
+            type=BillingEntryType.cycle,
+            start_timestamp=current_period_end,
+            end_timestamp=datetime(2025, 9, 1, tzinfo=UTC),
+            customer=customer,
+            product_price=price,
+            amount=price.price_amount,
+            currency=price.price_currency,
+            subscription=subscription,
+        )
+
+        order = await order_service.create_subscription_order(
+            session, subscription, billing_reason
+        )
+
+        assert len(order.items) == 1
+        assert order.items[0].amount == current_entry.amount
+        await session.refresh(current_entry)
+        await session.refresh(future_entry)
+        assert current_entry.order_item_id == order.items[0].id
+        assert future_entry.order_item_id is None
+
     async def test_cycle_discount(
         self,
         calculate_tax_mock: MagicMock,
@@ -1775,7 +1844,7 @@ class TestCreateSubscriptionOrder:
             False,
         )
 
-    async def test_metered_subscription_cycle_resets_meters(
+    async def test_metered_subscription_cycle_does_not_reset_meters(
         self,
         mocker: MockerFixture,
         save_fixture: SaveFixture,
@@ -1784,12 +1853,6 @@ class TestCreateSubscriptionOrder:
         customer: Customer,
         organization: Organization,
     ) -> None:
-        """
-        Test that subscription_cycle orders reset meters.
-
-        This is the expected behavior for new billing cycles - meters should be
-        reset to start fresh for the new period.
-        """
         subscription_service_mock = mocker.patch(
             "polar.order.service.subscription_service", spec=SubscriptionService
         )
@@ -1802,6 +1865,7 @@ class TestCreateSubscriptionOrder:
             save_fixture,
             organization=organization,
             customer=customer,
+            timestamp=subscription.current_period_start - timedelta(seconds=1),
         )
         await save_fixture(
             BillingEntry.from_metered_event(
@@ -1816,9 +1880,7 @@ class TestCreateSubscriptionOrder:
         assert len(order.items) == 1
         assert order.subtotal_amount == 100
 
-        subscription_service_mock.reset_meters.assert_awaited_once_with(
-            session, subscription
-        )
+        subscription_service_mock.reset_meters.assert_not_awaited()
 
     async def test_subscription_update_does_not_reset_meters(
         self,

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -1183,8 +1183,9 @@ class TestCreateSubscriptionOrder:
         organization: Organization,
         payment_method: PaymentMethod,
     ) -> None:
-        current_period_start = datetime(2025, 7, 1, tzinfo=UTC)
-        current_period_end = datetime(2025, 8, 1, tzinfo=UTC)
+        cycle_cutoff = datetime(2025, 7, 1, tzinfo=UTC)
+        next_period_start = datetime(2025, 8, 1, tzinfo=UTC)
+        next_period_end = datetime(2025, 9, 1, tzinfo=UTC)
         customer = await create_customer(
             save_fixture,
             organization=organization,
@@ -1195,16 +1196,16 @@ class TestCreateSubscriptionOrder:
             product=product,
             customer=customer,
             payment_method=payment_method,
-            current_period_start=current_period_start,
-            current_period_end=current_period_end,
+            current_period_start=next_period_start,
+            current_period_end=next_period_end,
         )
         price = product.prices[0]
         assert is_fixed_price(price)
         current_entry = await create_billing_entry(
             save_fixture,
             type=BillingEntryType.cycle,
-            start_timestamp=current_period_start,
-            end_timestamp=current_period_end,
+            start_timestamp=cycle_cutoff,
+            end_timestamp=next_period_start,
             customer=customer,
             product_price=price,
             amount=price.price_amount,
@@ -1214,8 +1215,8 @@ class TestCreateSubscriptionOrder:
         future_entry = await create_billing_entry(
             save_fixture,
             type=BillingEntryType.cycle,
-            start_timestamp=current_period_end,
-            end_timestamp=datetime(2025, 9, 1, tzinfo=UTC),
+            start_timestamp=next_period_start,
+            end_timestamp=next_period_end,
             customer=customer,
             product_price=price,
             amount=price.price_amount,
@@ -1224,7 +1225,7 @@ class TestCreateSubscriptionOrder:
         )
 
         order = await order_service.create_subscription_order(
-            session, subscription, billing_reason
+            session, subscription, billing_reason, cutoff=cycle_cutoff
         )
 
         assert len(order.items) == 1

--- a/server/tests/order/test_tasks.py
+++ b/server/tests/order/test_tasks.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import timedelta
-from unittest.mock import MagicMock
+from unittest.mock import ANY, AsyncMock, MagicMock
 
 import pytest
 import stripe as stripe_lib
@@ -18,6 +18,7 @@ from polar.order.repository import OrderRepository
 from polar.order.service import order as order_service
 from polar.order.tasks import (
     OrderDoesNotExist,
+    create_subscription_order,
     enqueue_stale_payment_locks,
     process_dunning,
     process_dunning_order,
@@ -33,6 +34,41 @@ from tests.fixtures.random_objects import (
     create_payment_method,
     create_subscription,
 )
+
+
+@pytest.mark.asyncio
+class TestCreateSubscriptionOrder:
+    async def test_uses_cutoff_from_job_payload(
+        self,
+        save_fixture: SaveFixture,
+        product: Product,
+        organization: Organization,
+        mocker: MockerFixture,
+    ) -> None:
+        customer = await create_customer(save_fixture, organization=organization)
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.active,
+        )
+        cutoff = subscription.current_period_start - timedelta(days=1)
+        create_order_mock = mocker.patch.object(
+            order_service, "create_subscription_order", new=AsyncMock()
+        )
+
+        await create_subscription_order(
+            subscription.id,
+            OrderBillingReasonInternal.subscription_cycle,
+            cutoff.isoformat(),
+        )
+
+        create_order_mock.assert_awaited_once_with(
+            ANY,
+            ANY,
+            OrderBillingReasonInternal.subscription_cycle,
+            cutoff=cutoff,
+        )
 
 
 @pytest.mark.asyncio

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -1095,6 +1095,37 @@ class TestApplyUpdate:
 
 @pytest.mark.asyncio
 class TestCycle:
+    @pytest.mark.parametrize("cancel_at_period_end", [False, True])
+    async def test_resets_meters_at_period_boundary(
+        self,
+        cancel_at_period_end: bool,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product_recurring_metered: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product_recurring_metered,
+            customer=customer,
+            scheduler_locked_at=utc_now(),
+            cancel_at_period_end=cancel_at_period_end,
+        )
+        cycle_at = subscription.current_period_end
+        reset_meters_mock = mocker.patch.object(subscription_service, "reset_meters")
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.cycle(
+                session, ctx, subscription
+            )
+
+        reset_meters_mock.assert_awaited_once_with(
+            session, updated_subscription, reset_at=cycle_at
+        )
+
     async def test_inactive(
         self,
         session: AsyncSession,
@@ -3105,7 +3136,7 @@ class TestResetMeter:
         )
 
         get_rollover_units_mock.assert_awaited_once_with(
-            session, customer, subscription_meter.meter
+            session, customer, subscription_meter.meter, cutoff=None
         )
         reset_events = await get_all_by_name(session, SystemEvent.meter_reset)
         assert len(reset_events) == 1
@@ -3127,17 +3158,25 @@ class TestResetMeter:
             save_fixture, product=product_recurring_metered, customer=customer
         )
         subscription_meter = subscription.meters[0]
-        mocker.patch(
+        reset_at = utc_now()
+        get_rollover_units_mock = mocker.patch(
             "polar.subscription.service.customer_meter_service.get_rollover_units",
             return_value=25,
         )
 
         await subscription_service.reset_meter(
-            session, subscription, subscription_meter
+            session, subscription, subscription_meter, reset_at=reset_at
         )
 
+        get_rollover_units_mock.assert_awaited_once_with(
+            session, customer, subscription_meter.meter, cutoff=reset_at
+        )
+        reset_events = await get_all_by_name(session, SystemEvent.meter_reset)
+        assert len(reset_events) == 1
+        assert reset_events[0].timestamp == reset_at
         credited_events = await get_all_by_name(session, SystemEvent.meter_credited)
         assert len(credited_events) == 1
+        assert credited_events[0].timestamp == reset_at
         assert credited_events[0].user_metadata == {
             "meter_id": str(subscription_meter.meter_id),
             "units": 25,

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -1096,7 +1096,8 @@ class TestApplyUpdate:
 @pytest.mark.asyncio
 class TestCycle:
     @pytest.mark.parametrize("cancel_at_period_end", [False, True])
-    async def test_resets_meters_at_period_boundary(
+    @freeze_time("2024-01-15 12:00:00")
+    async def test_clamps_meter_reset_to_now_when_cycling_early(
         self,
         cancel_at_period_end: bool,
         mocker: MockerFixture,
@@ -1112,7 +1113,36 @@ class TestCycle:
             scheduler_locked_at=utc_now(),
             cancel_at_period_end=cancel_at_period_end,
         )
-        cycle_at = subscription.current_period_end
+        reset_meters_mock = mocker.patch.object(subscription_service, "reset_meters")
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.cycle(
+                session, ctx, subscription
+            )
+
+        reset_meters_mock.assert_awaited_once_with(
+            session, updated_subscription, reset_at=utc_now()
+        )
+
+    @freeze_time("2024-01-15 12:00:00")
+    async def test_preserves_period_end_when_cycling_late(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product_recurring_metered: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product_recurring_metered,
+            customer=customer,
+            scheduler_locked_at=utc_now(),
+        )
+        cycle_at = utc_now() - timedelta(hours=1)
+        subscription.current_period_end = cycle_at
         reset_meters_mock = mocker.patch.object(subscription_service, "reset_meters")
 
         async with SubscriptionUpdateContext(

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -1217,6 +1217,7 @@ class TestCycle:
             "order.create_subscription_order",
             subscription.id,
             OrderBillingReasonInternal.subscription_cycle,
+            cutoff=previous_current_period_end.isoformat(),
         )
 
         assert_webhook_sent_once(
@@ -1515,6 +1516,7 @@ class TestCycle:
             "order.create_subscription_order",
             subscription.id,
             OrderBillingReasonInternal.subscription_cancel,
+            cutoff=previous_current_period_end.isoformat(),
         )
 
         assert_webhook_not_sent(
@@ -1606,6 +1608,7 @@ class TestCycle:
             "order.create_subscription_order",
             subscription.id,
             OrderBillingReasonInternal.subscription_cycle_after_trial,
+            cutoff=previous_current_period_end.isoformat(),
         )
 
         assert_webhook_sent_once(
@@ -1698,6 +1701,7 @@ class TestCycle:
             "order.create_subscription_order",
             subscription.id,
             OrderBillingReasonInternal.subscription_cancel,
+            cutoff=previous_current_period_end.isoformat(),
         )
         # The after-trial billing reason must NOT have been enqueued.
         for mock_call in enqueue_job_mock.call_args_list:
@@ -1990,6 +1994,7 @@ class TestCycle:
             "order.create_subscription_order",
             subscription.id,
             OrderBillingReasonInternal.subscription_cycle,
+            cutoff=previous_current_period_end.isoformat(),
         )
 
         enqueue_job_mock.assert_any_call(
@@ -2011,6 +2016,45 @@ class TestCycle:
         )
         assert updated_subscription_update is not None
         assert updated_subscription_update.applied_at is not None
+
+    async def test_pending_reset_update_with_unchanged_interval_keeps_cycle_boundary(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        product_second: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            scheduler_locked_at=utc_now(),
+        )
+        cycle_at = subscription.current_period_end
+
+        with freeze_time(cycle_at):
+            subscription_update, _ = generate_subscription_update(
+                subscription,
+                SubscriptionProrationBehavior.reset,
+                product=product_second,
+            )
+        await save_fixture(subscription_update)
+        subscription.pending_update = subscription_update
+        await save_fixture(subscription)
+
+        assert not subscription_update.is_interval_changed()
+        expected_period_end = subscription_update.new_cycle_end
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated_subscription = await subscription_service.cycle(
+                session, ctx, subscription
+            )
+
+        assert updated_subscription.current_period_start == cycle_at
+        assert updated_subscription.current_period_end == expected_period_end
 
     async def test_pending_update_product_prices_archived(
         self,
@@ -2079,6 +2123,7 @@ class TestCycle:
             "order.create_subscription_order",
             subscription.id,
             OrderBillingReasonInternal.subscription_cycle,
+            cutoff=previous_current_period_end.isoformat(),
         )
 
         assert not any(
@@ -3049,7 +3094,10 @@ class TestResume:
         )
         enqueue_benefits_grants_mock.assert_called_once_with(session, updated)
         enqueue_job_mock.assert_any_call(
-            "order.create_subscription_order", subscription.id, ANY
+            "order.create_subscription_order",
+            subscription.id,
+            ANY,
+            cutoff=frozen_time.isoformat(),
         )
         assert_hooks_called_once(subscription_hooks, {"updated", "resumed"})
 
@@ -3824,6 +3872,7 @@ class TestUpdate:
             "order.create_subscription_order",
             updated.id,
             OrderBillingReasonInternal.subscription_cycle_after_trial,
+            cutoff=ANY,
         )
 
     async def test_seats_update(
@@ -4098,6 +4147,7 @@ class TestUpdate:
             "order.create_subscription_order",
             updated.id,
             OrderBillingReasonInternal.subscription_cycle_after_trial,
+            cutoff=ANY,
         )
 
         assert_webhook_sent_once(
@@ -4327,6 +4377,7 @@ class TestUpdateProduct:
             "order.create_subscription_order",
             updated.id,
             OrderBillingReasonInternal.subscription_cycle_after_trial,
+            cutoff=ANY,
         )
 
     async def test_trial_to_no_trial_product_ends_trial(
@@ -4365,6 +4416,7 @@ class TestUpdateProduct:
             "order.create_subscription_order",
             updated.id,
             OrderBillingReasonInternal.subscription_cycle_after_trial,
+            cutoff=ANY,
         )
 
     async def test_trial_product_change_skips_proration_billing(

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -3011,6 +3011,7 @@ class TestResume:
     async def test_valid(
         self,
         frozen_time: datetime,
+        mocker: MockerFixture,
         session: AsyncSession,
         save_fixture: SaveFixture,
         enqueue_job_mock: MagicMock,
@@ -3029,6 +3030,7 @@ class TestResume:
         subscription.resumes_at = frozen_time
         await save_fixture(subscription)
         reset_hooks(subscription_hooks)
+        reset_meters_mock = mocker.patch.object(subscription_service, "reset_meters")
 
         async with SubscriptionUpdateContext(
             session, subscription, subscription_service
@@ -3042,6 +3044,9 @@ class TestResume:
         assert updated.current_period_start == frozen_time
         assert updated.current_period_end is not None
         assert updated.current_period_end > frozen_time
+        reset_meters_mock.assert_awaited_once_with(
+            session, updated, reset_at=frozen_time
+        )
         enqueue_benefits_grants_mock.assert_called_once_with(session, updated)
         enqueue_job_mock.assert_any_call(
             "order.create_subscription_order", subscription.id, ANY


### PR DESCRIPTION
Mostly exploratory, but I think it may work 😬

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13483"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788084284&installation_model_id=13063&pr_number=13483&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13483&signature=cc7adea89d915596eca550706d45b9d7b8599d31daa072876602df7732ba6634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use subscription cycle dates as the usage billing cutoff and reset meters at cycle/resume. Boundary usage moves to the next cycle; recurring charges at the boundary are billed in the new cycle.

- New Features
  - Cycle orders use a `cutoff` equal to `subscription.current_period_start` to select pending entries and events; the `order.create_subscription_order` job accepts an optional `cutoff` and forwards it.
  - Meter reset happens during `subscription.cycle` at `current_period_end` (`reset_at`), clamped to now if cycling early; it also runs on `subscription.resume` at resume time. Reset/credit events are stamped with this timestamp.
  - Pending selection rules: metered entries at the cutoff are excluded; static entries at the cutoff are included (new period’s recurring charge).
  - Event queries use `Event.timestamp` for period boundaries and `Event.ingested_at` for ordering, and apply the `cutoff`, so historical usage ingested after reset is included correctly.

<sup>Written for commit f86b70aba284f020681115aa5594b569d9f16521. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13483?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

