### PR TITLE
webhooks: Generate secrets spec compliantly

### DIFF
--- a/docs/integrate/webhooks/delivery.mdx
+++ b/docs/integrate/webhooks/delivery.mdx
@@ -102,11 +102,11 @@ easily validate signatures. Or you can follow their
 in case you want to roll your own.
 
 <Info>
-  **Note: Secret needs to be base64 encoded**
+  **Note: secrets created before 2026-08-05 need to be base64 encoded**
 
-One common gotcha with the specification is that the webhook secret is expected to be
-base64 encoded. You don't have to do this with our SDK as it takes care of the
-implementation details with better developer ergonomics.
+One common gotcha with the specification is that webhook secrets created before
+2026-08-05 are expected to be base64 encoded. You don't have to do this with our
+SDK as it takes care of the implementation details with better developer ergonomics.
 
 </Info>
 
@@ -216,6 +216,6 @@ A common cause is hosting providers like Vercel that redirect between `www` and 
 
 ### Invalid signature exceptions
 
-Rolling your own webhook validation logic? Make sure to base64 encode the secret
-you configured on Polar in your code before generating the signature to validate
-against.
+Rolling your own webhook validation logic? If your secret was created before
+2026-08-05, make sure to base64 encode the secret you configured on Polar in
+your code before generating the signature to validate against.

--- a/sdk/generator/python/template/polar/webhooks.py
+++ b/sdk/generator/python/template/polar/webhooks.py
@@ -10,6 +10,7 @@ import typing
 from polar.base import PolarError
 
 _WEBHOOK_TOLERANCE_SECONDS = 5 * 60
+_WEBHOOK_SECRET_PREFIX = "whsec_"
 _PayloadT = typing.TypeVar("_PayloadT")
 
 
@@ -87,9 +88,10 @@ def _verify_signature(body: str, headers: dict[str, str], secret: str) -> None:
         raise PolarWebhookVerificationError("Message timestamp too new")
 
     signed_content = f"{webhook_id}.{math.floor(timestamp)}.{body}".encode()
-    expected_signature = hmac.new(
-        secret.encode(), signed_content, hashlib.sha256
-    ).digest()
+    expected_signatures = [
+        hmac.new(key, signed_content, hashlib.sha256).digest()
+        for key in _signing_keys(secret)
+    ]
 
     for versioned_signature in webhook_signature.split():
         version, separator, signature = versioned_signature.partition(",")
@@ -99,7 +101,25 @@ def _verify_signature(body: str, headers: dict[str, str], secret: str) -> None:
             decoded_signature = base64.b64decode(signature, validate=True)
         except (binascii.Error, ValueError):
             continue
-        if hmac.compare_digest(expected_signature, decoded_signature):
+        if any(
+            hmac.compare_digest(expected_signature, decoded_signature)
+            for expected_signature in expected_signatures
+        ):
             return
 
     raise PolarWebhookVerificationError("No matching signature found")
+
+
+def _signing_keys(secret: str) -> list[bytes]:
+    keys = [secret.encode()]
+    if secret.startswith(_WEBHOOK_SECRET_PREFIX):
+        try:
+            keys.insert(
+                0,
+                base64.b64decode(
+                    secret[len(_WEBHOOK_SECRET_PREFIX) :], validate=True
+                ),
+            )
+        except binascii.Error:
+            pass
+    return keys

--- a/sdk/generator/python/template/tests/test_webhooks.py
+++ b/sdk/generator/python/template/tests/test_webhooks.py
@@ -59,6 +59,40 @@ def test_validate_event(as_bytes: bool) -> None:
     )
 
 
+def test_validate_event_standard_webhooks_secret() -> None:
+    standard_secret = "whsec_" + base64.b64encode(b"k" * 32).decode()
+    body = json.dumps({"type": _EVENT_TYPE, "value": "payload"})
+    timestamp = datetime.datetime.now(tz=datetime.UTC)
+    headers = {
+        "Webhook-Id": "test-webhook",
+        "Webhook-Timestamp": str(int(timestamp.timestamp())),
+        "Webhook-Signature": Webhook(standard_secret).sign(
+            "test-webhook", timestamp, body
+        ),
+    }
+
+    assert _validate_event(body, headers, standard_secret) == DummyPayload(
+        type=_EVENT_TYPE, value="payload"
+    )
+
+
+def test_validate_event_legacy_prefixed_secret() -> None:
+    legacy_secret = "whsec_" + "a" * 43
+    body = json.dumps({"type": _EVENT_TYPE, "value": "payload"})
+    timestamp = datetime.datetime.now(tz=datetime.UTC)
+    headers = {
+        "Webhook-Id": "test-webhook",
+        "Webhook-Timestamp": str(int(timestamp.timestamp())),
+        "Webhook-Signature": Webhook(
+            base64.b64encode(legacy_secret.encode()).decode()
+        ).sign("test-webhook", timestamp, body),
+    }
+
+    assert _validate_event(body, headers, legacy_secret) == DummyPayload(
+        type=_EVENT_TYPE, value="payload"
+    )
+
+
 def test_validate_event_rejects_invalid_signature() -> None:
     body = json.dumps({"type": _EVENT_TYPE, "value": "payload"})
 

--- a/sdk/generator/typescript/template/src/webhooks.test.ts
+++ b/sdk/generator/typescript/template/src/webhooks.test.ts
@@ -1,5 +1,4 @@
 import { Buffer } from "node:buffer";
-
 import { Webhook } from "standardwebhooks";
 import { describe, expect, test } from "vitest";
 
@@ -20,15 +19,8 @@ const secret = "test-secret";
 const base64Secret = Buffer.from(secret, "utf8").toString("base64");
 const eventTypes = new Set(["dummy.event"]);
 
-const getHeaders = (
-  body: string,
-  timestamp: Date = new Date(),
-): Record<string, string> => {
-  const signature = new Webhook(base64Secret).sign(
-    "test-webhook",
-    timestamp,
-    body,
-  );
+const getHeaders = (body: string, timestamp: Date = new Date()): Record<string, string> => {
+  const signature = new Webhook(base64Secret).sign("test-webhook", timestamp, body);
   return {
     "Webhook-Id": "test-webhook",
     "Webhook-Timestamp": String(Math.floor(timestamp.getTime() / 1000)),
@@ -51,12 +43,45 @@ describe("validateWebhook", () => {
   ])("validates a known event from a %s", async (_type, getRawBody) => {
     const body = JSON.stringify({ type: "dummy.event", value: "payload" });
 
-    await expect(
-      validateEvent(getRawBody(body), getHeaders(body)),
-    ).resolves.toEqual({
+    await expect(validateEvent(getRawBody(body), getHeaders(body))).resolves.toEqual({
       type: "dummy.event",
       value: "payload",
     });
+  });
+
+  test("validates a Standard Webhooks encoded secret", async () => {
+    const keyMaterial = Buffer.alloc(32, "k").toString("base64");
+    const standardSecret = `whsec_${keyMaterial}`;
+    const body = JSON.stringify({ type: "dummy.event", value: "payload" });
+    const timestamp = new Date();
+    const headers = {
+      "Webhook-Id": "test-webhook",
+      "Webhook-Timestamp": String(Math.floor(timestamp.getTime() / 1000)),
+      "Webhook-Signature": new Webhook(keyMaterial).sign("test-webhook", timestamp, body),
+    };
+
+    await expect(
+      validateWebhook<DummyPayload>(body, headers, standardSecret, eventTypes),
+    ).resolves.toEqual({ type: "dummy.event", value: "payload" });
+  });
+
+  test("validates a legacy whsec_-prefixed secret", async () => {
+    const legacySecret = `whsec_${"a".repeat(43)}`;
+    const body = JSON.stringify({ type: "dummy.event", value: "payload" });
+    const timestamp = new Date();
+    const headers = {
+      "Webhook-Id": "test-webhook",
+      "Webhook-Timestamp": String(Math.floor(timestamp.getTime() / 1000)),
+      "Webhook-Signature": new Webhook(Buffer.from(legacySecret, "utf8").toString("base64")).sign(
+        "test-webhook",
+        timestamp,
+        body,
+      ),
+    };
+
+    await expect(
+      validateWebhook<DummyPayload>(body, headers, legacySecret, eventTypes),
+    ).resolves.toEqual({ type: "dummy.event", value: "payload" });
   });
 
   test("rejects an invalid signature", async () => {
@@ -72,26 +97,20 @@ describe("validateWebhook", () => {
     const headers = getHeaders(body);
     headers["Webhook-Signature"] = "v1,not-base64!";
 
-    await expect(validateEvent(body, headers)).rejects.toThrow(
-      PolarWebhookVerificationError,
-    );
+    await expect(validateEvent(body, headers)).rejects.toThrow(PolarWebhookVerificationError);
   });
 
   test("rejects missing headers", async () => {
     const body = JSON.stringify({ type: "dummy.event", value: "payload" });
 
-    await expect(validateEvent(body, {})).rejects.toThrow(
-      PolarWebhookVerificationError,
-    );
+    await expect(validateEvent(body, {})).rejects.toThrow(PolarWebhookVerificationError);
   });
 
   test("rejects a stale timestamp", async () => {
     const body = JSON.stringify({ type: "dummy.event", value: "payload" });
     const timestamp = new Date(Date.now() - 6 * 60 * 1000);
 
-    await expect(
-      validateEvent(body, getHeaders(body, timestamp)),
-    ).rejects.toThrow(
+    await expect(validateEvent(body, getHeaders(body, timestamp))).rejects.toThrow(
       PolarWebhookVerificationError,
     );
   });
@@ -104,27 +123,19 @@ describe("validateWebhook", () => {
       throw new Error("Expected validateEvent to throw");
     } catch (error) {
       expect(error).toBeInstanceOf(PolarWebhookUnknownTypeError);
-      expect((error as PolarWebhookUnknownTypeError).eventType).toBe(
-        "future.event",
-      );
+      expect((error as PolarWebhookUnknownTypeError).eventType).toBe("future.event");
     }
   });
 
   test("wraps malformed signed payloads", async () => {
     const body = "{";
 
-    await expect(validateEvent(body, getHeaders(body))).rejects.toThrow(
-      PolarWebhookError,
-    );
+    await expect(validateEvent(body, getHeaders(body))).rejects.toThrow(PolarWebhookError);
   });
 
   test("uses the Polar webhook error hierarchy", () => {
     expect(new PolarWebhookError("error")).toBeInstanceOf(PolarError);
-    expect(new PolarWebhookVerificationError("error")).toBeInstanceOf(
-      PolarWebhookError,
-    );
-    expect(new PolarWebhookUnknownTypeError("future.event")).toBeInstanceOf(
-      PolarWebhookError,
-    );
+    expect(new PolarWebhookVerificationError("error")).toBeInstanceOf(PolarWebhookError);
+    expect(new PolarWebhookUnknownTypeError("future.event")).toBeInstanceOf(PolarWebhookError);
   });
 });

--- a/sdk/generator/typescript/template/src/webhooks.ts
+++ b/sdk/generator/typescript/template/src/webhooks.ts
@@ -1,6 +1,7 @@
 import { PolarError } from "./base";
 
 const webhookToleranceSeconds = 5 * 60;
+const webhookSecretPrefix = "whsec_";
 
 export class PolarWebhookError extends PolarError {
   constructor(message: string, options?: ErrorOptions) {
@@ -88,14 +89,17 @@ const verifySignature = async (
   }
 
   const signedContent = `${webhookId}.${Math.floor(timestamp)}.${body}`;
-  const textEncoder = new TextEncoder();
-  const signedContentBytes = textEncoder.encode(signedContent);
-  const signingKey = await globalThis.crypto.subtle.importKey(
-    "raw",
-    textEncoder.encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["verify"],
+  const signedContentBytes = new TextEncoder().encode(signedContent);
+  const signingKeys = await Promise.all(
+    signingKeyMaterials(secret).map((keyMaterial) =>
+      globalThis.crypto.subtle.importKey(
+        "raw",
+        keyMaterial,
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["verify"],
+      ),
+    ),
   );
 
   for (const versionedSignature of webhookSignature.split(" ")) {
@@ -104,20 +108,36 @@ const verifySignature = async (
       continue;
     }
     const decodedSignature = decodeBase64(signature);
-    if (
-      decodedSignature !== null &&
-      (await globalThis.crypto.subtle.verify(
-        "HMAC",
-        signingKey,
-        decodedSignature,
-        signedContentBytes,
-      ))
-    ) {
-      return;
+    if (decodedSignature === null) {
+      continue;
+    }
+    for (const signingKey of signingKeys) {
+      if (
+        await globalThis.crypto.subtle.verify(
+          "HMAC",
+          signingKey,
+          decodedSignature,
+          signedContentBytes,
+        )
+      ) {
+        return;
+      }
     }
   }
 
   throw new PolarWebhookVerificationError("No matching signature found");
+};
+
+const signingKeyMaterials = (secret: string): Uint8Array<ArrayBuffer>[] => {
+  const keyMaterials: Uint8Array<ArrayBuffer>[] = [new TextEncoder().encode(secret)];
+  if (secret.startsWith(webhookSecretPrefix)) {
+    const encodedKey = secret.slice(webhookSecretPrefix.length);
+    const decodedKey = encodedKey.length % 4 === 0 ? decodeBase64(encodedKey) : null;
+    if (decodedKey !== null) {
+      keyMaterials.unshift(decodedKey);
+    }
+  }
+  return keyMaterials;
 };
 
 const decodeBase64 = (value: string): Uint8Array<ArrayBuffer> | null => {

--- a/sdk/python/polar/webhooks.py
+++ b/sdk/python/polar/webhooks.py
@@ -10,6 +10,7 @@ import typing
 from polar.base import PolarError
 
 _WEBHOOK_TOLERANCE_SECONDS = 5 * 60
+_WEBHOOK_SECRET_PREFIX = "whsec_"
 _PayloadT = typing.TypeVar("_PayloadT")
 
 
@@ -87,9 +88,10 @@ def _verify_signature(body: str, headers: dict[str, str], secret: str) -> None:
         raise PolarWebhookVerificationError("Message timestamp too new")
 
     signed_content = f"{webhook_id}.{math.floor(timestamp)}.{body}".encode()
-    expected_signature = hmac.new(
-        secret.encode(), signed_content, hashlib.sha256
-    ).digest()
+    expected_signatures = [
+        hmac.new(key, signed_content, hashlib.sha256).digest()
+        for key in _signing_keys(secret)
+    ]
 
     for versioned_signature in webhook_signature.split():
         version, separator, signature = versioned_signature.partition(",")
@@ -99,7 +101,25 @@ def _verify_signature(body: str, headers: dict[str, str], secret: str) -> None:
             decoded_signature = base64.b64decode(signature, validate=True)
         except (binascii.Error, ValueError):
             continue
-        if hmac.compare_digest(expected_signature, decoded_signature):
+        if any(
+            hmac.compare_digest(expected_signature, decoded_signature)
+            for expected_signature in expected_signatures
+        ):
             return
 
     raise PolarWebhookVerificationError("No matching signature found")
+
+
+def _signing_keys(secret: str) -> list[bytes]:
+    keys = [secret.encode()]
+    if secret.startswith(_WEBHOOK_SECRET_PREFIX):
+        try:
+            keys.insert(
+                0,
+                base64.b64decode(
+                    secret[len(_WEBHOOK_SECRET_PREFIX) :], validate=True
+                ),
+            )
+        except binascii.Error:
+            pass
+    return keys

--- a/sdk/python/tests/test_webhooks.py
+++ b/sdk/python/tests/test_webhooks.py
@@ -59,6 +59,40 @@ def test_validate_event(as_bytes: bool) -> None:
     )
 
 
+def test_validate_event_standard_webhooks_secret() -> None:
+    standard_secret = "whsec_" + base64.b64encode(b"k" * 32).decode()
+    body = json.dumps({"type": _EVENT_TYPE, "value": "payload"})
+    timestamp = datetime.datetime.now(tz=datetime.UTC)
+    headers = {
+        "Webhook-Id": "test-webhook",
+        "Webhook-Timestamp": str(int(timestamp.timestamp())),
+        "Webhook-Signature": Webhook(standard_secret).sign(
+            "test-webhook", timestamp, body
+        ),
+    }
+
+    assert _validate_event(body, headers, standard_secret) == DummyPayload(
+        type=_EVENT_TYPE, value="payload"
+    )
+
+
+def test_validate_event_legacy_prefixed_secret() -> None:
+    legacy_secret = "whsec_" + "a" * 43
+    body = json.dumps({"type": _EVENT_TYPE, "value": "payload"})
+    timestamp = datetime.datetime.now(tz=datetime.UTC)
+    headers = {
+        "Webhook-Id": "test-webhook",
+        "Webhook-Timestamp": str(int(timestamp.timestamp())),
+        "Webhook-Signature": Webhook(
+            base64.b64encode(legacy_secret.encode()).decode()
+        ).sign("test-webhook", timestamp, body),
+    }
+
+    assert _validate_event(body, headers, legacy_secret) == DummyPayload(
+        type=_EVENT_TYPE, value="payload"
+    )
+
+
 def test_validate_event_rejects_invalid_signature() -> None:
     body = json.dumps({"type": _EVENT_TYPE, "value": "payload"})
 

--- a/sdk/typescript/src/webhooks.test.ts
+++ b/sdk/typescript/src/webhooks.test.ts
@@ -49,6 +49,41 @@ describe("validateWebhook", () => {
     });
   });
 
+  test("validates a Standard Webhooks encoded secret", async () => {
+    const keyMaterial = Buffer.alloc(32, "k").toString("base64");
+    const standardSecret = `whsec_${keyMaterial}`;
+    const body = JSON.stringify({ type: "dummy.event", value: "payload" });
+    const timestamp = new Date();
+    const headers = {
+      "Webhook-Id": "test-webhook",
+      "Webhook-Timestamp": String(Math.floor(timestamp.getTime() / 1000)),
+      "Webhook-Signature": new Webhook(keyMaterial).sign("test-webhook", timestamp, body),
+    };
+
+    await expect(
+      validateWebhook<DummyPayload>(body, headers, standardSecret, eventTypes),
+    ).resolves.toEqual({ type: "dummy.event", value: "payload" });
+  });
+
+  test("validates a legacy whsec_-prefixed secret", async () => {
+    const legacySecret = `whsec_${"a".repeat(43)}`;
+    const body = JSON.stringify({ type: "dummy.event", value: "payload" });
+    const timestamp = new Date();
+    const headers = {
+      "Webhook-Id": "test-webhook",
+      "Webhook-Timestamp": String(Math.floor(timestamp.getTime() / 1000)),
+      "Webhook-Signature": new Webhook(Buffer.from(legacySecret, "utf8").toString("base64")).sign(
+        "test-webhook",
+        timestamp,
+        body,
+      ),
+    };
+
+    await expect(
+      validateWebhook<DummyPayload>(body, headers, legacySecret, eventTypes),
+    ).resolves.toEqual({ type: "dummy.event", value: "payload" });
+  });
+
   test("rejects an invalid signature", async () => {
     const body = JSON.stringify({ type: "dummy.event", value: "payload" });
 

--- a/sdk/typescript/src/webhooks.ts
+++ b/sdk/typescript/src/webhooks.ts
@@ -1,6 +1,7 @@
 import { PolarError } from "./base";
 
 const webhookToleranceSeconds = 5 * 60;
+const webhookSecretPrefix = "whsec_";
 
 export class PolarWebhookError extends PolarError {
   constructor(message: string, options?: ErrorOptions) {
@@ -88,14 +89,17 @@ const verifySignature = async (
   }
 
   const signedContent = `${webhookId}.${Math.floor(timestamp)}.${body}`;
-  const textEncoder = new TextEncoder();
-  const signedContentBytes = textEncoder.encode(signedContent);
-  const signingKey = await globalThis.crypto.subtle.importKey(
-    "raw",
-    textEncoder.encode(secret),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["verify"],
+  const signedContentBytes = new TextEncoder().encode(signedContent);
+  const signingKeys = await Promise.all(
+    signingKeyMaterials(secret).map((keyMaterial) =>
+      globalThis.crypto.subtle.importKey(
+        "raw",
+        keyMaterial,
+        { name: "HMAC", hash: "SHA-256" },
+        false,
+        ["verify"],
+      ),
+    ),
   );
 
   for (const versionedSignature of webhookSignature.split(" ")) {
@@ -104,20 +108,36 @@ const verifySignature = async (
       continue;
     }
     const decodedSignature = decodeBase64(signature);
-    if (
-      decodedSignature !== null &&
-      (await globalThis.crypto.subtle.verify(
-        "HMAC",
-        signingKey,
-        decodedSignature,
-        signedContentBytes,
-      ))
-    ) {
-      return;
+    if (decodedSignature === null) {
+      continue;
+    }
+    for (const signingKey of signingKeys) {
+      if (
+        await globalThis.crypto.subtle.verify(
+          "HMAC",
+          signingKey,
+          decodedSignature,
+          signedContentBytes,
+        )
+      ) {
+        return;
+      }
     }
   }
 
   throw new PolarWebhookVerificationError("No matching signature found");
+};
+
+const signingKeyMaterials = (secret: string): Uint8Array<ArrayBuffer>[] => {
+  const keyMaterials: Uint8Array<ArrayBuffer>[] = [new TextEncoder().encode(secret)];
+  if (secret.startsWith(webhookSecretPrefix)) {
+    const encodedKey = secret.slice(webhookSecretPrefix.length);
+    const decodedKey = encodedKey.length % 4 === 0 ? decodeBase64(encodedKey) : null;
+    if (decodedKey !== null) {
+      keyMaterials.unshift(decodedKey);
+    }
+  }
+  return keyMaterials;
 };
 
 const decodeBase64 = (value: string): Uint8Array<ArrayBuffer> | null => {

--- a/server/polar/webhook/service.py
+++ b/server/polar/webhook/service.py
@@ -1,5 +1,7 @@
+import base64
 import datetime
 import json
+import secrets
 from collections.abc import Sequence
 from typing import Literal, cast, overload
 from uuid import UUID
@@ -24,7 +26,6 @@ from polar.customer.schemas.state import CustomerState
 from polar.email.schemas import EmailAdapter
 from polar.email.sender import enqueue_email_template
 from polar.exceptions import PolarError, PolarRequestValidationError, ResourceNotFound
-from polar.kit.crypto import generate_token
 from polar.kit.db.postgres import AsyncSession
 from polar.kit.pagination import PaginationParams
 from polar.kit.utils import utc_now
@@ -72,6 +73,10 @@ from .schemas import (
 from .webhooks import SkipEvent, UnsupportedTarget, WebhookPayloadTypeAdapter
 
 log: Logger = structlog.get_logger()
+
+
+def generate_standard_secret() -> str:
+    return WEBHOOK_SECRET_PREFIX + base64.b64encode(secrets.token_bytes(32)).decode()
 
 
 class WebhookError(PolarError): ...
@@ -151,7 +156,7 @@ class WebhookService:
         if create_schema.secret is not None:
             secret = create_schema.secret
         else:
-            secret = generate_token(prefix=WEBHOOK_SECRET_PREFIX)
+            secret = generate_standard_secret()
 
         endpoint = await repository.create(
             WebhookEndpoint(
@@ -211,7 +216,7 @@ class WebhookService:
         return await repository.update(
             endpoint,
             update_dict={
-                "secret": generate_token(prefix=WEBHOOK_SECRET_PREFIX),
+                "secret": generate_standard_secret(),
             },
         )
 

--- a/server/polar/webhook/tasks.py
+++ b/server/polar/webhook/tasks.py
@@ -1,4 +1,5 @@
 import base64
+import binascii
 from collections.abc import Mapping
 from ssl import SSLError
 from uuid import UUID
@@ -26,9 +27,19 @@ from polar.worker import (
     enqueue_job,
 )
 
+from .constants import WEBHOOK_SECRET_PREFIX
 from .service import webhook as webhook_service
 
 log: Logger = structlog.get_logger()
+
+
+def standard_webhooks_key(secret: str) -> bytes | None:
+    if not secret.startswith(WEBHOOK_SECRET_PREFIX):
+        return None
+    try:
+        return base64.b64decode(secret[len(WEBHOOK_SECRET_PREFIX) :], validate=True)
+    except binascii.Error:
+        return None
 
 
 # Safety-guard max_retries: enough for all ordering retries within the age
@@ -107,13 +118,16 @@ async def _webhook_event_send(
 
     ts = utc_now()
 
-    b64secret = base64.b64encode(event.webhook_endpoint.secret.encode("utf-8")).decode(
-        "utf-8"
-    )
-
-    # Sign the payload
-    wh = StandardWebhook(b64secret)
-    signature = wh.sign(str(event.id), ts, event.payload)
+    # Dual-signed: legacy raw-string-key verifiers must keep working
+    secret = event.webhook_endpoint.secret
+    b64secret = base64.b64encode(secret.encode("utf-8")).decode("utf-8")
+    signature = StandardWebhook(b64secret).sign(str(event.id), ts, event.payload)
+    standard_key = standard_webhooks_key(secret)
+    if standard_key is not None:
+        standard_signature = StandardWebhook(standard_key).sign(
+            str(event.id), ts, event.payload
+        )
+        signature = f"{standard_signature} {signature}"
 
     headers: Mapping[str, str] = {
         "user-agent": "polar.sh webhooks",

--- a/server/tests/webhooks/test_webhooks.py
+++ b/server/tests/webhooks/test_webhooks.py
@@ -1,3 +1,4 @@
+import base64
 from typing import cast
 from unittest.mock import MagicMock
 
@@ -9,6 +10,7 @@ from pytest_mock import MockerFixture
 from standardwebhooks.webhooks import Webhook as StandardWebhook
 
 from polar.config import settings
+from polar.kit.crypto import generate_token
 from polar.kit.db.postgres import AsyncSession
 from polar.models.organization import Organization
 from polar.models.subscription import Subscription
@@ -19,7 +21,9 @@ from polar.models.webhook_endpoint import (
     WebhookFormat,
 )
 from polar.models.webhook_event import WebhookEvent
+from polar.webhook.constants import WEBHOOK_SECRET_PREFIX
 from polar.webhook.repository import WebhookDeliveryRepository
+from polar.webhook.service import generate_standard_secret
 from polar.webhook.service import webhook as webhook_service
 from polar.webhook.tasks import _webhook_event_send, webhook_event_send
 from tests.fixtures.database import SaveFixture
@@ -274,3 +278,86 @@ async def test_webhook_standard_webhooks_compatible(
     request = route_mock.calls.last.request
     w = StandardWebhook(secret.encode("utf-8"))
     assert w.verify(request.content, cast(dict[str, str], request.headers)) is not None
+
+
+@pytest.mark.asyncio
+async def test_webhook_legacy_secret_single_signature(
+    session: AsyncSession,
+    save_fixture: SaveFixture,
+    respx_mock: respx.MockRouter,
+    organization: Organization,
+) -> None:
+    secret = generate_token(prefix=WEBHOOK_SECRET_PREFIX)
+    route_mock = respx_mock.post("https://example.com/hook").mock(
+        return_value=httpx.Response(200)
+    )
+
+    endpoint = WebhookEndpoint(
+        url="https://example.com/hook",
+        format=WebhookFormat.raw,
+        organization_id=organization.id,
+        secret=secret,
+    )
+    await save_fixture(endpoint)
+
+    event = WebhookEvent(
+        webhook_endpoint_id=endpoint.id,
+        type=WebhookEventType.customer_created,
+        payload='{"foo":"bar"}',
+    )
+    await save_fixture(event)
+
+    await _webhook_event_send(session=session, webhook_event_id=event.id)
+
+    request = route_mock.calls.last.request
+    assert len(request.headers["webhook-signature"].split(" ")) == 1
+    legacy_verifier = StandardWebhook(base64.b64encode(secret.encode()).decode())
+    assert (
+        legacy_verifier.verify(request.content, cast(dict[str, str], request.headers))
+        is not None
+    )
+
+
+@pytest.mark.asyncio
+async def test_webhook_standard_secret_dual_signature(
+    session: AsyncSession,
+    save_fixture: SaveFixture,
+    respx_mock: respx.MockRouter,
+    organization: Organization,
+) -> None:
+    secret = generate_standard_secret()
+    route_mock = respx_mock.post("https://example.com/hook").mock(
+        return_value=httpx.Response(200)
+    )
+
+    endpoint = WebhookEndpoint(
+        url="https://example.com/hook",
+        format=WebhookFormat.raw,
+        organization_id=organization.id,
+        secret=secret,
+    )
+    await save_fixture(endpoint)
+
+    event = WebhookEvent(
+        webhook_endpoint_id=endpoint.id,
+        type=WebhookEventType.customer_created,
+        payload='{"foo":"bar"}',
+    )
+    await save_fixture(event)
+
+    await _webhook_event_send(session=session, webhook_event_id=event.id)
+
+    request = route_mock.calls.last.request
+    assert len(request.headers["webhook-signature"].split(" ")) == 2
+
+    spec_verifier = StandardWebhook(secret)
+    assert (
+        spec_verifier.verify(request.content, cast(dict[str, str], request.headers))
+        is not None
+    )
+
+    legacy_verifier = StandardWebhook(base64.b64encode(secret.encode()).decode())
+    assert (
+        legacy_verifier.verify(request.content, cast(dict[str, str], request.headers))
+        is not None
+    )


### PR DESCRIPTION
Now that we switched our secret prefix from polar_whs_ to whsec_ the secrets we generate doesn't seem to be fully [https://www.standardwebhooks.com/](spec compliant).

Namely: Secret serialization base64 encoded, prefixed with whsec_ for easy identification.

Standard Webhooks libraries expect the secret to be base64 encoded and then prefixed with whsec_. We expect you to base64 encode the full secret including the prefix.

This changes that, but signs the secrets in both ways to ensure backward compatibility.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

