### PR TITLE
perf(billing_entry): count entries directly for count meters

### DIFF
--- a/server/polar/billing_entry/service.py
+++ b/server/polar/billing_entry/service.py
@@ -14,6 +14,7 @@ from polar.event.repository import EventRepository
 from polar.event.system import SystemEvent
 from polar.kit.math import non_negative_running_sum
 from polar.kit.utils import utc_now
+from polar.meter.aggregation import AggregationFunction
 from polar.meter.service import meter as meter_service
 from polar.models import BillingEntry, Event, OrderItem, Subscription
 from polar.models.billing_entry import BillingEntryDirection, BillingEntryType
@@ -305,15 +306,33 @@ class BillingEntryService:
             subscription.id, price.id, cutoff=cutoff
         )
         meter = price.meter
-        units = await meter_service.get_quantity(
-            session,
-            meter,
-            events_statement.where(
-                # Combining these two WHERE clauses allows us to hit a composite index
-                Event.organization_id == meter.organization_id,
-                Event.source == EventSource.user,
-            ),
-        )
+        if meter.aggregation.func == AggregationFunction.cnt:
+            # A count meter's quantity is the number of consumption events, and there
+            # is exactly one billing entry per event. Counting the entries directly
+            # (total minus the few system-event entries) avoids fanning the pending
+            # scan out into a per-event lookup on `events`, which times out for
+            # high-volume subscriptions.
+            total_units = await event_repository.count_pending_entries(
+                subscription.id, price.id, cutoff=cutoff
+            )
+            system_units = await event_repository.count_pending_system_entries(
+                subscription.id,
+                price.id,
+                organization_id=meter.organization_id,
+                customer_id=subscription.customer_id,
+                cutoff=cutoff,
+            )
+            units: float = total_units - system_units
+        else:
+            units = await meter_service.get_quantity(
+                session,
+                meter,
+                events_statement.where(
+                    # Combining these two WHERE clauses allows us to hit a composite index
+                    Event.organization_id == meter.organization_id,
+                    Event.source == EventSource.user,
+                ),
+            )
         credit_events_statement = events_statement.where(
             # Filter on organization_id + customer_id and unpack `is_meter_credit`
             # so we hit the ix_events_org_source_name_customer_id_ingested_at index.

--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -445,16 +445,14 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         cutoff: datetime,
     ) -> int:
         """
-        Count the pending billing entries backed by a system event (meter.credited,
-        meter.reset). These are the complement of the consumption events a `count`
-        meter bills; `count_pending_entries` minus this yields the `source='user'`
-        count without scanning every entry.
+        Count the pending billing entries backed by a system event. These are the
+        complement of the consumption events a `count` meter bills;
+        `count_pending_entries` minus this yields the `source='user'` count without
+        scanning every entry.
 
-        Matching on the two event names (rather than just source=system) keeps this on
-        the ix_events_org_source_name_customer_id_ingested_at index, pinning customer_id
-        instead of scanning every system event in the org. meter.credited/meter.reset are
-        the only system events that ever produce a metered billing entry
-        (see EventService._event_matches_meter) — extend this list if that changes.
+        Matching on all known system event names keeps this on the
+        ix_events_org_source_name_customer_id_ingested_at index, pinning customer_id
+        instead of scanning every system event in the org.
         """
         statement = (
             select(func.count())
@@ -465,7 +463,7 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
                 Event.organization_id == organization_id,
                 Event.customer_id == customer_id,
                 Event.source == EventSource.system,
-                Event.name.in_((SystemEvent.meter_credited, SystemEvent.meter_reset)),
+                Event.name.in_(tuple(SystemEvent)),
             )
         )
         return await self.session.scalar(statement) or 0

--- a/server/polar/event/repository.py
+++ b/server/polar/event/repository.py
@@ -381,6 +381,22 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         result = await self.session.execute(statement)
         return [(event, customer) for event, customer in result.all()]
 
+    def _pending_entries_clauses(
+        self,
+        subscription: UUID,
+        price: UUID,
+        *,
+        cutoff: datetime,
+    ) -> tuple[ColumnExpressionArgument[bool], ...]:
+        return (
+            BillingEntry.subscription_id == subscription,
+            BillingEntry.deleted_at.is_(None),
+            BillingEntry.order_item_id.is_(None),
+            BillingEntry.product_price_id == price,
+            BillingEntry.start_timestamp < cutoff,
+            BillingEntry.created_at <= cutoff,
+        )
+
     def get_by_pending_entries_statement(
         self,
         subscription: UUID,
@@ -391,17 +407,68 @@ class EventRepository(RepositoryBase[Event], RepositoryIDMixin[Event, UUID]):
         statement = (
             self.get_base_statement()
             .join(BillingEntry, Event.id == BillingEntry.event_id)
-            .where(
-                BillingEntry.subscription_id == subscription,
-                BillingEntry.deleted_at.is_(None),
-                BillingEntry.order_item_id.is_(None),
-                BillingEntry.product_price_id == price,
-                BillingEntry.start_timestamp < cutoff,
-                BillingEntry.created_at <= cutoff,
-            )
+            .where(*self._pending_entries_clauses(subscription, price, cutoff=cutoff))
             .order_by(Event.ingested_at.asc())
         )
         return statement
+
+    async def count_pending_entries(
+        self,
+        subscription: UUID,
+        price: UUID,
+        *,
+        cutoff: datetime,
+    ) -> int:
+        """
+        Count the pending billing entries for a price without joining `events`.
+
+        There is exactly one billing entry per event, so for a `count` meter this is
+        the consumed quantity. Counting the entries directly avoids fanning the scan
+        out into a per-event primary-key lookup on `events`, which times out for
+        high-volume subscriptions. System events (meter.credited, meter.reset) also
+        produce entries and must be excluded via `count_pending_system_entries`.
+        """
+        statement = (
+            select(func.count())
+            .select_from(BillingEntry)
+            .where(*self._pending_entries_clauses(subscription, price, cutoff=cutoff))
+        )
+        return await self.session.scalar(statement) or 0
+
+    async def count_pending_system_entries(
+        self,
+        subscription: UUID,
+        price: UUID,
+        *,
+        organization_id: UUID,
+        customer_id: UUID,
+        cutoff: datetime,
+    ) -> int:
+        """
+        Count the pending billing entries backed by a system event (meter.credited,
+        meter.reset). These are the complement of the consumption events a `count`
+        meter bills; `count_pending_entries` minus this yields the `source='user'`
+        count without scanning every entry.
+
+        Matching on the two event names (rather than just source=system) keeps this on
+        the ix_events_org_source_name_customer_id_ingested_at index, pinning customer_id
+        instead of scanning every system event in the org. meter.credited/meter.reset are
+        the only system events that ever produce a metered billing entry
+        (see EventService._event_matches_meter) — extend this list if that changes.
+        """
+        statement = (
+            select(func.count())
+            .select_from(BillingEntry)
+            .join(Event, Event.id == BillingEntry.event_id)
+            .where(
+                *self._pending_entries_clauses(subscription, price, cutoff=cutoff),
+                Event.organization_id == organization_id,
+                Event.customer_id == customer_id,
+                Event.source == EventSource.system,
+                Event.name.in_((SystemEvent.meter_credited, SystemEvent.meter_reset)),
+            )
+        )
+        return await self.session.scalar(statement) or 0
 
     def get_by_pending_entries_for_meter_statement(
         self,

--- a/server/tests/billing_entry/test_service.py
+++ b/server/tests/billing_entry/test_service.py
@@ -187,19 +187,20 @@ async def create_credit_billing_entry(
     return billing_entry
 
 
-async def create_reset_billing_entry(
+async def create_system_billing_entry(
     save_fixture: SaveFixture,
     *,
     customer: Customer,
     price: ProductPrice,
     subscription: Subscription,
     meter: Meter,
+    name: SystemEvent,
 ) -> BillingEntry:
     event = await create_event(
         save_fixture,
         organization=customer.organization,
         source=EventSource.system,
-        name=SystemEvent.meter_reset,
+        name=name,
         customer=customer,
         metadata={"meter_id": str(meter.id)},
     )
@@ -769,9 +770,8 @@ class TestCreateOrderItemsFromPending:
                 subscription=subscription,
                 tokens=1,
             )
-        # A credit and a reset also produce metered entries. They must NOT inflate the
-        # consumption count (they're only distinguishable by event.source), though the
-        # credited units are still subtracted separately.
+        # System events must not inflate the consumption count, though credited units
+        # are still subtracted separately.
         await create_credit_billing_entry(
             save_fixture,
             customer=customer,
@@ -780,12 +780,21 @@ class TestCreateOrderItemsFromPending:
             meter=count_meter,
             units=1,
         )
-        await create_reset_billing_entry(
+        await create_system_billing_entry(
             save_fixture,
             customer=customer,
             price=price,
             subscription=subscription,
             meter=count_meter,
+            name=SystemEvent.meter_reset,
+        )
+        await create_system_billing_entry(
+            save_fixture,
+            customer=customer,
+            price=price,
+            subscription=subscription,
+            meter=count_meter,
+            name=SystemEvent.subscription_created,
         )
 
         async with billing_entry_service.create_order_items_from_pending(

--- a/server/tests/billing_entry/test_service.py
+++ b/server/tests/billing_entry/test_service.py
@@ -8,7 +8,11 @@ from polar.billing_entry.service import billing_entry as billing_entry_service
 from polar.enums import SubscriptionProrationBehavior, SubscriptionRecurringInterval
 from polar.event.system import SystemEvent
 from polar.kit.utils import utc_now
-from polar.meter.aggregation import AggregationFunction, PropertyAggregation
+from polar.meter.aggregation import (
+    AggregationFunction,
+    CountAggregation,
+    PropertyAggregation,
+)
 from polar.meter.filter import Filter, FilterConjunction
 from polar.models import (
     BillingEntry,
@@ -179,6 +183,36 @@ async def create_credit_billing_entry(
         await save_fixture(order)
         billing_entry.order_item = order_item
 
+    await save_fixture(billing_entry)
+    return billing_entry
+
+
+async def create_reset_billing_entry(
+    save_fixture: SaveFixture,
+    *,
+    customer: Customer,
+    price: ProductPrice,
+    subscription: Subscription,
+    meter: Meter,
+) -> BillingEntry:
+    event = await create_event(
+        save_fixture,
+        organization=customer.organization,
+        source=EventSource.system,
+        name=SystemEvent.meter_reset,
+        customer=customer,
+        metadata={"meter_id": str(meter.id)},
+    )
+    billing_entry = BillingEntry(
+        start_timestamp=event.timestamp,
+        end_timestamp=event.timestamp,
+        type=BillingEntryType.metered,
+        direction=BillingEntryDirection.debit,
+        customer=customer,
+        product_price=price,
+        subscription=subscription,
+        event=event,
+    )
     await save_fixture(billing_entry)
     return billing_entry
 
@@ -700,6 +734,73 @@ class TestCreateOrderItemsFromPending:
         for entry in entries[1:]:
             await session.refresh(entry)
             assert entry.order_item_id == order_item.id
+
+    async def test_count_meter_excludes_system_entries(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        count_meter = await create_meter(
+            save_fixture,
+            filter=Filter(conjunction=FilterConjunction.and_, clauses=[]),
+            aggregation=CountAggregation(),
+            organization=organization,
+        )
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(count_meter, Decimal(100), None, "usd")],
+        )
+        subscription = await create_active_subscription(
+            save_fixture, customer=customer, product=product
+        )
+        price = product.prices[0]
+        assert is_metered_price(price)
+
+        # Three consumption events -> a count meter bills three units.
+        for _ in range(3):
+            await create_metered_event_billing_entry(
+                save_fixture,
+                customer=customer,
+                price=price,
+                subscription=subscription,
+                tokens=1,
+            )
+        # A credit and a reset also produce metered entries. They must NOT inflate the
+        # consumption count (they're only distinguishable by event.source), though the
+        # credited units are still subtracted separately.
+        await create_credit_billing_entry(
+            save_fixture,
+            customer=customer,
+            price=price,
+            subscription=subscription,
+            meter=count_meter,
+            units=1,
+        )
+        await create_reset_billing_entry(
+            save_fixture,
+            customer=customer,
+            price=price,
+            subscription=subscription,
+            meter=count_meter,
+        )
+
+        async with billing_entry_service.create_order_items_from_pending(
+            session, subscription
+        ) as order_items:
+            assert len(order_items) == 1
+
+            order_item = order_items[0]
+            assert count_meter.name in order_item.label
+            # 3 consumed units - 1 credited unit = 2 billable units
+            assert order_item.amount == 2_00
+
+            await create_order(
+                save_fixture, customer=customer, order_items=list(order_items)
+            )
 
     async def test_static_price(
         self,


### PR DESCRIPTION
Introduce a fast path for count meter calculations that doesn't require a JOIN on events.

Generated PR description:

`_get_metered_line_item` computed a count meter's quantity via `COUNT(events.id)` over the `events → billing_entry` join. The planner drives from `billing_entry` (the full pending set) and does one primary-key probe into `events` per entry — ~10s for a 200k-entry subscription and worse above that, timing out cycle order creation for high-volume metered subs.

There is exactly one billing entry per event (`from_metered_event`), and entries are pre-filtered to the meter at creation, so for a count meter the quantity is just the number of consumption entries. Count the entries directly (`count_pending_entries`, no join) and subtract the few system-event entries (`count_pending_system_entries`, index-driven on org+customer+source) to reproduce the `source='user'` count.

Only count meters are affected; sum/max/avg/unique still read per-event values and keep the existing events path.
