### PR TITLE
fix minor order table inconsistencies

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -208,7 +208,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
       ),
       cell: ({ row: { original: order } }) => (
         <Box display="block" textAlign="right">
-          <Text variant="body" tabularNums>
+          <Text tabularNums>
             {formatCurrency('accounting')(order.net_amount, order.currency)}
           </Text>
         </Box>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/CheckoutsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/CheckoutsPage.tsx
@@ -19,7 +19,7 @@ import {
   DataTableColumnHeader,
 } from '@polar-sh/orbit'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
-import { Input } from '@polar-sh/orbit'
+import { Input, Text } from '@polar-sh/orbit'
 import { useRouter } from 'next/navigation'
 import React from 'react'
 
@@ -173,10 +173,12 @@ const ClientPage: React.FC<ClientPageProps> = ({
         <DataTableColumnHeader column={column} title="Date" />
       ),
       cell: (props) => (
-        <FormattedDateTime
-          datetime={props.getValue() as string}
-          resolution="time"
-        />
+        <Text as="span" tabularNums>
+          <FormattedDateTime
+            datetime={props.getValue() as string}
+            resolution="time"
+          />
+        </Text>
       ),
     },
     {

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
@@ -213,7 +213,9 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
         <DataTableColumnHeader column={column} title="Subscription Date" />
       ),
       cell: (props) => (
-        <FormattedDateTime datetime={props.getValue() as string} />
+        <Text as="span" tabularNums>
+          <FormattedDateTime datetime={props.getValue() as string} />
+        </Text>
       ),
     },
     {
@@ -233,7 +235,9 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
           (status === 'active' || status === 'trialing') &&
           !cancel_at_period_end
         return datetime && willRenew ? (
-          <FormattedDateTime datetime={datetime} />
+          <Text as="span" tabularNums>
+            <FormattedDateTime datetime={datetime} />
+          </Text>
         ) : (
           '—'
         )

--- a/clients/apps/web/src/components/Transactions/TransactionsList.tsx
+++ b/clients/apps/web/src/components/Transactions/TransactionsList.tsx
@@ -8,6 +8,7 @@ import { ISODuration } from '@/utils/duration'
 import { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
 import {
+  Text,
   DataTable,
   DataTableColumnDef,
   DataTableColumnHeader,
@@ -60,7 +61,11 @@ const TransactionsList = ({
         if (isSameDayAsParent) {
           return null
         }
-        return <FormattedDateTime datetime={datetime} resolution="time" />
+        return (
+          <Text as="span" tabularNums>
+            <FormattedDateTime datetime={datetime} resolution="time" />
+          </Text>
+        )
       },
     },
     {


### PR DESCRIPTION
## Summary

Fixes small visual inconsistencies in table cell styling.

- Amount font-size to large in orders table
- Use tabularnums on dates

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788087471&installation_model_id=13063&pr_number=13485&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13485&signature=06a9e7bc873a5f2c9d4d55ec98bc3dfec0e427d099a1cc8085ebb7566658f3a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

