### PR TITLE
fix: let a clickable DataTable row be reached by keyboard

### DIFF
--- a/clients/packages/orbit/src/components/datatable/DataTable.tsx
+++ b/clients/packages/orbit/src/components/datatable/DataTable.tsx
@@ -171,54 +171,71 @@ export function DataTable<TData, TValue>({
             ) : (
               <>
                 {table.getRowModel().rows?.length ? (
-                  table.getRowModel().rows.map((row) => (
-                    <TableRow
-                      key={row.id}
-                      className={
-                        enableRowSelection || onRowClick
-                          ? row.getCanSelect()
-                            ? 'cursor-pointer'
-                            : ''
-                          : undefined
-                      }
-                      data-state={
-                        enableRowSelection
-                          ? row.getIsSelected()
-                            ? 'selected'
+                  table.getRowModel().rows.map((row) => {
+                    const activate = onRowClick
+                      ? () => onRowClick(row)
+                      : enableRowSelection
+                        ? row.getToggleSelectedHandler()
+                        : undefined
+                    return (
+                      <TableRow
+                        key={row.id}
+                        className={
+                          enableRowSelection || onRowClick
+                            ? row.getCanSelect()
+                              ? 'cursor-pointer'
+                              : ''
                             : undefined
-                          : undefined
-                      }
-                      onClick={
-                        onRowClick
-                          ? () => onRowClick(row)
-                          : enableRowSelection
-                            ? row.getToggleSelectedHandler()
+                        }
+                        data-state={
+                          enableRowSelection
+                            ? row.getIsSelected()
+                              ? 'selected'
+                              : undefined
                             : undefined
-                      }
-                    >
-                      {row.getVisibleCells().map((cell) => {
-                        const colSpan = getCellColSpan
-                          ? getCellColSpan(cell)
-                          : 1
+                        }
+                        // An activatable row must be reachable without a mouse.
+                        tabIndex={activate ? 0 : undefined}
+                        onClick={activate}
+                        onKeyDown={
+                          activate
+                            ? (event) => {
+                                if (event.target !== event.currentTarget) return
+                                if (
+                                  event.key === 'Enter' ||
+                                  event.key === ' '
+                                ) {
+                                  event.preventDefault()
+                                  activate(event)
+                                }
+                              }
+                            : undefined
+                        }
+                      >
+                        {row.getVisibleCells().map((cell) => {
+                          const colSpan = getCellColSpan
+                            ? getCellColSpan(cell)
+                            : 1
 
-                        return (
-                          <React.Fragment key={cell.id}>
-                            {colSpan ? (
-                              <TableCell
-                                colSpan={colSpan}
-                                style={{ width: cell.column.getSize() }}
-                              >
-                                {flexRender(
-                                  cell.column.columnDef.cell,
-                                  cell.getContext(),
-                                )}
-                              </TableCell>
-                            ) : null}
-                          </React.Fragment>
-                        )
-                      })}
-                    </TableRow>
-                  ))
+                          return (
+                            <React.Fragment key={cell.id}>
+                              {colSpan ? (
+                                <TableCell
+                                  colSpan={colSpan}
+                                  style={{ width: cell.column.getSize() }}
+                                >
+                                  {flexRender(
+                                    cell.column.columnDef.cell,
+                                    cell.getContext(),
+                                  )}
+                                </TableCell>
+                              ) : null}
+                            </React.Fragment>
+                          )
+                        })}
+                      </TableRow>
+                    )
+                  })
                 ) : (
                   <TableRow>
                     <TableCell

--- a/clients/packages/orbit/src/components/datatable/DataTable.tsx
+++ b/clients/packages/orbit/src/components/datatable/DataTable.tsx
@@ -71,6 +71,19 @@ const queryIsDisabled = (s: ReactQueryLoading): boolean => {
   return false
 }
 
+const activationKeyHandler =
+  (activate: (event: unknown) => void) =>
+  (event: React.KeyboardEvent<HTMLTableRowElement>) => {
+    // Let buttons, links and checkboxes inside the row keep their own keys.
+    if (event.target !== event.currentTarget) return
+    if (event.key !== 'Enter' && event.key !== ' ') return
+    event.preventDefault()
+    activate(event)
+  }
+
+const ACTIVATABLE_ROW_CLASS =
+  'cursor-pointer focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-inset focus-visible:outline-none'
+
 export function DataTable<TData, TValue>({
   columns,
   data,
@@ -174,42 +187,23 @@ export function DataTable<TData, TValue>({
                   table.getRowModel().rows.map((row) => {
                     const activate = onRowClick
                       ? () => onRowClick(row)
-                      : enableRowSelection
+                      : enableRowSelection && row.getCanSelect()
                         ? row.getToggleSelectedHandler()
                         : undefined
                     return (
                       <TableRow
                         key={row.id}
-                        className={
-                          enableRowSelection || onRowClick
-                            ? row.getCanSelect()
-                              ? 'cursor-pointer'
-                              : ''
-                            : undefined
-                        }
+                        className={activate ? ACTIVATABLE_ROW_CLASS : undefined}
                         data-state={
-                          enableRowSelection
-                            ? row.getIsSelected()
-                              ? 'selected'
-                              : undefined
+                          enableRowSelection && row.getIsSelected()
+                            ? 'selected'
                             : undefined
                         }
                         // An activatable row must be reachable without a mouse.
                         tabIndex={activate ? 0 : undefined}
                         onClick={activate}
                         onKeyDown={
-                          activate
-                            ? (event) => {
-                                if (event.target !== event.currentTarget) return
-                                if (
-                                  event.key === 'Enter' ||
-                                  event.key === ' '
-                                ) {
-                                  event.preventDefault()
-                                  activate(event)
-                                }
-                              }
-                            : undefined
+                          activate ? activationKeyHandler(activate) : undefined
                         }
                       >
                         {row.getVisibleCells().map((cell) => {


### PR DESCRIPTION
## Summary

A `DataTable` row with `onRowClick` only responded to a mouse. It had no
`tabIndex` and no key handler, so keyboard and screen-reader users could not
reach whatever the click opens.

## Why

Five pages already pass `onRowClick`: checkouts, disputes, payouts, the
transactions list and customer usage. In some of them the row click is the only
way to open a record's details.

## How

Rows that do something on click now take focus and activate on Enter or Space.
They also get the standard Orbit focus ring, so a keyboard user can see which
row they are on.

Keys pressed on a child element are ignored, so buttons, checkboxes and links
inside a row keep their own behaviour.

A row that cannot be selected is no longer a tab stop.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`pnpm lint`, `tsc --noEmit`)
- [x] No unrelated changes or drive-by fixes are included
