### PR TITLE
feat: only re-review orgs with revenue on product change

### DIFF
--- a/server/polar/organization_review/tasks.py
+++ b/server/polar/organization_review/tasks.py
@@ -6,7 +6,11 @@ import structlog
 from polar.config import Environment, settings
 from polar.exceptions import PolarTaskError
 from polar.integrations.polar.service import polar_self
-from polar.models.organization import Organization, OrganizationStatus
+from polar.models.organization import (
+    FIRST_REVIEW_THRESHOLD_CENTS,
+    Organization,
+    OrganizationStatus,
+)
 from polar.models.organization_review import OrganizationReview
 from polar.models.support_case import (
     SupportCaseAudience,
@@ -140,7 +144,8 @@ async def run_review_agent(
 
     For SUBMISSION context: creates an OrganizationReview record and auto-denies on DENY.
     For THRESHOLD context: log-only, persists to OrganizationAgentReview table.
-    For PRODUCT_CHANGED context: pulls an active org back into REVIEW on a bad verdict.
+    For PRODUCT_CHANGED context: pulls an active org with enough revenue back
+    into REVIEW on a bad verdict.
     """
     if settings.ENV == Environment.sandbox:
         return
@@ -170,17 +175,27 @@ async def run_review_agent(
         # to pull them back into review. Status may have changed between enqueue
         # and execution (debounce delay), so re-check here before spending an
         # agent run.
-        if (
-            review_context == ReviewContext.PRODUCT_CHANGED
-            and organization.status != OrganizationStatus.ACTIVE
-        ):
-            log.info(
-                "organization_review.product_changed.skip_non_active",
-                organization_id=str(organization_id),
-                slug=organization.slug,
-                status=organization.status,
-            )
-            return
+        if review_context == ReviewContext.PRODUCT_CHANGED:
+            if organization.status != OrganizationStatus.ACTIVE:
+                log.info(
+                    "organization_review.product_changed.skip_non_active",
+                    organization_id=str(organization_id),
+                    slug=organization.slug,
+                    status=organization.status,
+                )
+                return
+
+            # Most product changes come from merchants still experimenting, who
+            # have made close to no money. Reviewing them is noise, so we use
+            # the same revenue bar as the first threshold review.
+            if (organization.total_balance or 0) < FIRST_REVIEW_THRESHOLD_CENTS:
+                log.info(
+                    "organization_review.product_changed.skip_low_balance",
+                    organization_id=str(organization_id),
+                    slug=organization.slug,
+                    total_balance=organization.total_balance,
+                )
+                return
 
         result = await run_organization_review(
             session, organization, context=review_context

--- a/server/polar/product/service.py
+++ b/server/polar/product/service.py
@@ -794,6 +794,8 @@ class ProductService:
         per-organization and only pulls the org back into review on a bad
         verdict (see organization_review.tasks). Non-active orgs (e.g. still
         onboarding) are skipped — there is nothing to pull back into review.
+        The task also skips orgs below the first-review revenue bar, so
+        merchants still experimenting with products don't generate review noise.
         """
         if product.organization.status == OrganizationStatus.ACTIVE:
             enqueue_job(

--- a/server/tests/organization_review/test_tasks.py
+++ b/server/tests/organization_review/test_tasks.py
@@ -11,6 +11,7 @@ import pytest
 from sqlalchemy import update
 
 from polar.models.organization import (
+    FIRST_REVIEW_THRESHOLD_CENTS,
     STATUS_CAPABILITIES,
     Organization,
     OrganizationStatus,
@@ -690,16 +691,20 @@ class TestReviewAppeal:
 
 @pytest.mark.asyncio
 class TestRunReviewAgentProductChanged:
-    """PRODUCT_CHANGED re-reviews an active org when it creates or edits a
-    product. A bad verdict pulls it back into REVIEW for a human; a clean
-    APPROVE is a no-op. It never auto-denies."""
+    """PRODUCT_CHANGED re-reviews an active org with enough revenue when it
+    creates or edits a product. A bad verdict pulls it back into REVIEW for a
+    human; a clean APPROVE is a no-op. It never auto-denies."""
 
     async def test_deny_pulls_active_org_into_review(
         self,
+        save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
     ) -> None:
         # The `organization` fixture is ACTIVE by default.
+        organization.total_balance = FIRST_REVIEW_THRESHOLD_CENTS
+        await save_fixture(organization)
+
         agent_result = _make_agent_result(
             verdict=ReviewVerdict.DENY,
             risk_level=RiskLevel.HIGH,
@@ -736,10 +741,13 @@ class TestRunReviewAgentProductChanged:
 
     async def test_approve_keeps_org_active(
         self,
+        save_fixture: SaveFixture,
         session: AsyncSession,
         organization: Organization,
     ) -> None:
         assert organization.status == OrganizationStatus.ACTIVE
+        organization.total_balance = FIRST_REVIEW_THRESHOLD_CENTS
+        await save_fixture(organization)
 
         agent_result = _make_agent_result(verdict=ReviewVerdict.APPROVE)
 
@@ -798,6 +806,35 @@ class TestRunReviewAgentProductChanged:
         run_review_mock.assert_not_awaited()
         await session.refresh(organization)
         assert organization.status == OrganizationStatus.REVIEW
+
+    async def test_low_balance_org_is_skipped(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        organization.total_balance = FIRST_REVIEW_THRESHOLD_CENTS - 1
+        await save_fixture(organization)
+
+        run_review_mock = AsyncMock()
+        with (
+            patch(
+                "polar.organization_review.tasks.AsyncSessionMaker",
+                return_value=_mock_session_maker(session),
+            ),
+            patch(
+                "polar.organization_review.tasks.run_organization_review",
+                run_review_mock,
+            ),
+        ):
+            await _run_review_agent(
+                organization.id,
+                context=ReviewContext.PRODUCT_CHANGED,
+            )
+
+        run_review_mock.assert_not_awaited()
+        await session.refresh(organization)
+        assert organization.status == OrganizationStatus.ACTIVE
 
 
 class TestRunAgentDebounceKey:


### PR DESCRIPTION
## Summary

An active organization is put back under review when it changes a product and the review agent returns a bad verdict. This now only happens for organizations that have earned at least $10.

## Why

Many merchants create and edit products while they are still trying things out.

## How

- The product-changed task checks `total_balance` right after it checks that the org is active.
- Below the bar it logs `skip_low_balance` and returns before the agent runs.
- It reuses `FIRST_REVIEW_THRESHOLD_CENTS`, the same bar used for the first threshold review, so there is one number to tune.
- The check lives in the task, not at the enqueue site. The job is debounced per organization, so the task reads the fresher balance.

Organizations under the bar are not left unchecked. When they earn past the threshold, the normal threshold review pulls them into review anyway.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

