### PR TITLE
perf(billing_entry): partial index for pending static entries

### DIFF
--- a/server/migrations/versions/2026-08-01-1000_add_pending_static_billing_entry_index.py
+++ b/server/migrations/versions/2026-08-01-1000_add_pending_static_billing_entry_index.py
@@ -1,0 +1,45 @@
+"""add partial index for pending static billing entries
+
+Revision ID: c1a7e4b93f2d
+Revises: 5a1b80eeae48
+Create Date: 2026-08-01 10:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "c1a7e4b93f2d"
+down_revision = "5a1b80eeae48"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+INDEX_NAME = "ix_billing_entry_pending_static"
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            INDEX_NAME,
+            "billing_entry",
+            ["subscription_id"],
+            unique=False,
+            postgresql_where=sa.text(
+                "deleted_at IS NULL AND order_item_id IS NULL AND type != 'metered'"
+            ),
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            INDEX_NAME,
+            table_name="billing_entry",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/server/migrations/versions/2026-08-04-0900_add_pending_static_billing_entry_index.py
+++ b/server/migrations/versions/2026-08-04-0900_add_pending_static_billing_entry_index.py
@@ -1,0 +1,45 @@
+"""add partial index for pending static billing entries
+
+Revision ID: c1a7e4b93f2d
+Revises: aaa111ca733d
+Create Date: 2026-08-04 09:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "c1a7e4b93f2d"
+down_revision = "aaa111ca733d"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+INDEX_NAME = "ix_billing_entry_pending_static"
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.create_index(
+            INDEX_NAME,
+            "billing_entry",
+            ["subscription_id"],
+            unique=False,
+            postgresql_where=sa.text(
+                "deleted_at IS NULL AND order_item_id IS NULL AND type != 'metered'"
+            ),
+            postgresql_concurrently=True,
+            if_not_exists=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            INDEX_NAME,
+            table_name="billing_entry",
+            postgresql_concurrently=True,
+            if_exists=True,
+        )

--- a/server/polar/billing_entry/repository.py
+++ b/server/polar/billing_entry/repository.py
@@ -71,6 +71,13 @@ class BillingEntryRepository(
     ) -> AsyncGenerator[BillingEntry]:
         statement = (
             self.get_pending_by_subscription_statement(subscription_id, cutoff=cutoff)
+            # Metered entries are the only ones created with `type=metered`, so
+            # the static ones are exactly the non-metered ones. Filtering on
+            # `type` lets the planner use the partial `ix_billing_entry_pending_static`
+            # index and skip the pending metered entries entirely, instead of
+            # scanning them all and joining `product_prices` just to discard them
+            # — which times out on high-volume subscriptions.
+            .where(BillingEntry.type != BillingEntryType.metered)
             .join(BillingEntry.product_price)
             .where(ProductPrice.is_static.is_(True))
             .options(

--- a/server/polar/billing_entry/repository.py
+++ b/server/polar/billing_entry/repository.py
@@ -75,9 +75,11 @@ class BillingEntryRepository(
             .join(BillingEntry.product_price)
             # Metered entries always carry a metered price: `from_metered_event`
             # is the only writer of this type, and it takes the price from a
-            # meter-scoped lookup. So this predicate selects the same rows as
-            # `is_static` alone, but lets the `billing_entry` scan drop them
-            # before the join to `events` rather than after it.
+            # meter-scoped lookup. So filtering on `type` selects the same rows as
+            # `is_static` alone, but lets the planner use the partial
+            # `ix_billing_entry_pending_static` index and drop the pending metered
+            # entries during the `billing_entry` scan instead of walking the whole
+            # pending set — which was timing out on high-volume subscriptions.
             .where(
                 BillingEntry.type != BillingEntryType.metered,
                 ProductPrice.is_static.is_(True),

--- a/server/polar/models/billing_entry.py
+++ b/server/polar/models/billing_entry.py
@@ -3,7 +3,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Self
 from uuid import UUID
 
-from sqlalchemy import TIMESTAMP, BigInteger, ForeignKey, Index, String, Uuid
+from sqlalchemy import TIMESTAMP, BigInteger, ForeignKey, Index, String, Uuid, text
 from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
 from polar.kit.db.models import RecordModel
@@ -43,6 +43,16 @@ class BillingEntry(RecordModel):
             "deleted_at",
             "order_item_id",
             "product_price_id",
+        ),
+        # Pending static (non-metered) entries are rare next to the pending
+        # metered ones, so a partial index keeps the static line-item lookup off
+        # the full pending scan for high-volume subscriptions.
+        Index(
+            "ix_billing_entry_pending_static",
+            "subscription_id",
+            postgresql_where=text(
+                "deleted_at IS NULL AND order_item_id IS NULL AND type != 'metered'"
+            ),
         ),
     )
 

--- a/server/tests/billing_entry/test_service.py
+++ b/server/tests/billing_entry/test_service.py
@@ -936,6 +936,82 @@ class TestCreateOrderItemsFromPending:
         await session.refresh(entry)
         assert entry.order_item_id == order_item.id
 
+    async def test_static_entry_alongside_metered_entries(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        organization: Organization,
+        meter: Meter,
+    ) -> None:
+        # The static line-item query must find the (few) pending static entries
+        # even when they are outnumbered by pending metered entries — the
+        # high-volume shape that was timing out in production.
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.month,
+            prices=[(1000, "usd"), (meter, Decimal(100), None, "usd")],
+        )
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        static_price = product.prices[0]
+        metered_price = product.prices[1]
+        assert is_fixed_price(static_price)
+        assert is_metered_price(metered_price)
+
+        for tokens in (20, 30):
+            await create_metered_event_billing_entry(
+                save_fixture,
+                customer=customer,
+                price=metered_price,
+                subscription=subscription,
+                tokens=tokens,
+            )
+        static_entry = await create_static_price_billing_entry(
+            save_fixture,
+            customer=customer,
+            price=static_price,
+            subscription=subscription,
+            pending=True,
+        )
+
+        async with billing_entry_service.create_order_items_from_pending(
+            session, subscription
+        ) as order_items:
+            assert len(order_items) == 2
+
+            static_items = [
+                item
+                for item in order_items
+                if item.product_price is not None and is_fixed_price(item.product_price)
+            ]
+            metered_items = [
+                item
+                for item in order_items
+                if item.product_price is not None
+                and is_metered_price(item.product_price)
+            ]
+            assert len(static_items) == 1
+            assert len(metered_items) == 1
+
+            static_item = static_items[0]
+            assert static_item.amount == static_price.price_amount
+            assert static_item.proration is False
+            assert product.name in static_item.label
+
+            assert meter.name in metered_items[0].label
+
+            await create_order(
+                save_fixture,
+                customer=customer,
+                order_items=list(order_items),
+            )
+
+        await session.refresh(static_entry)
+        assert static_entry.order_item_id == static_item.id
+
     async def test_max_aggregation_across_product_prices(
         self,
         save_fixture: SaveFixture,


### PR DESCRIPTION
## Summary

Cycle order creation was timing out (`asyncpg TimeoutError`) for high-volume metered subscriptions while streaming static line items in `BillingEntryRepository.get_static_pending_by_subscription`.

> Rebased on latest `main`. Since this PR was opened, `main` independently landed the query-level `type != 'metered'` filter in `get_static_pending_by_subscription` (and dropped several unused `billing_entry` indexes in #—`71ec0612f44f`). This PR is now rebased onto that and reduced to the piece that isn't in `main`: the **partial index** that filter enables.

## What

- Add a partial index `ix_billing_entry_pending_static` on `billing_entry (subscription_id)` covering only pending non-metered entries (`WHERE deleted_at IS NULL AND order_item_id IS NULL AND type != 'metered'`), in the model and via a concurrent migration.
- Refresh the comment in `get_static_pending_by_subscription` to point at the index the existing `type != 'metered'` filter enables.
- Add a regression test for a subscription that has both static and metered pending entries.

## Why

`get_static_pending_by_subscription` already filters pending entries down to the static (non-metered) ones, but the driving scan still walked the **whole** pending set via `ix_billing_entries_s_d_oi_pp` and heap-checked `type` on every row. On high-volume metered subscriptions that pending set is millions of rows — so even with the filter, the scan blew past the statement timeout:

```
File "polar/order/service.py", line 1308, in create_subscription_order
File "polar/billing_entry/service.py", line 131, in compute_pending_subscription_line_items
File "polar/billing_entry/repository.py", line 81, in get_static_pending_by_subscription
...
asyncpg ... TimeoutError
```

The query-only filter (now in `main`) narrows the rows returned but doesn't stop the scan from visiting every pending metered row. The partial index does.

## How

Metered entries are the only ones created with `type=metered` (via `BillingEntry.from_metered_event`); every static entry (`cycle`/`proration`/`subscription_seats_*`) carries a static price. So "static" ≡ "non-metered" by construction, and a partial index keyed on that predicate contains only the handful of pending static entries per subscription.

- The existing `type != 'metered'` filter already **implies** the index predicate, so the planner drives the static lookup off this tiny index instead of the full pending scan — no query change required to benefit.
- Metered inserts fail the predicate, so they never touch the index: no write overhead on the ingestion hot path. This also complements #`71ec0612f44f`'s index cleanup rather than re-bloating writes.
- The migration creates the index `CONCURRENTLY` inside an `autocommit_block()`, matching the repo's existing index-migration convention. It is chained after `main`'s current head (`aaa111ca733d`), single-head.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

> **Note on verification:** the DB-backed test suite runs in CI. Locally I verified everything that doesn't need a database — the compiled query's `WHERE` clause implies the partial-index predicate exactly, the model index DDL and the rendered migration SQL are identical, the migration chain is single-head onto `main`, and ruff/format/mypy are clean on the changed files. The two DB-dependent checks left to CI are the E2E tests (including the new mixed-scenario regression test) and `alembic check` (model ↔ migration parity for the partial index).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ReQt23G1Raf8bbbLfAnKVQ