### PR TITLE
perf(event): use row comparison for meter billing keyset pagination

### DIFF
--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     literal,
     or_,
     select,
+    tuple_,
     update,
 )
 from sqlalchemy.dialects.postgresql import aggregate_order_by, insert
@@ -329,13 +330,8 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         if after_ingested_at is not None:
             assert after_event_id is not None
             page_statement = page_statement.where(
-                or_(
-                    MeterEvent.ingested_at > after_ingested_at,
-                    and_(
-                        MeterEvent.ingested_at == after_ingested_at,
-                        MeterEvent.event_id > after_event_id,
-                    ),
-                )
+                tuple_(MeterEvent.ingested_at, MeterEvent.event_id)
+                > (after_ingested_at, after_event_id)
             )
 
         event_page = page_statement.cte("meter_billing_event_page")


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788097087&installation_model_id=13063&pr_number=13492&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13492&signature=b42de004edbf7c973ea8b1ecfbed965114071a26e7b91e3e7c8b5cdc4ec15466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch meter billing keyset pagination to SQL row comparison on (ingested_at, event_id) so Postgres can use the index and seek to the watermark. This removes backlog rescans and prevents timeouts when a meter is far behind.

- **Performance**
  - Row comparison replaces the OR predicate, enabling index-bound scans.
  - Stable page time (~0.09 ms for 500 rows) even at 1.9M offset; previously ~188 ms due to filtering.
  - Avoids statement_timeout failures that caused dropped work in meter billing.

<sup>Written for commit cbe0dd2b3ad97eca8d6494bc1ec13d20be57d560. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

