### PR TITLE
Batch billing entry updates

### DIFF
--- a/server/polar/billing_entry/repository.py
+++ b/server/polar/billing_entry/repository.py
@@ -1,9 +1,10 @@
 from collections.abc import AsyncGenerator, Sequence
 from datetime import datetime
 from itertools import batched
+from typing import cast
 from uuid import UUID
 
-from sqlalchemy import Select, and_, func, or_, select, update
+from sqlalchemy import CursorResult, Select, and_, func, or_, select, update
 from sqlalchemy.orm.strategy_options import contains_eager, joinedload
 
 from polar.config import settings
@@ -16,6 +17,8 @@ from polar.kit.repository import (
 from polar.models import BillingEntry
 from polar.models.billing_entry import BillingEntryType
 from polar.models.product_price import ProductPrice, ProductPriceMeteredUnit
+
+_LINK_PENDING_BATCH_SIZE = 25_000
 
 
 class BillingEntryRepository(
@@ -127,7 +130,7 @@ class BillingEntryRepository(
         *,
         cutoff: datetime,
     ) -> None:
-        statement = update(BillingEntry).where(
+        pending_ids = select(BillingEntry.id).where(
             BillingEntry.subscription_id == subscription_id,
             BillingEntry.deleted_at.is_(None),
             BillingEntry.order_item_id.is_(None),
@@ -135,10 +138,7 @@ class BillingEntryRepository(
             BillingEntry.start_timestamp < cutoff,
             BillingEntry.created_at <= cutoff,
         )
-        statement = statement.values(order_item_id=order_item_id).execution_options(
-            synchronize_session=False
-        )
-        await self.session.execute(statement)
+        await self._link_pending(pending_ids, order_item_id)
 
     async def link_pending_by_subscription_and_meter(
         self,
@@ -148,7 +148,7 @@ class BillingEntryRepository(
         *,
         cutoff: datetime,
     ) -> None:
-        statement = update(BillingEntry).where(
+        pending_ids = select(BillingEntry.id).where(
             BillingEntry.subscription_id == subscription_id,
             BillingEntry.deleted_at.is_(None),
             BillingEntry.order_item_id.is_(None),
@@ -160,10 +160,24 @@ class BillingEntryRepository(
             BillingEntry.start_timestamp < cutoff,
             BillingEntry.created_at <= cutoff,
         )
-        statement = statement.values(order_item_id=order_item_id).execution_options(
-            synchronize_session=False
+        await self._link_pending(pending_ids, order_item_id)
+
+    async def _link_pending(
+        self, pending_ids: Select[tuple[UUID]], order_item_id: UUID
+    ) -> None:
+        batch_ids = pending_ids.limit(_LINK_PENDING_BATCH_SIZE)
+        statement = (
+            update(BillingEntry)
+            .where(BillingEntry.id.in_(batch_ids))
+            .values(order_item_id=order_item_id)
+            .execution_options(synchronize_session=False)
         )
-        await self.session.execute(statement)
+        while True:
+            result = cast(
+                CursorResult[BillingEntry], await self.session.execute(statement)
+            )
+            if result.rowcount < _LINK_PENDING_BATCH_SIZE:
+                break
 
     async def lock_pending_by_subscription(
         self, subscription_id: UUID, *, cutoff: datetime | None = None

--- a/server/tests/billing_entry/test_service.py
+++ b/server/tests/billing_entry/test_service.py
@@ -623,7 +623,7 @@ class TestCreateOrderItemsFromPending:
             call.args[0]
             for call in execute_spy.call_args_list
             if isinstance(call.args[0], Update)
-            and call.args[0].table.name == BillingEntry.__tablename__
+            and getattr(call.args[0].table, "name", None) == BillingEntry.__tablename__
         ]
         assert len(billing_entry_updates) > len(order_items)
         assert all("LIMIT" in str(statement) for statement in billing_entry_updates)

--- a/server/tests/billing_entry/test_service.py
+++ b/server/tests/billing_entry/test_service.py
@@ -3,6 +3,8 @@ from decimal import Decimal
 
 import pytest
 import pytest_asyncio
+from pytest_mock import MockerFixture
+from sqlalchemy import Update
 
 from polar.billing_entry.service import billing_entry as billing_entry_service
 from polar.enums import SubscriptionProrationBehavior, SubscriptionRecurringInterval
@@ -521,6 +523,8 @@ class TestCreateOrderItemsFromPending:
         self,
         save_fixture: SaveFixture,
         session: AsyncSession,
+        mocker: MockerFixture,
+        monkeypatch: pytest.MonkeyPatch,
         customer: Customer,
         meter: Meter,
         product_metered_unit: Product,
@@ -578,6 +582,12 @@ class TestCreateOrderItemsFromPending:
             ),
         ]
 
+        monkeypatch.setattr(
+            "polar.billing_entry.repository._LINK_PENDING_BATCH_SIZE",
+            1,
+        )
+        execute_spy = mocker.spy(session, "execute")
+
         async with billing_entry_service.create_order_items_from_pending(
             session, metered_subscription
         ) as order_items:
@@ -608,6 +618,15 @@ class TestCreateOrderItemsFromPending:
         for entry in entries[2:]:
             await session.refresh(entry)
             assert entry.order_item_id == order_item_current_price.id
+
+        billing_entry_updates = [
+            call.args[0]
+            for call in execute_spy.call_args_list
+            if isinstance(call.args[0], Update)
+            and call.args[0].table.name == BillingEntry.__tablename__
+        ]
+        assert len(billing_entry_updates) > len(order_items)
+        assert all("LIMIT" in str(statement) for statement in billing_entry_updates)
 
     @pytest.mark.parametrize(
         ("entry_type", "new_seats", "expected_transition"),


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788117845&installation_model_id=13063&pr_number=13503&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13503&signature=756634047e0775f89e2173af2b0cdd503c725d6c25c05199cd3cb1d8ea6af233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch-link pending billing entries to order items using repeated, limited UPDATEs to cut database load and avoid long-running locks. Adds a looped SQL LIMIT approach for safer high-volume processing.

- **Refactors**
  - Added `_LINK_PENDING_BATCH_SIZE` (25,000) and `_link_pending` that updates by subquery with `LIMIT`, looping until fewer than the batch size are updated.
  - Updated price- and meter-based linking to build ID subqueries and route through `_link_pending`.
  - Extended tests to monkeypatch the batch size and spy on `session.execute` to assert multiple `UPDATE ... LIMIT` statements.

- **Bug Fixes**
  - Adjusted the test’s `Update.table` name check to use `getattr(..., "name", None)` to satisfy mypy’s union-attr typing.

<sup>Written for commit 7d72a657312291cedca3a1836b91582b778976f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

