### PR TITLE
fix: prevent lenis from hijacking scroll when polar iframe is shown

### DIFF
--- a/clients/packages/checkout/src/checkout.ts
+++ b/clients/packages/checkout/src/checkout.ts
@@ -170,6 +170,10 @@ class EmbedCheckout {
     iframe.style.backgroundColor = 'rgba(0, 0, 0, 0.5)'
     iframe.style.colorScheme = 'normal'
 
+    // Opt the overlay out of smooth-scroll libraries (Lenis) on the embedding
+    // page, which would otherwise scroll it behind the checkout.
+    iframe.setAttribute('data-lenis-prevent', '')
+
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     const origins = __POLAR_CHECKOUT_EMBED_SCRIPT_ALLOWED_ORIGINS__


### PR DESCRIPTION
## Problem

On embedding pages using the Lenis smooth-scroll library, scrolling with the cursor over the embedded checkout scrolled the page behind the overlay. Safari only — Chromium was unaffected.

## Cause

Lenis replaces native scrolling: it listens for wheel on the window and drives the scroll position itself. In Safari, wheel events over our cross-origin checkout iframe still reach the parent window's listener, so Lenis picks them up and scrolls the host page. Chromium dispatches those events inside the iframe's document, where the parent never sees them.

## Fix

Mark the overlay iframe with data-lenis-prevent. Lenis walks event.composedPath() and skips any event whose path contains that attribute, so wheel events starting over the checkout are ignored.
```
iframe.setAttribute('data-lenis-prevent', '')
```

Lenis-specific. Verified GSAP ScrollSmoother and Locomotive Scroll v4 do not reproduce.

May take a while until customers get the fix since I think it's cached over CDN.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

