### PR TITLE
Optimize meter credit event queries with index-friendly filters

### DIFF
--- a/server/polar/billing_entry/service.py
+++ b/server/polar/billing_entry/service.py
@@ -11,6 +11,7 @@ from sqlalchemy.util.typing import Literal
 from typing_extensions import AsyncGenerator
 
 from polar.event.repository import EventRepository
+from polar.event.system import SystemEvent
 from polar.kit.math import non_negative_running_sum
 from polar.kit.utils import utc_now
 from polar.meter.service import meter as meter_service
@@ -314,7 +315,12 @@ class BillingEntryService:
             ),
         )
         credit_events_statement = events_statement.where(
-            Event.is_meter_credit.is_(True)
+            # Filter on organization_id + customer_id and unpack `is_meter_credit`
+            # so we hit the ix_events_org_source_name_customer_id_ingested_at index.
+            Event.organization_id == meter.organization_id,
+            Event.customer_id == subscription.customer_id,
+            Event.source == EventSource.system,
+            Event.name == SystemEvent.meter_credited,
         )
         credit_events = await event_repository.get_all(credit_events_statement)
         credited_units = non_negative_running_sum(
@@ -367,7 +373,12 @@ class BillingEntryService:
             ),
         )
         credit_events_statement = events_statement.where(
-            Event.is_meter_credit.is_(True)
+            # Filter on organization_id + customer_id and unpack `is_meter_credit`
+            # so we hit the ix_events_org_source_name_customer_id_ingested_at index.
+            Event.organization_id == meter.organization_id,
+            Event.customer_id == subscription.customer_id,
+            Event.source == EventSource.system,
+            Event.name == SystemEvent.meter_credited,
         )
         credit_events = await event_repository.get_all(credit_events_statement)
         credited_units = non_negative_running_sum(


### PR DESCRIPTION
## Summary

Refactor meter credit event filtering to use index-friendly query conditions that match the `ix_events_org_source_name_customer_id_ingested_at` index, improving query performance.

## What

Changed two locations in `billing_entry/service.py` where meter credit events are filtered:
- Replaced `Event.is_meter_credit.is_(True)` with explicit filters on `organization_id`, `customer_id`, `source`, and `name`
- Added `SystemEvent` import to support the new filtering approach

## Why

The previous filter on the `is_meter_credit` computed column doesn't align with the available database index. By unpacking the logic into its component filters (`organization_id`, `customer_id`, `source == EventSource.system`, `name == SystemEvent.meter_credited`), the query can now efficiently use the `ix_events_org_source_name_customer_id_ingested_at` index, resulting in better query performance.

## How

- Imported `SystemEvent` from `polar.event.system`
- Updated `_get_metered_line_item()` and `_get_metered_line_item_by_meter()` methods to filter on the specific event attributes that comprise a meter credit event
- Added explanatory comments documenting the index optimization

## Checklist

- [x] This PR addresses a single concern (query optimization)
- [x] The diff is reasonably sized and easy to review
- [x] No new functionality requiring tests
- [x] Linting and type checking pass
- [x] No unrelated changes included

https://claude.ai/code/session_011yfADKiBbH1KmG5KbBYiyr

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/polarsource/codesmith/polar/pr/13504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788119060&installation_model_id=13063&pr_number=13504&repository=polarsource%2Fpolar&return_to=https%3A%2F%2Fgithub.com%2Fpolarsource%2Fpolar%2Fpull%2F13504&signature=4bdf076c70317ba9b5f2d6e2e9b12b01ed52078c509c45173ce9a4bbd30ac179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

