### PR TITLE
feat(web): add mobile FilterPopover for sales filters

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesFilters.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesFilters.tsx
@@ -48,12 +48,15 @@ const SalesFilters: React.FC<SalesFiltersProps> = ({
 }) => {
   const [productQuery, setProductQuery] = useState('')
 
-  const { data: products } = useProducts(organization.id, {
-    is_archived: null,
-    ...(productQuery ? { query: productQuery } : {}),
-    sorting: ['name'],
-    limit: 50,
-  })
+  const { data: products, isPending: productsPending } = useProducts(
+    organization.id,
+    {
+      is_archived: null,
+      ...(productQuery ? { query: productQuery } : {}),
+      sorting: ['name'],
+      limit: 50,
+    },
+  )
   const { data: selectedProducts } = useSelectedProducts(productId ?? [], true)
 
   const productOptions = useMemo<FilterOption[]>(() => {
@@ -84,6 +87,7 @@ const SalesFilters: React.FC<SalesFiltersProps> = ({
         icon: <HiveOutlined fontSize="inherit" />,
         type: 'multi',
         options: productOptions,
+        loading: productsPending,
         searchPlaceholder: 'Search products…',
         searchQuery: productQuery,
         onSearchQueryChange: setProductQuery,
@@ -126,6 +130,7 @@ const SalesFilters: React.FC<SalesFiltersProps> = ({
   }, [
     organization,
     productOptions,
+    productsPending,
     productQuery,
     productId,
     onProductSelect,

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesFilters.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesFilters.tsx
@@ -1,6 +1,9 @@
 'use client'
 
-import FilterPopover, { Filter } from '@/components/Shared/FilterPopover'
+import FilterPopover, {
+  Filter,
+  FilterOption,
+} from '@/components/Shared/FilterPopover'
 import DateRangePicker, {
   DateRange,
   dateRangeIntervals,
@@ -9,7 +12,7 @@ import DateRangePicker, {
 import { OrderStatusDisplayTitle } from '@/components/Orders/OrderStatus'
 import OrderStatusSelect from '@/components/Orders/OrderStatusSelect'
 import ProductSelect from '@/components/Products/ProductSelect'
-import { useProducts } from '@/hooks/queries'
+import { useProducts, useSelectedProducts } from '@/hooks/queries'
 import CalendarMonthOutlined from '@mui/icons-material/CalendarMonthOutlined'
 import DonutLargeOutlined from '@mui/icons-material/DonutLargeOutlined'
 import FileDownloadOutlined from '@mui/icons-material/FileDownloadOutlined'
@@ -18,7 +21,7 @@ import { enums, schemas } from '@polar-sh/client'
 import { Button, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { startOfDay } from 'date-fns'
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 
 const CUSTOM_DATE_RANGE = 'custom'
 
@@ -43,11 +46,30 @@ const SalesFilters: React.FC<SalesFiltersProps> = ({
   onDateChange,
   onExport,
 }) => {
+  const [productQuery, setProductQuery] = useState('')
+
   const { data: products } = useProducts(organization.id, {
     is_archived: null,
+    ...(productQuery ? { query: productQuery } : {}),
     sorting: ['name'],
-    limit: 100,
+    limit: 50,
   })
+  const { data: selectedProducts } = useSelectedProducts(productId ?? [], true)
+
+  const productOptions = useMemo<FilterOption[]>(() => {
+    let items = products?.items ?? []
+    if (!productQuery) {
+      for (const product of selectedProducts ?? []) {
+        if (!items.some(({ id }) => id === product.id)) {
+          items = [...items, product]
+        }
+      }
+    }
+    return items.map((product) => ({
+      value: product.id,
+      label: `${product.name}${product.is_archived ? ' (Archived)' : ''}`,
+    }))
+  }, [products, selectedProducts, productQuery])
 
   const mobileFilters = useMemo<Filter[]>(() => {
     const intervals = dateRangeIntervals(organization)
@@ -61,10 +83,10 @@ const SalesFilters: React.FC<SalesFiltersProps> = ({
         label: 'Product',
         icon: <HiveOutlined fontSize="inherit" />,
         type: 'multi',
-        options: (products?.items ?? []).map((product) => ({
-          value: product.id,
-          label: `${product.name}${product.is_archived ? ' (Archived)' : ''}`,
-        })),
+        options: productOptions,
+        searchPlaceholder: 'Search products…',
+        searchQuery: productQuery,
+        onSearchQueryChange: setProductQuery,
         value: productId ?? [],
         onChange: onProductSelect,
       },
@@ -103,7 +125,8 @@ const SalesFilters: React.FC<SalesFiltersProps> = ({
     ]
   }, [
     organization,
-    products,
+    productOptions,
+    productQuery,
     productId,
     onProductSelect,
     status,

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesFilters.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesFilters.tsx
@@ -20,6 +20,8 @@ import { Box } from '@polar-sh/orbit/Box'
 import { startOfDay } from 'date-fns'
 import React, { useMemo } from 'react'
 
+const CUSTOM_DATE_RANGE = 'custom'
+
 interface SalesFiltersProps {
   organization: schemas['Organization']
   productId: string[] | null
@@ -85,7 +87,10 @@ const SalesFilters: React.FC<SalesFiltersProps> = ({
         icon: <CalendarMonthOutlined fontSize="inherit" />,
         type: 'single',
         options: intervals.map(({ slug, label }) => ({ value: slug, label })),
-        value: intervalSlug === 'allTime' ? null : (intervalSlug ?? null),
+        value:
+          intervalSlug === 'allTime'
+            ? null
+            : (intervalSlug ?? CUSTOM_DATE_RANGE),
         onChange: (slug) => {
           const interval =
             intervals.find((interval) => interval.slug === slug) ??

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesFilters.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesFilters.tsx
@@ -1,0 +1,164 @@
+'use client'
+
+import FilterPopover, { Filter } from '@/components/Shared/FilterPopover'
+import DateRangePicker, {
+  DateRange,
+  dateRangeIntervals,
+  dateRangeToMatchingInterval,
+} from '@/components/Metrics/DateRangePicker'
+import { OrderStatusDisplayTitle } from '@/components/Orders/OrderStatus'
+import OrderStatusSelect from '@/components/Orders/OrderStatusSelect'
+import ProductSelect from '@/components/Products/ProductSelect'
+import { useProducts } from '@/hooks/queries'
+import CalendarMonthOutlined from '@mui/icons-material/CalendarMonthOutlined'
+import DonutLargeOutlined from '@mui/icons-material/DonutLargeOutlined'
+import FileDownloadOutlined from '@mui/icons-material/FileDownloadOutlined'
+import HiveOutlined from '@mui/icons-material/HiveOutlined'
+import { enums, schemas } from '@polar-sh/client'
+import { Button, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { startOfDay } from 'date-fns'
+import React, { useMemo } from 'react'
+
+interface SalesFiltersProps {
+  organization: schemas['Organization']
+  productId: string[] | null
+  onProductSelect: (value: string[]) => void
+  status: schemas['OrderStatus'] | null
+  onStatusSelect: (value: schemas['OrderStatus'] | null) => void
+  dateRange: DateRange
+  onDateChange: (range: DateRange) => void
+  onExport: () => void
+}
+
+const SalesFilters: React.FC<SalesFiltersProps> = ({
+  organization,
+  productId,
+  onProductSelect,
+  status,
+  onStatusSelect,
+  dateRange,
+  onDateChange,
+  onExport,
+}) => {
+  const { data: products } = useProducts(organization.id, {
+    is_archived: null,
+    sorting: ['name'],
+    limit: 100,
+  })
+
+  const mobileFilters = useMemo<Filter[]>(() => {
+    const intervals = dateRangeIntervals(organization)
+    const intervalSlug = dateRangeToMatchingInterval(
+      dateRange,
+      organization,
+    )?.slug
+    return [
+      {
+        key: 'product',
+        label: 'Product',
+        icon: <HiveOutlined fontSize="inherit" />,
+        type: 'multi',
+        options: (products?.items ?? []).map((product) => ({
+          value: product.id,
+          label: `${product.name}${product.is_archived ? ' (Archived)' : ''}`,
+        })),
+        value: productId ?? [],
+        onChange: onProductSelect,
+      },
+      {
+        key: 'status',
+        label: 'Status',
+        icon: <DonutLargeOutlined fontSize="inherit" />,
+        type: 'single',
+        options: enums.orderStatusValues.map((value) => ({
+          value,
+          label: OrderStatusDisplayTitle[value],
+        })),
+        value: status,
+        onChange: (value) =>
+          onStatusSelect(value as schemas['OrderStatus'] | null),
+      },
+      {
+        key: 'date',
+        label: 'Date',
+        icon: <CalendarMonthOutlined fontSize="inherit" />,
+        type: 'single',
+        options: intervals.map(({ slug, label }) => ({ value: slug, label })),
+        value: intervalSlug === 'allTime' ? null : (intervalSlug ?? null),
+        onChange: (slug) => {
+          const interval =
+            intervals.find((interval) => interval.slug === slug) ??
+            intervals.find(({ slug }) => slug === 'allTime')
+          if (interval) {
+            onDateChange({ from: interval.value[0], to: interval.value[1] })
+          }
+        },
+      },
+    ]
+  }, [
+    organization,
+    products,
+    productId,
+    onProductSelect,
+    status,
+    onStatusSelect,
+    dateRange,
+    onDateChange,
+  ])
+
+  return (
+    <Box
+      flexDirection={{ base: 'column', md: 'row' }}
+      alignItems={{ base: 'stretch', md: 'center' }}
+      justifyContent="between"
+      gap="l"
+    >
+      <Box
+        display={{ base: 'none', sm: 'flex' }}
+        flexWrap="wrap"
+        alignItems="center"
+        gap="m"
+        width={{ base: '100%', md: 'auto' }}
+      >
+        <Box width={{ base: '100%', md: 300 }} flexGrow={{ sm: 1, md: 0 }}>
+          <ProductSelect
+            organization={organization}
+            value={productId ?? []}
+            onChange={onProductSelect}
+            className="w-full"
+            includeArchived
+          />
+        </Box>
+        <Box
+          width={{ base: '100%', sm: 'auto' }}
+          minWidth={{ sm: 160 }}
+          maxWidth={{ md: 200 }}
+          flexGrow={{ sm: 1, md: 0 }}
+        >
+          <OrderStatusSelect value={status} onChange={onStatusSelect} />
+        </Box>
+        <DateRangePicker
+          className="w-full shrink-0 sm:w-52 [&>button:last-child]:text-left"
+          date={dateRange}
+          onDateChange={onDateChange}
+          minDate={startOfDay(new Date(organization.created_at))}
+        />
+      </Box>
+      <Box display={{ base: 'flex', sm: 'none' }} width="100%">
+        <FilterPopover filters={mobileFilters} className="w-full" />
+      </Box>
+      <Button
+        onClick={onExport}
+        className="flex w-full flex-row items-center md:w-auto"
+        variant="secondary"
+        wrapperClassNames="gap-x-2"
+      >
+        <FileDownloadOutlined fontSize="inherit" />
+        <Text>Export</Text>
+      </Button>
+    </Box>
+  )
+}
+
+export default SalesFilters

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -1,13 +1,9 @@
 'use client'
 
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
-import DateRangePicker, {
-  DateRange,
-} from '@/components/Metrics/DateRangePicker'
+import { DateRange } from '@/components/Metrics/DateRangePicker'
 import { MiniMetricChartBox } from '@/components/Metrics/MiniMetricChartBox'
 import { OrderStatus } from '@/components/Orders/OrderStatus'
-import OrderStatusSelect from '@/components/Orders/OrderStatusSelect'
-import ProductSelect from '@/components/Products/ProductSelect'
 import { useMetrics } from '@/hooks/queries/metrics'
 import { useOrders } from '@/hooks/queries/orders'
 import { useDataTableQueryState } from '@/hooks/useDataTableQueryState'
@@ -15,14 +11,12 @@ import { getServerURL } from '@/utils/api'
 import { useDateRange } from '@/utils/date'
 import { getAPIParams } from '@/utils/datatable'
 import { dateRangeToInterval } from '@/utils/metrics'
-import FileDownloadOutlined from '@mui/icons-material/FileDownloadOutlined'
 import { enums, schemas } from '@polar-sh/client'
 import { Box } from '@polar-sh/orbit/Box'
 import { Text } from '@polar-sh/orbit'
 import { formatCurrency } from '@polar-sh/currency'
 import { Truncated } from '@polar-sh/orbit'
 import { Avatar } from '@polar-sh/orbit'
-import { Button } from '@polar-sh/orbit'
 import {
   DataTable,
   DataTableColumnDef,
@@ -31,7 +25,6 @@ import {
 import { Status } from '@polar-sh/orbit'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import { RowSelectionState } from '@tanstack/react-table'
-import { startOfDay } from 'date-fns'
 import { useRouter } from 'next/navigation'
 import {
   parseAsArrayOf,
@@ -40,6 +33,7 @@ import {
   useQueryStates,
 } from 'nuqs'
 import React, { useEffect, useState } from 'react'
+import SalesFilters from './SalesFilters'
 
 const filterParsers = {
   product_id: parseAsArrayOf(parseAsString),
@@ -260,53 +254,16 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
   return (
     <DashboardBody wide>
       <div className="flex flex-col gap-8">
-        <Box
-          flexDirection={{ base: 'column', md: 'row' }}
-          alignItems={{ base: 'stretch', md: 'center' }}
-          justifyContent="between"
-          gap="l"
-        >
-          <Box
-            flexDirection={{ base: 'column', sm: 'row' }}
-            flexWrap="wrap"
-            alignItems={{ base: 'stretch', sm: 'center' }}
-            gap="m"
-            width={{ base: '100%', md: 'auto' }}
-          >
-            <Box width={{ base: '100%', md: 300 }} flexGrow={{ sm: 1, md: 0 }}>
-              <ProductSelect
-                organization={organization}
-                value={productId || []}
-                onChange={onProductSelect}
-                className="w-full"
-                includeArchived
-              />
-            </Box>
-            <Box
-              width={{ base: '100%', sm: 'auto' }}
-              minWidth={{ sm: 160 }}
-              maxWidth={{ md: 200 }}
-              flexGrow={{ sm: 1, md: 0 }}
-            >
-              <OrderStatusSelect value={status} onChange={onStatusSelect} />
-            </Box>
-            <DateRangePicker
-              className="w-full shrink-0 sm:w-52 [&>button:last-child]:text-left"
-              date={{ from: startDate, to: endDate }}
-              onDateChange={onDateChange}
-              minDate={startOfDay(new Date(organization.created_at))}
-            />
-          </Box>
-          <Button
-            onClick={onExport}
-            className="flex w-full flex-row items-center md:w-auto"
-            variant={'secondary'}
-            wrapperClassNames="gap-x-2"
-          >
-            <FileDownloadOutlined fontSize="inherit" />
-            <span>Export</span>
-          </Button>
-        </Box>
+        <SalesFilters
+          organization={organization}
+          productId={productId}
+          onProductSelect={onProductSelect}
+          status={status}
+          onStatusSelect={onStatusSelect}
+          dateRange={{ from: startDate, to: endDate }}
+          onDateChange={onDateChange}
+          onExport={onExport}
+        />
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
           <MiniMetricChartBox
             title="Orders"

--- a/clients/apps/web/src/components/Metrics/DateRangePicker.tsx
+++ b/clients/apps/web/src/components/Metrics/DateRangePicker.tsx
@@ -33,7 +33,7 @@ import {
 import { useContext } from 'react'
 import { twMerge } from 'tailwind-merge'
 
-const intervals = (
+export const dateRangeIntervals = (
   organization: schemas['Organization'],
 ): DateRangeInterval[] => [
   {
@@ -89,7 +89,7 @@ const intervals = (
   },
 ]
 
-const dateToInterval = (
+export const dateRangeToMatchingInterval = (
   date: DateRange,
   organization: schemas['Organization'],
 ) => {
@@ -98,7 +98,7 @@ const dateToInterval = (
   const fromDate = format(date.from, 'yyyy-MM-dd')
   const toDate = format(date.to, 'yyyy-MM-dd')
 
-  return intervals(organization).find((interval) => {
+  return dateRangeIntervals(organization).find((interval) => {
     const intervalFromDate = format(interval.value[0], 'yyyy-MM-dd')
     const intervalToDate = format(interval.value[1], 'yyyy-MM-dd')
     return fromDate === intervalFromDate && toDate === intervalToDate
@@ -125,7 +125,9 @@ const DateRangePicker: React.FC<DateRangePickerProps> = ({
   additionalIntervals,
 }) => {
   const { organization } = useContext(OrganizationContext)
-  const interval = date ? dateToInterval(date, organization) : undefined
+  const interval = date
+    ? dateRangeToMatchingInterval(date, organization)
+    : undefined
 
   return (
     <div
@@ -221,7 +223,7 @@ const DateRangeIntervals = ({
   const { organization } = useContext(OrganizationContext)
   const allIntervals = [
     ...(additionalIntervals ?? []),
-    ...intervals(organization),
+    ...dateRangeIntervals(organization),
   ]
 
   return (

--- a/clients/apps/web/src/components/Shared/FilterPopover.tsx
+++ b/clients/apps/web/src/components/Shared/FilterPopover.tsx
@@ -205,9 +205,11 @@ const FilterPopover: React.FC<FilterPopoverProps> = ({
                     onSelect={() => onSelectOption(activeFilter, option)}
                     className={itemClassName}
                   >
-                    <Text as="span" className="flex-1 truncate">
-                      {option.label}
-                    </Text>
+                    <Box display="flex" flex={1}>
+                      <Text as="span" truncate>
+                        {option.label}
+                      </Text>
+                    </Box>
                     <CheckIcon
                       className={twMerge(
                         'h-4 w-4',
@@ -232,9 +234,11 @@ const FilterPopover: React.FC<FilterPopoverProps> = ({
                         className={itemClassName}
                       >
                         {filter.icon}
-                        <Text as="span" className="flex-1 truncate">
-                          {filter.label}
-                        </Text>
+                        <Box display="flex" flex={1}>
+                          <Text as="span" truncate>
+                            {filter.label}
+                          </Text>
+                        </Box>
                         {summary ? (
                           <Text as="span" variant="caption" color="muted">
                             {summary}

--- a/clients/apps/web/src/components/Shared/FilterPopover.tsx
+++ b/clients/apps/web/src/components/Shared/FilterPopover.tsx
@@ -1,0 +1,269 @@
+'use client'
+
+import ArrowBackOutlined from '@mui/icons-material/ArrowBackOutlined'
+import FilterListOutlined from '@mui/icons-material/FilterListOutlined'
+import { Button, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import {
+  Command,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '@polar-sh/ui/components/ui/command'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@polar-sh/ui/components/ui/popover'
+import { CheckIcon } from 'lucide-react'
+import React, { useState } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+export interface FilterOption {
+  value: string
+  label: string
+}
+
+interface FilterBase {
+  key: string
+  label: string
+  icon?: React.ReactNode
+  options: FilterOption[]
+}
+
+export interface SingleFilter extends FilterBase {
+  type: 'single'
+  value: string | null
+  onChange: (value: string | null) => void
+}
+
+export interface MultiFilter extends FilterBase {
+  type: 'multi'
+  value: string[]
+  onChange: (value: string[]) => void
+}
+
+export type Filter = SingleFilter | MultiFilter
+
+const itemClassName =
+  "gap-3 rounded-lg px-3 py-3 text-black data-[selected='true']:bg-transparent data-[selected=true]:text-black hover:bg-gray-100 active:bg-gray-100 dark:text-white dark:data-[selected=true]:text-white dark:hover:bg-polar-600 dark:active:bg-polar-600"
+
+const isActive = (filter: Filter): boolean =>
+  filter.type === 'single' ? filter.value !== null : filter.value.length > 0
+
+const isSelected = (filter: Filter, option: FilterOption): boolean =>
+  filter.type === 'single'
+    ? filter.value === option.value
+    : filter.value.includes(option.value)
+
+const clearFilter = (filter: Filter): void => {
+  if (filter.type === 'single') {
+    filter.onChange(null)
+  } else {
+    filter.onChange([])
+  }
+}
+
+const toggleOption = (filter: Filter, option: FilterOption): void => {
+  if (filter.type === 'single') {
+    filter.onChange(filter.value === option.value ? null : option.value)
+  } else {
+    filter.onChange(
+      filter.value.includes(option.value)
+        ? filter.value.filter((value) => value !== option.value)
+        : [...filter.value, option.value],
+    )
+  }
+}
+
+const filterSummary = (filter: Filter): string | null => {
+  if (!isActive(filter)) {
+    return null
+  }
+  if (filter.type === 'single') {
+    return (
+      filter.options.find(({ value }) => value === filter.value)?.label ?? null
+    )
+  }
+  if (filter.value.length === 1) {
+    return (
+      filter.options.find(({ value }) => value === filter.value[0])?.label ??
+      '1 selected'
+    )
+  }
+  return `${filter.value.length} selected`
+}
+
+interface FilterPopoverProps {
+  filters: Filter[]
+  label?: string
+  className?: string
+}
+
+const FilterPopover: React.FC<FilterPopoverProps> = ({
+  filters,
+  label = 'Filters',
+  className,
+}) => {
+  const [open, setOpen] = useState(false)
+  const [activeKey, setActiveKey] = useState<string | null>(null)
+
+  const activeFilter = filters.find(({ key }) => key === activeKey)
+  const activeCount = filters.filter(isActive).length
+
+  const onOpenChange = (value: boolean) => {
+    setOpen(value)
+    setActiveKey(null)
+  }
+
+  const goBack = () => setActiveKey(null)
+
+  const onSelectOption = (filter: Filter, option: FilterOption) => {
+    toggleOption(filter, option)
+    if (filter.type === 'single') {
+      onOpenChange(false)
+    }
+  }
+
+  const clearAll = () => {
+    for (const filter of filters) {
+      if (isActive(filter)) {
+        clearFilter(filter)
+      }
+    }
+    onOpenChange(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="secondary"
+          className={twMerge('flex flex-row items-center', className)}
+          wrapperClassNames="gap-x-2"
+        >
+          <FilterListOutlined fontSize="inherit" />
+          <Text>{label}</Text>
+          {activeCount > 0 && (
+            <Box
+              as="span"
+              alignItems="center"
+              justifyContent="center"
+              borderRadius="full"
+              backgroundColor="background-primary"
+              minWidth={20}
+              height={20}
+              paddingHorizontal="xs"
+            >
+              <Text as="span" variant="caption">
+                {activeCount}
+              </Text>
+            </Box>
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="dark:border-polar-600 dark:bg-polar-700 min-w-72 overflow-hidden rounded-2xl p-0"
+        style={{ width: 'var(--radix-popover-trigger-width)' }}
+        side="bottom"
+        align="start"
+      >
+        <Command
+          className="rounded-2xl bg-transparent"
+          shouldFilter={false}
+          onKeyDown={(e) => {
+            if (activeFilter && e.key === 'Backspace') {
+              e.preventDefault()
+              goBack()
+            }
+          }}
+        >
+          {activeFilter && (
+            <>
+              <Box alignItems="center" columnGap="xs" padding="s">
+                <Button variant="ghost" size="sm" onClick={goBack}>
+                  <ArrowBackOutlined fontSize="inherit" />
+                </Button>
+                <Text as="span" color="muted">
+                  {activeFilter.label}
+                </Text>
+              </Box>
+              <CommandSeparator
+                className="dark:bg-polar-600 mx-0"
+                alwaysRender
+              />
+            </>
+          )}
+          <CommandList>
+            {activeFilter ? (
+              <CommandGroup>
+                {activeFilter.options.map((option) => (
+                  <CommandItem
+                    key={option.value}
+                    value={`${option.label} ${option.value}`}
+                    onSelect={() => onSelectOption(activeFilter, option)}
+                    className={itemClassName}
+                  >
+                    <Text as="span" className="flex-1 truncate">
+                      {option.label}
+                    </Text>
+                    <CheckIcon
+                      className={twMerge(
+                        'h-4 w-4',
+                        isSelected(activeFilter, option)
+                          ? 'visible'
+                          : 'invisible',
+                      )}
+                    />
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ) : (
+              <>
+                <CommandGroup>
+                  {filters.map((filter) => {
+                    const summary = filterSummary(filter)
+                    return (
+                      <CommandItem
+                        key={filter.key}
+                        value={filter.label}
+                        onSelect={() => setActiveKey(filter.key)}
+                        className={itemClassName}
+                      >
+                        {filter.icon}
+                        <Text as="span" className="flex-1 truncate">
+                          {filter.label}
+                        </Text>
+                        {summary ? (
+                          <Text as="span" variant="caption" color="muted">
+                            {summary}
+                          </Text>
+                        ) : null}
+                      </CommandItem>
+                    )
+                  })}
+                </CommandGroup>
+                {activeCount > 0 && (
+                  <>
+                    <CommandSeparator className="dark:bg-polar-600" />
+                    <CommandGroup>
+                      <CommandItem
+                        onSelect={clearAll}
+                        className={itemClassName}
+                      >
+                        Clear filters
+                      </CommandItem>
+                    </CommandGroup>
+                  </>
+                )}
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+export default FilterPopover

--- a/clients/apps/web/src/components/Shared/FilterPopover.tsx
+++ b/clients/apps/web/src/components/Shared/FilterPopover.tsx
@@ -35,6 +35,7 @@ interface FilterBase {
   searchPlaceholder?: string
   searchQuery?: string
   onSearchQueryChange?: (query: string) => void
+  loading?: boolean
 }
 
 export interface SingleFilter extends FilterBase {
@@ -214,7 +215,7 @@ const FilterPopover: React.FC<FilterPopoverProps> = ({
               <Box alignItems="center" columnGap="xs" padding="s">
                 <Button
                   variant="ghost"
-                  size="sm"
+                  size="icon"
                   onClick={goBack}
                   aria-label="Back to filters"
                 >
@@ -260,8 +261,8 @@ const FilterPopover: React.FC<FilterPopoverProps> = ({
                 </Box>
                 {isSearchable && (
                   <Button
-                    variant="ghost"
-                    size="sm"
+                    variant="secondary"
+                    size="icon"
                     aria-label={searchExpanded ? 'Close search' : 'Search'}
                     onClick={() =>
                       searchExpanded
@@ -285,7 +286,7 @@ const FilterPopover: React.FC<FilterPopoverProps> = ({
                 {activeFilter.options.length === 0 && (
                   <Box justifyContent="center" paddingVertical="l">
                     <Text as="span" color="muted">
-                      No results found
+                      {activeFilter.loading ? 'Loading…' : 'No results found'}
                     </Text>
                   </Box>
                 )}

--- a/clients/apps/web/src/components/Shared/FilterPopover.tsx
+++ b/clients/apps/web/src/components/Shared/FilterPopover.tsx
@@ -2,11 +2,13 @@
 
 import ArrowBackOutlined from '@mui/icons-material/ArrowBackOutlined'
 import FilterListOutlined from '@mui/icons-material/FilterListOutlined'
+import SearchOutlined from '@mui/icons-material/SearchOutlined'
 import { Button, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import {
   Command,
   CommandGroup,
+  CommandInput,
   CommandItem,
   CommandList,
   CommandSeparator,
@@ -17,7 +19,7 @@ import {
   PopoverTrigger,
 } from '@polar-sh/ui/components/ui/popover'
 import { CheckIcon } from 'lucide-react'
-import React, { useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 export interface FilterOption {
@@ -30,6 +32,9 @@ interface FilterBase {
   label: string
   icon?: React.ReactNode
   options: FilterOption[]
+  searchPlaceholder?: string
+  searchQuery?: string
+  onSearchQueryChange?: (query: string) => void
 }
 
 export interface SingleFilter extends FilterBase {
@@ -48,6 +53,12 @@ export type Filter = SingleFilter | MultiFilter
 
 const itemClassName =
   "gap-3 rounded-lg px-3 py-3 text-black data-[selected='true']:bg-transparent data-[selected=true]:text-black hover:bg-gray-100 active:bg-gray-100 dark:text-white dark:data-[selected=true]:text-white dark:hover:bg-polar-600 dark:active:bg-polar-600"
+
+const crossfadeClassName = (hidden: boolean): string =>
+  twMerge(
+    'w-full transition-[opacity,filter] duration-100 ease-out motion-reduce:transition-none',
+    hidden ? 'opacity-0 blur-[2px]' : 'opacity-100 blur-0',
+  )
 
 const isActive = (filter: Filter): boolean =>
   filter.type === 'single' ? filter.value !== null : filter.value.length > 0
@@ -108,16 +119,35 @@ const FilterPopover: React.FC<FilterPopoverProps> = ({
 }) => {
   const [open, setOpen] = useState(false)
   const [activeKey, setActiveKey] = useState<string | null>(null)
+  const [searchExpanded, setSearchExpanded] = useState(false)
+  const searchInputRef = useRef<HTMLInputElement>(null)
 
   const activeFilter = filters.find(({ key }) => key === activeKey)
   const activeCount = filters.filter(isActive).length
+  const isSearchable = !!activeFilter?.onSearchQueryChange
+
+  const collapseSearch = () => {
+    setSearchExpanded(false)
+    searchInputRef.current?.blur()
+    activeFilter?.onSearchQueryChange?.('')
+  }
+
+  useEffect(() => {
+    if (searchExpanded) {
+      searchInputRef.current?.focus()
+    }
+  }, [searchExpanded])
 
   const onOpenChange = (value: boolean) => {
     setOpen(value)
     setActiveKey(null)
+    collapseSearch()
   }
 
-  const goBack = () => setActiveKey(null)
+  const goBack = () => {
+    setActiveKey(null)
+    collapseSearch()
+  }
 
   const onSelectOption = (filter: Filter, option: FilterOption) => {
     toggleOption(filter, option)
@@ -173,7 +203,7 @@ const FilterPopover: React.FC<FilterPopoverProps> = ({
           className="rounded-2xl bg-transparent"
           shouldFilter={false}
           onKeyDown={(e) => {
-            if (activeFilter && e.key === 'Backspace') {
+            if (activeFilter && !searchExpanded && e.key === 'Backspace') {
               e.preventDefault()
               goBack()
             }
@@ -185,9 +215,58 @@ const FilterPopover: React.FC<FilterPopoverProps> = ({
                 <Button variant="ghost" size="sm" onClick={goBack}>
                   <ArrowBackOutlined fontSize="inherit" />
                 </Button>
-                <Text as="span" color="muted">
-                  {activeFilter.label}
-                </Text>
+                <Box position="relative" flex={1} height={32}>
+                  <Box
+                    position="absolute"
+                    inset={0}
+                    alignItems="center"
+                    pointerEvents={searchExpanded ? 'none' : 'auto'}
+                  >
+                    <div className={crossfadeClassName(searchExpanded)}>
+                      <Text as="span" color="muted" truncate>
+                        {activeFilter.label}
+                      </Text>
+                    </div>
+                  </Box>
+                  {isSearchable && (
+                    <Box
+                      position="absolute"
+                      inset={0}
+                      alignItems="center"
+                      pointerEvents={searchExpanded ? 'auto' : 'none'}
+                    >
+                      <CommandInput
+                        ref={searchInputRef}
+                        tabIndex={searchExpanded ? 0 : -1}
+                        aria-hidden={!searchExpanded}
+                        className="h-8 rounded-none border-none shadow-none ring-0 outline-none focus:ring-0 focus:outline-none"
+                        wrapperClassName={twMerge(
+                          'border-b-0 px-0 [&>svg]:hidden',
+                          crossfadeClassName(!searchExpanded),
+                        )}
+                        placeholder={
+                          activeFilter.searchPlaceholder ?? 'Search…'
+                        }
+                        value={activeFilter.searchQuery ?? ''}
+                        onValueChange={activeFilter.onSearchQueryChange}
+                      />
+                    </Box>
+                  )}
+                </Box>
+                {isSearchable && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    aria-label={searchExpanded ? 'Close search' : 'Search'}
+                    onClick={() =>
+                      searchExpanded
+                        ? collapseSearch()
+                        : setSearchExpanded(true)
+                    }
+                  >
+                    <SearchOutlined fontSize="inherit" />
+                  </Button>
+                )}
               </Box>
               <CommandSeparator
                 className="dark:bg-polar-600 mx-0"
@@ -198,6 +277,13 @@ const FilterPopover: React.FC<FilterPopoverProps> = ({
           <CommandList>
             {activeFilter ? (
               <CommandGroup>
+                {activeFilter.options.length === 0 && (
+                  <Box justifyContent="center" paddingVertical="l">
+                    <Text as="span" color="muted">
+                      No results found
+                    </Text>
+                  </Box>
+                )}
                 {activeFilter.options.map((option) => (
                   <CommandItem
                     key={option.value}

--- a/clients/apps/web/src/components/Shared/FilterPopover.tsx
+++ b/clients/apps/web/src/components/Shared/FilterPopover.tsx
@@ -212,7 +212,12 @@ const FilterPopover: React.FC<FilterPopoverProps> = ({
           {activeFilter && (
             <>
               <Box alignItems="center" columnGap="xs" padding="s">
-                <Button variant="ghost" size="sm" onClick={goBack}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={goBack}
+                  aria-label="Back to filters"
+                >
                   <ArrowBackOutlined fontSize="inherit" />
                 </Button>
                 <Box position="relative" flex={1} height={32}>


### PR DESCRIPTION
## Summary
- Add a shared `FilterPopover` for mobile-friendly single/multi-select filter menus
- Extract sales filter controls into `SalesFilters` and use the popover below the `sm` breakpoint for product, status, and date

The filters on mobile started taking up too much space and needed to be grouped better. This PR implements a reusable Filter component intended to be used mainly on mobile devices.

| Screenshots |
|---|
| <img width="553" height="527" alt="Screenshot 2026-07-31 at 12 44 40" src="https://github.com/user-attachments/assets/8d6ceeeb-4460-4054-8d33-1190544875ba" /> |
| <img width="557" height="624" alt="Screenshot 2026-07-31 at 12 44 25" src="https://github.com/user-attachments/assets/06209ad7-9b61-44fe-a4c0-3f7548946153" /> |

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788086977&installation_model_id=13063&pr_number=13484&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13484&signature=2cede2b5990996ebff8af11a764372cd85b273c58b7f0123ccc763a14047f735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

