### PR TITLE
feat(dev): point local environments at a personal Stripe sandbox

### DIFF
--- a/.agents/skills/local-environment/rules/payment-testing.md
+++ b/.agents/skills/local-environment/rules/payment-testing.md
@@ -32,7 +32,7 @@ an approved org (`admin-org`) that already has a payout account, identity
 verification, and at least one product. That lets you go straight to
 checkout testing without onboarding work.
 
-## Stripe Webhooks
+## Stripe Sandbox and Webhooks
 
 ```bash
 dev stripe --listen
@@ -40,14 +40,29 @@ dev stripe --listen
 dev stripe --listen --port <api-port>
 ```
 
+Local environments always run against a **personal Stripe sandbox** — never a
+live account, and never the shared Polar Software Inc account
+(`acct_1LzIVeDG1jUQrXwC`). `dev` refuses both: it checks that the linked
+profile has test keys and, since a sandbox has no live mode, that the Stripe
+CLI stored no live key for it.
+
+The Stripe CLI profile is always named `polar-sandbox`, so `dev` never
+depends on whichever account the CLI happens to have active. Pass
+`-p polar-sandbox` when running `stripe` by hand.
+
 `dev stripe --listen` handles the full setup in one step: installs the
-Stripe CLI if missing, logs in, writes `POLAR_STRIPE_SECRET_KEY`,
-`POLAR_STRIPE_PUBLISHABLE_KEY`, and `POLAR_STRIPE_WEBHOOK_SECRET` into the
-central secrets file, runs `dev/setup-environment` to propagate them, and
-then starts `stripe listen` forwarding to both the regular webhook endpoint
-and the Stripe Connect endpoint (`/v1/integrations/stripe/webhook` and
+Stripe CLI if missing, walks through creating/linking a sandbox, writes
+`POLAR_STRIPE_SECRET_KEY`, `POLAR_STRIPE_PUBLISHABLE_KEY`, and
+`POLAR_STRIPE_WEBHOOK_SECRET` into the central secrets file, runs
+`dev/setup-environment` to propagate them, and then starts `stripe listen`
+forwarding to both the regular webhook endpoint and the Stripe Connect
+endpoint (`/v1/integrations/stripe/webhook` and
 `/v1/integrations/stripe/webhook-connect`). Re-running it later just starts
-the listener.
+the listener. `dev stripe --relink` switches to a different sandbox.
+
+Stripe CLI keys expire after 90 days. An expired key shows up as
+`The API key provided has expired` — `dev stripe` detects it and re-runs the
+link flow.
 
 `--port` defaults to `8000`. Conductor worktrees and multi-instance setups
 land outside the 0–2 base-port table, so read the api port from
@@ -56,6 +71,18 @@ land outside the 0–2 base-port table, so read the api port from
 Leave it running and `stripe listen` will log each event with the API's
 2xx response. Missing webhook → confirm the api port matches
 `dev docker ports`.
+
+One listener signs both endpoints, so `POLAR_STRIPE_WEBHOOK_SECRET` and
+`POLAR_STRIPE_CONNECT_WEBHOOK_SECRET` hold the same value. If they already
+differ, they came from dashboard endpoints and `dev stripe` leaves them
+alone.
+
+## Taxes
+
+Tax is off until the sandbox has a registration. Add one under Tax >
+Registrations in the sandbox: pick "I've already registered", then
+"Non-Union One-Stop Shop (OSS)" for Ireland, starting immediately. EU
+countries then get VAT (Ireland 23%, Sweden 25%, and so on).
 
 ## Checkout Email Validation
 

--- a/.agents/skills/local-environment/rules/payment-testing.md
+++ b/.agents/skills/local-environment/rules/payment-testing.md
@@ -41,10 +41,10 @@ dev stripe --listen --port <api-port>
 ```
 
 Local environments always run against a **personal Stripe sandbox** — never a
-live account, and never the shared Polar Software Inc account
-(`acct_1LzIVeDG1jUQrXwC`). `dev` refuses both: it checks that the linked
-profile has test keys and, since a sandbox has no live mode, that the Stripe
-CLI stored no live key for it.
+live account, and never a shared team account. `dev` refuses both with one
+structural check: the linked profile must hold test keys, and since a sandbox
+has no live mode at all, the Stripe CLI must have stored no live key for it.
+A shared team account is a live account, so it fails that check.
 
 The Stripe CLI profile is always named `polar-sandbox`, so `dev` never
 depends on whichever account the CLI happens to have active. Pass

--- a/.agents/skills/local-environment/rules/payment-testing.md
+++ b/.agents/skills/local-environment/rules/payment-testing.md
@@ -79,10 +79,19 @@ alone.
 
 ## Taxes
 
-Tax is off until the sandbox has a registration. Add one under Tax >
-Registrations in the sandbox: pick "I've already registered", then
-"Non-Union One-Stop Shop (OSS)" for Ireland, starting immediately. EU
-countries then get VAT (Ireland 23%, Sweden 25%, and so on).
+`dev stripe` reports on Stripe Tax, because checkout can't price an order
+without it:
+
+- **inactive/pending** — checkout fails with a tax calculation error. Activate
+  Stripe Tax in the sandbox (it needs a head office address).
+- **active, no registrations** — checkout works, every order is taxed at 0.
+- **active with registrations** — the countries are listed.
+
+To test real tax, add a registration under Tax > Registrations in the sandbox:
+pick "I've already registered", then "Non-Union One-Stop Shop (OSS)" for
+Ireland, starting immediately. EU countries then get VAT (Ireland 23%,
+Sweden 25%, and so on). Tax applies per the customer's billing country, so a
+US-only registration leaves EU orders at 0.
 
 ## Checkout Email Validation
 

--- a/.agents/skills/verifier-web/SKILL.md
+++ b/.agents/skills/verifier-web/SKILL.md
@@ -129,8 +129,9 @@ api 202s the webhook and the **worker** creates the order.
 
 ### 3a. Stripe account + keys
 
-Use **your own Stripe sandbox / test-mode account** — any test account works.
-Never use a production account or a real personal account; test mode only.
+Use **your own Stripe sandbox** (https://dashboard.stripe.com/sandboxes). Never a
+live account, and never the shared Polar Software Inc account — `dev stripe`
+refuses both. The Stripe CLI profile is always `polar-sandbox`.
 
 **Secrets are set up once and reused across worktrees.** They live centrally in
 `~/.config/polar/secrets.env` and `dev/setup-environment` propagates them into
@@ -147,9 +148,8 @@ listener (3b). If the CLI is already configured it skips straight to listening.
 
 CLI test keys expire every 90 days. Symptom of an expired key: checkout sticks on
 "We are processing your order" and the worker/api logs show
-`AuthenticationError: Expired API Key provided`. Refresh by re-running
-`stripe login` for your sandbox project (or `dev stripe`), then recreate services
-(3c).
+`AuthenticationError: Expired API Key provided`. Refresh with `dev stripe`, which
+detects the expired key and re-runs the link flow, then recreate services (3c).
 
 If you ever set keys by hand, set them in the central file (or `server/.env`) and
 keep them on the **same account**: `POLAR_STRIPE_SECRET_KEY` (the secret key),
@@ -258,6 +258,11 @@ stale-key retry, a confusing validation message) — that's the signal.
 - Restart ≠ recreate. `dev docker restart` keeps the old compose env; use
   `dev docker up -d <svc>` to load env/key changes.
 - The api session is DB-backed, so recreating the api keeps you logged in.
-- `dev stripe --listen` skips re-saving the webhook secret when keys are already
-  configured — so a rotated signing secret won't propagate. Set it by hand (3b)
-  if webhooks 400 on signature.
+- `dev stripe --listen` refreshes the webhook secret whenever it writes new API
+  keys, so switching sandbox propagates the new signing secret too. It leaves the
+  two secrets alone when they already differ from each other — that means they
+  came from dashboard endpoints, not the CLI listener.
+- `dev seed` runs on the **host** against `server/.env`
+  (`POLAR_POSTGRES_*`), which is not the dockerized `polar_dev_<N>`. For a
+  docker instance, seed inside the container instead:
+  `docker exec polar-app-<N>-api-1 sh -c 'cd /app/server && uv run python -m scripts.seeds_load'`

--- a/.agents/skills/verifier-web/SKILL.md
+++ b/.agents/skills/verifier-web/SKILL.md
@@ -130,8 +130,8 @@ api 202s the webhook and the **worker** creates the order.
 ### 3a. Stripe account + keys
 
 Use **your own Stripe sandbox** (https://dashboard.stripe.com/sandboxes). Never a
-live account, and never the shared Polar Software Inc account — `dev stripe`
-refuses both. The Stripe CLI profile is always `polar-sandbox`.
+live account, and never a shared team account — `dev stripe` refuses both. The
+Stripe CLI profile is always `polar-sandbox`.
 
 **Secrets are set up once and reused across worktrees.** They live centrally in
 `~/.config/polar/secrets.env` and `dev/setup-environment` propagates them into

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -107,8 +107,9 @@ If you want to work with payments and subscriptions, you need a Stripe **sandbox
 
 > [!IMPORTANT]
 > Every local environment runs against a sandbox you own. Never point it at a live account, and
-> never at the shared Polar Software Inc account — `dev` refuses both. A sandbox is free, is
-> yours alone, and has no live mode, so nothing you do locally can touch real money or team data.
+> never at a shared team account — `dev` refuses both. A sandbox is free, is yours alone, and has
+> no live mode at all, so nothing you do locally can touch real money or team data. That missing
+> live mode is also how `dev` tells a sandbox apart from a real account.
 
 The whole setup is one command:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -138,7 +138,9 @@ through linking again.
 > `dev stripe`, or a manual run), it rebuilds the file from the central secrets and those values win — so
 > edits made directly to `server/.env` are overwritten.
 
-To test **tax calculation**, add a tax registration to your sandbox — see
+**Stripe Tax** must be active in the sandbox, or checkout fails when it tries to price an order.
+`dev stripe` checks this and tells you if it isn't. Once active, orders are taxed at 0 until you
+add a tax registration — see
 [Testing taxes locally](https://handbook.polar.sh/engineering/oncall/developer-faq) in the handbook.
 
 <details>

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -103,32 +103,61 @@ You can override the secrets file location with `POLAR_SECRETS_FILE` environment
 > [!NOTE]
 > Some functions, such as product creation, may not work as expected due to missing Stripe environment variables.
 
-If you want to work with payments and subscriptions, you'll need to set up a Stripe development environment:
+If you want to work with payments and subscriptions, you need a Stripe **sandbox**.
+
+> [!IMPORTANT]
+> Every local environment runs against a sandbox you own. Never point it at a live account, and
+> never at the shared Polar Software Inc account — `dev` refuses both. A sandbox is free, is
+> yours alone, and has no live mode, so nothing you do locally can touch real money or team data.
+
+The whole setup is one command:
+
+```sh
+dev stripe
+```
+
+It installs the Stripe CLI if it's missing, opens the sandbox dashboard, links the CLI to the
+sandbox you pick (under the `polar-sandbox` profile), writes the keys into the central secrets
+file, regenerates the env files, and starts webhook forwarding. `dev up` runs the same flow.
+
+Later runs just start the listener:
+
+```sh
+dev stripe --listen                    # default instance (api on port 8000)
+dev stripe --listen --port <api-port>  # other instances, see `dev docker ports`
+dev stripe --relink                    # switch to a different sandbox
+```
+
+Stripe CLI keys expire after 90 days. When that happens `dev stripe` notices and walks you
+through linking again.
 
 > [!IMPORTANT]
 > Put all Stripe values in the central secrets file `~/.config/polar/secrets.env`, **not** in `server/.env`.
 > Whenever `setup-environment` regenerates `server/.env` (a fresh clone or worktree, `dev up --clean`,
 > `dev stripe`, or a manual run), it rebuilds the file from the central secrets and those values win — so
 > edits made directly to `server/.env` are overwritten.
->
-> Do **not** rely on `dev stripe` for the webhook secrets when using the dashboard-endpoint flow below: it
-> derives the secret from `stripe listen --print-secret` (the Stripe CLI listener, a different secret) and
-> writes that one value to *both* `POLAR_STRIPE_WEBHOOK_SECRET` and `POLAR_STRIPE_CONNECT_WEBHOOK_SECRET`,
-> clobbering your two distinct dashboard secrets. Set those by hand in the central file.
 
-1. **Create a Stripe account** at [https://dashboard.stripe.com/register](https://dashboard.stripe.com/register)
+To test **tax calculation**, add a tax registration to your sandbox — see
+[Testing taxes locally](https://handbook.polar.sh/engineering/oncall/developer-faq) in the handbook.
 
-2. **Copy your API keys** from the [Stripe API Keys page](https://dashboard.stripe.com/test/apikeys) and add them to your `~/.config/polar/secrets.env` file:
+<details>
+<summary>Manual setup, and receiving webhooks on a public URL</summary>
+
+`dev stripe` forwards webhooks through the Stripe CLI listener, which is enough for almost
+everything. Use dashboard endpoints instead only when you need Stripe to reach a public URL
+(for example an ngrok tunnel shared with someone else).
+
+1. **Create a sandbox** at [https://dashboard.stripe.com/sandboxes](https://dashboard.stripe.com/sandboxes)
+
+2. **Copy the sandbox API keys** from its API keys page and add them to `~/.config/polar/secrets.env`:
 
     ```
     POLAR_STRIPE_SECRET_KEY=sk_test_...
     POLAR_STRIPE_PUBLISHABLE_KEY=pk_test_...
     ```
 
-3. **Enable tax calculation** by visiting [https://dashboard.stripe.com/test/tax](https://dashboard.stripe.com/test/tax)
-
-4. **Create webhook endpoints** to handle Stripe events:
-    - Go to [Stripe Webhooks](https://dashboard.stripe.com/test/webhooks)
+3. **Create webhook endpoints** to handle Stripe events:
+    - Go to Webhooks in your sandbox
     - Click "Add destination"
     - Select "Your account"
     - Set API version to the latest (not the preview)
@@ -146,6 +175,11 @@ If you want to work with payments and subscriptions, you'll need to set up a Str
             ```
             POLAR_STRIPE_CONNECT_WEBHOOK_SECRET=whsec_...
             ```
+
+These two secrets differ from each other, and `dev stripe` leaves them alone when it sees that —
+it only writes the CLI listener secret when both entries are empty or already identical.
+
+</details>
 
 **Optional: setup SSO (local mock OIDC)**
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -180,7 +180,8 @@ everything. Use dashboard endpoints instead only when you need Stripe to reach a
             ```
 
 These two secrets differ from each other, and `dev stripe` leaves them alone when it sees that —
-it only writes the CLI listener secret when both entries are empty or already identical.
+it writes the CLI listener secret only when the two entries are identical (including both empty),
+and leaves them untouched whenever they differ.
 
 </details>
 

--- a/dev/cli/commands/docker.py
+++ b/dev/cli/commands/docker.py
@@ -29,6 +29,7 @@ from shared import (
     SERVER_DIR,
     console,
     is_docker_running,
+    read_secrets,
     run_command,
 )
 
@@ -343,12 +344,8 @@ def _ensure_env_file() -> None:
 
 
 def _load_central_secrets() -> dict[str, str]:
-    """Load secrets from central file if it exists."""
-    if not SECRETS_FILE.exists():
-        return {}
-    from dotenv import dotenv_values
-
-    return {k: v for k, v in dotenv_values(SECRETS_FILE).items() if v}
+    """Load secrets that carry a value, so blanks don't override template defaults."""
+    return {k: v for k, v in read_secrets().items() if v}
 
 
 def _ensure_server_env() -> None:

--- a/dev/cli/commands/seed.py
+++ b/dev/cli/commands/seed.py
@@ -7,34 +7,13 @@ from rich.text import Text
 
 from shared import (
     ROOT_DIR,
-    SECRETS_FILE,
     SERVER_DIR,
     console,
     run_command,
     step_spinner,
     step_status,
+    update_secrets,
 )
-
-
-def _update_secrets_file(key: str, value: str) -> None:
-    """Update a key in the central secrets file."""
-    SECRETS_FILE.parent.mkdir(parents=True, exist_ok=True)
-
-    existing = {}
-    if SECRETS_FILE.exists():
-        for line in SECRETS_FILE.read_text().split("\n"):
-            if "=" in line and not line.startswith("#"):
-                k, v = line.split("=", 1)
-                existing[k.strip()] = v.strip().strip("\"'")
-
-    existing[key] = value
-
-    with open(SECRETS_FILE, "w") as f:
-        f.write("# Polar Development Secrets\n")
-        f.write("# Shared across Git worktrees\n\n")
-        for k, v in existing.items():
-            delimiter = "'" if '"' in v else '"'
-            f.write(f"{k}={delimiter}{v}{delimiter}\n")
 
 
 def _configure_polar_self_integration() -> None:
@@ -47,10 +26,12 @@ def _configure_polar_self_integration() -> None:
     if not result or result.returncode != 0:
         return
 
+    values = {}
     for line in result.stdout.strip().split("\n"):
         if "=" in line:
             key, value = line.split("=", 1)
-            _update_secrets_file(key.strip(), value.strip())
+            values[key.strip()] = value.strip()
+    update_secrets(values)
 
     run_command([str(ROOT_DIR / "dev" / "setup-environment")], capture=True)
     console.print("[dim]Configured Polar self-integration in .env[/dim]")

--- a/dev/cli/commands/stripe.py
+++ b/dev/cli/commands/stripe.py
@@ -3,7 +3,7 @@
 import typer
 
 import stripe_config
-from shared import ROOT_DIR, console, run_command, step_status
+from shared import console, run_command
 
 
 def register(app: typer.Typer, prompt_setup: callable) -> None:
@@ -21,59 +21,10 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
         """Set up Stripe sandbox integration for local development."""
         console.print("\n[bold blue]Stripe Setup[/bold blue]\n")
 
-        if not stripe_config.is_cli_installed():
-            step_status(False, "Stripe CLI", "not installed")
-            if not typer.confirm("\n  Install Stripe CLI via Homebrew now?", default=True):
-                console.print("[yellow]Stripe CLI is required. Install it and re-run dev stripe.[/yellow]")
-                raise typer.Exit(1)
-            console.print()
-            if not stripe_config.install_cli():
-                console.print("[red]Installation failed. Install manually: brew install stripe/stripe-cli/stripe[/red]")
-                raise typer.Exit(1)
-        step_status(True, "Stripe CLI", "installed")
-
-        if relink:
-            stripe_config.print_sandbox_instructions()
-            if not stripe_config.login():
-                console.print("[red]Stripe login failed. Please try again.[/red]")
-                raise typer.Exit(1)
-
-        profile = stripe_config.ensure_sandbox_profile()
-        if profile is None:
+        if stripe_config.configure(relink=relink) is None:
             raise typer.Exit(1)
-        step_status(True, "Stripe sandbox", profile.display_name)
 
-        status, _ = stripe_config.secrets_status()
-        changed = False
-
-        if status == "ok":
-            step_status(True, "Stripe API keys", "configured")
-        else:
-            stripe_config.save_keys(profile)
-            step_status(True, "Stripe API keys", "saved")
-            changed = True
-
-        # New keys mean a different sandbox, so the stored listener secret is stale.
-        if changed or not stripe_config.read_secrets().get("POLAR_STRIPE_WEBHOOK_SECRET"):
-            console.print("\n[bold]Getting webhook secret from Stripe CLI...[/bold]")
-            webhook_secret = stripe_config.fetch_webhook_secret()
-            if not webhook_secret:
-                console.print("[yellow]Could not get webhook secret automatically.[/yellow]")
-                webhook_secret = typer.prompt(
-                    "Enter webhook secret manually (whsec_...), or press Enter to skip", default=""
-                )
-            if webhook_secret:
-                stripe_config.save_webhook_secret(webhook_secret)
-                step_status(True, "Webhook secret", "saved")
-                changed = True
-
-        if changed:
-            console.print("[dim]Updating environment files...[/dim]")
-            run_command([str(ROOT_DIR / "dev" / "setup-environment")], capture=True)
-            step_status(True, "Environment files", "updated")
-            console.print("\n[bold green]Stripe setup complete![/bold green]\n")
-
-        if listen or typer.confirm("Start webhook forwarding now?", default=True):
+        if listen or typer.confirm("\nStart webhook forwarding now?", default=True):
             _start_webhook_listener(port)
         else:
             console.print("[bold]To start webhook forwarding later:[/bold]")

--- a/dev/cli/commands/stripe.py
+++ b/dev/cli/commands/stripe.py
@@ -2,92 +2,15 @@
 
 import typer
 
-from shared import ROOT_DIR, SECRETS_FILE, console, run_command, step_status
-
-
-def _is_stripe_cli_installed() -> bool:
-    """Check if Stripe CLI is installed."""
-    result = run_command(["which", "stripe"], capture=True)
-    return result is not None and result.returncode == 0
-
-
-def _is_stripe_cli_logged_in() -> bool:
-    """Check if Stripe CLI is logged in by verifying API keys exist."""
-    secret_key, publishable_key = _get_stripe_keys_from_cli()
-    return bool(secret_key and publishable_key)
-
-
-def _get_stripe_keys_from_cli() -> tuple[str, str]:
-    """Get test mode API keys from Stripe CLI config."""
-    result = run_command(["stripe", "config", "--list"], capture=True)
-    if not result or result.returncode != 0:
-        return "", ""
-
-    secret_key = ""
-    publishable_key = ""
-
-    for line in result.stdout.split("\n"):
-        line = line.strip()
-        if line.startswith("test_mode_api_key"):
-            secret_key = line.split("=", 1)[1].strip().strip("'\"")
-        elif line.startswith("test_mode_pub_key"):
-            publishable_key = line.split("=", 1)[1].strip().strip("'\"")
-
-    return secret_key, publishable_key
-
-
-def _is_stripe_configured() -> bool:
-    """Check if Stripe keys are configured."""
-    if SECRETS_FILE.exists():
-        content = SECRETS_FILE.read_text()
-        has_secret = False
-        has_publishable = False
-        for line in content.split("\n"):
-            if line.startswith("POLAR_STRIPE_SECRET_KEY="):
-                value = line.split("=", 1)[1].strip().strip("\"'")
-                has_secret = bool(value)
-            if line.startswith("POLAR_STRIPE_PUBLISHABLE_KEY="):
-                value = line.split("=", 1)[1].strip().strip("\"'")
-                has_publishable = bool(value)
-        return has_secret and has_publishable
-    return False
-
-
-def _update_secrets_file(key: str, value: str | None) -> None:
-    """Update a key in the secrets file."""
-    SECRETS_FILE.parent.mkdir(parents=True, exist_ok=True)
-
-    existing = {}
-    if SECRETS_FILE.exists():
-        for line in SECRETS_FILE.read_text().split("\n"):
-            if "=" in line and not line.startswith("#"):
-                k, v = line.split("=", 1)
-                existing[k.strip()] = v.strip().strip("\"'")
-
-    if value is None:
-        existing.pop(key, None)
-    else:
-        existing[key] = value
-
-    with open(SECRETS_FILE, "w") as f:
-        for k, v in existing.items():
-            delimiter = "'" if '"' in v else '"'
-            f.write(f"{k}={delimiter}{v}{delimiter}\n")
-
-
-def _save_stripe_keys(secret_key: str, publishable_key: str, webhook_secret: str = "") -> None:
-    """Save Stripe keys to the central secrets file."""
-    _update_secrets_file("POLAR_STRIPE_SECRET_KEY", secret_key)
-    _update_secrets_file("POLAR_STRIPE_PUBLISHABLE_KEY", publishable_key)
-    if webhook_secret:
-        _update_secrets_file("POLAR_STRIPE_WEBHOOK_SECRET", webhook_secret)
-        _update_secrets_file("POLAR_STRIPE_CONNECT_WEBHOOK_SECRET", webhook_secret)
+import stripe_config
+from shared import ROOT_DIR, console, run_command, step_status
 
 
 def register(app: typer.Typer, prompt_setup: callable) -> None:
     @app.command()
     def stripe(
         listen: bool = typer.Option(False, "--listen", help="Start webhook forwarding after setup"),
+        relink: bool = typer.Option(False, "--relink", help="Link the Stripe CLI to a different sandbox"),
         port: int = typer.Option(
             8000,
             "--port",
@@ -95,70 +18,60 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
             help="API port to forward webhooks to (use the port shown by `dev docker up`)",
         ),
     ) -> None:
-        """Set up Stripe integration for local development."""
+        """Set up Stripe sandbox integration for local development."""
         console.print("\n[bold blue]Stripe Setup[/bold blue]\n")
 
-        if not _is_stripe_cli_installed():
+        if not stripe_config.is_cli_installed():
             step_status(False, "Stripe CLI", "not installed")
-            if typer.confirm("\n  Install Stripe CLI via Homebrew now?", default=True):
-                console.print()
-                result = run_command(["brew", "install", "stripe/stripe-cli/stripe"], capture=False)
-                if not result or result.returncode != 0 or not _is_stripe_cli_installed():
-                    console.print("[red]Installation failed. Install manually: brew install stripe/stripe-cli/stripe[/red]")
-                    raise typer.Exit(1)
-            else:
+            if not typer.confirm("\n  Install Stripe CLI via Homebrew now?", default=True):
                 console.print("[yellow]Stripe CLI is required. Install it and re-run dev stripe.[/yellow]")
+                raise typer.Exit(1)
+            console.print()
+            if not stripe_config.install_cli():
+                console.print("[red]Installation failed. Install manually: brew install stripe/stripe-cli/stripe[/red]")
                 raise typer.Exit(1)
         step_status(True, "Stripe CLI", "installed")
 
-        if not _is_stripe_cli_logged_in():
-            step_status(False, "Stripe CLI", "not logged in")
-            console.print("\n  This will open your browser to authenticate.\n")
-            if typer.confirm("  Run 'stripe login' now?", default=True):
-                run_command(["stripe", "login"], capture=False)
-                if not _is_stripe_cli_logged_in():
-                    console.print("[red]Stripe login failed. Please try again.[/red]")
-                    raise typer.Exit(1)
-            else:
-                console.print("[yellow]Stripe login required to continue.[/yellow]")
+        if relink:
+            stripe_config.print_sandbox_instructions()
+            if not stripe_config.login():
+                console.print("[red]Stripe login failed. Please try again.[/red]")
                 raise typer.Exit(1)
-        step_status(True, "Stripe CLI", "logged in")
 
-        if _is_stripe_configured():
+        profile = stripe_config.ensure_sandbox_profile()
+        if profile is None:
+            raise typer.Exit(1)
+        step_status(True, "Stripe sandbox", profile.display_name)
+
+        status, _ = stripe_config.secrets_status()
+        changed = False
+
+        if status == "ok":
             step_status(True, "Stripe API keys", "configured")
-            _start_webhook_listener(port)
-            return
-
-        console.print("\n[bold]Fetching API keys from Stripe CLI...[/bold]")
-        secret_key, publishable_key = _get_stripe_keys_from_cli()
-
-        if secret_key and publishable_key:
-            console.print(f"[green]✓ Secret key: {secret_key[:12]}...{secret_key[-4:]}[/green]")
-            console.print(f"[green]✓ Publishable key: {publishable_key[:12]}...{publishable_key[-4:]}[/green]")
         else:
-            console.print("[yellow]Could not fetch keys automatically. Please enter manually.[/yellow]")
-            console.print("Get your test API keys from: [link=https://dashboard.stripe.com/test/apikeys]https://dashboard.stripe.com/test/apikeys[/link]\n")
-            secret_key = typer.prompt("Stripe Secret Key (sk_test_...)")
-            publishable_key = typer.prompt("Stripe Publishable Key (pk_test_...)")
+            stripe_config.save_keys(profile)
+            step_status(True, "Stripe API keys", "saved")
+            changed = True
 
-        console.print("\n[bold]Getting webhook secret from Stripe CLI...[/bold]")
-        result = run_command(["stripe", "listen", "--print-secret"], capture=True)
-        webhook_secret = ""
-        if result and result.returncode == 0:
-            webhook_secret = result.stdout.strip()
-            console.print("[green]✓ Webhook secret obtained[/green]")
-        else:
-            console.print("[yellow]Could not get webhook secret automatically.[/yellow]")
-            webhook_secret = typer.prompt("Enter webhook secret manually (whsec_...), or press Enter to skip", default="")
+        # New keys mean a different sandbox, so the stored listener secret is stale.
+        if changed or not stripe_config.read_secrets().get("POLAR_STRIPE_WEBHOOK_SECRET"):
+            console.print("\n[bold]Getting webhook secret from Stripe CLI...[/bold]")
+            webhook_secret = stripe_config.fetch_webhook_secret()
+            if not webhook_secret:
+                console.print("[yellow]Could not get webhook secret automatically.[/yellow]")
+                webhook_secret = typer.prompt(
+                    "Enter webhook secret manually (whsec_...), or press Enter to skip", default=""
+                )
+            if webhook_secret:
+                stripe_config.save_webhook_secret(webhook_secret)
+                step_status(True, "Webhook secret", "saved")
+                changed = True
 
-        _save_stripe_keys(secret_key, publishable_key, webhook_secret)
-        step_status(True, "Stripe API keys", "saved")
-
-        console.print("[dim]Updating environment files...[/dim]")
-        run_command([str(ROOT_DIR / "dev" / "setup-environment")], capture=True)
-        step_status(True, "Environment files", "updated")
-
-        console.print("\n[bold green]Stripe setup complete![/bold green]\n")
+        if changed:
+            console.print("[dim]Updating environment files...[/dim]")
+            run_command([str(ROOT_DIR / "dev" / "setup-environment")], capture=True)
+            step_status(True, "Environment files", "updated")
+            console.print("\n[bold green]Stripe setup complete![/bold green]\n")
 
         if listen or typer.confirm("Start webhook forwarding now?", default=True):
             _start_webhook_listener(port)
@@ -177,6 +90,7 @@ def _start_webhook_listener(port: int = 8000) -> None:
     run_command(
         [
             "stripe", "listen",
+            "-p", stripe_config.STRIPE_CLI_PROFILE,
             "--forward-to", f"{base}/v1/integrations/stripe/webhook",
             "--forward-connect-to", f"{base}/v1/integrations/stripe/webhook-connect",
         ],

--- a/dev/cli/secrets_io.py
+++ b/dev/cli/secrets_io.py
@@ -1,0 +1,116 @@
+"""Reading and writing the central development secrets file.
+
+Both `dev/cli` and the standalone `dev/setup-environment` script write this
+file, so the rules for locking, quoting and permissions live here and nowhere
+else. Keep this module to the standard library plus python-dotenv: the
+setup-environment script depends on only those.
+"""
+
+import fcntl
+import os
+import shutil
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+SECRETS_FILE = Path(
+    os.environ.get(
+        "POLAR_SECRETS_FILE", Path.home() / ".config" / "polar" / "secrets.env"
+    )
+)
+TEMPLATE_FILE = Path(__file__).parent.parent / "secrets.env.template"
+
+_HEADER = (
+    "# Polar Development Secrets\n"
+    "# Shared across Git worktrees. See dev/secrets.env.template\n\n"
+)
+
+
+@contextmanager
+def secrets_lock():
+    """Serialize the whole read/merge/write so parallel runs don't drop keys.
+
+    flock is per open file description, so this must not be nested: a second
+    acquisition in the same process would block on the first.
+    """
+    SECRETS_FILE.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    lock_path = SECRETS_FILE.with_name(f"{SECRETS_FILE.name}.lock")
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def quote(value: str) -> str:
+    """Quote a value so any content survives a dotenv round-trip."""
+    escaped = str(value).replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def read_secrets() -> dict[str, str]:
+    """Read the secrets file literally, keeping entries set to an empty string.
+
+    Interpolation is off: a secret containing `${...}` is a literal value, not
+    a reference to another entry.
+    """
+    if not SECRETS_FILE.exists():
+        return {}
+    return {
+        k: v
+        for k, v in dotenv_values(SECRETS_FILE, interpolate=False).items()
+        if v is not None
+    }
+
+
+def _write(secrets: dict[str, str]) -> None:
+    """Replace the secrets file atomically. Caller must hold the lock."""
+    # mkstemp creates with 0600, and the rename is atomic, so the values are
+    # never briefly world-readable and an interrupted write keeps the old file.
+    fd, tmp_path = tempfile.mkstemp(
+        dir=SECRETS_FILE.parent, prefix=f".{SECRETS_FILE.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(_HEADER)
+            for key, value in secrets.items():
+                # The file has to stay plain text: dev/setup-environment reads it
+                # to build server/.env, which docker compose loads as-is.
+                f.write(f"{key}={quote(value)}\n")  # codeql[py/clear-text-storage-sensitive-data]
+        os.replace(tmp_path, SECRETS_FILE)
+    except BaseException:
+        os.unlink(tmp_path)
+        raise
+
+
+def update_secrets(values: dict[str, str | None]) -> None:
+    """Merge values into the secrets file, dropping keys set to None."""
+    if not values:
+        return
+
+    with secrets_lock():
+        secrets = read_secrets()
+        for key, value in values.items():
+            if value is None:
+                secrets.pop(key, None)
+            else:
+                secrets[key] = value
+        _write(secrets)
+
+
+def ensure_secrets_file() -> bool:
+    """Create the secrets file from the template. Returns True if it created one."""
+    with secrets_lock():
+        if SECRETS_FILE.exists():
+            return False
+
+        if TEMPLATE_FILE.exists():
+            shutil.copy(TEMPLATE_FILE, SECRETS_FILE)
+        else:
+            SECRETS_FILE.write_text(_HEADER)
+        SECRETS_FILE.chmod(0o600)
+        return True

--- a/dev/cli/secrets_io.py
+++ b/dev/cli/secrets_io.py
@@ -9,6 +9,7 @@ setup-environment script depends on only those.
 import fcntl
 import os
 import shutil
+import stat
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
@@ -103,9 +104,16 @@ def update_secrets(values: dict[str, str | None]) -> None:
 
 
 def ensure_secrets_file() -> bool:
-    """Create the secrets file from the template. Returns True if it created one."""
+    """Create the secrets file if missing and keep it private.
+
+    Returns True if it created one. Files created before this ran, or copied in
+    from elsewhere, are tightened to 0600 here rather than staying readable
+    until something happens to rewrite them.
+    """
     with secrets_lock():
         if SECRETS_FILE.exists():
+            if stat.S_IMODE(SECRETS_FILE.stat().st_mode) != 0o600:
+                SECRETS_FILE.chmod(0o600)
             return False
 
         if TEMPLATE_FILE.exists():

--- a/dev/cli/shared.py
+++ b/dev/cli/shared.py
@@ -7,6 +7,7 @@ import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from dotenv import dotenv_values
 from rich.console import Console
 from rich.live import Live
 from rich.padding import Padding
@@ -35,6 +36,35 @@ class Context:
     skip_tinybird: bool = False
     database_name: str | None = None
     state: dict = field(default_factory=dict)
+
+
+def read_secrets() -> dict[str, str]:
+    """Read the central secrets file."""
+    if not SECRETS_FILE.exists():
+        return {}
+    return {k: v for k, v in dotenv_values(SECRETS_FILE).items() if v is not None}
+
+
+def update_secrets(values: dict[str, str | None]) -> None:
+    """Merge values into the central secrets file, dropping keys set to None.
+
+    Values are read and written quoted, so multi-line secrets such as the
+    GitHub App private key survive a rewrite intact.
+    """
+    secrets = read_secrets()
+    for key, value in values.items():
+        if value is None:
+            secrets.pop(key, None)
+        else:
+            secrets[key] = value
+
+    SECRETS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with open(SECRETS_FILE, "w") as f:
+        f.write("# Polar Development Secrets\n")
+        f.write("# Shared across Git worktrees. See dev/secrets.env.template\n\n")
+        for key, value in secrets.items():
+            delimiter = "'" if '"' in value else '"'
+            f.write(f"{key}={delimiter}{value}{delimiter}\n")
 
 
 def run_command(

--- a/dev/cli/shared.py
+++ b/dev/cli/shared.py
@@ -1,9 +1,12 @@
 """Shared utilities and context for the Polar Development CLI."""
 
+import fcntl
 import os
 import shutil
 import socket
 import subprocess
+import tempfile
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -43,35 +46,74 @@ class Context:
 
 
 def read_secrets() -> dict[str, str]:
+    """Read the central secrets file literally.
+
+    Interpolation is off: a secret containing `${...}` is a literal value here,
+    not a reference to another entry.
+    """
     if not SECRETS_FILE.exists():
         return {}
-    return {k: v for k, v in dotenv_values(SECRETS_FILE).items() if v is not None}
+    return {
+        k: v
+        for k, v in dotenv_values(SECRETS_FILE, interpolate=False).items()
+        if v is not None
+    }
+
+
+@contextmanager
+def _secrets_lock():
+    """Serialize read/merge/write so parallel worktrees don't drop each other's keys."""
+    SECRETS_FILE.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    lock_path = SECRETS_FILE.with_name(f"{SECRETS_FILE.name}.lock")
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def _quote(value: str) -> str:
+    """Quote a value so any content survives a dotenv round-trip."""
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
 
 
 def update_secrets(values: dict[str, str | None]) -> None:
     """Merge values into the central secrets file, dropping keys set to None.
 
-    Values are read and written quoted, so multi-line secrets such as the
-    GitHub App private key survive a rewrite intact.
+    Values are written quoted and escaped, so multi-line secrets such as the
+    GitHub App private key survive a rewrite intact. The file is replaced
+    atomically, so an interrupted write can't destroy the previous contents.
     """
     if not values:
         return
 
-    secrets = read_secrets()
-    for key, value in values.items():
-        if value is None:
-            secrets.pop(key, None)
-        else:
-            secrets[key] = value
+    with _secrets_lock():
+        secrets = read_secrets()
+        for key, value in values.items():
+            if value is None:
+                secrets.pop(key, None)
+            else:
+                secrets[key] = value
 
-    SECRETS_FILE.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    with open(SECRETS_FILE, "w") as f:
-        f.write("# Polar Development Secrets\n")
-        f.write("# Shared across Git worktrees. See dev/secrets.env.template\n\n")
-        for key, value in secrets.items():
-            delimiter = "'" if '"' in value else '"'
-            f.write(f"{key}={delimiter}{value}{delimiter}\n")
-    SECRETS_FILE.chmod(0o600)
+        # mkstemp creates with 0600, so the values are never briefly world-readable.
+        fd, tmp_path = tempfile.mkstemp(
+            dir=SECRETS_FILE.parent, prefix=f".{SECRETS_FILE.name}.", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(fd, "w") as f:
+                f.write("# Polar Development Secrets\n")
+                f.write("# Shared across Git worktrees. See dev/secrets.env.template\n\n")
+                for key, value in secrets.items():
+                    # The file has to stay plain text: dev/setup-environment reads it
+                    # to build server/.env, which docker compose loads as-is.
+                    f.write(f"{key}={_quote(value)}\n")  # codeql[py/clear-text-storage-sensitive-data]
+            os.replace(tmp_path, SECRETS_FILE)
+        except BaseException:
+            os.unlink(tmp_path)
+            raise
 
 
 def run_command(

--- a/dev/cli/shared.py
+++ b/dev/cli/shared.py
@@ -61,13 +61,14 @@ def update_secrets(values: dict[str, str | None]) -> None:
         else:
             secrets[key] = value
 
-    SECRETS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    SECRETS_FILE.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     with open(SECRETS_FILE, "w") as f:
         f.write("# Polar Development Secrets\n")
         f.write("# Shared across Git worktrees. See dev/secrets.env.template\n\n")
         for key, value in secrets.items():
             delimiter = "'" if '"' in value else '"'
             f.write(f"{key}={delimiter}{value}{delimiter}\n")
+    SECRETS_FILE.chmod(0o600)
 
 
 def run_command(

--- a/dev/cli/shared.py
+++ b/dev/cli/shared.py
@@ -24,7 +24,11 @@ DEFAULT_DB_PORT = 5432
 DEFAULT_REDIS_PORT = 6379
 DEFAULT_MINIO_PORT = 9000
 DEFAULT_TINYBIRD_PORT = 7181
-SECRETS_FILE = Path.home() / ".config" / "polar" / "secrets.env"
+SECRETS_FILE = Path(
+    os.environ.get(
+        "POLAR_SECRETS_FILE", Path.home() / ".config" / "polar" / "secrets.env"
+    )
+)
 
 
 @dataclass
@@ -39,7 +43,6 @@ class Context:
 
 
 def read_secrets() -> dict[str, str]:
-    """Read the central secrets file."""
     if not SECRETS_FILE.exists():
         return {}
     return {k: v for k, v in dotenv_values(SECRETS_FILE).items() if v is not None}

--- a/dev/cli/shared.py
+++ b/dev/cli/shared.py
@@ -1,21 +1,21 @@
 """Shared utilities and context for the Polar Development CLI."""
 
-import fcntl
 import os
 import shutil
 import socket
 import subprocess
-import tempfile
-from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from dotenv import dotenv_values
 from rich.console import Console
 from rich.live import Live
 from rich.padding import Padding
 from rich.spinner import Spinner
 from rich.text import Text
+
+from secrets_io import SECRETS_FILE, read_secrets, update_secrets
+
+__all__ = ["SECRETS_FILE", "read_secrets", "update_secrets"]
 
 console = Console()
 ROOT_DIR = Path(__file__).parent.parent.parent.resolve()
@@ -27,11 +27,6 @@ DEFAULT_DB_PORT = 5432
 DEFAULT_REDIS_PORT = 6379
 DEFAULT_MINIO_PORT = 9000
 DEFAULT_TINYBIRD_PORT = 7181
-SECRETS_FILE = Path(
-    os.environ.get(
-        "POLAR_SECRETS_FILE", Path.home() / ".config" / "polar" / "secrets.env"
-    )
-)
 
 
 @dataclass
@@ -43,77 +38,6 @@ class Context:
     skip_tinybird: bool = False
     database_name: str | None = None
     state: dict = field(default_factory=dict)
-
-
-def read_secrets() -> dict[str, str]:
-    """Read the central secrets file literally.
-
-    Interpolation is off: a secret containing `${...}` is a literal value here,
-    not a reference to another entry.
-    """
-    if not SECRETS_FILE.exists():
-        return {}
-    return {
-        k: v
-        for k, v in dotenv_values(SECRETS_FILE, interpolate=False).items()
-        if v is not None
-    }
-
-
-@contextmanager
-def _secrets_lock():
-    """Serialize read/merge/write so parallel worktrees don't drop each other's keys."""
-    SECRETS_FILE.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    lock_path = SECRETS_FILE.with_name(f"{SECRETS_FILE.name}.lock")
-    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
-    try:
-        fcntl.flock(fd, fcntl.LOCK_EX)
-        yield
-    finally:
-        fcntl.flock(fd, fcntl.LOCK_UN)
-        os.close(fd)
-
-
-def _quote(value: str) -> str:
-    """Quote a value so any content survives a dotenv round-trip."""
-    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
-    return f'"{escaped}"'
-
-
-def update_secrets(values: dict[str, str | None]) -> None:
-    """Merge values into the central secrets file, dropping keys set to None.
-
-    Values are written quoted and escaped, so multi-line secrets such as the
-    GitHub App private key survive a rewrite intact. The file is replaced
-    atomically, so an interrupted write can't destroy the previous contents.
-    """
-    if not values:
-        return
-
-    with _secrets_lock():
-        secrets = read_secrets()
-        for key, value in values.items():
-            if value is None:
-                secrets.pop(key, None)
-            else:
-                secrets[key] = value
-
-        # mkstemp creates with 0600, so the values are never briefly world-readable.
-        fd, tmp_path = tempfile.mkstemp(
-            dir=SECRETS_FILE.parent, prefix=f".{SECRETS_FILE.name}.", suffix=".tmp"
-        )
-        try:
-            with os.fdopen(fd, "w") as f:
-                f.write("# Polar Development Secrets\n")
-                f.write("# Shared across Git worktrees. See dev/secrets.env.template\n\n")
-                for key, value in secrets.items():
-                    # The file has to stay plain text: dev/setup-environment reads it
-                    # to build server/.env, which docker compose loads as-is.
-                    f.write(f"{key}={_quote(value)}\n")  # codeql[py/clear-text-storage-sensitive-data]
-            os.replace(tmp_path, SECRETS_FILE)
-        except BaseException:
-            os.unlink(tmp_path)
-            raise
 
 
 def run_command(

--- a/dev/cli/shared.py
+++ b/dev/cli/shared.py
@@ -54,6 +54,9 @@ def update_secrets(values: dict[str, str | None]) -> None:
     Values are read and written quoted, so multi-line secrets such as the
     GitHub App private key survive a rewrite intact.
     """
+    if not values:
+        return
+
     secrets = read_secrets()
     for key, value in values.items():
         if value is None:

--- a/dev/cli/stripe_config.py
+++ b/dev/cli/stripe_config.py
@@ -124,7 +124,7 @@ def saved_keys_rejection() -> str | None:
         return f"there is no '{STRIPE_CLI_PROFILE}' Stripe CLI profile"
     if secret_key != profile.secret_key:
         return f"the keys don't match the '{STRIPE_CLI_PROFILE}' sandbox"
-    return None
+    return sandbox_rejection(profile)
 
 
 def print_sandbox_instructions() -> None:

--- a/dev/cli/stripe_config.py
+++ b/dev/cli/stripe_config.py
@@ -9,6 +9,7 @@ import webbrowser
 from dataclasses import dataclass
 
 import typer
+from dotenv import dotenv_values
 
 from shared import (
     ROOT_DIR,
@@ -100,12 +101,49 @@ def sandbox_rejection(profile: StripeProfile) -> str | None:
     return None
 
 
-def keys_are_usable() -> bool:
-    """Check the stored keys still work — Stripe CLI keys expire after 90 days."""
+def key_auth_failure() -> str | None:
+    """Why Stripe rejected the stored key, or None if it didn't reject it.
+
+    Only an authentication answer counts. A missing CLI, an outage or a
+    dropped network gives a non-zero exit too, and sending someone through a
+    re-link for that would be wrong — so anything unrecognised passes.
+    """
     result = run_command(
         ["stripe", "get", "/v1/account", "-p", STRIPE_CLI_PROFILE], capture=True
     )
-    return result is not None and result.returncode == 0
+    if result is None or result.returncode == 0:
+        return None
+
+    output = f"{result.stdout} {result.stderr}".lower()
+    if "expired" in output:
+        return "the Stripe CLI key has expired"
+    if "invalid api key" in output or "authentication" in output:
+        return "Stripe rejected the stored key"
+    return None
+
+
+def env_needs_sync() -> bool:
+    """True when server/.env doesn't carry the Stripe values from the secrets file.
+
+    Without this, a run that saved the keys but failed to regenerate the env
+    files would look fully configured next time, leaving the services on the
+    previous account's credentials.
+    """
+    env_path = ROOT_DIR / "server" / ".env"
+    if not env_path.exists():
+        return True
+
+    env = dotenv_values(env_path, interpolate=False)
+    secrets = read_secrets()
+    return any(
+        env.get(key) != secrets.get(key)
+        for key in (
+            "POLAR_STRIPE_SECRET_KEY",
+            "POLAR_STRIPE_PUBLISHABLE_KEY",
+            "POLAR_STRIPE_WEBHOOK_SECRET",
+            "POLAR_STRIPE_CONNECT_WEBHOOK_SECRET",
+        )
+    )
 
 
 def has_saved_keys() -> bool:
@@ -191,14 +229,10 @@ def ensure_sandbox_profile(relink: bool = False) -> StripeProfile | None:
 
     profile = read_profile()
     if profile is not None:
-        rejection = sandbox_rejection(profile)
-        if rejection is not None:
-            step_status(False, "Stripe sandbox", rejection)
-        elif keys_are_usable():
+        rejection = sandbox_rejection(profile) or key_auth_failure()
+        if rejection is None:
             return profile
-        else:
-            step_status(False, "Stripe sandbox", "the stored key has expired")
-            console.print("\n  [dim]Stripe CLI keys expire after 90 days.[/dim]")
+        step_status(False, "Stripe sandbox", rejection)
 
     return link_sandbox()
 
@@ -332,7 +366,7 @@ def configure(relink: bool = False) -> StripeProfile | None:
                 "  Re-run `dev stripe` once the Stripe CLI can reach Stripe.[/yellow]"
             )
 
-    if changed:
+    if changed or env_needs_sync():
         console.print("  [dim]Updating environment files...[/dim]")
         result = run_command([str(ROOT_DIR / "dev" / "setup-environment")], capture=True)
         if result and result.returncode == 0:

--- a/dev/cli/stripe_config.py
+++ b/dev/cli/stripe_config.py
@@ -4,6 +4,7 @@ A local environment must talk to a personal Stripe sandbox: never a live
 account, and never a shared team account.
 """
 
+import json
 import webbrowser
 from dataclasses import dataclass
 
@@ -22,6 +23,8 @@ from shared import (
 
 STRIPE_CLI_PROFILE = "polar-sandbox"
 SANDBOX_DASHBOARD_URL = "https://dashboard.stripe.com/sandboxes"
+TAX_SETTINGS_URL = "https://dashboard.stripe.com/test/tax/settings"
+TAX_REGISTRATIONS_URL = "https://dashboard.stripe.com/test/tax/registrations"
 
 
 @dataclass
@@ -194,6 +197,47 @@ def ensure_sandbox_profile(relink: bool = False) -> StripeProfile | None:
     return link_sandbox()
 
 
+def _get_json(path: str) -> dict | None:
+    result = run_command(["stripe", "get", path, "-p", STRIPE_CLI_PROFILE], capture=True)
+    if not result or result.returncode != 0:
+        return None
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def check_tax() -> None:
+    """Report on Stripe Tax, which checkout needs before it can price an order."""
+    settings = _get_json("/v1/tax/settings")
+    if settings is None:
+        return
+
+    if settings.get("status") != "active":
+        step_status(False, "Stripe Tax", settings.get("status", "not set up"))
+        console.print(
+            "\n  [yellow]Checkout fails while Stripe Tax is inactive — it can't price\n"
+            "  an order. Activate it (set a head office address) at[/yellow]"
+        )
+        console.print(f"  [link={TAX_SETTINGS_URL}]{TAX_SETTINGS_URL}[/link]\n")
+        return
+
+    registrations = _get_json("/v1/tax/registrations")
+    if registrations is None:
+        step_status(True, "Stripe Tax", "active")
+        return
+
+    active = [r for r in registrations.get("data", []) if r.get("status") == "active"]
+    if active:
+        countries = ", ".join(sorted({r.get("country", "?") for r in active}))
+        step_status(True, "Stripe Tax", f"active ({countries})")
+        return
+
+    step_status(True, "Stripe Tax", "active, no registrations")
+    console.print("  [dim]Every order is taxed at 0. Add a registration to test tax:[/dim]")
+    console.print(f"  [dim][link={TAX_REGISTRATIONS_URL}]{TAX_REGISTRATIONS_URL}[/link][/dim]")
+
+
 def save_keys(profile: StripeProfile) -> None:
     update_secrets(
         {
@@ -255,6 +299,7 @@ def configure(relink: bool = False) -> StripeProfile | None:
     if profile is None:
         return None
     step_status(True, "Stripe sandbox", profile.display_name)
+    check_tax()
 
     changed = False
     if saved_keys_rejection(profile) is None:

--- a/dev/cli/stripe_config.py
+++ b/dev/cli/stripe_config.py
@@ -113,13 +113,14 @@ def has_saved_keys() -> bool:
     )
 
 
-def saved_keys_rejection() -> str | None:
+def saved_keys_rejection(profile: StripeProfile | None) -> str | None:
     """Why the saved Stripe keys can't back a local environment, or None if they can."""
+    if not has_saved_keys():
+        return "no Stripe keys are configured"
+
     secret_key = read_secrets().get("POLAR_STRIPE_SECRET_KEY", "")
     if not secret_key.startswith("sk_test_"):
         return "a live secret key is configured"
-
-    profile = read_profile()
     if profile is None:
         return f"there is no '{STRIPE_CLI_PROFILE}' Stripe CLI profile"
     if secret_key != profile.secret_key:
@@ -256,7 +257,7 @@ def configure(relink: bool = False) -> StripeProfile | None:
     step_status(True, "Stripe sandbox", profile.display_name)
 
     changed = False
-    if has_saved_keys() and saved_keys_rejection() is None:
+    if saved_keys_rejection(profile) is None:
         step_status(True, "Stripe API keys", "configured")
     else:
         save_keys(profile)

--- a/dev/cli/stripe_config.py
+++ b/dev/cli/stripe_config.py
@@ -121,12 +121,18 @@ def saved_keys_rejection(profile: StripeProfile | None) -> str | None:
     if not has_saved_keys():
         return "no Stripe keys are configured"
 
-    secret_key = read_secrets().get("POLAR_STRIPE_SECRET_KEY", "")
+    secrets = read_secrets()
+    secret_key = secrets.get("POLAR_STRIPE_SECRET_KEY", "")
+    publishable_key = secrets.get("POLAR_STRIPE_PUBLISHABLE_KEY", "")
     if not secret_key.startswith("sk_test_"):
         return "a live secret key is configured"
+    if not publishable_key.startswith("pk_test_"):
+        return "a live publishable key is configured"
     if profile is None:
         return f"there is no '{STRIPE_CLI_PROFILE}' Stripe CLI profile"
-    if secret_key != profile.secret_key:
+    # The browser tokenizes the card with the publishable key while the backend
+    # charges with the secret key, so a split pair silently talks to two accounts.
+    if secret_key != profile.secret_key or publishable_key != profile.publishable_key:
         return f"the keys don't match the '{STRIPE_CLI_PROFILE}' sandbox"
     return sandbox_rejection(profile)
 
@@ -259,9 +265,13 @@ def obtain_webhook_secret() -> str:
         return result.stdout.strip()
 
     console.print("  [yellow]Could not get webhook secret automatically.[/yellow]")
-    return typer.prompt(
+    entered = typer.prompt(
         "  Enter webhook secret manually (whsec_...), or press Enter to skip", default=""
-    )
+    ).strip()
+    if entered and not entered.startswith("whsec_"):
+        console.print("  [yellow]That isn't a webhook secret (they start with whsec_). Skipping.[/yellow]")
+        return ""
+    return entered
 
 
 def save_webhook_secret(webhook_secret: str) -> None:
@@ -274,7 +284,7 @@ def save_webhook_secret(webhook_secret: str) -> None:
     secrets = read_secrets()
     direct = secrets.get("POLAR_STRIPE_WEBHOOK_SECRET", "")
     connect = secrets.get("POLAR_STRIPE_CONNECT_WEBHOOK_SECRET", "")
-    if direct and connect and direct != connect:
+    if direct != connect:
         console.print(
             "  [yellow]Kept your existing webhook secrets — they differ from each\n"
             "  other, so they look like dashboard endpoints, not the CLI listener.[/yellow]"
@@ -315,10 +325,21 @@ def configure(relink: bool = False) -> StripeProfile | None:
         if webhook_secret:
             save_webhook_secret(webhook_secret)
             changed = True
+        elif changed:
+            step_status(False, "Webhook secret", "still the previous sandbox's")
+            console.print(
+                "  [yellow]Webhooks will fail signature checks until you set it.\n"
+                "  Re-run `dev stripe` once the Stripe CLI can reach Stripe.[/yellow]"
+            )
 
     if changed:
         console.print("  [dim]Updating environment files...[/dim]")
-        run_command([str(ROOT_DIR / "dev" / "setup-environment")], capture=True)
-        step_status(True, "Environment files", "updated")
+        result = run_command([str(ROOT_DIR / "dev" / "setup-environment")], capture=True)
+        if result and result.returncode == 0:
+            step_status(True, "Environment files", "updated")
+        else:
+            step_status(False, "Environment files", "update failed")
+            console.print("  [yellow]Run dev/setup-environment by hand to see why.[/yellow]")
+            return None
 
     return profile

--- a/dev/cli/stripe_config.py
+++ b/dev/cli/stripe_config.py
@@ -116,34 +116,46 @@ def key_auth_failure() -> str | None:
 
     output = f"{result.stdout} {result.stderr}".lower()
     if "expired" in output:
-        return "the Stripe CLI key has expired"
+        return "the Stripe CLI key has expired (they last 90 days)"
     if "invalid api key" in output or "authentication" in output:
         return "Stripe rejected the stored key"
     return None
 
 
 def env_needs_sync() -> bool:
-    """True when server/.env doesn't carry the Stripe values from the secrets file.
+    """True when the generated env files don't carry the Stripe values from secrets.
 
     Without this, a run that saved the keys but failed to regenerate the env
     files would look fully configured next time, leaving the services on the
-    previous account's credentials.
+    previous account's credentials. The web env is checked too: it carries the
+    publishable key the browser tokenizes with, so a stale one would have the
+    browser and the backend on different sandboxes.
     """
-    env_path = ROOT_DIR / "server" / ".env"
-    if not env_path.exists():
+    secrets = read_secrets()
+    server_env = ROOT_DIR / "server" / ".env"
+    web_env = ROOT_DIR / "clients" / "apps" / "web" / ".env.local"
+
+    if not server_env.exists() or not web_env.exists():
         return True
 
-    env = dotenv_values(env_path, interpolate=False)
-    secrets = read_secrets()
-    return any(
-        env.get(key) != secrets.get(key)
+    server = dotenv_values(server_env, interpolate=False)
+    if any(
+        server.get(key) != secrets.get(key)
         for key in (
             "POLAR_STRIPE_SECRET_KEY",
             "POLAR_STRIPE_PUBLISHABLE_KEY",
             "POLAR_STRIPE_WEBHOOK_SECRET",
             "POLAR_STRIPE_CONNECT_WEBHOOK_SECRET",
         )
-    )
+    ):
+        return True
+
+    publishable_key = secrets.get("POLAR_STRIPE_PUBLISHABLE_KEY")
+    if server.get("NEXT_PUBLIC_STRIPE_KEY") != publishable_key:
+        return True
+
+    web = dotenv_values(web_env, interpolate=False)
+    return web.get("NEXT_PUBLIC_STRIPE_KEY") != publishable_key
 
 
 def has_saved_keys() -> bool:

--- a/dev/cli/stripe_config.py
+++ b/dev/cli/stripe_config.py
@@ -1,30 +1,31 @@
 """Stripe sandbox setup shared by `dev up` and `dev stripe`.
 
-A local environment must talk to a personal Stripe **sandbox**: never a live
-account, and never the shared Polar Software Inc account.
+A local environment must talk to a personal Stripe sandbox: never a live
+account, and never a shared team account.
 """
 
-import tomllib
 import webbrowser
 from dataclasses import dataclass
-from pathlib import Path
 
 import typer
 
-from shared import console, read_secrets, run_command, step_status, update_secrets
+from shared import (
+    ROOT_DIR,
+    check_command_exists,
+    console,
+    read_secrets,
+    run_command,
+    step_spinner,
+    step_status,
+    update_secrets,
+)
 
 STRIPE_CLI_PROFILE = "polar-sandbox"
-STRIPE_CLI_CONFIG = Path.home() / ".config" / "stripe" / "config.toml"
 SANDBOX_DASHBOARD_URL = "https://dashboard.stripe.com/sandboxes"
-
-BLOCKED_ACCOUNT_IDS = {
-    "acct_1LzIVeDG1jUQrXwC": "the shared Polar Software Inc account",
-}
 
 
 @dataclass
 class StripeProfile:
-    name: str
     account_id: str
     display_name: str
     secret_key: str
@@ -32,37 +33,53 @@ class StripeProfile:
     has_live_key: bool
 
 
-def is_cli_installed() -> bool:
-    result = run_command(["which", "stripe"], capture=True)
-    return result is not None and result.returncode == 0
+def ensure_cli() -> bool:
+    """Make sure the Stripe CLI is installed, offering to install it."""
+    if check_command_exists("stripe"):
+        step_status(True, "Stripe CLI", "installed")
+        return True
+
+    step_status(False, "Stripe CLI", "not installed")
+    if not typer.confirm("\n  Install Stripe CLI via Homebrew now?", default=True):
+        console.print("  [yellow]Stripe CLI is required to continue.[/yellow]")
+        return False
+
+    with step_spinner("Installing Stripe CLI..."):
+        result = run_command(["brew", "install", "stripe/stripe-cli/stripe"], capture=True)
+    if not result or result.returncode != 0 or not check_command_exists("stripe"):
+        console.print(
+            "  [red]Installation failed. Install manually: brew install stripe/stripe-cli/stripe[/red]"
+        )
+        return False
+
+    step_status(True, "Stripe CLI", "installed")
+    return True
 
 
-def install_cli() -> bool:
-    """Install the Stripe CLI via Homebrew. Returns True once it is available."""
-    result = run_command(["brew", "install", "stripe/stripe-cli/stripe"], capture=False)
-    return result is not None and result.returncode == 0 and is_cli_installed()
-
-
-def read_profile(name: str = STRIPE_CLI_PROFILE) -> StripeProfile | None:
-    """Read a profile out of the Stripe CLI config, or None if it isn't there."""
-    if not STRIPE_CLI_CONFIG.exists():
+def read_profile() -> StripeProfile | None:
+    """Read the sandbox profile through the Stripe CLI's own config resolution."""
+    result = run_command(
+        ["stripe", "config", "--list", "-p", STRIPE_CLI_PROFILE], capture=True
+    )
+    if not result or result.returncode != 0:
         return None
-    try:
-        config = tomllib.loads(STRIPE_CLI_CONFIG.read_text())
-    except (tomllib.TOMLDecodeError, OSError):
-        return None
 
-    section = config.get(name)
-    if not isinstance(section, dict):
+    values = {}
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if "=" in line and not line.startswith("["):
+            key, value = line.split("=", 1)
+            values[key.strip()] = value.strip().strip("'\"")
+
+    if not values:
         return None
 
     return StripeProfile(
-        name=name,
-        account_id=str(section.get("account_id", "")),
-        display_name=str(section.get("display_name", name)),
-        secret_key=str(section.get("test_mode_api_key", "")),
-        publishable_key=str(section.get("test_mode_pub_key", "")),
-        has_live_key=bool(section.get("live_mode_api_key")),
+        account_id=values.get("account_id", ""),
+        display_name=values.get("display_name", STRIPE_CLI_PROFILE),
+        secret_key=values.get("test_mode_api_key", ""),
+        publishable_key=values.get("test_mode_pub_key", ""),
+        has_live_key=bool(values.get("live_mode_api_key")),
     )
 
 
@@ -77,51 +94,103 @@ def sandbox_rejection(profile: StripeProfile) -> str | None:
     # A sandbox has no live mode at all, so the CLI stores no live key for one.
     if profile.has_live_key:
         return f"'{profile.display_name}' is a full Stripe account, not a sandbox"
-    blocked = BLOCKED_ACCOUNT_IDS.get(profile.account_id)
-    if blocked:
-        return f"it is {blocked}"
     return None
 
 
-def keys_are_usable(profile_name: str = STRIPE_CLI_PROFILE) -> bool:
-    """Check the stored keys still work — CLI keys expire after 90 days."""
+def keys_are_usable() -> bool:
+    """Check the stored keys still work — Stripe CLI keys expire after 90 days."""
     result = run_command(
-        ["stripe", "get", "/v1/account", "-p", profile_name], capture=True
+        ["stripe", "get", "/v1/account", "-p", STRIPE_CLI_PROFILE], capture=True
     )
     return result is not None and result.returncode == 0
 
 
-def login(profile_name: str = STRIPE_CLI_PROFILE) -> bool:
-    result = run_command(
-        ["stripe", "login", "--project-name", profile_name], capture=False
-    )
-    return result is not None and result.returncode == 0
-
-
-def secrets_status() -> tuple[str, str]:
-    """Classify the Stripe keys currently in the secrets file.
-
-    Returns (status, detail) where status is one of:
-      ok        - keys match the sandbox profile
-      missing   - no keys configured
-      live      - live keys, which must never reach a local environment
-      mismatch  - test keys from some other account than the sandbox profile
-    """
+def has_saved_keys() -> bool:
     secrets = read_secrets()
-    secret_key = secrets.get("POLAR_STRIPE_SECRET_KEY", "")
-    publishable_key = secrets.get("POLAR_STRIPE_PUBLISHABLE_KEY", "")
+    return bool(
+        secrets.get("POLAR_STRIPE_SECRET_KEY")
+        and secrets.get("POLAR_STRIPE_PUBLISHABLE_KEY")
+    )
 
-    if not secret_key or not publishable_key:
-        return "missing", "no keys configured"
+
+def saved_keys_rejection() -> str | None:
+    """Why the saved Stripe keys can't back a local environment, or None if they can."""
+    secret_key = read_secrets().get("POLAR_STRIPE_SECRET_KEY", "")
     if not secret_key.startswith("sk_test_"):
-        return "live", "a live secret key is configured"
+        return "a live secret key is configured"
 
     profile = read_profile()
     if profile is None:
-        return "mismatch", f"no '{STRIPE_CLI_PROFILE}' Stripe CLI profile"
+        return f"there is no '{STRIPE_CLI_PROFILE}' Stripe CLI profile"
     if secret_key != profile.secret_key:
-        return "mismatch", f"keys don't match the '{STRIPE_CLI_PROFILE}' sandbox"
-    return "ok", profile.display_name
+        return f"the keys don't match the '{STRIPE_CLI_PROFILE}' sandbox"
+    return None
+
+
+def print_sandbox_instructions() -> None:
+    console.print(
+        "\n  Local development runs against your own Stripe [bold]sandbox[/bold] —"
+    )
+    console.print("  no live account, no shared team account.\n")
+    console.print("  [bold]1.[/bold] Create a sandbox (or pick an existing one) at")
+    console.print(f"     [link={SANDBOX_DASHBOARD_URL}]{SANDBOX_DASHBOARD_URL}[/link]")
+    console.print("  [bold]2.[/bold] Open that sandbox, so it's the selected account")
+    console.print("  [bold]3.[/bold] Confirm the pairing in the browser tab we open next\n")
+
+
+def link_sandbox() -> StripeProfile | None:
+    """Walk the user through pairing the Stripe CLI with a sandbox."""
+    print_sandbox_instructions()
+    if not typer.confirm("  Open the Stripe sandbox dashboard now?", default=True):
+        console.print("  [yellow]A sandbox is required to continue.[/yellow]")
+        return None
+
+    webbrowser.open(SANDBOX_DASHBOARD_URL)
+    typer.prompt(
+        "  Press Enter once your sandbox is open in the dashboard",
+        default="",
+        show_default=False,
+    )
+
+    console.print("\n  Linking the Stripe CLI to that sandbox...\n")
+    result = run_command(
+        ["stripe", "login", "--project-name", STRIPE_CLI_PROFILE], capture=False
+    )
+    if not result or result.returncode != 0:
+        console.print("  [red]Stripe login failed. Please try again.[/red]")
+        return None
+
+    profile = read_profile()
+    if profile is None:
+        console.print("  [red]Stripe login didn't store any keys.[/red]")
+        return None
+
+    rejection = sandbox_rejection(profile)
+    if rejection is not None:
+        console.print(f"\n  [red]You linked '{profile.display_name}', but {rejection}.[/red]")
+        console.print("  [red]Re-run this and pick a sandbox instead.[/red]")
+        return None
+
+    return profile
+
+
+def ensure_sandbox_profile(relink: bool = False) -> StripeProfile | None:
+    """Get a usable sandbox profile, walking through pairing when needed."""
+    if relink:
+        return link_sandbox()
+
+    profile = read_profile()
+    if profile is not None:
+        rejection = sandbox_rejection(profile)
+        if rejection is not None:
+            step_status(False, "Stripe sandbox", rejection)
+        elif keys_are_usable():
+            return profile
+        else:
+            step_status(False, "Stripe sandbox", "the stored key has expired")
+            console.print("\n  [dim]Stripe CLI keys expire after 90 days.[/dim]")
+
+    return link_sandbox()
 
 
 def save_keys(profile: StripeProfile) -> None:
@@ -133,7 +202,24 @@ def save_keys(profile: StripeProfile) -> None:
     )
 
 
-def save_webhook_secret(webhook_secret: str) -> bool:
+def obtain_webhook_secret() -> str:
+    console.print("\n  [bold]Getting webhook secret from the Stripe CLI...[/bold]")
+    console.print(
+        "  [dim]Webhooks let Stripe notify your local server about payment events.[/dim]"
+    )
+    result = run_command(
+        ["stripe", "listen", "--print-secret", "-p", STRIPE_CLI_PROFILE], capture=True
+    )
+    if result and result.returncode == 0 and result.stdout.strip():
+        return result.stdout.strip()
+
+    console.print("  [yellow]Could not get webhook secret automatically.[/yellow]")
+    return typer.prompt(
+        "  Enter webhook secret manually (whsec_...), or press Enter to skip", default=""
+    )
+
+
+def save_webhook_secret(webhook_secret: str) -> None:
     """Store the `stripe listen` secret for both webhook endpoints.
 
     One listener signs both the direct and the Connect endpoint, so both
@@ -144,7 +230,11 @@ def save_webhook_secret(webhook_secret: str) -> bool:
     direct = secrets.get("POLAR_STRIPE_WEBHOOK_SECRET", "")
     connect = secrets.get("POLAR_STRIPE_CONNECT_WEBHOOK_SECRET", "")
     if direct and connect and direct != connect:
-        return False
+        console.print(
+            "  [yellow]Kept your existing webhook secrets — they differ from each\n"
+            "  other, so they look like dashboard endpoints, not the CLI listener.[/yellow]"
+        )
+        return
 
     update_secrets(
         {
@@ -152,76 +242,37 @@ def save_webhook_secret(webhook_secret: str) -> bool:
             "POLAR_STRIPE_CONNECT_WEBHOOK_SECRET": webhook_secret,
         }
     )
-    return True
+    step_status(True, "Webhook secret", "saved")
 
 
-def print_sandbox_instructions() -> None:
-    console.print(
-        "\n  Local development runs against your own Stripe [bold]sandbox[/bold] —"
-    )
-    console.print("  no live account, no shared Polar account.\n")
-    console.print("  [bold]1.[/bold] Create a sandbox (or pick an existing one) at")
-    console.print(f"     [link={SANDBOX_DASHBOARD_URL}]{SANDBOX_DASHBOARD_URL}[/link]")
-    console.print("  [bold]2.[/bold] Open that sandbox, so it's the selected account")
-    console.print("  [bold]3.[/bold] Confirm the pairing in the browser tab we open next\n")
-
-
-def ensure_sandbox_profile(interactive: bool = True) -> StripeProfile | None:
-    """Get a usable sandbox profile, walking through login when needed."""
-    profile = read_profile()
-
-    if profile is not None:
-        rejection = sandbox_rejection(profile)
-        if rejection is not None:
-            step_status(False, "Stripe sandbox", rejection)
-            console.print(
-                f"\n  The '{STRIPE_CLI_PROFILE}' profile can't be used: {rejection}."
-            )
-        elif keys_are_usable():
-            return profile
-        else:
-            step_status(False, "Stripe sandbox", "the stored key has expired")
-            console.print("\n  [dim]Stripe CLI keys expire after 90 days.[/dim]")
-
-    if not interactive:
+def configure(relink: bool = False) -> StripeProfile | None:
+    """Link a sandbox and write its keys into the central secrets file."""
+    if not ensure_cli():
         return None
 
-    print_sandbox_instructions()
-    if not typer.confirm("  Open the Stripe sandbox dashboard now?", default=True):
-        console.print("  [yellow]A sandbox is required to continue.[/yellow]")
-        return None
-
-    webbrowser.open(SANDBOX_DASHBOARD_URL)
-    typer.prompt(
-        "  Press Enter once your sandbox is open in the dashboard", default="", show_default=False
-    )
-
-    console.print("\n  Linking the Stripe CLI to that sandbox...\n")
-    if not login():
-        console.print("  [red]Stripe login failed. Please try again.[/red]")
-        return None
-
-    profile = read_profile()
+    profile = ensure_sandbox_profile(relink=relink)
     if profile is None:
-        console.print("  [red]Stripe login didn't store any keys.[/red]")
         return None
+    step_status(True, "Stripe sandbox", profile.display_name)
 
-    rejection = sandbox_rejection(profile)
-    if rejection is not None:
-        step_status(False, "Stripe sandbox", rejection)
-        console.print(
-            f"\n  [red]You linked '{profile.display_name}', but {rejection}.[/red]"
-        )
-        console.print("  [red]Re-run this and pick a sandbox instead.[/red]")
-        return None
+    changed = False
+    if has_saved_keys() and saved_keys_rejection() is None:
+        step_status(True, "Stripe API keys", "configured")
+    else:
+        save_keys(profile)
+        step_status(True, "Stripe API keys", "saved")
+        changed = True
+
+    # New keys mean a different sandbox, so the stored listener secret is stale.
+    if changed or not read_secrets().get("POLAR_STRIPE_WEBHOOK_SECRET"):
+        webhook_secret = obtain_webhook_secret()
+        if webhook_secret:
+            save_webhook_secret(webhook_secret)
+            changed = True
+
+    if changed:
+        console.print("  [dim]Updating environment files...[/dim]")
+        run_command([str(ROOT_DIR / "dev" / "setup-environment")], capture=True)
+        step_status(True, "Environment files", "updated")
 
     return profile
-
-
-def fetch_webhook_secret() -> str:
-    result = run_command(
-        ["stripe", "listen", "--print-secret", "-p", STRIPE_CLI_PROFILE], capture=True
-    )
-    if result and result.returncode == 0:
-        return result.stdout.strip()
-    return ""

--- a/dev/cli/stripe_config.py
+++ b/dev/cli/stripe_config.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 import typer
 from dotenv import dotenv_values
 
+from secrets_io import ensure_secrets_file
 from shared import (
     ROOT_DIR,
     check_command_exists,
@@ -348,6 +349,9 @@ def save_webhook_secret(webhook_secret: str) -> None:
 
 def configure(relink: bool = False) -> StripeProfile | None:
     """Link a sandbox and write its keys into the central secrets file."""
+    # Also tightens the file to 0600 if an older run left it readable.
+    ensure_secrets_file()
+
     if not ensure_cli():
         return None
 

--- a/dev/cli/stripe_config.py
+++ b/dev/cli/stripe_config.py
@@ -1,0 +1,227 @@
+"""Stripe sandbox setup shared by `dev up` and `dev stripe`.
+
+A local environment must talk to a personal Stripe **sandbox**: never a live
+account, and never the shared Polar Software Inc account.
+"""
+
+import tomllib
+import webbrowser
+from dataclasses import dataclass
+from pathlib import Path
+
+import typer
+
+from shared import console, read_secrets, run_command, step_status, update_secrets
+
+STRIPE_CLI_PROFILE = "polar-sandbox"
+STRIPE_CLI_CONFIG = Path.home() / ".config" / "stripe" / "config.toml"
+SANDBOX_DASHBOARD_URL = "https://dashboard.stripe.com/sandboxes"
+
+BLOCKED_ACCOUNT_IDS = {
+    "acct_1LzIVeDG1jUQrXwC": "the shared Polar Software Inc account",
+}
+
+
+@dataclass
+class StripeProfile:
+    name: str
+    account_id: str
+    display_name: str
+    secret_key: str
+    publishable_key: str
+    has_live_key: bool
+
+
+def is_cli_installed() -> bool:
+    result = run_command(["which", "stripe"], capture=True)
+    return result is not None and result.returncode == 0
+
+
+def install_cli() -> bool:
+    """Install the Stripe CLI via Homebrew. Returns True once it is available."""
+    result = run_command(["brew", "install", "stripe/stripe-cli/stripe"], capture=False)
+    return result is not None and result.returncode == 0 and is_cli_installed()
+
+
+def read_profile(name: str = STRIPE_CLI_PROFILE) -> StripeProfile | None:
+    """Read a profile out of the Stripe CLI config, or None if it isn't there."""
+    if not STRIPE_CLI_CONFIG.exists():
+        return None
+    try:
+        config = tomllib.loads(STRIPE_CLI_CONFIG.read_text())
+    except (tomllib.TOMLDecodeError, OSError):
+        return None
+
+    section = config.get(name)
+    if not isinstance(section, dict):
+        return None
+
+    return StripeProfile(
+        name=name,
+        account_id=str(section.get("account_id", "")),
+        display_name=str(section.get("display_name", name)),
+        secret_key=str(section.get("test_mode_api_key", "")),
+        publishable_key=str(section.get("test_mode_pub_key", "")),
+        has_live_key=bool(section.get("live_mode_api_key")),
+    )
+
+
+def sandbox_rejection(profile: StripeProfile) -> str | None:
+    """Explain why this profile can't back a local environment, or None if it can."""
+    if not profile.secret_key or not profile.publishable_key:
+        return "no test keys stored for this profile"
+    if not profile.secret_key.startswith("sk_test_"):
+        return "it holds a live secret key"
+    if not profile.publishable_key.startswith("pk_test_"):
+        return "it holds a live publishable key"
+    # A sandbox has no live mode at all, so the CLI stores no live key for one.
+    if profile.has_live_key:
+        return f"'{profile.display_name}' is a full Stripe account, not a sandbox"
+    blocked = BLOCKED_ACCOUNT_IDS.get(profile.account_id)
+    if blocked:
+        return f"it is {blocked}"
+    return None
+
+
+def keys_are_usable(profile_name: str = STRIPE_CLI_PROFILE) -> bool:
+    """Check the stored keys still work — CLI keys expire after 90 days."""
+    result = run_command(
+        ["stripe", "get", "/v1/account", "-p", profile_name], capture=True
+    )
+    return result is not None and result.returncode == 0
+
+
+def login(profile_name: str = STRIPE_CLI_PROFILE) -> bool:
+    result = run_command(
+        ["stripe", "login", "--project-name", profile_name], capture=False
+    )
+    return result is not None and result.returncode == 0
+
+
+def secrets_status() -> tuple[str, str]:
+    """Classify the Stripe keys currently in the secrets file.
+
+    Returns (status, detail) where status is one of:
+      ok        - keys match the sandbox profile
+      missing   - no keys configured
+      live      - live keys, which must never reach a local environment
+      mismatch  - test keys from some other account than the sandbox profile
+    """
+    secrets = read_secrets()
+    secret_key = secrets.get("POLAR_STRIPE_SECRET_KEY", "")
+    publishable_key = secrets.get("POLAR_STRIPE_PUBLISHABLE_KEY", "")
+
+    if not secret_key or not publishable_key:
+        return "missing", "no keys configured"
+    if not secret_key.startswith("sk_test_"):
+        return "live", "a live secret key is configured"
+
+    profile = read_profile()
+    if profile is None:
+        return "mismatch", f"no '{STRIPE_CLI_PROFILE}' Stripe CLI profile"
+    if secret_key != profile.secret_key:
+        return "mismatch", f"keys don't match the '{STRIPE_CLI_PROFILE}' sandbox"
+    return "ok", profile.display_name
+
+
+def save_keys(profile: StripeProfile) -> None:
+    update_secrets(
+        {
+            "POLAR_STRIPE_SECRET_KEY": profile.secret_key,
+            "POLAR_STRIPE_PUBLISHABLE_KEY": profile.publishable_key,
+        }
+    )
+
+
+def save_webhook_secret(webhook_secret: str) -> bool:
+    """Store the `stripe listen` secret for both webhook endpoints.
+
+    One listener signs both the direct and the Connect endpoint, so both
+    secrets are the same value. Someone using dashboard endpoints instead has
+    two *different* secrets — leave those alone rather than clobber them.
+    """
+    secrets = read_secrets()
+    direct = secrets.get("POLAR_STRIPE_WEBHOOK_SECRET", "")
+    connect = secrets.get("POLAR_STRIPE_CONNECT_WEBHOOK_SECRET", "")
+    if direct and connect and direct != connect:
+        return False
+
+    update_secrets(
+        {
+            "POLAR_STRIPE_WEBHOOK_SECRET": webhook_secret,
+            "POLAR_STRIPE_CONNECT_WEBHOOK_SECRET": webhook_secret,
+        }
+    )
+    return True
+
+
+def print_sandbox_instructions() -> None:
+    console.print(
+        "\n  Local development runs against your own Stripe [bold]sandbox[/bold] —"
+    )
+    console.print("  no live account, no shared Polar account.\n")
+    console.print("  [bold]1.[/bold] Create a sandbox (or pick an existing one) at")
+    console.print(f"     [link={SANDBOX_DASHBOARD_URL}]{SANDBOX_DASHBOARD_URL}[/link]")
+    console.print("  [bold]2.[/bold] Open that sandbox, so it's the selected account")
+    console.print("  [bold]3.[/bold] Confirm the pairing in the browser tab we open next\n")
+
+
+def ensure_sandbox_profile(interactive: bool = True) -> StripeProfile | None:
+    """Get a usable sandbox profile, walking through login when needed."""
+    profile = read_profile()
+
+    if profile is not None:
+        rejection = sandbox_rejection(profile)
+        if rejection is not None:
+            step_status(False, "Stripe sandbox", rejection)
+            console.print(
+                f"\n  The '{STRIPE_CLI_PROFILE}' profile can't be used: {rejection}."
+            )
+        elif keys_are_usable():
+            return profile
+        else:
+            step_status(False, "Stripe sandbox", "the stored key has expired")
+            console.print("\n  [dim]Stripe CLI keys expire after 90 days.[/dim]")
+
+    if not interactive:
+        return None
+
+    print_sandbox_instructions()
+    if not typer.confirm("  Open the Stripe sandbox dashboard now?", default=True):
+        console.print("  [yellow]A sandbox is required to continue.[/yellow]")
+        return None
+
+    webbrowser.open(SANDBOX_DASHBOARD_URL)
+    typer.prompt(
+        "  Press Enter once your sandbox is open in the dashboard", default="", show_default=False
+    )
+
+    console.print("\n  Linking the Stripe CLI to that sandbox...\n")
+    if not login():
+        console.print("  [red]Stripe login failed. Please try again.[/red]")
+        return None
+
+    profile = read_profile()
+    if profile is None:
+        console.print("  [red]Stripe login didn't store any keys.[/red]")
+        return None
+
+    rejection = sandbox_rejection(profile)
+    if rejection is not None:
+        step_status(False, "Stripe sandbox", rejection)
+        console.print(
+            f"\n  [red]You linked '{profile.display_name}', but {rejection}.[/red]"
+        )
+        console.print("  [red]Re-run this and pick a sandbox instead.[/red]")
+        return None
+
+    return profile
+
+
+def fetch_webhook_secret() -> str:
+    result = run_command(
+        ["stripe", "listen", "--print-secret", "-p", STRIPE_CLI_PROFILE], capture=True
+    )
+    if result and result.returncode == 0:
+        return result.stdout.strip()
+    return ""

--- a/dev/cli/up_steps/05_wait_for_services.py
+++ b/dev/cli/up_steps/05_wait_for_services.py
@@ -6,12 +6,12 @@ import urllib.request
 
 from shared import (
     ROOT_DIR,
-    SECRETS_FILE,
     SERVER_DIR,
     Context,
     run_command,
     step_spinner,
     step_status,
+    update_secrets,
 )
 
 NAME = "Waiting for services to be ready"
@@ -78,27 +78,6 @@ def wait_for_tinybird_and_get_token(timeout: int = 90) -> str | None:
     return None
 
 
-def _update_secrets_file(key: str, value: str) -> None:
-    """Update a key in the central secrets file."""
-    SECRETS_FILE.parent.mkdir(parents=True, exist_ok=True)
-
-    existing = {}
-    if SECRETS_FILE.exists():
-        for line in SECRETS_FILE.read_text().split("\n"):
-            if "=" in line and not line.startswith("#"):
-                k, v = line.split("=", 1)
-                existing[k.strip()] = v.strip().strip("\"'")
-
-    existing[key] = value
-
-    with open(SECRETS_FILE, "w") as f:
-        f.write("# Polar Development Secrets\n")
-        f.write("# Shared across Git worktrees\n\n")
-        for k, v in existing.items():
-            delimiter = "'" if '"' in v else '"'
-            f.write(f"{k}={delimiter}{v}{delimiter}\n")
-
-
 def run(ctx: Context) -> bool:
     """Wait for PostgreSQL, Redis, and optionally Tinybird to be ready."""
     with step_spinner("Waiting for PostgreSQL..."):
@@ -122,9 +101,13 @@ def run(ctx: Context) -> bool:
         with step_spinner("Waiting for Tinybird..."):
             token = wait_for_tinybird_and_get_token(timeout=90)
             if token:
-                _update_secrets_file("POLAR_TINYBIRD_API_TOKEN", token)
-                _update_secrets_file("POLAR_TINYBIRD_READ_TOKEN", token)
-                _update_secrets_file("POLAR_TINYBIRD_CLICKHOUSE_TOKEN", token)
+                update_secrets(
+                    {
+                        "POLAR_TINYBIRD_API_TOKEN": token,
+                        "POLAR_TINYBIRD_READ_TOKEN": token,
+                        "POLAR_TINYBIRD_CLICKHOUSE_TOKEN": token,
+                    }
+                )
                 run_command([str(ROOT_DIR / "dev" / "setup-environment")], capture=True)
                 step_status(True, "Tinybird", "ready (token configured)")
             else:

--- a/dev/cli/up_steps/09_configure_integrations.py
+++ b/dev/cli/up_steps/09_configure_integrations.py
@@ -3,14 +3,16 @@
 
 import typer
 
+import stripe_config
 from shared import (
     ROOT_DIR,
-    SECRETS_FILE,
     Context,
     console,
+    read_secrets,
     run_command,
     step_spinner,
     step_status,
+    update_secrets,
 )
 
 NAME = "Configuring integrations"
@@ -18,196 +20,72 @@ NAME = "Configuring integrations"
 
 def is_github_configured() -> bool:
     """Check if GitHub App is configured."""
-    if SECRETS_FILE.exists():
-        content = SECRETS_FILE.read_text()
-        if "POLAR_GITHUB_CLIENT_ID=" in content:
-            for line in content.split("\n"):
-                if line.startswith("POLAR_GITHUB_CLIENT_ID="):
-                    value = line.split("=", 1)[1].strip().strip("\"'")
-                    return bool(value)
-    return False
+    return bool(read_secrets().get("POLAR_GITHUB_CLIENT_ID"))
 
 
 def is_github_skipped() -> bool:
     """Check if user chose to skip GitHub setup."""
-    if SECRETS_FILE.exists():
-        for line in SECRETS_FILE.read_text().split("\n"):
-            if line.startswith("POLAR_SKIP_GITHUB_SETUP="):
-                value = line.split("=", 1)[1].strip().strip("\"'")
-                return value.lower() == "true"
-    return False
+    value = read_secrets().get("POLAR_SKIP_GITHUB_SETUP", "")
+    return value.lower() == "true"
 
 
 def set_github_skipped(skipped: bool = True) -> None:
     """Remember that user chose to skip GitHub setup."""
-    _update_secrets_file("POLAR_SKIP_GITHUB_SETUP", "true" if skipped else None)
-
-
-def is_stripe_configured() -> bool:
-    """Check if Stripe is configured."""
-    if SECRETS_FILE.exists():
-        content = SECRETS_FILE.read_text()
-        has_secret = False
-        has_publishable = False
-        for line in content.split("\n"):
-            if line.startswith("POLAR_STRIPE_SECRET_KEY="):
-                value = line.split("=", 1)[1].strip().strip("\"'")
-                has_secret = bool(value)
-            if line.startswith("POLAR_STRIPE_PUBLISHABLE_KEY="):
-                value = line.split("=", 1)[1].strip().strip("\"'")
-                has_publishable = bool(value)
-        return has_secret and has_publishable
-    return False
+    update_secrets(
+        {"POLAR_SKIP_GITHUB_SETUP": "true" if skipped else None}
+    )
 
 
 def is_stripe_skipped() -> bool:
     """Check if user chose to skip Stripe setup."""
-    if SECRETS_FILE.exists():
-        for line in SECRETS_FILE.read_text().split("\n"):
-            if line.startswith("POLAR_SKIP_STRIPE_SETUP="):
-                value = line.split("=", 1)[1].strip().strip("\"'")
-                return value.lower() == "true"
-    return False
+    value = read_secrets().get("POLAR_SKIP_STRIPE_SETUP", "")
+    return value.lower() == "true"
 
 
 def set_stripe_skipped(skipped: bool = True) -> None:
     """Remember that user chose to skip Stripe setup."""
-    _update_secrets_file("POLAR_SKIP_STRIPE_SETUP", "true" if skipped else None)
-
-
-def save_stripe_keys(secret_key: str, publishable_key: str, webhook_secret: str = "") -> None:
-    """Save Stripe keys to the central secrets file."""
-    _update_secrets_file("POLAR_STRIPE_SECRET_KEY", secret_key)
-    _update_secrets_file("POLAR_STRIPE_PUBLISHABLE_KEY", publishable_key)
-    if webhook_secret:
-        _update_secrets_file("POLAR_STRIPE_WEBHOOK_SECRET", webhook_secret)
-        _update_secrets_file("POLAR_STRIPE_CONNECT_WEBHOOK_SECRET", webhook_secret)
-
-
-def _update_secrets_file(key: str, value: str | None) -> None:
-    """Update a key in the secrets file."""
-    SECRETS_FILE.parent.mkdir(parents=True, exist_ok=True)
-
-    existing = {}
-    if SECRETS_FILE.exists():
-        for line in SECRETS_FILE.read_text().split("\n"):
-            if "=" in line and not line.startswith("#"):
-                k, v = line.split("=", 1)
-                existing[k.strip()] = v.strip().strip("\"'")
-
-    if value is None:
-        existing.pop(key, None)
-    else:
-        existing[key] = value
-
-    with open(SECRETS_FILE, "w") as f:
-        f.write("# Polar Development Secrets\n")
-        f.write("# Shared across Git worktrees\n\n")
-        for k, v in existing.items():
-            delimiter = "'" if '"' in v else '"'
-            f.write(f"{k}={delimiter}{v}{delimiter}\n")
-
-
-def _is_stripe_cli_installed() -> bool:
-    """Check if Stripe CLI is installed."""
-    result = run_command(["which", "stripe"], capture=True)
-    return result is not None and result.returncode == 0
-
-
-def _get_stripe_keys_from_cli() -> tuple[str, str]:
-    """Get test mode API keys from Stripe CLI config."""
-    result = run_command(["stripe", "config", "--list"], capture=True)
-    if not result or result.returncode != 0:
-        return "", ""
-
-    secret_key = ""
-    publishable_key = ""
-
-    for line in result.stdout.split("\n"):
-        line = line.strip()
-        if line.startswith("test_mode_api_key"):
-            secret_key = line.split("=", 1)[1].strip().strip("'\"")
-        elif line.startswith("test_mode_pub_key"):
-            publishable_key = line.split("=", 1)[1].strip().strip("'\"")
-
-    return secret_key, publishable_key
-
-
-def _is_stripe_cli_logged_in() -> bool:
-    """Check if Stripe CLI is logged in by verifying API keys exist."""
-    secret_key, publishable_key = _get_stripe_keys_from_cli()
-    return bool(secret_key and publishable_key)
+    update_secrets(
+        {"POLAR_SKIP_STRIPE_SETUP": "true" if skipped else None}
+    )
 
 
 def _setup_stripe() -> None:
-    """Interactive Stripe setup using Stripe CLI."""
-    import webbrowser
-
+    """Interactive Stripe sandbox setup using the Stripe CLI."""
     console.print("\n  [bold]Stripe Setup[/bold]\n")
     console.print("  Polar uses Stripe for payment processing. You'll need a Stripe")
-    console.print("  account and the Stripe CLI to develop locally.\n")
-    console.print("  [dim]All keys are test mode only — no real charges will be made.[/dim]\n")
+    console.print("  sandbox and the Stripe CLI to develop locally.\n")
 
-    # Step 1: Install Stripe CLI
-    if not _is_stripe_cli_installed():
+    if not stripe_config.is_cli_installed():
         step_status(False, "Stripe CLI", "not installed")
-        if typer.confirm("\n  Install Stripe CLI via Homebrew now?", default=True):
-            with step_spinner("Installing Stripe CLI..."):
-                result = run_command(["brew", "install", "stripe/stripe-cli/stripe"], capture=True)
-            if not result or result.returncode != 0 or not _is_stripe_cli_installed():
-                console.print("  [red]Installation failed. Install manually: brew install stripe/stripe-cli/stripe[/red]")
-                return
-        else:
+        if not typer.confirm("\n  Install Stripe CLI via Homebrew now?", default=True):
             console.print("  [yellow]Stripe CLI is required. Install it and re-run dev up.[/yellow]")
+            return
+        with step_spinner("Installing Stripe CLI..."):
+            installed = stripe_config.install_cli()
+        if not installed:
+            console.print("  [red]Installation failed. Install manually: brew install stripe/stripe-cli/stripe[/red]")
             return
     step_status(True, "Stripe CLI", "installed")
 
-    # Step 2: Log in to Stripe
-    if not _is_stripe_cli_logged_in():
-        step_status(False, "Stripe CLI", "not logged in")
+    profile = stripe_config.ensure_sandbox_profile()
+    if profile is None:
+        return
+    step_status(True, "Stripe sandbox", profile.display_name)
 
-        console.print("\n  [dim]Don't have a Stripe account? Ask your team which account to use,[/dim]")
-        console.print("  [dim]or create one at https://dashboard.stripe.com/register[/dim]\n")
+    stripe_config.save_keys(profile)
 
-        has_account = typer.confirm("  Do you have a Stripe account?", default=True)
-        if not has_account:
-            console.print("\n  Opening Stripe signup in your browser...")
-            webbrowser.open("https://dashboard.stripe.com/register")
-            typer.prompt("  Press Enter once you've created your account", default="")
-
-        console.print("\n  Logging in to Stripe — this will open your browser to authenticate.\n")
-        run_command(["stripe", "login"], capture=False)
-        if not _is_stripe_cli_logged_in():
-            console.print("  [red]Stripe login failed. Please try again.[/red]")
-            return
-    step_status(True, "Stripe CLI", "logged in")
-
-    # Step 3: Fetch API keys
-    console.print("\n  [bold]Fetching test API keys from Stripe CLI...[/bold]")
-    secret_key, publishable_key = _get_stripe_keys_from_cli()
-
-    if secret_key and publishable_key:
-        console.print(f"  [green]✓ Secret key: {secret_key[:12]}...{secret_key[-4:]}[/green]")
-        console.print(f"  [green]✓ Publishable key: {publishable_key[:12]}...{publishable_key[-4:]}[/green]")
-    else:
-        console.print("  [yellow]Could not fetch keys automatically. Please enter manually.[/yellow]")
-        console.print("  Get your test API keys from: [link=https://dashboard.stripe.com/test/apikeys]https://dashboard.stripe.com/test/apikeys[/link]\n")
-        secret_key = typer.prompt("  Stripe Secret Key (sk_test_...)")
-        publishable_key = typer.prompt("  Stripe Publishable Key (pk_test_...)")
-
-    # Step 4: Get webhook secret
     console.print("\n  [bold]Getting webhook secret...[/bold]")
     console.print("  [dim]Webhooks let Stripe notify your local server about payment events (e.g. checkout completed).[/dim]")
-    result = run_command(["stripe", "listen", "--print-secret"], capture=True)
-    webhook_secret = ""
-    if result and result.returncode == 0:
-        webhook_secret = result.stdout.strip()
+    webhook_secret = stripe_config.fetch_webhook_secret()
+    if webhook_secret:
         console.print("  [green]✓ Webhook secret obtained[/green]")
     else:
         console.print("  [yellow]Could not get webhook secret automatically.[/yellow]")
         webhook_secret = typer.prompt("  Enter webhook secret manually (whsec_...), or press Enter to skip", default="")
 
-    save_stripe_keys(secret_key, publishable_key, webhook_secret)
+    if webhook_secret and not stripe_config.save_webhook_secret(webhook_secret):
+        console.print("  [yellow]Kept your existing webhook secrets — they look like dashboard endpoints.[/yellow]")
+
     set_stripe_skipped(False)
     step_status(True, "Stripe", "configured")
 
@@ -218,68 +96,89 @@ def _setup_stripe() -> None:
     console.print("    [bold]dev stripe --listen[/bold]\n")
 
 
+def _configure_stripe() -> None:
+    status, detail = stripe_config.secrets_status()
+
+    if status == "ok":
+        step_status(True, "Stripe sandbox", detail)
+        return
+
+    if status in ("live", "mismatch"):
+        step_status(False, "Stripe", detail)
+        console.print("\n  [yellow]Local environments must use your own Stripe sandbox.[/yellow]")
+        if typer.confirm("  Switch to a sandbox now?", default=True):
+            _setup_stripe()
+        return
+
+    if is_stripe_skipped():
+        step_status(True, "Stripe", "skipped (run with --clean to reconfigure)")
+        return
+
+    console.print("\n  [dim]Stripe is required for payments, subscriptions, and checkout.[/dim]")
+    if typer.confirm("  Set up Stripe now?", default=True):
+        _setup_stripe()
+    elif typer.confirm("  Remember this choice?", default=True):
+        set_stripe_skipped(True)
+        step_status(True, "Stripe", "skipped (remembered)")
+    else:
+        step_status(True, "Stripe", "skipped (will ask again next time)")
+
+
+def _configure_github() -> None:
+    if is_github_configured():
+        step_status(True, "GitHub App", "configured")
+        return
+
+    if is_github_skipped():
+        step_status(True, "GitHub App", "skipped (run with --clean to reconfigure)")
+        return
+
+    console.print("\n  [dim]GitHub App enables login with GitHub and repository integrations.[/dim]")
+    console.print("  [dim]You can skip this and still develop most features without it.[/dim]\n")
+    if not typer.confirm("  Set up GitHub App now?", default=False):
+        if typer.confirm("  Remember this choice?", default=True):
+            set_github_skipped(True)
+            step_status(True, "GitHub App", "skipped (remembered)")
+        else:
+            step_status(True, "GitHub App", "skipped (will ask again next time)")
+        return
+
+    console.print("\n  [bold]GitHub App Setup[/bold]\n")
+    console.print("  [bold]Step 1:[/bold] Start ngrok to get an external URL")
+    console.print("    Run in another terminal: [bold]ngrok http 8000[/bold]")
+    console.print("    Get ngrok at: [link=https://ngrok.com]https://ngrok.com[/link]\n")
+
+    external_url = typer.prompt("  Enter your ngrok URL (e.g., https://abc123.ngrok.dev)")
+
+    console.print("\n  [bold]Step 2:[/bold] Your browser will open to create a GitHub App")
+    console.print("    Just click through - all settings are pre-configured!\n")
+
+    result = run_command(
+        [
+            str(ROOT_DIR / "dev" / "setup-environment"),
+            "--setup-github-app",
+            "--backend-external-url",
+            external_url,
+        ],
+        capture=False,
+    )
+    if result and result.returncode == 0:
+        step_status(True, "GitHub App", "configured")
+        set_github_skipped(False)
+    else:
+        step_status(False, "GitHub App", "setup failed")
+
+
 def run(ctx: Context) -> bool:
     """Configure GitHub and Stripe integrations."""
     if ctx.skip_integrations:
         return True
 
-    # Reset skip flags on clean
     if ctx.clean:
         set_github_skipped(False)
         set_stripe_skipped(False)
 
-    # GitHub
-    if is_github_configured():
-        step_status(True, "GitHub App", "configured")
-    elif is_github_skipped():
-        step_status(True, "GitHub App", "skipped (run with --clean to reconfigure)")
-    else:
-        console.print("\n  [dim]GitHub App enables login with GitHub and repository integrations.[/dim]")
-        console.print("  [dim]You can skip this and still develop most features without it.[/dim]\n")
-        if typer.confirm("  Set up GitHub App now?", default=False):
-            console.print("\n  [bold]GitHub App Setup[/bold]\n")
-            console.print("  [bold]Step 1:[/bold] Start ngrok to get an external URL")
-            console.print("    Run in another terminal: [bold]ngrok http 8000[/bold]")
-            console.print("    Get ngrok at: [link=https://ngrok.com]https://ngrok.com[/link]\n")
-
-            external_url = typer.prompt("  Enter your ngrok URL (e.g., https://abc123.ngrok.dev)")
-
-            console.print("\n  [bold]Step 2:[/bold] Your browser will open to create a GitHub App")
-            console.print("    Just click through - all settings are pre-configured!\n")
-
-            setup_args = [
-                str(ROOT_DIR / "dev" / "setup-environment"),
-                "--setup-github-app",
-                "--backend-external-url",
-                external_url,
-            ]
-            result = run_command(setup_args, capture=False)
-            if result and result.returncode == 0:
-                step_status(True, "GitHub App", "configured")
-                set_github_skipped(False)
-            else:
-                step_status(False, "GitHub App", "setup failed")
-        else:
-            if typer.confirm("  Remember this choice?", default=True):
-                set_github_skipped(True)
-                step_status(True, "GitHub App", "skipped (remembered)")
-            else:
-                step_status(True, "GitHub App", "skipped (will ask again next time)")
-
-    # Stripe
-    if is_stripe_configured():
-        step_status(True, "Stripe", "configured")
-    elif is_stripe_skipped():
-        step_status(True, "Stripe", "skipped (run with --clean to reconfigure)")
-    else:
-        console.print("\n  [dim]Stripe is required for payments, subscriptions, and checkout.[/dim]")
-        if typer.confirm("  Set up Stripe now?", default=True):
-            _setup_stripe()
-        else:
-            if typer.confirm("  Remember this choice?", default=True):
-                set_stripe_skipped(True)
-                step_status(True, "Stripe", "skipped (remembered)")
-            else:
-                step_status(True, "Stripe", "skipped (will ask again next time)")
+    _configure_github()
+    _configure_stripe()
 
     return True

--- a/dev/cli/up_steps/09_configure_integrations.py
+++ b/dev/cli/up_steps/09_configure_integrations.py
@@ -69,10 +69,11 @@ def _configure_stripe() -> None:
     rejection = stripe_config.saved_keys_rejection(profile)
 
     if rejection is None:
-        if stripe_config.keys_are_usable():
+        auth_failure = stripe_config.key_auth_failure()
+        if auth_failure is None:
             step_status(True, "Stripe sandbox", profile.display_name)
             return
-        step_status(False, "Stripe", "the Stripe CLI key has expired")
+        step_status(False, "Stripe", auth_failure)
         console.print("\n  [dim]Stripe CLI keys expire after 90 days.[/dim]")
         if typer.confirm("  Link your sandbox again now?", default=True):
             _setup_stripe()

--- a/dev/cli/up_steps/09_configure_integrations.py
+++ b/dev/cli/up_steps/09_configure_integrations.py
@@ -10,7 +10,6 @@ from shared import (
     console,
     read_secrets,
     run_command,
-    step_spinner,
     step_status,
     update_secrets,
 )
@@ -55,56 +54,25 @@ def _setup_stripe() -> None:
     console.print("  Polar uses Stripe for payment processing. You'll need a Stripe")
     console.print("  sandbox and the Stripe CLI to develop locally.\n")
 
-    if not stripe_config.is_cli_installed():
-        step_status(False, "Stripe CLI", "not installed")
-        if not typer.confirm("\n  Install Stripe CLI via Homebrew now?", default=True):
-            console.print("  [yellow]Stripe CLI is required. Install it and re-run dev up.[/yellow]")
-            return
-        with step_spinner("Installing Stripe CLI..."):
-            installed = stripe_config.install_cli()
-        if not installed:
-            console.print("  [red]Installation failed. Install manually: brew install stripe/stripe-cli/stripe[/red]")
-            return
-    step_status(True, "Stripe CLI", "installed")
-
-    profile = stripe_config.ensure_sandbox_profile()
-    if profile is None:
+    if stripe_config.configure() is None:
         return
-    step_status(True, "Stripe sandbox", profile.display_name)
 
-    stripe_config.save_keys(profile)
-
-    console.print("\n  [bold]Getting webhook secret...[/bold]")
-    console.print("  [dim]Webhooks let Stripe notify your local server about payment events (e.g. checkout completed).[/dim]")
-    webhook_secret = stripe_config.fetch_webhook_secret()
-    if webhook_secret:
-        console.print("  [green]✓ Webhook secret obtained[/green]")
-    else:
-        console.print("  [yellow]Could not get webhook secret automatically.[/yellow]")
-        webhook_secret = typer.prompt("  Enter webhook secret manually (whsec_...), or press Enter to skip", default="")
-
-    if webhook_secret and not stripe_config.save_webhook_secret(webhook_secret):
-        console.print("  [yellow]Kept your existing webhook secrets — they look like dashboard endpoints.[/yellow]")
-
-    set_stripe_skipped(False)
-    step_status(True, "Stripe", "configured")
-
-    console.print("  [dim]Updating environment files...[/dim]")
-    run_command([str(ROOT_DIR / "dev" / "setup-environment")], capture=True)
+    if is_stripe_skipped():
+        set_stripe_skipped(False)
 
     console.print("\n  [bold]To receive webhooks locally, run:[/bold]")
     console.print("    [bold]dev stripe --listen[/bold]\n")
 
 
 def _configure_stripe() -> None:
-    status, detail = stripe_config.secrets_status()
+    if stripe_config.has_saved_keys():
+        rejection = stripe_config.saved_keys_rejection()
+        if rejection is None:
+            profile = stripe_config.read_profile()
+            step_status(True, "Stripe sandbox", profile.display_name if profile else "configured")
+            return
 
-    if status == "ok":
-        step_status(True, "Stripe sandbox", detail)
-        return
-
-    if status in ("live", "mismatch"):
-        step_status(False, "Stripe", detail)
+        step_status(False, "Stripe", rejection)
         console.print("\n  [yellow]Local environments must use your own Stripe sandbox.[/yellow]")
         if typer.confirm("  Switch to a sandbox now?", default=True):
             _setup_stripe()

--- a/dev/cli/up_steps/09_configure_integrations.py
+++ b/dev/cli/up_steps/09_configure_integrations.py
@@ -74,8 +74,7 @@ def _configure_stripe() -> None:
             step_status(True, "Stripe sandbox", profile.display_name)
             return
         step_status(False, "Stripe", auth_failure)
-        console.print("\n  [dim]Stripe CLI keys expire after 90 days.[/dim]")
-        if typer.confirm("  Link your sandbox again now?", default=True):
+        if typer.confirm("\n  Link your sandbox again now?", default=True):
             _setup_stripe()
         else:
             console.print("  [yellow]Stripe calls will fail until you run `dev stripe`.[/yellow]")

--- a/dev/cli/up_steps/09_configure_integrations.py
+++ b/dev/cli/up_steps/09_configure_integrations.py
@@ -65,13 +65,14 @@ def _setup_stripe() -> None:
 
 
 def _configure_stripe() -> None:
-    if stripe_config.has_saved_keys():
-        rejection = stripe_config.saved_keys_rejection()
-        if rejection is None:
-            profile = stripe_config.read_profile()
-            step_status(True, "Stripe sandbox", profile.display_name if profile else "configured")
-            return
+    profile = stripe_config.read_profile()
+    rejection = stripe_config.saved_keys_rejection(profile)
 
+    if rejection is None:
+        step_status(True, "Stripe sandbox", profile.display_name)
+        return
+
+    if stripe_config.has_saved_keys():
         step_status(False, "Stripe", rejection)
         console.print("\n  [yellow]Local environments must use your own Stripe sandbox.[/yellow]")
         if typer.confirm("  Switch to a sandbox now?", default=True):

--- a/dev/cli/up_steps/09_configure_integrations.py
+++ b/dev/cli/up_steps/09_configure_integrations.py
@@ -69,7 +69,15 @@ def _configure_stripe() -> None:
     rejection = stripe_config.saved_keys_rejection(profile)
 
     if rejection is None:
-        step_status(True, "Stripe sandbox", profile.display_name)
+        if stripe_config.keys_are_usable():
+            step_status(True, "Stripe sandbox", profile.display_name)
+            return
+        step_status(False, "Stripe", "the Stripe CLI key has expired")
+        console.print("\n  [dim]Stripe CLI keys expire after 90 days.[/dim]")
+        if typer.confirm("  Link your sandbox again now?", default=True):
+            _setup_stripe()
+        else:
+            console.print("  [yellow]Stripe calls will fail until you run `dev stripe`.[/yellow]")
         return
 
     if stripe_config.has_saved_keys():
@@ -77,6 +85,11 @@ def _configure_stripe() -> None:
         console.print("\n  [yellow]Local environments must use your own Stripe sandbox.[/yellow]")
         if typer.confirm("  Switch to a sandbox now?", default=True):
             _setup_stripe()
+        else:
+            console.print(
+                f"  [yellow]Keeping the current keys — {rejection}.\n"
+                "  Local Stripe calls will run against that account.[/yellow]"
+            )
         return
 
     if is_stripe_skipped():

--- a/dev/secrets.env.template
+++ b/dev/secrets.env.template
@@ -20,7 +20,9 @@ POLAR_GITHUB_REPOSITORY_BENEFITS_APP_PRIVATE_KEY=
 POLAR_GITHUB_REPOSITORY_BENEFITS_CLIENT_ID=
 POLAR_GITHUB_REPOSITORY_BENEFITS_CLIENT_SECRET=
 
-# Stripe - from https://dashboard.stripe.com/test/apikeys
+# Stripe - keys from your own sandbox at https://dashboard.stripe.com/sandboxes
+# Or run: dev stripe   (creates/links the sandbox and fills these in)
+# Never a live account, and never the shared Polar Software Inc account.
 POLAR_STRIPE_SECRET_KEY=
 POLAR_STRIPE_PUBLISHABLE_KEY=
 POLAR_STRIPE_WEBHOOK_SECRET=

--- a/dev/secrets.env.template
+++ b/dev/secrets.env.template
@@ -22,7 +22,7 @@ POLAR_GITHUB_REPOSITORY_BENEFITS_CLIENT_SECRET=
 
 # Stripe - keys from your own sandbox at https://dashboard.stripe.com/sandboxes
 # Or run: dev stripe   (creates/links the sandbox and fills these in)
-# Never a live account, and never the shared Polar Software Inc account.
+# Never a live account, and never a shared team account.
 POLAR_STRIPE_SECRET_KEY=
 POLAR_STRIPE_PUBLISHABLE_KEY=
 POLAR_STRIPE_WEBHOOK_SECRET=

--- a/dev/setup-environment
+++ b/dev/setup-environment
@@ -9,6 +9,8 @@
 # ]
 # ///
 import argparse
+import contextlib
+import fcntl
 import functools
 import http.server
 import json
@@ -18,6 +20,7 @@ import queue
 import random
 import shutil
 import string
+import tempfile
 import typing
 import urllib.parse
 import webbrowser
@@ -213,10 +216,38 @@ def _register_github_app(code: str) -> dict[str, typing.Any]:
 
 
 def _load_central_secrets() -> dict[str, str]:
-    """Load secrets from central file if it exists."""
+    """Load secrets from central file if it exists.
+
+    Interpolation is off, matching dev/cli/shared.py: a secret containing
+    `${...}` is a literal value, not a reference to another entry.
+    """
     if SECRETS_FILE_PATH.exists():
-        return {k: v for k, v in dotenv_values(SECRETS_FILE_PATH).items() if v}
+        return {
+            k: v
+            for k, v in dotenv_values(SECRETS_FILE_PATH, interpolate=False).items()
+            if v
+        }
     return {}
+
+
+@contextlib.contextmanager
+def _secrets_lock() -> typing.Iterator[None]:
+    """Same lock dev/cli/shared.py takes, so the two writers can't interleave."""
+    SECRETS_FILE_PATH.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    lock_path = SECRETS_FILE_PATH.with_name(f"{SECRETS_FILE_PATH.name}.lock")
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+def _quote_secret(value: str) -> str:
+    """Quote a value so any content survives a dotenv round-trip."""
+    escaped = str(value).replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
 
 
 def _ensure_secrets_file() -> bool:
@@ -238,6 +269,11 @@ def _ensure_secrets_file() -> bool:
 def _save_github_app_to_secrets(github_app: dict[str, typing.Any]) -> None:
     """Save GitHub App credentials to central secrets file."""
     _ensure_secrets_file()
+    with _secrets_lock():
+        _write_github_app_secrets(github_app)
+
+
+def _write_github_app_secrets(github_app: dict[str, typing.Any]) -> None:
     secrets = _load_central_secrets()
     secrets.update(
         {
@@ -259,12 +295,23 @@ def _save_github_app_to_secrets(github_app: dict[str, typing.Any]) -> None:
         }
     )
 
-    with open(SECRETS_FILE_PATH, "w") as f:
-        f.write("# Polar Development Secrets\n")
-        f.write("# Shared across Git worktrees. See dev/secrets.env.template\n\n")
-        for key, value in secrets.items():
-            delimiter = "'" if '"' in str(value) else '"'
-            f.write(f"{key}={delimiter}{value}{delimiter}\n")
+    # mkstemp creates with 0600, and the rename is atomic, so an interrupted
+    # write can't leave a truncated secrets file behind.
+    fd, tmp_path = tempfile.mkstemp(
+        dir=SECRETS_FILE_PATH.parent,
+        prefix=f".{SECRETS_FILE_PATH.name}.",
+        suffix=".tmp",
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write("# Polar Development Secrets\n")
+            f.write("# Shared across Git worktrees. See dev/secrets.env.template\n\n")
+            for key, value in secrets.items():
+                f.write(f"{key}={_quote_secret(value)}\n")
+        os.replace(tmp_path, SECRETS_FILE_PATH)
+    except BaseException:
+        os.unlink(tmp_path)
+        raise
 
 
 def _write_env_file(

--- a/dev/setup-environment
+++ b/dev/setup-environment
@@ -9,18 +9,14 @@
 # ]
 # ///
 import argparse
-import contextlib
-import fcntl
 import functools
 import http.server
 import json
-import os
 import pathlib
 import queue
 import random
-import shutil
 import string
-import tempfile
+import sys
 import typing
 import urllib.parse
 import webbrowser
@@ -32,12 +28,12 @@ from yaspin import yaspin
 from yaspin.spinners import Spinners
 
 ROOT_PATH = pathlib.Path(__file__).parent.parent
-SECRETS_FILE_PATH = pathlib.Path(
-    os.environ.get(
-        "POLAR_SECRETS_FILE",
-        pathlib.Path.home() / ".config" / "polar" / "secrets.env",
-    )
-)
+
+# One implementation of the secrets file rules, shared with the dev CLI.
+sys.path.insert(0, str(ROOT_PATH / "dev" / "cli"))
+import secrets_io
+
+SECRETS_FILE_PATH = secrets_io.SECRETS_FILE
 SETUP_PAGE = """
 <form id="setup-form" action="https://github.com/settings/apps/new" method="post">
  Register a GitHub App Manifest: <input type="text" name="manifest" id="manifest"><br>
@@ -216,66 +212,19 @@ def _register_github_app(code: str) -> dict[str, typing.Any]:
 
 
 def _load_central_secrets() -> dict[str, str]:
-    """Load secrets from central file if it exists.
-
-    Interpolation is off, matching dev/cli/shared.py: a secret containing
-    `${...}` is a literal value, not a reference to another entry.
-    """
-    if SECRETS_FILE_PATH.exists():
-        return {
-            k: v
-            for k, v in dotenv_values(SECRETS_FILE_PATH, interpolate=False).items()
-            if v
-        }
-    return {}
-
-
-@contextlib.contextmanager
-def _secrets_lock() -> typing.Iterator[None]:
-    """Same lock dev/cli/shared.py takes, so the two writers can't interleave."""
-    SECRETS_FILE_PATH.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    lock_path = SECRETS_FILE_PATH.with_name(f"{SECRETS_FILE_PATH.name}.lock")
-    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
-    try:
-        fcntl.flock(fd, fcntl.LOCK_EX)
-        yield
-    finally:
-        fcntl.flock(fd, fcntl.LOCK_UN)
-        os.close(fd)
-
-
-def _quote_secret(value: str) -> str:
-    """Quote a value so any content survives a dotenv round-trip."""
-    escaped = str(value).replace("\\", "\\\\").replace('"', '\\"')
-    return f'"{escaped}"'
+    """Load secrets that carry a value, so blanks don't override template defaults."""
+    return {k: v for k, v in secrets_io.read_secrets().items() if v}
 
 
 def _ensure_secrets_file() -> bool:
     """Create secrets file from template if it doesn't exist. Returns True if created."""
-    if SECRETS_FILE_PATH.exists():
-        return False
-
-    SECRETS_FILE_PATH.parent.mkdir(parents=True, exist_ok=True)
-    template_path = ROOT_PATH / "dev" / "secrets.env.template"
-    if template_path.exists():
-        shutil.copy(template_path, SECRETS_FILE_PATH)
-    else:
-        with open(SECRETS_FILE_PATH, "w") as f:
-            f.write("# Polar Development Secrets\n")
-            f.write("# See dev/secrets.env.template for all options\n")
-    return True
+    return secrets_io.ensure_secrets_file()
 
 
 def _save_github_app_to_secrets(github_app: dict[str, typing.Any]) -> None:
     """Save GitHub App credentials to central secrets file."""
     _ensure_secrets_file()
-    with _secrets_lock():
-        _write_github_app_secrets(github_app)
-
-
-def _write_github_app_secrets(github_app: dict[str, typing.Any]) -> None:
-    secrets = _load_central_secrets()
-    secrets.update(
+    secrets_io.update_secrets(
         {
             "POLAR_GITHUB_APP_NAMESPACE": github_app["slug"],
             "POLAR_GITHUB_CLIENT_ID": github_app["client_id"],
@@ -294,24 +243,6 @@ def _write_github_app_secrets(github_app: dict[str, typing.Any]) -> None:
             "NEXT_PUBLIC_GITHUB_APP_NAMESPACE": github_app["slug"],
         }
     )
-
-    # mkstemp creates with 0600, and the rename is atomic, so an interrupted
-    # write can't leave a truncated secrets file behind.
-    fd, tmp_path = tempfile.mkstemp(
-        dir=SECRETS_FILE_PATH.parent,
-        prefix=f".{SECRETS_FILE_PATH.name}.",
-        suffix=".tmp",
-    )
-    try:
-        with os.fdopen(fd, "w") as f:
-            f.write("# Polar Development Secrets\n")
-            f.write("# Shared across Git worktrees. See dev/secrets.env.template\n\n")
-            for key, value in secrets.items():
-                f.write(f"{key}={_quote_secret(value)}\n")
-        os.replace(tmp_path, SECRETS_FILE_PATH)
-    except BaseException:
-        os.unlink(tmp_path)
-        raise
 
 
 def _write_env_file(


### PR DESCRIPTION
## Summary

Local dev used whichever Stripe account the Stripe CLI happened to have active. If you were logged into a shared team account, your local environment ran against that account's test mode.

Now `dev up` and `dev stripe` set up a **personal Stripe sandbox** and refuse anything else.

## What

- `dev stripe` walks you through creating or picking a sandbox, then links the Stripe CLI to it.
- The CLI profile is always named `polar-sandbox`, so the tooling never depends on which account is active.
- Live accounts and shared team accounts are rejected before any key is saved.
- `dev stripe --relink` switches to a different sandbox. An expired key (they last 90 days) is detected and re-linked.
- Docs updated: `DEVELOPMENT.md`, the secrets template, and the two agent skills.

Also fixes a bug found while doing this: the central secrets file was read line by line, so a multi-line value was cut at its first newline on the next write. This destroyed the GitHub App private key. Four copies of that reader/writer are now one helper that reads and writes quoted values. The file is also written `0600` now, since it holds Stripe keys.

## Why

Test mode on a shared account is still shared: everyone sees the same customers, products and Connect accounts, and a mistake there is visible to the whole team. A sandbox is free, private, and has no live mode at all, so local work cannot touch real money.

That missing live mode is also how we detect a sandbox: the Stripe CLI stores no live key for one. No account allowlist to maintain.

## How

- New `dev/cli/stripe_config.py` holds the whole flow, so `dev up` and `dev stripe` share it.
- The profile is read through `stripe config --list`, so the Stripe CLI resolves its own config location.
- `read_secrets` / `update_secrets` moved into `dev/cli/shared.py` as the single reader and writer.

Verified against a real sandbox: a $20/mo subscription checkout completed, all webhooks returned 202, and the order, subscription and payment rows were created.

Note for reviewers: the `verifier-web` skill also gains a note that `dev seed` runs against the host database rather than the dockerized one. That is a drive-by doc fix, found while verifying this change.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

