### PR TITLE
Explore a direct UPDATE WHERE

### DIFF
--- a/server/polar/billing_entry/repository.py
+++ b/server/polar/billing_entry/repository.py
@@ -56,18 +56,25 @@ class BillingEntryRepository(
         subscription_id: UUID,
         *,
         cutoff: datetime | None = None,
+        watermark: datetime | None = None,
         options: Options = (),
     ) -> Sequence[BillingEntry]:
         statement = self.get_pending_by_subscription_statement(
-            subscription_id, cutoff=cutoff, options=options
+            subscription_id, cutoff=cutoff, watermark=watermark, options=options
         )
         return await self.get_all(statement)
 
     async def get_static_pending_by_subscription(
-        self, subscription_id: UUID, *, cutoff: datetime | None = None
+        self,
+        subscription_id: UUID,
+        watermark: datetime,
+        *,
+        cutoff: datetime | None = None,
     ) -> AsyncGenerator[BillingEntry]:
         statement = (
-            self.get_pending_by_subscription_statement(subscription_id, cutoff=cutoff)
+            self.get_pending_by_subscription_statement(
+                subscription_id, cutoff=cutoff, watermark=watermark
+            )
             .join(BillingEntry.product_price)
             .where(ProductPrice.is_static.is_(True))
             .options(
@@ -79,7 +86,11 @@ class BillingEntryRepository(
             yield result
 
     async def get_pending_metered_by_subscription_tuples(
-        self, subscription_id: UUID, *, cutoff: datetime | None = None
+        self,
+        subscription_id: UUID,
+        watermark: datetime,
+        *,
+        cutoff: datetime | None = None,
     ) -> AsyncGenerator[tuple[UUID, UUID, datetime, datetime]]:
         """
         Get pending metered billing entries grouped by (product_price_id, meter_id).
@@ -93,7 +104,9 @@ class BillingEntryRepository(
         subscription.subscription_product_prices, not from these tuples.
         """
         statement = (
-            self.get_pending_by_subscription_statement(subscription_id, cutoff=cutoff)
+            self.get_pending_by_subscription_statement(
+                subscription_id, cutoff=cutoff, watermark=watermark
+            )
             .join(
                 ProductPriceMeteredUnit,
                 BillingEntry.product_price_id == ProductPriceMeteredUnit.id,
@@ -118,45 +131,60 @@ class BillingEntryRepository(
         finally:
             await results.close()
 
-    async def get_pending_ids_by_subscription_and_price(
+    async def link_pending_by_price(
         self,
         subscription_id: UUID,
         product_price_id: UUID,
+        order_item_id: UUID,
+        watermark: datetime,
         *,
         cutoff: datetime | None = None,
-    ) -> Sequence[UUID]:
-        statement = (
-            self.get_pending_by_subscription_statement(subscription_id, cutoff=cutoff)
-            .with_only_columns(BillingEntry.id)
-            .where(BillingEntry.product_price_id == product_price_id)
+    ) -> None:
+        statement = update(BillingEntry).where(
+            BillingEntry.subscription_id == subscription_id,
+            BillingEntry.order_item_id.is_(None),
+            BillingEntry.product_price_id == product_price_id,
+            BillingEntry.created_at <= watermark,
         )
-        results = await self.session.execute(statement)
-        return results.scalars().unique().all()
+        if cutoff is not None:
+            statement = statement.where(BillingEntry.start_timestamp < cutoff)
+        statement = statement.values(order_item_id=order_item_id).execution_options(
+            synchronize_session=False
+        )
+        await self.session.execute(statement)
 
-    async def get_pending_ids_by_subscription_and_meter(
+    async def link_pending_by_meter(
         self,
         subscription_id: UUID,
         meter_id: UUID,
+        order_item_id: UUID,
+        watermark: datetime,
         *,
         cutoff: datetime | None = None,
-    ) -> Sequence[UUID]:
-        """
-        Get all pending billing entry IDs for a subscription and meter across all prices.
-        """
-        statement = (
-            self.get_pending_by_subscription_statement(subscription_id, cutoff=cutoff)
-            .join(
-                ProductPriceMeteredUnit,
-                BillingEntry.product_price_id == ProductPriceMeteredUnit.id,
-            )
-            .with_only_columns(BillingEntry.id)
-            .where(ProductPriceMeteredUnit.meter_id == meter_id)
+    ) -> None:
+        statement = update(BillingEntry).where(
+            BillingEntry.subscription_id == subscription_id,
+            BillingEntry.order_item_id.is_(None),
+            BillingEntry.product_price_id.in_(
+                select(ProductPriceMeteredUnit.id).where(
+                    ProductPriceMeteredUnit.meter_id == meter_id
+                )
+            ),
+            BillingEntry.created_at <= watermark,
         )
-        results = await self.session.execute(statement)
-        return results.scalars().unique().all()
+        if cutoff is not None:
+            statement = statement.where(BillingEntry.start_timestamp < cutoff)
+        statement = statement.values(order_item_id=order_item_id).execution_options(
+            synchronize_session=False
+        )
+        await self.session.execute(statement)
 
     async def lock_pending_by_subscription(
-        self, subscription_id: UUID, *, cutoff: datetime | None = None
+        self,
+        subscription_id: UUID,
+        watermark: datetime,
+        *,
+        cutoff: datetime | None = None,
     ) -> None:
         """
         Acquire FOR UPDATE locks on all pending billing entries for a subscription.
@@ -167,7 +195,9 @@ class BillingEntryRepository(
         the entries are no longer pending.
         """
         statement = (
-            self.get_pending_by_subscription_statement(subscription_id, cutoff=cutoff)
+            self.get_pending_by_subscription_statement(
+                subscription_id, cutoff=cutoff, watermark=watermark
+            )
             .with_only_columns(BillingEntry.id)
             .with_for_update()
         )
@@ -178,6 +208,7 @@ class BillingEntryRepository(
         subscription_id: UUID,
         *,
         cutoff: datetime | None = None,
+        watermark: datetime | None = None,
         options: Options = (),
     ) -> Select[tuple["BillingEntry"]]:
         statement = (
@@ -201,4 +232,6 @@ class BillingEntryRepository(
                     ),
                 )
             )
+        if watermark is not None:
+            statement = statement.where(BillingEntry.created_at <= watermark)
         return statement

--- a/server/polar/billing_entry/repository.py
+++ b/server/polar/billing_entry/repository.py
@@ -64,10 +64,7 @@ class BillingEntryRepository(
         return await self.get_all(statement)
 
     async def get_static_pending_by_subscription(
-        self,
-        subscription_id: UUID,
-        *,
-        cutoff: datetime | None = None,
+        self, subscription_id: UUID, *, cutoff: datetime | None = None
     ) -> AsyncGenerator[BillingEntry]:
         statement = (
             self.get_pending_by_subscription_statement(subscription_id, cutoff=cutoff)
@@ -82,10 +79,7 @@ class BillingEntryRepository(
             yield result
 
     async def get_pending_metered_by_subscription_tuples(
-        self,
-        subscription_id: UUID,
-        *,
-        cutoff: datetime,
+        self, subscription_id: UUID, *, cutoff: datetime
     ) -> AsyncGenerator[tuple[UUID, UUID, datetime, datetime]]:
         """
         Get pending metered billing entries grouped by (product_price_id, meter_id).
@@ -125,7 +119,7 @@ class BillingEntryRepository(
         finally:
             await results.close()
 
-    async def link_pending_by_price(
+    async def link_pending_by_subscription_and_price(
         self,
         subscription_id: UUID,
         product_price_id: UUID,
@@ -145,7 +139,7 @@ class BillingEntryRepository(
         )
         await self.session.execute(statement)
 
-    async def link_pending_by_meter(
+    async def link_pending_by_subscription_and_meter(
         self,
         subscription_id: UUID,
         meter_id: UUID,
@@ -170,10 +164,7 @@ class BillingEntryRepository(
         await self.session.execute(statement)
 
     async def lock_pending_by_subscription(
-        self,
-        subscription_id: UUID,
-        *,
-        cutoff: datetime | None = None,
+        self, subscription_id: UUID, *, cutoff: datetime | None = None
     ) -> None:
         """
         Acquire FOR UPDATE locks on all pending billing entries for a subscription.

--- a/server/polar/billing_entry/repository.py
+++ b/server/polar/billing_entry/repository.py
@@ -56,25 +56,21 @@ class BillingEntryRepository(
         subscription_id: UUID,
         *,
         cutoff: datetime | None = None,
-        watermark: datetime | None = None,
         options: Options = (),
     ) -> Sequence[BillingEntry]:
         statement = self.get_pending_by_subscription_statement(
-            subscription_id, cutoff=cutoff, watermark=watermark, options=options
+            subscription_id, cutoff=cutoff, options=options
         )
         return await self.get_all(statement)
 
     async def get_static_pending_by_subscription(
         self,
         subscription_id: UUID,
-        watermark: datetime,
         *,
         cutoff: datetime | None = None,
     ) -> AsyncGenerator[BillingEntry]:
         statement = (
-            self.get_pending_by_subscription_statement(
-                subscription_id, cutoff=cutoff, watermark=watermark
-            )
+            self.get_pending_by_subscription_statement(subscription_id, cutoff=cutoff)
             .join(BillingEntry.product_price)
             .where(ProductPrice.is_static.is_(True))
             .options(
@@ -88,9 +84,8 @@ class BillingEntryRepository(
     async def get_pending_metered_by_subscription_tuples(
         self,
         subscription_id: UUID,
-        watermark: datetime,
         *,
-        cutoff: datetime | None = None,
+        cutoff: datetime,
     ) -> AsyncGenerator[tuple[UUID, UUID, datetime, datetime]]:
         """
         Get pending metered billing entries grouped by (product_price_id, meter_id).
@@ -104,13 +99,12 @@ class BillingEntryRepository(
         subscription.subscription_product_prices, not from these tuples.
         """
         statement = (
-            self.get_pending_by_subscription_statement(
-                subscription_id, cutoff=cutoff, watermark=watermark
-            )
+            self.get_pending_by_subscription_statement(subscription_id, cutoff=cutoff)
             .join(
                 ProductPriceMeteredUnit,
                 BillingEntry.product_price_id == ProductPriceMeteredUnit.id,
             )
+            .where(BillingEntry.created_at <= cutoff)
             .with_only_columns(
                 BillingEntry.product_price_id,
                 ProductPriceMeteredUnit.meter_id,
@@ -136,18 +130,16 @@ class BillingEntryRepository(
         subscription_id: UUID,
         product_price_id: UUID,
         order_item_id: UUID,
-        watermark: datetime,
         *,
-        cutoff: datetime | None = None,
+        cutoff: datetime,
     ) -> None:
         statement = update(BillingEntry).where(
             BillingEntry.subscription_id == subscription_id,
             BillingEntry.order_item_id.is_(None),
             BillingEntry.product_price_id == product_price_id,
-            BillingEntry.created_at <= watermark,
+            BillingEntry.start_timestamp < cutoff,
+            BillingEntry.created_at <= cutoff,
         )
-        if cutoff is not None:
-            statement = statement.where(BillingEntry.start_timestamp < cutoff)
         statement = statement.values(order_item_id=order_item_id).execution_options(
             synchronize_session=False
         )
@@ -158,9 +150,8 @@ class BillingEntryRepository(
         subscription_id: UUID,
         meter_id: UUID,
         order_item_id: UUID,
-        watermark: datetime,
         *,
-        cutoff: datetime | None = None,
+        cutoff: datetime,
     ) -> None:
         statement = update(BillingEntry).where(
             BillingEntry.subscription_id == subscription_id,
@@ -170,10 +161,9 @@ class BillingEntryRepository(
                     ProductPriceMeteredUnit.meter_id == meter_id
                 )
             ),
-            BillingEntry.created_at <= watermark,
+            BillingEntry.start_timestamp < cutoff,
+            BillingEntry.created_at <= cutoff,
         )
-        if cutoff is not None:
-            statement = statement.where(BillingEntry.start_timestamp < cutoff)
         statement = statement.values(order_item_id=order_item_id).execution_options(
             synchronize_session=False
         )
@@ -182,7 +172,6 @@ class BillingEntryRepository(
     async def lock_pending_by_subscription(
         self,
         subscription_id: UUID,
-        watermark: datetime,
         *,
         cutoff: datetime | None = None,
     ) -> None:
@@ -195,9 +184,7 @@ class BillingEntryRepository(
         the entries are no longer pending.
         """
         statement = (
-            self.get_pending_by_subscription_statement(
-                subscription_id, cutoff=cutoff, watermark=watermark
-            )
+            self.get_pending_by_subscription_statement(subscription_id, cutoff=cutoff)
             .with_only_columns(BillingEntry.id)
             .with_for_update()
         )
@@ -208,7 +195,6 @@ class BillingEntryRepository(
         subscription_id: UUID,
         *,
         cutoff: datetime | None = None,
-        watermark: datetime | None = None,
         options: Options = (),
     ) -> Select[tuple["BillingEntry"]]:
         statement = (
@@ -232,6 +218,4 @@ class BillingEntryRepository(
                     ),
                 )
             )
-        if watermark is not None:
-            statement = statement.where(BillingEntry.created_at <= watermark)
         return statement

--- a/server/polar/billing_entry/service.py
+++ b/server/polar/billing_entry/service.py
@@ -100,14 +100,14 @@ class BillingEntryService:
         repository = BillingEntryRepository.from_session(session)
         for order_item, selector in item_entries_map.items():
             if isinstance(selector, PendingByPrice):
-                await repository.link_pending_by_price(
+                await repository.link_pending_by_subscription_and_price(
                     subscription.id,
                     selector.product_price_id,
                     order_item.id,
                     cutoff=cutoff,
                 )
             elif isinstance(selector, PendingByMeter):
-                await repository.link_pending_by_meter(
+                await repository.link_pending_by_subscription_and_meter(
                     subscription.id,
                     selector.meter_id,
                     order_item.id,

--- a/server/polar/billing_entry/service.py
+++ b/server/polar/billing_entry/service.py
@@ -12,6 +12,7 @@ from typing_extensions import AsyncGenerator
 
 from polar.event.repository import EventRepository
 from polar.kit.math import non_negative_running_sum
+from polar.kit.utils import utc_now
 from polar.meter.service import meter as meter_service
 from polar.models import BillingEntry, Event, OrderItem, Subscription
 from polar.models.billing_entry import BillingEntryDirection, BillingEntryType
@@ -51,6 +52,19 @@ class MeteredLineItem:
     proration: Literal[False] = False
 
 
+@dataclasses.dataclass(frozen=True)
+class PendingByPrice:
+    product_price_id: uuid.UUID
+
+
+@dataclasses.dataclass(frozen=True)
+class PendingByMeter:
+    meter_id: uuid.UUID
+
+
+type BillingEntrySelector = Sequence[uuid.UUID] | PendingByPrice | PendingByMeter
+
+
 class BillingEntryService:
     @contextlib.asynccontextmanager
     async def create_order_items_from_pending(
@@ -61,11 +75,14 @@ class BillingEntryService:
         cutoff: datetime | None = None,
     ) -> AsyncGenerator[Sequence[OrderItem]]:
         repository = BillingEntryRepository.from_session(session)
-        await repository.lock_pending_by_subscription(subscription.id, cutoff=cutoff)
+        watermark = utc_now()
+        await repository.lock_pending_by_subscription(
+            subscription.id, watermark, cutoff=cutoff
+        )
 
-        item_entries_map: dict[OrderItem, Sequence[uuid.UUID]] = {}
-        async for line_item, entries in self.compute_pending_subscription_line_items(
-            session, subscription, cutoff=cutoff
+        item_entries_map: dict[OrderItem, BillingEntrySelector] = {}
+        async for line_item, selector in self.compute_pending_subscription_line_items(
+            session, subscription, cutoff=cutoff, watermark=watermark
         ):
             order_item = OrderItem(
                 id=uuid.uuid4(),
@@ -76,13 +93,30 @@ class BillingEntryService:
                 proration=line_item.proration,
                 product_price=line_item.price,
             )
-            item_entries_map[order_item] = entries
+            item_entries_map[order_item] = selector
 
         yield list(item_entries_map.keys())
 
         repository = BillingEntryRepository.from_session(session)
-        for order_item, entries in item_entries_map.items():
-            await repository.update_order_item_id(entries, order_item.id)
+        for order_item, selector in item_entries_map.items():
+            if isinstance(selector, PendingByPrice):
+                await repository.link_pending_by_price(
+                    subscription.id,
+                    selector.product_price_id,
+                    order_item.id,
+                    watermark,
+                    cutoff=cutoff,
+                )
+            elif isinstance(selector, PendingByMeter):
+                await repository.link_pending_by_meter(
+                    subscription.id,
+                    selector.meter_id,
+                    order_item.id,
+                    watermark,
+                    cutoff=cutoff,
+                )
+            else:
+                await repository.update_order_item_id(selector, order_item.id)
 
     async def compute_pending_subscription_line_items(
         self,
@@ -90,11 +124,13 @@ class BillingEntryService:
         subscription: Subscription,
         *,
         cutoff: datetime | None = None,
-    ) -> AsyncGenerator[tuple[StaticLineItem | MeteredLineItem, Sequence[uuid.UUID]]]:
+        watermark: datetime | None = None,
+    ) -> AsyncGenerator[tuple[StaticLineItem | MeteredLineItem, BillingEntrySelector]]:
+        watermark = watermark or utc_now()
         repository = BillingEntryRepository.from_session(session)
 
         async for entry in repository.get_static_pending_by_subscription(
-            subscription.id, cutoff=cutoff
+            subscription.id, watermark, cutoff=cutoff
         ):
             static_price = cast(StaticPrice, entry.product_price)
             static_line_item = await self._get_static_price_line_item(
@@ -122,7 +158,7 @@ class BillingEntryService:
             start_timestamp,
             end_timestamp,
         ) in repository.get_pending_metered_by_subscription_tuples(
-            subscription.id, cutoff=cutoff
+            subscription.id, watermark, cutoff=cutoff
         ):
             metered_price = cast(
                 MeteredPrice, await product_price_repository.get_by_id(product_price_id)
@@ -162,13 +198,10 @@ class BillingEntryService:
                     subscription,
                     start_timestamp,
                     end_timestamp,
+                    watermark,
                     cutoff=cutoff,
                 )
-                pending_entries_ids = (
-                    await repository.get_pending_ids_by_subscription_and_meter(
-                        subscription.id, meter_id, cutoff=cutoff
-                    )
-                )
+                selector: BillingEntrySelector = PendingByMeter(meter_id)
             else:
                 # For summable aggregations (sum, count), we also need to verify
                 # the price is still active on the subscription. This prevents
@@ -191,15 +224,12 @@ class BillingEntryService:
                     subscription,
                     start_timestamp,
                     end_timestamp,
+                    watermark,
                     cutoff=cutoff,
                 )
-                pending_entries_ids = (
-                    await repository.get_pending_ids_by_subscription_and_price(
-                        subscription.id, product_price_id, cutoff=cutoff
-                    )
-                )
+                selector = PendingByPrice(product_price_id)
 
-            yield metered_line_item, pending_entries_ids
+            yield metered_line_item, selector
 
     async def _get_static_price_line_item(
         self,
@@ -267,6 +297,7 @@ class BillingEntryService:
         subscription: Subscription,
         start_timestamp: datetime,
         end_timestamp: datetime,
+        watermark: datetime,
         *,
         cutoff: datetime | None,
     ) -> MeteredLineItem:
@@ -276,7 +307,7 @@ class BillingEntryService:
         """
         event_repository = EventRepository.from_session(session)
         events_statement = event_repository.get_by_pending_entries_statement(
-            subscription.id, price.id, cutoff=cutoff
+            subscription.id, price.id, watermark, cutoff=cutoff
         )
         meter = price.meter
         units = await meter_service.get_quantity(
@@ -316,6 +347,7 @@ class BillingEntryService:
         subscription: Subscription,
         start_timestamp: datetime,
         end_timestamp: datetime,
+        watermark: datetime,
         *,
         cutoff: datetime | None,
     ) -> MeteredLineItem:
@@ -330,7 +362,7 @@ class BillingEntryService:
 
         # Get events across ALL prices for this meter
         events_statement = event_repository.get_by_pending_entries_for_meter_statement(
-            subscription.id, meter.id, cutoff=cutoff
+            subscription.id, meter.id, watermark, cutoff=cutoff
         )
         units = await meter_service.get_quantity(
             session,

--- a/server/polar/billing_entry/service.py
+++ b/server/polar/billing_entry/service.py
@@ -75,14 +75,14 @@ class BillingEntryService:
         cutoff: datetime | None = None,
     ) -> AsyncGenerator[Sequence[OrderItem]]:
         repository = BillingEntryRepository.from_session(session)
-        watermark = utc_now()
-        await repository.lock_pending_by_subscription(
-            subscription.id, watermark, cutoff=cutoff
-        )
+        cutoff = cutoff or utc_now()
+        await repository.lock_pending_by_subscription(subscription.id, cutoff=cutoff)
 
         item_entries_map: dict[OrderItem, BillingEntrySelector] = {}
         async for line_item, selector in self.compute_pending_subscription_line_items(
-            session, subscription, cutoff=cutoff, watermark=watermark
+            session,
+            subscription,
+            cutoff=cutoff,
         ):
             order_item = OrderItem(
                 id=uuid.uuid4(),
@@ -104,7 +104,6 @@ class BillingEntryService:
                     subscription.id,
                     selector.product_price_id,
                     order_item.id,
-                    watermark,
                     cutoff=cutoff,
                 )
             elif isinstance(selector, PendingByMeter):
@@ -112,7 +111,6 @@ class BillingEntryService:
                     subscription.id,
                     selector.meter_id,
                     order_item.id,
-                    watermark,
                     cutoff=cutoff,
                 )
             else:
@@ -124,13 +122,12 @@ class BillingEntryService:
         subscription: Subscription,
         *,
         cutoff: datetime | None = None,
-        watermark: datetime | None = None,
     ) -> AsyncGenerator[tuple[StaticLineItem | MeteredLineItem, BillingEntrySelector]]:
-        watermark = watermark or utc_now()
+        cutoff = cutoff or utc_now()
         repository = BillingEntryRepository.from_session(session)
 
         async for entry in repository.get_static_pending_by_subscription(
-            subscription.id, watermark, cutoff=cutoff
+            subscription.id, cutoff=cutoff
         ):
             static_price = cast(StaticPrice, entry.product_price)
             static_line_item = await self._get_static_price_line_item(
@@ -158,7 +155,7 @@ class BillingEntryService:
             start_timestamp,
             end_timestamp,
         ) in repository.get_pending_metered_by_subscription_tuples(
-            subscription.id, watermark, cutoff=cutoff
+            subscription.id, cutoff=cutoff
         ):
             metered_price = cast(
                 MeteredPrice, await product_price_repository.get_by_id(product_price_id)
@@ -198,7 +195,6 @@ class BillingEntryService:
                     subscription,
                     start_timestamp,
                     end_timestamp,
-                    watermark,
                     cutoff=cutoff,
                 )
                 selector: BillingEntrySelector = PendingByMeter(meter_id)
@@ -224,7 +220,6 @@ class BillingEntryService:
                     subscription,
                     start_timestamp,
                     end_timestamp,
-                    watermark,
                     cutoff=cutoff,
                 )
                 selector = PendingByPrice(product_price_id)
@@ -297,9 +292,8 @@ class BillingEntryService:
         subscription: Subscription,
         start_timestamp: datetime,
         end_timestamp: datetime,
-        watermark: datetime,
         *,
-        cutoff: datetime | None,
+        cutoff: datetime,
     ) -> MeteredLineItem:
         """
         Compute a metered line item for a specific price.
@@ -307,7 +301,7 @@ class BillingEntryService:
         """
         event_repository = EventRepository.from_session(session)
         events_statement = event_repository.get_by_pending_entries_statement(
-            subscription.id, price.id, watermark, cutoff=cutoff
+            subscription.id, price.id, cutoff=cutoff
         )
         meter = price.meter
         units = await meter_service.get_quantity(
@@ -347,9 +341,8 @@ class BillingEntryService:
         subscription: Subscription,
         start_timestamp: datetime,
         end_timestamp: datetime,
-        watermark: datetime,
         *,
-        cutoff: datetime | None,
+        cutoff: datetime,
     ) -> MeteredLineItem:
         """
         Compute a metered line item grouped by meter.
@@ -362,7 +355,7 @@ class BillingEntryService:
 
         # Get events across ALL prices for this meter
         events_statement = event_repository.get_by_pending_entries_for_meter_statement(
-            subscription.id, meter.id, watermark, cutoff=cutoff
+            subscription.id, meter.id, cutoff=cutoff
         )
         units = await meter_service.get_quantity(
             session,

--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -385,6 +385,7 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         self,
         subscription: UUID,
         price: UUID,
+        watermark: datetime,
         *,
         cutoff: datetime | None = None,
     ) -> Select[tuple[Event]]:
@@ -395,6 +396,7 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
                 BillingEntry.subscription_id == subscription,
                 BillingEntry.order_item_id.is_(None),
                 BillingEntry.product_price_id == price,
+                BillingEntry.created_at <= watermark,
             )
             .order_by(Event.ingested_at.asc())
         )
@@ -406,6 +408,7 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         self,
         subscription: UUID,
         meter: UUID,
+        watermark: datetime,
         *,
         cutoff: datetime | None = None,
     ) -> Select[tuple[Event]]:
@@ -425,6 +428,7 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
                 BillingEntry.subscription_id == subscription,
                 BillingEntry.order_item_id.is_(None),
                 ProductPriceMeteredUnit.meter_id == meter,
+                BillingEntry.created_at <= watermark,
             )
             .order_by(Event.ingested_at.asc())
         )

--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -385,9 +385,8 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         self,
         subscription: UUID,
         price: UUID,
-        watermark: datetime,
         *,
-        cutoff: datetime | None = None,
+        cutoff: datetime,
     ) -> Select[tuple[Event]]:
         statement = (
             self.get_base_statement()
@@ -396,21 +395,19 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
                 BillingEntry.subscription_id == subscription,
                 BillingEntry.order_item_id.is_(None),
                 BillingEntry.product_price_id == price,
-                BillingEntry.created_at <= watermark,
+                BillingEntry.start_timestamp < cutoff,
+                BillingEntry.created_at <= cutoff,
             )
             .order_by(Event.ingested_at.asc())
         )
-        if cutoff is not None:
-            statement = statement.where(BillingEntry.start_timestamp < cutoff)
         return statement
 
     def get_by_pending_entries_for_meter_statement(
         self,
         subscription: UUID,
         meter: UUID,
-        watermark: datetime,
         *,
-        cutoff: datetime | None = None,
+        cutoff: datetime,
     ) -> Select[tuple[Event]]:
         """
         Get events for pending billing entries grouped by meter.
@@ -428,12 +425,11 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
                 BillingEntry.subscription_id == subscription,
                 BillingEntry.order_item_id.is_(None),
                 ProductPriceMeteredUnit.meter_id == meter,
-                BillingEntry.created_at <= watermark,
+                BillingEntry.start_timestamp < cutoff,
+                BillingEntry.created_at <= cutoff,
             )
             .order_by(Event.ingested_at.asc())
         )
-        if cutoff is not None:
-            statement = statement.where(BillingEntry.start_timestamp < cutoff)
         return statement
 
     def get_eager_options(self) -> Options:

--- a/server/tests/billing_entry/test_service.py
+++ b/server/tests/billing_entry/test_service.py
@@ -401,6 +401,67 @@ class TestCreateOrderItemsFromPending:
         assert current_entry.order_item_id == order_item.id
         assert future_entry.order_item_id is None
 
+    async def test_metered_entries_use_one_watermark_for_amount_and_linking(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        meter: Meter,
+        product_metered_unit: Product,
+        metered_subscription: Subscription,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        price = product_metered_unit.prices[0]
+        assert is_metered_price(price)
+
+        included_entry = await create_metered_event_billing_entry(
+            save_fixture,
+            customer=customer,
+            price=price,
+            subscription=metered_subscription,
+            tokens=20,
+        )
+        watermark = included_entry.created_at + timedelta(seconds=1)
+        future_entry = await create_metered_event_billing_entry(
+            save_fixture,
+            customer=customer,
+            price=price,
+            subscription=metered_subscription,
+            tokens=100,
+        )
+        future_entry.created_at = watermark + timedelta(seconds=1)
+        await save_fixture(future_entry)
+        monkeypatch.setattr("polar.billing_entry.service.utc_now", lambda: watermark)
+
+        async with billing_entry_service.create_order_items_from_pending(
+            session, metered_subscription
+        ) as order_items:
+            assert len(order_items) == 1
+            order_item = order_items[0]
+            assert order_item.amount == 20_00
+
+            late_entry = await create_metered_event_billing_entry(
+                save_fixture,
+                customer=customer,
+                price=price,
+                subscription=metered_subscription,
+                tokens=200,
+            )
+            late_entry.created_at = watermark + timedelta(seconds=2)
+            await save_fixture(late_entry)
+            await create_order(
+                save_fixture,
+                customer=customer,
+                order_items=list(order_items),
+            )
+
+        await session.refresh(included_entry)
+        await session.refresh(future_entry)
+        await session.refresh(late_entry)
+        assert included_entry.order_item_id == order_item.id
+        assert future_entry.order_item_id is None
+        assert late_entry.order_item_id is None
+
     async def test_several_metered_prices(
         self,
         save_fixture: SaveFixture,
@@ -696,6 +757,7 @@ class TestCreateOrderItemsFromPending:
         session: AsyncSession,
         customer: Customer,
         organization: Organization,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """
         Test that MAX aggregation computes correctly across multiple product prices
@@ -787,6 +849,21 @@ class TestCreateOrderItemsFromPending:
                 ),
             ]
         )
+        watermark = entries[0].created_at
+        for entry in entries:
+            entry.created_at = watermark
+        await session.flush()
+        future_entry = await create_metered_event_billing_entry(
+            save_fixture,
+            customer=customer,
+            price=price_b,
+            subscription=subscription,
+            tokens=100,
+            metadata_key="servers",
+        )
+        future_entry.created_at = watermark + timedelta(seconds=1)
+        await save_fixture(future_entry)
+        monkeypatch.setattr("polar.billing_entry.service.utc_now", lambda: watermark)
 
         # When computing order items, MAX should be 3 (not 3 + 2 = 5)
         async with billing_entry_service.create_order_items_from_pending(
@@ -812,6 +889,8 @@ class TestCreateOrderItemsFromPending:
         for entry in entries:
             await session.refresh(entry)
             assert entry.order_item_id == order_item.id
+        await session.refresh(future_entry)
+        assert future_entry.order_item_id is None
 
     async def test_inactive_price_skipped_after_product_switch(
         self,

--- a/server/tests/billing_entry/test_service.py
+++ b/server/tests/billing_entry/test_service.py
@@ -372,6 +372,7 @@ class TestCreateOrderItemsFromPending:
         )
         current_entry.start_timestamp = cutoff - timedelta(seconds=1)
         current_entry.end_timestamp = cutoff - timedelta(seconds=1)
+        current_entry.created_at = cutoff - timedelta(seconds=1)
         await save_fixture(current_entry)
         future_entry = await create_metered_event_billing_entry(
             save_fixture,
@@ -382,6 +383,7 @@ class TestCreateOrderItemsFromPending:
         )
         future_entry.start_timestamp = cutoff
         future_entry.end_timestamp = cutoff
+        future_entry.created_at = cutoff - timedelta(seconds=1)
         await save_fixture(future_entry)
 
         async with billing_entry_service.create_order_items_from_pending(
@@ -401,7 +403,7 @@ class TestCreateOrderItemsFromPending:
         assert current_entry.order_item_id == order_item.id
         assert future_entry.order_item_id is None
 
-    async def test_metered_entries_use_one_watermark_for_amount_and_linking(
+    async def test_metered_entries_use_cutoff_for_amount_and_linking(
         self,
         save_fixture: SaveFixture,
         session: AsyncSession,
@@ -409,7 +411,6 @@ class TestCreateOrderItemsFromPending:
         meter: Meter,
         product_metered_unit: Product,
         metered_subscription: Subscription,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         price = product_metered_unit.prices[0]
         assert is_metered_price(price)
@@ -421,7 +422,10 @@ class TestCreateOrderItemsFromPending:
             subscription=metered_subscription,
             tokens=20,
         )
-        watermark = included_entry.created_at + timedelta(seconds=1)
+        cutoff = included_entry.created_at + timedelta(seconds=1)
+        included_entry.start_timestamp = cutoff - timedelta(seconds=1)
+        included_entry.end_timestamp = cutoff - timedelta(seconds=1)
+        await save_fixture(included_entry)
         future_entry = await create_metered_event_billing_entry(
             save_fixture,
             customer=customer,
@@ -429,12 +433,13 @@ class TestCreateOrderItemsFromPending:
             subscription=metered_subscription,
             tokens=100,
         )
-        future_entry.created_at = watermark + timedelta(seconds=1)
+        future_entry.start_timestamp = cutoff - timedelta(seconds=1)
+        future_entry.end_timestamp = cutoff - timedelta(seconds=1)
+        future_entry.created_at = cutoff + timedelta(seconds=1)
         await save_fixture(future_entry)
-        monkeypatch.setattr("polar.billing_entry.service.utc_now", lambda: watermark)
 
         async with billing_entry_service.create_order_items_from_pending(
-            session, metered_subscription
+            session, metered_subscription, cutoff=cutoff
         ) as order_items:
             assert len(order_items) == 1
             order_item = order_items[0]
@@ -447,7 +452,9 @@ class TestCreateOrderItemsFromPending:
                 subscription=metered_subscription,
                 tokens=200,
             )
-            late_entry.created_at = watermark + timedelta(seconds=2)
+            late_entry.start_timestamp = cutoff - timedelta(seconds=1)
+            late_entry.end_timestamp = cutoff - timedelta(seconds=1)
+            late_entry.created_at = cutoff + timedelta(seconds=2)
             await save_fixture(late_entry)
             await create_order(
                 save_fixture,
@@ -751,13 +758,48 @@ class TestCreateOrderItemsFromPending:
         await session.refresh(entries[2])
         assert entries[2].order_item_id == order_item_2.id
 
+    async def test_static_entry_created_after_cutoff_is_included(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        price = product.prices[0]
+        assert is_fixed_price(price)
+        cutoff = subscription.current_period_start
+        entry = await create_static_price_billing_entry(
+            save_fixture,
+            customer=customer,
+            price=price,
+            subscription=subscription,
+        )
+        entry.created_at = cutoff + timedelta(seconds=1)
+        await save_fixture(entry)
+
+        async with billing_entry_service.create_order_items_from_pending(
+            session, subscription, cutoff=cutoff
+        ) as order_items:
+            assert len(order_items) == 1
+            order_item = order_items[0]
+            await create_order(
+                save_fixture,
+                customer=customer,
+                order_items=list(order_items),
+            )
+
+        await session.refresh(entry)
+        assert entry.order_item_id == order_item.id
+
     async def test_max_aggregation_across_product_prices(
         self,
         save_fixture: SaveFixture,
         session: AsyncSession,
         customer: Customer,
         organization: Organization,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """
         Test that MAX aggregation computes correctly across multiple product prices
@@ -849,9 +891,11 @@ class TestCreateOrderItemsFromPending:
                 ),
             ]
         )
-        watermark = entries[0].created_at
+        cutoff = entries[0].created_at + timedelta(seconds=1)
         for entry in entries:
-            entry.created_at = watermark
+            entry.start_timestamp = cutoff - timedelta(seconds=1)
+            entry.end_timestamp = cutoff - timedelta(seconds=1)
+            entry.created_at = cutoff - timedelta(seconds=1)
         await session.flush()
         future_entry = await create_metered_event_billing_entry(
             save_fixture,
@@ -861,14 +905,16 @@ class TestCreateOrderItemsFromPending:
             tokens=100,
             metadata_key="servers",
         )
-        future_entry.created_at = watermark + timedelta(seconds=1)
+        future_entry.start_timestamp = cutoff - timedelta(seconds=1)
+        future_entry.end_timestamp = cutoff - timedelta(seconds=1)
+        future_entry.created_at = cutoff + timedelta(seconds=1)
         await save_fixture(future_entry)
-        monkeypatch.setattr("polar.billing_entry.service.utc_now", lambda: watermark)
 
         # When computing order items, MAX should be 3 (not 3 + 2 = 5)
         async with billing_entry_service.create_order_items_from_pending(
             session,
             subscription,
+            cutoff=cutoff,
         ) as order_items:
             # Should create ONE line item (grouped by meter, not by price)
             assert len(order_items) == 1


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788096185&installation_model_id=13063&pr_number=13491&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13491&signature=282d46517cbfc6f8ce8b7dcaa61f704e9e5b5646cbd2e4eef6ad5adf5acf65df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use a single cutoff when creating order items so amount calculation and entry linking use the exact same pending set. Switch linking to a direct UPDATE WHERE (by price or meter) to reduce round-trips and prevent late metered entries from being linked.

- **Bug Fixes**
  - Apply one UTC cutoff (start_timestamp < cutoff, created_at <= cutoff) across locks, selection, event queries, and linking for metered entries.
  - Amounts and linking use the same pending set; late metered entries are excluded, static entries created after the cutoff remain eligible.
  - Default cutoff to `utc_now()` when none is provided; tests cover cutoff behavior, amount/linking parity, static-after-cutoff inclusion, and max aggregation across prices.

- **Refactors**
  - Replace fetch+update with direct UPDATE WHERE via `link_pending_by_price` and `link_pending_by_meter`, using the cutoff.
  - Introduce `PendingByPrice` and `PendingByMeter` selectors; make cutoff required in metered selectors and event repository statements.

<sup>Written for commit 03300232287adb15c177bda322acf9c4daf0e9ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

