### PR TITLE
feat(dispute): concede disputes below the merchant's threshold

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -34240,6 +34240,9 @@ export interface components {
       | 'dispute_lost'
       | 'dispute_prevented'
       | 'merchant_accepted'
+      | 'dispute_auto_accept_scheduled'
+      | 'dispute_auto_accept_canceled'
+      | 'dispute_auto_accepted'
     /**
      * SupportCaseSortProperty
      * @enum {string}
@@ -66115,6 +66118,9 @@ export const supportCaseMessageTypeValues: ReadonlyArray<
   'dispute_lost',
   'dispute_prevented',
   'merchant_accepted',
+  'dispute_auto_accept_scheduled',
+  'dispute_auto_accept_canceled',
+  'dispute_auto_accepted',
 ]
 export const supportCaseSortPropertyValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SupportCaseSortProperty']

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -34989,6 +34989,9 @@ export interface components {
       | 'dispute_lost'
       | 'dispute_prevented'
       | 'merchant_accepted'
+      | 'dispute_auto_accept_scheduled'
+      | 'dispute_auto_accept_canceled'
+      | 'dispute_auto_accepted'
     /**
      * SupportCaseSortProperty
      * @enum {string}
@@ -67471,6 +67474,9 @@ export const supportCaseMessageTypeValues: ReadonlyArray<
   'dispute_lost',
   'dispute_prevented',
   'merchant_accepted',
+  'dispute_auto_accept_scheduled',
+  'dispute_auto_accept_canceled',
+  'dispute_auto_accepted',
 ]
 export const supportCaseSortPropertyValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['SupportCaseSortProperty']

--- a/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/support_case_section.py
@@ -87,6 +87,9 @@ _EVENT_TITLES: dict[SupportCaseMessageType, str] = {
     SupportCaseMessageType.dispute_lost: "Dispute lost",
     SupportCaseMessageType.dispute_prevented: "Dispute prevented",
     SupportCaseMessageType.merchant_accepted: "Merchant accepted the dispute",
+    SupportCaseMessageType.dispute_auto_accept_scheduled: "Auto-accept scheduled",
+    SupportCaseMessageType.dispute_auto_accept_canceled: "Auto-accept canceled",
+    SupportCaseMessageType.dispute_auto_accepted: "Auto-accepted the dispute",
     SupportCaseMessageType.assigned: "Case assigned",
     SupportCaseMessageType.released: "Case unassigned",
 }
@@ -119,6 +122,9 @@ _EVENT_NODES: dict[SupportCaseMessageType, tuple[str, str]] = {
         "bg-success text-success-content",
     ),
     SupportCaseMessageType.merchant_accepted: ("icon-x", _MUTED_NODE),
+    SupportCaseMessageType.dispute_auto_accept_scheduled: ("icon-clock", _MUTED_NODE),
+    SupportCaseMessageType.dispute_auto_accept_canceled: ("icon-undo-2", _MUTED_NODE),
+    SupportCaseMessageType.dispute_auto_accepted: ("icon-x", _MUTED_NODE),
     SupportCaseMessageType.assigned: ("icon-user-check", _MUTED_NODE),
     SupportCaseMessageType.released: ("icon-user-x", _MUTED_NODE),
 }

--- a/server/polar/dispute/dispute_case.py
+++ b/server/polar/dispute/dispute_case.py
@@ -158,7 +158,10 @@ class DisputeCaseService:
             body=(
                 "This dispute is below the threshold you set, so we plan to "
                 f"accept it on your behalf on {deadline:%d %B %Y at %H:%M} UTC. "
-                "Reply here before then and we'll leave it to you."
+                "You lose the disputed amount and the dispute fee, and the "
+                "dispute closes. To handle it yourself instead, reply here "
+                "before then — any reply stops us, and you can still accept it "
+                "later from the dispute page."
             ),
             audience=[SupportCaseAudience.merchant],
         )

--- a/server/polar/dispute/dispute_case.py
+++ b/server/polar/dispute/dispute_case.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from datetime import datetime
 from uuid import UUID
 
 from polar.exceptions import PolarError
@@ -115,9 +116,13 @@ class DisputeCaseService:
         )
 
     async def accept(
-        self, session: AsyncSession, case: DisputeSupportCase
+        self,
+        session: AsyncSession,
+        case: DisputeSupportCase,
+        *,
+        automatic: bool = False,
     ) -> SupportCaseMessage:
-        """Record the merchant's acceptance (concede) on the thread.
+        """Record the acceptance (concede) on the thread.
 
         A ``system`` lifecycle event, like the other ``dispute_*`` events —
         merchant/platform/customer author kinds are reserved for chat.
@@ -126,8 +131,58 @@ class DisputeCaseService:
         return await support_case_service.post_message(
             session,
             case,
-            type=SupportCaseMessageType.merchant_accepted,
+            type=SupportCaseMessageType.dispute_auto_accepted
+            if automatic
+            else SupportCaseMessageType.merchant_accepted,
             author_kind=SupportCaseMessageAuthorKind.system,
+            audience=[SupportCaseAudience.merchant],
+        )
+
+    async def announce_auto_accept(
+        self,
+        session: AsyncSession,
+        case: DisputeSupportCase,
+        *,
+        deadline: datetime,
+    ) -> SupportCaseMessage:
+        """Warn that Polar plans to concede this dispute, and when.
+
+        The deadline lives in the body, not in client-side copy: the wait is tunable.
+        """
+        await self._assert_open(session, case)
+        return await support_case_service.post_message(
+            session,
+            case,
+            type=SupportCaseMessageType.dispute_auto_accept_scheduled,
+            author_kind=SupportCaseMessageAuthorKind.system,
+            body=(
+                "This dispute is below the threshold you set, so we plan to "
+                f"accept it on your behalf on {deadline:%d %B %Y at %H:%M} UTC. "
+                "Reply here before then and we'll leave it to you."
+            ),
+            audience=[SupportCaseAudience.merchant],
+        )
+
+    async def cancel_auto_accept(
+        self, session: AsyncSession, case: DisputeSupportCase
+    ) -> SupportCaseMessage | None:
+        """Retract the announcement once the merchant answers."""
+        repository = SupportCaseMessageRepository.from_session(session)
+        if not await repository.has_message_type(
+            case.id, SupportCaseMessageType.dispute_auto_accept_scheduled
+        ) or await repository.has_message_type(
+            case.id, SupportCaseMessageType.dispute_auto_accept_canceled
+        ):
+            return None
+        return await support_case_service.post_message(
+            session,
+            case,
+            type=SupportCaseMessageType.dispute_auto_accept_canceled,
+            author_kind=SupportCaseMessageAuthorKind.system,
+            body=(
+                "You replied, so this dispute stays with you. We won't accept "
+                "it on your behalf."
+            ),
             audience=[SupportCaseAudience.merchant],
         )
 
@@ -156,9 +211,10 @@ class DisputeCaseService:
             case.win_reason = reply.win_reason
             case.win_reason_other = reply.win_reason_other
 
+        message_repository = SupportCaseMessageRepository.from_session(session)
         is_first_merchant_reply = (
             author_kind == SupportCaseMessageAuthorKind.merchant
-            and not await self._has_merchant_message(session, case)
+            and not await message_repository.has_merchant_message(case.id)
         )
 
         audience = [] if internal else [SupportCaseAudience.merchant]
@@ -180,6 +236,9 @@ class DisputeCaseService:
                 message_id=message.id,
             )
 
+        if author_kind == SupportCaseMessageAuthorKind.merchant:
+            await self.cancel_auto_accept(session, case)
+
         if is_first_merchant_reply:
             enqueue_job(
                 "dispute.post_dispute_greeting",
@@ -188,16 +247,6 @@ class DisputeCaseService:
             )
 
         return message
-
-    async def _has_merchant_message(
-        self, session: AsyncSession, case: DisputeSupportCase
-    ) -> bool:
-        repository = SupportCaseMessageRepository.from_session(session)
-        messages = await repository.list_by_case(case.id, visible_to=None)
-        return any(
-            message.author_kind == SupportCaseMessageAuthorKind.merchant
-            for message in messages
-        )
 
     async def resolve(
         self, session: AsyncSession, case: DisputeSupportCase, *, won: bool

--- a/server/polar/dispute/repository.py
+++ b/server/polar/dispute/repository.py
@@ -1,3 +1,5 @@
+from collections.abc import AsyncGenerator
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy import Select
@@ -14,7 +16,7 @@ from polar.kit.repository import (
     RepositorySortingMixin,
     SortingClause,
 )
-from polar.models import Dispute, Order, Payment
+from polar.models import Dispute, Order, Organization, Payment
 from polar.models.dispute import DisputeAlertProcessor, DisputeStatus
 
 from .sorting import DisputeSortProperty
@@ -129,6 +131,29 @@ class DisputeRepository(
             .options(contains_eager(Dispute.payment))
             .where(Payment.organization_id.in_(org_ids))
         )
+
+    async def stream_auto_accept_candidates(
+        self, *, before: datetime
+    ) -> AsyncGenerator[Dispute, None]:
+        """Disputes past the delay on an organization that opted in."""
+        feature_settings = Organization.feature_settings
+        statement = (
+            self.get_base_statement()
+            .join(Order, Dispute.order_id == Order.id)
+            .join(Organization, Order.organization_id == Organization.id)
+            .where(
+                Dispute.status == DisputeStatus.needs_response,
+                Dispute.created_at < before,
+                feature_settings["disputes_enabled"].as_boolean().is_(True),
+                feature_settings["dispute_auto_accept_enabled"].as_boolean().is_(True),
+                Organization.dispute_settings["auto_accept_below_amount"]
+                .as_integer()
+                .isnot(None),
+            )
+            .order_by(Dispute.created_at.asc())
+        )
+        async for dispute in self.stream(statement):
+            yield dispute
 
     def get_eager_options(self) -> Options:
         return (

--- a/server/polar/dispute/repository.py
+++ b/server/polar/dispute/repository.py
@@ -2,7 +2,7 @@ from collections.abc import AsyncGenerator
 from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import Select
+from sqlalchemy import Select, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import contains_eager, joinedload
 
@@ -18,6 +18,11 @@ from polar.kit.repository import (
 )
 from polar.models import Dispute, Order, Organization, Payment
 from polar.models.dispute import DisputeAlertProcessor, DisputeStatus
+from polar.models.support_case import (
+    DisputeSupportCase,
+    SupportCaseMessage,
+    SupportCaseMessageType,
+)
 
 from .sorting import DisputeSortProperty
 
@@ -135,15 +140,30 @@ class DisputeRepository(
     async def stream_auto_accept_candidates(
         self, *, before: datetime
     ) -> AsyncGenerator[Dispute, None]:
-        """Disputes past the delay on an organization that opted in."""
+        """Disputes whose announced deadline has passed, on an opted-in
+        organization."""
         feature_settings = Organization.feature_settings
+        announced = (
+            select(SupportCaseMessage.id)
+            .join(
+                DisputeSupportCase,
+                DisputeSupportCase.id == SupportCaseMessage.case_id,
+            )
+            .where(
+                DisputeSupportCase.dispute_id == Dispute.id,
+                SupportCaseMessage.type
+                == SupportCaseMessageType.dispute_auto_accept_scheduled,
+                SupportCaseMessage.created_at < before,
+            )
+            .exists()
+        )
         statement = (
             self.get_base_statement()
             .join(Order, Dispute.order_id == Order.id)
             .join(Organization, Order.organization_id == Organization.id)
             .where(
                 Dispute.status == DisputeStatus.needs_response,
-                Dispute.created_at < before,
+                announced,
                 feature_settings["disputes_enabled"].as_boolean().is_(True),
                 feature_settings["dispute_auto_accept_enabled"].as_boolean().is_(True),
                 Organization.dispute_settings["auto_accept_below_amount"]

--- a/server/polar/dispute/service.py
+++ b/server/polar/dispute/service.py
@@ -1,11 +1,12 @@
 import uuid
 from collections.abc import Sequence
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import assert_never
 
 import stripe as stripe_lib
 from sqlalchemy.orm import joinedload
 
+from polar.account.repository import AccountRepository
 from polar.auth.models import AuthSubject, Organization, User
 from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
@@ -17,10 +18,12 @@ from polar.exceptions import PolarError
 from polar.integrations.chargeback_stop.types import ChargebackStopAlert
 from polar.integrations.stripe.service import stripe as stripe_service
 from polar.integrations.stripe.utils import get_expandable_id
+from polar.kit.math import polar_round
 from polar.kit.pagination import PaginationParams
 from polar.kit.sorting import Sorting
 from polar.models import Dispute, Order, Payment
 from polar.models.dispute import DisputeAlertProcessor, DisputeStatus
+from polar.models.support_case import DisputeSupportCase
 from polar.payment.repository import PaymentRepository
 from polar.postgres import AsyncReadSession, AsyncSession
 from polar.product.repository import ProductRepository
@@ -28,16 +31,25 @@ from polar.refund.service import refund as refund_service
 from polar.subscription.repository import SubscriptionRepository
 from polar.subscription.service import SubscriptionUpdateContext
 from polar.subscription.service import subscription as subscription_service
+from polar.support_case.repository import SupportCaseMessageRepository
+from polar.transaction.repository import PaymentTransactionRepository
 from polar.transaction.service.dispute import (
     DisputeTransactionAlreadyExistsError,
 )
 from polar.transaction.service.dispute import (
     dispute_transaction as dispute_transaction_service,
 )
+from polar.transaction.service.transaction import (
+    transaction as transaction_service,
+)
 
 from .repository import DisputeRepository
 from .sorting import DisputeSortProperty
 from .stripe import get_dispute_balance_transaction, is_rapid_resolution_dispute
+
+# Long enough for a late ChargebackStop alert, an RDR resolution or the
+# merchant's own reply to take the dispute out of scope.
+DISPUTE_AUTO_ACCEPT_DELAY = timedelta(hours=24)
 
 
 class DisputeError(PolarError):
@@ -115,12 +127,14 @@ class DisputeService:
         )
         return await repository.get_one_or_none(statement)
 
-    async def accept(self, session: AsyncSession, dispute: Dispute) -> Dispute:
-        """Merchant concedes the chargeback.
+    async def accept(
+        self, session: AsyncSession, dispute: Dispute, *, automatic: bool = False
+    ) -> Dispute:
+        """Concede the chargeback.
 
         Closes the dispute with the processor — which settles it as ``lost`` —
-        and records the merchant's decision on the support thread. The resulting
-        ``lost`` state is reconciled through the same path as the Stripe webhook.
+        and records the decision on the support thread. The resulting ``lost``
+        state is reconciled through the same path as the Stripe webhook.
         """
         if dispute.status != DisputeStatus.needs_response:
             raise DisputeNotOpenError(dispute.id)
@@ -129,7 +143,7 @@ class DisputeService:
 
         case = await dispute_case_service.get_case(session, dispute)
         if case is not None:
-            await dispute_case_service.accept(session, case)
+            await dispute_case_service.accept(session, case, automatic=automatic)
 
         stripe_dispute = await stripe_service.close_dispute(
             dispute.payment_processor_id
@@ -142,6 +156,77 @@ class DisputeService:
         )
         assert reloaded is not None
         return reloaded
+
+    async def _announce_auto_accept(
+        self, session: AsyncSession, dispute: Dispute, case: DisputeSupportCase
+    ) -> None:
+        if not await self.auto_accept_applies(session, dispute):
+            return
+        await dispute_case_service.announce_auto_accept(
+            session, case, deadline=dispute.created_at + DISPUTE_AUTO_ACCEPT_DELAY
+        )
+
+    async def auto_accept_applies(
+        self, session: AsyncSession, dispute: Dispute
+    ) -> bool:
+        """Judged at case open, to announce it, and again when the sweep runs."""
+        if dispute.status != DisputeStatus.needs_response:
+            return False
+
+        # ChargebackStop is already working this one, and may yet prevent it.
+        if dispute.dispute_alert_processor_id is not None:
+            return False
+
+        organization = dispute.order.organization
+        if not organization.is_dispute_auto_accept_enabled:
+            return False
+
+        threshold = organization.dispute_auto_accept_below_amount
+        if threshold is None:
+            return False
+
+        settlement_amount = await self._settlement_amount(session, dispute)
+        if settlement_amount is None or settlement_amount >= threshold:
+            return False
+
+        # Replying cancels it, as the announcement promises.
+        case = await dispute_case_service.get_case(session, dispute)
+        if case is not None:
+            message_repository = SupportCaseMessageRepository.from_session(session)
+            if await message_repository.has_merchant_message(case.id):
+                return False
+
+        return await self._balance_covers(session, organization, settlement_amount)
+
+    async def _settlement_amount(
+        self, session: AsyncSession, dispute: Dispute
+    ) -> int | None:
+        """The dispute in settlement currency, at the rate its charge settled at."""
+        payment_transaction_repository = PaymentTransactionRepository.from_session(
+            session
+        )
+        payment_transaction = await payment_transaction_repository.get_by_payment_id(
+            dispute.payment_id
+        )
+        if payment_transaction is None or payment_transaction.exchange_rate is None:
+            return None
+        return polar_round(
+            (dispute.amount + dispute.tax_amount) * payment_transaction.exchange_rate
+        )
+
+    async def _balance_covers(
+        self, session: AsyncSession, organization: Organization, amount: int
+    ) -> bool:
+        """``balance``, not ``available_balance``: the payout hold is about
+        payout timing, not whether the loss nets out."""
+        if organization.account_id is None:
+            return False
+        account_repository = AccountRepository.from_session(session)
+        account = await account_repository.get_by_id(organization.account_id)
+        if account is None:
+            return False
+        summary = await transaction_service.get_summary(session, account)
+        return summary.balance.amount >= amount
 
     async def upsert_from_stripe(
         self, session: AsyncSession, stripe_dispute: stripe_lib.Dispute
@@ -271,9 +356,10 @@ class DisputeService:
         # Open (or reopen) the case the first time the dispute needs a response.
         if dispute.status == DisputeStatus.needs_response:
             if case is None:
-                await dispute_case_service.open_case(
+                case = await dispute_case_service.open_case(
                     session, dispute, organization=dispute.order.organization
                 )
+                await self._announce_auto_accept(session, dispute, case)
             elif not await dispute_case_service.is_open(session, case):
                 # Dispute reopened after we'd closed the case (e.g. a prevented
                 # dispute that Stripe escalated back to needs_response).

--- a/server/polar/dispute/service.py
+++ b/server/polar/dispute/service.py
@@ -21,6 +21,7 @@ from polar.integrations.stripe.utils import get_expandable_id
 from polar.kit.math import polar_round
 from polar.kit.pagination import PaginationParams
 from polar.kit.sorting import Sorting
+from polar.kit.utils import utc_now
 from polar.models import Dispute, Order, Payment
 from polar.models.dispute import DisputeAlertProcessor, DisputeStatus
 from polar.models.support_case import DisputeSupportCase
@@ -163,7 +164,7 @@ class DisputeService:
         if not await self.auto_accept_applies(session, dispute):
             return
         await dispute_case_service.announce_auto_accept(
-            session, case, deadline=dispute.created_at + DISPUTE_AUTO_ACCEPT_DELAY
+            session, case, deadline=utc_now() + DISPUTE_AUTO_ACCEPT_DELAY
         )
 
     async def auto_accept_applies(

--- a/server/polar/dispute/tasks.py
+++ b/server/polar/dispute/tasks.py
@@ -1,5 +1,6 @@
 import uuid
 
+from polar.kit.utils import utc_now
 from polar.models.support_case import (
     SupportCaseAudience,
     SupportCaseMessageAuthorKind,
@@ -9,9 +10,18 @@ from polar.support_case.repository import (
     SupportCaseRepository,
 )
 from polar.support_case.service import support_case as support_case_service
-from polar.worker import AsyncSessionMaker, TaskPriority, actor
+from polar.worker import (
+    AsyncSessionMaker,
+    CronTrigger,
+    TaskPriority,
+    actor,
+    enqueue_job,
+)
 
 from .dispute_case import DISPUTE_GREETING
+from .repository import DisputeRepository
+from .service import DISPUTE_AUTO_ACCEPT_DELAY
+from .service import dispute as dispute_service
 
 
 @actor(actor_name="dispute.post_dispute_greeting", priority=TaskPriority.LOW)
@@ -37,3 +47,34 @@ async def post_dispute_greeting(case_id: uuid.UUID) -> None:
             body=DISPUTE_GREETING,
             audience=[SupportCaseAudience.merchant],
         )
+
+
+@actor(
+    actor_name="dispute.enqueue_auto_accepts",
+    cron_trigger=CronTrigger.from_crontab("30 * * * *"),
+    priority=TaskPriority.LOW,
+)
+async def enqueue_auto_accepts() -> None:
+    """Hand each dispute past the delay to its own job."""
+    async with AsyncSessionMaker() as session:
+        repository = DisputeRepository.from_session(session)
+        before = utc_now() - DISPUTE_AUTO_ACCEPT_DELAY
+        async for dispute in repository.stream_auto_accept_candidates(before=before):
+            enqueue_job("dispute.auto_accept", dispute.id)
+
+
+@actor(actor_name="dispute.auto_accept", priority=TaskPriority.LOW)
+async def auto_accept(dispute_id: uuid.UUID) -> None:
+    """Concede a single dispute. The sweep only narrows, so re-check first."""
+    async with AsyncSessionMaker() as session:
+        repository = DisputeRepository.from_session(session)
+        dispute = await repository.get_by_id(
+            dispute_id, options=repository.get_eager_options()
+        )
+        if dispute is None:
+            return
+
+        if not await dispute_service.auto_accept_applies(session, dispute):
+            return
+
+        await dispute_service.accept(session, dispute, automatic=True)

--- a/server/polar/dispute/tasks.py
+++ b/server/polar/dispute/tasks.py
@@ -69,7 +69,7 @@ async def auto_accept(dispute_id: uuid.UUID) -> None:
     async with AsyncSessionMaker() as session:
         repository = DisputeRepository.from_session(session)
         dispute = await repository.get_by_id(
-            dispute_id, options=repository.get_eager_options()
+            dispute_id, options=repository.get_eager_options(), for_update=True
         )
         if dispute is None:
             return

--- a/server/polar/models/support_case.py
+++ b/server/polar/models/support_case.py
@@ -96,6 +96,10 @@ class SupportCaseMessageType(StrEnum):
     dispute_prevented = "dispute_prevented"
     # the merchant's decision on a dispute (records the lifecycle in the thread)
     merchant_accepted = "merchant_accepted"
+    # Polar conceding a dispute for the merchant, under their threshold
+    dispute_auto_accept_scheduled = "dispute_auto_accept_scheduled"
+    dispute_auto_accept_canceled = "dispute_auto_accept_canceled"
+    dispute_auto_accepted = "dispute_auto_accepted"
 
 
 class SupportCase(RecordModel):

--- a/server/polar/support_case/repository.py
+++ b/server/polar/support_case/repository.py
@@ -105,6 +105,30 @@ class SupportCaseMessageRepository(
             )
         return await self.get_all(statement)
 
+    async def has_merchant_message(self, case_id: UUID) -> bool:
+        statement = (
+            self.get_base_statement()
+            .where(
+                SupportCaseMessage.case_id == case_id,
+                SupportCaseMessage.author_kind == SupportCaseMessageAuthorKind.merchant,
+            )
+            .limit(1)
+        )
+        return await self.get_one_or_none(statement) is not None
+
+    async def has_message_type(
+        self, case_id: UUID, type: SupportCaseMessageType
+    ) -> bool:
+        statement = (
+            self.get_base_statement()
+            .where(
+                SupportCaseMessage.case_id == case_id,
+                SupportCaseMessage.type == type,
+            )
+            .limit(1)
+        )
+        return await self.get_one_or_none(statement) is not None
+
     async def get_latest_lifecycle_event(
         self, case_id: UUID
     ) -> SupportCaseMessage | None:

--- a/server/tests/dispute/test_service.py
+++ b/server/tests/dispute/test_service.py
@@ -3,6 +3,7 @@ from typing import Literal
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import pytest_asyncio
 from pytest_mock import MockerFixture
 
 from polar.benefit.grant.service import BenefitGrantService
@@ -11,15 +12,18 @@ from polar.dispute.service import DisputeNotOpenError, DisputePaymentNotFoundErr
 from polar.dispute.service import dispute as dispute_service
 from polar.enums import PaymentProcessor, TaxProcessor
 from polar.integrations.chargeback_stop.types import ChargebackStopAlert
-from polar.models import Customer, Organization, Product
+from polar.models import Customer, Dispute, Organization, Product, User
 from polar.models.dispute import DisputeAlertProcessor, DisputeStatus
 from polar.models.support_case import (
     DisputeSupportCase,
+    SupportCaseMessageAuthorKind,
     SupportCaseMessageType,
+    SupportCaseType,
 )
 from polar.postgres import AsyncSession
 from polar.refund.service import RefundService
 from polar.support_case.repository import SupportCaseMessageRepository
+from polar.support_case.schemas import DisputeSupportCaseMessageCreate
 from polar.tax.calculation.base import AlreadyRevertedError
 from polar.transaction.service.dispute import (
     DisputeTransactionAlreadyExistsError,
@@ -27,10 +31,12 @@ from polar.transaction.service.dispute import (
 )
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
+    create_account,
     create_active_subscription,
     create_dispute,
     create_order,
     create_payment,
+    create_payment_transaction,
     create_refund,
 )
 from tests.fixtures.stripe import (
@@ -1334,3 +1340,409 @@ class TestAccept:
             await dispute_service.accept(session, dispute)
 
         close_mock.assert_not_awaited()
+
+
+async def _eligible_dispute(
+    save_fixture: SaveFixture,
+    organization: Organization,
+    customer: Customer,
+    product: Product,
+    *,
+    threshold: int | None = 2500,
+    disputes_enabled: bool = True,
+    auto_accept_enabled: bool = True,
+    amount: int = 1000,
+    currency: str = "usd",
+    exchange_rate: float | None = 1.0,
+    status: DisputeStatus = DisputeStatus.needs_response,
+    alert_processor: DisputeAlertProcessor | None = None,
+) -> Dispute:
+    organization.feature_settings = {
+        "disputes_enabled": disputes_enabled,
+        "dispute_auto_accept_enabled": auto_accept_enabled,
+    }
+    organization.dispute_settings = {"auto_accept_below_amount": threshold}
+    await save_fixture(organization)
+
+    order = await create_order(save_fixture, customer=customer, product=product)
+    payment = await create_payment(
+        save_fixture, organization, order=order, processor_id="STRIPE_CHARGE_ID"
+    )
+    transaction = await create_payment_transaction(save_fixture, order=order)
+    transaction.exchange_rate = exchange_rate
+    await save_fixture(transaction)
+
+    return await create_dispute(
+        save_fixture,
+        order,
+        payment,
+        status=status,
+        amount=amount,
+        currency=currency,
+        alert_processor=alert_processor,
+        alert_processor_id="ALERT_ID" if alert_processor else None,
+    )
+
+
+@pytest.fixture
+def balance_mock(mocker: MockerFixture) -> MagicMock:
+    """Account balance the guard reads, in settlement currency."""
+    summary = MagicMock()
+    summary.balance.amount = 100_000
+    mock = mocker.patch("polar.dispute.service.transaction_service.get_summary")
+    mock.return_value = summary
+    return mock
+
+
+@pytest_asyncio.fixture
+async def organization_with_account(
+    save_fixture: SaveFixture, organization: Organization, user: User
+) -> Organization:
+    account = await create_account(save_fixture, user)
+    organization.account = account
+    await save_fixture(organization)
+    return organization
+
+
+@pytest.mark.asyncio
+class TestAutoAcceptApplies:
+    async def test_under_threshold(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization_with_account: Organization,
+        customer: Customer,
+        product: Product,
+        balance_mock: MagicMock,
+    ) -> None:
+        dispute = await _eligible_dispute(
+            save_fixture, organization_with_account, customer, product
+        )
+
+        assert await dispute_service.auto_accept_applies(session, dispute) is True
+
+    async def test_at_threshold(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization_with_account: Organization,
+        customer: Customer,
+        product: Product,
+        balance_mock: MagicMock,
+    ) -> None:
+        dispute = await _eligible_dispute(
+            save_fixture, organization_with_account, customer, product, amount=2500
+        )
+
+        assert await dispute_service.auto_accept_applies(session, dispute) is False
+
+    async def test_foreign_currency_converts_under_threshold(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization_with_account: Organization,
+        customer: Customer,
+        product: Product,
+        balance_mock: MagicMock,
+    ) -> None:
+        # ¥300,000 at 0.0065 settles near $19.50, under a $25 threshold.
+        dispute = await _eligible_dispute(
+            save_fixture,
+            organization_with_account,
+            customer,
+            product,
+            amount=300_000,
+            currency="jpy",
+            exchange_rate=0.0065,
+        )
+
+        assert await dispute_service.auto_accept_applies(session, dispute) is True
+
+    async def test_foreign_currency_converts_over_threshold(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization_with_account: Organization,
+        customer: Customer,
+        product: Product,
+        balance_mock: MagicMock,
+    ) -> None:
+        dispute = await _eligible_dispute(
+            save_fixture,
+            organization_with_account,
+            customer,
+            product,
+            amount=500_000,
+            currency="jpy",
+            exchange_rate=0.0065,
+        )
+
+        assert await dispute_service.auto_accept_applies(session, dispute) is False
+
+    async def test_no_exchange_rate(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization_with_account: Organization,
+        customer: Customer,
+        product: Product,
+        balance_mock: MagicMock,
+    ) -> None:
+        dispute = await _eligible_dispute(
+            save_fixture,
+            organization_with_account,
+            customer,
+            product,
+            exchange_rate=None,
+        )
+
+        assert await dispute_service.auto_accept_applies(session, dispute) is False
+
+    async def test_no_threshold(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization_with_account: Organization,
+        customer: Customer,
+        product: Product,
+        balance_mock: MagicMock,
+    ) -> None:
+        dispute = await _eligible_dispute(
+            save_fixture, organization_with_account, customer, product, threshold=None
+        )
+
+        assert await dispute_service.auto_accept_applies(session, dispute) is False
+
+    async def test_auto_accept_flag_off(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization_with_account: Organization,
+        customer: Customer,
+        product: Product,
+        balance_mock: MagicMock,
+    ) -> None:
+        dispute = await _eligible_dispute(
+            save_fixture,
+            organization_with_account,
+            customer,
+            product,
+            auto_accept_enabled=False,
+        )
+
+        assert await dispute_service.auto_accept_applies(session, dispute) is False
+
+    async def test_disputes_flag_off(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization_with_account: Organization,
+        customer: Customer,
+        product: Product,
+        balance_mock: MagicMock,
+    ) -> None:
+        dispute = await _eligible_dispute(
+            save_fixture,
+            organization_with_account,
+            customer,
+            product,
+            disputes_enabled=False,
+        )
+
+        assert await dispute_service.auto_accept_applies(session, dispute) is False
+
+    async def test_balance_below_dispute(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization_with_account: Organization,
+        customer: Customer,
+        product: Product,
+        balance_mock: MagicMock,
+    ) -> None:
+        balance_mock.return_value.balance.amount = 500
+        dispute = await _eligible_dispute(
+            save_fixture, organization_with_account, customer, product
+        )
+
+        assert await dispute_service.auto_accept_applies(session, dispute) is False
+
+    async def test_chargeback_stop_covered(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization_with_account: Organization,
+        customer: Customer,
+        product: Product,
+        balance_mock: MagicMock,
+    ) -> None:
+        dispute = await _eligible_dispute(
+            save_fixture,
+            organization_with_account,
+            customer,
+            product,
+            alert_processor=DisputeAlertProcessor.chargeback_stop,
+        )
+
+        assert await dispute_service.auto_accept_applies(session, dispute) is False
+
+    @pytest.mark.parametrize(
+        "status",
+        [
+            DisputeStatus.early_warning,
+            DisputeStatus.under_review,
+            DisputeStatus.prevented,
+            DisputeStatus.lost,
+            DisputeStatus.won,
+        ],
+    )
+    async def test_not_awaiting_response(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization_with_account: Organization,
+        customer: Customer,
+        product: Product,
+        balance_mock: MagicMock,
+        status: DisputeStatus,
+    ) -> None:
+        dispute = await _eligible_dispute(
+            save_fixture, organization_with_account, customer, product, status=status
+        )
+
+        assert await dispute_service.auto_accept_applies(session, dispute) is False
+
+
+@pytest.mark.asyncio
+class TestAnnounceAutoAccept:
+    async def test_announces_when_eligible(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization_with_account: Organization,
+        customer: Customer,
+        product: Product,
+        balance_mock: MagicMock,
+    ) -> None:
+        dispute = await _eligible_dispute(
+            save_fixture, organization_with_account, customer, product
+        )
+        stripe_dispute = build_stripe_dispute(
+            status="needs_response",
+            charge_id="STRIPE_CHARGE_ID",
+            balance_transactions=[],
+        )
+
+        await dispute_service.upsert_from_stripe(session, stripe_dispute)
+
+        case = await dispute_case_service.get_case(session, dispute)
+        assert case is not None
+        assert (
+            SupportCaseMessageType.dispute_auto_accept_scheduled
+            in await _message_types(session, case)
+        )
+
+    async def test_silent_when_ineligible(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization_with_account: Organization,
+        customer: Customer,
+        product: Product,
+        balance_mock: MagicMock,
+    ) -> None:
+        dispute = await _eligible_dispute(
+            save_fixture, organization_with_account, customer, product, threshold=None
+        )
+        stripe_dispute = build_stripe_dispute(
+            status="needs_response",
+            charge_id="STRIPE_CHARGE_ID",
+            balance_transactions=[],
+        )
+
+        await dispute_service.upsert_from_stripe(session, stripe_dispute)
+
+        case = await dispute_case_service.get_case(session, dispute)
+        assert case is not None
+        assert (
+            SupportCaseMessageType.dispute_auto_accept_scheduled
+            not in await _message_types(session, case)
+        )
+
+
+@pytest.mark.asyncio
+class TestAutoAcceptCancelledByReply:
+    async def test_merchant_reply_blocks_and_retracts(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization_with_account: Organization,
+        customer: Customer,
+        product: Product,
+        balance_mock: MagicMock,
+    ) -> None:
+        mocker.patch("polar.dispute.dispute_case.enqueue_job")
+        dispute = await _eligible_dispute(
+            save_fixture, organization_with_account, customer, product
+        )
+        stripe_dispute = build_stripe_dispute(
+            status="needs_response",
+            charge_id="STRIPE_CHARGE_ID",
+            balance_transactions=[],
+        )
+        await dispute_service.upsert_from_stripe(session, stripe_dispute)
+        case = await dispute_case_service.get_case(session, dispute)
+        assert case is not None
+
+        await dispute_case_service.add_reply(
+            session,
+            case,
+            DisputeSupportCaseMessageCreate(
+                type=SupportCaseType.dispute, body="We're fighting this one."
+            ),
+            author_kind=SupportCaseMessageAuthorKind.merchant,
+        )
+
+        assert (
+            SupportCaseMessageType.dispute_auto_accept_canceled
+            in await _message_types(session, case)
+        )
+        assert await dispute_service.auto_accept_applies(session, dispute) is False
+
+    async def test_no_retraction_without_announcement(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization_with_account: Organization,
+        customer: Customer,
+        product: Product,
+        balance_mock: MagicMock,
+    ) -> None:
+        mocker.patch("polar.dispute.dispute_case.enqueue_job")
+        dispute = await _eligible_dispute(
+            save_fixture, organization_with_account, customer, product, threshold=None
+        )
+        stripe_dispute = build_stripe_dispute(
+            status="needs_response",
+            charge_id="STRIPE_CHARGE_ID",
+            balance_transactions=[],
+        )
+        await dispute_service.upsert_from_stripe(session, stripe_dispute)
+        case = await dispute_case_service.get_case(session, dispute)
+        assert case is not None
+
+        await dispute_case_service.add_reply(
+            session,
+            case,
+            DisputeSupportCaseMessageCreate(
+                type=SupportCaseType.dispute, body="Any update?"
+            ),
+            author_kind=SupportCaseMessageAuthorKind.merchant,
+        )
+
+        assert (
+            SupportCaseMessageType.dispute_auto_accept_canceled
+            not in await _message_types(session, case)
+        )

--- a/server/tests/dispute/test_tasks.py
+++ b/server/tests/dispute/test_tasks.py
@@ -10,7 +10,13 @@ from polar.dispute.dispute_case import DISPUTE_GREETING
 from polar.dispute.tasks import auto_accept, enqueue_auto_accepts, post_dispute_greeting
 from polar.kit.utils import utc_now
 from polar.models import Customer, Dispute, Organization, Product
-from polar.models.support_case import SupportCaseMessageAuthorKind
+from polar.models.support_case import (
+    DisputeSupportCase,
+    SupportCaseAudience,
+    SupportCaseMessage,
+    SupportCaseMessageAuthorKind,
+    SupportCaseMessageType,
+)
 from polar.postgres import AsyncSession
 from polar.support_case.repository import SupportCaseMessageRepository
 from tests.fixtures.database import SaveFixture
@@ -32,7 +38,7 @@ async def _dispute(
     customer: Customer,
     product: Product,
     *,
-    created_at: datetime | None = None,
+    announced_at: datetime | None = None,
     processor_id: str = "STRIPE_DISPUTE_ID",
 ) -> Dispute:
     order = await create_order(save_fixture, customer=customer, product=product)
@@ -40,9 +46,17 @@ async def _dispute(
     dispute = await create_dispute(
         save_fixture, order, payment, payment_processor_id=processor_id
     )
-    if created_at is not None:
-        dispute.created_at = created_at
-        await save_fixture(dispute)
+    case = DisputeSupportCase(dispute=dispute, organization=organization)
+    await save_fixture(case)
+    if announced_at is not None:
+        message = SupportCaseMessage(
+            case=case,
+            type=SupportCaseMessageType.dispute_auto_accept_scheduled,
+            author_kind=SupportCaseMessageAuthorKind.system,
+            audience=[SupportCaseAudience.merchant],
+            created_at=announced_at,
+        )
+        await save_fixture(message)
     return dispute
 
 
@@ -131,7 +145,7 @@ class TestEnqueueAutoAccepts:
             organization,
             customer,
             product,
-            created_at=utc_now() - timedelta(hours=48),
+            announced_at=utc_now() - timedelta(hours=48),
         )
         await _dispute(
             save_fixture, organization, customer, product, processor_id="STRIPE_FRESH"
@@ -167,8 +181,35 @@ class TestEnqueueAutoAccepts:
             organization,
             customer,
             product,
-            created_at=utc_now() - timedelta(hours=48),
+            announced_at=utc_now() - timedelta(hours=48),
         )
+
+        mocker.patch(
+            "polar.dispute.tasks.AsyncSessionMaker",
+            side_effect=lambda: _session_maker(session),
+        )
+        enqueue_mock = mocker.patch("polar.dispute.tasks.enqueue_job")
+
+        await _enqueue_auto_accepts()
+
+        enqueue_mock.assert_not_called()
+
+    async def test_skips_disputes_never_announced(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        organization.feature_settings = {
+            "disputes_enabled": True,
+            "dispute_auto_accept_enabled": True,
+        }
+        organization.dispute_settings = {"auto_accept_below_amount": 2500}
+        await save_fixture(organization)
+        await _dispute(save_fixture, organization, customer, product)
 
         mocker.patch(
             "polar.dispute.tasks.AsyncSessionMaker",

--- a/server/tests/dispute/test_tasks.py
+++ b/server/tests/dispute/test_tasks.py
@@ -1,19 +1,49 @@
 import contextlib
 from collections.abc import AsyncIterator
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock
 
 import pytest
 from pytest_mock import MockerFixture
 
 from polar.dispute.dispute_case import DISPUTE_GREETING
-from polar.dispute.tasks import post_dispute_greeting
-from polar.models import Customer, Organization, Product
+from polar.dispute.tasks import auto_accept, enqueue_auto_accepts, post_dispute_greeting
+from polar.kit.utils import utc_now
+from polar.models import Customer, Dispute, Organization, Product
 from polar.models.support_case import SupportCaseMessageAuthorKind
 from polar.postgres import AsyncSession
 from polar.support_case.repository import SupportCaseMessageRepository
 from tests.fixtures.database import SaveFixture
-from tests.fixtures.random_objects import create_dispute_case
+from tests.fixtures.random_objects import (
+    create_dispute,
+    create_dispute_case,
+    create_order,
+    create_payment,
+)
 
 _post_dispute_greeting = post_dispute_greeting.__wrapped__  # type: ignore[attr-defined]
+_enqueue_auto_accepts = enqueue_auto_accepts.__wrapped__  # type: ignore[attr-defined]
+_auto_accept = auto_accept.__wrapped__  # type: ignore[attr-defined]
+
+
+async def _dispute(
+    save_fixture: SaveFixture,
+    organization: Organization,
+    customer: Customer,
+    product: Product,
+    *,
+    created_at: datetime | None = None,
+    processor_id: str = "STRIPE_DISPUTE_ID",
+) -> Dispute:
+    order = await create_order(save_fixture, customer=customer, product=product)
+    payment = await create_payment(save_fixture, organization, order=order)
+    dispute = await create_dispute(
+        save_fixture, order, payment, payment_processor_id=processor_id
+    )
+    if created_at is not None:
+        dispute.created_at = created_at
+        await save_fixture(dispute)
+    return dispute
 
 
 @contextlib.asynccontextmanager
@@ -76,3 +106,101 @@ class TestPostDisputeGreeting:
             message for message in messages if message.body == DISPUTE_GREETING
         ]
         assert len(greetings) == 1
+
+
+@pytest.mark.asyncio
+class TestEnqueueAutoAccepts:
+    async def test_enqueues_only_aged_opted_in_disputes(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        organization.feature_settings = {
+            "disputes_enabled": True,
+            "dispute_auto_accept_enabled": True,
+        }
+        organization.dispute_settings = {"auto_accept_below_amount": 2500}
+        await save_fixture(organization)
+
+        aged = await _dispute(
+            save_fixture,
+            organization,
+            customer,
+            product,
+            created_at=utc_now() - timedelta(hours=48),
+        )
+        await _dispute(
+            save_fixture, organization, customer, product, processor_id="STRIPE_FRESH"
+        )
+
+        mocker.patch(
+            "polar.dispute.tasks.AsyncSessionMaker",
+            side_effect=lambda: _session_maker(session),
+        )
+        enqueue_mock = mocker.patch("polar.dispute.tasks.enqueue_job")
+
+        await _enqueue_auto_accepts()
+
+        enqueue_mock.assert_called_once_with("dispute.auto_accept", aged.id)
+
+    async def test_skips_organizations_without_a_threshold(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        organization.feature_settings = {
+            "disputes_enabled": True,
+            "dispute_auto_accept_enabled": True,
+        }
+        organization.dispute_settings = {"auto_accept_below_amount": None}
+        await save_fixture(organization)
+        await _dispute(
+            save_fixture,
+            organization,
+            customer,
+            product,
+            created_at=utc_now() - timedelta(hours=48),
+        )
+
+        mocker.patch(
+            "polar.dispute.tasks.AsyncSessionMaker",
+            side_effect=lambda: _session_maker(session),
+        )
+        enqueue_mock = mocker.patch("polar.dispute.tasks.enqueue_job")
+
+        await _enqueue_auto_accepts()
+
+        enqueue_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestAutoAccept:
+    async def test_noop_when_no_longer_eligible(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        dispute = await _dispute(save_fixture, organization, customer, product)
+        mocker.patch(
+            "polar.dispute.tasks.AsyncSessionMaker",
+            side_effect=lambda: _session_maker(session),
+        )
+        accept_mock = mocker.patch(
+            "polar.dispute.tasks.dispute_service.accept", new_callable=AsyncMock
+        )
+
+        await _auto_accept(dispute.id)
+
+        accept_mock.assert_not_awaited()


### PR DESCRIPTION
## Summary

**Related Issue**: #<!-- issue number -->

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->

## Why

<!-- Explain why this change is needed -->

## How

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788099401&installation_model_id=13063&pr_number=13493&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13493&signature=e4f51654c506bad8fb4c4752f0a6fa153c02526ccad0e75d1189f3a4504d3e11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-concede disputes below a merchant-set threshold after a 24h wait. The case announces the plan with a UTC deadline, cancels on merchant reply, and records when Polar accepts.

- New Features
  - Announce auto-accept on case open; retract if the merchant replies.
  - Hourly sweep enqueues disputes whose auto-accept announcement is >24h old; per-dispute jobs re-check eligibility and accept via the existing path, recording `dispute_auto_accepted`.
  - Eligibility: status `needs_response`, not ChargebackStop-covered, org flags `disputes_enabled` and `dispute_auto_accept_enabled` on with a threshold set, settlement amount (amount+tax at the payment’s settlement rate) below threshold, org account balance covers the loss, and no merchant reply.
  - Support case messages: `dispute_auto_accept_scheduled`, `dispute_auto_accept_canceled`, `dispute_auto_accepted`; backoffice shows labels/icons; client schema includes these types.

<sup>Written for commit f47d496f98331901e3ea01c2aba9e4c48ca21e70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

