### PR TITLE
tailscale: Allow Render node to be exit node

### DIFF
--- a/infra/tailscale/run-tailscale.sh
+++ b/infra/tailscale/run-tailscale.sh
@@ -4,7 +4,11 @@
 PID=$!
 
 ADVERTISE_ROUTES=${ADVERTISE_ROUTES:-10.208.0.0/16}
-until /render/tailscale up --authkey="${TAILSCALE_AUTHKEY}?ephemeral=true&preauthorized=true" --hostname="${RENDER_SERVICE_NAME}" --advertise-routes="$ADVERTISE_ROUTES" --advertise-tags="tag:render"; do
+EXIT_NODE_FLAG=""
+if [ "${ADVERTISE_EXIT_NODE}" = "true" ]; then
+  EXIT_NODE_FLAG="--advertise-exit-node"
+fi
+until /render/tailscale up --authkey="${TAILSCALE_AUTHKEY}?ephemeral=true&preauthorized=true" --hostname="${RENDER_SERVICE_NAME}" --advertise-routes="$ADVERTISE_ROUTES" --advertise-tags="tag:render" $EXIT_NODE_FLAG; do
   sleep 0.1
 done
 export ALL_PROXY=socks5://localhost:1055/

--- a/terraform/modules/tailscale_router/main.tf
+++ b/terraform/modules/tailscale_router/main.tf
@@ -16,6 +16,7 @@ resource "render_background_worker" "tailscale_router" {
   env_vars = {
     TAILSCALE_AUTHKEY   = { value = var.tailscale_authkey }
     ADVERTISE_ROUTES    = { value = var.advertise_routes }
+    ADVERTISE_EXIT_NODE = { value = var.advertise_exit_node ? "true" : "false" }
     TAILSCALE_VERSION   = { value = var.tailscale_version }
     RENDER_SERVICE_NAME = { value = "tailscale-router-${var.environment}" }
   }

--- a/terraform/modules/tailscale_router/variables.tf
+++ b/terraform/modules/tailscale_router/variables.tf
@@ -42,6 +42,12 @@ variable "advertise_routes" {
   type        = string
 }
 
+variable "advertise_exit_node" {
+  description = "Advertise this router as a Tailscale exit node"
+  type        = bool
+  default     = false
+}
+
 variable "tailscale_version" {
   description = "Tailscale version to install"
   type        = string

--- a/terraform/production/render.tf
+++ b/terraform/production/render.tf
@@ -507,6 +507,7 @@ module "tailscale_router" {
   registry_credential_id = render_registry_credential.ghcr.id
   tailscale_authkey      = var.tailscale_authkey
   advertise_routes       = var.tailscale_advertise_routes
+  advertise_exit_node    = true
 
   depends_on = [render_registry_credential.ghcr, render_project.polar]
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a toggle to advertise the Render Tailscale router as an exit node, and enables it in production. This lets devices route internet traffic through the Render node when selected as an exit node.

- **New Features**
  - `run-tailscale.sh` supports `ADVERTISE_EXIT_NODE=true`, passing `--advertise-exit-node` to `/render/tailscale up`.
  - Terraform: new `advertise_exit_node` variable (default `false`) wired to `ADVERTISE_EXIT_NODE`; set to `true` in `production`.

<sup>Written for commit e1940b64a39c93c33b36521b15cf1d0c308d2802. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

