### PR TITLE
fix(migration): review dashboard refinements on the backend

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
@@ -37,6 +37,7 @@ export function ReviewTable({ migrationId }: { migrationId: string }) {
   const {
     counts,
     attentionCount,
+    blockers,
     isLoading: countsLoading,
     isError: countsError,
   } = useMigrationEntityCounts(migrationId)
@@ -120,9 +121,7 @@ export function ReviewTable({ migrationId }: { migrationId: string }) {
       importError={importCatalog.isError}
       onRerunPrecheck={() => rerunPrecheck.mutate()}
       rerunning={rerunPrecheck.isPending}
-      blockers={rerunPrecheck.data?.issues.filter(
-        (issue) => issue.level === 'blocker',
-      )}
+      blockers={blockers}
     />
   )
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
@@ -121,7 +121,7 @@ export function ReviewTableView({
 
   if (blockers.length > 0) {
     return (
-      <Box flexDirection="column" rowGap="l">
+      <Box flexDirection="column" rowGap="l" alignItems="start">
         {blockers.map((blocker) => (
           <Alert
             key={blocker.code}
@@ -130,6 +130,17 @@ export function ReviewTableView({
             description={blocker.message}
           />
         ))}
+        {/* Without this the step is a dead end once a blocker shows. */}
+        {onRerunPrecheck && (
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={onRerunPrecheck}
+            disabled={rerunning}
+          >
+            {rerunning ? 'Checking…' : 'Check again'}
+          </Button>
+        )}
       </Box>
     )
   }

--- a/clients/apps/web/src/hooks/queries/merchantMigrations.ts
+++ b/clients/apps/web/src/hooks/queries/merchantMigrations.ts
@@ -44,6 +44,16 @@ export const useCreateMerchantMigration = (organizationId: string) =>
     },
   })
 
+// Both mutations reshape the ledger, so everything drawn from it goes stale.
+const invalidateMigration = (id: string) => {
+  const queryClient = getQueryClient()
+  queryClient.invalidateQueries({ queryKey: ['merchantMigration', { id }] })
+  queryClient.invalidateQueries({ queryKey: ['merchantMigrationRecords'] })
+  queryClient.invalidateQueries({
+    queryKey: ['merchantMigrationCounts', { id }],
+  })
+}
+
 export const useRunMerchantMigrationPrecheck = (id: string) =>
   useMutation({
     mutationFn: () =>
@@ -52,17 +62,7 @@ export const useRunMerchantMigrationPrecheck = (id: string) =>
           params: { path: { id } },
         }),
       ),
-    onSuccess: () => {
-      getQueryClient().invalidateQueries({
-        queryKey: ['merchantMigration', { id }],
-      })
-      getQueryClient().invalidateQueries({
-        queryKey: ['merchantMigrationRecords'],
-      })
-      getQueryClient().invalidateQueries({
-        queryKey: ['merchantMigrationCounts', { id }],
-      })
-    },
+    onSuccess: () => invalidateMigration(id),
   })
 
 interface ImportOptions {
@@ -84,17 +84,7 @@ export const useImportMerchantMigrationCatalog = (id: string) =>
           },
         }),
       ),
-    onSuccess: () => {
-      getQueryClient().invalidateQueries({
-        queryKey: ['merchantMigration', { id }],
-      })
-      getQueryClient().invalidateQueries({
-        queryKey: ['merchantMigrationRecords'],
-      })
-      getQueryClient().invalidateQueries({
-        queryKey: ['merchantMigrationCounts', { id }],
-      })
-    },
+    onSuccess: () => invalidateMigration(id),
   })
 
 export const useMigrationRecords = (

--- a/clients/apps/web/src/hooks/queries/merchantMigrations.ts
+++ b/clients/apps/web/src/hooks/queries/merchantMigrations.ts
@@ -130,7 +130,8 @@ export const useMigrationRecords = (
     enabled: !!id,
   })
 
-export type CountEntity = 'subscriptions' | 'products' | 'customers'
+// Prices import with their product, so they have no tab of their own.
+export type CountEntity = Exclude<schemas['PrecheckEntity'], 'prices'>
 
 export interface EntityCount {
   importable: number
@@ -152,16 +153,12 @@ export const useMigrationEntityCounts = (id: string) => {
     enabled: !!id,
   })
 
-  const byEntity = new Map(
-    query.data?.entities.map((entity) => [
-      entity.entity,
-      { importable: entity.importable, skipped: entity.skipped },
-    ]),
-  )
+  const countFor = (entity: CountEntity): EntityCount =>
+    query.data?.entities.find((item) => item.entity === entity) ?? EMPTY_COUNT
   const counts: Record<CountEntity, EntityCount> = {
-    subscriptions: byEntity.get('subscriptions') ?? EMPTY_COUNT,
-    products: byEntity.get('products') ?? EMPTY_COUNT,
-    customers: byEntity.get('customers') ?? EMPTY_COUNT,
+    subscriptions: countFor('subscriptions'),
+    products: countFor('products'),
+    customers: countFor('customers'),
   }
 
   return {

--- a/clients/apps/web/src/hooks/queries/merchantMigrations.ts
+++ b/clients/apps/web/src/hooks/queries/merchantMigrations.ts
@@ -59,6 +59,9 @@ export const useRunMerchantMigrationPrecheck = (id: string) =>
       getQueryClient().invalidateQueries({
         queryKey: ['merchantMigrationRecords'],
       })
+      getQueryClient().invalidateQueries({
+        queryKey: ['merchantMigrationCounts', { id }],
+      })
     },
   })
 
@@ -87,6 +90,9 @@ export const useImportMerchantMigrationCatalog = (id: string) =>
       })
       getQueryClient().invalidateQueries({
         queryKey: ['merchantMigrationRecords'],
+      })
+      getQueryClient().invalidateQueries({
+        queryKey: ['merchantMigrationCounts', { id }],
       })
     },
   })
@@ -131,66 +137,40 @@ export interface EntityCount {
   skipped: number
 }
 
-const useEntityCount = (
-  id: string,
-  entity: CountEntity,
-): EntityCount & {
-  isLoading: boolean
-  isError: boolean
-} => {
-  const importable = useMigrationRecords(id, {
-    entity,
-    status: 'importable',
-    page: 1,
-    limit: 1,
-  })
-  const skipped = useMigrationRecords(id, {
-    entity,
-    status: 'skipped',
-    page: 1,
-    limit: 1,
-  })
-  return {
-    importable: importable.data?.pagination.total_count ?? 0,
-    skipped: skipped.data?.pagination.total_count ?? 0,
-    isLoading: importable.isLoading || skipped.isLoading,
-    // A failed count would otherwise read as zero, which the caller can't tell
-    // apart from an empty catalog.
-    isError: importable.isError || skipped.isError,
-  }
-}
+const EMPTY_COUNT: EntityCount = { importable: 0, skipped: 0 }
 
 export const useMigrationEntityCounts = (id: string) => {
-  const subscriptions = useEntityCount(id, 'subscriptions')
-  const products = useEntityCount(id, 'products')
-  const customers = useEntityCount(id, 'customers')
-  const attention = useMigrationRecords(id, {
-    reasonLevel: 'action_required',
-    page: 1,
-    limit: 1,
+  const query = useQuery({
+    queryKey: ['merchantMigrationCounts', { id }],
+    queryFn: () =>
+      unwrap(
+        api.GET('/v1/merchant-migrations/{id}/counts', {
+          params: { path: { id } },
+        }),
+      ),
+    retry: defaultRetry,
+    enabled: !!id,
   })
 
+  const byEntity = new Map(
+    query.data?.entities.map((entity) => [
+      entity.entity,
+      { importable: entity.importable, skipped: entity.skipped },
+    ]),
+  )
   const counts: Record<CountEntity, EntityCount> = {
-    subscriptions: {
-      importable: subscriptions.importable,
-      skipped: subscriptions.skipped,
-    },
-    products: { importable: products.importable, skipped: products.skipped },
-    customers: { importable: customers.importable, skipped: customers.skipped },
+    subscriptions: byEntity.get('subscriptions') ?? EMPTY_COUNT,
+    products: byEntity.get('products') ?? EMPTY_COUNT,
+    customers: byEntity.get('customers') ?? EMPTY_COUNT,
   }
 
   return {
     counts,
-    attentionCount: attention.data?.pagination.total_count ?? 0,
-    isLoading:
-      subscriptions.isLoading ||
-      products.isLoading ||
-      customers.isLoading ||
-      attention.isLoading,
-    isError:
-      subscriptions.isError ||
-      products.isError ||
-      customers.isError ||
-      attention.isError,
+    attentionCount: query.data?.action_required ?? 0,
+    blockers: query.data?.blockers ?? [],
+    isLoading: query.isLoading,
+    // A failed count would otherwise read as zero, which the caller can't tell
+    // apart from an empty catalog.
+    isError: query.isError,
   }
 }

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -5168,6 +5168,26 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/merchant-migrations/{id}/counts': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Count Merchant Migration Records
+     * @description **Scopes**: `organizations:write`
+     */
+    get: operations['merchant-migrations:counts']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/merchant-migrations/{id}/records': {
     parameters: {
       query?: never
@@ -23119,6 +23139,27 @@ export interface components {
         [key: string]: unknown
       } | null
     }
+    /**
+     * MerchantMigrationCounts
+     * @description Everything the review page needs to draw its tabs and totals, in one call.
+     */
+    MerchantMigrationCounts: {
+      /**
+       * Entities
+       * @description Per-entity counts, for products, customers and subscriptions.
+       */
+      entities: components['schemas']['MerchantMigrationEntityCount'][]
+      /**
+       * Action Required
+       * @description How many records the merchant has to act on.
+       */
+      action_required: number
+      /**
+       * Blockers
+       * @description What stops the import right now, re-checked against the organization and the source account. Empty when it can run.
+       */
+      blockers: components['schemas']['PrecheckIssue'][]
+    }
     /** MerchantMigrationCreate */
     MerchantMigrationCreate: {
       /**
@@ -23134,6 +23175,26 @@ export interface components {
        * @description A Stripe API key for the source account (a restricted `rk_...` key is recommended). It is validated for all required permissions before the migration is saved.
        */
       api_key: string
+    }
+    /** MerchantMigrationEntityCount */
+    MerchantMigrationEntityCount: {
+      /** @description The source entity type. */
+      entity: components['schemas']['PrecheckEntity']
+      /**
+       * Importable
+       * @description How many will be imported into Polar.
+       */
+      importable: number
+      /**
+       * Skipped
+       * @description How many won't be imported and stay on the source.
+       */
+      skipped: number
+      /**
+       * Imported
+       * @description How many are already imported.
+       */
+      imported: number
     }
     /** MerchantMigrationImportReport */
     MerchantMigrationImportReport: {
@@ -51493,6 +51554,66 @@ export interface operations {
           'application/json':
             | components['schemas']['CatalogImportNotReady']
             | components['schemas']['CatalogImportBlocked']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'merchant-migrations:counts': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationCounts']
+        }
+      }
+      /** @description The source is not connected or isn't supported. */
+      400: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json':
+            | components['schemas']['SourceNotConnected']
+            | components['schemas']['UnsupportedMigrationSource']
+        }
+      }
+      /** @description Not allowed to manage this organization. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['NotPermitted']
+        }
+      }
+      /** @description Merchant migration not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationNotFound']
         }
       }
       /** @description Validation Error */

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -5177,7 +5177,7 @@ export interface paths {
     }
     /**
      * Count Merchant Migration Records
-     * @description **Scopes**: `organizations:write`
+     * @description **Scopes**: `organizations:read` `organizations:write`
      */
     get: operations['merchant-migrations:counts']
     put?: never
@@ -5197,7 +5197,7 @@ export interface paths {
     }
     /**
      * List Merchant Migration Records
-     * @description **Scopes**: `organizations:write`
+     * @description **Scopes**: `organizations:read` `organizations:write`
      */
     get: operations['merchant-migrations:records']
     put?: never
@@ -23148,7 +23148,7 @@ export interface components {
        * Entities
        * @description Per-entity counts, for products, customers and subscriptions.
        */
-      entities: components['schemas']['MerchantMigrationEntityCount'][]
+      entities: components['schemas']['PrecheckEntitySummary'][]
       /**
        * Action Required
        * @description How many records the merchant has to act on.
@@ -23175,26 +23175,6 @@ export interface components {
        * @description A Stripe API key for the source account (a restricted `rk_...` key is recommended). It is validated for all required permissions before the migration is saved.
        */
       api_key: string
-    }
-    /** MerchantMigrationEntityCount */
-    MerchantMigrationEntityCount: {
-      /** @description The source entity type. */
-      entity: components['schemas']['PrecheckEntity']
-      /**
-       * Importable
-       * @description How many will be imported into Polar.
-       */
-      importable: number
-      /**
-       * Skipped
-       * @description How many won't be imported and stay on the source.
-       */
-      skipped: number
-      /**
-       * Imported
-       * @description How many are already imported.
-       */
-      imported: number
     }
     /** MerchantMigrationImportReport */
     MerchantMigrationImportReport: {
@@ -51585,17 +51565,6 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['MerchantMigrationCounts']
-        }
-      }
-      /** @description The source is not connected or isn't supported. */
-      400: {
-        headers: {
-          [name: string]: unknown
-        }
-        content: {
-          'application/json':
-            | components['schemas']['SourceNotConnected']
-            | components['schemas']['UnsupportedMigrationSource']
         }
       }
       /** @description Not allowed to manage this organization. */

--- a/server/polar/merchant_migration/adapters/stripe.py
+++ b/server/polar/merchant_migration/adapters/stripe.py
@@ -36,6 +36,7 @@ class StripeAdapter:
         self._client = stripe_lib.StripeClient(
             access_token, stripe_version=STRIPE_API_VERSION
         )
+        self._account: stripe_lib.Account | None = None
 
     async def verify_scopes(self) -> list[str]:
         """Probe every permission the migration needs, concurrently, and return the
@@ -87,11 +88,14 @@ class StripeAdapter:
             pass
 
     async def _current_account(self) -> stripe_lib.Account | None:
-        # Best-effort: a restricted key may lack account read scope.
-        try:
-            return await self._client.v1.accounts.retrieve_current_async()
-        except stripe_lib.StripeError:
-            return None
+        # Best-effort: a restricted key may lack account read scope. Held on the
+        # adapter so the callers that need it don't each pay for the round-trip.
+        if self._account is None:
+            try:
+                self._account = await self._client.v1.accounts.retrieve_current_async()
+            except stripe_lib.StripeError:
+                return None
+        return self._account
 
     async def get_account_id(self) -> str | None:
         account = await self._current_account()

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -191,10 +191,6 @@ async def import_catalog(
     response_model=MerchantMigrationCounts,
     summary="Count Merchant Migration Records",
     responses={
-        400: {
-            "description": "The source is not connected or isn't supported.",
-            "model": SourceNotConnected.schema() | UnsupportedMigrationSource.schema(),
-        },
         403: {
             "description": "Not allowed to manage this organization.",
             "model": NotPermitted.schema(),
@@ -207,8 +203,8 @@ async def import_catalog(
 )
 async def counts(
     id: UUID4,
-    auth_subject: MerchantMigrationWrite,
-    session: AsyncSession = Depends(get_db_session),
+    auth_subject: MerchantMigrationRead,
+    session: AsyncReadSession = Depends(get_db_read_session),
 ) -> MerchantMigrationCounts:
     return await merchant_migration_service.count_records(session, auth_subject, id)
 
@@ -234,12 +230,12 @@ async def counts(
 )
 async def records(
     id: UUID4,
-    auth_subject: MerchantMigrationWrite,
+    auth_subject: MerchantMigrationRead,
     pagination: PaginationParamsQuery,
     entity: Annotated[PrecheckEntity | None, Query()] = None,
     status: Annotated[PrecheckRecordStatus | None, Query()] = None,
     reason_level: Annotated[PrecheckReasonLevel | None, Query()] = None,
-    session: AsyncSession = Depends(get_db_session),
+    session: AsyncReadSession = Depends(get_db_read_session),
 ) -> ListResource[MerchantMigrationRecordItem]:
     items, count = await merchant_migration_service.list_records(
         session,

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -15,6 +15,7 @@ from polar.routing import APIRouter
 from .auth import MerchantMigrationRead, MerchantMigrationWrite
 from .schemas import MerchantMigration as MerchantMigrationSchema
 from .schemas import (
+    MerchantMigrationCounts,
     MerchantMigrationCreate,
     MerchantMigrationImportReport,
     MerchantMigrationImportRequest,
@@ -183,6 +184,33 @@ async def import_catalog(
         record_ids=body.record_ids if body is not None else None,
         exclude_record_ids=body.exclude_record_ids if body is not None else None,
     )
+
+
+@router.get(
+    "/{id}/counts",
+    response_model=MerchantMigrationCounts,
+    summary="Count Merchant Migration Records",
+    responses={
+        400: {
+            "description": "The source is not connected or isn't supported.",
+            "model": SourceNotConnected.schema() | UnsupportedMigrationSource.schema(),
+        },
+        403: {
+            "description": "Not allowed to manage this organization.",
+            "model": NotPermitted.schema(),
+        },
+        404: {
+            "description": "Merchant migration not found.",
+            "model": MerchantMigrationNotFound.schema(),
+        },
+    },
+)
+async def counts(
+    id: UUID4,
+    auth_subject: MerchantMigrationWrite,
+    session: AsyncSession = Depends(get_db_session),
+) -> MerchantMigrationCounts:
+    return await merchant_migration_service.count_records(session, auth_subject, id)
 
 
 @router.get(

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -425,8 +425,8 @@ class PrecheckEngine:
                 level=PrecheckIssueLevel.warning,
                 code="subscription_has_discount",
                 message=(
-                    "Subscription has a discount, which isn't migrated yet; it "
-                    "won't be imported so the customer isn't overcharged."
+                    "Discounts aren't migrated yet. Importing would charge the "
+                    "full price, so this subscription stays on the source."
                 ),
                 source_id=source_id,
             )

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -83,7 +83,7 @@ class MerchantMigrationRecordRepository(
         self,
         merchant_migration: MerchantMigration,
         seen: Collection[tuple[MerchantMigrationRecordType, str]],
-    ) -> int:
+    ) -> None:
         """Drop staged records the source no longer returns. Only pending rows
         go: an imported, skipped or failed one is the record of what a past run
         did, and deleting it would let a later run import the same thing twice.
@@ -92,13 +92,9 @@ class MerchantMigrationRecordRepository(
             MerchantMigrationRecord.merchant_migration_id == merchant_migration.id,
             MerchantMigrationRecord.status == MerchantMigrationRecordStatus.pending,
         )
-        pruned = 0
         for record in await self.get_all(statement):
-            if (record.type, record.source_id) in seen:
-                continue
-            await self.soft_delete(record)
-            pruned += 1
-        return pruned
+            if (record.type, record.source_id) not in seen:
+                await self.soft_delete(record)
 
     async def upsert(
         self,

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -83,14 +83,19 @@ class MerchantMigrationRecordRepository(
         self,
         merchant_migration: MerchantMigration,
         seen: Collection[tuple[MerchantMigrationRecordType, str]],
+        types: Collection[MerchantMigrationRecordType],
     ) -> None:
-        """Drop staged records the source no longer returns. Only pending rows
-        go: an imported, skipped or failed one is the record of what a past run
-        did, and deleting it would let a later run import the same thing twice.
+        """Drop staged records the source no longer returns.
+
+        ``types`` is what the pass reads, so a type it never looks at is never
+        mistaken for a record the source dropped. Only pending rows go: an
+        imported, skipped or failed one is the record of what a past run did, and
+        deleting it would let a later run import the same thing twice.
         """
         statement = self.get_base_statement().where(
             MerchantMigrationRecord.merchant_migration_id == merchant_migration.id,
             MerchantMigrationRecord.status == MerchantMigrationRecordStatus.pending,
+            MerchantMigrationRecord.type.in_(types),
         )
         for record in await self.get_all(statement):
             if (record.type, record.source_id) not in seen:

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -1,4 +1,4 @@
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from uuid import UUID
 
 from sqlalchemy import Select
@@ -78,6 +78,27 @@ class MerchantMigrationRecordRepository(
             )
         )
         return await self.get_all(statement)
+
+    async def prune_missing(
+        self,
+        merchant_migration: MerchantMigration,
+        seen: Collection[tuple[MerchantMigrationRecordType, str]],
+    ) -> int:
+        """Drop staged records the source no longer returns. Only pending rows
+        go: an imported, skipped or failed one is the record of what a past run
+        did, and deleting it would let a later run import the same thing twice.
+        """
+        statement = self.get_base_statement().where(
+            MerchantMigrationRecord.merchant_migration_id == merchant_migration.id,
+            MerchantMigrationRecord.status == MerchantMigrationRecordStatus.pending,
+        )
+        pruned = 0
+        for record in await self.get_all(statement):
+            if (record.type, record.source_id) in seen:
+                continue
+            await self.soft_delete(record)
+            pruned += 1
+        return pruned
 
     async def upsert(
         self,

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -121,19 +121,10 @@ class MerchantMigrationRecordItem(Schema):
     )
 
 
-class MerchantMigrationEntityCount(Schema):
-    entity: PrecheckEntity = Field(description="The source entity type.")
-    importable: int = Field(description="How many will be imported into Polar.")
-    skipped: int = Field(
-        description="How many won't be imported and stay on the source."
-    )
-    imported: int = Field(description="How many are already imported.")
-
-
 class MerchantMigrationCounts(Schema):
     """Everything the review page needs to draw its tabs and totals, in one call."""
 
-    entities: list[MerchantMigrationEntityCount] = Field(
+    entities: list[PrecheckEntitySummary] = Field(
         description="Per-entity counts, for products, customers and subscriptions."
     )
     action_required: int = Field(

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -121,6 +121,32 @@ class MerchantMigrationRecordItem(Schema):
     )
 
 
+class MerchantMigrationEntityCount(Schema):
+    entity: PrecheckEntity = Field(description="The source entity type.")
+    importable: int = Field(description="How many will be imported into Polar.")
+    skipped: int = Field(
+        description="How many won't be imported and stay on the source."
+    )
+    imported: int = Field(description="How many are already imported.")
+
+
+class MerchantMigrationCounts(Schema):
+    """Everything the review page needs to draw its tabs and totals, in one call."""
+
+    entities: list[MerchantMigrationEntityCount] = Field(
+        description="Per-entity counts, for products, customers and subscriptions."
+    )
+    action_required: int = Field(
+        description="How many records the merchant has to act on."
+    )
+    blockers: list[PrecheckIssue] = Field(
+        description=(
+            "What stops the import right now, re-checked against the "
+            "organization and the source account. Empty when it can run."
+        )
+    )
+
+
 class MerchantMigrationImportRequest(Schema):
     record_ids: list[UUID4] | None = Field(
         default=None,

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -17,7 +17,10 @@ from polar.models.merchant_migration import (
     MerchantMigrationSourcePlatform,
     MerchantMigrationStep,
 )
-from polar.models.merchant_migration_record import MerchantMigrationRecordType
+from polar.models.merchant_migration_record import (
+    MerchantMigrationRecordStatus,
+    MerchantMigrationRecordType,
+)
 from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncReadSession
 from polar.product.repository import ProductRepository
@@ -31,7 +34,9 @@ from .repository import (
     MerchantMigrationRepository,
 )
 from .schemas import (
+    MerchantMigrationCounts,
     MerchantMigrationCreate,
+    MerchantMigrationEntityCount,
     MerchantMigrationImportReport,
     MerchantMigrationRecordItem,
     PrecheckEntity,
@@ -266,18 +271,22 @@ class MerchantMigrationService:
             session
         ).get_active_names_by_organization(organization.id)
         record_repository = MerchantMigrationRecordRepository.from_session(session)
+        seen: set[tuple[MerchantMigrationRecordType, str]] = set()
         report = await precheck_engine.run(
             self._stage_records(
-                record_repository, migration, organization, adapter.extract()
+                record_repository, migration, organization, adapter.extract(), seen
             ),
             organization,
             source_account,
             existing_product_names,
         )
+        await record_repository.prune_missing(migration, seen)
 
-        # Re-running the precheck to refresh the ledger must not regress a
-        # migration that has already moved on.
-        if migration.step == MerchantMigrationStep.source_setup:
+        # A blocked migration stays on source setup, so the merchant keeps the
+        # panel that tells them what to fix instead of landing on a review table
+        # they can't import from. Re-running to refresh the ledger must also not
+        # regress a migration that has already moved on.
+        if migration.step == MerchantMigrationStep.source_setup and report.can_start:
             repository = MerchantMigrationRepository.from_session(session)
             await repository.update(
                 migration, update_dict={"step": MerchantMigrationStep.pre_check}
@@ -377,22 +386,11 @@ class MerchantMigrationService:
         (`action_required`) or only needs to know about (`info`). Reads what
         ``run_precheck`` persisted."""
         migration = await self._get_manageable(session, auth_subject, migration_id)
-
-        record_repository = MerchantMigrationRecordRepository.from_session(session)
-        staged = await record_repository.list_by_migration(migration.id)
-        records = [deserialize(record.type, record.canonical) for record in staged]
-        existing_product_names = await ProductRepository.from_session(
-            session
-        ).get_active_names_by_organization(migration.organization_id)
-
-        entities = [entity] if entity is not None else list(_ENTITY_RECORD_TYPE)
-        items: list[MerchantMigrationRecordItem] = []
-        for entity_type in entities:
-            entity_items = classify_records(
-                records, entity_type, existing_product_names
-            )
-            self._attach_record_ids(entity_items, staged, entity_type)
-            items.extend(entity_items)
+        items = await self._classify_staged(
+            session,
+            migration,
+            entities=[entity] if entity is not None else list(_ENTITY_RECORD_TYPE),
+        )
 
         if status is not None:
             items = [item for item in items if item.status == status]
@@ -401,6 +399,93 @@ class MerchantMigrationService:
 
         start = (pagination.page - 1) * pagination.limit
         return items[start : start + pagination.limit], len(items)
+
+    async def count_records(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        migration_id: UUID,
+    ) -> MerchantMigrationCounts:
+        """Everything the review page needs to draw its tabs and totals. It
+        classifies the ledger once, where per-entity listings made the page ask
+        for the same work seven times."""
+        migration = await self._get_manageable(session, auth_subject, migration_id)
+        organization = await OrganizationRepository.from_session(session).get_by_id(
+            migration.organization_id
+        )
+        if organization is None:
+            raise MerchantMigrationNotFound()
+
+        items = await self._classify_staged(
+            session, migration, entities=list(_ENTITY_RECORD_TYPE)
+        )
+        by_entity: dict[PrecheckEntity, list[MerchantMigrationRecordItem]] = {
+            entity: [] for entity in _ENTITY_RECORD_TYPE
+        }
+        for item in items:
+            by_entity[item.entity].append(item)
+
+        adapter = await self._build_adapter(migration)
+        return MerchantMigrationCounts(
+            entities=[
+                MerchantMigrationEntityCount(
+                    entity=entity,
+                    importable=self._count(
+                        entity_items, status=PrecheckRecordStatus.importable
+                    ),
+                    skipped=self._count(
+                        entity_items, status=PrecheckRecordStatus.skipped
+                    ),
+                    imported=self._count(
+                        entity_items,
+                        import_status=MerchantMigrationRecordStatus.imported,
+                    ),
+                )
+                for entity, entity_items in by_entity.items()
+            ],
+            action_required=self._count(
+                items, reason_level=PrecheckReasonLevel.action_required
+            ),
+            blockers=import_blockers(organization, await adapter.get_source_account()),
+        )
+
+    def _count(
+        self,
+        items: Sequence[MerchantMigrationRecordItem],
+        *,
+        status: PrecheckRecordStatus | None = None,
+        import_status: MerchantMigrationRecordStatus | None = None,
+        reason_level: PrecheckReasonLevel | None = None,
+    ) -> int:
+        return sum(
+            1
+            for item in items
+            if (status is None or item.status == status)
+            and (import_status is None or item.import_status == import_status)
+            and (reason_level is None or item.reason_level == reason_level)
+        )
+
+    async def _classify_staged(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        *,
+        entities: Sequence[PrecheckEntity],
+    ) -> Sequence[MerchantMigrationRecordItem]:
+        """Classify what ``run_precheck`` staged, for the given entity types."""
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        staged = await record_repository.list_by_migration(migration.id)
+        records = [deserialize(record.type, record.canonical) for record in staged]
+        existing_product_names = await ProductRepository.from_session(
+            session
+        ).get_active_names_by_organization(migration.organization_id)
+
+        items: list[MerchantMigrationRecordItem] = []
+        for entity in entities:
+            entity_items = classify_records(records, entity, existing_product_names)
+            self._attach_record_ids(entity_items, staged, entity)
+            items.extend(entity_items)
+        return items
 
     def _attach_record_ids(
         self,
@@ -429,11 +514,15 @@ class MerchantMigrationService:
         migration: MerchantMigration,
         organization: Organization,
         records: AsyncIterator[CanonicalRecord],
+        seen: set[tuple[MerchantMigrationRecordType, str]],
     ) -> AsyncIterator[CanonicalRecord]:
         """Stage each record as it streams past, so we persist the catalog in
-        the same single pass the precheck reads (extraction stays incremental)."""
+        the same single pass the precheck reads (extraction stays incremental).
+        Collects the keys it saw, so the caller can drop what the source no
+        longer has."""
         async for record in records:
             await record_repository.upsert(migration, organization, record)
+            seen.add((record.type, record.source_id))
             yield record
 
     async def _build_adapter(self, migration: MerchantMigration) -> SourceAdapter:

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -1,5 +1,6 @@
 from collections.abc import AsyncIterator, Sequence
-from typing import TypedDict
+from dataclasses import dataclass, field
+from typing import Any, TypedDict
 from uuid import UUID
 
 import stripe as stripe_lib
@@ -18,7 +19,6 @@ from polar.models.merchant_migration import (
     MerchantMigrationStep,
 )
 from polar.models.merchant_migration_record import (
-    MerchantMigrationRecordStatus,
     MerchantMigrationRecordType,
 )
 from polar.organization.repository import OrganizationRepository
@@ -26,7 +26,7 @@ from polar.postgres import AsyncReadSession
 from polar.product.repository import ProductRepository
 
 from .adapters import SourceAdapter, StripeAdapter
-from .canonical import CanonicalRecord, deserialize
+from .canonical import CanonicalAccount, CanonicalRecord, deserialize
 from .importer import CatalogImporter
 from .precheck import classify_records, import_blockers, precheck_engine
 from .repository import (
@@ -36,10 +36,10 @@ from .repository import (
 from .schemas import (
     MerchantMigrationCounts,
     MerchantMigrationCreate,
-    MerchantMigrationEntityCount,
     MerchantMigrationImportReport,
     MerchantMigrationRecordItem,
     PrecheckEntity,
+    PrecheckEntitySummary,
     PrecheckIssue,
     PrecheckReasonLevel,
     PrecheckRecordStatus,
@@ -76,6 +76,19 @@ class StripeSourceCredentials(TypedDict):
     api_key_encrypted: str
     stripe_user_id: str | None
     livemode: bool
+    # The two account facts the blockers depend on, so a read can answer "can
+    # this import run?" without calling Stripe. Refreshed on every pre-check.
+    country: str | None
+    is_connect_platform: bool
+
+
+@dataclass
+class _StagedKeys:
+    """What a staging pass saw. ``complete`` says the source stream was read to
+    the end, which is what makes it safe to prune everything it didn't mention."""
+
+    keys: set[tuple[MerchantMigrationRecordType, str]] = field(default_factory=set)
+    complete: bool = False
 
 
 class MerchantMigrationError(PolarError): ...
@@ -253,8 +266,8 @@ class MerchantMigrationService:
         migration_id: UUID,
     ) -> PrecheckReport:
         """Read the connected source, normalize it, and report whether it can be
-        imported. Advances the migration from source setup to the precheck step.
-        """
+        imported. Advances the migration from source setup to the pre-check step,
+        unless the report says something blocks the import."""
         migration = await self._get_manageable(
             session, auth_subject, migration_id, for_update=True
         )
@@ -271,26 +284,34 @@ class MerchantMigrationService:
             session
         ).get_active_names_by_organization(organization.id)
         record_repository = MerchantMigrationRecordRepository.from_session(session)
-        seen: set[tuple[MerchantMigrationRecordType, str]] = set()
+        staged = _StagedKeys()
         report = await precheck_engine.run(
             self._stage_records(
-                record_repository, migration, organization, adapter.extract(), seen
+                record_repository, migration, organization, adapter.extract(), staged
             ),
             organization,
             source_account,
             existing_product_names,
         )
-        await record_repository.prune_missing(migration, seen)
+        # Pruning against a half-read source would delete records it still has.
+        if staged.complete:
+            await record_repository.prune_missing(migration, staged.keys)
 
+        repository = MerchantMigrationRepository.from_session(session)
+        update_dict: dict[str, Any] = {
+            "source_credentials": {
+                **migration.source_credentials,
+                "country": source_account.country,
+                "is_connect_platform": source_account.is_connect_platform,
+            }
+        }
         # A blocked migration stays on source setup, so the merchant keeps the
         # panel that tells them what to fix instead of landing on a review table
         # they can't import from. Re-running to refresh the ledger must also not
         # regress a migration that has already moved on.
         if migration.step == MerchantMigrationStep.source_setup and report.can_start:
-            repository = MerchantMigrationRepository.from_session(session)
-            await repository.update(
-                migration, update_dict={"step": MerchantMigrationStep.pre_check}
-            )
+            update_dict["step"] = MerchantMigrationStep.pre_check
+        await repository.update(migration, update_dict=update_dict)
         return report
 
     async def import_catalog(
@@ -344,12 +365,14 @@ class MerchantMigrationService:
 
     async def _get_manageable(
         self,
-        session: AsyncSession,
+        session: AsyncReadSession,
         auth_subject: AuthSubject[User | Organization],
         migration_id: UUID,
         *,
         for_update: bool = False,
     ) -> MerchantMigration:
+        """``for_update`` locks the row, so it needs a write session: a replica
+        can't take one."""
         repository = MerchantMigrationRepository.from_session(session)
         statement = repository.get_readable_statement(auth_subject).where(
             MerchantMigration.id == migration_id
@@ -370,7 +393,7 @@ class MerchantMigrationService:
 
     async def list_records(
         self,
-        session: AsyncSession,
+        session: AsyncReadSession,
         auth_subject: AuthSubject[User | Organization],
         migration_id: UUID,
         *,
@@ -386,11 +409,7 @@ class MerchantMigrationService:
         (`action_required`) or only needs to know about (`info`). Reads what
         ``run_precheck`` persisted."""
         migration = await self._get_manageable(session, auth_subject, migration_id)
-        items = await self._classify_staged(
-            session,
-            migration,
-            entities=[entity] if entity is not None else list(_ENTITY_RECORD_TYPE),
-        )
+        items = await self._classify_staged(session, migration, entity=entity)
 
         if status is not None:
             items = [item for item in items if item.status == status]
@@ -402,7 +421,7 @@ class MerchantMigrationService:
 
     async def count_records(
         self,
-        session: AsyncSession,
+        session: AsyncReadSession,
         auth_subject: AuthSubject[User | Organization],
         migration_id: UUID,
     ) -> MerchantMigrationCounts:
@@ -416,63 +435,48 @@ class MerchantMigrationService:
         if organization is None:
             raise MerchantMigrationNotFound()
 
-        items = await self._classify_staged(
-            session, migration, entities=list(_ENTITY_RECORD_TYPE)
-        )
-        by_entity: dict[PrecheckEntity, list[MerchantMigrationRecordItem]] = {
-            entity: [] for entity in _ENTITY_RECORD_TYPE
+        items = await self._classify_staged(session, migration)
+        by_entity = {
+            entity: [item for item in items if item.entity == entity]
+            for entity in _ENTITY_RECORD_TYPE
         }
-        for item in items:
-            by_entity[item.entity].append(item)
-
-        adapter = await self._build_adapter(migration)
         return MerchantMigrationCounts(
             entities=[
-                MerchantMigrationEntityCount(
+                PrecheckEntitySummary(
                     entity=entity,
-                    importable=self._count(
-                        entity_items, status=PrecheckRecordStatus.importable
+                    total=len(entity_items),
+                    importable=sum(
+                        1
+                        for item in entity_items
+                        if item.status == PrecheckRecordStatus.importable
                     ),
-                    skipped=self._count(
-                        entity_items, status=PrecheckRecordStatus.skipped
-                    ),
-                    imported=self._count(
-                        entity_items,
-                        import_status=MerchantMigrationRecordStatus.imported,
+                    skipped=sum(
+                        1
+                        for item in entity_items
+                        if item.status == PrecheckRecordStatus.skipped
                     ),
                 )
                 for entity, entity_items in by_entity.items()
             ],
-            action_required=self._count(
-                items, reason_level=PrecheckReasonLevel.action_required
+            action_required=sum(
+                1
+                for item in items
+                if item.reason_level == PrecheckReasonLevel.action_required
             ),
-            blockers=import_blockers(organization, await adapter.get_source_account()),
-        )
-
-    def _count(
-        self,
-        items: Sequence[MerchantMigrationRecordItem],
-        *,
-        status: PrecheckRecordStatus | None = None,
-        import_status: MerchantMigrationRecordStatus | None = None,
-        reason_level: PrecheckReasonLevel | None = None,
-    ) -> int:
-        return sum(
-            1
-            for item in items
-            if (status is None or item.status == status)
-            and (import_status is None or item.import_status == import_status)
-            and (reason_level is None or item.reason_level == reason_level)
+            blockers=import_blockers(
+                organization, self._stored_source_account(migration)
+            ),
         )
 
     async def _classify_staged(
         self,
-        session: AsyncSession,
+        session: AsyncReadSession,
         migration: MerchantMigration,
         *,
-        entities: Sequence[PrecheckEntity],
+        entity: PrecheckEntity | None = None,
     ) -> Sequence[MerchantMigrationRecordItem]:
-        """Classify what ``run_precheck`` staged, for the given entity types."""
+        """Classify what ``run_precheck`` staged. ``None`` covers every entity
+        that has its own ledger row."""
         record_repository = MerchantMigrationRecordRepository.from_session(session)
         staged = await record_repository.list_by_migration(migration.id)
         records = [deserialize(record.type, record.canonical) for record in staged]
@@ -481,9 +485,13 @@ class MerchantMigrationService:
         ).get_active_names_by_organization(migration.organization_id)
 
         items: list[MerchantMigrationRecordItem] = []
-        for entity in entities:
-            entity_items = classify_records(records, entity, existing_product_names)
-            self._attach_record_ids(entity_items, staged, entity)
+        for entity_type in (
+            [entity] if entity is not None else list(_ENTITY_RECORD_TYPE)
+        ):
+            entity_items = classify_records(
+                records, entity_type, existing_product_names
+            )
+            self._attach_record_ids(entity_items, staged, entity_type)
             items.extend(entity_items)
         return items
 
@@ -514,7 +522,7 @@ class MerchantMigrationService:
         migration: MerchantMigration,
         organization: Organization,
         records: AsyncIterator[CanonicalRecord],
-        seen: set[tuple[MerchantMigrationRecordType, str]],
+        staged: "_StagedKeys",
     ) -> AsyncIterator[CanonicalRecord]:
         """Stage each record as it streams past, so we persist the catalog in
         the same single pass the precheck reads (extraction stays incremental).
@@ -522,8 +530,9 @@ class MerchantMigrationService:
         longer has."""
         async for record in records:
             await record_repository.upsert(migration, organization, record)
-            seen.add((record.type, record.source_id))
+            staged.keys.add((record.type, record.source_id))
             yield record
+        staged.complete = True
 
     async def _build_adapter(self, migration: MerchantMigration) -> SourceAdapter:
         if migration.source_platform != MerchantMigrationSourcePlatform.stripe:
@@ -548,10 +557,22 @@ class MerchantMigrationService:
             api_key,
             context={**SOURCE_CREDENTIALS_ENCRYPTION_CONTEXT, "id": str(migration.id)},
         )
+        account = await adapter.get_source_account()
         return StripeSourceCredentials(
             api_key_encrypted=encrypted.encrypted_value,
             stripe_user_id=await adapter.get_account_id(),
             livemode=_is_live_key(api_key),
+            country=account.country,
+            is_connect_platform=account.is_connect_platform,
+        )
+
+    def _stored_source_account(self, migration: MerchantMigration) -> CanonicalAccount:
+        """The source account as last seen, so a read can report blockers without
+        a Stripe round-trip. `run_precheck` refreshes it."""
+        credentials = migration.source_credentials
+        return CanonicalAccount(
+            country=credentials.get("country"),
+            is_connect_platform=bool(credentials.get("is_connect_platform")),
         )
 
     async def _assert_feature_enabled(

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -268,9 +268,7 @@ class MerchantMigrationService:
         """Read the connected source, normalize it, and report whether it can be
         imported. Advances the migration from source setup to the pre-check step,
         unless the report says something blocks the import."""
-        migration = await self._get_manageable(
-            session, auth_subject, migration_id, for_update=True
-        )
+        migration = await self._lock_manageable(session, auth_subject, migration_id)
 
         organization = await OrganizationRepository.from_session(session).get_by_id(
             migration.organization_id
@@ -326,9 +324,7 @@ class MerchantMigrationService:
         """Create the Polar catalog from the staged importable records, then
         advance the migration to the create-catalog step. Idempotent: re-running
         only imports records still pending in the ledger."""
-        migration = await self._get_manageable(
-            session, auth_subject, migration_id, for_update=True
-        )
+        migration = await self._lock_manageable(session, auth_subject, migration_id)
         if migration.step not in IMPORTABLE_STEPS:
             raise CatalogImportNotReady()
 
@@ -363,6 +359,18 @@ class MerchantMigrationService:
         report.step = MerchantMigrationStep.create_catalog
         return report
 
+    async def _lock_manageable(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        migration_id: UUID,
+    ) -> MerchantMigration:
+        """Serialized so a double-click or retry can't run twice. Takes the write
+        session on purpose: a replica can't lock a row."""
+        return await self._get_manageable(
+            session, auth_subject, migration_id, for_update=True
+        )
+
     async def _get_manageable(
         self,
         session: AsyncReadSession,
@@ -371,8 +379,6 @@ class MerchantMigrationService:
         *,
         for_update: bool = False,
     ) -> MerchantMigration:
-        """``for_update`` locks the row, so it needs a write session: a replica
-        can't take one."""
         repository = MerchantMigrationRepository.from_session(session)
         statement = repository.get_readable_statement(auth_subject).where(
             MerchantMigration.id == migration_id

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -69,8 +69,9 @@ class StripeSourceCredentials(TypedDict):
     """Shape of ``MerchantMigration.source_credentials`` for a Stripe source.
 
     Only ``api_key_encrypted`` is a secret: the ciphertext of the merchant's
-    restricted API key, decrypted on demand to read their account. The other
-    fields are non-secret metadata surfaced to the API.
+    restricted API key, decrypted on demand to read their account. The rest is
+    non-secret metadata; `MerchantMigration.source` decides which of it the API
+    exposes.
     """
 
     api_key_encrypted: str
@@ -293,23 +294,29 @@ class MerchantMigrationService:
         )
         # Pruning against a half-read source would delete records it still has.
         if staged.complete:
-            await record_repository.prune_missing(migration, staged.keys)
+            await record_repository.prune_missing(
+                migration, staged.keys, _ENTITY_RECORD_TYPE.values()
+            )
 
         repository = MerchantMigrationRepository.from_session(session)
-        update_dict: dict[str, Any] = {
-            "source_credentials": {
+        update_dict: dict[str, Any] = {}
+        # `get_source_account` is best-effort: it returns an empty country when
+        # it couldn't read the account at all. Storing that would erase a
+        # blocker we already know about.
+        if source_account.country is not None:
+            update_dict["source_credentials"] = {
                 **migration.source_credentials,
                 "country": source_account.country,
                 "is_connect_platform": source_account.is_connect_platform,
             }
-        }
         # A blocked migration stays on source setup, so the merchant keeps the
         # panel that tells them what to fix instead of landing on a review table
         # they can't import from. Re-running to refresh the ledger must also not
         # regress a migration that has already moved on.
         if migration.step == MerchantMigrationStep.source_setup and report.can_start:
             update_dict["step"] = MerchantMigrationStep.pre_check
-        await repository.update(migration, update_dict=update_dict)
+        if update_dict:
+            await repository.update(migration, update_dict=update_dict)
         return report
 
     async def import_catalog(
@@ -365,8 +372,7 @@ class MerchantMigrationService:
         auth_subject: AuthSubject[User | Organization],
         migration_id: UUID,
     ) -> MerchantMigration:
-        """Serialized so a double-click or retry can't run twice. Takes the write
-        session on purpose: a replica can't lock a row."""
+        # Takes the write session on purpose: a replica can't lock a row.
         return await self._get_manageable(
             session, auth_subject, migration_id, for_update=True
         )
@@ -470,7 +476,7 @@ class MerchantMigrationService:
                 if item.reason_level == PrecheckReasonLevel.action_required
             ),
             blockers=import_blockers(
-                organization, self._stored_source_account(migration)
+                organization, await self._source_account(migration)
             ),
         )
 
@@ -572,12 +578,15 @@ class MerchantMigrationService:
             is_connect_platform=account.is_connect_platform,
         )
 
-    def _stored_source_account(self, migration: MerchantMigration) -> CanonicalAccount:
-        """The source account as last seen, so a read can report blockers without
-        a Stripe round-trip. `run_precheck` refreshes it."""
+    async def _source_account(self, migration: MerchantMigration) -> CanonicalAccount:
+        """The source account as the last pre-check saw it, so a read can report
+        blockers without a Stripe round-trip. A migration connected before we
+        stored it falls back to asking Stripe, once, until its next pre-check."""
         credentials = migration.source_credentials
+        if credentials.get("country") is None:
+            return await (await self._build_adapter(migration)).get_source_account()
         return CanonicalAccount(
-            country=credentials.get("country"),
+            country=credentials["country"],
             is_connect_platform=bool(credentials.get("is_connect_platform")),
         )
 

--- a/server/tests/merchant_migration/_helpers.py
+++ b/server/tests/merchant_migration/_helpers.py
@@ -26,6 +26,8 @@ async def build_stripe_credentials(
         api_key_encrypted=encrypted.encrypted_value,
         stripe_user_id=stripe_user_id,
         livemode=api_key.startswith(("rk_live_", "sk_live_")),
+        country="US",
+        is_connect_platform=False,
     )
 
 

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -360,6 +360,49 @@ class TestRecords:
         assert json_body["items"][0]["status"] == "importable"
 
 
+@pytest.mark.asyncio
+class TestCounts:
+    async def test_anonymous(
+        self, client: AsyncClient, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        migration = await _create_migration(save_fixture, organization)
+        response = await client.get(
+            f"/v1/merchant-migrations/{migration.id}/counts",
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_counts_the_staged_catalog(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        adapter = mocker.MagicMock()
+        adapter.extract.return_value = _catalog_extract()
+        adapter.get_source_account = mocker.AsyncMock(
+            return_value=CanonicalAccount(country="US", is_connect_platform=False)
+        )
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
+        )
+        precheck = await client.post(f"/v1/merchant-migrations/{migration.id}/precheck")
+        assert precheck.status_code == 200
+
+        response = await client.get(f"/v1/merchant-migrations/{migration.id}/counts")
+
+        assert response.status_code == 200
+        json_body = response.json()
+        products = next(
+            entity for entity in json_body["entities"] if entity["entity"] == "products"
+        )
+        assert products["importable"] == 1
+        assert json_body["blockers"] == []
+
+
 async def _catalog_with_customer_extract() -> AsyncIterator[CanonicalRecord]:
     async for record in _catalog_extract():
         yield record

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -57,6 +57,9 @@ def _mock_stripe_adapter(
     else:
         adapter.verify_scopes = mocker.AsyncMock(return_value=missing_scopes or [])
     adapter.get_account_id = mocker.AsyncMock(return_value="acct_test")
+    adapter.get_source_account = mocker.AsyncMock(
+        return_value=CanonicalAccount(country="US", is_connect_platform=False)
+    )
     mocker.patch("polar.merchant_migration.service.StripeAdapter", return_value=adapter)
 
 

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -24,6 +24,7 @@ from polar.merchant_migration.canonical import (
     CanonicalSubscription,
     CanonicalSubscriptionStatus,
 )
+from polar.merchant_migration.precheck import precheck_engine
 from polar.merchant_migration.repository import (
     MerchantMigrationRecordRepository,
     MerchantMigrationRepository,
@@ -32,6 +33,7 @@ from polar.merchant_migration.schemas import (
     MerchantMigrationCreate,
     PrecheckEntity,
     PrecheckRecordStatus,
+    PrecheckReport,
 )
 from polar.merchant_migration.service import (
     CatalogImportBlocked,
@@ -476,6 +478,37 @@ class TestRunPrecheck:
         assert {record.source_id for record in remaining} == {"prod_1:month:1"}
 
     @pytest.mark.auth
+    async def test_keeps_everything_when_the_source_read_stops_short(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter",
+            return_value=_FakeAdapter(_importable_catalog()),
+        )
+        # A pass that never reaches the end has only seen part of the source, so
+        # what it didn't see says nothing about what the source still has.
+        mocker.patch.object(
+            precheck_engine,
+            "run",
+            side_effect=lambda records, *args: _run_partially(records),
+        )
+
+        await service.run_precheck(session, auth_subject, migration.id)
+
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        remaining = await record_repository.list_by_migration(migration.id)
+        assert len(remaining) == len(_importable_catalog())
+
+    @pytest.mark.auth
     async def test_keeps_imported_records_the_source_no_longer_has(
         self,
         mocker: MockerFixture,
@@ -500,6 +533,14 @@ class TestRunPrecheck:
         record_repository = MerchantMigrationRecordRepository.from_session(session)
         remaining = await record_repository.list_by_migration(migration.id)
         assert "prod_1:month:1" in {record.source_id for record in remaining}
+
+
+async def _run_partially(records: AsyncIterator[CanonicalRecord]) -> PrecheckReport:
+    """Read one record, then stop — the generator never reaches its end, so it
+    never marks the pass complete."""
+    async for _ in records:
+        break
+    return PrecheckReport(can_start=True, issues=[], entities=[])
 
 
 def _catalog() -> list[CanonicalRecord]:

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -423,6 +423,87 @@ class TestRunPrecheck:
         with pytest.raises(UnsupportedMigrationSource):
             await service.run_precheck(session, auth_subject, migration.id)
 
+    @pytest.mark.auth
+    async def test_blocked_migration_stays_on_source_setup(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        organization.status = OrganizationStatus.CREATED
+        await save_fixture(organization)
+        migration = await build_connected_migration(save_fixture, organization)
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter",
+            return_value=_FakeAdapter(_importable_catalog()),
+        )
+
+        report = await service.run_precheck(session, auth_subject, migration.id)
+
+        assert report.can_start is False
+        # advancing would swap the panel that says what to fix for a review
+        # table the merchant can't import from
+        repository = MerchantMigrationRepository.from_session(session)
+        updated = await repository.get_by_id(migration.id)
+        assert updated is not None
+        assert updated.step == MerchantMigrationStep.source_setup
+
+    @pytest.mark.auth
+    async def test_drops_pending_records_the_source_no_longer_has(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter",
+            return_value=_FakeAdapter(_catalog()[:1]),
+        )
+
+        await service.run_precheck(session, auth_subject, migration.id)
+
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        remaining = await record_repository.list_by_migration(migration.id)
+        assert {record.source_id for record in remaining} == {"prod_1:month:1"}
+
+    @pytest.mark.auth
+    async def test_keeps_imported_records_the_source_no_longer_has(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+        await service.import_catalog(session, auth_subject, migration.id)
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter",
+            return_value=_FakeAdapter([]),
+        )
+
+        await service.run_precheck(session, auth_subject, migration.id)
+
+        # dropping a settled row would let a later run import the same thing again
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        remaining = await record_repository.list_by_migration(migration.id)
+        assert "prod_1:month:1" in {record.source_id for record in remaining}
+        assert MerchantMigrationRecordStatus.pending not in {
+            record.status for record in remaining
+        }
+
 
 def _catalog() -> list[CanonicalRecord]:
     return [
@@ -1194,3 +1275,73 @@ class TestImportCatalog:
 
         with pytest.raises(CatalogImportNotReady):
             await service.import_catalog(session, auth_subject, migration.id)
+
+
+@pytest.mark.asyncio
+class TestCountRecords:
+    @pytest.mark.auth
+    async def test_counts_every_entity_in_one_call(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+
+        counts = await service.count_records(session, auth_subject, migration.id)
+
+        by_entity = {count.entity: count for count in counts.entities}
+        assert by_entity[PrecheckEntity.products].importable == 1
+        assert by_entity[PrecheckEntity.products].skipped == 1
+        assert by_entity[PrecheckEntity.customers].importable == 1
+        assert by_entity[PrecheckEntity.subscriptions].importable == 0
+        assert counts.blockers == []
+
+    @pytest.mark.auth
+    async def test_counts_imported_records(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+        await service.import_catalog(session, auth_subject, migration.id)
+
+        counts = await service.count_records(session, auth_subject, migration.id)
+
+        by_entity = {count.entity: count for count in counts.entities}
+        assert by_entity[PrecheckEntity.products].imported == 1
+        assert by_entity[PrecheckEntity.customers].imported == 1
+
+    @pytest.mark.auth
+    async def test_reports_what_blocks_the_import(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+        organization.status = OrganizationStatus.CREATED
+        await save_fixture(organization)
+
+        counts = await service.count_records(session, auth_subject, migration.id)
+
+        # a reload has no precheck response to read, so the counts carry them
+        assert [blocker.code for blocker in counts.blockers] == [
+            "organization_not_renewal_enabled"
+        ]

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -466,7 +466,7 @@ class TestRunPrecheck:
         )
         mocker.patch(
             "polar.merchant_migration.service.StripeAdapter",
-            return_value=_FakeAdapter(_catalog()[:1]),
+            return_value=_FakeAdapter(_importable_catalog()[:1]),
         )
 
         await service.run_precheck(session, auth_subject, migration.id)
@@ -500,9 +500,6 @@ class TestRunPrecheck:
         record_repository = MerchantMigrationRecordRepository.from_session(session)
         remaining = await record_repository.list_by_migration(migration.id)
         assert "prod_1:month:1" in {record.source_id for record in remaining}
-        assert MerchantMigrationRecordStatus.pending not in {
-            record.status for record in remaining
-        }
 
 
 def _catalog() -> list[CanonicalRecord]:
@@ -1303,27 +1300,6 @@ class TestCountRecords:
         assert counts.blockers == []
 
     @pytest.mark.auth
-    async def test_counts_imported_records(
-        self,
-        mocker: MockerFixture,
-        session: AsyncSession,
-        save_fixture: SaveFixture,
-        auth_subject: AuthSubject[User],
-        organization: Organization,
-        user_organization: UserOrganization,
-    ) -> None:
-        migration = await _staged_migration(
-            mocker, session, save_fixture, auth_subject, organization
-        )
-        await service.import_catalog(session, auth_subject, migration.id)
-
-        counts = await service.count_records(session, auth_subject, migration.id)
-
-        by_entity = {count.entity: count for count in counts.entities}
-        assert by_entity[PrecheckEntity.products].imported == 1
-        assert by_entity[PrecheckEntity.customers].imported == 1
-
-    @pytest.mark.auth
     async def test_reports_what_blocks_the_import(
         self,
         mocker: MockerFixture,
@@ -1345,3 +1321,52 @@ class TestCountRecords:
         assert [blocker.code for blocker in counts.blockers] == [
             "organization_not_renewal_enabled"
         ]
+
+    @pytest.mark.auth
+    async def test_reads_the_source_account_without_calling_stripe(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+        # the pre-check stored what the account is, so drawing the tabs doesn't
+        # pay for a Stripe round-trip
+        stripe_adapter = mocker.patch("polar.merchant_migration.service.StripeAdapter")
+
+        await service.count_records(session, auth_subject, migration.id)
+
+        stripe_adapter.assert_not_called()
+
+    @pytest.mark.auth
+    async def test_blocks_a_connect_platform_seen_by_the_last_precheck(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        adapter = _FakeAdapter(_importable_catalog())
+        adapter.get_source_account = _connect_platform_account  # type: ignore[method-assign]
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
+        )
+        await service.run_precheck(session, auth_subject, migration.id)
+
+        counts = await service.count_records(session, auth_subject, migration.id)
+
+        assert [blocker.code for blocker in counts.blockers] == [
+            "connect_platform_account"
+        ]
+
+
+async def _connect_platform_account() -> CanonicalAccount:
+    return CanonicalAccount(country="US", is_connect_platform=True)


### PR DESCRIPTION
## Summary

Four fixes the migration review dashboard needed from the server.

## What

**A blocked migration no longer moves on.** The pre-check advanced the step
whatever it found, so the panel explaining what to fix unmounted and the
merchant landed on a review table they could not import from. The step now only
moves when the report says the import can start, and a blocked review step keeps
a "Check again" button so the merchant can re-run it once they fix the cause.

**One request for the tab counts, not seven.** The review page asked for seven
record listings just to draw its counters, and each one re-read and
re-classified the whole ledger. `GET /merchant-migrations/{id}/counts` replaces
them.

**Blockers survive a reload.** They used to live only in the pre-check response,
so refreshing the page lost them. The counts carry them now. The pre-check
already reads the Stripe account, so it stores the two facts the blockers depend
on and the read serves them from the row, with no Stripe call on page load.

**Deleted Stripe records leave the ledger.** Staging only ever added, so a
product removed in Stripe stayed forever. A re-run now drops the pending rows
the source no longer returns. Imported, skipped and failed rows stay: they record
what a past run did, and losing them would let a later run import the same thing
twice.

Also: the discount skip reason now says why it matters, and the two read
endpoints take a read session and the read scope (ADR-0003).

## Safety

Reading the Stripe account is best-effort — it reports an empty country when the
key can't read the account at all. A pass like that no longer overwrites what we
already know, so a rate limit can't erase a blocker and let the migration
advance. A migration connected before this change has nothing stored, so it asks
Stripe once until its next pre-check.

Pruning only runs when the source stream was read to the end, and only covers
the record types the pass actually reads.

## Known trade-off

`/counts` and `/records` now read the replica, per ADR-0003. The page refetches
both right after the pre-check commits on the primary, so replication lag can
briefly show the pre-run ledger. Following the ADR is the right default; if this
turns out to bite, the fix belongs in how the page refetches, not in the session
choice.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint`, `lint_types`, `pnpm lint`, `tsc --noEmit`)
- [x] No unrelated changes or drive-by fixes are included
