### PR TITLE
Remove unused A/B testing methods

### DIFF
--- a/server/polar/customer_meter/service.py
+++ b/server/polar/customer_meter/service.py
@@ -279,49 +279,6 @@ class CustomerMeterService:
             )
             return result.scalar_one_or_none()
 
-    async def _get_current_window_events_statement(
-        self, session: AsyncSession, customer: Customer, meter: Meter
-    ) -> Select[tuple[Event]]:
-        """
-        Get a chainable statement for all events in the current meter window.
-
-        Uses a subquery with UNION optimization to filter events. This avoids:
-        1. Slow BitmapOr scans from OR clauses on different indexed columns
-        2. Round-trips to fetch IDs into Python then back to PostgreSQL
-        3. The 32k parameter limit in asyncpg
-
-
-        Events are ordered by timestamp to ensure correct ordering for running
-        sum calculations (e.g., non_negative_running_sum for credits).
-        """
-        event_repository = EventRepository.from_session(session)
-        meter_reset_event = await event_repository.get_latest_meter_reset(
-            customer, meter.id
-        )
-
-        by_customer_id = self._build_events_statement(
-            event_repository, customer, meter, meter_reset_event, by_external_id=False
-        )
-
-        if customer.external_id is None:
-            return by_customer_id.order_by(Event.timestamp.asc())
-
-        by_external_id = self._build_events_statement(
-            event_repository, customer, meter, meter_reset_event, by_external_id=True
-        )
-
-        # UNION to avoid BitmapOr
-        event_ids_subquery = union_all(
-            by_customer_id.with_only_columns(Event.id),
-            by_external_id.with_only_columns(Event.id),
-        ).subquery()
-
-        return (
-            event_repository.get_base_statement()
-            .where(Event.id.in_(select(event_ids_subquery.c.id)))
-            .order_by(Event.timestamp.asc())
-        )
-
     def _build_events_statement(
         self,
         event_repository: EventRepository,

--- a/server/polar/customer_meter/service.py
+++ b/server/polar/customer_meter/service.py
@@ -25,7 +25,7 @@ from polar.meter.aggregation import (
     UniqueAggregation,
 )
 from polar.meter.repository import MeterRepository
-from polar.models import Customer, CustomerMeter, Event, Meter, MeterEvent
+from polar.models import Customer, CustomerMeter, Event, Meter
 from polar.models.event import EventSource
 from polar.postgres import AsyncSession
 from polar.worker import enqueue_job
@@ -149,27 +149,10 @@ class CustomerMeterService:
             utc_now() - settings.CUSTOMER_METER_UPDATE_DEBOUNCE_MAX_THRESHOLD
         )
 
-        # A/B Test: Compare old (JSONB) vs new (MeterEvent) implementations
-        with logfire.span("get_latest_event.old"):
+        with logfire.span("get_latest_event"):
             last_event = await self._get_latest_current_window_event(
                 session, customer, meter, ingested_at_lower_bound
             )
-
-        # with logfire.span("get_latest_event.new"):
-        #     new_last_event = await self._get_latest_current_window_event_new(
-        #         session, customer, meter, ingested_at_lower_bound
-        #     )
-
-        # old_last_event_id = last_event.id if last_event else None
-        # new_last_event_id = new_last_event.id if new_last_event else None
-        # if old_last_event_id != new_last_event_id:
-        #     logfire.error(
-        #         "last_event mismatch",
-        #         customer_id=str(customer.id),
-        #         meter_id=str(meter.id),
-        #         old_event_id=str(old_last_event_id) if old_last_event_id else None,
-        #         new_event_id=str(new_last_event_id) if new_last_event_id else None,
-        #     )
 
         if customer_meter is None:
             activated_at = (
@@ -187,51 +170,15 @@ class CustomerMeterService:
 
         event_repository = EventRepository.from_session(session)
 
-        with logfire.span("get_usage.old"):
+        with logfire.span("get_usage"):
             usage_units = await self._get_usage_quantity(session, customer, meter)
-
-        # with logfire.span("get_usage.new"):
-        #     new_usage_units = await self._get_usage_quantity_new(
-        #         session, customer, meter
-        #     )
-
-        # if usage_units != new_usage_units:
-        #     logfire.error(
-        #         "usage mismatch",
-        #         customer_id=str(customer.id),
-        #         meter_id=str(meter.id),
-        #         old_usage=usage_units,
-        #         new_usage=new_usage_units,
-        #     )
 
         customer_meter.consumed_units = Decimal(usage_units)
 
-        with logfire.span("get_credits.old"):
+        with logfire.span("get_credits"):
             credit_events = await self._get_credit_events(
                 customer, meter, event_repository
             )
-
-        # with logfire.span("get_credits.new"):
-        #     new_credit_events = await self._get_credit_events_new(
-        #         session, customer, meter
-        #     )
-
-        # old_credit_ids = {e.id for e in credit_events}
-        # new_credit_ids = {e.id for e in new_credit_events}
-        # if old_credit_ids != new_credit_ids:
-        #     logfire.error(
-        #         "credit_events mismatch",
-        #         customer_id=str(customer.id),
-        #         meter_id=str(meter.id),
-        #         old_count=len(old_credit_ids),
-        #         new_count=len(new_credit_ids),
-        #         only_in_old=[
-        #             str(e) for e in list(old_credit_ids - new_credit_ids)[:5]
-        #         ],
-        #         only_in_new=[
-        #             str(e) for e in list(new_credit_ids - old_credit_ids)[:5]
-        #         ],
-        #     )
 
         credited_units = non_negative_running_sum(
             event.user_metadata["units"] for event in credit_events
@@ -331,48 +278,6 @@ class CustomerMeterService:
                 select(Event).from_statement(union_statement)
             )
             return result.scalar_one_or_none()
-
-    async def _get_latest_current_window_event_new(
-        self,
-        session: AsyncSession,
-        customer: Customer,
-        meter: Meter,
-        ingested_at_lower_bound: datetime | None = None,
-    ) -> Event | None:
-        """Get latest event using MeterEvent table (no JSONB filtering)."""
-        event_repository = EventRepository.from_session(session)
-        meter_reset_event = await event_repository.get_latest_meter_reset(
-            customer, meter.id
-        )
-
-        statement = (
-            event_repository.get_base_statement()
-            .join(MeterEvent, MeterEvent.event_id == Event.id)
-            .where(MeterEvent.meter_id == meter.id)
-        )
-
-        if customer.external_id is not None:
-            statement = statement.where(
-                or_(
-                    MeterEvent.customer_id == customer.id,
-                    MeterEvent.external_customer_id == customer.external_id,
-                )
-            )
-        else:
-            statement = statement.where(MeterEvent.customer_id == customer.id)
-
-        if meter_reset_event is not None:
-            statement = statement.where(
-                MeterEvent.ingested_at >= meter_reset_event.ingested_at
-            )
-
-        if ingested_at_lower_bound is not None:
-            statement = statement.where(
-                MeterEvent.ingested_at >= ingested_at_lower_bound
-            )
-
-        statement = statement.order_by(MeterEvent.ingested_at.desc()).limit(1)
-        return await event_repository.get_one_or_none(statement)
 
     async def _get_current_window_events_statement(
         self, session: AsyncSession, customer: Customer, meter: Meter
@@ -579,75 +484,6 @@ class CustomerMeterService:
             .order_by(Event.timestamp.asc())
         )
 
-        return await event_repository.get_all(statement)
-
-    async def _get_usage_quantity_new(
-        self, session: AsyncSession, customer: Customer, meter: Meter
-    ) -> float:
-        """Get usage quantity using MeterEvent table (no JSONB filtering)."""
-        event_repository = EventRepository.from_session(session)
-        meter_reset_event = await event_repository.get_latest_meter_reset(
-            customer, meter.id
-        )
-
-        agg_column = func.coalesce(meter.aggregation.get_sql_column(Event), 0)
-
-        statement = (
-            select(agg_column)
-            .select_from(Event)
-            .join(MeterEvent, MeterEvent.event_id == Event.id)
-            .where(
-                MeterEvent.meter_id == meter.id,
-                Event.source == EventSource.user,
-            )
-        )
-
-        if customer.external_id is not None:
-            statement = statement.where(
-                or_(
-                    MeterEvent.customer_id == customer.id,
-                    MeterEvent.external_customer_id == customer.external_id,
-                )
-            )
-        else:
-            statement = statement.where(MeterEvent.customer_id == customer.id)
-
-        if meter_reset_event is not None:
-            statement = statement.where(
-                MeterEvent.ingested_at >= meter_reset_event.ingested_at
-            )
-
-        result = await session.scalar(statement)
-        return result or 0.0
-
-    async def _get_credit_events_new(
-        self,
-        session: AsyncSession,
-        customer: Customer,
-        meter: Meter,
-    ) -> Sequence[Event]:
-        """Get credit events using MeterEvent table (no JSONB filtering)."""
-        event_repository = EventRepository.from_session(session)
-        meter_reset_event = await event_repository.get_latest_meter_reset(
-            customer, meter.id
-        )
-
-        statement = (
-            event_repository.get_base_statement()
-            .join(MeterEvent, MeterEvent.event_id == Event.id)
-            .where(
-                MeterEvent.meter_id == meter.id,
-                MeterEvent.customer_id == customer.id,
-                Event.is_meter_credit.is_(True),
-            )
-        )
-
-        if meter_reset_event is not None:
-            statement = statement.where(
-                MeterEvent.ingested_at >= meter_reset_event.ingested_at
-            )
-
-        statement = statement.order_by(Event.timestamp.asc())
         return await event_repository.get_all(statement)
 
 


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13489"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788092309&installation_model_id=13063&pr_number=13489&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13489&signature=927e38df9b638263e1483c3b4e1045791eb24409a44586bb300390fad2870532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the disabled `MeterEvent` A/B paths in the customer meter service to simplify the code and reduce logging noise. No behavior changes; only cleanup and span name normalization.

- **Refactors**
  - Removed `_get_latest_current_window_event_new`, `_get_usage_quantity_new`, `_get_credit_events_new`, and `_get_current_window_events_statement`.
  - Dropped `MeterEvent` import, deleted all comparison blocks, and removed the `.old` suffix from `logfire` spans.

<sup>Written for commit d04c12d0d0c88646427dcfecc3b65c6d4d0343b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

