### PR TITLE
fix misaligned auth buttons

### DIFF
--- a/clients/apps/web/src/components/Auth/AppleLoginButton.tsx
+++ b/clients/apps/web/src/components/Auth/AppleLoginButton.tsx
@@ -49,15 +49,9 @@ const AppleLoginButton = ({
 
   return (
     <a onClick={onClick}>
-      <Button
-        variant={variant}
-        wrapperClassNames="space-x-2 p-2.5 px-5"
-        fullWidth
-      >
+      <Button variant={variant} wrapperClassNames="space-x-2 " fullWidth>
         <Apple />
-        <div className="w-32 text-left">
-          {signup ? 'Sign up with Apple' : 'Sign in with Apple'}
-        </div>
+        <div>{signup ? 'Sign up with Apple' : 'Sign in with Apple'}</div>
       </Button>
     </a>
   )

--- a/clients/apps/web/src/components/Auth/AppleLoginButton.tsx
+++ b/clients/apps/web/src/components/Auth/AppleLoginButton.tsx
@@ -49,7 +49,7 @@ const AppleLoginButton = ({
 
   return (
     <a onClick={onClick}>
-      <Button variant={variant} wrapperClassNames="space-x-2 " fullWidth>
+      <Button variant={variant} wrapperClassNames="space-x-2" fullWidth>
         <Apple />
         <div>{signup ? 'Sign up with Apple' : 'Sign in with Apple'}</div>
       </Button>

--- a/clients/apps/web/src/components/Auth/GitHubLoginButton.tsx
+++ b/clients/apps/web/src/components/Auth/GitHubLoginButton.tsx
@@ -49,15 +49,9 @@ const GitHubLoginButton = ({
 
   return (
     <a onClick={onClick}>
-      <Button
-        variant={variant}
-        wrapperClassNames="space-x-2 p-2.5 px-5"
-        fullWidth
-      >
+      <Button variant={variant} wrapperClassNames="space-x-2" fullWidth>
         <GitHub />
-        <div className="w-32 text-left">
-          {signup ? 'Sign up with GitHub' : 'Sign in with GitHub'}
-        </div>
+        <div>{signup ? 'Sign up with GitHub' : 'Sign in with GitHub'}</div>
       </Button>
     </a>
   )

--- a/clients/apps/web/src/components/Auth/GoogleLoginButton.tsx
+++ b/clients/apps/web/src/components/Auth/GoogleLoginButton.tsx
@@ -49,15 +49,9 @@ const GoogleLoginButton = ({
 
   return (
     <a onClick={onClick}>
-      <Button
-        variant={variant}
-        wrapperClassNames="space-x-2 p-2.5 px-5"
-        fullWidth
-      >
+      <Button variant={variant} wrapperClassNames="space-x-2" fullWidth>
         <Google />
-        <div className="w-32 text-left">
-          {signup ? 'Sign up with Google' : 'Sign in with Google'}
-        </div>
+        <div>{signup ? 'Sign up with Google' : 'Sign in with Google'}</div>
       </Button>
     </a>
   )

--- a/clients/apps/web/src/components/Auth/SSOLoginButton.tsx
+++ b/clients/apps/web/src/components/Auth/SSOLoginButton.tsx
@@ -49,15 +49,9 @@ const SSOLoginButton = ({
 
   return (
     <a onClick={onClick}>
-      <Button
-        variant={variant}
-        wrapperClassNames="space-x-2 p-2.5 px-5"
-        fullWidth
-      >
+      <Button variant={variant} wrapperClassNames="space-x-2 " fullWidth>
         <Key fontSize="small" />
-        <div className="w-32 text-left">
-          {connection.name ?? 'Sign in with SSO'}
-        </div>
+        <div>{connection.name ?? 'Sign in with SSO'}</div>
       </Button>
     </a>
   )

--- a/clients/apps/web/src/components/Auth/SSOLoginButton.tsx
+++ b/clients/apps/web/src/components/Auth/SSOLoginButton.tsx
@@ -49,7 +49,7 @@ const SSOLoginButton = ({
 
   return (
     <a onClick={onClick}>
-      <Button variant={variant} wrapperClassNames="space-x-2 " fullWidth>
+      <Button variant={variant} wrapperClassNames="space-x-2" fullWidth>
         <Key fontSize="small" />
         <div>{connection.name ?? 'Sign in with SSO'}</div>
       </Button>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed misaligned auth buttons by removing hard‑coded padding/label widths and standardizing spacing to `space-x-2`; plus minor formatting cleanup. Icons and labels now align across Apple, GitHub, Google, and SSO.

<sup>Written for commit 740dcd70e506beef9c35302658f4295c0348edcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

