### PR TITLE
perf: filter static billing entries before the events join

### DIFF
--- a/server/polar/billing_entry/repository.py
+++ b/server/polar/billing_entry/repository.py
@@ -72,7 +72,15 @@ class BillingEntryRepository(
         statement = (
             self.get_pending_by_subscription_statement(subscription_id, cutoff=cutoff)
             .join(BillingEntry.product_price)
-            .where(ProductPrice.is_static.is_(True))
+            # Metered entries always carry a metered price: `from_metered_event`
+            # is the only writer of this type, and it takes the price from a
+            # meter-scoped lookup. So this predicate selects the same rows as
+            # `is_static` alone, but lets the `billing_entry` scan drop them
+            # before the join to `events` rather than after it.
+            .where(
+                BillingEntry.type != BillingEntryType.metered,
+                ProductPrice.is_static.is_(True),
+            )
             .options(
                 contains_eager(BillingEntry.product_price),
                 joinedload(BillingEntry.event),


### PR DESCRIPTION
## Summary

`get_static_pending_by_subscription` timed out on subscriptions with a large backlog of pending billing entries. It now returns in about 360ms instead of over 30 seconds.

## Why

The query filtered on `ProductPrice.is_static`, a column on the joined `product_prices` table. Postgres could only apply it *after* joining `events`, a very large table. So the query read every pending entry, probed `events` for each one, sorted the result, then discarded all but one row.

The planner expects that filter to match a large share of rows. In practice it matches a handful.

This is one reason the `order.create_subscription_order` task hit its 60 second limit and retried forever.

## How

Add `BillingEntry.type != metered` next to the existing filter. That column is on `billing_entry` itself, so the scan drops metered rows before the join.

The new predicate cannot change which rows come back:

- `type = metered` is only ever written by `BillingEntry.from_metered_event`, and that takes its price from a meter-scoped lookup. A metered entry therefore always has a metered price.
- A check against production data found no row with `type = metered` on a non-metered price.
- The original `is_static` filter is kept, so the result can only narrow, never widen.

Measured on the production read replica: rows reaching the `events` join went from every pending entry down to 1, and the query from over 30s (timeout) to ~360ms. An inner join on `events` was also tested as an alternative, and does not change the plan.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

Existing tests cover this path. No new tests were added, since behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)