### PR TITLE
fix: stop invariant alerting during subscription dunning recovery

### DIFF
--- a/server/polar/observability/invariants/rules/subscriptions_current_period_end.py
+++ b/server/polar/observability/invariants/rules/subscriptions_current_period_end.py
@@ -34,9 +34,18 @@ class SubscriptionsCurrentPeriodEndInvariant(Invariant):
     """
 
     LEEWAY = timedelta(minutes=10)
+    SETTLE_GRACE = timedelta(minutes=5)
+    """
+    A dunning recovery flips the subscription back to active while current_period_end
+    is still days old, so LEEWAY never applies. Every step of the handover writes the
+    row: an untouched row is the one that is actually stuck. The trade is that a
+    stuck subscription written more often than this would never be reported.
+    """
+
     LIMIT = 10
 
     async def check(self) -> None:
+        last_write = func.coalesce(Subscription.modified_at, Subscription.created_at)
         statement = (
             select(Subscription.id, over(func.count()))
             .join(Subscription.organization)
@@ -45,6 +54,7 @@ class SubscriptionsCurrentPeriodEndInvariant(Invariant):
                 Organization.deleted_at.is_(None),
                 Subscription.current_period_end < (func.now() - self.LEEWAY),
                 Organization.can_renew_subscriptions.is_(True),
+                last_write < (func.now() - self.SETTLE_GRACE),
             )
             .order_by(Subscription.current_period_end.asc(), Subscription.id.asc())
             .limit(self.LIMIT)

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -1156,6 +1156,8 @@ async def create_subscription(
     scheduler_locked_at: datetime | None = None,
     seats: int | None = None,
     past_due_at: datetime | None = None,
+    created_at: datetime | None = None,
+    modified_at: datetime | None = None,
 ) -> Subscription:
     currency_prices = PriceSet.from_product(product, currency)
     prices = prices or currency_prices.prices
@@ -1193,6 +1195,8 @@ async def create_subscription(
             canceled_at = now
 
     subscription = Subscription(
+        created_at=created_at or utc_now(),
+        modified_at=modified_at,
         recurring_interval=recurring_interval,
         recurring_interval_count=recurring_interval_count,
         status=status,

--- a/server/tests/observability/invariants/rules/test_subscriptions_current_period_end.py
+++ b/server/tests/observability/invariants/rules/test_subscriptions_current_period_end.py
@@ -11,6 +11,7 @@ from polar.observability.invariants.rules.subscriptions_current_period_end impor
     SubscriptionsCurrentPeriodEndInvariantError,
 )
 from polar.postgres import AsyncSession
+from polar.subscription.repository import SubscriptionRepository
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_subscription
 
@@ -27,12 +28,41 @@ async def test_failure(
     product: Product,
     customer: Customer,
 ) -> None:
+    stale = utc_now() - timedelta(days=1)
     subscription = await create_subscription(
         save_fixture,
         status=SubscriptionStatus.active,
         product=product,
         customer=customer,
-        current_period_end=utc_now() - timedelta(days=1),
+        current_period_end=stale,
+        created_at=stale,
+        modified_at=stale,
+    )
+
+    with pytest.raises(SubscriptionsCurrentPeriodEndInvariantError) as exc_info:
+        await invariant.check()
+    assert exc_info.value.context == {
+        "count": 1,
+        "subscriptions": {"ids": [subscription.id], "has_more": False},
+    }
+
+
+@pytest.mark.asyncio
+async def test_failure_never_updated_subscription(
+    invariant: SubscriptionsCurrentPeriodEndInvariant,
+    save_fixture: SaveFixture,
+    product: Product,
+    customer: Customer,
+) -> None:
+    """A subscription that never cycled has a NULL modified_at, which must not hide it."""
+    stale = utc_now() - timedelta(days=1)
+    subscription = await create_subscription(
+        save_fixture,
+        status=SubscriptionStatus.active,
+        product=product,
+        customer=customer,
+        current_period_end=stale,
+        created_at=stale,
     )
 
     with pytest.raises(SubscriptionsCurrentPeriodEndInvariantError) as exc_info:
@@ -50,13 +80,16 @@ async def test_failure_over_limit(
     product: Product,
     customer: Customer,
 ) -> None:
+    stale = utc_now() - timedelta(days=1)
     for _ in range(15):
         await create_subscription(
             save_fixture,
             status=SubscriptionStatus.active,
             product=product,
             customer=customer,
-            current_period_end=utc_now() - timedelta(days=1),
+            current_period_end=stale,
+            created_at=stale,
+            modified_at=stale,
         )
 
     with pytest.raises(SubscriptionsCurrentPeriodEndInvariantError) as exc_info:
@@ -87,5 +120,50 @@ async def test_success(
         customer=customer,
         current_period_end=utc_now() - timedelta(minutes=1),
     )
+
+    await invariant.check()
+
+
+@pytest.mark.asyncio
+async def test_success_just_created_subscription(
+    invariant: SubscriptionsCurrentPeriodEndInvariant,
+    save_fixture: SaveFixture,
+    product: Product,
+    customer: Customer,
+) -> None:
+    """The dunning recovery race: overdue by days, but written seconds ago."""
+    await create_subscription(
+        save_fixture,
+        status=SubscriptionStatus.active,
+        product=product,
+        customer=customer,
+        current_period_end=utc_now() - timedelta(days=7),
+    )
+
+    await invariant.check()
+
+
+@pytest.mark.asyncio
+async def test_success_just_updated_subscription(
+    session: AsyncSession,
+    invariant: SubscriptionsCurrentPeriodEndInvariant,
+    save_fixture: SaveFixture,
+    product: Product,
+    customer: Customer,
+) -> None:
+    """The grace relies on any write bumping modified_at."""
+    stale = utc_now() - timedelta(days=7)
+    subscription = await create_subscription(
+        save_fixture,
+        status=SubscriptionStatus.active,
+        product=product,
+        customer=customer,
+        current_period_end=stale,
+        created_at=stale,
+        modified_at=stale,
+    )
+
+    repository = SubscriptionRepository.from_session(session)
+    await repository.update(subscription, update_dict={"user_metadata": {"key": "1"}})
 
     await invariant.check()


### PR DESCRIPTION
## Summary

`SubscriptionsCurrentPeriodEndInvariant` alerts about 3 times a day for subscriptions that are fine. This adds a settle grace so it only reports subscriptions that are really stuck.

## Why

When a dunning retry succeeds, `mark_active` sets the subscription back to `active`. It does not move `current_period_end`, which by then is often days in the past. That status change is what makes the row visible to the cycle scheduler, which advances the period a few seconds later.

The check ran inside that short window, so it reported a subscription that was already being fixed.

`LEEWAY` cannot help here. It measures from `current_period_end`, and that value is already old, so the grace never applies.

## How

Filter on the row's last write instead. Every step of the handover writes the row, so a row nobody has touched is the one that is actually stuck.

`coalesce` falls back to `created_at` because `modified_at` is `NULL` until a subscription is updated for the first time.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13563?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

