### PR TITLE
update company page

### DIFF
--- a/clients/apps/web/src/app/(main)/(website)/(landing)/company/HowWeWork.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/company/HowWeWork.tsx
@@ -1,0 +1,72 @@
+import { SectionHeader } from '@/components/Landing/SectionHeader'
+import { Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+
+const PRINCIPLES = [
+  {
+    title: 'Own the outcome',
+    description: 'Take problems end to end with high ownership and autonomy.',
+  },
+  {
+    title: 'Build in the open',
+    description:
+      'Polar is open source. We build in public, with our community.',
+  },
+  {
+    title: 'Obsess over developers',
+    description: 'Great developer experience is the product.',
+  },
+  {
+    title: 'Keep the team small',
+    description: 'Fewer people with more ownership. Wear multiple hats.',
+  },
+  {
+    title: 'Design by subtraction',
+    description: "Say no often. Clarity comes from what's removed.",
+  },
+]
+
+export const HowWeWork = () => (
+  <Box as="section" flexDirection="column" rowGap="5xl">
+    <SectionHeader
+      title={
+        <>
+          Fewer people,
+          <br />
+          more ownership
+        </>
+      }
+      description="Our mission is to build the finance layer for the next generation of AI products. To get there, we work by a small set of principles that keep us fast and focused."
+    />
+    <Box as="ul" flexDirection="column">
+      {PRINCIPLES.map((principle, index) => (
+        <Box
+          key={principle.title}
+          as="li"
+          display="flex"
+          flexDirection={{ base: 'column', md: 'row' }}
+          rowGap="xs"
+          columnGap="4xl"
+          paddingVertical="xl"
+          borderTopWidth={index > 0 ? 1 : 0}
+          borderStyle="solid"
+          borderColor="border-primary"
+        >
+          <Box flex={1} alignItems="baseline" columnGap="l">
+            <Text as="span" variant="heading-xxs" color="muted">
+              {String(index + 1).padStart(2, '0')}
+            </Text>
+            <Text variant="heading-xxs" as="h3">
+              {principle.title}
+            </Text>
+          </Box>
+          <Box flex={1}>
+            <Text variant="heading-xxs" color="muted">
+              {principle.description}
+            </Text>
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  </Box>
+)

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/company/TeamCarousel.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/company/TeamCarousel.tsx
@@ -23,7 +23,7 @@ export function TeamCarousel() {
   return (
     <section className="w-full overflow-hidden">
       <div
-        className="flex w-max gap-2"
+        className="flex w-max gap-4"
         style={{ animation: 'marquee 230s linear infinite' }}
       >
         {order.map((n, i) => (

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/company/investors.ts
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/company/investors.ts
@@ -10,7 +10,7 @@ export const investors = [
   { name: 'Thomas Paul Mann', company: 'Raycast' },
   { name: 'Jorn van Dijk & Koen Bok', company: 'Framer' },
   { name: 'Harley Finkelstein', company: 'Shopify' },
-  { name: 'Jared Palmer', company: 'GitHub & Microsoft' },
+  { name: 'Jared Palmer', company: 'Cognition' },
   { name: 'Zeno Rocha', company: 'Resend' },
   { name: 'Steven Tey', company: 'Dub' },
   { name: 'Sébastien & Alexandre Chopin', company: 'Nuxt' },

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/company/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/company/page.tsx
@@ -136,7 +136,7 @@ export default function CompanyPage() {
               <Box backgroundColor="background-secondary">
                 <TextRings />
               </Box>
-              <Box position="relative" overflow="hidden">
+              <Box position="relative" overflow="hidden" aspectRatio="1 / 1">
                 <StaticImage
                   src="/assets/brand/marketing/billboard_01.jpg"
                   alt="Polar billboard reading 'Your customers 10x'd their usage overnight. Polar already invoiced for it.'"

--- a/clients/apps/web/src/app/(main)/(website)/(landing)/company/page.tsx
+++ b/clients/apps/web/src/app/(main)/(website)/(landing)/company/page.tsx
@@ -1,7 +1,14 @@
+import { StaticImage } from '@/components/Image/StaticImage'
+import { Section } from '@/components/Landing/Section'
+import { SectionHeader } from '@/components/Landing/SectionHeader'
 import ArrowOutwardOutlined from '@mui/icons-material/ArrowOutwardOutlined'
+import { Button, Grid, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
 import Link from 'next/link'
+import { HowWeWork } from './HowWeWork'
 import { investors } from './investors'
 import { TeamCarouselWrapper } from './TeamCarouselWrapper'
+import { TextRings } from '@/components/Landing/graphics/TextRings'
 
 // ── Data ──────────────────────────────────────────────────────────────────────
 
@@ -29,121 +36,208 @@ const JOBS = [
 
 export default function CompanyPage() {
   return (
-    <div className="dark:bg-polar-950 min-h-screen bg-white text-gray-900 dark:text-white">
+    <Box
+      flexDirection="column"
+      minHeight="100vh"
+      backgroundColor="background-primary"
+      color="text-primary"
+    >
       {/* Hero */}
-      <section className="flex flex-col items-center gap-8 pt-12 pb-24 text-center md:px-4">
-        <h1 className="font-display leading-tighter max-w-2xl text-5xl font-medium text-balance md:text-7xl">
-          Small team, big ambitions.
-        </h1>
-        <p className="max-w-xl text-lg text-balance">
-          We&apos;re building the billing layer for the next generation of AI
-          products. Come build it with us.
-        </p>
-        <a
-          href="#open-roles"
-          className="mt-2 inline-flex items-center rounded-full bg-gray-900 px-6 py-3 text-sm font-semibold text-white transition-opacity hover:opacity-80 dark:bg-white dark:text-gray-900"
-        >
-          Join Us
-        </a>
-      </section>
+      <Box
+        as="section"
+        flexDirection="column"
+        alignItems="center"
+        rowGap="2xl"
+        paddingTop="3xl"
+        paddingBottom="5xl"
+        paddingHorizontal={{ md: 'l' }}
+        textAlign="center"
+      >
+        <Box display="block" maxWidth="42rem">
+          <Text variant="heading-xl" as="h1">
+            Small team, big ambitions.
+          </Text>
+        </Box>
+        <Box display="block" maxWidth="36rem">
+          <Text variant="heading-xxs" wrap="balance">
+            We&apos;re building the billing layer for the next generation of AI
+            products. Come build it with us.
+          </Text>
+        </Box>
+        <Box display="block" marginTop="s">
+          <a href="#open-roles">
+            <Button size="lg">Join Us</Button>
+          </a>
+        </Box>
+      </Box>
 
       <TeamCarouselWrapper />
 
       {/* About */}
-      <section className="mx-auto flex w-full max-w-xl flex-col gap-8 py-24 md:px-6">
-        <h2 className="font-display text-2xl font-medium md:text-4xl">
-          billing = fn(events)
-        </h2>
-        <div className="flex flex-col gap-4 text-lg leading-relaxed">
-          <p>
-            Modern software is priced around usage. Yet billing systems remain
-            static.
-          </p>
-          <p>
-            We believe analytics & billing belong in the same platform —
-            real-time event ingestion powering instant unit economics and
-            analytics, leading to deterministic and versioned billing as code.
-          </p>
-          <p>
-            We&apos;re building Polar to become the standard Events → Analytics
-            → Billing stack for the next generation of software.
-          </p>
-          <p>
-            We&apos;re a small team with big ambitions, working with high
-            ownership and autonomy. Polar is open source and built in the open
-            with our community.
-          </p>
-        </div>
-      </section>
+      <Section>
+        <Box display="block" paddingVertical="5xl">
+          <SectionHeader
+            align="start"
+            title="billing = fn(events)"
+            description={
+              <Box flexDirection="column" rowGap="xl">
+                <Text variant="heading-xs">
+                  Modern software is priced around usage. Yet billing systems
+                  remain static.
+                </Text>
+                <Text variant="heading-xxs" color="muted">
+                  We believe analytics & billing belong in the same platform.
+                  Real-time event ingestion powers instant unit economics and
+                  analytics, leading to deterministic and versioned billing as
+                  code.
+                </Text>
+                <Text variant="heading-xxs" color="muted">
+                  We&apos;re building Polar to become the standard Events →
+                  Analytics → Billing stack for the next generation of software.
+                </Text>
+                <Text variant="heading-xxs" color="muted">
+                  We&apos;re a small team with big ambitions, working with high
+                  ownership and autonomy. Polar is open source and built in the
+                  open with our community.
+                </Text>
+              </Box>
+            }
+          />
+        </Box>
+      </Section>
+
+      <Section>
+        <HowWeWork />
+      </Section>
+
+      {/* Design */}
+      <Section>
+        <Box flexDirection="column" rowGap="4xl">
+          <SectionHeader
+            title="We take design as seriously as uptime"
+            description={
+              <Box flexDirection="column" alignItems="start" rowGap="2xl">
+                <Text variant="heading-xs" color="muted" wrap="pretty">
+                  Design at Polar spans the entire stack. Great developer
+                  ergonomics, docs that respect your time, dashboards that make
+                  usage billing legible & checkouts your customers trust.
+                </Text>
+                <Link href="/brand">
+                  <Button size="lg">Explore the brand</Button>
+                </Link>
+              </Box>
+            }
+          />
+          <Link href="/brand">
+            <Grid
+              templateColumns={{ base: '1fr', md: 'repeat(2, 1fr)' }}
+              gap="4xl"
+            >
+              <Box backgroundColor="background-secondary">
+                <TextRings />
+              </Box>
+              <Box position="relative" overflow="hidden">
+                <StaticImage
+                  src="/assets/brand/marketing/billboard_01.jpg"
+                  alt="Polar billboard reading 'Your customers 10x'd their usage overnight. Polar already invoiced for it.'"
+                  fill
+                  className="object-cover"
+                  sizes="(min-width: 768px) 40rem, 100vw"
+                />
+              </Box>
+            </Grid>
+          </Link>
+        </Box>
+      </Section>
 
       {/* Open roles */}
-      <section id="open-roles">
-        <div className="mx-auto max-w-xl py-16 md:px-6">
-          <h2 className="font-display mb-16 text-3xl font-medium">
-            Open Roles
-          </h2>
-          <div className="flex flex-col gap-16">
+      <Section id="open-roles">
+        <Box flexDirection="column" rowGap="4xl">
+          <SectionHeader
+            title="Open Roles"
+            description="We're a small, senior team working remotely across the world. High ownership, high pace and a direct line to the people using what you build."
+          />
+          <Box flexDirection="column" rowGap="5xl">
             {JOBS.map(({ category, roles }) => (
-              <div key={category} className="flex flex-col gap-4">
-                <h3 className="text-lg">{category}</h3>
-                <div className="flex flex-col">
+              <Box key={category} flexDirection="column" rowGap="xl">
+                <Text variant="heading-xxs" as="h3">
+                  {category}
+                </Text>
+                <Box flexDirection="column">
                   {roles.map((job) => (
                     <Link
                       key={job.link}
                       href={job.link}
                       target="_blank"
-                      className="dark:border-polar-800 group flex flex-row items-baseline justify-between gap-4 border-t border-gray-100 py-6"
+                      className="group"
                     >
-                      <div className="flex flex-1 flex-col gap-1">
-                        <span className="font-medium group-hover:underline">
-                          {job.role}
-                        </span>
-                        <div className="dark:text-polar-500 flex flex-row gap-x-2 text-gray-500">
-                          {job.experience && (
-                            <>
-                              <span>{job.experience}</span>
-                              <span>·</span>
-                            </>
-                          )}
-                          <span>{job.location}</span>
-                        </div>
-                      </div>
-                      <div className="flex gap-2">
+                      <Box
+                        alignItems="baseline"
+                        justifyContent="between"
+                        columnGap="l"
+                        paddingVertical="xl"
+                        borderTopWidth={1}
+                        borderStyle="solid"
+                        borderColor="border-primary"
+                      >
+                        <Box flexDirection="column" rowGap="xs" flex={1}>
+                          <Text variant="body" as="span">
+                            <span className="group-hover:underline">
+                              {job.role}
+                            </span>
+                          </Text>
+                          <Box columnGap="s">
+                            {job.experience && (
+                              <>
+                                <Text as="span" color="muted" variant="body">
+                                  {job.experience}
+                                </Text>
+                                <Text as="span" color="muted" variant="body">
+                                  ·
+                                </Text>
+                              </>
+                            )}
+                            <Text as="span" color="muted" variant="body">
+                              {job.location}
+                            </Text>
+                          </Box>
+                        </Box>
                         <ArrowOutwardOutlined fontSize="inherit" />
-                      </div>
+                      </Box>
                     </Link>
                   ))}
-                </div>
-              </div>
+                </Box>
+              </Box>
             ))}
-          </div>
-        </div>
-      </section>
+          </Box>
+        </Box>
+      </Section>
 
       {/* Investors */}
-      <section>
-        <div className="mx-auto max-w-xl py-16 md:px-6">
-          <div className="mb-12 flex flex-col gap-3">
-            <h2 className="font-display text-3xl font-medium">
-              Investors, Angels & Advisors
-            </h2>
-            <p className="text-lg">
-              The incredible people and early stage firms who have had our back
-              through thick and thin — supporting us from Day 1.
-            </p>
-          </div>
-          <div className="grid grid-cols-2 gap-6">
+      <Section>
+        <Box flexDirection="column" rowGap="4xl">
+          <SectionHeader
+            title="Investors, Angels & Advisors"
+            description="The incredible people and early stage firms who have had our back through thick and thin, supporting us from Day 1."
+          />
+          <Grid
+            templateColumns={{ base: 'repeat(2, 1fr)', md: 'repeat(4, 1fr)' }}
+            columnGap="4xl"
+            rowGap="xl"
+          >
             {investors.map((investor) => (
-              <div key={investor.name} className="flex flex-col gap-0.5">
-                <span className="font-medium">{investor.name}</span>
-                <span className="dark:text-polar-500 text-gray-500">
+              <Box key={investor.name} flexDirection="column">
+                <Text variant="body" as="span">
+                  {investor.name}
+                </Text>
+                <Text variant="body" as="span" color="muted">
                   {investor.company}
-                </span>
-              </div>
+                </Text>
+              </Box>
             ))}
-          </div>
-        </div>
-      </section>
-    </div>
+          </Grid>
+        </Box>
+      </Section>
+    </Box>
   )
 }

--- a/clients/apps/web/src/components/Landing/Hero/Hero.tsx
+++ b/clients/apps/web/src/components/Landing/Hero/Hero.tsx
@@ -29,7 +29,7 @@ export const Hero = () => {
       whileInView="visible"
       viewport={{ once: true }}
     >
-      <Box maxWidth="64rem">
+      <Box>
         <Text variant="heading-2xl">
           Finance layer for software that thinks
         </Text>

--- a/clients/apps/web/src/components/Landing/SectionHeader.tsx
+++ b/clients/apps/web/src/components/Landing/SectionHeader.tsx
@@ -5,19 +5,22 @@ import type { ReactNode } from 'react'
 interface SectionHeaderProps {
   title: ReactNode
   description: ReactNode
+  align?: 'start' | 'center'
 }
 
 /**
  * The shared landing-section header: title on the left, supporting
  * description on the right. The two halves share the row equally and sit
- * vertically centered, stacking to a single column below `xl`. The title's
- * text width is capped so it wraps to roughly two lines, keeping its
- * vertical weight in balance with the description.
+ * vertically centered (pass `align="start"` to top-align, e.g. next to a
+ * multi-paragraph description), stacking to a single column below `xl`. The
+ * title's text width is capped so it wraps to roughly two lines, keeping its
+ * vertical weight in balance with the description. A string description gets
+ * the standard muted styling; pass a node to fully control the right column.
  */
 export const SectionHeader = ({ title, description }: SectionHeaderProps) => (
   <Box
     flexDirection={{ base: 'column', xl: 'row' }}
-    alignItems={{ base: 'start', xl: 'center' }}
+    alignItems="start"
     rowGap="l"
     columnGap="4xl"
   >
@@ -29,9 +32,13 @@ export const SectionHeader = ({ title, description }: SectionHeaderProps) => (
       </Box>
     </Box>
     <Box display="block" flex={1}>
-      <Text variant="heading-xs" color="muted" wrap="pretty">
-        {description}
-      </Text>
+      {typeof description === 'string' ? (
+        <Text variant="heading-xs" color="muted" wrap="pretty">
+          {description}
+        </Text>
+      ) : (
+        description
+      )}
     </Box>
   </Box>
 )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Rebuilt the Company page with new content and a cleaner layout, including a “How we work” section, design showcase, improved Open Roles, and a refreshed Investors list. Also added small UI tweaks to `SectionHeader`, the hero, and carousel spacing, and fixed the brand billboard image asset.

- **New Features**
  - Added “How we work” section with five core principles.
  - Added design/brand showcase with `TextRings` and billboard imagery, plus a link to /brand.
  - Updated Investors section layout and copy; set Jared Palmer’s company to “Cognition”.

- **Refactors**
  - Rewrote the page using `Section`, `SectionHeader`, `Box`, and `Grid` for consistent layout and spacing; refined Open Roles copy and item styling.
  - Made `SectionHeader` accept string or custom node descriptions with sensible defaults.
  - Increased `TeamCarousel` gap to `gap-4`, removed max-width from landing `Hero` heading, and fixed the billboard image asset path.

<sup>Written for commit 579262f2d1dbe31e58c18567b4556191cff904d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

