### PR TITLE
discount: Handle concurrent discount code creation

### DIFF
--- a/server/polar/discount/service.py
+++ b/server/polar/discount/service.py
@@ -5,7 +5,7 @@ from typing import Any, Literal
 
 import structlog
 from sqlalchemy import Select, UnaryExpression, asc, delete, desc, func, or_, select
-from sqlalchemy.exc import DBAPIError
+from sqlalchemy.exc import DBAPIError, IntegrityError
 
 from polar.auth.models import AuthSubject, is_organization, is_user
 from polar.auth.permission import OrganizationPermission
@@ -130,22 +130,9 @@ class DiscountService(ResourceServiceReader[Discount]):
         repository = DiscountRepository.from_session(session)
 
         if discount_create.code is not None:
-            existing_discount = (
-                await repository.get_by_code_and_organization_for_update(
-                    discount_create.code, organization.id
-                )
+            await self._assert_code_available(
+                repository, discount_create.code, organization.id
             )
-            if existing_discount is not None:
-                raise PolarRequestValidationError(
-                    [
-                        {
-                            "type": "value_error",
-                            "loc": ("body", "code"),
-                            "msg": "Discount with this code already exists.",
-                            "input": discount_create.code,
-                        }
-                    ]
-                )
 
         discount_products: list[DiscountProduct] = []
         if discount_create.products:
@@ -190,11 +177,38 @@ class DiscountService(ResourceServiceReader[Discount]):
             discount_redemptions=[],
             redemptions_count=0,
         )
-        discount = await repository.create(discount, flush=True)
+        nested = await session.begin_nested()
+        try:
+            discount = await repository.create(discount, flush=True)
+        except IntegrityError:
+            await nested.rollback()
+            if discount_create.code is not None:
+                await self._assert_code_available(
+                    repository, discount_create.code, organization.id
+                )
+            raise
 
         await self._send_webhook(session, discount, WebhookEventType.discount_created)
 
         return discount
+
+    async def _assert_code_available(
+        self, repository: DiscountRepository, code: str, organization_id: uuid.UUID
+    ) -> None:
+        existing_discount = await repository.get_by_code_and_organization_for_update(
+            code, organization_id
+        )
+        if existing_discount is not None:
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("body", "code"),
+                        "msg": "Discount with this code already exists.",
+                        "input": code,
+                    }
+                ]
+            )
 
     async def update(
         self,

--- a/server/tests/discount/test_service.py
+++ b/server/tests/discount/test_service.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from pytest_mock import MockerFixture
-from sqlalchemy.exc import DBAPIError
+from sqlalchemy.exc import DBAPIError, IntegrityError
 
 from polar.auth.models import AuthSubject, User
 from polar.checkout.schemas import CheckoutUpdatePublic
@@ -115,6 +115,83 @@ class TestCreate:
         webhook_service_send_mock.assert_called_once_with(
             session, organization, WebhookEventType.discount_created, discount
         )
+
+    @pytest.mark.auth
+    async def test_concurrent_duplicate_code(
+        self,
+        mocker: MockerFixture,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        existing_discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            code="RACE",
+        )
+        mocker.patch.object(
+            DiscountRepository,
+            "get_by_code_and_organization_for_update",
+            side_effect=[None, existing_discount],
+        )
+
+        with pytest.raises(PolarRequestValidationError):
+            await discount_service.create(
+                session,
+                DiscountFixedCreate(
+                    duration=DiscountDuration.once,
+                    type=DiscountType.fixed,
+                    amount=1000,
+                    currency=PresentmentCurrency.usd,
+                    name="Discount",
+                    code="RACE",
+                    starts_at=None,
+                    ends_at=None,
+                    max_redemptions=None,
+                    products=None,
+                    organization_id=organization.id,
+                ),
+                auth_subject,
+            )
+
+    @pytest.mark.auth
+    async def test_unrelated_integrity_error(
+        self,
+        mocker: MockerFixture,
+        auth_subject: AuthSubject[User],
+        session: AsyncSession,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        mocker.patch.object(
+            DiscountRepository,
+            "create",
+            side_effect=IntegrityError("INSERT", None, Exception("violation")),
+        )
+
+        with pytest.raises(IntegrityError):
+            await discount_service.create(
+                session,
+                DiscountFixedCreate(
+                    duration=DiscountDuration.once,
+                    type=DiscountType.fixed,
+                    amount=1000,
+                    currency=PresentmentCurrency.usd,
+                    name="Discount",
+                    code="NEW",
+                    starts_at=None,
+                    ends_at=None,
+                    max_redemptions=None,
+                    products=None,
+                    organization_id=organization.id,
+                ),
+                auth_subject,
+            )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a race condition in discount creation so concurrent requests can’t create the same code. Users now get a clear validation error when a code is already taken.

- **Bug Fixes**
  - Added `_assert_code_available` using `get_by_code_and_organization_for_update` to lock and validate code uniqueness.
  - Wrapped create in a nested transaction; on `IntegrityError`, re-check code and raise a validation error for duplicates, otherwise re-raise.
  - Added tests for concurrent duplicate codes and unrelated integrity errors.

<sup>Written for commit aee4c9f10eb270e6710f344946fbac5e6524c069. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

