### PR TITLE
feat(web): add the dispute auto-accept UI

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/SettingsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/SettingsPage.tsx
@@ -6,6 +6,7 @@ import FeatureSettings from '@/components/Settings/FeatureSettings'
 import OrganizationAccessTokensSettings from '@/components/Settings/OrganizationAccessTokensSettings'
 import OrganizationCustomerEmailSettings from '@/components/Settings/OrganizationCustomerEmailSettings'
 import OrganizationCustomerPortalSettings from '@/components/Settings/OrganizationCustomerPortalSettings'
+import OrganizationDisputeSettings from '@/components/Settings/OrganizationDisputeSettings'
 import OrganizationEmbedSettings from '@/components/Settings/OrganizationEmbedSettings'
 import OrganizationDeleteSettings from '@/components/Settings/OrganizationDeleteSettings'
 import OrganizationNotificationSettings from '@/components/Settings/OrganizationNotificationSettings'
@@ -58,6 +59,17 @@ export default function ClientPage({
             readOnly={!canManageOrganization}
           />
         </Section>
+
+        {org.feature_settings?.disputes_enabled &&
+          org.feature_settings?.dispute_auto_accept_enabled && (
+            <Section id="disputes">
+              <SectionDescription title="Disputes" />
+              <OrganizationDisputeSettings
+                organization={org}
+                readOnly={!canManageOrganization}
+              />
+            </Section>
+          )}
 
         <Section id="customer_portal">
           <SectionDescription title="Customer portal" />

--- a/clients/apps/web/src/components/Disputes/DisputeConversation.tsx
+++ b/clients/apps/web/src/components/Disputes/DisputeConversation.tsx
@@ -16,6 +16,9 @@ const EVENT_LABELS: Record<string, string> = {
   dispute_lost: 'Dispute lost',
   dispute_prevented: 'Dispute prevented',
   merchant_accepted: 'You accepted the dispute',
+  dispute_auto_accept_scheduled: 'Auto-accept scheduled',
+  dispute_auto_accept_canceled: 'Auto-accept canceled',
+  dispute_auto_accepted: 'Polar accepted the dispute',
 }
 
 const MerchantAvatar = ({
@@ -61,7 +64,7 @@ export const DisputeConversation = ({
       if (message.type !== 'chat') {
         return (
           <Text variant="caption" color="muted" align="center">
-            {EVENT_LABELS[message.type] ?? message.type}
+            {message.body || EVENT_LABELS[message.type] || message.type}
           </Text>
         )
       }

--- a/clients/apps/web/src/components/Disputes/DisputeTimeline.tsx
+++ b/clients/apps/web/src/components/Disputes/DisputeTimeline.tsx
@@ -55,6 +55,18 @@ const EVENT_META: Partial<
     title: 'Dispute prevented',
     description: 'Refunded before it escalated, avoiding any fees.',
   },
+  dispute_auto_accept_scheduled: {
+    title: 'Auto-accept scheduled',
+    description: 'This dispute is below the threshold you set.',
+  },
+  dispute_auto_accept_canceled: {
+    title: 'Auto-accept canceled',
+    description: 'You replied, so this dispute stays with you.',
+  },
+  dispute_auto_accepted: {
+    title: 'Polar accepted the dispute',
+    description: 'Conceded under the threshold you set.',
+  },
 }
 
 const dueDescription = (dispute: schemas['Dispute'], now: Date): string => {
@@ -106,7 +118,8 @@ const buildSteps = (
       key: message.id,
       title: meta.title,
       date: message.created_at,
-      description: meta.description,
+      // The scheduled event names a deadline, so it carries its own copy.
+      description: message.body || meta.description,
       state: 'complete',
     })
   }

--- a/clients/apps/web/src/components/Settings/OrganizationDisputeSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationDisputeSettings.tsx
@@ -1,0 +1,149 @@
+import { useUpdateOrganization } from '@/hooks/queries'
+import { useAutoSave } from '@/hooks/useAutoSave'
+import { extractApiErrorMessage, setValidationErrors } from '@/utils/api/errors'
+import { isValidationError, schemas } from '@polar-sh/client'
+import { formatCurrency } from '@polar-sh/currency'
+import { Switch } from '@polar-sh/orbit'
+import MoneyInput from '@polar-sh/ui/components/atoms/MoneyInput'
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from '@polar-sh/ui/components/ui/form'
+import React from 'react'
+import { useForm } from 'react-hook-form'
+import { toast } from '../Toast/use-toast'
+import { SettingsGroup, SettingsGroupItem } from './SettingsGroup'
+
+interface OrganizationDisputeSettingsProps {
+  organization: schemas['Organization']
+  readOnly: boolean
+}
+
+// Mirrors DISPUTE_AUTO_ACCEPT_MAX_AMOUNT on the server.
+const MAX_AMOUNT = 10_000
+
+const format = formatCurrency('accounting')
+
+const OrganizationDisputeSettings: React.FC<
+  OrganizationDisputeSettingsProps
+> = ({ organization, readOnly }) => {
+  const form = useForm<schemas['OrganizationDisputeSettings']>({
+    defaultValues: organization.dispute_settings,
+  })
+  const { control, setError, setValue, reset } = form
+  const [enabled, setEnabled] = React.useState(
+    organization.dispute_settings.auto_accept_below_amount !== null,
+  )
+
+  const updateOrganization = useUpdateOrganization()
+  const onSave = async (
+    dispute_settings: schemas['OrganizationDisputeSettings'],
+  ) => {
+    // useAutoSave saves without validating, so the ceiling would only be
+    // caught by the API — in cents, which is not what the field shows.
+    if (!(await form.trigger())) {
+      return
+    }
+
+    const { data, error } = await updateOrganization.mutateAsync({
+      id: organization.id,
+      body: {
+        dispute_settings,
+      },
+    })
+
+    if (error) {
+      if (isValidationError(error.detail)) {
+        setValidationErrors(error.detail, setError)
+      } else {
+        setError('root', { message: error.detail })
+      }
+
+      toast({
+        title: 'Dispute Settings Update Failed',
+        description: `Error updating dispute settings: ${extractApiErrorMessage(error)}`,
+      })
+
+      return
+    }
+
+    reset(data.dispute_settings)
+  }
+
+  useAutoSave({
+    form,
+    onSave,
+    delay: 1000,
+  })
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+        }}
+      >
+        <SettingsGroup>
+          <SettingsGroupItem
+            title="Accept small disputes"
+            description="Polar concedes them for you, a day after they open, unless you reply first. The disputed amount and the processor's dispute fee are still deducted."
+          >
+            <Switch
+              checked={enabled}
+              disabled={readOnly}
+              onCheckedChange={(checked) => {
+                setEnabled(checked)
+                if (!checked) {
+                  setValue('auto_accept_below_amount', null, {
+                    shouldDirty: true,
+                  })
+                }
+              }}
+            />
+          </SettingsGroupItem>
+
+          {enabled && (
+            <SettingsGroupItem
+              title="Up to"
+              description={`Whole dollars, up to ${format(MAX_AMOUNT, 'usd')}. A dispute charged in another currency is converted.`}
+            >
+              <FormField
+                control={control}
+                name="auto_accept_below_amount"
+                rules={{
+                  max: {
+                    value: MAX_AMOUNT,
+                    message: `Enter an amount up to ${format(MAX_AMOUNT, 'usd')}.`,
+                  },
+                  validate: (value) =>
+                    !value || value % 100 === 0 || 'Use whole dollars.',
+                }}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormControl>
+                      <MoneyInput
+                        name={field.name}
+                        currency="usd"
+                        placeholder={2500}
+                        step={1}
+                        value={field.value}
+                        disabled={readOnly}
+                        onChange={(value) => field.onChange(value || null)}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </SettingsGroupItem>
+          )}
+        </SettingsGroup>
+      </form>
+    </Form>
+  )
+}
+
+export default OrganizationDisputeSettings

--- a/clients/apps/web/src/components/Settings/OrganizationDisputeSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationDisputeSettings.tsx
@@ -33,7 +33,7 @@ const OrganizationDisputeSettings: React.FC<
   const form = useForm<schemas['OrganizationDisputeSettings']>({
     defaultValues: organization.dispute_settings,
   })
-  const { control, setError, setValue, reset } = form
+  const { control, setError, setValue, clearErrors, reset } = form
   const [enabled, setEnabled] = React.useState(
     organization.dispute_settings.auto_accept_below_amount !== null,
   )
@@ -96,7 +96,9 @@ const OrganizationDisputeSettings: React.FC<
               disabled={readOnly}
               onCheckedChange={(checked) => {
                 setEnabled(checked)
-                if (!checked) {
+                if (checked) {
+                  clearErrors('auto_accept_below_amount')
+                } else {
                   setValue('auto_accept_below_amount', null, {
                     shouldDirty: true,
                   })
@@ -118,8 +120,15 @@ const OrganizationDisputeSettings: React.FC<
                     value: MAX_AMOUNT,
                     message: `Enter an amount up to ${format(MAX_AMOUNT, 'usd')}.`,
                   },
-                  validate: (value) =>
-                    !value || value % 100 === 0 || 'Use whole dollars.',
+                  validate: (value) => {
+                    if (!enabled) {
+                      return true
+                    }
+                    if (!value) {
+                      return 'Set an amount, or turn this off.'
+                    }
+                    return value % 100 === 0 || 'Use whole dollars.'
+                  },
                 }}
                 render={({ field }) => (
                   <FormItem>

--- a/server/polar/backoffice/organizations_v2/views/sections/settings_section.py
+++ b/server/polar/backoffice/organizations_v2/views/sections/settings_section.py
@@ -10,6 +10,7 @@ from tagflow import tag, text
 from polar.models import Organization
 from polar.models.organization import CAPABILITY_METADATA, STATUS_CAPABILITIES
 
+from .... import formatters
 from ....components import button, card
 
 
@@ -127,6 +128,27 @@ class SettingsSection:
                             text("Require 3DS")
                         with tag.div(classes="text-xs text-base-content/60 ml-auto"):
                             text("Enabled" if require_3ds else "Disabled")
+
+            # Dispute settings card, for organizations working disputes
+            if self.org.feature_settings.get("disputes_enabled", False):
+                with card(bordered=True):
+                    with tag.div(classes="flex items-center justify-between mb-4"):
+                        with tag.h2(classes="text-lg font-bold"):
+                            text("Dispute Settings")
+
+                    threshold = self.org.dispute_auto_accept_below_amount
+                    with tag.div():
+                        with tag.div(classes="text-sm text-base-content/60 mb-1"):
+                            text("Auto-accept below")
+                        with tag.div(classes="text-sm"):
+                            if threshold is None:
+                                text("Off")
+                            elif not self.org.is_dispute_auto_accept_enabled:
+                                text(
+                                    f"{formatters.currency(threshold, 'usd')} (flag off)"
+                                )
+                            else:
+                                text(formatters.currency(threshold, "usd"))
 
             # Rate limit group card
             with card(bordered=True):


### PR DESCRIPTION
## Summary


https://github.com/user-attachments/assets/23cb60cb-67de-4f27-a675-f64ec01749a2

<img width="1140" height="247" alt="Screenshot 2026-07-31 at 16 58 10" src="https://github.com/user-attachments/assets/59142806-5610-4671-b2d3-8e5359373ccb" />

<img width="1375" height="312" alt="Screenshot 2026-07-31 at 17 19 56" src="https://github.com/user-attachments/assets/c1ac1bfc-8b7c-431e-9260-2c404fd6dc11" />

<img width="1375" height="312" alt="Screenshot 2026-07-31 at 17 19 34" src="https://github.com/user-attachments/assets/c7f3a9d7-eb18-4034-9354-d26f30c15c13" />



**Related Issue**: #<!-- issue number -->

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->

## Why

<!-- Explain why this change is needed -->

## How

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13495"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788103230&installation_model_id=13063&pr_number=13495&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13495&signature=315cf8a6c30dc13e9b634848f285e459aa1f1de76a5e340e1c4a4af4e9c90cfa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dispute auto-accept UI with a USD threshold and shows related events in dispute threads and backoffice. This lets orgs auto-concede small disputes and see when they’re scheduled, canceled, or accepted.

- **New Features**
  - Settings: New Disputes section (shown when `disputes_enabled` and `dispute_auto_accept_enabled`). Toggle “Accept small disputes” and set an “Up to” USD amount (whole dollars, max $10,000). Autosaves with validation, respects read-only, and converts non-USD disputes to USD. Polar concedes a day after opening unless you reply first.
  - Disputes UI: Conversation and timeline show `dispute_auto_accept_scheduled`, `dispute_auto_accept_canceled`, and `dispute_auto_accepted` with clear labels; use the message body when present (e.g., scheduled deadline).
  - Backoffice: Dispute Settings card shows the current threshold, “Off” when disabled, and “(flag off)” if the feature flag is disabled.

- **Bug Fixes**
  - Settings toggle clears the saved amount when turned off and validates before autosave to keep the UI and saved state in sync.

<sup>Written for commit 35ea7508406c3776f3db311d1eadaeee54c12e21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

