### PR TITLE
fix(order): bound metered usage to the cycle boundary

### DIFF
--- a/server/polar/billing_entry/repository.py
+++ b/server/polar/billing_entry/repository.py
@@ -70,7 +70,10 @@ class BillingEntryRepository(
             yield result
 
     async def get_pending_metered_by_subscription_tuples(
-        self, subscription_id: UUID
+        self,
+        subscription_id: UUID,
+        *,
+        entries_started_before: datetime | None = None,
     ) -> AsyncGenerator[tuple[UUID, UUID, datetime, datetime]]:
         """
         Get pending metered billing entries grouped by (product_price_id, meter_id).
@@ -99,6 +102,10 @@ class BillingEntryRepository(
             .order_by(None)  # Clear existing ORDER BY from base statement
             .order_by(ProductPriceMeteredUnit.meter_id.asc())
         )
+        if entries_started_before is not None:
+            statement = statement.where(
+                BillingEntry.start_timestamp < entries_started_before
+            )
         results = await self.session.stream(
             statement,
             execution_options={"yield_per": settings.DATABASE_STREAM_YIELD_PER},
@@ -110,18 +117,30 @@ class BillingEntryRepository(
             await results.close()
 
     async def get_pending_ids_by_subscription_and_price(
-        self, subscription_id: UUID, product_price_id: UUID
+        self,
+        subscription_id: UUID,
+        product_price_id: UUID,
+        *,
+        entries_started_before: datetime | None = None,
     ) -> Sequence[UUID]:
         statement = (
             self.get_pending_by_subscription_statement(subscription_id)
             .with_only_columns(BillingEntry.id)
             .where(BillingEntry.product_price_id == product_price_id)
         )
+        if entries_started_before is not None:
+            statement = statement.where(
+                BillingEntry.start_timestamp < entries_started_before
+            )
         results = await self.session.execute(statement)
         return results.scalars().unique().all()
 
     async def get_pending_ids_by_subscription_and_meter(
-        self, subscription_id: UUID, meter_id: UUID
+        self,
+        subscription_id: UUID,
+        meter_id: UUID,
+        *,
+        entries_started_before: datetime | None = None,
     ) -> Sequence[UUID]:
         """
         Get all pending billing entry IDs for a subscription and meter across all prices.
@@ -135,6 +154,10 @@ class BillingEntryRepository(
             .with_only_columns(BillingEntry.id)
             .where(ProductPriceMeteredUnit.meter_id == meter_id)
         )
+        if entries_started_before is not None:
+            statement = statement.where(
+                BillingEntry.start_timestamp < entries_started_before
+            )
         results = await self.session.execute(statement)
         return results.scalars().unique().all()
 

--- a/server/polar/billing_entry/service.py
+++ b/server/polar/billing_entry/service.py
@@ -54,14 +54,18 @@ class MeteredLineItem:
 class BillingEntryService:
     @contextlib.asynccontextmanager
     async def create_order_items_from_pending(
-        self, session: AsyncSession, subscription: Subscription
+        self,
+        session: AsyncSession,
+        subscription: Subscription,
+        *,
+        metered_usage_billed_until: datetime | None = None,
     ) -> AsyncGenerator[Sequence[OrderItem]]:
         repository = BillingEntryRepository.from_session(session)
         await repository.lock_pending_by_subscription(subscription.id)
 
         item_entries_map: dict[OrderItem, Sequence[uuid.UUID]] = {}
         async for line_item, entries in self.compute_pending_subscription_line_items(
-            session, subscription
+            session, subscription, metered_usage_billed_until=metered_usage_billed_until
         ):
             order_item = OrderItem(
                 id=uuid.uuid4(),
@@ -81,7 +85,11 @@ class BillingEntryService:
             await repository.update_order_item_id(entries, order_item.id)
 
     async def compute_pending_subscription_line_items(
-        self, session: AsyncSession, subscription: Subscription
+        self,
+        session: AsyncSession,
+        subscription: Subscription,
+        *,
+        metered_usage_billed_until: datetime | None = None,
     ) -> AsyncGenerator[tuple[StaticLineItem | MeteredLineItem, Sequence[uuid.UUID]]]:
         repository = BillingEntryRepository.from_session(session)
 
@@ -113,7 +121,9 @@ class BillingEntryService:
             meter_id,
             start_timestamp,
             end_timestamp,
-        ) in repository.get_pending_metered_by_subscription_tuples(subscription.id):
+        ) in repository.get_pending_metered_by_subscription_tuples(
+            subscription.id, entries_started_before=metered_usage_billed_until
+        ):
             metered_price = cast(
                 MeteredPrice, await product_price_repository.get_by_id(product_price_id)
             )
@@ -147,11 +157,18 @@ class BillingEntryService:
                     continue
 
                 metered_line_item = await self._get_metered_line_item_by_meter(
-                    session, active_price, subscription, start_timestamp, end_timestamp
+                    session,
+                    active_price,
+                    subscription,
+                    start_timestamp,
+                    end_timestamp,
+                    metered_usage_billed_until=metered_usage_billed_until,
                 )
                 pending_entries_ids = (
                     await repository.get_pending_ids_by_subscription_and_meter(
-                        subscription.id, meter_id
+                        subscription.id,
+                        meter_id,
+                        entries_started_before=metered_usage_billed_until,
                     )
                 )
             else:
@@ -171,11 +188,18 @@ class BillingEntryService:
                     continue
 
                 metered_line_item = await self._get_metered_line_item(
-                    session, metered_price, subscription, start_timestamp, end_timestamp
+                    session,
+                    metered_price,
+                    subscription,
+                    start_timestamp,
+                    end_timestamp,
+                    metered_usage_billed_until=metered_usage_billed_until,
                 )
                 pending_entries_ids = (
                     await repository.get_pending_ids_by_subscription_and_price(
-                        subscription.id, product_price_id
+                        subscription.id,
+                        product_price_id,
+                        entries_started_before=metered_usage_billed_until,
                     )
                 )
 
@@ -247,6 +271,8 @@ class BillingEntryService:
         subscription: Subscription,
         start_timestamp: datetime,
         end_timestamp: datetime,
+        *,
+        metered_usage_billed_until: datetime | None = None,
     ) -> MeteredLineItem:
         """
         Compute a metered line item for a specific price.
@@ -254,7 +280,9 @@ class BillingEntryService:
         """
         event_repository = EventRepository.from_session(session)
         events_statement = event_repository.get_by_pending_entries_statement(
-            subscription.id, price.id
+            subscription.id,
+            price.id,
+            entries_started_before=metered_usage_billed_until,
         )
         meter = price.meter
         units = await meter_service.get_quantity(
@@ -294,6 +322,8 @@ class BillingEntryService:
         subscription: Subscription,
         start_timestamp: datetime,
         end_timestamp: datetime,
+        *,
+        metered_usage_billed_until: datetime | None = None,
     ) -> MeteredLineItem:
         """
         Compute a metered line item grouped by meter.
@@ -306,7 +336,9 @@ class BillingEntryService:
 
         # Get events across ALL prices for this meter
         events_statement = event_repository.get_by_pending_entries_for_meter_statement(
-            subscription.id, meter.id
+            subscription.id,
+            meter.id,
+            entries_started_before=metered_usage_billed_until,
         )
         units = await meter_service.get_quantity(
             session,

--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -376,9 +376,13 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         return [(event, customer) for event, customer in result.all()]
 
     def get_by_pending_entries_statement(
-        self, subscription: UUID, price: UUID
+        self,
+        subscription: UUID,
+        price: UUID,
+        *,
+        entries_started_before: datetime | None = None,
     ) -> Select[tuple[Event]]:
-        return (
+        statement = (
             self.get_base_statement()
             .join(BillingEntry, Event.id == BillingEntry.event_id)
             .where(
@@ -388,16 +392,25 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
             )
             .order_by(Event.ingested_at.asc())
         )
+        if entries_started_before is not None:
+            statement = statement.where(
+                BillingEntry.start_timestamp < entries_started_before
+            )
+        return statement
 
     def get_by_pending_entries_for_meter_statement(
-        self, subscription: UUID, meter: UUID
+        self,
+        subscription: UUID,
+        meter: UUID,
+        *,
+        entries_started_before: datetime | None = None,
     ) -> Select[tuple[Event]]:
         """
         Get events for pending billing entries grouped by meter.
         Used for non-summable aggregations where we need to compute across all events
         in the period, regardless of which price was active when the event occurred.
         """
-        return (
+        statement = (
             self.get_base_statement()
             .join(BillingEntry, Event.id == BillingEntry.event_id)
             .join(
@@ -411,6 +424,11 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
             )
             .order_by(Event.ingested_at.asc())
         )
+        if entries_started_before is not None:
+            statement = statement.where(
+                BillingEntry.start_timestamp < entries_started_before
+            )
+        return statement
 
     def get_eager_options(self) -> Options:
         return (joinedload(Event.customer), joinedload(Event.event_types))

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1440,6 +1440,13 @@ class OrderService:
         # Note: subscription_update is intentionally excluded - meter credits from
         # benefit grants should persist within a billing cycle. Subscription updates
         # are for prorations, not new billing periods.
+        # Known limitation: resetting here, at order time, leaves the meter window
+        # (bounded by the latest reset event's `ingested_at`) drifting from the
+        # billing period whenever a cycle order is delayed or retried. Usage in that
+        # gap shrinks the closed period's rollover while still being billed in the
+        # next one, so it doesn't follow the `metered_usage_billed_until` bound set
+        # in `create_subscription_order`. Pinning the two together means resetting in
+        # the cycle transaction instead, which also has to cover the `resume` path.
         if billing_reason in {
             OrderBillingReasonInternal.subscription_cycle,
             OrderBillingReasonInternal.subscription_cycle_after_trial,

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -1303,8 +1303,23 @@ class OrderService:
         Returns:
             The created Order object.
         """
+        # On a cycle, the billing period has already been advanced, so
+        # ``current_period_start`` marks the end of the period being billed. Bound
+        # metered usage to it so usage accrued in the new period isn't swept into
+        # this order — important when a delayed/retried cycle order runs well after
+        # the period boundary. Other billing reasons don't advance the period, so
+        # they keep billing all pending usage up to now.
+        metered_usage_billed_until = (
+            subscription.current_period_start
+            if billing_reason
+            in (
+                OrderBillingReasonInternal.subscription_cycle,
+                OrderBillingReasonInternal.subscription_cycle_after_trial,
+            )
+            else None
+        )
         async with billing_entry_service.create_order_items_from_pending(
-            session, subscription
+            session, subscription, metered_usage_billed_until=metered_usage_billed_until
         ) as items:
             if len(items) == 0:
                 raise NoPendingBillingEntries(subscription)

--- a/server/tests/billing_entry/test_service.py
+++ b/server/tests/billing_entry/test_service.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from decimal import Decimal
 
 import pytest
@@ -6,6 +7,7 @@ import pytest_asyncio
 from polar.billing_entry.service import billing_entry as billing_entry_service
 from polar.enums import SubscriptionProrationBehavior, SubscriptionRecurringInterval
 from polar.event.system import SystemEvent
+from polar.kit.utils import utc_now
 from polar.meter.aggregation import AggregationFunction, PropertyAggregation
 from polar.meter.filter import Filter, FilterConjunction
 from polar.models import (
@@ -101,12 +103,14 @@ async def create_metered_event_billing_entry(
     pending: bool = True,
     order: Order | None = None,
     metadata_key: str = "tokens",
+    timestamp: datetime | None = None,
 ) -> BillingEntry:
     event = await create_event(
         save_fixture,
         organization=customer.organization,
         customer=customer,
         metadata={metadata_key: tokens},
+        timestamp=timestamp,
     )
     billing_entry = BillingEntry(
         start_timestamp=event.timestamp,
@@ -867,3 +871,114 @@ class TestCreateOrderItemsFromPending:
         for entry in old_entries:
             await session.refresh(entry)
             assert entry.order_item_id is None
+
+    async def test_metered_usage_billed_until_excludes_later_usage(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        meter: Meter,
+        product_metered_unit: Product,
+        metered_subscription: Subscription,
+    ) -> None:
+        """
+        When ``metered_usage_billed_until`` is set, usage accrued at or after that
+        timestamp is left pending for the next order instead of being swept in.
+        """
+        price = product_metered_unit.prices[0]
+        assert is_metered_price(price)
+        boundary = utc_now()
+
+        before_entries = [
+            await create_metered_event_billing_entry(
+                save_fixture,
+                customer=customer,
+                price=price,
+                subscription=metered_subscription,
+                tokens=10,
+                timestamp=boundary - timedelta(days=2),
+            ),
+            await create_metered_event_billing_entry(
+                save_fixture,
+                customer=customer,
+                price=price,
+                subscription=metered_subscription,
+                tokens=20,
+                timestamp=boundary - timedelta(days=1),
+            ),
+        ]
+        after_entry = await create_metered_event_billing_entry(
+            save_fixture,
+            customer=customer,
+            price=price,
+            subscription=metered_subscription,
+            tokens=30,
+            timestamp=boundary + timedelta(days=1),
+        )
+
+        async with billing_entry_service.create_order_items_from_pending(
+            session, metered_subscription, metered_usage_billed_until=boundary
+        ) as order_items:
+            assert len(order_items) == 1
+
+            order_item = order_items[0]
+            # Only the 10 + 20 tokens before the boundary are billed.
+            assert order_item.amount == 30_00
+
+            await create_order(
+                save_fixture,
+                customer=customer,
+                order_items=list(order_items),
+            )
+
+        for entry in before_entries:
+            await session.refresh(entry)
+            assert entry.order_item_id == order_item.id
+
+        # Usage after the boundary stays pending for the next order.
+        await session.refresh(after_entry)
+        assert after_entry.order_item_id is None
+
+    async def test_metered_usage_billed_until_does_not_bound_static(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        """
+        The boundary only applies to metered usage. Static entries (e.g. the
+        advance recurring charge, stamped with the upcoming period) must still be
+        billed even when their timestamps fall on/after the boundary.
+        """
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        price = product.prices[0]
+        assert is_fixed_price(price)
+
+        entry = await create_static_price_billing_entry(
+            save_fixture,
+            customer=customer,
+            price=price,
+            subscription=subscription,
+            pending=True,
+        )
+
+        async with billing_entry_service.create_order_items_from_pending(
+            session,
+            subscription,
+            metered_usage_billed_until=subscription.current_period_start,
+        ) as order_items:
+            assert len(order_items) == 1
+            order_item = order_items[0]
+            assert order_item.product_price == price
+
+            await create_order(
+                save_fixture,
+                customer=customer,
+                order_items=list(order_items),
+            )
+
+        await session.refresh(entry)
+        assert entry.order_item_id == order_item.id

--- a/server/tests/billing_entry/test_service.py
+++ b/server/tests/billing_entry/test_service.py
@@ -149,6 +149,7 @@ async def create_credit_billing_entry(
     meter: Meter,
     pending: bool = True,
     order: Order | None = None,
+    timestamp: datetime | None = None,
 ) -> BillingEntry:
     event = await create_event(
         save_fixture,
@@ -157,6 +158,7 @@ async def create_credit_billing_entry(
         name=SystemEvent.meter_credited,
         customer=customer,
         metadata={"meter_id": str(meter.id), "units": units},
+        timestamp=timestamp,
     )
     billing_entry = BillingEntry(
         start_timestamp=event.timestamp,
@@ -982,3 +984,89 @@ class TestCreateOrderItemsFromPending:
 
         await session.refresh(entry)
         assert entry.order_item_id == order_item.id
+
+    async def test_rollover_credit_applies_to_next_order(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        meter: Meter,
+        product_metered_unit: Product,
+        metered_subscription: Subscription,
+    ) -> None:
+        """
+        Meters are reset after the order's line items are computed, so a rollover
+        credit is always stamped past the cycle boundary. It must not discount the
+        order being created, and must discount the following one.
+        """
+        price = product_metered_unit.prices[0]
+        assert is_metered_price(price)
+        boundary = utc_now()
+
+        usage_before = await create_metered_event_billing_entry(
+            save_fixture,
+            customer=customer,
+            price=price,
+            subscription=metered_subscription,
+            tokens=30,
+            timestamp=boundary - timedelta(days=1),
+        )
+        credit = await create_credit_billing_entry(
+            save_fixture,
+            customer=customer,
+            price=price,
+            subscription=metered_subscription,
+            meter=meter,
+            units=10,
+            timestamp=boundary + timedelta(hours=1),
+        )
+        usage_after = await create_metered_event_billing_entry(
+            save_fixture,
+            customer=customer,
+            price=price,
+            subscription=metered_subscription,
+            tokens=25,
+            timestamp=boundary + timedelta(hours=2),
+        )
+
+        async with billing_entry_service.create_order_items_from_pending(
+            session, metered_subscription, metered_usage_billed_until=boundary
+        ) as order_items:
+            assert len(order_items) == 1
+            cycle_item = order_items[0]
+            # The full 30 tokens: the credit is past the boundary.
+            assert cycle_item.amount == 30_00
+
+            await create_order(
+                save_fixture,
+                customer=customer,
+                order_items=list(order_items),
+            )
+
+        await session.refresh(usage_before)
+        assert usage_before.order_item_id == cycle_item.id
+
+        await session.refresh(credit)
+        assert credit.order_item_id is None
+
+        async with billing_entry_service.create_order_items_from_pending(
+            session,
+            metered_subscription,
+            metered_usage_billed_until=boundary + timedelta(days=1),
+        ) as order_items:
+            assert len(order_items) == 1
+            next_item = order_items[0]
+            # 25 tokens consumed, less the 10 rolled-over units.
+            assert next_item.amount == 15_00
+
+            await create_order(
+                save_fixture,
+                customer=customer,
+                order_items=list(order_items),
+            )
+
+        await session.refresh(credit)
+        assert credit.order_item_id == next_item.id
+
+        await session.refresh(usage_after)
+        assert usage_after.order_item_id == next_item.id

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -1798,10 +1798,13 @@ class TestCreateSubscriptionOrder:
             save_fixture, product=product_recurring_metered, customer=customer
         )
 
+        # On a real cycle the period is advanced before the order is created, so
+        # the usage being billed occurred before ``current_period_start``.
         event = await create_event(
             save_fixture,
             organization=organization,
             customer=customer,
+            timestamp=subscription.current_period_start - timedelta(days=1),
         )
         await save_fixture(
             BillingEntry.from_metered_event(


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788089610&installation_model_id=13063&pr_number=13487&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13487&signature=d4e91ae240aeaf6d7aa720447ec2f195a099fdf78688e0123d64a297ec52edf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound metered usage to the billing cycle boundary to prevent late cycle orders from billing new-period usage. Usage at or after `subscription.current_period_start` stays pending for the next order; static items are unaffected.

- **Bug Fixes**
  - Added `metered_usage_billed_until` to bound metered entries; plumbed through services and applied `entries_started_before` filters in repositories.
  - Applied only for `subscription_cycle` and `subscription_cycle_after_trial`.
  - Ensured rollover credits (posted after the boundary) discount the next order, not the current one.
  - Added tests covering usage exclusion, static items, and rollover credit behavior.
  - Noted known limitation: meter reset window can drift from the billing period on delayed orders.

<sup>Written for commit 69af2ce6f3b53f6a84a9c429224c60fc7585fcf3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

