### PR TITLE
billing entry: Remove unused indexes

### DIFF
--- a/server/migrations/versions/2026-08-03-1545_drop_unused_billing_entry_indexes.py
+++ b/server/migrations/versions/2026-08-03-1545_drop_unused_billing_entry_indexes.py
@@ -1,0 +1,53 @@
+"""drop unused billing entry indexes
+
+Revision ID: 71ec0612f44f
+Revises: 5a1b80eeae48
+Create Date: 2026-08-03 15:45:19.881549
+
+"""
+
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "71ec0612f44f"
+down_revision = "5a1b80eeae48"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+INDEXES = {
+    "ix_billing_entry_deleted_at": ["deleted_at"],
+    "ix_billing_entry_subscription_id": ["subscription_id"],
+    "ix_billing_entry_type": ["type"],
+    "ix_billing_entry_end_timestamp": ["end_timestamp"],
+}
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        for index_name in INDEXES:
+            op.drop_index(
+                index_name,
+                table_name="billing_entry",
+                if_exists=True,
+                postgresql_concurrently=True,
+            )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        for index_name, columns in INDEXES.items():
+            op.drop_index(
+                index_name,
+                table_name="billing_entry",
+                if_exists=True,
+                postgresql_concurrently=True,
+            )
+            op.create_index(
+                index_name,
+                "billing_entry",
+                columns,
+                unique=False,
+                postgresql_concurrently=True,
+            )

--- a/server/polar/models/billing_entry.py
+++ b/server/polar/models/billing_entry.py
@@ -50,10 +50,13 @@ class BillingEntry(RecordModel):
         TIMESTAMP(timezone=True), nullable=False, index=True
     )
     end_timestamp: Mapped[datetime] = mapped_column(
-        TIMESTAMP(timezone=True), nullable=False, index=True
+        TIMESTAMP(timezone=True), nullable=False
     )
     type: Mapped[BillingEntryType] = mapped_column(
-        StringEnum(BillingEntryType), nullable=False, index=True
+        StringEnum(BillingEntryType), nullable=False
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=True, default=None
     )
     direction: Mapped[BillingEntryDirection] = mapped_column(
         StringEnum(BillingEntryDirection), nullable=False
@@ -78,7 +81,6 @@ class BillingEntry(RecordModel):
         Uuid,
         ForeignKey("subscriptions.id", ondelete="cascade"),
         nullable=True,
-        index=True,
     )
     discount_id: Mapped[UUID | None] = mapped_column(
         Uuid, ForeignKey("discounts.id", ondelete="restrict"), nullable=True


### PR DESCRIPTION
Hopefully this will speed up updates on the billing_entry table

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove four unused indexes on the `billing_entry` table to cut write overhead and speed up updates. Aligns the SQLAlchemy model so these indexes aren’t recreated.

- **Migration**
  - Drops `ix_billing_entry_deleted_at`, `ix_billing_entry_subscription_id`, `ix_billing_entry_type`, `ix_billing_entry_end_timestamp` concurrently.
  - Removes `index=True` on `subscription_id`, `type`, and `end_timestamp` in the model to prevent re-adding.
  - Maps `deleted_at` on the model without an index.
  - No data changes; concurrent drops avoid write locks.

<sup>Written for commit 09dccbf55e25532a1c269244fa76799163c4c2f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

