### PR TITLE
feat(organization): add dispute auto-accept threshold setting

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -20503,6 +20503,17 @@ export interface components {
        */
       case_id: string | null
     }
+    /** DisputeAutoAcceptNotEnabled */
+    DisputeAutoAcceptNotEnabled: {
+      /**
+       * Error
+       * @example DisputeAutoAcceptNotEnabled
+       * @constant
+       */
+      error: 'DisputeAutoAcceptNotEnabled'
+      /** Detail */
+      detail: string
+    }
     /** DisputeCustomer */
     DisputeCustomer: {
       /**
@@ -25649,6 +25660,8 @@ export interface components {
       customer_email_settings: components['schemas']['OrganizationCustomerEmailSettings']
       /** @description Settings related to the customer portal */
       customer_portal_settings: components['schemas']['OrganizationCustomerPortalSettings']
+      /** @description Settings related to disputes */
+      dispute_settings: components['schemas']['OrganizationDisputeSettings']
       /**
        * Embed Hosts
        * @description Hosts allowed to embed this organization's checkout. An entry is a host and an optional port, without a scheme: HTTPS is always allowed, and HTTP too for local hosts — `localhost`, any `.localhost` or `.local` name, and loopback or private addresses. `*.example.com` matches any subdomain, but not `example.com` itself. An app origin such as `chrome-extension://abcdef` carries its scheme, having no host to match on.
@@ -26682,6 +26695,24 @@ export interface components {
        */
       previous_annual_revenue?: number | null
     }
+    /**
+     * OrganizationDisputeSettings
+     * @description `auto_accept_below_amount` is in the account's settlement currency, the
+     *     one disputes are deducted in. Disputes charged in another currency convert
+     *     through the exchange rate their payment settled at.
+     */
+    OrganizationDisputeSettings: {
+      /** Auto Accept Below Amount */
+      auto_accept_below_amount: number | null
+    }
+    /** OrganizationDisputeSettingsUpdate */
+    OrganizationDisputeSettingsUpdate: {
+      /**
+       * Auto Accept Below Amount
+       * @description Concede disputes below this amount, in cents of the organization's payout currency, without asking it. A dispute charged in another currency converts at the rate its payment settled at. `null` turns it off. The disputed amount and the processor's dispute fee are still deducted.
+       */
+      auto_accept_below_amount?: number | null
+    }
     /** OrganizationEmbedStatus */
     OrganizationEmbedStatus: {
       /**
@@ -26783,6 +26814,12 @@ export interface components {
        * @default false
        */
       sso_enabled: boolean
+      /**
+       * Dispute Auto Accept Enabled
+       * @description If this organization can set a threshold below which Polar concedes disputes on its behalf. Requires `disputes_enabled`.
+       * @default false
+       */
+      dispute_auto_accept_enabled: boolean
       /**
        * Compass Enabled
        * @description If this organization has the split product navigation (Billing / Compass / Customers) enabled in the dashboard
@@ -26929,6 +26966,8 @@ export interface components {
       customer_email_settings: components['schemas']['OrganizationCustomerEmailSettings']
       /** @description Settings related to the customer portal */
       customer_portal_settings: components['schemas']['OrganizationCustomerPortalSettings']
+      /** @description Settings related to disputes */
+      dispute_settings: components['schemas']['OrganizationDisputeSettings']
       /**
        * Embed Hosts
        * @description Hosts allowed to embed this organization's checkout. An entry is a host and an optional port, without a scheme: HTTPS is always allowed, and HTTP too for local hosts — `localhost`, any `.localhost` or `.local` name, and loopback or private addresses. `*.example.com` matches any subdomain, but not `example.com` itself. An app origin such as `chrome-extension://abcdef` carries its scheme, having no host to match on.
@@ -28240,6 +28279,9 @@ export interface components {
       customer_portal_settings?:
         | components['schemas']['OrganizationCustomerPortalSettings']
         | null
+      dispute_settings?:
+        | components['schemas']['OrganizationDisputeSettingsUpdate']
+        | null
       /** Embed Hosts */
       embed_hosts?: string[] | null
       /** @description Default presentment currency for the organization */
@@ -28375,6 +28417,8 @@ export interface components {
       customer_email_settings: components['schemas']['OrganizationCustomerEmailSettings']
       /** @description Settings related to the customer portal */
       customer_portal_settings: components['schemas']['OrganizationCustomerPortalSettings']
+      /** @description Settings related to disputes */
+      dispute_settings: components['schemas']['OrganizationDisputeSettings']
       /**
        * Embed Hosts
        * @description Hosts allowed to embed this organization's checkout. An entry is a host and an optional port, without a scheme: HTTPS is always allowed, and HTTP too for local hosts — `localhost`, any `.localhost` or `.local` name, and loopback or private addresses. `*.example.com` matches any subdomain, but not `example.com` itself. An app origin such as `chrome-extension://abcdef` carries its scheme, having no host to match on.
@@ -38153,13 +38197,15 @@ export interface operations {
           'application/json': components['schemas']['Organization']
         }
       }
-      /** @description You don't have the permission to update this organization. */
+      /** @description You don't have the permission to update this organization, or dispute auto-accept isn't enabled for it. */
       403: {
         headers: {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['NotPermitted']
+          'application/json':
+            | components['schemas']['NotPermitted']
+            | components['schemas']['DisputeAutoAcceptNotEnabled']
         }
       }
       /** @description Organization not found. */

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -20833,6 +20833,17 @@ export interface components {
        */
       case_id: string | null
     }
+    /** DisputeAutoAcceptNotEnabled */
+    DisputeAutoAcceptNotEnabled: {
+      /**
+       * Error
+       * @example DisputeAutoAcceptNotEnabled
+       * @constant
+       */
+      error: 'DisputeAutoAcceptNotEnabled'
+      /** Detail */
+      detail: string
+    }
     /** DisputeCustomer */
     DisputeCustomer: {
       /**
@@ -26162,6 +26173,8 @@ export interface components {
       customer_email_settings: components['schemas']['OrganizationCustomerEmailSettings']
       /** @description Settings related to the customer portal */
       customer_portal_settings: components['schemas']['OrganizationCustomerPortalSettings']
+      /** @description Settings related to disputes */
+      dispute_settings: components['schemas']['OrganizationDisputeSettings']
       /**
        * Embed Hosts
        * @description Hosts allowed to embed this organization's checkout. An entry is a host and an optional port, without a scheme: HTTPS is always allowed, and HTTP too for local hosts — `localhost`, any `.localhost` or `.local` name, and loopback or private addresses. `*.example.com` matches any subdomain, but not `example.com` itself. An app origin such as `chrome-extension://abcdef` carries its scheme, having no host to match on.
@@ -27195,6 +27208,24 @@ export interface components {
        */
       previous_annual_revenue?: number | null
     }
+    /**
+     * OrganizationDisputeSettings
+     * @description `auto_accept_below_amount` is in the account's settlement currency, the
+     *     one disputes are deducted in. Disputes charged in another currency convert
+     *     through the exchange rate their payment settled at.
+     */
+    OrganizationDisputeSettings: {
+      /** Auto Accept Below Amount */
+      auto_accept_below_amount: number | null
+    }
+    /** OrganizationDisputeSettingsUpdate */
+    OrganizationDisputeSettingsUpdate: {
+      /**
+       * Auto Accept Below Amount
+       * @description Concede disputes below this amount, in cents of the organization's payout currency, without asking it. A dispute charged in another currency converts at the rate its payment settled at. `null` turns it off. The disputed amount and the processor's dispute fee are still deducted.
+       */
+      auto_accept_below_amount?: number | null
+    }
     /** OrganizationEmbedStatus */
     OrganizationEmbedStatus: {
       /**
@@ -27296,6 +27327,12 @@ export interface components {
        * @default false
        */
       sso_enabled: boolean
+      /**
+       * Dispute Auto Accept Enabled
+       * @description If this organization can set a threshold below which Polar concedes disputes on its behalf. Requires `disputes_enabled`.
+       * @default false
+       */
+      dispute_auto_accept_enabled: boolean
       /**
        * Compass Enabled
        * @description If this organization has the split product navigation (Billing / Compass / Customers) enabled in the dashboard
@@ -27442,6 +27479,8 @@ export interface components {
       customer_email_settings: components['schemas']['OrganizationCustomerEmailSettings']
       /** @description Settings related to the customer portal */
       customer_portal_settings: components['schemas']['OrganizationCustomerPortalSettings']
+      /** @description Settings related to disputes */
+      dispute_settings: components['schemas']['OrganizationDisputeSettings']
       /**
        * Embed Hosts
        * @description Hosts allowed to embed this organization's checkout. An entry is a host and an optional port, without a scheme: HTTPS is always allowed, and HTTP too for local hosts — `localhost`, any `.localhost` or `.local` name, and loopback or private addresses. `*.example.com` matches any subdomain, but not `example.com` itself. An app origin such as `chrome-extension://abcdef` carries its scheme, having no host to match on.
@@ -28753,6 +28792,9 @@ export interface components {
       customer_portal_settings?:
         | components['schemas']['OrganizationCustomerPortalSettings']
         | null
+      dispute_settings?:
+        | components['schemas']['OrganizationDisputeSettingsUpdate']
+        | null
       /** Embed Hosts */
       embed_hosts?: string[] | null
       /** @description Default presentment currency for the organization */
@@ -28888,6 +28930,8 @@ export interface components {
       customer_email_settings: components['schemas']['OrganizationCustomerEmailSettings']
       /** @description Settings related to the customer portal */
       customer_portal_settings: components['schemas']['OrganizationCustomerPortalSettings']
+      /** @description Settings related to disputes */
+      dispute_settings: components['schemas']['OrganizationDisputeSettings']
       /**
        * Embed Hosts
        * @description Hosts allowed to embed this organization's checkout. An entry is a host and an optional port, without a scheme: HTTPS is always allowed, and HTTP too for local hosts — `localhost`, any `.localhost` or `.local` name, and loopback or private addresses. `*.example.com` matches any subdomain, but not `example.com` itself. An app origin such as `chrome-extension://abcdef` carries its scheme, having no host to match on.
@@ -38915,13 +38959,15 @@ export interface operations {
           'application/json': components['schemas']['Organization']
         }
       }
-      /** @description You don't have the permission to update this organization. */
+      /** @description You don't have the permission to update this organization, or dispute auto-accept isn't enabled for it. */
       403: {
         headers: {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['NotPermitted']
+          'application/json':
+            | components['schemas']['NotPermitted']
+            | components['schemas']['DisputeAutoAcceptNotEnabled']
         }
       }
       /** @description Organization not found. */

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -27210,9 +27210,7 @@ export interface components {
     }
     /**
      * OrganizationDisputeSettings
-     * @description `auto_accept_below_amount` is in the account's settlement currency, the
-     *     one disputes are deducted in. Disputes charged in another currency convert
-     *     through the exchange rate their payment settled at.
+     * @description `auto_accept_below_amount` is in Polar's settlement currency (USD).
      */
     OrganizationDisputeSettings: {
       /** Auto Accept Below Amount */
@@ -27222,7 +27220,7 @@ export interface components {
     OrganizationDisputeSettingsUpdate: {
       /**
        * Auto Accept Below Amount
-       * @description Concede disputes below this amount, in cents of the organization's payout currency, without asking it. A dispute charged in another currency converts at the rate its payment settled at. `null` turns it off. The disputed amount and the processor's dispute fee are still deducted.
+       * @description Concede disputes below this amount, in USD cents, without asking the organization. A dispute charged in another currency converts at the rate its payment settled at. `null` turns it off. The disputed amount and the processor's dispute fee are still deducted.
        */
       auto_accept_below_amount?: number | null
     }

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -26697,9 +26697,7 @@ export interface components {
     }
     /**
      * OrganizationDisputeSettings
-     * @description `auto_accept_below_amount` is in the account's settlement currency, the
-     *     one disputes are deducted in. Disputes charged in another currency convert
-     *     through the exchange rate their payment settled at.
+     * @description `auto_accept_below_amount` is in Polar's settlement currency (USD).
      */
     OrganizationDisputeSettings: {
       /** Auto Accept Below Amount */
@@ -26709,7 +26707,7 @@ export interface components {
     OrganizationDisputeSettingsUpdate: {
       /**
        * Auto Accept Below Amount
-       * @description Concede disputes below this amount, in cents of the organization's payout currency, without asking it. A dispute charged in another currency converts at the rate its payment settled at. `null` turns it off. The disputed amount and the processor's dispute fee are still deducted.
+       * @description Concede disputes below this amount, in USD cents, without asking the organization. A dispute charged in another currency converts at the rate its payment settled at. `null` turns it off. The disputed amount and the processor's dispute fee are still deducted.
        */
       auto_accept_below_amount?: number | null
     }

--- a/server/emails/src/types/openapi.ts
+++ b/server/emails/src/types/openapi.ts
@@ -1654,6 +1654,8 @@ export interface components {
       customer_email_settings: components['schemas']['OrganizationCustomerEmailSettings']
       /** @description Settings related to the customer portal */
       customer_portal_settings: components['schemas']['OrganizationCustomerPortalSettings']
+      /** @description Settings related to disputes */
+      dispute_settings: components['schemas']['OrganizationDisputeSettings']
       /**
        * Embed Hosts
        * @description Hosts allowed to embed this organization's checkout. An entry is a host and an optional port, without a scheme: HTTPS is always allowed, and HTTP too for local hosts — `localhost`, any `.localhost` or `.local` name, and loopback or private addresses. `*.example.com` matches any subdomain, but not `example.com` itself. An app origin such as `chrome-extension://abcdef` carries its scheme, having no host to match on.
@@ -2025,6 +2027,14 @@ export interface components {
       subscription: components['schemas']['CustomerPortalSubscriptionSettings']
       customer?: components['schemas']['CustomerPortalCustomerSettings']
     }
+    /**
+     * OrganizationDisputeSettings
+     * @description `auto_accept_below_amount` is in Polar's settlement currency (USD).
+     */
+    OrganizationDisputeSettings: {
+      /** Auto Accept Below Amount */
+      auto_accept_below_amount: number | null
+    }
     /** OrganizationFeatureSettings */
     OrganizationFeatureSettings: {
       /**
@@ -2099,6 +2109,12 @@ export interface components {
        * @default false
        */
       sso_enabled: boolean
+      /**
+       * Dispute Auto Accept Enabled
+       * @description If this organization can set a threshold below which Polar concedes disputes on its behalf. Requires `disputes_enabled`.
+       * @default false
+       */
+      dispute_auto_accept_enabled: boolean
       /**
        * Compass Enabled
        * @description If this organization has the split product navigation (Billing / Compass / Customers) enabled in the dashboard

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -223,14 +223,16 @@ def _default_checkout_settings() -> OrganizationCheckoutSettings:
 
 
 class OrganizationDisputeSettings(TypedDict):
+    """`auto_accept_below_amount` is in the account's settlement currency, the
+    one disputes are deducted in. Disputes charged in another currency convert
+    through the exchange rate their payment settled at."""
+
     auto_accept_below_amount: int | None
-    auto_accept_currency: str | None
 
 
 def _default_dispute_settings() -> OrganizationDisputeSettings:
     return {
         "auto_accept_below_amount": None,
-        "auto_accept_currency": None,
     }
 
 
@@ -716,6 +718,14 @@ class Organization(RateLimitGroupMixin, RecordModel):
         return self.feature_settings.get("sso_enabled", False)
 
     @property
+    def is_dispute_auto_accept_enabled(self) -> bool:
+        """Auto-accept is useless without the dispute dashboard: the merchant
+        would have no thread to read and no way to respond to stop it."""
+        return self.feature_settings.get("disputes_enabled", False) and (
+            self.feature_settings.get("dispute_auto_accept_enabled", False)
+        )
+
+    @property
     def is_compass_enabled(self) -> bool:
         return self.feature_settings.get("compass_enabled", False)
 
@@ -907,10 +917,6 @@ class Organization(RateLimitGroupMixin, RecordModel):
     @property
     def dispute_auto_accept_below_amount(self) -> int | None:
         return self.dispute_settings["auto_accept_below_amount"]
-
-    @property
-    def dispute_auto_accept_currency(self) -> str | None:
-        return self.dispute_settings["auto_accept_currency"]
 
     @declared_attr
     def all_products(cls) -> Mapped[list["Product"]]:

--- a/server/polar/models/organization.py
+++ b/server/polar/models/organization.py
@@ -223,9 +223,7 @@ def _default_checkout_settings() -> OrganizationCheckoutSettings:
 
 
 class OrganizationDisputeSettings(TypedDict):
-    """`auto_accept_below_amount` is in the account's settlement currency, the
-    one disputes are deducted in. Disputes charged in another currency convert
-    through the exchange rate their payment settled at."""
+    """`auto_accept_below_amount` is in Polar's settlement currency (USD)."""
 
     auto_accept_below_amount: int | None
 

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -129,7 +129,11 @@ from .schemas import (
     OrganizationValidateWebsiteRequest,
     OrganizationValidateWebsiteResponse,
 )
-from .service import CannotCreateOrganizationError, SSOEnforcementRequiresConnection
+from .service import (
+    CannotCreateOrganizationError,
+    DisputeAutoAcceptNotEnabled,
+    SSOEnforcementRequiresConnection,
+)
 from .service import organization as organization_service
 
 router = APIRouter(prefix="/organizations", tags=["organizations"])
@@ -337,8 +341,11 @@ async def check_slug(
     responses={
         200: {"description": "Organization updated."},
         403: {
-            "description": "You don't have the permission to update this organization.",
-            "model": NotPermitted.schema(),
+            "description": (
+                "You don't have the permission to update this organization, or "
+                "dispute auto-accept isn't enabled for it."
+            ),
+            "model": NotPermitted.schema() | DisputeAutoAcceptNotEnabled.schema(),
         },
         404: OrganizationNotFound,
         409: {

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -270,11 +270,10 @@ class OrganizationDisputeSettingsUpdate(Schema):
         ge=1,
         le=DISPUTE_AUTO_ACCEPT_MAX_AMOUNT,
         description=(
-            "Concede disputes below this amount, in cents of the organization's "
-            "payout currency, without asking it. A dispute charged in another "
-            "currency converts at the rate its payment settled at. `null` turns "
-            "it off. The disputed amount and the processor's dispute fee are "
-            "still deducted."
+            "Concede disputes below this amount, in USD cents, without asking "
+            "the organization. A dispute charged in another currency converts "
+            "at the rate its payment settled at. `null` turns it off. The "
+            "disputed amount and the processor's dispute fee are still deducted."
         ),
     )
 

--- a/server/polar/organization/schemas.py
+++ b/server/polar/organization/schemas.py
@@ -34,6 +34,7 @@ from polar.kit.schemas import (
 from polar.models.organization import (
     OrganizationCustomerEmailSettings,
     OrganizationCustomerPortalSettings,
+    OrganizationDisputeSettings,
     OrganizationStatus,
     OrganizationSubscriptionSettings,
     resolve_default_customer_email_settings,
@@ -214,6 +215,13 @@ class OrganizationFeatureSettings(Schema):
         False,
         description="If this organization has single sign-on configuration enabled",
     )
+    dispute_auto_accept_enabled: bool = Field(
+        False,
+        description=(
+            "If this organization can set a threshold below which Polar concedes "
+            "disputes on its behalf. Requires `disputes_enabled`."
+        ),
+    )
     compass_enabled: bool = Field(
         False,
         description=(
@@ -250,6 +258,24 @@ class OrganizationFeatureSettingsUpdate(Schema):
     overview_metrics: OverviewMetrics = Field(
         None,
         description="Ordered list of metric slugs shown on the dashboard overview.",
+    )
+
+
+DISPUTE_AUTO_ACCEPT_MAX_AMOUNT = 10_000
+
+
+class OrganizationDisputeSettingsUpdate(Schema):
+    auto_accept_below_amount: int | None = Field(
+        None,
+        ge=1,
+        le=DISPUTE_AUTO_ACCEPT_MAX_AMOUNT,
+        description=(
+            "Concede disputes below this amount, in cents of the organization's "
+            "payout currency, without asking it. A dispute charged in another "
+            "currency converts at the rate its payment settled at. `null` turns "
+            "it off. The disputed amount and the processor's dispute fee are "
+            "still deducted."
+        ),
     )
 
 
@@ -507,6 +533,9 @@ class Organization(OrganizationBase):
     customer_portal_settings: OrganizationCustomerPortalSettings = Field(
         description="Settings related to the customer portal",
     )
+    dispute_settings: OrganizationDisputeSettings = Field(
+        description="Settings related to disputes",
+    )
     embed_hosts: list[str] = Field(description=_embed_hosts_description)
     embed_hosts_enforced: bool = Field(
         description=(
@@ -683,6 +712,7 @@ class OrganizationUpdate(Schema):
     subscription_settings: OrganizationSubscriptionSettings | None = None
     customer_email_settings: OrganizationCustomerEmailSettings | None = None
     customer_portal_settings: OrganizationCustomerPortalSettings | None = None
+    dispute_settings: OrganizationDisputeSettingsUpdate | None = None
     embed_hosts: EmbedHostsInput | None = None
     default_presentment_currency: PresentmentCurrency | None = Field(
         None, description="Default presentment currency for the organization"

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -57,6 +57,7 @@ from polar.models.organization import (
     CapabilityName,
     OrganizationCapabilities,
     OrganizationDetails,
+    OrganizationDisputeSettings,
     OrganizationStatus,
     SnoozeType,
 )
@@ -253,6 +254,14 @@ class CannotCreateOrganizationError(OrganizationError):
         super().__init__(
             "You cannot create an organization from a session restricted to a "
             "specific organization.",
+            403,
+        )
+
+
+class DisputeAutoAcceptNotEnabled(OrganizationError):
+    def __init__(self) -> None:
+        super().__init__(
+            "Dispute auto-accept is not enabled for this organization.",
             403,
         )
 
@@ -561,6 +570,17 @@ class OrganizationService:
                 )
             organization.subscription_settings = update_schema.subscription_settings
 
+        if update_schema.dispute_settings is not None:
+            if (
+                update_schema.dispute_settings.auto_accept_below_amount is not None
+                and not organization.is_dispute_auto_accept_enabled
+            ):
+                raise DisputeAutoAcceptNotEnabled()
+            organization.dispute_settings = cast(
+                OrganizationDisputeSettings,
+                update_schema.dispute_settings.model_dump(mode="json"),
+            )
+
         if update_schema.default_presentment_currency is not None:
             await self._validate_currency_change(
                 session, organization, update_schema.default_presentment_currency
@@ -577,6 +597,7 @@ class OrganizationService:
                 "profile_settings",
                 "feature_settings",
                 "subscription_settings",
+                "dispute_settings",
                 "details",
             },
         )

--- a/server/polar/organization/service.py
+++ b/server/polar/organization/service.py
@@ -578,7 +578,12 @@ class OrganizationService:
                 raise DisputeAutoAcceptNotEnabled()
             organization.dispute_settings = cast(
                 OrganizationDisputeSettings,
-                update_schema.dispute_settings.model_dump(mode="json"),
+                {
+                    **organization.dispute_settings,
+                    **update_schema.dispute_settings.model_dump(
+                        mode="json", exclude_unset=True
+                    ),
+                },
             )
 
         if update_schema.default_presentment_currency is not None:

--- a/server/scripts/cleanup_organization_dispute_settings_currency.py
+++ b/server/scripts/cleanup_organization_dispute_settings_currency.py
@@ -17,7 +17,7 @@ Usage:
 import structlog
 import typer
 from rich.console import Console
-from sqlalchemy import func, select, update
+from sqlalchemy import Select, Update, func, select, update
 
 from polar.kit.db.postgres import create_async_sessionmaker
 from polar.models import Organization
@@ -35,7 +35,27 @@ log = structlog.get_logger()
 
 configure_script_console_logging()
 
-HAS_CURRENCY_KEY = Organization.dispute_settings.has_key("auto_accept_currency")
+CURRENCY_KEY = "auto_accept_currency"
+HAS_CURRENCY_KEY = Organization.dispute_settings.has_key(CURRENCY_KEY)
+
+
+def pending_count_statement() -> Select[tuple[int]]:
+    return select(func.count()).select_from(Organization).where(HAS_CURRENCY_KEY)
+
+
+def drop_key_statement() -> Update:
+    subquery = (
+        select(Organization.id)
+        .where(HAS_CURRENCY_KEY)
+        .order_by(Organization.id)
+        .limit(limit_bindparam())
+        .scalar_subquery()
+    )
+    return (
+        update(Organization)
+        .where(Organization.id.in_(subquery))
+        .values(dispute_settings=Organization.dispute_settings - CURRENCY_KEY)
+    )
 
 
 @cli.command()
@@ -54,7 +74,7 @@ async def cleanup(
 
     try:
         async with sessionmaker() as session:
-            result = await session.execute(select(func.count()).where(HAS_CURRENCY_KEY))
+            result = await session.execute(pending_count_statement())
             total = result.scalar_one()
 
         if total == 0:
@@ -69,22 +89,8 @@ async def cleanup(
             return
 
         console.rule("[bold]Executing cleanup")
-        subquery = (
-            select(Organization.id)
-            .where(HAS_CURRENCY_KEY)
-            .order_by(Organization.id)
-            .limit(limit_bindparam())
-            .scalar_subquery()
-        )
-        stmt = (
-            update(Organization)
-            .where(Organization.id.in_(subquery))
-            .values(
-                dispute_settings=Organization.dispute_settings - "auto_accept_currency"
-            )
-        )
         rows_updated = await run_batched_update(
-            stmt, batch_size=batch_size, sleep_seconds=sleep_seconds
+            drop_key_statement(), batch_size=batch_size, sleep_seconds=sleep_seconds
         )
         log.info("cleanup.complete", rowcount=rows_updated)
         console.print(

--- a/server/scripts/cleanup_organization_dispute_settings_currency.py
+++ b/server/scripts/cleanup_organization_dispute_settings_currency.py
@@ -1,23 +1,17 @@
 """
-Backfill organizations.dispute_settings to the default settings.
+Drop the `auto_accept_currency` key from organizations.dispute_settings.
 
-The column was added as nullable to avoid a locking migration on the hot
-`organizations` table. New rows get the defaults from the model, but rows that
-existed before the column was added are still NULL. This script fills them so a
-later migration can safely enforce NOT NULL.
-
-Every physical row must be filled — including soft-deleted ones — since the
-future NOT NULL constraint applies to the whole table, so we intentionally do
-not filter on `deleted_at`.
+The threshold is denominated in the account's settlement currency, so the key
+carries no meaning. It was written by the column's first backfill and never read.
 
 Usage:
     cd server
 
-    # Dry-run (default) — show how many rows would be backfilled:
-    uv run python -m scripts.backfill_organization_dispute_settings
+    # Dry-run (default) — show how many rows still carry the key:
+    uv run python -m scripts.cleanup_organization_dispute_settings_currency
 
-    # Execute the backfill (batched):
-    uv run python -m scripts.backfill_organization_dispute_settings --execute
+    # Execute (batched):
+    uv run python -m scripts.cleanup_organization_dispute_settings_currency --execute
 """
 
 import structlog
@@ -41,12 +35,14 @@ log = structlog.get_logger()
 
 configure_script_console_logging()
 
+HAS_CURRENCY_KEY = Organization.dispute_settings.has_key("auto_accept_currency")
+
 
 @cli.command()
 @typer_async
-async def backfill(
+async def cleanup(
     execute: bool = typer.Option(
-        False, help="Actually run the backfill (default: dry-run)"
+        False, help="Actually run the cleanup (default: dry-run)"
     ),
     batch_size: int = typer.Option(
         5000, min=1, help="Number of rows to process per batch"
@@ -58,26 +54,24 @@ async def backfill(
 
     try:
         async with sessionmaker() as session:
-            result = await session.execute(
-                select(func.count()).where(Organization.dispute_settings.is_(None))
-            )
+            result = await session.execute(select(func.count()).where(HAS_CURRENCY_KEY))
             total = result.scalar_one()
 
         if total == 0:
-            console.print("[green]No organizations with a NULL dispute_settings.")
+            console.print("[green]No organizations carry auto_accept_currency.")
             return
 
         if not execute:
             console.print(
-                f"[yellow]Dry-run — use --execute to backfill {total} "
-                "organization(s) to the default dispute settings."
+                f"[yellow]Dry-run — use --execute to drop the key from {total} "
+                "organization(s)."
             )
             return
 
-        console.rule("[bold]Executing backfill")
+        console.rule("[bold]Executing cleanup")
         subquery = (
             select(Organization.id)
-            .where(Organization.dispute_settings.is_(None))
+            .where(HAS_CURRENCY_KEY)
             .order_by(Organization.id)
             .limit(limit_bindparam())
             .scalar_subquery()
@@ -85,15 +79,17 @@ async def backfill(
         stmt = (
             update(Organization)
             .where(Organization.id.in_(subquery))
-            .values(dispute_settings={"auto_accept_below_amount": None})
+            .values(
+                dispute_settings=Organization.dispute_settings - "auto_accept_currency"
+            )
         )
         rows_updated = await run_batched_update(
             stmt, batch_size=batch_size, sleep_seconds=sleep_seconds
         )
-        log.info("backfill.complete", rowcount=rows_updated)
+        log.info("cleanup.complete", rowcount=rows_updated)
         console.print(
-            f"\n[green]Backfilled {rows_updated} organization(s) to the default "
-            "dispute settings."
+            f"\n[green]Dropped auto_accept_currency from {rows_updated} "
+            "organization(s)."
         )
 
     finally:

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -22,6 +22,7 @@ from polar.models.organization_sso_connection import (
 )
 from polar.models.subscription import SubscriptionStatus
 from polar.models.user_organization import OrganizationRole, UserOrganization
+from polar.organization.schemas import DISPUTE_AUTO_ACCEPT_MAX_AMOUNT
 from polar.payout_account.service import PayoutAccountServiceError
 from polar.postgres import AsyncSession
 from polar.user_organization.service import (
@@ -609,6 +610,137 @@ class TestUpdateOrganization:
         response = await client.post(f"/v1/organizations/{uuid.uuid4()}/submit-review")
 
         assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestUpdateDisputeSettings:
+    async def _enable(
+        self,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        *,
+        disputes: bool = True,
+        auto_accept: bool = True,
+    ) -> None:
+        organization.feature_settings = {
+            "disputes_enabled": disputes,
+            "dispute_auto_accept_enabled": auto_accept,
+        }
+        await save_fixture(organization)
+
+    @pytest.mark.auth
+    async def test_valid(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await self._enable(save_fixture, organization)
+
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={"dispute_settings": {"auto_accept_below_amount": 2500}},
+        )
+
+        assert response.status_code == 200
+        dispute_settings = response.json()["dispute_settings"]
+        assert dispute_settings["auto_accept_below_amount"] == 2500
+
+    @pytest.mark.auth
+    async def test_flag_disabled(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await self._enable(save_fixture, organization, auto_accept=False)
+
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={"dispute_settings": {"auto_accept_below_amount": 2500}},
+        )
+
+        assert response.status_code == 403
+
+    @pytest.mark.auth
+    async def test_disputes_disabled(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await self._enable(save_fixture, organization, disputes=False)
+
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={"dispute_settings": {"auto_accept_below_amount": 2500}},
+        )
+
+        assert response.status_code == 403
+
+    @pytest.mark.auth
+    async def test_above_ceiling(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await self._enable(save_fixture, organization)
+
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={
+                "dispute_settings": {
+                    "auto_accept_below_amount": DISPUTE_AUTO_ACCEPT_MAX_AMOUNT + 1,
+                },
+            },
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.auth
+    async def test_clear(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await self._enable(save_fixture, organization)
+        organization.dispute_settings = {"auto_accept_below_amount": 2500}
+        await save_fixture(organization)
+
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={"dispute_settings": {"auto_accept_below_amount": None}},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["dispute_settings"]["auto_accept_below_amount"] is None
+
+    @pytest.mark.auth
+    async def test_flag_not_self_grantable(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await self._enable(save_fixture, organization, auto_accept=False)
+
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={"feature_settings": {"dispute_auto_accept_enabled": True}},
+        )
+
+        assert response.status_code == 200
+        assert (
+            response.json()["feature_settings"]["dispute_auto_accept_enabled"] is False
+        )
 
 
 @pytest.mark.asyncio

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -723,6 +723,26 @@ class TestUpdateDisputeSettings:
         assert response.json()["dispute_settings"]["auto_accept_below_amount"] is None
 
     @pytest.mark.auth
+    async def test_empty_object_keeps_threshold(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await self._enable(save_fixture, organization)
+        organization.dispute_settings = {"auto_accept_below_amount": 2500}
+        await save_fixture(organization)
+
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}",
+            json={"dispute_settings": {}},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["dispute_settings"]["auto_accept_below_amount"] == 2500
+
+    @pytest.mark.auth
     async def test_flag_not_self_grantable(
         self,
         client: AsyncClient,

--- a/server/tests/scripts/test_cleanup_organization_dispute_settings_currency.py
+++ b/server/tests/scripts/test_cleanup_organization_dispute_settings_currency.py
@@ -1,0 +1,62 @@
+from typing import cast
+
+import pytest
+
+from polar.kit.db.postgres import AsyncSession
+from polar.models import Organization
+from polar.models.organization import OrganizationDisputeSettings
+from scripts.cleanup_organization_dispute_settings_currency import (
+    drop_key_statement,
+    pending_count_statement,
+)
+from scripts.helper import run_batched_update
+from tests.fixtures.database import SaveFixture
+
+
+def _with_currency(amount: int | None) -> OrganizationDisputeSettings:
+    """Settings as the first backfill wrote them, before the key was dropped."""
+    return cast(
+        OrganizationDisputeSettings,
+        {"auto_accept_below_amount": amount, "auto_accept_currency": "usd"},
+    )
+
+
+async def _cleanup(session: AsyncSession, *, batch_size: int = 5000) -> int:
+    return await run_batched_update(
+        drop_key_statement(),
+        batch_size=batch_size,
+        sleep_seconds=0,
+        session=session,
+    )
+
+
+@pytest.mark.asyncio
+class TestCleanupDisputeSettingsCurrency:
+    async def test_drops_only_the_currency_key(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        organization.dispute_settings = _with_currency(2500)
+        await save_fixture(organization)
+
+        assert await _cleanup(session) == 1
+
+        await session.refresh(organization)
+        assert organization.dispute_settings == {"auto_accept_below_amount": 2500}
+
+    async def test_batches_until_none_left(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        organization_second: Organization,
+    ) -> None:
+        for org in (organization, organization_second):
+            org.dispute_settings = _with_currency(None)
+            await save_fixture(org)
+
+        assert await _cleanup(session, batch_size=1) == 2
+        assert await session.scalar(pending_count_statement()) == 0
+        assert await _cleanup(session) == 0


### PR DESCRIPTION

Includes a batched script to drop the orphan auto_accept_currency key written by the column's first backfill.

Sorry for the back and forth with the currency, i misunderstood something during planning

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13488"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788090399&installation_model_id=13063&pr_number=13488&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13488&signature=0568a48645dafeb4fbce298f903e47a1429532ab9fce5a72268665a0672d32f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

