### PR TITLE
implement a timeline widget on home

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/DashboardPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/(home)/DashboardPage.tsx
@@ -6,8 +6,8 @@ import { CompassWidget } from '@/components/Compass/CompassWidget'
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import { PlanUpsell } from '@/components/Upsell/PlanUpsell'
 import { AccountWidget } from '@/components/Widgets/AccountWidget'
-import { OrdersWidget } from '@/components/Widgets/OrdersWidget'
 import RevenueWidget from '@/components/Widgets/RevenueWidget'
+import { TimelineWidget } from '@/components/Widgets/TimelineWidget/TimelineWidget'
 import { useHasPermission } from '@/hooks/permissions'
 import { schemas } from '@polar-sh/client'
 import { DisputesBanner } from './DisputesBanner'
@@ -48,7 +48,7 @@ export default function OverviewPage({ organization }: OverviewPageProps) {
       <div className="dark:border-polar-700 overflow-hidden rounded-xl border border-gray-200">
         <div className="grid grid-cols-1 [clip-path:inset(1px_1px_1px_1px)] lg:grid-cols-3">
           <RevenueWidget className={cellClassName} />
-          <OrdersWidget className={cellClassName} />
+          <TimelineWidget className={cellClassName} />
           <AccountWidget className={cellClassName} />
         </div>
       </div>

--- a/clients/apps/web/src/components/Widgets/TimelineWidget/TimelineItem.tsx
+++ b/clients/apps/web/src/components/Widgets/TimelineWidget/TimelineItem.tsx
@@ -1,0 +1,117 @@
+import { schemas } from '@polar-sh/client'
+import { Text, Tooltip, TooltipContent, TooltipTrigger } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { ChevronRightIcon } from 'lucide-react'
+import Link from 'next/link'
+import { twMerge } from 'tailwind-merge'
+import { resolveTimelineEventHref } from './links'
+import type { TimelineEntry } from './renderers'
+
+export const formatRelativeTime = (timestamp: string): string => {
+  const date = new Date(timestamp)
+  const minutes = Math.floor((Date.now() - date.getTime()) / 60_000)
+  if (minutes < 1) return 'now'
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `${days}d ago`
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+}
+
+interface TimelineItemProps {
+  event: schemas['Event']
+  entry: TimelineEntry
+  organizationSlug: string
+}
+
+export const TimelineItem = ({
+  event,
+  entry,
+  organizationSlug,
+}: TimelineItemProps) => (
+  <Link
+    href={resolveTimelineEventHref(event, organizationSlug)}
+    className="block"
+  >
+    <Box
+      columnGap="m"
+      paddingVertical="s"
+      paddingHorizontal="m"
+      borderRadius="s"
+      backgroundColor={{ hover: 'background-card' }}
+      transitionProperty="colors"
+      transitionDuration="fast"
+    >
+      <span className="flex h-5 w-4 shrink-0 items-center justify-center text-sm text-black dark:text-white">
+        {entry.icon}
+      </span>
+      <Box flexDirection="column" flexGrow={1} minWidth={0}>
+        <Box alignItems="baseline" justifyContent="between" columnGap="m">
+          <Text variant="title" truncate>
+            {entry.title}
+          </Text>
+          <Tooltip>
+            <TooltipTrigger>
+              <Text variant="caption" color="muted" wrap="nowrap">
+                {formatRelativeTime(event.timestamp)}
+              </Text>
+            </TooltipTrigger>
+            <TooltipContent side="top" align="end">
+              {new Date(event.timestamp).toLocaleString('en-US', {
+                dateStyle: 'medium',
+                timeStyle: 'medium',
+              })}
+            </TooltipContent>
+          </Tooltip>
+        </Box>
+        {entry.summary ? (
+          <Text variant="caption" color="muted" truncate>
+            {entry.summary}
+          </Text>
+        ) : null}
+      </Box>
+    </Box>
+  </Link>
+)
+
+interface TimelineFoldProps {
+  count: number
+  expanded: boolean
+  onToggle: () => void
+}
+
+export const TimelineFold = ({
+  count,
+  expanded,
+  onToggle,
+}: TimelineFoldProps) => (
+  <Box
+    alignItems="center"
+    columnGap="m"
+    paddingVertical="s"
+    paddingHorizontal="m"
+    borderRadius="s"
+    backgroundColor={{ hover: 'background-card' }}
+    transitionProperty="colors"
+    transitionDuration="fast"
+    cursor={{ hover: 'pointer' }}
+    onClick={onToggle}
+    aria-expanded={expanded}
+  >
+    <span className="flex h-5 w-4 shrink-0 items-center justify-center">
+      <ChevronRightIcon
+        className={twMerge(
+          'dark:text-polar-500 size-3.5 text-gray-500 transition-transform',
+          expanded && 'rotate-90',
+        )}
+        strokeWidth={1.5}
+      />
+    </span>
+    <Text variant="caption" color="muted">
+      {expanded
+        ? 'Hide collapsed events'
+        : `${count} collapsed ${count === 1 ? 'event' : 'events'}`}
+    </Text>
+  </Box>
+)

--- a/clients/apps/web/src/components/Widgets/TimelineWidget/TimelineWidget.tsx
+++ b/clients/apps/web/src/components/Widgets/TimelineWidget/TimelineWidget.tsx
@@ -1,0 +1,212 @@
+'use client'
+
+import { useEvents } from '@/hooks/queries/events'
+import { OrganizationContext } from '@/providers/maintainerOrganization'
+import { schemas } from '@polar-sh/client'
+import { SegmentedControl, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import Link from 'next/link'
+import { Fragment, useContext, useMemo, useState } from 'react'
+import { twMerge } from 'tailwind-merge'
+import { WidgetContainer } from '../WidgetContainer'
+import { WidgetGuard } from '../WidgetGuard'
+import { resolveTimelineEntry, type TimelineEntry } from './renderers'
+import { TimelineFold, TimelineItem } from './TimelineItem'
+
+const WIDGET_TITLE = 'Timeline'
+const EVENT_COUNT = 50
+const FOLD_THRESHOLD = 1
+
+type SourceFilter = 'system' | 'all'
+
+interface TimelineEventItem {
+  event: schemas['Event']
+  entry: TimelineEntry
+}
+
+type TimelineSegment =
+  | { type: 'event'; item: TimelineEventItem }
+  | { type: 'fold'; items: TimelineEventItem[] }
+
+const buildSegments = (events: schemas['Event'][]): TimelineSegment[] => {
+  const segments: TimelineSegment[] = []
+  let buffer: TimelineEventItem[] = []
+
+  const flush = () => {
+    if (buffer.length >= FOLD_THRESHOLD) {
+      segments.push({ type: 'fold', items: buffer })
+    } else {
+      segments.push(...buffer.map((item) => ({ type: 'event' as const, item })))
+    }
+    buffer = []
+  }
+
+  for (const event of events) {
+    const item = { event, entry: resolveTimelineEntry(event) }
+    if (item.entry.importance === 'low') {
+      buffer.push(item)
+    } else {
+      flush()
+      segments.push({ type: 'event', item })
+    }
+  }
+  flush()
+
+  return segments
+}
+
+export interface TimelineWidgetProps {
+  className?: string
+}
+
+export const TimelineWidget = ({ className }: TimelineWidgetProps) => (
+  <WidgetGuard
+    permission="analytics:read"
+    title={WIDGET_TITLE}
+    className={twMerge('min-h-80', className)}
+  >
+    <TimelineWidgetContent className={className} />
+  </WidgetGuard>
+)
+
+const TimelineWidgetContent = ({ className }: TimelineWidgetProps) => {
+  const { organization: org } = useContext(OrganizationContext)
+  const [source, setSource] = useState<SourceFilter>('system')
+  const [expandedFolds, setExpandedFolds] = useState<Set<string>>(new Set())
+
+  const events = useEvents(org.id, {
+    limit: EVENT_COUNT,
+    sorting: ['-timestamp'],
+    depth: 0,
+    ...(source === 'system' ? { source: 'system' } : {}),
+  })
+
+  const segments = useMemo(
+    () => buildSegments(events.data?.items ?? []),
+    [events.data],
+  )
+
+  const toggleFold = (foldId: string) => {
+    setExpandedFolds((current) => {
+      const next = new Set(current)
+      if (next.has(foldId)) {
+        next.delete(foldId)
+      } else {
+        next.add(foldId)
+      }
+      return next
+    })
+  }
+
+  return (
+    <WidgetContainer
+      title={WIDGET_TITLE}
+      action={
+        <SegmentedControl<SourceFilter>
+          size="sm"
+          options={[
+            { value: 'system', label: 'System' },
+            { value: 'all', label: 'All' },
+          ]}
+          value={source}
+          onChange={setSource}
+        />
+      }
+      className={twMerge('min-h-80', className)}
+    >
+      {events.isLoading ? (
+        <div className="animate-pulse">
+          <Box
+            height={128}
+            borderRadius="s"
+            backgroundColor="background-card"
+          />
+        </div>
+      ) : segments.length > 0 ? (
+        <div className="-mx-3">
+          <Box flexDirection="column" rowGap="xs" paddingBottom="xl">
+            {segments.map((segment) => {
+              if (segment.type === 'event') {
+                return (
+                  <TimelineItem
+                    key={segment.item.event.id}
+                    event={segment.item.event}
+                    entry={segment.item.entry}
+                    organizationSlug={org.slug}
+                  />
+                )
+              }
+              const foldId = segment.items[0].event.id
+              const expanded = expandedFolds.has(foldId)
+              return (
+                <Fragment key={foldId}>
+                  <TimelineFold
+                    count={segment.items.length}
+                    expanded={expanded}
+                    onToggle={() => toggleFold(foldId)}
+                  />
+                  {expanded && (
+                    <>
+                      {segment.items.map((item) => (
+                        <TimelineItem
+                          key={item.event.id}
+                          event={item.event}
+                          entry={item.entry}
+                          organizationSlug={org.slug}
+                        />
+                      ))}
+                      <Box
+                        borderBottomWidth={1}
+                        borderStyle="solid"
+                        borderColor="border-primary"
+                        marginVertical="xs"
+                      />
+                    </>
+                  )}
+                </Fragment>
+              )
+            })}
+            <Link
+              href={`/dashboard/${org.slug}/analytics/events`}
+              className="block"
+            >
+              <Box
+                justifyContent="center"
+                paddingVertical="s"
+                paddingHorizontal="m"
+                borderRadius="s"
+                backgroundColor={{ hover: 'background-card' }}
+                transitionProperty="colors"
+                transitionDuration="fast"
+              >
+                <Text variant="caption" color="muted">
+                  View all events
+                </Text>
+              </Box>
+            </Link>
+          </Box>
+        </div>
+      ) : (
+        <Box
+          flexDirection="column"
+          alignItems="center"
+          justifyContent="center"
+          flex={1}
+          marginBottom="xl"
+          padding="2xl"
+          borderRadius="s"
+          backgroundColor="background-card"
+          rowGap="s"
+          textAlign="center"
+        >
+          <Text variant="body" as="h3">
+            No events yet
+          </Text>
+          <Text color="muted">
+            Events from your organization will appear here.
+          </Text>
+        </Box>
+      )}
+    </WidgetContainer>
+  )
+}

--- a/clients/apps/web/src/components/Widgets/TimelineWidget/TimelineWidget.tsx
+++ b/clients/apps/web/src/components/Widgets/TimelineWidget/TimelineWidget.tsx
@@ -3,7 +3,7 @@
 import { useEvents } from '@/hooks/queries/events'
 import { OrganizationContext } from '@/providers/maintainerOrganization'
 import { schemas } from '@polar-sh/client'
-import { SegmentedControl, Text } from '@polar-sh/orbit'
+import { Button, SegmentedControl, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import Link from 'next/link'
 import { Fragment, useContext, useMemo, useState } from 'react'
@@ -122,6 +122,32 @@ const TimelineWidgetContent = ({ className }: TimelineWidgetProps) => {
             backgroundColor="background-card"
           />
         </div>
+      ) : events.isError ? (
+        <Box
+          flexDirection="column"
+          alignItems="center"
+          justifyContent="center"
+          flex={1}
+          marginBottom="xl"
+          padding="2xl"
+          borderRadius="s"
+          backgroundColor="background-card"
+          rowGap="s"
+          textAlign="center"
+        >
+          <Text variant="body" as="h3">
+            Couldn&apos;t load events
+          </Text>
+          <Text color="muted">Something went wrong. Please try again.</Text>
+          <Button
+            variant="secondary"
+            size="sm"
+            loading={events.isRefetching}
+            onClick={() => events.refetch()}
+          >
+            Retry
+          </Button>
+        </Box>
       ) : segments.length > 0 ? (
         <div className="-mx-3">
           <Box flexDirection="column" rowGap="xs" paddingBottom="xl">

--- a/clients/apps/web/src/components/Widgets/TimelineWidget/links.ts
+++ b/clients/apps/web/src/components/Widgets/TimelineWidget/links.ts
@@ -1,0 +1,67 @@
+import { buildCustomerDashboardPath } from '@/utils/customer'
+import { schemas } from '@polar-sh/client'
+
+const asId = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.length > 0 ? value : undefined
+
+const resolveResourcePath = (
+  event: schemas['SystemEvent'],
+  organizationSlug: string,
+): string | undefined => {
+  const base = `/dashboard/${organizationSlug}`
+  const metadata = event.metadata as Record<string, unknown>
+
+  switch (event.name.split('.')[0]) {
+    case 'subscription': {
+      const id = asId(metadata.subscription_id)
+      return id && `${base}/sales/subscriptions/${id}`
+    }
+    case 'order': {
+      const id = asId(metadata.order_id)
+      return id && `${base}/sales/${id}`
+    }
+    case 'checkout': {
+      const id = asId(metadata.checkout_id)
+      return id && `${base}/sales/checkouts/${id}`
+    }
+    case 'customer': {
+      if (event.name === 'customer.deleted') {
+        return undefined
+      }
+      if (event.customer) {
+        return buildCustomerDashboardPath(organizationSlug, event.customer)
+      }
+      const id = asId(metadata.customer_id)
+      return id && `${base}/customers/${id}`
+    }
+    case 'benefit': {
+      const id = asId(metadata.benefit_id)
+      return id && `${base}/products/benefits/${id}`
+    }
+    case 'meter': {
+      const id = asId(metadata.meter_id)
+      return id && `${base}/products/meters/${id}`
+    }
+    case 'balance': {
+      const disputeId = asId(metadata.dispute_id)
+      if (disputeId) {
+        return `${base}/sales/disputes/${disputeId}`
+      }
+      const orderId = asId(metadata.order_id)
+      return orderId && `${base}/sales/${orderId}`
+    }
+  }
+
+  return undefined
+}
+
+export const resolveTimelineEventHref = (
+  event: schemas['Event'],
+  organizationSlug: string,
+): string => {
+  const fallback = `/dashboard/${organizationSlug}/analytics/events/${event.id}`
+  if (event.source !== 'system') {
+    return fallback
+  }
+  return resolveResourcePath(event, organizationSlug) ?? fallback
+}

--- a/clients/apps/web/src/components/Widgets/TimelineWidget/renderers.tsx
+++ b/clients/apps/web/src/components/Widgets/TimelineWidget/renderers.tsx
@@ -71,7 +71,7 @@ const timelineRenderers: TimelineRendererMap = {
   'subscription.cycled': {
     importance: 'medium',
     summary: ({ metadata }) =>
-      metadata.amount && metadata.currency
+      metadata.amount !== undefined && metadata.currency
         ? currency(metadata.amount, metadata.currency)
         : undefined,
   },

--- a/clients/apps/web/src/components/Widgets/TimelineWidget/renderers.tsx
+++ b/clients/apps/web/src/components/Widgets/TimelineWidget/renderers.tsx
@@ -1,0 +1,216 @@
+import AllInclusiveOutlined from '@mui/icons-material/AllInclusiveOutlined'
+import AttachMoneyOutlined from '@mui/icons-material/AttachMoneyOutlined'
+import BoltOutlined from '@mui/icons-material/BoltOutlined'
+import DiamondOutlined from '@mui/icons-material/DiamondOutlined'
+import DonutLargeOutlined from '@mui/icons-material/DonutLargeOutlined'
+import PersonOutlineOutlined from '@mui/icons-material/PersonOutlineOutlined'
+import ShoppingBagOutlined from '@mui/icons-material/ShoppingBagOutlined'
+import ShoppingCartOutlined from '@mui/icons-material/ShoppingCartOutlined'
+import { benefitsDisplayNames } from '@/components/Benefit/utils'
+import { schemas } from '@polar-sh/client'
+import { formatCurrency } from '@polar-sh/currency'
+import type { ReactNode } from 'react'
+
+export type TimelineImportance = 'high' | 'medium' | 'low'
+
+export interface TimelineEntry {
+  importance: TimelineImportance
+  title: string
+  icon: ReactNode
+  summary?: ReactNode
+}
+
+type SystemEventName = schemas['SystemEvent']['name']
+type SystemEventByName<N extends SystemEventName> = Extract<
+  schemas['SystemEvent'],
+  { name: N }
+>
+
+interface TimelineRenderer<N extends SystemEventName> {
+  importance: TimelineImportance
+  summary?: (event: SystemEventByName<N>) => ReactNode
+}
+
+type TimelineRendererMap = {
+  [N in SystemEventName]: TimelineRenderer<N>
+}
+
+const currency = formatCurrency('standard')
+
+const humanize = (value: string): string =>
+  value.replace(/_/g, ' ').replace(/^./, (c) => c.toUpperCase())
+
+const recurringPrice = (
+  amount: number,
+  currencyCode: string,
+  interval?: string,
+  intervalCount?: number,
+): string => {
+  const price = currency(amount, currencyCode)
+  if (!interval) {
+    return price
+  }
+  const cadence =
+    intervalCount && intervalCount > 1
+      ? `every ${intervalCount} ${interval}s`
+      : `per ${interval}`
+  return `${price} ${cadence}`
+}
+
+const timelineRenderers: TimelineRendererMap = {
+  'subscription.created': {
+    importance: 'high',
+    summary: ({ metadata }) =>
+      recurringPrice(
+        metadata.amount,
+        metadata.currency,
+        metadata.recurring_interval,
+        metadata.recurring_interval_count,
+      ),
+  },
+  'subscription.cycled': {
+    importance: 'medium',
+    summary: ({ metadata }) =>
+      metadata.amount && metadata.currency
+        ? currency(metadata.amount, metadata.currency)
+        : undefined,
+  },
+  'subscription.updated': { importance: 'medium' },
+  'subscription.product_updated': { importance: 'medium' },
+  'subscription.seats_updated': {
+    importance: 'medium',
+    summary: ({ metadata }) =>
+      `${metadata.old_seats} → ${metadata.new_seats} seats`,
+  },
+  'subscription.billing_period_updated': { importance: 'low' },
+  'subscription.update_cleared': { importance: 'low' },
+  'subscription.uncanceled': { importance: 'high' },
+  'subscription.reactivated': { importance: 'high' },
+  'subscription.reinstated': { importance: 'high' },
+  'subscription.resumed': { importance: 'medium' },
+  'subscription.paused': { importance: 'medium' },
+  'subscription.canceled': {
+    importance: 'high',
+    summary: ({ metadata }) =>
+      metadata.customer_cancellation_reason
+        ? humanize(metadata.customer_cancellation_reason)
+        : undefined,
+  },
+  'subscription.revoked': { importance: 'high' },
+  'subscription.past_due': { importance: 'high' },
+  'order.paid': {
+    importance: 'high',
+    summary: ({ metadata }) =>
+      currency(metadata.amount, metadata.currency ?? 'usd'),
+  },
+  'order.refunded': {
+    importance: 'high',
+    summary: ({ metadata }) =>
+      currency(metadata.refunded_amount, metadata.currency),
+  },
+  'order.voided': {
+    importance: 'high',
+    summary: ({ metadata }) => currency(metadata.amount, metadata.currency),
+  },
+  'order.unvoided': {
+    importance: 'medium',
+    summary: ({ metadata }) => currency(metadata.amount, metadata.currency),
+  },
+  'checkout.created': {
+    importance: 'low',
+    summary: ({ metadata }) => humanize(metadata.checkout_status),
+  },
+  'customer.created': {
+    importance: 'medium',
+    summary: ({ metadata }) =>
+      metadata.customer_name || metadata.customer_email || undefined,
+  },
+  'customer.updated': { importance: 'low' },
+  'customer.deleted': {
+    importance: 'medium',
+    summary: ({ metadata }) =>
+      metadata.customer_name || metadata.customer_email || undefined,
+  },
+  'benefit.granted': {
+    importance: 'medium',
+    summary: ({ metadata }) => benefitsDisplayNames[metadata.benefit_type],
+  },
+  'benefit.revoked': {
+    importance: 'medium',
+    summary: ({ metadata }) => benefitsDisplayNames[metadata.benefit_type],
+  },
+  'benefit.cycled': {
+    importance: 'low',
+    summary: ({ metadata }) => benefitsDisplayNames[metadata.benefit_type],
+  },
+  'benefit.updated': {
+    importance: 'low',
+    summary: ({ metadata }) => benefitsDisplayNames[metadata.benefit_type],
+  },
+  'balance.order': { importance: 'low' },
+  'balance.credit_order': { importance: 'low' },
+  'balance.refund': {
+    importance: 'high',
+    summary: ({ metadata }) => currency(metadata.amount, metadata.currency),
+  },
+  'balance.refund_reversal': { importance: 'medium' },
+  'balance.dispute': {
+    importance: 'high',
+    summary: ({ metadata }) => currency(metadata.amount, metadata.currency),
+  },
+  'balance.dispute_reversal': { importance: 'medium' },
+  'meter.credited': {
+    importance: 'low',
+    summary: ({ metadata }) =>
+      `${metadata.units.toLocaleString()} ${metadata.units === 1 ? 'unit' : 'units'}`,
+  },
+  'meter.reset': { importance: 'low' },
+}
+
+const CATEGORY_ICONS: Record<string, ReactNode> = {
+  subscription: <AllInclusiveOutlined fontSize="inherit" />,
+  order: <ShoppingBagOutlined fontSize="inherit" />,
+  checkout: <ShoppingCartOutlined fontSize="inherit" />,
+  customer: <PersonOutlineOutlined fontSize="inherit" />,
+  benefit: <DiamondOutlined fontSize="inherit" />,
+  balance: <AttachMoneyOutlined fontSize="inherit" />,
+  meter: <DonutLargeOutlined fontSize="inherit" />,
+}
+
+const USER_EVENT_ICON = <BoltOutlined fontSize="inherit" />
+
+const resolveTimelineIcon = (event: schemas['Event']): ReactNode => {
+  if (event.source === 'user') {
+    return USER_EVENT_ICON
+  }
+  return CATEGORY_ICONS[event.name.split('.')[0]] ?? USER_EVENT_ICON
+}
+
+export const resolveTimelineEntry = (
+  event: schemas['Event'],
+): TimelineEntry => {
+  const icon = resolveTimelineIcon(event)
+
+  if (event.source === 'user') {
+    return {
+      importance: 'low',
+      title: event.label,
+      icon,
+    }
+  }
+
+  const renderer = timelineRenderers[event.name] as
+    | TimelineRenderer<SystemEventName>
+    | undefined
+
+  if (!renderer) {
+    return { importance: 'low', title: event.label, icon }
+  }
+
+  return {
+    importance: renderer.importance,
+    title: event.label,
+    icon,
+    summary: renderer.summary?.(event as never),
+  }
+}


### PR DESCRIPTION

<img width="1382" height="471" alt="Screenshot 2026-08-05 at 10 52 57" src="https://github.com/user-attachments/assets/accc9759-a157-407b-b277-45c2b934daa5" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Timeline widget to the dashboard home to surface recent system and user events with quick links to related resources. Replaces the Orders widget in the 3-up grid.

- **New Features**
  - Timeline shows the latest 50 events with relative time and precise tooltip.
  - Filter by source (System or All) via a segmented control.
  - Low-importance events can be folded to reduce noise.
  - Click-through links resolve to the related resource when possible; fallback to the event detail page. Covers subscriptions, orders, checkouts, customers, benefits, meters, balance, and disputes.
  - Compact summaries for common events (amounts, seat changes, statuses).
  - Includes “View all events” link and an empty state.
  - Guarded by analytics:read permission.

- **Bug Fixes**
  - Small UI and behavior fixes for folding and navigation, plus minor polish to loading/error states.

<sup>Written for commit 5677893a58984a261ffa0dc658c88afdc6d6b2fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



