### PR TITLE
adjust brand palette

### DIFF
--- a/clients/apps/web/src/app/(main)/brand/page.tsx
+++ b/clients/apps/web/src/app/(main)/brand/page.tsx
@@ -25,8 +25,8 @@ export default function BrandPage() {
         <BrandHero />
         <LogoSection />
         <ColorSection />
-        <TypographySection />
         <IllustrationSection />
+        <TypographySection />
         <VoiceSection />
         <MarketingSection />
       </main>

--- a/clients/apps/web/src/components/Brand/BrandNav.tsx
+++ b/clients/apps/web/src/components/Brand/BrandNav.tsx
@@ -15,15 +15,14 @@ const navColumns: NavLink[][] = [
   [
     { label: 'Logo', href: '#logo' },
     { label: 'Color', href: '#color' },
-    { label: 'Typography', href: '#typography' },
+    { label: 'Illustration', href: '#illustration' },
   ],
   [
-    { label: 'Illustration', href: '#illustration' },
+    { label: 'Typography', href: '#typography' },
     { label: 'Voice', href: '#voice' },
     { label: 'Marketing', href: '#marketing' },
   ],
   [
-    { label: 'Design', href: '#design' },
     {
       label: 'Assets',
       href: '/assets/brand/polar_brand.zip',
@@ -106,7 +105,7 @@ export function BrandNav() {
         <div className="flex items-start justify-between">
           <Link href="/" className="flex flex-col text-xl">
             <span className="text-brand-foreground">— Polar</span>
-            <span className="text-brand-muted">The Billing Company</span>
+            <span className="text-brand-muted">Brand Identity</span>
           </Link>
         </div>
         <nav className="hidden grid-cols-3 gap-x-12 md:grid md:gap-x-24">

--- a/clients/apps/web/src/components/Brand/IllustrationSection.tsx
+++ b/clients/apps/web/src/components/Brand/IllustrationSection.tsx
@@ -7,14 +7,20 @@ import { OrbitingSpheres } from '../Landing/graphics/OrbitingSpheres'
 import { VennCluster } from '../Landing/graphics/VennCluster'
 import { BrandSection } from './BrandSection'
 import { brandSections } from './brand'
+import { SteppedRadial } from '../Landing/graphics/SteppedRadial'
+import { Compass } from '../Landing/graphics/Compass'
+import { RadialSpinner } from '../Landing/graphics/RadialSpinner'
 
 const illustrations: { name: string; Graphic: React.ComponentType }[] = [
-  { name: 'Concentric', Graphic: ConcentricDraw },
+  { name: 'Radial Spinner', Graphic: RadialSpinner },
+  { name: 'Stepped Radial', Graphic: SteppedRadial },
+  { name: 'Compass', Graphic: Compass },
+  { name: 'Cycle', Graphic: CycleArrow },
   { name: 'Linked Rings', Graphic: LinkedRings },
   { name: 'Orbit', Graphic: OrbitingSpheres },
   { name: 'Cluster', Graphic: VennCluster },
   { name: 'Gauge', Graphic: GaugeSweep },
-  { name: 'Cycle', Graphic: CycleArrow },
+  { name: 'Concentric', Graphic: ConcentricDraw },
 ]
 
 // Recolor the shared landing graphics for the dark brand surface. The canvas

--- a/clients/apps/web/src/components/Brand/TypographySection.tsx
+++ b/clients/apps/web/src/components/Brand/TypographySection.tsx
@@ -20,20 +20,20 @@ export function TypographySection() {
         <div className="bg-brand-raised flex flex-col gap-8 overflow-hidden p-8 md:p-16">
           <Label>PP Neue Montreal</Label>
           <Specimen>Usage billing</Specimen>
-          <span className="text-brand-muted text-3xl md:text-4xl">
+          <span className="text-brand-muted text-2xl md:text-3xl">
             Meter every token. Invoice every cent.
           </span>
         </div>
         <div className="bg-brand-raised flex flex-col gap-8 overflow-hidden p-8 md:p-16">
           <Label>Geist Mono</Label>
           <Specimen>Usage</Specimen>
-          <div className="flex flex-col gap-2 font-mono text-xl tabular-nums md:text-2xl">
+          <div className="flex flex-col gap-2 font-mono text-lg tabular-nums md:text-xl">
             {invoice.map((row) => (
               <div
                 key={row.label}
                 className={`flex items-baseline justify-between gap-6 ${row.total ? 'border-brand-line text-brand-foreground border-t pt-3' : 'text-brand-muted'}`}
               >
-                <span>{row.label}</span>
+                <span className="text-brand-foreground">{row.label}</span>
                 <span className="text-brand-foreground">{row.value}</span>
               </div>
             ))}

--- a/clients/apps/web/src/components/Brand/VoiceSection.tsx
+++ b/clients/apps/web/src/components/Brand/VoiceSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { BrandSection } from './BrandSection'
 import { brandSections } from './brand'
-import { Lead, Mono, Trait } from './primitives'
+import { Lead, Trait } from './primitives'
 
 const traits = [
   {
@@ -34,14 +34,13 @@ export function VoiceSection() {
       lead="The voice is the brand in words. Four principles keep every sentence recognizably Polar."
     >
       <div className="flex flex-col">
-        {traits.map((item, index) => (
+        {traits.map((item) => (
           <div
             key={item.trait}
-            className="border-brand-line grid grid-cols-1 gap-6 border-t py-12 first:border-t-0 first:pt-0 md:grid-cols-12 md:gap-8 md:py-16"
+            className="border-brand-line grid grid-cols-1 gap-6 border-t py-12 first:border-t-0 first:pt-0 md:grid-cols-2 md:gap-8 md:py-16"
           >
-            <Mono className="md:col-span-1">0{index + 1}</Mono>
-            <Trait className="md:col-span-5">{item.trait}</Trait>
-            <Lead className="md:col-span-6">{item.description}</Lead>
+            <Trait>{item.trait}</Trait>
+            <Lead>{item.description}</Lead>
           </div>
         ))}
       </div>

--- a/clients/apps/web/src/components/Brand/brand.ts
+++ b/clients/apps/web/src/components/Brand/brand.ts
@@ -9,16 +9,16 @@ export interface BrandColor {
 export const brandColors: BrandColor[] = [
   {
     name: 'Night',
-    hex: '#171717',
-    oklch: '20.5% 0 0',
+    hex: '#090909',
+    oklch: '14% 0 0',
     role: 'Surface',
     flex: 3,
   },
   {
     name: 'Ash',
     role: 'Raised',
-    hex: '#1D1D1D',
-    oklch: '23% 0 0',
+    hex: '#141414',
+    oklch: '19.1% 0 0',
     flex: 1,
   },
   {
@@ -30,8 +30,8 @@ export const brandColors: BrandColor[] = [
   },
   {
     name: 'Snow',
-    hex: '#BDBDBD',
-    oklch: '79.8% 0 0',
+    hex: '#d8d8d8',
+    oklch: '88.2% 0 0',
     role: 'Foreground',
     flex: 3,
   },

--- a/clients/apps/web/src/components/Landing/Pipeline.tsx
+++ b/clients/apps/web/src/components/Landing/Pipeline.tsx
@@ -168,7 +168,7 @@ export const Pipeline = () => {
           paddingHorizontal={{ base: '2xl', md: '5xl' }}
           rowGap="xl"
           borderWidth={1}
-          borderColor="border-secondary"
+          borderColor="border-primary"
         >
           {/* Customer */}
           <Box

--- a/clients/apps/web/src/components/Landing/graphics/GaugeSweep.tsx
+++ b/clients/apps/web/src/components/Landing/graphics/GaugeSweep.tsx
@@ -10,7 +10,7 @@ import { useInView } from '@/hooks/useInView'
  */
 
 const BAND_COUNT = 4
-const RAY_COUNT = 10
+const RAY_COUNT = 8
 const ANG_SPEED = 0.15
 
 export const GaugeSweep = () => {

--- a/clients/apps/web/src/styles/globals.css
+++ b/clients/apps/web/src/styles/globals.css
@@ -106,11 +106,11 @@
 
   /* Brand microsite palette (dark-only /brand page). Single source of truth
      for the otherwise hard-coded hex values used across Brand components. */
-  --color-brand-surface: #171717;
-  --color-brand-raised: #1d1d1d;
+  --color-brand-surface: #090909;
+  --color-brand-raised: #141414;
   --color-brand-line: #7b7b7b;
   --color-brand-muted: #7b7b7b;
-  --color-brand-foreground: #bdbdbd;
+  --color-brand-foreground: #d8d8d8;
   --color-brand-bright: #f5f6fa;
   --color-brand-accent: #625fff;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Deepens the /brand dark palette and improves text contrast. Also updates nav, illustrations, typography/voice, and fixes the Landing pipeline border.

- **Refactors**
  - Palette: set `--color-brand-surface` `#090909`, `--color-brand-raised` `#141414`, `--color-brand-foreground` `#d8d8d8`; align `brand.ts` (`Night`, `Ash`, `Snow`) with matching OKLCH.
  - Navigation/order: swap "Illustration" and "Typography" in nav and page; rename tagline to "Brand Identity"; remove "Design" link.
  - Illustrations: add Radial Spinner, Stepped Radial, Compass; reorder list; reduce Gauge rays 10→8.
  - Typography & Voice: smaller specimen sizes and stronger labels; simplify voice to a 2‑column grid and remove numeric index.
  - Landing: set Pipeline border color to `border-primary`.

<sup>Written for commit fb39113fcd05c8043ea8b451f588c1a1d918a7bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

