### PR TITLE
adjust SubscriptionsCurrentPeriodEndInvariant leeway from 5 to 10

### DIFF
--- a/server/polar/observability/invariants/rules/subscriptions_current_period_end.py
+++ b/server/polar/observability/invariants/rules/subscriptions_current_period_end.py
@@ -33,7 +33,7 @@ class SubscriptionsCurrentPeriodEndInvariant(Invariant):
     Failure of this invariant indicate there is an issue with the subscription cycle process.
     """
 
-    LEEWAY = timedelta(minutes=5)
+    LEEWAY = timedelta(minutes=10)
     LIMIT = 10
 
     async def check(self) -> None:


### PR DESCRIPTION
## Summary

The invariant check is reporting to eagerly. Bumping `LEEWAY` from 5 to 10 to give it more time to self-resolve.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

