### PR TITLE
email: Handle broken markdown in Benefit notes

### DIFF
--- a/server/emails/src/components/Benefits.tsx
+++ b/server/emails/src/components/Benefits.tsx
@@ -1,6 +1,16 @@
+import { renderToStaticMarkup } from 'react-dom/server'
 import { Heading, Markdown, Section } from 'react-email'
 import { schemas } from '../types'
 import { Check, Discord, Download, Gauge, GitHub, Key } from './Icons'
+
+const BenefitNote = ({ note }: { note: string }) => {
+  try {
+    renderToStaticMarkup(<Markdown>{note}</Markdown>)
+  } catch {
+    return <div className="whitespace-pre-wrap">{note}</div>
+  }
+  return <Markdown>{note}</Markdown>
+}
 
 const BenefitIcon = ({
   benefit: { type },
@@ -41,7 +51,7 @@ const Benefit = ({ benefit }: { benefit: schemas['Benefit'] }) => {
           </Heading>
           {type === 'custom' && properties.note && (
             <div className="mt-[8px] text-[14px] leading-[24px] text-gray-500">
-              <Markdown>{properties.note}</Markdown>
+              <BenefitNote note={properties.note} />
             </div>
           )}
         </div>


### PR DESCRIPTION
Instead of failing to render, we try and catch the error, and with broken markdown we just render the plain text directly


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

