### PR TITLE
fix layout on event cost span page

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/events/[eventId]/EventsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/events/[eventId]/EventsPage.tsx
@@ -130,15 +130,13 @@ export default function EventDetailPage({
       }
       contextViewClassName="bg-transparent dark:bg-transparent border-none rounded-none md:shadow-none"
     >
-      <div className="grid grid-cols-1 items-start gap-12 md:grid-cols-[1fr_300px]">
+      <div className="flex flex-col gap-12 md:flex-row">
         {/* Left column — event rows */}
-        <div className="flex flex-col gap-y-8">
+        <div className="flex flex-3 flex-col gap-y-8">
           <div className="flex flex-row items-baseline justify-between gap-x-4">
-            <h3 className="min-w-0 text-2xl break-words sm:text-4xl">
-              {event.label}
-            </h3>
+            <h3 className="min-w-0 text-2xl wrap-break-word">{event.label}</h3>
             {'_cost' in event.metadata && event.metadata._cost && (
-              <h3 className="dark:text-polar-500 shrink-0 font-mono text-2xl whitespace-nowrap text-gray-400 sm:text-4xl">
+              <h3 className="dark:text-polar-500 shrink-0 font-mono text-2xl whitespace-nowrap text-gray-400">
                 {formatCurrency('subcent')(
                   Number(event.metadata._cost?.amount ?? 0),
                   event.metadata._cost?.currency ?? 'usd',
@@ -159,8 +157,8 @@ export default function EventDetailPage({
           {children.length > 0 && (
             <div className="flex flex-col gap-y-8">
               <div className="flex flex-row items-baseline justify-between">
-                <h3 className="text-xl sm:text-2xl">Child Events</h3>
-                <h3 className="dark:text-polar-500 text-xl text-gray-400 sm:text-2xl">
+                <h3 className="text-xl">Child Events</h3>
+                <h3 className="dark:text-polar-500 text-xl text-gray-400">
                   {children.length} {children.length === 1 ? 'Event' : 'Events'}
                 </h3>
               </div>
@@ -190,7 +188,7 @@ export default function EventDetailPage({
         </div>
 
         {/* Right column — insights */}
-        <div className="flex flex-col gap-y-5">
+        <div className="flex flex-1 flex-col gap-y-5">
           <Field label="Timestamp">
             <span className="font-mono text-sm capitalize dark:text-white">
               {new Date(event.timestamp).toLocaleDateString('en-US', {


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the event detail cost header layout by switching to a responsive flex layout and adjusting text behavior so long labels wrap while the cost stays aligned and readable.

- **Bug Fixes**
  - Replaced grid with flex (stack on mobile, side-by-side on md+).
  - Set left column to flex-3 and right column to flex-1 for stable proportions.
  - Enabled word wrapping for the event label and kept the cost on one line; simplified oversized heading variants.

<sup>Written for commit 3992e7a885f8e74058eb5135fb6cd346b45066c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

