### PR TITLE
tinybird/metrics: Speed up metrics revenue

### DIFF
--- a/server/tinybird/datasources/order_revenue_by_quarter_hour.datasource
+++ b/server/tinybird/datasources/order_revenue_by_quarter_hour.datasource
@@ -1,0 +1,10 @@
+SCHEMA >
+    `organization_id` UUID,
+    `quarter_hour` DateTime,
+    `product_id` UUID,
+    `event_name` LowCardinality(String),
+    `settlement_revenue` AggregateFunction(sum, Int64),
+    `settlement_fee` AggregateFunction(sum, Int64)
+
+ENGINE AggregatingMergeTree
+ENGINE_SORTING_KEY organization_id, quarter_hour, product_id, event_name

--- a/server/tinybird/endpoints/metrics_revenue.pipe
+++ b/server/tinybird/endpoints/metrics_revenue.pipe
@@ -1,6 +1,6 @@
 DESCRIPTION >
     Revenue metrics endpoint.
-    Fast path reads from orders_base_state_by_quarter_hour MV.
+    Fast path reads from order_revenue_by_quarter_hour MV.
     Direct path scans raw events when customer_ids or external_customer_ids are provided.
     Both paths overlay refund and dispute adjustments from system events.
     Supplies the following metrics:
@@ -29,7 +29,7 @@ SQL >
         {% end %}
         COALESCE(sumMerge(m.settlement_revenue), 0) AS settlement_revenue,
         COALESCE(sumMerge(m.settlement_fee), 0) AS settlement_fee
-    FROM orders_base_state_by_quarter_hour AS m
+    FROM order_revenue_by_quarter_hour AS m
     WHERE
         m.organization_id IN (
             SELECT
@@ -134,43 +134,69 @@ SQL >
         {% end %}
     GROUP BY day
 
-NODE credit_resolve_fx
+NODE credit_lookup_resolve
 SQL >
     %
     SELECT
-        e.organization_id,
-        e.order_id,
         COALESCE(e.order_created_at, e.timestamp) AS event_ts,
         e.product_id,
-        e.amount,
-        multiIf(
-            e.exchange_rate IS NOT NULL AND e.exchange_rate != 0,
-            toFloat64(e.exchange_rate),
-            e.presentment_amount IS NOT NULL AND e.presentment_amount != 0,
-            toFloat64(e.amount) / toFloat64(e.presentment_amount),
-            NULL
-        ) AS own_fx,
-        argMax(
-            multiIf(
-                s.exchange_rate IS NOT NULL AND s.exchange_rate != 0,
-                toFloat64(s.exchange_rate),
-                s.presentment_amount IS NOT NULL AND s.presentment_amount != 0,
-                toFloat64(s.amount) / toFloat64(s.presentment_amount),
-                NULL
-            ),
-            tuple(
-                toUInt8(
-                    if(e.subscription_id IS NOT NULL AND s.subscription_id = e.subscription_id, 1, 0)
-                ),
-                s.timestamp
+        toInt64(
+            round(
+                COALESCE(e.amount, 0) * COALESCE(
+                    argMax(
+                        multiIf(
+                            s.exchange_rate IS NOT NULL AND s.exchange_rate != 0,
+                            toFloat64(s.exchange_rate),
+                            s.presentment_amount IS NOT NULL AND s.presentment_amount != 0,
+                            toFloat64(s.amount) / toFloat64(s.presentment_amount),
+                            NULL
+                        ),
+                        tuple(
+                            toUInt8(
+                                if(
+                                    e.subscription_id IS NOT NULL
+                                    AND s.subscription_id = e.subscription_id,
+                                    1,
+                                    0
+                                )
+                            ),
+                            s.timestamp
+                        )
+                    ),
+                    1.0
+                )
             )
-        ) AS lookup_fx
+        ) AS credit_lookup_amount
     FROM system_events_by_org AS e
     LEFT JOIN
-        system_events_by_org AS s
+        (
+            SELECT
+                organization_id,
+                order_id,
+                customer_id,
+                subscription_id,
+                timestamp,
+                exchange_rate,
+                presentment_amount,
+                amount,
+                presentment_currency,
+                currency
+            FROM system_events_by_org
+            WHERE
+                name = 'balance.order'
+                AND order_id IS NOT NULL
+                AND organization_id IN (
+                    SELECT
+                        toUUID(
+                            arrayJoin(
+                                splitByChar(
+                                    ',', {{ String(org_ids, '00000000-0000-0000-0000-000000000000') }}
+                                )
+                            )
+                        )
+                )
+        ) AS s
         ON s.organization_id = e.organization_id
-        AND s.name = 'balance.order'
-        AND s.order_id IS NOT NULL
         AND s.customer_id = e.customer_id
         AND COALESCE(s.presentment_currency, s.currency) = e.currency
         AND s.timestamp < e.timestamp
@@ -178,6 +204,9 @@ SQL >
     WHERE
         e.order_id IS NOT NULL
         AND e.name = 'balance.credit_order'
+        AND (e.exchange_rate IS NULL OR e.exchange_rate = 0)
+        AND (e.presentment_amount IS NULL OR e.presentment_amount = 0)
+        AND COALESCE(e.net_amount, e.amount, 0) != 0
         AND e.organization_id IN (
             SELECT
                 toUUID(
@@ -188,9 +217,9 @@ SQL >
         )
         AND COALESCE(e.order_created_at, e.timestamp)
         <= toDateTime({{ String(bounds_end, '2024-01-02 00:00:00') }}, {{ String(tz, 'UTC') }})
-    GROUP BY e.organization_id, e.order_id, event_ts, e.product_id, e.subscription_id, e.amount, own_fx
+    GROUP BY e.organization_id, e.order_id, event_ts, e.product_id, e.subscription_id, e.amount
 
-NODE credit_by_bucket
+NODE credit_lookup_by_bucket
 SQL >
     %
     SELECT
@@ -206,10 +235,8 @@ SQL >
             toStartOfYear(toDateTime(cfx.event_ts, {{ String(tz, 'UTC') }})) AS day,
         {% else %} toStartOfDay(toDateTime(cfx.event_ts, {{ String(tz, 'UTC') }})) AS day,
         {% end %}
-        COALESCE(
-            SUM(toInt64(round(COALESCE(cfx.amount, 0) * COALESCE(cfx.own_fx, cfx.lookup_fx, 1.0)))), 0
-        ) AS credit_revenue
-    FROM credit_resolve_fx AS cfx
+        COALESCE(SUM(cfx.credit_lookup_amount), 0) AS credit_lookup_revenue
+    FROM credit_lookup_resolve AS cfx
     WHERE
         cfx.event_ts
         >= toDateTime({{ String(bounds_start, '2024-01-01 00:00:00') }}, {{ String(tz, 'UTC') }})
@@ -221,14 +248,11 @@ SQL >
         {% end %}
     GROUP BY day
 
-NODE credit_baseline
+NODE credit_lookup_baseline
 SQL >
     %
-    SELECT
-        COALESCE(
-            SUM(toInt64(round(COALESCE(cfx.amount, 0) * COALESCE(cfx.own_fx, cfx.lookup_fx, 1.0)))), 0
-        ) AS hist_credit_revenue
-    FROM credit_resolve_fx AS cfx
+    SELECT COALESCE(SUM(cfx.credit_lookup_amount), 0) AS hist_credit_lookup_revenue
+    FROM credit_lookup_resolve AS cfx
     WHERE
         cfx.event_ts
         < toDateTime({{ String(bounds_start, '2024-01-01 00:00:00') }}, {{ String(tz, 'UTC') }})
@@ -243,7 +267,7 @@ SQL >
     SELECT
         COALESCE(sumMerge(m.settlement_revenue), 0) AS hist_settlement_revenue,
         COALESCE(sumMerge(m.settlement_fee), 0) AS hist_settlement_fee
-    FROM orders_base_state_by_quarter_hour AS m
+    FROM order_revenue_by_quarter_hour AS m
     WHERE
         m.organization_id IN (
             SELECT
@@ -300,40 +324,40 @@ SQL >
     %
     SELECT
         w.interval AS timestamp,
-        COALESCE(r.settlement_revenue, 0) + COALESCE(c.credit_revenue, 0) AS revenue,
-        (COALESCE(r.settlement_revenue, 0) + COALESCE(c.credit_revenue, 0))
+        COALESCE(r.settlement_revenue, 0) + COALESCE(c.credit_lookup_revenue, 0) AS revenue,
+        (COALESCE(r.settlement_revenue, 0) + COALESCE(c.credit_lookup_revenue, 0))
         - COALESCE(r.settlement_fee, 0)
         + COALESCE(a.adjustment_net_amount, 0) AS net_revenue,
         COALESCE(
-            sum(COALESCE(r.settlement_revenue, 0) + COALESCE(c.credit_revenue, 0)) OVER (
+            sum(COALESCE(r.settlement_revenue, 0) + COALESCE(c.credit_lookup_revenue, 0)) OVER (
                 ORDER BY w.interval
             ),
             0
         )
-        + (mb.hist_settlement_revenue + cb.hist_credit_revenue) AS cumulative_revenue,
+        + (mb.hist_settlement_revenue + cb.hist_credit_lookup_revenue) AS cumulative_revenue,
         COALESCE(
             sum(
-                (COALESCE(r.settlement_revenue, 0) + COALESCE(c.credit_revenue, 0))
+                (COALESCE(r.settlement_revenue, 0) + COALESCE(c.credit_lookup_revenue, 0))
                 - COALESCE(r.settlement_fee, 0)
                 + COALESCE(a.adjustment_net_amount, 0)
             ) OVER (ORDER BY w.interval),
             0
         ) + (
             mb.hist_settlement_revenue
-            + cb.hist_credit_revenue
+            + cb.hist_credit_lookup_revenue
             - mb.hist_settlement_fee
             + ab.hist_adjustment_net_amount
         ) AS net_cumulative_revenue
     FROM intervals w
     LEFT JOIN revenue_from_mv r ON r.day = w.interval
     LEFT JOIN adjustments_by_bucket a ON a.day = w.interval
-    LEFT JOIN credit_by_bucket c ON c.day = w.interval
+    LEFT JOIN credit_lookup_by_bucket c ON c.day = w.interval
     CROSS JOIN mv_baseline mb
     CROSS JOIN adj_baseline ab
-    CROSS JOIN credit_baseline cb
+    CROSS JOIN credit_lookup_baseline cb
     ORDER BY w.interval
 
-NODE direct_resolve_fx
+NODE direct_events
 SQL >
     %
     SELECT
@@ -342,45 +366,24 @@ SQL >
         COALESCE(e.order_created_at, e.timestamp) AS event_ts,
         e.product_id,
         e.name,
+        e.customer_id,
+        e.subscription_id,
+        e.currency,
+        e.timestamp,
         e.net_amount,
         e.amount,
         e.fee,
-        e.applied_balance_amount,
         multiIf(
             e.exchange_rate IS NOT NULL AND e.exchange_rate != 0,
             toFloat64(e.exchange_rate),
             e.presentment_amount IS NOT NULL AND e.presentment_amount != 0,
             toFloat64(e.amount) / toFloat64(e.presentment_amount),
             NULL
-        ) AS own_fx,
-        argMax(
-            multiIf(
-                s.exchange_rate IS NOT NULL AND s.exchange_rate != 0,
-                toFloat64(s.exchange_rate),
-                s.presentment_amount IS NOT NULL AND s.presentment_amount != 0,
-                toFloat64(s.amount) / toFloat64(s.presentment_amount),
-                NULL
-            ),
-            tuple(
-                toUInt8(
-                    if(e.subscription_id IS NOT NULL AND s.subscription_id = e.subscription_id, 1, 0)
-                ),
-                s.timestamp
-            )
-        ) AS lookup_fx
+        ) AS own_fx
     FROM system_events_by_org AS e
-    LEFT JOIN
-        system_events_by_org AS s
-        ON s.organization_id = e.organization_id
-        AND s.name = 'balance.order'
-        AND s.order_id IS NOT NULL
-        AND s.customer_id = e.customer_id
-        AND COALESCE(s.presentment_currency, s.currency) = e.currency
-        AND s.timestamp < e.timestamp
-        AND s.order_id != e.order_id
     WHERE
         e.order_id IS NOT NULL
-        AND e.name IN ('order.paid', 'balance.order', 'balance.credit_order')
+        AND e.name IN ('balance.order', 'balance.credit_order')
         AND e.organization_id IN (
             SELECT
                 toUUID(
@@ -445,18 +448,114 @@ SQL >
                     )
             )
         {% end %}
+
+NODE direct_resolve_fx
+SQL >
+    %
+    SELECT
+        e.organization_id,
+        e.order_id,
+        e.event_ts,
+        e.product_id,
+        e.name,
+        e.net_amount,
+        e.amount,
+        e.fee,
+        e.own_fx,
+        CAST(NULL AS Nullable(Float64)) AS lookup_fx
+    FROM direct_events AS e
+    WHERE
+        NOT (
+            e.name = 'balance.credit_order'
+            AND e.own_fx IS NULL
+            AND COALESCE(e.net_amount, e.amount, 0) != 0
+        )
     GROUP BY
         e.organization_id,
         e.order_id,
-        event_ts,
+        e.event_ts,
         e.product_id,
         e.name,
         e.subscription_id,
         e.net_amount,
         e.amount,
         e.fee,
-        e.applied_balance_amount,
-        own_fx
+        e.own_fx
+    UNION ALL
+    SELECT
+        e.organization_id,
+        e.order_id,
+        e.event_ts,
+        e.product_id,
+        e.name,
+        e.net_amount,
+        e.amount,
+        e.fee,
+        e.own_fx,
+        argMax(
+            multiIf(
+                s.exchange_rate IS NOT NULL AND s.exchange_rate != 0,
+                toFloat64(s.exchange_rate),
+                s.presentment_amount IS NOT NULL AND s.presentment_amount != 0,
+                toFloat64(s.amount) / toFloat64(s.presentment_amount),
+                NULL
+            ),
+            tuple(
+                toUInt8(
+                    if(e.subscription_id IS NOT NULL AND s.subscription_id = e.subscription_id, 1, 0)
+                ),
+                s.timestamp
+            )
+        ) AS lookup_fx
+    FROM direct_events AS e
+    LEFT JOIN
+        (
+            SELECT
+                organization_id,
+                order_id,
+                customer_id,
+                subscription_id,
+                timestamp,
+                exchange_rate,
+                presentment_amount,
+                amount,
+                presentment_currency,
+                currency
+            FROM system_events_by_org
+            WHERE
+                name = 'balance.order'
+                AND order_id IS NOT NULL
+                AND organization_id IN (
+                    SELECT
+                        toUUID(
+                            arrayJoin(
+                                splitByChar(
+                                    ',', {{ String(org_ids, '00000000-0000-0000-0000-000000000000') }}
+                                )
+                            )
+                        )
+                )
+        ) AS s
+        ON s.organization_id = e.organization_id
+        AND s.customer_id = e.customer_id
+        AND COALESCE(s.presentment_currency, s.currency) = e.currency
+        AND s.timestamp < e.timestamp
+        AND s.order_id != e.order_id
+    WHERE
+        e.name = 'balance.credit_order'
+        AND e.own_fx IS NULL
+        AND COALESCE(e.net_amount, e.amount, 0) != 0
+    GROUP BY
+        e.organization_id,
+        e.order_id,
+        e.event_ts,
+        e.product_id,
+        e.name,
+        e.subscription_id,
+        e.net_amount,
+        e.amount,
+        e.fee,
+        e.own_fx
 
 NODE direct_revenue_by_bucket
 SQL >
@@ -476,44 +575,16 @@ SQL >
         {% end %}
         COALESCE(
             SUM(
-                IF(
-                    rfx.name IN ('balance.order', 'balance.credit_order'),
-                    toInt64(
-                        round(
-                            COALESCE(rfx.net_amount, rfx.amount, 0)
-                            * COALESCE(rfx.own_fx, rfx.lookup_fx, 1.0)
-                        )
-                    ),
-                    toInt64(0)
+                toInt64(
+                    round(
+                        COALESCE(rfx.net_amount, rfx.amount, 0)
+                        * COALESCE(rfx.own_fx, rfx.lookup_fx, 1.0)
+                    )
                 )
             ),
             0
         ) AS settlement_revenue,
-        COALESCE(
-            SUM(
-                IF(
-                    rfx.name IN ('balance.order', 'balance.credit_order'),
-                    toInt64(COALESCE(rfx.fee, 0)),
-                    toInt64(0)
-                )
-            ),
-            0
-        ) AS settlement_fee,
-        COALESCE(
-            SUM(
-                IF(
-                    rfx.name IN ('balance.order', 'balance.credit_order') AND rfx.net_amount IS NULL,
-                    toInt64(
-                        round(
-                            greatest(COALESCE(rfx.applied_balance_amount, 0), 0)
-                            * COALESCE(rfx.own_fx, rfx.lookup_fx, 1.0)
-                        )
-                    ),
-                    toInt64(0)
-                )
-            ),
-            0
-        ) AS applied_balance_settlement
+        COALESCE(SUM(toInt64(COALESCE(rfx.fee, 0))), 0) AS settlement_fee
     FROM direct_resolve_fx AS rfx
     WHERE
         rfx.event_ts
@@ -532,44 +603,16 @@ SQL >
     SELECT
         COALESCE(
             SUM(
-                IF(
-                    rfx.name IN ('balance.order', 'balance.credit_order'),
-                    toInt64(
-                        round(
-                            COALESCE(rfx.net_amount, rfx.amount, 0)
-                            * COALESCE(rfx.own_fx, rfx.lookup_fx, 1.0)
-                        )
-                    ),
-                    toInt64(0)
+                toInt64(
+                    round(
+                        COALESCE(rfx.net_amount, rfx.amount, 0)
+                        * COALESCE(rfx.own_fx, rfx.lookup_fx, 1.0)
+                    )
                 )
             ),
             0
         ) AS hist_settlement_revenue,
-        COALESCE(
-            SUM(
-                IF(
-                    rfx.name IN ('balance.order', 'balance.credit_order'),
-                    toInt64(COALESCE(rfx.fee, 0)),
-                    toInt64(0)
-                )
-            ),
-            0
-        ) AS hist_settlement_fee,
-        COALESCE(
-            SUM(
-                IF(
-                    rfx.name IN ('balance.order', 'balance.credit_order') AND rfx.net_amount IS NULL,
-                    toInt64(
-                        round(
-                            greatest(COALESCE(rfx.applied_balance_amount, 0), 0)
-                            * COALESCE(rfx.own_fx, rfx.lookup_fx, 1.0)
-                        )
-                    ),
-                    toInt64(0)
-                )
-            ),
-            0
-        ) AS hist_applied_balance_settlement
+        COALESCE(SUM(toInt64(COALESCE(rfx.fee, 0))), 0) AS hist_settlement_fee
     FROM direct_resolve_fx AS rfx
     WHERE
         rfx.event_ts
@@ -710,29 +753,21 @@ SQL >
     %
     SELECT
         w.interval AS timestamp,
-        COALESCE(r.settlement_revenue, 0) - COALESCE(r.applied_balance_settlement, 0) AS revenue,
-        (COALESCE(r.settlement_revenue, 0) - COALESCE(r.applied_balance_settlement, 0))
+        COALESCE(r.settlement_revenue, 0) AS revenue,
+        COALESCE(r.settlement_revenue, 0)
         - COALESCE(r.settlement_fee, 0)
         + COALESCE(a.adjustment_net_amount, 0) AS net_revenue,
-        COALESCE(
-            sum(COALESCE(r.settlement_revenue, 0) - COALESCE(r.applied_balance_settlement, 0)) OVER (
-                ORDER BY w.interval
-            ),
-            0
-        )
-        + (mb.hist_settlement_revenue - mb.hist_applied_balance_settlement) AS cumulative_revenue,
+        COALESCE(sum(COALESCE(r.settlement_revenue, 0)) OVER (ORDER BY w.interval), 0)
+        + mb.hist_settlement_revenue AS cumulative_revenue,
         COALESCE(
             sum(
-                (COALESCE(r.settlement_revenue, 0) - COALESCE(r.applied_balance_settlement, 0))
+                COALESCE(r.settlement_revenue, 0)
                 - COALESCE(r.settlement_fee, 0)
                 + COALESCE(a.adjustment_net_amount, 0)
             ) OVER (ORDER BY w.interval),
             0
         ) + (
-            mb.hist_settlement_revenue
-            - mb.hist_applied_balance_settlement
-            - mb.hist_settlement_fee
-            + ab.hist_adjustment_net_amount
+            mb.hist_settlement_revenue - mb.hist_settlement_fee + ab.hist_adjustment_net_amount
         ) AS net_cumulative_revenue
     FROM intervals w
     LEFT JOIN direct_revenue_by_bucket r ON r.day = w.interval

--- a/server/tinybird/pipes/order_revenue_by_quarter_hour_mv.pipe
+++ b/server/tinybird/pipes/order_revenue_by_quarter_hour_mv.pipe
@@ -1,0 +1,39 @@
+NODE materialize
+SQL >
+    SELECT
+        organization_id,
+        toStartOfFifteenMinutes(COALESCE(order_created_at, timestamp)) AS quarter_hour,
+        COALESCE(product_id, toUUID('00000000-0000-0000-0000-000000000000')) AS product_id,
+        name AS event_name,
+        sumState(
+            toInt64(
+                round(
+                    COALESCE(net_amount, amount, 0) * COALESCE(
+                        multiIf(
+                            exchange_rate IS NOT NULL AND exchange_rate != 0,
+                            toFloat64(exchange_rate),
+                            presentment_amount IS NOT NULL AND presentment_amount != 0,
+                            toFloat64(amount) / toFloat64(presentment_amount),
+                            NULL
+                        ),
+                        1.0
+                    )
+                )
+            )
+        ) AS settlement_revenue,
+        sumState(toInt64(COALESCE(fee, 0))) AS settlement_fee
+    FROM events_by_ingested_at
+    WHERE
+        source = 'system'
+        AND name IN ('balance.order', 'balance.credit_order')
+        AND order_id IS NOT NULL
+        AND NOT (
+            name = 'balance.credit_order'
+            AND (exchange_rate IS NULL OR exchange_rate = 0)
+            AND (presentment_amount IS NULL OR presentment_amount = 0)
+            AND COALESCE(net_amount, amount, 0) != 0
+        )
+    GROUP BY organization_id, quarter_hour, product_id, event_name
+
+TYPE MATERIALIZED
+DATASOURCE order_revenue_by_quarter_hour


### PR DESCRIPTION
metrics_revenue resolved FX for balance.credit_order events at query time via a self-join of system_events_by_org against prior balance.order events (millions of rows on both sides), causing timeouts for large organizations.

This adds an order_revenue_by_quarter_hour materialized view that pre-aggregates settlement revenue and fees for balance.order and balance.credit_order events at ingestion, resolving FX inline from the event's own exchange_rate or amount/presentment_amount ratio.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

