### PR TITLE
adjust hero

### DIFF
--- a/clients/apps/web/src/components/Landing/Hero/Hero.tsx
+++ b/clients/apps/web/src/components/Landing/Hero/Hero.tsx
@@ -23,25 +23,26 @@ const itemVariants = {
 export const Hero = () => {
   return (
     <motion.div
-      className="relative mx-auto flex max-w-7xl flex-col items-center justify-center gap-8 px-4 pt-8 text-center md:pt-12"
+      className="relative mx-auto flex max-w-7xl flex-col items-center justify-center gap-8 px-4 py-8 text-center md:py-12"
       variants={containerVariants}
       initial="hidden"
       whileInView="visible"
       viewport={{ once: true }}
     >
-      <Box>
-        <Text variant="heading-2xl">
-          Finance layer for software that thinks
+      <Box maxWidth="64rem">
+        <Text variant="heading-xl">
+          The finance layer for intelligent software
         </Text>
       </Box>
       <motion.p
-        className="dark:text-polar-500 max-w-2xl text-center text-2xl leading-relaxed! text-balance text-gray-500"
+        className="dark:text-polar-500 max-w-2xl text-center text-2xl leading-snug! text-balance text-gray-500"
         variants={itemVariants}
       >
-        The financial substrate for the intelligence era
+        A financial substrate for modern software, from first inference call to
+        net revenue.
       </motion.p>
       <motion.div
-        className="mt-6 flex flex-col items-center gap-4 md:flex-row md:gap-6"
+        className="mt-2 flex flex-col items-center gap-4 md:flex-row md:gap-6"
         variants={itemVariants}
       >
         <GetStartedButton size="lg" text="Get Started" />

--- a/clients/apps/web/src/components/Landing/Hero/Hero.tsx
+++ b/clients/apps/web/src/components/Landing/Hero/Hero.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import GetStartedButton from '@/components/Auth/GetStartedButton'
+import { PolarLogotype } from '@/components/Layout/Public/PolarLogotype'
 import { Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { motion } from 'motion/react'
@@ -29,7 +30,13 @@ export const Hero = () => {
       whileInView="visible"
       viewport={{ once: true }}
     >
-      <Box maxWidth="64rem">
+      <Box
+        maxWidth="64rem"
+        alignItems="center"
+        rowGap="3xl"
+        flexDirection="column"
+      >
+        <PolarLogotype size={60} />
         <Text variant="heading-xl">
           The finance layer for intelligent software
         </Text>

--- a/clients/apps/web/src/components/Landing/Logotypes.tsx
+++ b/clients/apps/web/src/components/Landing/Logotypes.tsx
@@ -4,7 +4,6 @@ import { JSX } from 'react'
 import {
   Confidence,
   FastAPICloud,
-  Midday,
   MiddayWordmark,
   // Goals,
   StillaAIWordmark,

--- a/clients/apps/web/src/components/Landing/Logotypes.tsx
+++ b/clients/apps/web/src/components/Landing/Logotypes.tsx
@@ -4,6 +4,8 @@ import { JSX } from 'react'
 import {
   Confidence,
   FastAPICloud,
+  Midday,
+  MiddayWordmark,
   // Goals,
   StillaAIWordmark,
   Tailwind,
@@ -33,6 +35,10 @@ const items = [
   {
     icon: <Confidence size={32} />,
     link: 'https://confidence.spotify.com',
+  },
+  {
+    icon: <MiddayWordmark size={32} />,
+    link: 'https://midday.ai',
   },
 ]
 

--- a/clients/apps/web/src/components/Landing/graphics/SteppedRadial.tsx
+++ b/clients/apps/web/src/components/Landing/graphics/SteppedRadial.tsx
@@ -5,38 +5,47 @@ import { useInView } from '@/hooks/useInView'
 
 /**
  * SteppedRadial — a ring of radial ticks whose angular spacing is fixed
- * in screen space: tight on the right, opening into a wide gap on the
- * far left. The ticks advance through that distribution one pitch at a
- * time, like a turning mechanism — each step snaps every tick into the
- * slot vacated by its neighbour, so every resting frame shows the same
- * dense-right / sparse-left pattern.
+ * in screen space: tight at the bottom, opening into a wide gap at the
+ * top. The ticks advance through that distribution one pitch at a
+ * time, like a turning mechanism — each step eases every tick into the
+ * slot vacated by its neighbour and flows straight into the next step,
+ * so the ring never rests while always cycling through the same
+ * sparse-top / dense-bottom pattern.
  */
 
 const SPOKE_COUNT = 14
 const INNER_R_FRAC = 0.1
 const OUTER_R_FRAC = 0.32
 
-// Widest gap (far left) is (1 + GAP_SPREAD)× the tightest gap (right)
-const GAP_SPREAD = 3
+// Widest gap is (1 + GAP_SPREAD)× the tightest gap (opposite side)
+const GAP_SPREAD = 8
+// Where the widest gap sits, in canvas angle (y is down): -π/2 is up
+const GAP_ANGLE = -Math.PI / 2
 const WARP_SAMPLES = 720
 
-const STEP_MOVE = 2 // seconds a single turn takes
-const STEP_DWELL = 1 // rest between turns
-const STEP_PERIOD = STEP_MOVE + STEP_DWELL
+const STEP_DURATION = 2 // seconds a single turn takes
+// Fraction of each step that is constant-speed drift. The bezier alone
+// has zero velocity at the step boundaries, which reads as a brief
+// stop; blending in linear motion keeps the ring creeping between
+// surges instead of halting.
+const DRIFT = 0.45
 
 // Cubic-bezier ease-in-out (same curve as CycleArrow) — each turn
-// accelerates out of rest and settles into the next position.
-const ease = (x: number): number =>
+// surges through its middle, then decays to a slow drift until the
+// next surge picks up, so the mechanism never fully stops.
+const bezier = (x: number): number =>
   x < 0.5 ? 4 * x * x * x : 1 - Math.pow(-2 * x + 2, 3) / 2
 
-// Cumulative tick density around the circle: high density (small gaps)
-// at angle 0 (right), low density at π (left). Maps a uniform parameter
-// u ∈ [0, 2π) to a warped screen angle via inverse lookup.
+const ease = (x: number): number => (1 - DRIFT) * bezier(x) + DRIFT * x
+
+// Cumulative tick density around the circle: low density (wide gaps)
+// around GAP_ANGLE, high density on the opposite side. Maps a uniform
+// parameter u ∈ [0, 2π) to a warped screen angle via inverse lookup.
 const buildWarpTable = () => {
   const cumulative = new Float64Array(WARP_SAMPLES + 1)
   for (let k = 1; k <= WARP_SAMPLES; k++) {
     const midAngle = ((k - 0.5) / WARP_SAMPLES) * Math.PI * 2
-    const gap = 1 + (GAP_SPREAD * (1 - Math.cos(midAngle))) / 2
+    const gap = 1 + (GAP_SPREAD * (1 + Math.cos(midAngle - GAP_ANGLE))) / 2
     cumulative[k] = cumulative[k - 1] + 1 / gap
   }
   const scale = (Math.PI * 2) / cumulative[WARP_SAMPLES]
@@ -90,6 +99,15 @@ export const SteppedRadial = () => {
     const cumulative = buildWarpTable()
     const pitch = (Math.PI * 2) / SPOKE_COUNT
 
+    // Phase the ticks so that at every step boundary — the slowest
+    // moment of the drift — one tick sits exactly at GAP_ANGLE,
+    // centered in the wide gap. Since the density warp is symmetric
+    // around GAP_ANGLE, that frame mirrors about the vertical axis.
+    const gapFrac =
+      (((GAP_ANGLE % (Math.PI * 2)) + Math.PI * 2) % (Math.PI * 2)) /
+      (Math.PI * 2)
+    const uGap = cumulative[Math.round(gapFrac * WARP_SAMPLES)]
+
     let lastTime: number | null = null
     let time = 0
 
@@ -98,9 +116,8 @@ export const SteppedRadial = () => {
       lastTime = now
       time += dt
 
-      const step = Math.floor(time / STEP_PERIOD)
-      const stepTime = time - step * STEP_PERIOD
-      const moveT = Math.min(1, stepTime / STEP_MOVE)
+      const step = Math.floor(time / STEP_DURATION)
+      const moveT = time / STEP_DURATION - step
       const offset = (step + ease(moveT)) * pitch
 
       ctx.clearRect(0, 0, size, size)
@@ -109,7 +126,8 @@ export const SteppedRadial = () => {
 
       for (let i = 0; i < SPOKE_COUNT; i++) {
         const u =
-          (((i * pitch + offset) % (Math.PI * 2)) + Math.PI * 2) % (Math.PI * 2)
+          (((i * pitch + offset + uGap) % (Math.PI * 2)) + Math.PI * 2) %
+          (Math.PI * 2)
         const angle = warpAngle(cumulative, u)
         const cos = Math.cos(angle)
         const sin = Math.sin(angle)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Polishes the landing hero and reworks the SteppedRadial animation for smoother, continuous motion with clearer visual balance. Adds Midday to the logo marquee.

- **Refactors**
  - Hero: new headline/subcopy, added `PolarLogotype`, reduced heading size, width cap, tighter vertical spacing.
  - SteppedRadial: widest gap moved to the top with higher spread; continuous 2s step blends bezier surge with linear drift; ticks phased so a spoke centers on the top gap; warp respects a configurable `GAP_ANGLE`.

<sup>Written for commit 438bbc2f7846ea4fe421dbe7942f78ad5d037dda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

