### PR TITLE
fix mobile layout for preference pagetoggles and token rows

### DIFF
--- a/clients/apps/web/src/components/Settings/AccessTokenSettings.tsx
+++ b/clients/apps/web/src/components/Settings/AccessTokenSettings.tsx
@@ -44,10 +44,10 @@ const AccessToken = (props: schemas['PersonalAccessToken']) => {
 
   return (
     <div className="flex flex-col gap-y-4">
-      <div className="flex flex-row items-center justify-between">
-        <div className="flex flex-row">
-          <div className="gap-y flex flex-col">
-            <h3 className="text-md">{props.comment}</h3>
+      <div className="flex flex-col gap-y-2 md:flex-row md:items-center md:justify-between md:gap-x-4">
+        <div className="flex min-w-0 flex-row">
+          <div className="flex min-w-0 flex-col">
+            <h3 className="text-md truncate">{props.comment}</h3>
             <p className="dark:text-polar-400 text-sm text-gray-500">
               {props.expires_at ? (
                 new Date(props.expires_at) < new Date() ? (
@@ -87,7 +87,7 @@ const AccessToken = (props: schemas['PersonalAccessToken']) => {
             </p>
           </div>
         </div>{' '}
-        <div className="dark:text-polar-400 flex flex-row items-center gap-x-4 space-x-4 text-gray-500">
+        <div className="dark:text-polar-400 flex shrink-0 flex-row items-center justify-end gap-x-4 space-x-4 text-gray-500">
           <AlertDialog>
             <AlertDialogTrigger asChild>
               <Button variant="destructive">Revoke</Button>

--- a/clients/apps/web/src/components/Settings/FeatureSettings.tsx
+++ b/clients/apps/web/src/components/Settings/FeatureSettings.tsx
@@ -84,6 +84,7 @@ export default function FeatureSettings({
       >
         <SettingsGroup>
           <SettingsGroupItem
+            layout="inline"
             title="Localized Checkout"
             description={
               <>
@@ -115,6 +116,7 @@ export default function FeatureSettings({
             />
           </SettingsGroupItem>
           <SettingsGroupItem
+            layout="inline"
             title="Seat-Based Billing"
             description={
               <>

--- a/clients/apps/web/src/components/Settings/OrganizationAccessTokensSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationAccessTokensSettings.tsx
@@ -237,10 +237,10 @@ const AccessTokenItem = ({
 
   return (
     <div className="flex flex-col gap-y-4">
-      <div className="flex flex-row items-center justify-between">
-        <div className="flex flex-row">
-          <div className="gap-y flex flex-col">
-            <h3 className="text-md">{token.comment}</h3>
+      <div className="flex flex-col gap-y-2 md:flex-row md:items-center md:justify-between md:gap-x-4">
+        <div className="flex min-w-0 flex-row">
+          <div className="flex min-w-0 flex-col">
+            <h3 className="text-md truncate">{token.comment}</h3>
             {!minimal && (
               <p className="dark:text-polar-400 text-sm text-gray-500">
                 {token.expires_at ? (
@@ -282,7 +282,7 @@ const AccessTokenItem = ({
             )}
           </div>
         </div>{' '}
-        <div className="dark:text-polar-400 flex flex-row items-center gap-2 text-gray-500">
+        <div className="dark:text-polar-400 flex shrink-0 flex-row items-center justify-end gap-2 text-gray-500">
           <Button onClick={showUpdateModal} size="sm">
             Update
           </Button>

--- a/clients/apps/web/src/components/Settings/OrganizationCustomerEmailSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationCustomerEmailSettings.tsx
@@ -121,7 +121,12 @@ const OrganizationCustomerEmailSettings: React.FC<
   return (
     <SettingsGroup>
       {customerEmails.map(({ key, title, description }) => (
-        <SettingsGroupItem key={key} title={title} description={description}>
+        <SettingsGroupItem
+          key={key}
+          layout="inline"
+          title={title}
+          description={description}
+        >
           <Switch
             checked={settings[key]}
             disabled={readOnly}

--- a/clients/apps/web/src/components/Settings/OrganizationCustomerPortalSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationCustomerPortalSettings.tsx
@@ -82,6 +82,7 @@ const OrganizationCustomerPortalSettings: React.FC<
       >
         <SettingsGroup>
           <SettingsGroupItem
+            layout="inline"
             title="Show metered usage"
             description="Show customer usage in the portal (API endpoints unaffected)"
           >
@@ -104,6 +105,7 @@ const OrganizationCustomerPortalSettings: React.FC<
           </SettingsGroupItem>
 
           <SettingsGroupItem
+            layout="inline"
             title="Enable subscription seat management"
             description="Allow customers to assign and manage seats for their subscriptions."
           >
@@ -126,6 +128,7 @@ const OrganizationCustomerPortalSettings: React.FC<
           </SettingsGroupItem>
 
           <SettingsGroupItem
+            layout="inline"
             title="Allow email address changes"
             description="Allow customers to change the email address associated with their account."
           >
@@ -148,6 +151,7 @@ const OrganizationCustomerPortalSettings: React.FC<
           </SettingsGroupItem>
 
           <SettingsGroupItem
+            layout="inline"
             title="Enable subscription plan changes"
             description="Allow customers to change their subscription plan from the portal."
           >
@@ -170,6 +174,7 @@ const OrganizationCustomerPortalSettings: React.FC<
           </SettingsGroupItem>
 
           <SettingsGroupItem
+            layout="inline"
             title="Enable subscription pausing"
             description="Allow customers to pause and resume their subscriptions from the portal."
           >

--- a/clients/apps/web/src/components/Settings/OrganizationEmbedSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationEmbedSettings.tsx
@@ -100,7 +100,7 @@ const OrganizationEmbedSettings: React.FC<OrganizationEmbedSettingsProps> = ({
             ? 'Only these hosts can embed your checkout.'
             : 'Only these hosts will be able to embed your checkout once we enforce the list. Nothing changes until then.'
         }
-        vertical
+        layout="stacked"
       >
         <Box flexDirection="column" gap="m" width="100%">
           {hosts.length > 0 ? (

--- a/clients/apps/web/src/components/Settings/OrganizationNotificationSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationNotificationSettings.tsx
@@ -44,6 +44,7 @@ const OrganizationNotificationSettings: React.FC<
   return (
     <SettingsGroup>
       <SettingsGroupItem
+        layout="inline"
         title="New Orders"
         description="Receive a notification when new orders are created"
       >
@@ -56,6 +57,7 @@ const OrganizationNotificationSettings: React.FC<
       </SettingsGroupItem>
 
       <SettingsGroupItem
+        layout="inline"
         title="New Subscriptions"
         description="Receive a notification when new subscriptions are created"
       >
@@ -69,6 +71,7 @@ const OrganizationNotificationSettings: React.FC<
 
       {canManage === true && (
         <SettingsGroupItem
+          layout="inline"
           title="Prevented Chargebacks"
           description="Receive a notification when a refund is issued to prevent a chargeback"
         >

--- a/clients/apps/web/src/components/Settings/OrganizationSubscriptionSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationSubscriptionSettings.tsx
@@ -74,6 +74,7 @@ const OrganizationSubscriptionSettings: React.FC<
       >
         <SettingsGroup>
           <SettingsGroupItem
+            layout="inline"
             title="Allow multiple subscriptions"
             description="Customers can have multiple active subscriptions at the same time."
           >
@@ -142,6 +143,7 @@ const OrganizationSubscriptionSettings: React.FC<
           </SettingsGroupItem>
 
           <SettingsGroupItem
+            layout="inline"
             title="Prevent trial abuse"
             description="When enabled, customers who previously had a trial on any of your products won't be eligible for another trial."
           >

--- a/clients/apps/web/src/components/Settings/SettingsGroup.tsx
+++ b/clients/apps/web/src/components/Settings/SettingsGroup.tsx
@@ -8,40 +8,50 @@ export const SettingsGroup: React.FC<React.PropsWithChildren> = ({
   </div>
 )
 
+const layouts = {
+  split: {
+    row: 'flex-col gap-x-12 md:flex-row md:items-start md:justify-between',
+    label: 'w-full md:max-w-1/2',
+    control: 'w-full md:justify-end',
+  },
+  stacked: {
+    row: 'flex-col gap-x-12',
+    label: 'w-full md:max-w-1/2',
+    control: 'w-full',
+  },
+  inline: {
+    row: 'flex-row items-start justify-between gap-x-4 md:gap-x-12',
+    label: 'min-w-0 flex-1 md:max-w-1/2',
+    control: 'shrink-0 justify-end',
+  },
+} as const
+
 export interface SettingsGroupItemProps {
   title: React.ReactNode
   description?: React.ReactNode
-  vertical?: boolean
+  layout?: keyof typeof layouts
 }
 
 export const SettingsGroupItem: React.FC<
   React.PropsWithChildren<SettingsGroupItemProps>
-> = ({ children, title, description, vertical }) => (
-  <div
-    className={twMerge(
-      'flex gap-x-12 gap-y-4 p-4',
-      vertical
-        ? 'flex-col'
-        : 'flex-col md:flex-row md:items-start md:justify-between',
-    )}
-  >
-    <div className="flex w-full flex-col md:max-w-1/2">
-      <h3 className="text-sm font-medium">{title}</h3>
-      {description && (
-        <p className="dark:text-polar-500 text-xs text-gray-500">
-          {description}
-        </p>
+> = ({ children, title, description, layout = 'split' }) => {
+  const { row, label, control } = layouts[layout]
+
+  return (
+    <div className={twMerge('flex gap-y-4 p-4', row)}>
+      <div className={twMerge('flex flex-col', label)}>
+        <h3 className="text-sm font-medium">{title}</h3>
+        {description && (
+          <p className="dark:text-polar-500 text-xs text-gray-500">
+            {description}
+          </p>
+        )}
+      </div>
+      {children && (
+        <div className={twMerge('flex flex-row gap-y-2', control)}>
+          {children}
+        </div>
       )}
     </div>
-    {children && (
-      <div
-        className={twMerge(
-          'flex w-full flex-row gap-y-2 md:w-full',
-          vertical ? '' : 'md:justify-end',
-        )}
-      >
-        {children}
-      </div>
-    )}
-  </div>
-)
+  )
+}

--- a/clients/apps/web/src/components/Settings/SettingsGroup.tsx
+++ b/clients/apps/web/src/components/Settings/SettingsGroup.tsx
@@ -1,4 +1,4 @@
-import { twMerge } from 'tailwind-merge'
+import { Box } from '@polar-sh/orbit/Box'
 
 export const SettingsGroup: React.FC<React.PropsWithChildren> = ({
   children,
@@ -10,19 +10,29 @@ export const SettingsGroup: React.FC<React.PropsWithChildren> = ({
 
 const layouts = {
   split: {
-    row: 'flex-col gap-x-12 md:flex-row md:items-start md:justify-between',
-    label: 'w-full md:max-w-1/2',
-    control: 'w-full md:justify-end',
+    row: {
+      flexDirection: { base: 'column', md: 'row' },
+      columnGap: '3xl',
+      alignItems: { md: 'start' },
+      justifyContent: { md: 'between' },
+    },
+    label: { width: '100%', maxWidth: { md: '50%' } },
+    control: { width: '100%', justifyContent: { md: 'end' } },
   },
   stacked: {
-    row: 'flex-col gap-x-12',
-    label: 'w-full md:max-w-1/2',
-    control: 'w-full',
+    row: { flexDirection: 'column', columnGap: '3xl' },
+    label: { width: '100%', maxWidth: { md: '50%' } },
+    control: { width: '100%' },
   },
   inline: {
-    row: 'flex-row items-start justify-between gap-x-4 md:gap-x-12',
-    label: 'min-w-0 flex-1 md:max-w-1/2',
-    control: 'shrink-0 justify-end',
+    row: {
+      flexDirection: 'row',
+      columnGap: { base: 'l', md: '3xl' },
+      alignItems: 'start',
+      justifyContent: 'between',
+    },
+    label: { minWidth: 0, flex: 1, maxWidth: { md: '50%' } },
+    control: { flexShrink: 0, justifyContent: 'end' },
   },
 } as const
 
@@ -38,20 +48,20 @@ export const SettingsGroupItem: React.FC<
   const { row, label, control } = layouts[layout]
 
   return (
-    <div className={twMerge('flex gap-y-4 p-4', row)}>
-      <div className={twMerge('flex flex-col', label)}>
+    <Box padding="l" rowGap="l" {...row}>
+      <Box flexDirection="column" {...label}>
         <h3 className="text-sm font-medium">{title}</h3>
         {description && (
           <p className="dark:text-polar-500 text-xs text-gray-500">
             {description}
           </p>
         )}
-      </div>
+      </Box>
       {children && (
-        <div className={twMerge('flex flex-row gap-y-2', control)}>
+        <Box flexDirection="row" rowGap="s" {...control}>
           {children}
-        </div>
+        </Box>
       )}
-    </div>
+    </Box>
   )
 }


### PR DESCRIPTION
## Summary

On mobile, every toggle on the Preferences page sat on its own line below its description, taking up a lot of vertical space as the preference page grows with more and more settings. The access-token rows Revoke button was sometimes pushed off the edge of the card on mobile.

- Toggles now sit to the right of their label on mobile, matching desktop.
- Token rows stack properly, with the buttons right-aligned and reachable.
- Replaced the vertical/inline flags on SettingsGroupItem with a single layout prop (split / stacked / inline), so each row declares what it needs instead of combining booleans that could contradict each other.
- Migrated the component to Orbit <Box /> while it was being reworked.


| Toggles on side (top right) |
|---|
| <img width="565" height="773" alt="Screenshot 2026-08-05 at 10 02 27" src="https://github.com/user-attachments/assets/4026c2df-4fdc-4385-ac87-0bee2c5a998a" /> |


No intended change on desktop.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

