### PR TITLE
feat(scripts): emit and find missing subscription meter reset events

### DIFF
--- a/server/scripts/emit_meter_reset_events.py
+++ b/server/scripts/emit_meter_reset_events.py
@@ -91,7 +91,8 @@ def emit_meter_reset_events(
             event_repository = EventRepository.from_session(session)
 
             subscriptions = []
-            for subscription_id in subscription_ids:
+            # Dedupe so passing the same id twice can't emit duplicate resets.
+            for subscription_id in dict.fromkeys(subscription_ids):
                 subscription = await repository.get_by_id(
                     subscription_id, options=repository.get_eager_options()
                 )

--- a/server/scripts/emit_meter_reset_events.py
+++ b/server/scripts/emit_meter_reset_events.py
@@ -1,0 +1,160 @@
+"""Manually emit meter reset events for subscriptions that already cycled.
+
+Normally a subscription's meters are reset during ``subscription.cycle`` (see
+#13483), which emits a ``meter.reset`` system event (plus a ``meter.credited``
+event for any rollover) stamped at the cycle boundary. That reset event is what
+bounds the *next* period's usage window and, crucially, keeps the *current*
+cycle order from billing usage past the boundary.
+
+Some subscriptions cycled before #13483 shipped and got stuck retrying their
+cycle order (the perf issue #13479 fixes). Their cycle already advanced the
+period dates, so ``subscription.cycle`` won't run again for them — meaning the
+meter reset event that #13483 would have created never gets emitted. Without it,
+the eventual order would bill usage all the way up to now instead of stopping at
+the cycle date.
+
+This script emits those missing reset events out-of-band, exactly as the cycle
+flow would have, using ``current_period_start`` as the reset timestamp (the
+cycle boundary the subscription already moved to).
+
+It is idempotent: a meter whose latest reset event is already at or after that
+timestamp is skipped, so re-running never emits duplicate resets.
+
+Usage:
+
+    uv run python -m scripts.emit_meter_reset_events <subscription_id>... [--execute]
+
+Defaults to a dry-run; pass --execute to actually emit the events.
+
+Options:
+    --execute   actually emit the reset events (default: dry-run)
+    --yes       skip the confirmation prompt
+"""
+
+import asyncio
+import logging.config
+import uuid
+from datetime import datetime
+from typing import Any
+
+import dramatiq
+import structlog
+import typer
+
+from polar import tasks  # noqa: F401
+from polar.event.repository import EventRepository
+from polar.kit.db.postgres import create_async_sessionmaker
+from polar.kit.utils import utc_now
+from polar.models import Subscription, SubscriptionMeter
+from polar.postgres import create_async_engine
+from polar.redis import create_redis
+from polar.subscription.repository import SubscriptionRepository
+from polar.subscription.service import subscription as subscription_service
+from polar.worker import JobQueueManager
+
+cli = typer.Typer()
+
+
+def drop_all(*args: Any, **kwargs: Any) -> Any:
+    raise structlog.DropEvent
+
+
+structlog.configure(processors=[drop_all])
+logging.config.dictConfig(
+    {
+        "version": 1,
+        "disable_existing_loggers": True,
+    }
+)
+
+
+@cli.command()
+def emit_meter_reset_events(
+    subscription_ids: list[uuid.UUID] = typer.Argument(
+        ..., help="Subscription id(s) to emit meter reset events for."
+    ),
+    execute: bool = typer.Option(
+        False, "--execute", help="Actually emit the events (default: dry-run)."
+    ),
+    yes: bool = typer.Option(False, "--yes", help="Skip the confirmation prompt."),
+) -> None:
+    async def run() -> None:
+        engine = create_async_engine("script")
+        sessionmaker = create_async_sessionmaker(engine)
+        redis = create_redis("app")
+
+        async with (
+            JobQueueManager.open(dramatiq.get_broker(), redis) as job_queue_manager,
+            sessionmaker() as session,
+        ):
+            repository = SubscriptionRepository.from_session(session)
+            event_repository = EventRepository.from_session(session)
+
+            subscriptions = []
+            for subscription_id in subscription_ids:
+                subscription = await repository.get_by_id(
+                    subscription_id, options=repository.get_eager_options()
+                )
+                if subscription is None:
+                    typer.echo(f"Subscription '{subscription_id}' not found.")
+                    raise typer.Exit(code=1)
+                subscriptions.append(subscription)
+
+            async def is_already_reset(
+                subscription: Subscription,
+                subscription_meter: SubscriptionMeter,
+                reset_at: datetime,
+            ) -> bool:
+                # Idempotency guard: skip meters that already have a reset event
+                # at or after the boundary, so re-running emits no duplicates.
+                latest_reset = await event_repository.get_latest_meter_reset(
+                    subscription.customer, subscription_meter.meter_id
+                )
+                return latest_reset is not None and latest_reset.timestamp >= reset_at
+
+            to_reset: list[tuple[Subscription, SubscriptionMeter, datetime]] = []
+            for subscription in subscriptions:
+                # Mirror the cycle flow: reset at the boundary the subscription
+                # already moved to, never in the future.
+                reset_at = min(subscription.current_period_start, utc_now())
+                for subscription_meter in subscription.meters:
+                    if await is_already_reset(
+                        subscription, subscription_meter, reset_at
+                    ):
+                        typer.echo(
+                            f"{subscription.id}: meter {subscription_meter.meter_id} "
+                            f"already reset at or after {reset_at.isoformat()}, "
+                            "skipping."
+                        )
+                        continue
+                    to_reset.append((subscription, subscription_meter, reset_at))
+                    typer.echo(
+                        f"{subscription.id}: reset meter "
+                        f"{subscription_meter.meter_id} at {reset_at.isoformat()}"
+                    )
+
+            if not to_reset:
+                typer.echo("Nothing to do — all meters already reset.")
+                raise typer.Exit(code=0)
+
+            if not execute:
+                typer.echo("Dry run — no events emitted. Pass --execute to apply.")
+                raise typer.Exit(code=0)
+
+            if not yes and not typer.confirm("Proceed?"):
+                raise typer.Exit(code=1)
+
+            for subscription, subscription_meter, reset_at in to_reset:
+                await subscription_service.reset_meter(
+                    session, subscription, subscription_meter, reset_at=reset_at
+                )
+
+            await session.commit()
+            await job_queue_manager.flush(dramatiq.get_broker(), redis)
+            typer.echo(f"Emitted {len(to_reset)} meter reset event(s).")
+
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/scripts/find_subscriptions_missing_reset_events.py
+++ b/server/scripts/find_subscriptions_missing_reset_events.py
@@ -1,0 +1,132 @@
+"""Find subscriptions whose meters are missing a reset event for the current cycle.
+
+Every cycle, ``subscription.cycle`` emits a ``meter.reset`` system event stamped
+at the cycle boundary (see #13483). That event bounds the current period's usage
+window. Subscriptions that cycled before #13483 shipped — or otherwise got stuck
+retrying their cycle order (the perf issue #13479 fixes) — never got that event,
+so their meters have no reset at or after ``current_period_start``.
+
+This script reports those subscriptions. It's read-only; feed the ids it prints
+to ``scripts.emit_meter_reset_events`` to emit the missing events.
+
+A meter is considered missing its reset when it has no ``meter.reset`` event with
+a timestamp at or after the subscription's ``current_period_start``.
+
+Usage:
+
+    uv run python -m scripts.find_subscriptions_missing_reset_events [--ids-only]
+
+Options:
+    --ids-only   print only the subscription ids (one per line), for piping.
+"""
+
+import asyncio
+import logging.config
+from typing import Any
+
+import structlog
+import typer
+from rich.progress import Progress
+from sqlalchemy import exists, func
+
+from polar.event.repository import EventRepository
+from polar.kit.db.postgres import create_async_sessionmaker
+from polar.models import Subscription, SubscriptionMeter
+from polar.postgres import create_async_engine
+from polar.subscription.repository import SubscriptionRepository
+
+cli = typer.Typer()
+
+
+def drop_all(*args: Any, **kwargs: Any) -> Any:
+    raise structlog.DropEvent
+
+
+structlog.configure(processors=[drop_all])
+logging.config.dictConfig(
+    {
+        "version": 1,
+        "disable_existing_loggers": True,
+    }
+)
+
+
+@cli.command()
+def find_subscriptions_missing_reset_events(
+    ids_only: bool = typer.Option(
+        False,
+        "--ids-only",
+        help="Print only the subscription ids (one per line), for piping.",
+    ),
+) -> None:
+    async def run() -> None:
+        engine = create_async_engine("script")
+        sessionmaker = create_async_sessionmaker(engine)
+
+        async with sessionmaker() as session:
+            repository = SubscriptionRepository.from_session(session)
+            event_repository = EventRepository.from_session(session)
+
+            statement = (
+                repository.get_base_statement()
+                .where(
+                    Subscription.active.is_(True),
+                    exists().where(
+                        SubscriptionMeter.subscription_id == Subscription.id
+                    ),
+                )
+                .options(*repository.get_eager_options())
+            )
+            count = await session.scalar(
+                statement.with_only_columns(func.count()).order_by(None)
+            )
+
+            missing: list[tuple[Subscription, list[SubscriptionMeter]]] = []
+            with Progress(disable=ids_only) as progress:
+                task = progress.add_task(
+                    "[cyan]Checking metered subscriptions...", total=count
+                )
+                async for subscription in repository.stream(statement):
+                    missing_meters = []
+                    for subscription_meter in subscription.meters:
+                        latest_reset = await event_repository.get_latest_meter_reset(
+                            subscription.customer, subscription_meter.meter_id
+                        )
+                        if (
+                            latest_reset is None
+                            or latest_reset.timestamp
+                            < subscription.current_period_start
+                        ):
+                            missing_meters.append(subscription_meter)
+                    if missing_meters:
+                        missing.append((subscription, missing_meters))
+                    progress.advance(task)
+
+            if ids_only:
+                for subscription, _ in missing:
+                    typer.echo(str(subscription.id))
+                return
+
+            if not missing:
+                typer.echo("No subscriptions missing reset events. ✨")
+                return
+
+            for subscription, missing_meters in missing:
+                meter_ids = ", ".join(str(sm.meter_id) for sm in missing_meters)
+                typer.echo(
+                    f"{subscription.id} "
+                    f"(period start {subscription.current_period_start.isoformat()}): "
+                    f"{len(missing_meters)} meter(s) missing reset — {meter_ids}"
+                )
+            typer.echo(
+                f"\n{len(missing)} subscription(s) missing reset events. "
+                "Emit them with:\n"
+                "    uv run python -m scripts.emit_meter_reset_events "
+                + " ".join(str(subscription.id) for subscription, _ in missing)
+            )
+
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/scripts/find_subscriptions_missing_reset_events.py
+++ b/server/scripts/find_subscriptions_missing_reset_events.py
@@ -67,15 +67,9 @@ def find_subscriptions_missing_reset_events(
             repository = SubscriptionRepository.from_session(session)
             event_repository = EventRepository.from_session(session)
 
-            statement = (
-                repository.get_base_statement()
-                .where(
-                    Subscription.active.is_(True),
-                    exists().where(
-                        SubscriptionMeter.subscription_id == Subscription.id
-                    ),
-                )
-                .options(*repository.get_eager_options())
+            statement = repository.get_base_statement().where(
+                Subscription.active.is_(True),
+                exists().where(SubscriptionMeter.subscription_id == Subscription.id),
             )
             count = await session.scalar(
                 statement.with_only_columns(func.count()).order_by(None)
@@ -86,7 +80,8 @@ def find_subscriptions_missing_reset_events(
                 task = progress.add_task(
                     "[cyan]Checking metered subscriptions...", total=count
                 )
-                async for subscription in repository.stream(statement):
+                eager_statement = statement.options(*repository.get_eager_options())
+                async for subscription in repository.stream(eager_statement):
                     missing_meters = []
                     for subscription_meter in subscription.meters:
                         latest_reset = await event_repository.get_latest_meter_reset(


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788094140&installation_model_id=13063&pr_number=13490&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13490&signature=b77979a1df55e3c077de4906f38a32c254b544e0e2728b36d27aa0e88c582012"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two maintenance scripts to find and backfill missing `meter.reset` events for subscriptions that advanced cycles without them, preventing usage past the cycle boundary.

- **New Features**
  - `scripts.find_subscriptions_missing_reset_events`: lists active metered subscriptions missing a `meter.reset` at or after `current_period_start`; supports `--ids-only` for piping.
  - `scripts.emit_meter_reset_events`: idempotently emits `meter.reset` events at `current_period_start` for given subscription IDs; dry-run by default, use `--execute` (and `--yes`) to apply.

- **Bug Fixes**
  - `scripts.find_subscriptions_missing_reset_events`: drop eager options from the count query to avoid unnecessary joins and speed up counting.
  - `scripts.emit_meter_reset_events`: dedupe subscription IDs to prevent duplicate processing when the same ID is passed multiple times.

<sup>Written for commit 3a1c883a45263d3869b602d4cadf5aaf4bea819f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

