### PR TITLE
perf(billing_entry): index-scope the meter-credit lookup in order creation

### DIFF
--- a/server/migrations/versions/2026-07-31-1230_add_partial_index_for_meter_credited_.py
+++ b/server/migrations/versions/2026-07-31-1230_add_partial_index_for_meter_credited_.py
@@ -1,0 +1,50 @@
+"""add partial index for meter.credited events
+
+Revision ID: c9a17e3f4b52
+Revises: 5a1b80eeae48
+Create Date: 2026-07-31 12:30:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "c9a17e3f4b52"
+down_revision = "5a1b80eeae48"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+INDEX_NAME = "ix_events_meter_credited"
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        # A failed/canceled concurrent build leaves an INVALID index behind;
+        # drop it first so rerunning this (unrecorded) migration recovers.
+        op.drop_index(
+            INDEX_NAME,
+            table_name="events",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            INDEX_NAME,
+            "events",
+            ["organization_id", "ingested_at"],
+            unique=False,
+            postgresql_concurrently=True,
+            postgresql_where=sa.text("source = 'system' AND name = 'meter.credited'"),
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            INDEX_NAME,
+            table_name="events",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )

--- a/server/polar/billing_entry/service.py
+++ b/server/polar/billing_entry/service.py
@@ -11,6 +11,7 @@ from sqlalchemy.util.typing import Literal
 from typing_extensions import AsyncGenerator
 
 from polar.event.repository import EventRepository
+from polar.event.system import SystemEvent
 from polar.kit.math import non_negative_running_sum
 from polar.kit.utils import utc_now
 from polar.meter.service import meter as meter_service
@@ -314,7 +315,12 @@ class BillingEntryService:
             ),
         )
         credit_events_statement = events_statement.where(
-            Event.is_meter_credit.is_(True)
+            # Spelled out (rather than `Event.is_meter_credit`) and scoped to the
+            # organization so the planner can use the partial credit index instead
+            # of scanning every pending billing entry.
+            Event.organization_id == meter.organization_id,
+            Event.source == EventSource.system,
+            Event.name == SystemEvent.meter_credited,
         )
         credit_events = await event_repository.get_all(credit_events_statement)
         credited_units = non_negative_running_sum(
@@ -367,7 +373,12 @@ class BillingEntryService:
             ),
         )
         credit_events_statement = events_statement.where(
-            Event.is_meter_credit.is_(True)
+            # Spelled out (rather than `Event.is_meter_credit`) and scoped to the
+            # organization so the planner can use the partial credit index instead
+            # of scanning every pending billing entry.
+            Event.organization_id == meter.organization_id,
+            Event.source == EventSource.system,
+            Event.name == SystemEvent.meter_credited,
         )
         credit_events = await event_repository.get_all(credit_events_statement)
         credited_units = non_negative_running_sum(

--- a/server/polar/models/event.py
+++ b/server/polar/models/event.py
@@ -231,6 +231,12 @@ class Event(Model, MetadataMixin):
             "pending_parent_external_id",
             postgresql_where="pending_parent_external_id IS NOT NULL",
         ),
+        Index(
+            "ix_events_meter_credited",
+            "organization_id",
+            "ingested_at",
+            postgresql_where="source = 'system' AND name = 'meter.credited'",
+        ),
     )
 
     id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=generate_uuid)


### PR DESCRIPTION
When creating a subscription order for a customer with many events, the
credit-events query in `_get_metered_line_item(_by_meter)` fanned out over
every pending billing entry to find the handful of `meter.credited` events,
taking 15s+ at scale.

Spell out the credit predicate as plain `source`/`name` equalities (instead
of `Event.is_meter_credit.is_(True)`, which renders as `(...) IS TRUE` and
defeats partial-index matching) and scope it to the organization, mirroring
the sibling usage query. Add a partial index on
`events (organization_id, ingested_at)` where `source = 'system' AND
name = 'meter.credited'` so the planner seeks the org's credit events
directly rather than scanning the whole pending set.

Purely an index/access-path change: the org filter is already implied by the
billing-entry subscription join, and the explicit predicates are equivalent
to `is_meter_credit`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TZ2BerRmmh8ax2FF6RksHa

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788114168&installation_model_id=13063&pr_number=13502&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13502&signature=4a4905a5490b144b71d5b84bb93155fda8db6bce2a72b5e06f48a6e0449d49d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

