### PR TITLE
fix(billing_entry): filter deleted_at in link_pending UPDATEs

### DIFF
--- a/server/polar/billing_entry/repository.py
+++ b/server/polar/billing_entry/repository.py
@@ -129,6 +129,7 @@ class BillingEntryRepository(
     ) -> None:
         statement = update(BillingEntry).where(
             BillingEntry.subscription_id == subscription_id,
+            BillingEntry.deleted_at.is_(None),
             BillingEntry.order_item_id.is_(None),
             BillingEntry.product_price_id == product_price_id,
             BillingEntry.start_timestamp < cutoff,
@@ -149,6 +150,7 @@ class BillingEntryRepository(
     ) -> None:
         statement = update(BillingEntry).where(
             BillingEntry.subscription_id == subscription_id,
+            BillingEntry.deleted_at.is_(None),
             BillingEntry.order_item_id.is_(None),
             BillingEntry.product_price_id.in_(
                 select(ProductPriceMeteredUnit.id).where(

--- a/server/tests/billing_entry/test_service.py
+++ b/server/tests/billing_entry/test_service.py
@@ -361,6 +361,9 @@ class TestCreateOrderItemsFromPending:
             await session.refresh(entry)
             assert entry.order_item_id == order_item.id
 
+        await session.refresh(deleted_entry)
+        assert deleted_entry.order_item_id is None
+
     async def test_metered_entries_respect_cutoff(
         self,
         save_fixture: SaveFixture,
@@ -957,6 +960,8 @@ class TestCreateOrderItemsFromPending:
             assert entry.order_item_id == order_item.id
         await session.refresh(future_entry)
         assert future_entry.order_item_id is None
+        await session.refresh(deleted_entry)
+        assert deleted_entry.order_item_id is None
 
     async def test_inactive_price_skipped_after_product_switch(
         self,


### PR DESCRIPTION
The direct UPDATE WHERE statements in link_pending_by_subscription_and_price
and link_pending_by_subscription_and_meter build a raw update() and bypass
the repository's soft-deletion base statement, so they omitted the
`deleted_at IS NULL` predicate.

Two consequences:

- Performance: the only remaining composite index is
  ix_billing_entries_s_d_oi_pp (subscription_id, deleted_at, order_item_id,
  product_price_id). Without a predicate on deleted_at (column 2), Postgres
  can only bound the scan on subscription_id and reads every billing entry
  for the subscription, filtering order_item_id/product_price_id in the
  index instead of using them as bounds. On long-lived, high-volume
  subscriptions that scans the entire history instead of just the pending
  entries. Adding `deleted_at IS NULL` restores full index usage.

- Correctness: the compute path filters soft-deleted entries via
  get_base_statement(), but the link path did not, so a soft-deleted
  pending entry could be linked to a new order item it was excluded from.

Add `deleted_at IS NULL` to both UPDATEs and assert soft-deleted entries
stay unlinked in the existing tests.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012ZkCpr37MCJP9fAHSgSdQ1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788113026&installation_model_id=13063&pr_number=13500&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13500&signature=1f80829b78df8170292ba5fa6398414a09a67601bd1a95c62cf2f26fcb49d9c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

