### PR TITLE
feat(web): add mobile FilterPopover to subscriptions

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionFilters.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionFilters.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import DateRangePicker, {
+  DateRange,
+  dateRangeIntervals,
+  dateRangeToMatchingInterval,
+} from '@/components/Metrics/DateRangePicker'
+import FilterPopover, {
+  Filter,
+  FilterOption,
+} from '@/components/Shared/FilterPopover'
+import SubscriptionCancellationSelect from '@/components/Subscriptions/SubscriptionCancellationSelect'
+import SubscriptionStatusSelect, {
+  subscriptionStatusFilterValues,
+  type SubscriptionStatusFilter,
+} from '@/components/Subscriptions/SubscriptionStatusSelect'
+import SubscriptionTiersSelect from '@/components/Subscriptions/SubscriptionTiersSelect'
+import { subscriptionStatusDisplayNames } from '@/components/Subscriptions/utils'
+import AutorenewOutlined from '@mui/icons-material/AutorenewOutlined'
+import CalendarMonthOutlined from '@mui/icons-material/CalendarMonthOutlined'
+import DonutLargeOutlined from '@mui/icons-material/DonutLargeOutlined'
+import FileDownloadOutlined from '@mui/icons-material/FileDownloadOutlined'
+import HiveOutlined from '@mui/icons-material/HiveOutlined'
+import { schemas } from '@polar-sh/client'
+import { Button, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { startOfDay } from 'date-fns'
+import React, { useMemo } from 'react'
+
+const CUSTOM_DATE_RANGE = 'custom'
+
+const cancellationOptions: FilterOption[] = [
+  { value: 'false', label: 'Renewing subscriptions' },
+  { value: 'true', label: 'Ending at period end' },
+]
+
+interface SubscriptionFiltersProps {
+  organization: schemas['Organization']
+  products: schemas['Product'][]
+  productId: string | null
+  onProductSelect: (value: string | null) => void
+  status: SubscriptionStatusFilter
+  onStatusSelect: (value: SubscriptionStatusFilter) => void
+  cancelAtPeriodEnd: boolean | null
+  onCancelAtPeriodEndSelect: (value: boolean | null) => void
+  dateRange: DateRange
+  onDateChange: (range: DateRange) => void
+  onExport: () => void
+}
+
+const SubscriptionFilters: React.FC<SubscriptionFiltersProps> = ({
+  organization,
+  products,
+  productId,
+  onProductSelect,
+  status,
+  onStatusSelect,
+  cancelAtPeriodEnd,
+  onCancelAtPeriodEndSelect,
+  dateRange,
+  onDateChange,
+  onExport,
+}) => {
+  const mobileFilters = useMemo<Filter[]>(() => {
+    const intervals = dateRangeIntervals(organization)
+    const intervalSlug = dateRangeToMatchingInterval(
+      dateRange,
+      organization,
+    )?.slug
+    return [
+      {
+        key: 'status',
+        label: 'Status',
+        icon: <DonutLargeOutlined fontSize="inherit" />,
+        type: 'single',
+        options: subscriptionStatusFilterValues
+          .filter((value) => value !== 'any')
+          .map((value) => ({
+            value,
+            label:
+              subscriptionStatusDisplayNames[
+                value as schemas['SubscriptionStatus']
+              ],
+          })),
+        value: status === 'any' ? null : status,
+        onChange: (value) =>
+          onStatusSelect((value ?? 'any') as SubscriptionStatusFilter),
+      },
+      ...(status === 'active'
+        ? [
+            {
+              key: 'cancellation',
+              label: 'Cancellation',
+              icon: <AutorenewOutlined fontSize="inherit" />,
+              type: 'single' as const,
+              options: cancellationOptions,
+              value:
+                cancelAtPeriodEnd === null ? null : String(cancelAtPeriodEnd),
+              onChange: (value: string | null) =>
+                onCancelAtPeriodEndSelect(
+                  value === null ? null : value === 'true',
+                ),
+            },
+          ]
+        : []),
+      {
+        key: 'product',
+        label: 'Product',
+        icon: <HiveOutlined fontSize="inherit" />,
+        type: 'single',
+        options: products.map((product) => ({
+          value: product.id,
+          label: product.name,
+        })),
+        value: productId,
+        onChange: onProductSelect,
+      },
+      {
+        key: 'date',
+        label: 'Date',
+        icon: <CalendarMonthOutlined fontSize="inherit" />,
+        type: 'single',
+        options: intervals.map(({ slug, label }) => ({ value: slug, label })),
+        value:
+          intervalSlug === 'allTime'
+            ? null
+            : (intervalSlug ?? CUSTOM_DATE_RANGE),
+        onChange: (slug) => {
+          const interval =
+            intervals.find((interval) => interval.slug === slug) ??
+            intervals.find(({ slug }) => slug === 'allTime')
+          if (interval) {
+            onDateChange({ from: interval.value[0], to: interval.value[1] })
+          }
+        },
+      },
+    ]
+  }, [
+    organization,
+    products,
+    productId,
+    onProductSelect,
+    status,
+    onStatusSelect,
+    cancelAtPeriodEnd,
+    onCancelAtPeriodEndSelect,
+    dateRange,
+    onDateChange,
+  ])
+
+  return (
+    <Box
+      flexDirection={{ base: 'column', md: 'row' }}
+      alignItems={{ base: 'stretch', md: 'center' }}
+      justifyContent="between"
+      gap="l"
+    >
+      <Box
+        display={{ base: 'none', sm: 'flex' }}
+        flexWrap="wrap"
+        alignItems="center"
+        gap="l"
+        width={{ base: '100%', md: 'auto' }}
+      >
+        <SubscriptionStatusSelect value={status} onChange={onStatusSelect} />
+        {status === 'active' && (
+          <SubscriptionCancellationSelect
+            value={cancelAtPeriodEnd}
+            onChange={onCancelAtPeriodEndSelect}
+          />
+        )}
+        <SubscriptionTiersSelect
+          products={products}
+          value={productId}
+          onChange={onProductSelect}
+        />
+        <DateRangePicker
+          date={dateRange}
+          onDateChange={onDateChange}
+          className="shrink-0 [&>button:last-child]:text-left"
+          minDate={startOfDay(new Date(organization.created_at))}
+        />
+      </Box>
+      <Box display={{ base: 'flex', sm: 'none' }} width="100%">
+        <FilterPopover filters={mobileFilters} className="w-full" />
+      </Box>
+      <Button
+        onClick={onExport}
+        className="flex w-full flex-row items-center md:w-auto"
+        variant="secondary"
+        wrapperClassNames="gap-x-2"
+      >
+        <FileDownloadOutlined fontSize="inherit" />
+        <Text>Export</Text>
+      </Button>
+    </Box>
+  )
+}
+
+export default SubscriptionFilters

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionFilters.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionFilters.tsx
@@ -11,11 +11,13 @@ import FilterPopover, {
 } from '@/components/Shared/FilterPopover'
 import SubscriptionCancellationSelect from '@/components/Subscriptions/SubscriptionCancellationSelect'
 import SubscriptionStatusSelect, {
+  DEFAULT_SUBSCRIPTION_STATUS,
   subscriptionStatusFilterValues,
   type SubscriptionStatusFilter,
 } from '@/components/Subscriptions/SubscriptionStatusSelect'
 import SubscriptionTiersSelect from '@/components/Subscriptions/SubscriptionTiersSelect'
 import { subscriptionStatusDisplayNames } from '@/components/Subscriptions/utils'
+import { useProducts, useSelectedProducts } from '@/hooks/queries'
 import AutorenewOutlined from '@mui/icons-material/AutorenewOutlined'
 import CalendarMonthOutlined from '@mui/icons-material/CalendarMonthOutlined'
 import DonutLargeOutlined from '@mui/icons-material/DonutLargeOutlined'
@@ -25,7 +27,7 @@ import { schemas } from '@polar-sh/client'
 import { Button, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { startOfDay } from 'date-fns'
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 
 const CUSTOM_DATE_RANGE = 'custom'
 
@@ -36,7 +38,6 @@ const cancellationOptions: FilterOption[] = [
 
 interface SubscriptionFiltersProps {
   organization: schemas['Organization']
-  products: schemas['Product'][]
   productId: string | null
   onProductSelect: (value: string | null) => void
   status: SubscriptionStatusFilter
@@ -50,7 +51,6 @@ interface SubscriptionFiltersProps {
 
 const SubscriptionFilters: React.FC<SubscriptionFiltersProps> = ({
   organization,
-  products,
   productId,
   onProductSelect,
   status,
@@ -61,6 +61,34 @@ const SubscriptionFilters: React.FC<SubscriptionFiltersProps> = ({
   onDateChange,
   onExport,
 }) => {
+  const [productQuery, setProductQuery] = useState('')
+
+  const { data: queriedProducts, isPending: productsPending } = useProducts(
+    organization.id,
+    {
+      is_recurring: true,
+      ...(productQuery ? { query: productQuery } : {}),
+      sorting: ['name'],
+      limit: 100,
+    },
+  )
+  const { data: selectedProducts } = useSelectedProducts(
+    productId ? [productId] : [],
+    true,
+  )
+
+  const products = useMemo<schemas['Product'][]>(() => {
+    let items = queriedProducts?.items ?? []
+    if (!productQuery) {
+      for (const product of selectedProducts ?? []) {
+        if (!items.some(({ id }) => id === product.id)) {
+          items = [...items, product]
+        }
+      }
+    }
+    return items
+  }, [queriedProducts, selectedProducts, productQuery])
+
   const mobileFilters = useMemo<Filter[]>(() => {
     const intervals = dateRangeIntervals(organization)
     const intervalSlug = dateRangeToMatchingInterval(
@@ -83,6 +111,7 @@ const SubscriptionFilters: React.FC<SubscriptionFiltersProps> = ({
               ],
           })),
         value: status === 'any' ? null : status,
+        defaultValue: DEFAULT_SUBSCRIPTION_STATUS,
         onChange: (value) =>
           onStatusSelect((value ?? 'any') as SubscriptionStatusFilter),
       },
@@ -110,8 +139,12 @@ const SubscriptionFilters: React.FC<SubscriptionFiltersProps> = ({
         type: 'single',
         options: products.map((product) => ({
           value: product.id,
-          label: product.name,
+          label: `${product.name}${product.is_archived ? ' (Archived)' : ''}`,
         })),
+        loading: productsPending,
+        searchPlaceholder: 'Search products…',
+        searchQuery: productQuery,
+        onSearchQueryChange: setProductQuery,
         value: productId,
         onChange: onProductSelect,
       },
@@ -138,6 +171,8 @@ const SubscriptionFilters: React.FC<SubscriptionFiltersProps> = ({
   }, [
     organization,
     products,
+    productsPending,
+    productQuery,
     productId,
     onProductSelect,
     status,

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionFilters.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionFilters.tsx
@@ -162,18 +162,24 @@ const SubscriptionFilters: React.FC<SubscriptionFiltersProps> = ({
         gap="l"
         width={{ base: '100%', md: 'auto' }}
       >
-        <SubscriptionStatusSelect value={status} onChange={onStatusSelect} />
+        <Box display="block">
+          <SubscriptionStatusSelect value={status} onChange={onStatusSelect} />
+        </Box>
         {status === 'active' && (
-          <SubscriptionCancellationSelect
-            value={cancelAtPeriodEnd}
-            onChange={onCancelAtPeriodEndSelect}
-          />
+          <Box display="block">
+            <SubscriptionCancellationSelect
+              value={cancelAtPeriodEnd}
+              onChange={onCancelAtPeriodEndSelect}
+            />
+          </Box>
         )}
-        <SubscriptionTiersSelect
-          products={products}
-          value={productId}
-          onChange={onProductSelect}
-        />
+        <Box display="block">
+          <SubscriptionTiersSelect
+            products={products}
+            value={productId}
+            onChange={onProductSelect}
+          />
+        </Box>
         <DateRangePicker
           date={dateRange}
           onDateChange={onDateChange}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionFilters.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionFilters.tsx
@@ -101,16 +101,14 @@ const SubscriptionFilters: React.FC<SubscriptionFiltersProps> = ({
         label: 'Status',
         icon: <DonutLargeOutlined fontSize="inherit" />,
         type: 'single',
-        options: subscriptionStatusFilterValues
-          .filter((value) => value !== 'any')
-          .map((value) => ({
-            value,
-            label:
-              subscriptionStatusDisplayNames[
-                value as schemas['SubscriptionStatus']
-              ],
-          })),
-        value: status === 'any' ? null : status,
+        options: subscriptionStatusFilterValues.map((value) => ({
+          value,
+          label:
+            value === 'any'
+              ? 'Any status'
+              : subscriptionStatusDisplayNames[value],
+        })),
+        value: status,
         defaultValue: DEFAULT_SUBSCRIPTION_STATUS,
         onChange: (value) =>
           onStatusSelect((value ?? 'any') as SubscriptionStatusFilter),

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
@@ -1,26 +1,20 @@
 'use client'
 
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
-import DateRangePicker, {
-  DateRange,
-} from '@/components/Metrics/DateRangePicker'
-import SubscriptionCancellationSelect from '@/components/Subscriptions/SubscriptionCancellationSelect'
+import { DateRange } from '@/components/Metrics/DateRangePicker'
 import { SubscriptionStatus as SubscriptionStatusComponent } from '@/components/Subscriptions/SubscriptionStatus'
-import SubscriptionStatusSelect, {
+import {
   subscriptionStatusFilterValues,
   type SubscriptionStatusFilter,
 } from '@/components/Subscriptions/SubscriptionStatusSelect'
-import SubscriptionTiersSelect from '@/components/Subscriptions/SubscriptionTiersSelect'
 import { useProducts, useSubscriptions } from '@/hooks/queries'
 import { useDataTableQueryState } from '@/hooks/useDataTableQueryState'
 import { getServerURL } from '@/utils/api'
 import { DataTableSortingState, getAPIParams } from '@/utils/datatable'
 import { useDateRange } from '@/utils/date'
-import FileDownloadOutlined from '@mui/icons-material/FileDownloadOutlined'
 import { schemas } from '@polar-sh/client'
 import { Box } from '@polar-sh/orbit/Box'
 import { Avatar } from '@polar-sh/orbit'
-import { Button } from '@polar-sh/orbit'
 import {
   DataTable,
   DataTableColumnDef,
@@ -43,7 +37,7 @@ import {
   useQueryStates,
 } from 'nuqs'
 import React, { useEffect, useState } from 'react'
-import { startOfDay } from 'date-fns'
+import SubscriptionFilters from './SubscriptionFilters'
 
 const filterParsers = {
   product_id: parseAsString,
@@ -289,46 +283,19 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
   return (
     <DashboardBody wide>
       <div className="flex flex-col gap-8">
-        <div className="flex w-full flex-row items-center justify-between gap-2 overflow-x-auto">
-          <div className="flex shrink-0 items-center gap-4">
-            <div className="w-auto">
-              <SubscriptionStatusSelect
-                value={status}
-                onChange={onStatusSelect}
-              />
-            </div>
-            {status === 'active' && (
-              <div className="w-auto">
-                <SubscriptionCancellationSelect
-                  value={cancelAtPeriodEnd}
-                  onChange={onCancelAtPeriodEndSelect}
-                />
-              </div>
-            )}
-            <div className="w-auto">
-              <SubscriptionTiersSelect
-                products={subscriptionTiers.data?.items || []}
-                value={productId}
-                onChange={onProductSelect}
-              />
-            </div>
-            <DateRangePicker
-              date={{ from: startDate, to: endDate }}
-              onDateChange={onDateChange}
-              className="[&>button:last-child]:text-left"
-              minDate={startOfDay(new Date(organization.created_at))}
-            />
-          </div>
-          <Button
-            onClick={onExport}
-            className="flex shrink-0 flex-row items-center"
-            variant={'secondary'}
-            wrapperClassNames="gap-x-2"
-          >
-            <FileDownloadOutlined fontSize="inherit" />
-            <span>Export</span>
-          </Button>
-        </div>
+        <SubscriptionFilters
+          organization={organization}
+          products={subscriptionTiers.data?.items || []}
+          productId={productId}
+          onProductSelect={onProductSelect}
+          status={status}
+          onStatusSelect={onStatusSelect}
+          cancelAtPeriodEnd={cancelAtPeriodEnd}
+          onCancelAtPeriodEndSelect={onCancelAtPeriodEndSelect}
+          dateRange={{ from: startDate, to: endDate }}
+          onDateChange={onDateChange}
+          onExport={onExport}
+        />
         {subscriptions && pageCount !== undefined ? (
           <DataTable
             columns={columns}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
@@ -4,10 +4,11 @@ import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import { DateRange } from '@/components/Metrics/DateRangePicker'
 import { SubscriptionStatus as SubscriptionStatusComponent } from '@/components/Subscriptions/SubscriptionStatus'
 import {
+  DEFAULT_SUBSCRIPTION_STATUS,
   subscriptionStatusFilterValues,
   type SubscriptionStatusFilter,
 } from '@/components/Subscriptions/SubscriptionStatusSelect'
-import { useProducts, useSubscriptions } from '@/hooks/queries'
+import { useSubscriptions } from '@/hooks/queries'
 import { useDataTableQueryState } from '@/hooks/useDataTableQueryState'
 import { getServerURL } from '@/utils/api'
 import { DataTableSortingState, getAPIParams } from '@/utils/datatable'
@@ -42,7 +43,7 @@ import SubscriptionFilters from './SubscriptionFilters'
 const filterParsers = {
   product_id: parseAsString,
   status: parseAsStringLiteral(subscriptionStatusFilterValues).withDefault(
-    'active',
+    DEFAULT_SUBSCRIPTION_STATUS,
   ),
   cancel_at_period_end: parseAsBoolean,
   metadata: parseAsArrayOf(parseAsString),
@@ -72,11 +73,6 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
     useState<RowSelectionState>({})
 
   const router = useRouter()
-
-  const subscriptionTiers = useProducts(organization.id, {
-    is_recurring: true,
-    limit: 100,
-  })
 
   const {
     pagination,
@@ -285,7 +281,6 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
       <div className="flex flex-col gap-8">
         <SubscriptionFilters
           organization={organization}
-          products={subscriptionTiers.data?.items || []}
           productId={productId}
           onProductSelect={onProductSelect}
           status={status}

--- a/clients/apps/web/src/components/Shared/FilterPopover.tsx
+++ b/clients/apps/web/src/components/Shared/FilterPopover.tsx
@@ -41,6 +41,7 @@ interface FilterBase {
 export interface SingleFilter extends FilterBase {
   type: 'single'
   value: string | null
+  defaultValue?: string | null
   onChange: (value: string | null) => void
 }
 
@@ -64,6 +65,13 @@ const crossfadeClassName = (hidden: boolean): string =>
 const isActive = (filter: Filter): boolean =>
   filter.type === 'single' ? filter.value !== null : filter.value.length > 0
 
+// A filter sitting on the value the page loads with isn't a user-applied
+// filter, so it shouldn't count towards the badge — it still shows a summary.
+const isDefaulted = (filter: Filter): boolean =>
+  filter.type === 'single' &&
+  filter.defaultValue !== undefined &&
+  filter.value === filter.defaultValue
+
 const isSelected = (filter: Filter, option: FilterOption): boolean =>
   filter.type === 'single'
     ? filter.value === option.value
@@ -71,7 +79,7 @@ const isSelected = (filter: Filter, option: FilterOption): boolean =>
 
 const clearFilter = (filter: Filter): void => {
   if (filter.type === 'single') {
-    filter.onChange(null)
+    filter.onChange(filter.defaultValue ?? null)
   } else {
     filter.onChange([])
   }
@@ -124,7 +132,9 @@ const FilterPopover: React.FC<FilterPopoverProps> = ({
   const searchInputRef = useRef<HTMLInputElement>(null)
 
   const activeFilter = filters.find(({ key }) => key === activeKey)
-  const activeCount = filters.filter(isActive).length
+  const activeCount = filters.filter(
+    (filter) => isActive(filter) && !isDefaulted(filter),
+  ).length
   const isSearchable = !!activeFilter?.onSearchQueryChange
 
   const collapseSearch = () => {

--- a/clients/apps/web/src/components/Shared/FilterPopover.tsx
+++ b/clients/apps/web/src/components/Shared/FilterPopover.tsx
@@ -297,14 +297,14 @@ const FilterPopover: React.FC<FilterPopoverProps> = ({
                     onSelect={() => onSelectOption(activeFilter, option)}
                     className={itemClassName}
                   >
-                    <Box display="flex" flex={1}>
+                    <Box display="flex" flex={1} minWidth={0}>
                       <Text as="span" truncate>
                         {option.label}
                       </Text>
                     </Box>
                     <CheckIcon
                       className={twMerge(
-                        'h-4 w-4',
+                        'h-4 w-4 shrink-0',
                         isSelected(activeFilter, option)
                           ? 'visible'
                           : 'invisible',
@@ -326,15 +326,27 @@ const FilterPopover: React.FC<FilterPopoverProps> = ({
                         className={itemClassName}
                       >
                         {filter.icon}
-                        <Box display="flex" flex={1}>
+                        <Box display="flex" flexShrink={0}>
                           <Text as="span" truncate>
                             {filter.label}
                           </Text>
                         </Box>
                         {summary ? (
-                          <Text as="span" variant="caption" color="muted">
-                            {summary}
-                          </Text>
+                          <Box
+                            display="flex"
+                            flex={1}
+                            minWidth={0}
+                            justifyContent="end"
+                          >
+                            <Text
+                              as="span"
+                              variant="caption"
+                              color="muted"
+                              truncate
+                            >
+                              {summary}
+                            </Text>
+                          </Box>
                         ) : null}
                       </CommandItem>
                     )

--- a/clients/apps/web/src/components/Shared/FilterPopover.tsx
+++ b/clients/apps/web/src/components/Shared/FilterPopover.tsx
@@ -153,7 +153,7 @@ const FilterPopover: React.FC<FilterPopoverProps> = ({
   const onSelectOption = (filter: Filter, option: FilterOption) => {
     toggleOption(filter, option)
     if (filter.type === 'single') {
-      onOpenChange(false)
+      goBack()
     }
   }
 

--- a/clients/apps/web/src/components/Shared/FilterPopover.tsx
+++ b/clients/apps/web/src/components/Shared/FilterPopover.tsx
@@ -87,7 +87,11 @@ const clearFilter = (filter: Filter): void => {
 
 const toggleOption = (filter: Filter, option: FilterOption): void => {
   if (filter.type === 'single') {
-    filter.onChange(filter.value === option.value ? null : option.value)
+    filter.onChange(
+      filter.value === option.value
+        ? (filter.defaultValue ?? null)
+        : option.value,
+    )
   } else {
     filter.onChange(
       filter.value.includes(option.value)

--- a/clients/apps/web/src/components/Subscriptions/SubscriptionStatusSelect.tsx
+++ b/clients/apps/web/src/components/Subscriptions/SubscriptionStatusSelect.tsx
@@ -28,6 +28,8 @@ export const subscriptionStatusFilterValues = [
 export type SubscriptionStatusFilter =
   (typeof subscriptionStatusFilterValues)[number]
 
+export const DEFAULT_SUBSCRIPTION_STATUS: SubscriptionStatusFilter = 'active'
+
 interface SubscriptionStatusSelectProps {
   value: SubscriptionStatusFilter
   onChange: (value: SubscriptionStatusFilter) => void


### PR DESCRIPTION
## Summary

Subscriptions' filter row was four selects in a horizontally scrolling strip on mobile. This swaps them for the `FilterPopover` already used on the orders page, below the `sm` breakpoint.

This matches the pattern on the orders page for mobile

| Screenshot |
|---|
| <img width="656" height="624" alt="Screenshot 2026-08-04 at 10 54 51" src="https://github.com/user-attachments/assets/f733a8a9-533b-4f95-a726-fb5ec0b5f0db" /> |


- Extract the filter bar into `SubscriptionFilters` (Status, Cancellation, Product, Date), dropping `SubscriptionsPage` from 331 to 295 lines.
- Move the products query into the filter component and add search plus `useSelectedProducts` hydration, so the picker isn't capped at one page and a `product_id` from the URL always resolves to a name.
- Picking a single-value filter returns to the filter list instead of closing the popover.
- Long summaries and option labels truncate instead of wrapping.
- New optional `defaultValue` on single filters: a filter sitting on its default doesn't count towards the badge, and clearing restores it. Subscriptions default to `active` status, which previously rendered as "Filters 1" on a fresh load.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

