### PR TITLE
refactor(dashboard): use nuqs for checkouts table filters

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -208,7 +208,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
       ),
       cell: ({ row: { original: order } }) => (
         <Box display="block" textAlign="right">
-          <Text variant="body" tabularNums>
+          <Text tabularNums>
             {formatCurrency('accounting')(order.net_amount, order.currency)}
           </Text>
         </Box>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -100,7 +100,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
     {
       accessorKey: 'created_at',
       enableSorting: true,
-      size: 120,
+      size: 160,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Date" />
       ),

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/CheckoutsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/CheckoutsPage.tsx
@@ -81,6 +81,7 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
     {
       accessorKey: 'created_at',
       enableSorting: true,
+      size: 160,
       header: ({ column }) => (
         <DataTableColumnHeader column={column} title="Date" />
       ),

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/CheckoutsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/CheckoutsPage.tsx
@@ -19,7 +19,7 @@ import {
   DataTableColumnHeader,
 } from '@polar-sh/orbit'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
-import { Input } from '@polar-sh/orbit'
+import { Input, Text } from '@polar-sh/orbit'
 import { useRouter } from 'next/navigation'
 import React from 'react'
 
@@ -173,10 +173,12 @@ const ClientPage: React.FC<ClientPageProps> = ({
         <DataTableColumnHeader column={column} title="Date" />
       ),
       cell: (props) => (
-        <FormattedDateTime
-          datetime={props.getValue() as string}
-          resolution="time"
-        />
+        <Text as="span" tabularNums>
+          <FormattedDateTime
+            datetime={props.getValue() as string}
+            resolution="time"
+          />
+        </Text>
       ),
     },
     {

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/CheckoutsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/CheckoutsPage.tsx
@@ -5,14 +5,10 @@ import CheckoutStatusSelect from '@/components/CheckoutStatusSelect/CheckoutStat
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import ProductSelect from '@/components/Products/ProductSelect'
 import { useCheckouts } from '@/hooks/queries/checkouts'
+import { useDataTableQueryState } from '@/hooks/useDataTableQueryState'
 import { useDebouncedCallback } from '@/hooks/utils'
-import {
-  DataTablePaginationState,
-  DataTableSortingState,
-  getAPIParams,
-  serializeSearchParams,
-} from '@/utils/datatable'
-import { schemas } from '@polar-sh/client'
+import { getAPIParams } from '@/utils/datatable'
+import { enums, schemas } from '@polar-sh/client'
 import {
   DataTable,
   DataTableColumnDef,
@@ -21,144 +17,60 @@ import {
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import { Input, Text } from '@polar-sh/orbit'
 import { useRouter } from 'next/navigation'
+import {
+  parseAsArrayOf,
+  parseAsString,
+  parseAsStringLiteral,
+  useQueryStates,
+} from 'nuqs'
 import React from 'react'
+
+const filterParsers = {
+  product_id: parseAsArrayOf(parseAsString),
+  customer_id: parseAsString,
+  status: parseAsStringLiteral(enums.checkoutStatusValues),
+  query: parseAsString,
+}
 
 interface ClientPageProps {
   organization: schemas['Organization']
-  pagination: DataTablePaginationState
-  sorting: DataTableSortingState
-  productId?: string[]
-  customerId?: string
-  status?: schemas['CheckoutStatus']
-  query?: string
 }
 
-const ClientPage: React.FC<ClientPageProps> = ({
-  organization,
-  pagination,
-  sorting,
-  productId,
-  customerId,
-  status,
-  query,
-}) => {
-  const getSearchParams = (
-    pagination: DataTablePaginationState,
-    sorting: DataTableSortingState,
-    productId?: string[],
-    customerId?: string,
-    status?: string,
-    query?: string,
-  ) => {
-    const params = serializeSearchParams(pagination, sorting)
-    if (productId) {
-      productId.forEach((id) => {
-        params.append('product_id', id)
-      })
-    }
-    if (customerId) {
-      params.append('customer_id', customerId)
-    }
-    if (status) {
-      params.append('status', status)
-    }
-    if (query) {
-      params.append('query', query)
-    }
-    return params
-  }
-
+const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
   const router = useRouter()
 
-  const setPagination = (
-    updaterOrValue:
-      | DataTablePaginationState
-      | ((old: DataTablePaginationState) => DataTablePaginationState),
-  ) => {
-    const updatedPagination =
-      typeof updaterOrValue === 'function'
-        ? updaterOrValue(pagination)
-        : updaterOrValue
+  const { pagination, setPagination, sorting, setSorting, resetPage } =
+    useDataTableQueryState({
+      defaultSorting: [{ id: 'created_at', desc: true }],
+      defaultPageSize: 50,
+    })
 
-    router.push(
-      `/dashboard/${organization.slug}/sales/checkouts?${getSearchParams(
-        updatedPagination,
-        sorting,
-        productId,
-        customerId,
-        status,
-        query,
-      )}`,
-    )
+  const [
+    { product_id: productId, customer_id: customerId, status, query },
+    setFilters,
+  ] = useQueryStates(filterParsers)
+
+  const onProductSelect = (value: string[]) => {
+    setFilters({ product_id: value.length > 0 ? value : null })
+    resetPage()
   }
 
-  const setSorting = (
-    updaterOrValue:
-      | DataTableSortingState
-      | ((old: DataTableSortingState) => DataTableSortingState),
-  ) => {
-    const updatedSorting =
-      typeof updaterOrValue === 'function'
-        ? updaterOrValue(sorting)
-        : updaterOrValue
-
-    router.push(
-      `/dashboard/${organization.slug}/sales/checkouts?${getSearchParams(
-        pagination,
-        updatedSorting,
-        productId,
-        customerId,
-        status,
-        query,
-      )}`,
-    )
+  const onStatusSelect = (value: schemas['CheckoutStatus'] | null) => {
+    setFilters({ status: value })
+    resetPage()
   }
 
-  const setStatus = (status: string) => {
-    router.push(
-      `/dashboard/${organization.slug}/sales/checkouts?${getSearchParams(
-        pagination,
-        sorting,
-        productId,
-        customerId,
-        status,
-        query,
-      )}`,
-    )
-  }
-
-  const setProductId = (productId: string[]) => {
-    router.push(
-      `/dashboard/${organization.slug}/sales/checkouts?${getSearchParams(
-        pagination,
-        sorting,
-        productId,
-        customerId,
-        status,
-        query,
-      )}`,
-    )
-  }
-
-  const setQuery = useDebouncedCallback((query: string) => {
-    router.push(
-      `/dashboard/${organization.slug}/sales/checkouts?${getSearchParams(
-        pagination,
-        sorting,
-        productId,
-        customerId,
-        status,
-        query,
-      )}`,
-    )
+  const onQueryChange = useDebouncedCallback((value: string) => {
+    setFilters({ query: value || null })
+    resetPage()
   }, 500)
 
   const checkoutsHook = useCheckouts(organization.id, {
     ...getAPIParams(pagination, sorting),
-    ...(productId ? { product_id: productId } : {}),
-    ...(customerId ? { customer_id: customerId } : {}),
-    ...(status ? { status } : {}),
-    ...(query ? { query } : {}),
+    product_id: productId ?? undefined,
+    customer_id: customerId ?? undefined,
+    status: status ?? undefined,
+    query: query ?? undefined,
   })
 
   const checkouts = checkoutsHook.data?.items || []
@@ -251,15 +163,16 @@ const ClientPage: React.FC<ClientPageProps> = ({
               <Input
                 type="text"
                 placeholder="Filter by email"
-                onChange={(e) => setQuery(e.target.value)}
+                defaultValue={query ?? ''}
+                onChange={(e) => onQueryChange(e.target.value)}
               />
             </div>
-            <CheckoutStatusSelect value={status || ''} onChange={setStatus} />
+            <CheckoutStatusSelect value={status} onChange={onStatusSelect} />
             <ProductSelect
               organization={organization}
               includeArchived
               value={productId || []}
-              onChange={setProductId}
+              onChange={onProductSelect}
             />
           </div>
         </div>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/checkouts/page.tsx
@@ -1,7 +1,5 @@
 import { getServerSideAPI } from '@/utils/client/serverside'
-import { DataTableSearchParams, parseSearchParams } from '@/utils/datatable'
 import { getOrganizationBySlugOrNotFound } from '@/utils/organization'
-import { schemas } from '@polar-sh/client'
 import { Metadata } from 'next'
 import CheckoutsPage from './CheckoutsPage'
 
@@ -13,16 +11,7 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function Page(props: {
   params: Promise<{ organization: string }>
-  searchParams: Promise<
-    DataTableSearchParams & {
-      product_id?: string | string[]
-      customer_id?: string
-      status?: schemas['CheckoutStatus']
-      query?: string
-    }
-  >
 }) {
-  const searchParams = await props.searchParams
   const params = await props.params
   const api = await getServerSideAPI()
   const organization = await getOrganizationBySlugOrNotFound(
@@ -30,27 +19,5 @@ export default async function Page(props: {
     params.organization,
   )
 
-  const { pagination, sorting } = parseSearchParams(
-    searchParams,
-    [{ id: 'created_at', desc: true }],
-    50,
-  )
-
-  const productId = searchParams.product_id
-    ? Array.isArray(searchParams.product_id)
-      ? searchParams.product_id
-      : [searchParams.product_id]
-    : undefined
-
-  return (
-    <CheckoutsPage
-      organization={organization}
-      pagination={pagination}
-      sorting={sorting}
-      productId={productId}
-      customerId={searchParams.customer_id}
-      status={searchParams.status}
-      query={searchParams.query}
-    />
-  )
+  return <CheckoutsPage organization={organization} />
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
@@ -213,7 +213,9 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
         <DataTableColumnHeader column={column} title="Subscription Date" />
       ),
       cell: (props) => (
-        <FormattedDateTime datetime={props.getValue() as string} />
+        <Text as="span" tabularNums>
+          <FormattedDateTime datetime={props.getValue() as string} />
+        </Text>
       ),
     },
     {
@@ -233,7 +235,9 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
           (status === 'active' || status === 'trialing') &&
           !cancel_at_period_end
         return datetime && willRenew ? (
-          <FormattedDateTime datetime={datetime} />
+          <Text as="span" tabularNums>
+            <FormattedDateTime datetime={datetime} />
+          </Text>
         ) : (
           '—'
         )

--- a/clients/apps/web/src/components/CheckoutStatusSelect/CheckoutStatusSelect.tsx
+++ b/clients/apps/web/src/components/CheckoutStatusSelect/CheckoutStatusSelect.tsx
@@ -1,18 +1,18 @@
 import { CheckoutStatusDisplayTitle } from '@/utils/checkout'
-import { enums } from '@polar-sh/client'
+import { enums, schemas } from '@polar-sh/client'
 import {
   Select,
   SelectContent,
-  SelectGroup,
   SelectItem,
+  SelectSeparator,
   SelectTrigger,
   SelectValue,
 } from '@polar-sh/orbit'
 import React from 'react'
 
 interface CheckoutStatusSelectProps {
-  value: string
-  onChange: (value: string) => void
+  value: schemas['CheckoutStatus'] | null
+  onChange: (value: schemas['CheckoutStatus'] | null) => void
 }
 
 const CheckoutStatusSelect: React.FC<CheckoutStatusSelectProps> = ({
@@ -20,21 +20,24 @@ const CheckoutStatusSelect: React.FC<CheckoutStatusSelectProps> = ({
   onChange,
 }) => {
   return (
-    <Select value={value} onValueChange={onChange}>
+    <Select
+      value={value ?? 'any'}
+      onValueChange={(value) =>
+        onChange(value === 'any' ? null : (value as schemas['CheckoutStatus']))
+      }
+    >
       <SelectTrigger>
         <SelectValue placeholder="Select a status" />
       </SelectTrigger>
       <SelectContent>
+        <SelectItem value="any">
+          <span className="whitespace-nowrap">Any status</span>
+        </SelectItem>
+        <SelectSeparator />
         {enums.checkoutStatusValues.map((status) => (
-          <React.Fragment key={status}>
-            <SelectGroup>
-              <SelectItem value={status} className="font-medium">
-                <div className="flex items-center gap-2 whitespace-normal">
-                  {CheckoutStatusDisplayTitle[status]}
-                </div>
-              </SelectItem>
-            </SelectGroup>
-          </React.Fragment>
+          <SelectItem key={status} value={status}>
+            {CheckoutStatusDisplayTitle[status]}
+          </SelectItem>
         ))}
       </SelectContent>
     </Select>

--- a/clients/apps/web/src/components/Transactions/TransactionsList.tsx
+++ b/clients/apps/web/src/components/Transactions/TransactionsList.tsx
@@ -8,6 +8,7 @@ import { ISODuration } from '@/utils/duration'
 import { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
 import {
+  Text,
   DataTable,
   DataTableColumnDef,
   DataTableColumnHeader,
@@ -60,7 +61,11 @@ const TransactionsList = ({
         if (isSameDayAsParent) {
           return null
         }
-        return <FormattedDateTime datetime={datetime} resolution="time" />
+        return (
+          <Text as="span" tabularNums>
+            <FormattedDateTime datetime={datetime} resolution="time" />
+          </Text>
+        )
       },
     },
     {


### PR DESCRIPTION
## Summary

- Migrate the checkouts table to **nuqs** (`useQueryStates` + `useDataTableQueryState`) so pagination, sorting, and filters live in the URL on the client instead of being parsed/serialized in the server page.
- Tighten **CheckoutStatusSelect** typing (`CheckoutStatus | null`) and add an “Any status” clear option.


This is similar as previous refactors on orders page and subscription page where there was unnecessary round trips to server and instead utilize nuqs for more streamlined url filters.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13499"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788107473&installation_model_id=13063&pr_number=13499&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13499&signature=0b7bac7e4979066048b8340e6ada1e837d57121257ba3cdcbc4db56d9d3e4955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

