### PR TITLE
refactor(billing_entry): lock pending subscription with pg_advisory_xact_lock

### DIFF
--- a/server/polar/billing_entry/repository.py
+++ b/server/polar/billing_entry/repository.py
@@ -7,6 +7,7 @@ from sqlalchemy import Select, and_, func, or_, select, update
 from sqlalchemy.orm.strategy_options import contains_eager, joinedload
 
 from polar.config import settings
+from polar.kit.db.locking import pg_advisory_xact_lock
 from polar.kit.repository import (
     Options,
     RepositoryBase,
@@ -163,23 +164,21 @@ class BillingEntryRepository(
         )
         await self.session.execute(statement)
 
-    async def lock_pending_by_subscription(
-        self, subscription_id: UUID, *, cutoff: datetime | None = None
-    ) -> None:
+    async def lock_pending_by_subscription(self, subscription_id: UUID) -> None:
         """
-        Acquire FOR UPDATE locks on all pending billing entries for a subscription.
+        Serialize order creation for a subscription's pending billing entries
+        with a transaction-level advisory lock.
 
-        This prevents concurrent order creation from reading the same pending
-        entries. With READ COMMITTED isolation, a blocked transaction will
-        re-evaluate the WHERE clause after acquiring the lock and see that
-        the entries are no longer pending.
+        Unlike a ``FOR UPDATE`` on the pending rows, the advisory lock doesn't
+        depend on those rows existing, so it also blocks a concurrent
+        transaction that is about to insert new pending entries. With READ
+        COMMITTED isolation, a blocked transaction resumes once the holder
+        commits and sees the entries are no longer pending. The lock is
+        released automatically when the transaction ends.
         """
-        statement = (
-            self.get_pending_by_subscription_statement(subscription_id, cutoff=cutoff)
-            .with_only_columns(BillingEntry.id)
-            .with_for_update()
+        await pg_advisory_xact_lock(
+            self.session, "billing_entry.pending", subscription_id
         )
-        await self.session.execute(statement)
 
     def get_pending_by_subscription_statement(
         self,

--- a/server/polar/billing_entry/service.py
+++ b/server/polar/billing_entry/service.py
@@ -76,7 +76,7 @@ class BillingEntryService:
     ) -> AsyncGenerator[Sequence[OrderItem]]:
         repository = BillingEntryRepository.from_session(session)
         cutoff = cutoff or utc_now()
-        await repository.lock_pending_by_subscription(subscription.id, cutoff=cutoff)
+        await repository.lock_pending_by_subscription(subscription.id)
 
         item_entries_map: dict[OrderItem, BillingEntrySelector] = {}
         async for line_item, selector in self.compute_pending_subscription_line_items(

--- a/server/polar/kit/db/locking.py
+++ b/server/polar/kit/db/locking.py
@@ -1,4 +1,24 @@
+import uuid
+
+from sqlalchemy import func, select
 from sqlalchemy.exc import DBAPIError
+
+from polar.kit.db.postgres import AsyncReadSession, AsyncSession
+
+
+async def pg_advisory_xact_lock(
+    session: AsyncSession | AsyncReadSession, namespace: str, key: uuid.UUID
+) -> None:
+    """
+    Acquire a transaction-level exclusive advisory lock.
+
+    The lock is derived from a stable hash of ``namespace`` and ``key`` and is
+    released automatically when the transaction ends. Unlike ``FOR UPDATE``, it
+    doesn't require the target rows to exist, so concurrent transactions
+    serialize even when there are no rows yet to lock.
+    """
+    lock_key = func.hashtextextended(f"{namespace}:{key}", 0)
+    await session.execute(select(func.pg_advisory_xact_lock(lock_key)))
 
 
 def is_lock_not_available_error(e: DBAPIError) -> bool:


### PR DESCRIPTION
Replace the `FOR UPDATE` lock on a subscription's pending billing entries
with a transaction-level advisory lock keyed on the subscription.

`FOR UPDATE` only locks rows that already exist, so it can't serialize a
concurrent transaction that is about to insert new pending entries. The
advisory lock doesn't depend on rows existing and serializes all order
creation for a subscription, while still auto-releasing at transaction end.
Double-billing protection is preserved: a blocked transaction resumes once
the holder commits and, under READ COMMITTED, sees the entries are no
longer pending.

Add a reusable `pg_advisory_xact_lock` helper in `polar/kit/db/locking.py`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01G3RFZ99z5GoVtoMeKAjdRE

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788113600&installation_model_id=13063&pr_number=13501&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13501&signature=6cd51f64470a1b33393e07ad5d498113390c1495fd0ff398015ee3fca2fb06e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

