### PR TITLE
prevent flagged malicous files from being downloadable in dashboard

### DIFF
--- a/server/polar/file/endpoints.py
+++ b/server/polar/file/endpoints.py
@@ -102,6 +102,11 @@ async def download(
     if file is None or not file.is_uploaded:
         raise ResourceNotFound()
 
+    if file.flagged_malicious_at is not None:
+        raise NotPermitted(
+            "This file has been flagged as malicious and cannot be downloaded."
+        )
+
     if file.service == FileServiceTypes.support_case_attachment:
         raise NotPermitted(
             "Support case attachments cannot be downloaded through the files API."

--- a/server/tests/file/test_endpoints.py
+++ b/server/tests/file/test_endpoints.py
@@ -7,6 +7,7 @@ from httpx import AsyncClient, ReadError
 from polar.file.repository import FileRepository
 from polar.file.s3 import S3_SERVICES
 from polar.integrations.aws.s3.exceptions import S3FileError
+from polar.kit.utils import utc_now
 from polar.models import Organization, UserOrganization
 from polar.models.file import FileServiceTypes
 from polar.postgres import AsyncSession
@@ -223,6 +224,28 @@ class TestDownload:
         response = await client.get(f"/v1/files/{file.id}/download")
 
         assert response.status_code == 403
+
+    @pytest.mark.auth
+    async def test_flagged_malicious_not_permitted(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        file = await create_support_case_attachment_file(
+            save_fixture,
+            organization,
+            name="malware.zip",
+            service=FileServiceTypes.downloadable,
+        )
+        file.flagged_malicious_at = utc_now()
+        await save_fixture(file)
+
+        response = await client.get(f"/v1/files/{file.id}/download")
+
+        assert response.status_code == 403
+        assert "download" not in response.json()
 
     @pytest.mark.auth(
         AuthSubjectFixture(subject="user"),


### PR DESCRIPTION
## Summary

**Related Issue**: https://github.com/polarsource/feedback/issues/336

This adds a `flagged_malicious_at` check to the endpoint, before the presigned URL is
generated. Flagged files now return `403 NotPermitted` (already declared in the endpoint's
`responses=`) instead of a download URL.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788089250&installation_model_id=13063&pr_number=13486&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13486&signature=ee08860b99e351097ef1410d8cc7f229c3cfef7e1bfbf7532de87a3b5c5ebb1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

