### PR TITLE
order: increase timeout for order.create_subscription_order

### DIFF
--- a/server/polar/order/tasks.py
+++ b/server/polar/order/tasks.py
@@ -72,7 +72,11 @@ async def order_created(order_id: uuid.UUID) -> None:
             raise OrderDoesNotExist(order_id)
 
 
-@actor(actor_name="order.create_subscription_order", priority=TaskPriority.LOW)
+@actor(
+    actor_name="order.create_subscription_order",
+    priority=TaskPriority.LOW,
+    time_limit=1_800_000,  # 30 min: linking large billing entry backlogs exceeds the 60s default
+)
 async def create_subscription_order(
     subscription_id: uuid.UUID,
     order_reason: OrderBillingReasonInternal,


### PR DESCRIPTION
Since the linking of billing entries, when there are a lot of them, takes a long time we need to increase the task timeout.

This isn't an ideal solution, but it is a stop gap to help us process the few tasks that are hitting the limit currently.

We need to rethink how we handle a large number of billing entries within a single billing period.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

