### PR TITLE
feat: merchant-migration PAN transfer checklist engine

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -5168,6 +5168,50 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/merchant-migrations/{id}/pan-transfer': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get Merchant Migration Card Transfer
+     * @description **Scopes**: `organizations:write`
+     */
+    get: operations['merchant-migrations:pan_transfer']
+    put?: never
+    /**
+     * Start Merchant Migration Card Transfer
+     * @description **Scopes**: `organizations:write`
+     */
+    post: operations['merchant-migrations:start_pan_transfer']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v1/merchant-migrations/{id}/pan-transfer/steps/{key}/complete': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Complete Merchant Migration Card Transfer Step
+     * @description **Scopes**: `organizations:write`
+     */
+    post: operations['merchant-migrations:complete_pan_transfer_step']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/merchant-migrations/{id}/records': {
     parameters: {
       query?: never
@@ -28798,6 +28842,199 @@ export interface components {
       /** Max Page */
       max_page: number
     }
+    /**
+     * PanStepActor
+     * @description Who is asking to move a step, which decides what they're allowed to move.
+     * @enum {string}
+     */
+    PanStepActor: 'merchant' | 'ops' | 'system'
+    /**
+     * PanStepKind
+     * @description What the owner has to do, which is what the frontend renders.
+     * @enum {string}
+     */
+    PanStepKind: 'auto' | 'input' | 'confirm'
+    /** PanStepNotActionable */
+    PanStepNotActionable: {
+      /**
+       * Error
+       * @example PanStepNotActionable
+       * @constant
+       */
+      error: 'PanStepNotActionable'
+      /** Detail */
+      detail: string
+    }
+    /** PanStepNotFound */
+    PanStepNotFound: {
+      /**
+       * Error
+       * @example PanStepNotFound
+       * @constant
+       */
+      error: 'PanStepNotFound'
+      /** Detail */
+      detail: string
+    }
+    /** PanStepNotOwned */
+    PanStepNotOwned: {
+      /**
+       * Error
+       * @example PanStepNotOwned
+       * @constant
+       */
+      error: 'PanStepNotOwned'
+      /** Detail */
+      detail: string
+    }
+    /**
+     * PanStepOwner
+     * @description Who moves a step forward.
+     * @enum {string}
+     */
+    PanStepOwner: 'merchant' | 'polar_ops' | 'polar_app' | 'stripe' | 'provider'
+    /**
+     * PanStepStatus
+     * @enum {string}
+     */
+    PanStepStatus: 'blocked' | 'pending' | 'in_progress' | 'completed'
+    /** PanTransferAlreadyStarted */
+    PanTransferAlreadyStarted: {
+      /**
+       * Error
+       * @example PanTransferAlreadyStarted
+       * @constant
+       */
+      error: 'PanTransferAlreadyStarted'
+      /** Detail */
+      detail: string
+    }
+    /** PanTransferChecklist */
+    PanTransferChecklist: {
+      /** @description How the cards move: `pan_copy` for a Stripe source (account to account), `pan_import` for any other vault. */
+      method: components['schemas']['PanTransferMethod']
+      /**
+       * Started
+       * @description Whether the card transfer has been started. Steps are empty until it is.
+       */
+      started: boolean
+      /**
+       * Current Step Key
+       * @description The one step that can be acted on now. Null once every step is done.
+       */
+      current_step_key: string | null
+      /**
+       * Destination Account Id
+       * @description The Stripe account the cards move into. The merchant needs it to address the copy or import to Polar.
+       */
+      destination_account_id: string | null
+      /**
+       * Steps
+       * @description The ordered checklist. Titles and guidance live in the client, keyed by `key`.
+       */
+      steps: components['schemas']['PanTransferStep'][]
+    }
+    /**
+     * PanTransferMethod
+     * @description How the cards reach Polar's Stripe account.
+     * @enum {string}
+     */
+    PanTransferMethod: 'pan_copy' | 'pan_import'
+    /** PanTransferNotReady */
+    PanTransferNotReady: {
+      /**
+       * Error
+       * @example PanTransferNotReady
+       * @constant
+       */
+      error: 'PanTransferNotReady'
+      /** Detail */
+      detail: string
+    }
+    /** PanTransferNotStarted */
+    PanTransferNotStarted: {
+      /**
+       * Error
+       * @example PanTransferNotStarted
+       * @constant
+       */
+      error: 'PanTransferNotStarted'
+      /** Detail */
+      detail: string
+    }
+    /**
+     * PanTransferStep
+     * @description One checklist step, as persisted on `MerchantMigration.pan_transfer_steps`.
+     *
+     *     The row is self-contained: owner and kind are copied off the template so both
+     *     the stored JSONB and the API response can be read without resolving a
+     *     template. The template stays authoritative for the rules that gate a
+     *     transition (`auto_complete`, the accepted inputs), so a step whose key no
+     *     longer has a template can't be completed.
+     */
+    PanTransferStep: {
+      /**
+       * Key
+       * @description Stable identifier. The client keys its copy off it.
+       */
+      key: string
+      /** @description Who moves this step forward. */
+      owner: components['schemas']['PanStepOwner']
+      /** @description What the owner does, so the client knows what to render. */
+      kind: components['schemas']['PanStepKind']
+      /** @description Where the step is. Only one step is actionable at a time. */
+      status: components['schemas']['PanStepStatus']
+      /**
+       * Inputs
+       * @description Values collected on this step.
+       */
+      inputs: {
+        [key: string]: string
+      }
+      /**
+       * Note
+       * @description Free text from Polar Ops, shown to the merchant. How a weeks-long wait on Stripe or the provider gets explained without a support thread.
+       */
+      note: string | null
+      /**
+       * Expected At
+       * @description When Ops expects this step to land.
+       */
+      expected_at: string | null
+      /**
+       * Started At
+       * @description When the step became actionable.
+       */
+      started_at: string | null
+      /**
+       * Completed At
+       * @description When the step was completed.
+       */
+      completed_at: string | null
+      /** @description Who completed the step. */
+      completed_by: components['schemas']['PanStepActor'] | null
+    }
+    /** PanTransferStepComplete */
+    PanTransferStepComplete: {
+      /**
+       * Inputs
+       * @description Values the step collects. Which keys it accepts depends on the step; unknown keys are rejected.
+       */
+      inputs?: {
+        [key: string]: string
+      }
+    }
+    /** PanTransferUnavailable */
+    PanTransferUnavailable: {
+      /**
+       * Error
+       * @example PanTransferUnavailable
+       * @constant
+       */
+      error: 'PanTransferUnavailable'
+      /** Detail */
+      detail: string
+    }
     /** PauseResumeNotAllowed */
     PauseResumeNotAllowed: {
       /**
@@ -51506,6 +51743,187 @@ export interface operations {
       }
     }
   }
+  'merchant-migrations:pan_transfer': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PanTransferChecklist']
+        }
+      }
+      /** @description Not allowed to manage this organization. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['NotPermitted']
+        }
+      }
+      /** @description Merchant migration not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'merchant-migrations:start_pan_transfer': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PanTransferChecklist']
+        }
+      }
+      /** @description Not allowed to manage this organization. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['NotPermitted']
+        }
+      }
+      /** @description Merchant migration not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationNotFound']
+        }
+      }
+      /** @description The catalog isn't imported yet, the transfer already started, or card transfers aren't configured. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json':
+            | components['schemas']['PanTransferNotReady']
+            | components['schemas']['PanTransferAlreadyStarted']
+            | components['schemas']['PanTransferUnavailable']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'merchant-migrations:complete_pan_transfer_step': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+        key: string
+      }
+      cookie?: never
+    }
+    requestBody?: {
+      content: {
+        'application/json':
+          | components['schemas']['PanTransferStepComplete']
+          | null
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PanTransferChecklist']
+        }
+      }
+      /** @description Not allowed to manage this organization, or the step is completed by someone else. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json':
+            | components['schemas']['NotPermitted']
+            | components['schemas']['PanStepNotOwned']
+        }
+      }
+      /** @description Merchant migration or step not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json':
+            | components['schemas']['MerchantMigrationNotFound']
+            | components['schemas']['PanStepNotFound']
+        }
+      }
+      /** @description The card transfer hasn't started, or this isn't the step to act on. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json':
+            | components['schemas']['PanTransferNotStarted']
+            | components['schemas']['PanStepNotActionable']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
   'merchant-migrations:records': {
     parameters: {
       query?: {
@@ -65737,6 +66155,21 @@ export const organizationWithRoleCountryAnyOf0Values: ReadonlyArray<
   'ZM',
   'ZW',
 ]
+export const panStepActorValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['PanStepActor']
+> = ['merchant', 'ops', 'system']
+export const panStepKindValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['PanStepKind']
+> = ['auto', 'input', 'confirm']
+export const panStepOwnerValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['PanStepOwner']
+> = ['merchant', 'polar_ops', 'polar_app', 'stripe', 'provider']
+export const panStepStatusValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['PanStepStatus']
+> = ['blocked', 'pending', 'in_progress', 'completed']
+export const panTransferMethodValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['PanTransferMethod']
+> = ['pan_copy', 'pan_import']
 export const paymentProcessorValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['PaymentProcessor']
 > = ['stripe']

--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -280,6 +280,9 @@ class Settings(BaseSettings):
     # Account risk signals (preview). Empty disables the endpoint.
     STRIPE_ACCOUNT_RISK_WEBHOOK_SECRET: str = ""
     STRIPE_STATEMENT_DESCRIPTOR: str = "POLAR"
+    # The Stripe account merchants copy or import their saved cards into. Shown to
+    # the merchant so they can address the transfer to us.
+    MERCHANT_MIGRATION_DESTINATION_STRIPE_ACCOUNT_ID: str = ""
 
     # Numeral
     NUMERAL_API_KEY: str | None = None

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -13,12 +13,23 @@ from polar.postgres import AsyncReadSession, get_db_read_session, get_db_session
 from polar.routing import APIRouter
 
 from .auth import MerchantMigrationRead, MerchantMigrationWrite
+from .pan_transfer import (
+    PanStepNotActionable,
+    PanStepNotFound,
+    PanStepNotOwned,
+    PanTransferAlreadyStarted,
+    PanTransferNotReady,
+    PanTransferNotStarted,
+    PanTransferUnavailable,
+)
 from .schemas import MerchantMigration as MerchantMigrationSchema
 from .schemas import (
     MerchantMigrationCreate,
     MerchantMigrationImportReport,
     MerchantMigrationImportRequest,
     MerchantMigrationRecordItem,
+    PanTransferChecklist,
+    PanTransferStepComplete,
     PrecheckEntity,
     PrecheckReasonLevel,
     PrecheckRecordStatus,
@@ -182,6 +193,98 @@ async def import_catalog(
         id,
         record_ids=body.record_ids if body is not None else None,
         exclude_record_ids=body.exclude_record_ids if body is not None else None,
+    )
+
+
+@router.get(
+    "/{id}/pan-transfer",
+    response_model=PanTransferChecklist,
+    summary="Get Merchant Migration Card Transfer",
+    responses={
+        403: {
+            "description": "Not allowed to manage this organization.",
+            "model": NotPermitted.schema(),
+        },
+        404: {
+            "description": "Merchant migration not found.",
+            "model": MerchantMigrationNotFound.schema(),
+        },
+    },
+)
+async def pan_transfer(
+    id: UUID4,
+    auth_subject: MerchantMigrationWrite,
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> PanTransferChecklist:
+    return await merchant_migration_service.get_pan_transfer(session, auth_subject, id)
+
+
+@router.post(
+    "/{id}/pan-transfer",
+    response_model=PanTransferChecklist,
+    summary="Start Merchant Migration Card Transfer",
+    responses={
+        403: {
+            "description": "Not allowed to manage this organization.",
+            "model": NotPermitted.schema(),
+        },
+        404: {
+            "description": "Merchant migration not found.",
+            "model": MerchantMigrationNotFound.schema(),
+        },
+        409: {
+            "description": "The catalog isn't imported yet, the transfer already "
+            "started, or card transfers aren't configured.",
+            "model": PanTransferNotReady.schema()
+            | PanTransferAlreadyStarted.schema()
+            | PanTransferUnavailable.schema(),
+        },
+    },
+)
+async def start_pan_transfer(
+    id: UUID4,
+    auth_subject: MerchantMigrationWrite,
+    session: AsyncSession = Depends(get_db_session),
+) -> PanTransferChecklist:
+    return await merchant_migration_service.start_pan_transfer(
+        session, auth_subject, id
+    )
+
+
+@router.post(
+    "/{id}/pan-transfer/steps/{key}/complete",
+    response_model=PanTransferChecklist,
+    summary="Complete Merchant Migration Card Transfer Step",
+    responses={
+        403: {
+            "description": "Not allowed to manage this organization, or the step "
+            "is completed by someone else.",
+            "model": NotPermitted.schema() | PanStepNotOwned.schema(),
+        },
+        404: {
+            "description": "Merchant migration or step not found.",
+            "model": MerchantMigrationNotFound.schema() | PanStepNotFound.schema(),
+        },
+        409: {
+            "description": "The card transfer hasn't started, or this isn't the "
+            "step to act on.",
+            "model": PanTransferNotStarted.schema() | PanStepNotActionable.schema(),
+        },
+    },
+)
+async def complete_pan_transfer_step(
+    id: UUID4,
+    key: str,
+    auth_subject: MerchantMigrationWrite,
+    body: PanTransferStepComplete | None = None,
+    session: AsyncSession = Depends(get_db_session),
+) -> PanTransferChecklist:
+    return await merchant_migration_service.complete_pan_step(
+        session,
+        auth_subject,
+        id,
+        key,
+        inputs=body.inputs if body is not None else {},
     )
 
 

--- a/server/polar/merchant_migration/errors.py
+++ b/server/polar/merchant_migration/errors.py
@@ -1,0 +1,6 @@
+from polar.exceptions import PolarError
+
+
+class MerchantMigrationError(PolarError):
+    """Base for everything this module raises, so a caller can catch the whole
+    feature in one clause."""

--- a/server/polar/merchant_migration/pan_transfer.py
+++ b/server/polar/merchant_migration/pan_transfer.py
@@ -1,0 +1,471 @@
+"""The PAN transfer checklist: moving saved cards onto Polar's Stripe account.
+
+Moving cards takes days (Stripe to Stripe) or weeks (any other vault), and the work
+is split between the merchant, Polar Ops, Polar itself, Stripe, and the source
+provider. So it's tracked as an ordered checklist: exactly one step is actionable
+at a time, and completing it unblocks the next.
+
+This module is the engine: the step templates, the persisted step state, and the
+transitions. It holds no copy — titles and guidance live in the frontend, keyed by
+`key`, so wording can change without a data migration.
+
+Kept free of `polar.models` imports so the model layer can use `PanTransferStep`
+as its column type.
+"""
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import Field
+from sqlalchemy import Dialect
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.types import TypeDecorator
+
+from polar.exceptions import PolarRequestValidationError, ValidationError
+from polar.kit.schemas import Schema
+from polar.kit.utils import utc_now
+
+from .errors import MerchantMigrationError
+
+
+class PanTransferMethod(StrEnum):
+    """How the cards reach Polar's Stripe account."""
+
+    # Stripe to Stripe. Self-serve in the Stripe Dashboard, hours to 72h.
+    pan_copy = "pan_copy"
+    # Any other vault to Stripe. Coordinated with Stripe and the provider, weeks.
+    pan_import = "pan_import"
+
+
+class PanStepOwner(StrEnum):
+    """Who moves a step forward."""
+
+    merchant = "merchant"
+    polar_ops = "polar_ops"
+    polar_app = "polar_app"
+    stripe = "stripe"
+    provider = "provider"
+
+
+class PanStepKind(StrEnum):
+    """What the owner has to do, which is what the frontend renders."""
+
+    # Nothing to click: Polar, Stripe or the provider is working.
+    auto = "auto"
+    # Fill in values we need before the next step can run.
+    input = "input"
+    # Acknowledge that something done elsewhere is finished.
+    confirm = "confirm"
+
+
+class PanStepStatus(StrEnum):
+    blocked = "blocked"
+    pending = "pending"
+    in_progress = "in_progress"
+    completed = "completed"
+
+
+class PanStepActor(StrEnum):
+    """Who is asking to move a step, which decides what they're allowed to move."""
+
+    merchant = "merchant"
+    ops = "ops"
+    system = "system"
+
+
+# Ops can unblock a merchant who is stuck, but never stands in for `polar_app`:
+# those steps have side effects (creating payment methods, moving subscriptions)
+# that completing the step would skip rather than perform.
+_ACTOR_OWNERS: dict[PanStepActor, frozenset[PanStepOwner]] = {
+    PanStepActor.merchant: frozenset({PanStepOwner.merchant}),
+    PanStepActor.ops: frozenset(
+        {
+            PanStepOwner.merchant,
+            PanStepOwner.polar_ops,
+            PanStepOwner.stripe,
+            PanStepOwner.provider,
+        }
+    ),
+    PanStepActor.system: frozenset({PanStepOwner.polar_app}),
+}
+
+_ACTIONABLE = (PanStepStatus.pending, PanStepStatus.in_progress)
+
+
+class PanTransferError(MerchantMigrationError): ...
+
+
+class PanTransferNotStarted(PanTransferError):
+    def __init__(self) -> None:
+        super().__init__("The card transfer hasn't started yet.", 409)
+
+
+class PanTransferAlreadyStarted(PanTransferError):
+    def __init__(self) -> None:
+        super().__init__("The card transfer has already started.", 409)
+
+
+class PanTransferNotReady(PanTransferError):
+    def __init__(self) -> None:
+        super().__init__("Import the catalog before starting the card transfer.", 409)
+
+
+class PanTransferUnavailable(PanTransferError):
+    def __init__(self) -> None:
+        super().__init__(
+            "Card transfers aren't configured on this environment yet.", 409
+        )
+
+
+class PanStepNotFound(PanTransferError):
+    def __init__(self, key: str) -> None:
+        super().__init__(f"There is no `{key}` step in this card transfer.", 404)
+
+
+class PanStepNotActionable(PanTransferError):
+    def __init__(self, key: str) -> None:
+        super().__init__(f"The `{key}` step isn't the one to act on right now.", 409)
+
+
+class PanStepNotOwned(PanTransferError):
+    def __init__(self, key: str, owner: PanStepOwner) -> None:
+        super().__init__(f"The `{key}` step is completed by {owner.value}.", 403)
+
+
+@dataclass(frozen=True)
+class PanStepTemplate:
+    key: str
+    owner: PanStepOwner
+    kind: PanStepKind
+    required_inputs: tuple[str, ...] = ()
+    optional_inputs: tuple[str, ...] = ()
+    # Steps that only surface information Polar already holds. They complete the
+    # moment they become current, so the merchant never waits on a no-op.
+    auto_complete: bool = False
+
+    @property
+    def accepted_inputs(self) -> frozenset[str]:
+        return frozenset(self.required_inputs) | frozenset(self.optional_inputs)
+
+
+class PanTransferStep(Schema):
+    """One checklist step, as persisted on `MerchantMigration.pan_transfer_steps`.
+
+    The row is self-contained: owner and kind are copied off the template so both
+    the stored JSONB and the API response can be read without resolving a
+    template. The template stays authoritative for the rules that gate a
+    transition (`auto_complete`, the accepted inputs), so a step whose key no
+    longer has a template can't be completed.
+    """
+
+    key: str = Field(description="Stable identifier. The client keys its copy off it.")
+    owner: PanStepOwner = Field(description="Who moves this step forward.")
+    kind: PanStepKind = Field(
+        description="What the owner does, so the client knows what to render."
+    )
+    status: PanStepStatus = Field(
+        description="Where the step is. Only one step is actionable at a time."
+    )
+    inputs: dict[str, str] = Field(description="Values collected on this step.")
+    note: str | None = Field(
+        description=(
+            "Free text from Polar Ops, shown to the merchant. How a weeks-long "
+            "wait on Stripe or the provider gets explained without a support thread."
+        )
+    )
+    expected_at: datetime | None = Field(
+        description="When Ops expects this step to land."
+    )
+    started_at: datetime | None = Field(description="When the step became actionable.")
+    completed_at: datetime | None = Field(description="When the step was completed.")
+    completed_by: PanStepActor | None = Field(description="Who completed the step.")
+
+
+class PanTransferStepsType(TypeDecorator[Any]):
+    impl = JSONB
+    cache_ok = True
+
+    def process_bind_param(self, value: Any, dialect: Dialect) -> Any:
+        if value is None:
+            return value
+        return [
+            step.model_dump(mode="json") if isinstance(step, PanTransferStep) else step
+            for step in value
+        ]
+
+    def process_result_value(self, value: Any, dialect: Dialect) -> Any:
+        if value is None:
+            return value
+        return [PanTransferStep.model_validate(step) for step in value]
+
+
+# Stripe to Stripe. See Appendix B of the merchant-migrations design doc.
+PAN_COPY_TEMPLATES: tuple[PanStepTemplate, ...] = (
+    PanStepTemplate(
+        key="share_destination_account",
+        owner=PanStepOwner.polar_app,
+        kind=PanStepKind.auto,
+        auto_complete=True,
+    ),
+    PanStepTemplate(
+        key="start_copy",
+        owner=PanStepOwner.merchant,
+        kind=PanStepKind.confirm,
+        optional_inputs=("stripe_migration_request_id",),
+    ),
+    PanStepTemplate(
+        key="authorize_copy",
+        owner=PanStepOwner.polar_ops,
+        kind=PanStepKind.confirm,
+    ),
+    PanStepTemplate(
+        key="stripe_copy",
+        owner=PanStepOwner.stripe,
+        kind=PanStepKind.auto,
+    ),
+    PanStepTemplate(
+        key="verify_cards",
+        owner=PanStepOwner.polar_app,
+        kind=PanStepKind.auto,
+    ),
+    PanStepTemplate(
+        key="resolve_uncovered",
+        owner=PanStepOwner.merchant,
+        kind=PanStepKind.confirm,
+    ),
+    PanStepTemplate(
+        key="cutover",
+        owner=PanStepOwner.merchant,
+        kind=PanStepKind.confirm,
+    ),
+    PanStepTemplate(
+        key="move_subscriptions",
+        owner=PanStepOwner.polar_app,
+        kind=PanStepKind.auto,
+    ),
+)
+
+# Any other vault to Stripe.
+PAN_IMPORT_TEMPLATES: tuple[PanStepTemplate, ...] = (
+    PanStepTemplate(
+        key="open_stripe_request",
+        owner=PanStepOwner.polar_ops,
+        kind=PanStepKind.input,
+        required_inputs=("stripe_migration_request_id",),
+    ),
+    PanStepTemplate(
+        key="request_provider_export",
+        owner=PanStepOwner.merchant,
+        kind=PanStepKind.input,
+        required_inputs=("provider_reference",),
+        optional_inputs=("provider_contact",),
+    ),
+    PanStepTemplate(
+        key="provider_export",
+        owner=PanStepOwner.provider,
+        kind=PanStepKind.auto,
+    ),
+    PanStepTemplate(
+        key="map_customers",
+        owner=PanStepOwner.polar_app,
+        kind=PanStepKind.auto,
+    ),
+    PanStepTemplate(
+        key="stripe_review",
+        owner=PanStepOwner.stripe,
+        kind=PanStepKind.auto,
+    ),
+    PanStepTemplate(
+        key="approve_import",
+        owner=PanStepOwner.polar_ops,
+        kind=PanStepKind.confirm,
+    ),
+    PanStepTemplate(
+        key="stripe_import",
+        owner=PanStepOwner.stripe,
+        kind=PanStepKind.auto,
+    ),
+    PanStepTemplate(
+        key="verify_cards",
+        owner=PanStepOwner.polar_app,
+        kind=PanStepKind.auto,
+    ),
+    PanStepTemplate(
+        key="resolve_uncovered",
+        owner=PanStepOwner.merchant,
+        kind=PanStepKind.confirm,
+    ),
+    PanStepTemplate(
+        key="cutover",
+        owner=PanStepOwner.merchant,
+        kind=PanStepKind.confirm,
+    ),
+    PanStepTemplate(
+        key="move_subscriptions",
+        owner=PanStepOwner.polar_app,
+        kind=PanStepKind.auto,
+    ),
+)
+
+_TEMPLATES: dict[PanTransferMethod, tuple[PanStepTemplate, ...]] = {
+    PanTransferMethod.pan_copy: PAN_COPY_TEMPLATES,
+    PanTransferMethod.pan_import: PAN_IMPORT_TEMPLATES,
+}
+
+_TEMPLATES_BY_KEY: dict[PanTransferMethod, dict[str, PanStepTemplate]] = {
+    method: {template.key: template for template in templates}
+    for method, templates in _TEMPLATES.items()
+}
+
+
+def templates_for(method: PanTransferMethod) -> tuple[PanStepTemplate, ...]:
+    return _TEMPLATES[method]
+
+
+def _template(method: PanTransferMethod, key: str) -> PanStepTemplate:
+    template = _TEMPLATES_BY_KEY[method].get(key)
+    if template is None:
+        raise PanStepNotFound(key)
+    return template
+
+
+def build(method: PanTransferMethod) -> list[PanTransferStep]:
+    """Instantiate a fresh checklist with only its first step actionable."""
+    # Every field is set explicitly: this model is also an API response, and
+    # ADR-0007 keeps output schemas free of defaults so the generated clients
+    # don't mark always-present fields optional.
+    steps = [
+        PanTransferStep(
+            key=template.key,
+            owner=template.owner,
+            kind=template.kind,
+            status=PanStepStatus.blocked,
+            inputs={},
+            note=None,
+            expected_at=None,
+            started_at=None,
+            completed_at=None,
+            completed_by=None,
+        )
+        for template in templates_for(method)
+    ]
+    _advance(method, steps)
+    return steps
+
+
+def current(steps: Sequence[PanTransferStep]) -> PanTransferStep | None:
+    """The one step that can be acted on, or None once the checklist is done."""
+    for step in steps:
+        if step.status in _ACTIONABLE:
+            return step
+    return None
+
+
+def _get(steps: Sequence[PanTransferStep], key: str) -> PanTransferStep:
+    for step in steps:
+        if step.key == key:
+            return step
+    raise PanStepNotFound(key)
+
+
+def _advance(method: PanTransferMethod, steps: list[PanTransferStep]) -> None:
+    """Make the first unfinished step actionable, walking past any that complete
+    on their own."""
+    for step in steps:
+        if step.status == PanStepStatus.completed:
+            continue
+        if step.status == PanStepStatus.blocked:
+            step.status = PanStepStatus.pending
+            step.started_at = utc_now()
+        if not _template(method, step.key).auto_complete:
+            return
+        _settle(step, PanStepActor.system)
+
+
+def _settle(step: PanTransferStep, actor: PanStepActor) -> None:
+    step.status = PanStepStatus.completed
+    step.completed_at = utc_now()
+    step.completed_by = actor
+
+
+def _validate_inputs(template: PanStepTemplate, inputs: dict[str, str]) -> None:
+    errors: list[ValidationError] = [
+        {
+            "type": "extra_forbidden",
+            "loc": ("body", "inputs", key),
+            "msg": "This step doesn't accept this input.",
+            "input": inputs[key],
+        }
+        for key in sorted(set(inputs) - template.accepted_inputs)
+    ]
+    errors += [
+        {
+            "type": "missing",
+            "loc": ("body", "inputs", key),
+            "msg": "This step needs this input.",
+            "input": None,
+        }
+        for key in sorted(set(template.required_inputs) - set(inputs))
+    ]
+    if errors:
+        raise PolarRequestValidationError(errors)
+
+
+def complete(
+    method: PanTransferMethod,
+    steps: list[PanTransferStep],
+    key: str,
+    *,
+    actor: PanStepActor,
+    inputs: dict[str, str],
+) -> list[PanTransferStep]:
+    """Complete the current step and unblock whatever comes next.
+
+    Raises rather than no-oping on a step that isn't current, so a stale client
+    can't skip ahead or silently re-complete.
+    """
+    step = _get(steps, key)
+    if step.status not in _ACTIONABLE:
+        raise PanStepNotActionable(key)
+    if step.owner not in _ACTOR_OWNERS[actor]:
+        raise PanStepNotOwned(key, step.owner)
+
+    # Blank is the same as absent, so an untouched optional field doesn't get
+    # stored and an all-whitespace required one still reads as missing.
+    provided = {k: v.strip() for k, v in inputs.items() if v.strip()}
+    _validate_inputs(_template(method, key), provided)
+
+    step.inputs = {**step.inputs, **provided}
+    _settle(step, actor)
+    _advance(method, steps)
+    return steps
+
+
+def annotate(
+    steps: list[PanTransferStep],
+    key: str,
+    *,
+    note: str | None = None,
+    expected_at: datetime | None = None,
+    in_progress: bool = False,
+) -> list[PanTransferStep]:
+    """Ops-only. Say what a step we're waiting on is doing and when it should land.
+
+    This is what turns "Stripe" from a dead badge into an explanation the merchant
+    can read without opening a support thread.
+    """
+    step = _get(steps, key)
+    if step.status == PanStepStatus.completed:
+        raise PanStepNotActionable(key)
+    if note is not None:
+        step.note = note or None
+    if expected_at is not None:
+        step.expected_at = expected_at
+    if in_progress:
+        if step.status != PanStepStatus.pending:
+            raise PanStepNotActionable(key)
+        step.status = PanStepStatus.in_progress
+    return steps

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from enum import StrEnum
 from typing import Any
 
@@ -9,6 +10,8 @@ from polar.models.merchant_migration import (
     MerchantMigrationStep,
 )
 from polar.models.merchant_migration_record import MerchantMigrationRecordStatus
+
+from .pan_transfer import PanTransferMethod, PanTransferStep
 
 
 class MerchantMigrationCreate(Schema):
@@ -153,6 +156,40 @@ class MerchantMigrationImportReport(Schema):
     )
     results: list[MerchantMigrationImportResult] = Field(
         description="Per-entity counts of what was imported vs skipped."
+    )
+
+
+class PanTransferStepComplete(Schema):
+    inputs: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Values the step collects. Which keys it accepts depends on the step; "
+            "unknown keys are rejected."
+        ),
+    )
+
+
+class PanTransferChecklist(Schema):
+    method: PanTransferMethod = Field(
+        description=(
+            "How the cards move: `pan_copy` for a Stripe source (account to "
+            "account), `pan_import` for any other vault."
+        )
+    )
+    started: bool = Field(
+        description="Whether the card transfer has been started. Steps are empty until it is."
+    )
+    current_step_key: str | None = Field(
+        description="The one step that can be acted on now. Null once every step is done."
+    )
+    destination_account_id: str | None = Field(
+        description=(
+            "The Stripe account the cards move into. The merchant needs it to "
+            "address the copy or import to Polar."
+        )
+    )
+    steps: Sequence[PanTransferStep] = Field(
+        description="The ordered checklist. Titles and guidance live in the client, keyed by `key`."
     )
 
 

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -8,7 +8,6 @@ from polar.auth.models import AuthSubject, Organization, User
 from polar.auth.permission import OrganizationPermission
 from polar.authz.service import assert_organization_permission
 from polar.config import settings
-from polar.exceptions import PolarError
 from polar.kit.db.postgres import AsyncSession
 from polar.kit.encryption import EncryptedString
 from polar.kit.pagination import PaginationParams
@@ -22,9 +21,19 @@ from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncReadSession
 from polar.product.repository import ProductRepository
 
+from . import pan_transfer
 from .adapters import SourceAdapter, StripeAdapter
 from .canonical import CanonicalRecord, deserialize
+from .errors import MerchantMigrationError
 from .importer import CatalogImporter
+from .pan_transfer import (
+    PanStepActor,
+    PanTransferAlreadyStarted,
+    PanTransferNotReady,
+    PanTransferNotStarted,
+    PanTransferStep,
+    PanTransferUnavailable,
+)
 from .precheck import classify_records, import_blockers, precheck_engine
 from .repository import (
     MerchantMigrationRecordRepository,
@@ -34,6 +43,7 @@ from .schemas import (
     MerchantMigrationCreate,
     MerchantMigrationImportReport,
     MerchantMigrationRecordItem,
+    PanTransferChecklist,
     PrecheckEntity,
     PrecheckIssue,
     PrecheckReasonLevel,
@@ -71,9 +81,6 @@ class StripeSourceCredentials(TypedDict):
     api_key_encrypted: str
     stripe_user_id: str | None
     livemode: bool
-
-
-class MerchantMigrationError(PolarError): ...
 
 
 class MerchantMigrationNotFound(MerchantMigrationError):
@@ -333,9 +340,103 @@ class MerchantMigrationService:
         report.step = MerchantMigrationStep.create_catalog
         return report
 
-    async def _get_manageable(
+    async def get_pan_transfer(
+        self,
+        session: AsyncReadSession,
+        auth_subject: AuthSubject[User | Organization],
+        migration_id: UUID,
+    ) -> PanTransferChecklist:
+        """The card-move checklist. Returns an empty one before it's started, so
+        the client can show the method and the destination account up front."""
+        migration = await self._get_manageable(session, auth_subject, migration_id)
+        return self._checklist(migration)
+
+    async def start_pan_transfer(
         self,
         session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        migration_id: UUID,
+    ) -> PanTransferChecklist:
+        """Move the migration onto the card step and lay out its checklist. The
+        catalog has to exist first: the checklist verifies cards against imported
+        subscriptions, and there's nothing to verify against without them."""
+        migration = await self._get_manageable(
+            session, auth_subject, migration_id, for_update=True
+        )
+        if migration.pan_transfer_steps:
+            raise PanTransferAlreadyStarted()
+        if migration.step != MerchantMigrationStep.create_catalog:
+            raise PanTransferNotReady()
+        # The first step tells the merchant which Stripe account to send the cards
+        # to. Without it configured we'd mark that step done while showing them
+        # nothing, and they'd address the transfer to no one.
+        if not settings.MERCHANT_MIGRATION_DESTINATION_STRIPE_ACCOUNT_ID:
+            raise PanTransferUnavailable()
+
+        steps = pan_transfer.build(migration.pan_transfer_method)
+        repository = MerchantMigrationRepository.from_session(session)
+        await repository.update(
+            migration,
+            update_dict={
+                "step": MerchantMigrationStep.copy_cards,
+                "pan_transfer_steps": steps,
+            },
+        )
+        return self._checklist(migration, steps)
+
+    async def complete_pan_step(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        migration_id: UUID,
+        key: str,
+        *,
+        inputs: dict[str, str],
+    ) -> PanTransferChecklist:
+        """Complete a merchant-owned step. Steps owned by Polar Ops, Stripe or the
+        source provider are moved from the backoffice, not here."""
+        migration = await self._get_manageable(
+            session, auth_subject, migration_id, for_update=True
+        )
+        if not migration.pan_transfer_steps:
+            raise PanTransferNotStarted()
+
+        steps = pan_transfer.complete(
+            migration.pan_transfer_method,
+            list(migration.pan_transfer_steps),
+            key,
+            actor=PanStepActor.merchant,
+            inputs=inputs,
+        )
+        repository = MerchantMigrationRepository.from_session(session)
+        await repository.update(migration, update_dict={"pan_transfer_steps": steps})
+        return self._checklist(migration, steps)
+
+    def _checklist(
+        self,
+        migration: MerchantMigration,
+        # `Sequence`, not `list`: this class defines a `list` method, which would
+        # shadow the builtin in an annotation evaluated in the class body.
+        steps: Sequence[PanTransferStep] | None = None,
+    ) -> PanTransferChecklist:
+        if steps is None:
+            steps = migration.pan_transfer_steps
+        current = pan_transfer.current(steps)
+        return PanTransferChecklist(
+            method=migration.pan_transfer_method,
+            started=bool(steps),
+            current_step_key=current.key if current is not None else None,
+            destination_account_id=(
+                settings.MERCHANT_MIGRATION_DESTINATION_STRIPE_ACCOUNT_ID or None
+            ),
+            steps=steps,
+        )
+
+    async def _get_manageable(
+        self,
+        # Widened for the read paths: `AsyncSession` is a `NewType` over
+        # `AsyncReadSession`, so the write callers still type-check.
+        session: AsyncReadSession,
         auth_subject: AuthSubject[User | Organization],
         migration_id: UUID,
         *,

--- a/server/polar/models/merchant_migration.py
+++ b/server/polar/models/merchant_migration.py
@@ -8,6 +8,11 @@ from sqlalchemy.orm import Mapped, declared_attr, mapped_column, relationship
 
 from polar.kit.db.models import RecordModel
 from polar.kit.extensions.sqlalchemy.types import StringEnum
+from polar.merchant_migration.pan_transfer import (
+    PanTransferMethod,
+    PanTransferStep,
+    PanTransferStepsType,
+)
 
 if TYPE_CHECKING:
     from polar.models.organization import Organization
@@ -59,14 +64,22 @@ class MerchantMigration(RecordModel):
     source_credentials: Mapped[dict[str, Any]] = mapped_column(
         JSONB, nullable=False, default=dict
     )
-    # The PAN transfer checklist: a list of step objects (see PanTransferStep).
-    pan_transfer_steps: Mapped[list[dict[str, Any]]] = mapped_column(
-        JSONB, nullable=False, default=list
+    # The PAN transfer checklist. Empty until the card move starts.
+    pan_transfer_steps: Mapped[list[PanTransferStep]] = mapped_column(
+        PanTransferStepsType, nullable=False, default=list
     )
 
     @declared_attr
     def organization(cls) -> Mapped["Organization"]:
         return relationship("Organization", lazy="raise")
+
+    @property
+    def pan_transfer_method(self) -> PanTransferMethod:
+        """Stripe sources copy account to account; every other vault goes through
+        a Stripe-coordinated import."""
+        if self.source_platform == MerchantMigrationSourcePlatform.stripe:
+            return PanTransferMethod.pan_copy
+        return PanTransferMethod.pan_import
 
     @property
     def source_connected(self) -> bool:

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -6,6 +6,7 @@ from httpx import AsyncClient
 from pytest_mock import MockerFixture
 
 from polar.auth.scope import Scope
+from polar.config import settings
 from polar.merchant_migration.canonical import (
     CanonicalAccount,
     CanonicalCustomer,
@@ -464,13 +465,264 @@ class TestImport:
         assert results["products"]["imported"] == 0
 
 
+def _configure_destination(mocker: MockerFixture) -> None:
+    mocker.patch.object(
+        settings, "MERCHANT_MIGRATION_DESTINATION_STRIPE_ACCOUNT_ID", "acct_polar"
+    )
+
+
+@pytest.mark.asyncio
+class TestGetPanTransfer:
+    async def test_anonymous(
+        self, client: AsyncClient, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        migration = await _create_migration(save_fixture, organization)
+        response = await client.get(
+            f"/v1/merchant-migrations/{migration.id}/pan-transfer"
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_not_started_still_reports_the_method(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        _configure_destination(mocker)
+        migration = await _create_migration(save_fixture, organization)
+
+        response = await client.get(
+            f"/v1/merchant-migrations/{migration.id}/pan-transfer"
+        )
+        assert response.status_code == 200
+        json_body = response.json()
+        assert json_body["method"] == "pan_copy"
+        assert json_body["started"] is False
+        assert json_body["steps"] == []
+        assert json_body["current_step_key"] is None
+
+
+@pytest.mark.asyncio
+class TestStartPanTransfer:
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_start_requires_an_imported_catalog(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        _configure_destination(mocker)
+        migration = await _create_migration(save_fixture, organization)
+
+        response = await client.post(
+            f"/v1/merchant-migrations/{migration.id}/pan-transfer"
+        )
+        assert response.status_code == 409
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_start_needs_a_destination_account(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        mocker.patch.object(
+            settings, "MERCHANT_MIGRATION_DESTINATION_STRIPE_ACCOUNT_ID", ""
+        )
+        migration = await _create_migration(
+            save_fixture, organization, step=MerchantMigrationStep.create_catalog
+        )
+
+        # Otherwise we'd tell the merchant we shared an account and show nothing.
+        response = await client.post(
+            f"/v1/merchant-migrations/{migration.id}/pan-transfer"
+        )
+        assert response.status_code == 409
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_start_lays_out_the_checklist(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        _configure_destination(mocker)
+        migration = await _create_migration(
+            save_fixture, organization, step=MerchantMigrationStep.create_catalog
+        )
+
+        response = await client.post(
+            f"/v1/merchant-migrations/{migration.id}/pan-transfer"
+        )
+        assert response.status_code == 200
+        json_body = response.json()
+        assert json_body["started"] is True
+        # Sharing our destination account is information only, so the merchant
+        # opens on the step they actually have to do.
+        assert json_body["current_step_key"] == "start_copy"
+
+        migration_response = await client.get(f"/v1/merchant-migrations/{migration.id}")
+        assert migration_response.json()["step"] == "copy_cards"
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_start_is_not_repeatable(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        _configure_destination(mocker)
+        migration = await _create_migration(
+            save_fixture, organization, step=MerchantMigrationStep.create_catalog
+        )
+        assert (
+            await client.post(f"/v1/merchant-migrations/{migration.id}/pan-transfer")
+        ).status_code == 200
+
+        response = await client.post(
+            f"/v1/merchant-migrations/{migration.id}/pan-transfer"
+        )
+        assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+class TestCompletePanTransferStep:
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_complete_advances_and_persists(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        _configure_destination(mocker)
+        migration = await _create_migration(
+            save_fixture, organization, step=MerchantMigrationStep.create_catalog
+        )
+        await client.post(f"/v1/merchant-migrations/{migration.id}/pan-transfer")
+
+        response = await client.post(
+            f"/v1/merchant-migrations/{migration.id}/pan-transfer/steps/start_copy/complete",
+            json={"inputs": {"stripe_migration_request_id": "mig_123"}},
+        )
+        assert response.status_code == 200
+        assert response.json()["current_step_key"] == "authorize_copy"
+
+        reread = await client.get(
+            f"/v1/merchant-migrations/{migration.id}/pan-transfer"
+        )
+        steps = {step["key"]: step for step in reread.json()["steps"]}
+        assert steps["start_copy"]["status"] == "completed"
+        assert steps["start_copy"]["completed_by"] == "merchant"
+        assert steps["start_copy"]["inputs"] == {
+            "stripe_migration_request_id": "mig_123"
+        }
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_complete_rejects_an_ops_step(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        _configure_destination(mocker)
+        migration = await _create_migration(
+            save_fixture, organization, step=MerchantMigrationStep.create_catalog
+        )
+        await client.post(f"/v1/merchant-migrations/{migration.id}/pan-transfer")
+        await client.post(
+            f"/v1/merchant-migrations/{migration.id}/pan-transfer/steps/start_copy/complete"
+        )
+
+        response = await client.post(
+            f"/v1/merchant-migrations/{migration.id}/pan-transfer/steps/authorize_copy/complete"
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_complete_rejects_skipping_ahead(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        _configure_destination(mocker)
+        migration = await _create_migration(
+            save_fixture, organization, step=MerchantMigrationStep.create_catalog
+        )
+        await client.post(f"/v1/merchant-migrations/{migration.id}/pan-transfer")
+
+        response = await client.post(
+            f"/v1/merchant-migrations/{migration.id}/pan-transfer/steps/cutover/complete"
+        )
+        assert response.status_code == 409
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_complete_rejects_unknown_inputs(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        _configure_destination(mocker)
+        migration = await _create_migration(
+            save_fixture, organization, step=MerchantMigrationStep.create_catalog
+        )
+        await client.post(f"/v1/merchant-migrations/{migration.id}/pan-transfer")
+
+        response = await client.post(
+            f"/v1/merchant-migrations/{migration.id}/pan-transfer/steps/start_copy/complete",
+            json={"inputs": {"whatever": "x"}},
+        )
+        # Per-field, so the client can point at the offending input.
+        assert response.status_code == 422
+        assert response.json()["detail"][0]["loc"] == ["body", "inputs", "whatever"]
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_complete_before_start(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        _configure_destination(mocker)
+        migration = await _create_migration(save_fixture, organization)
+
+        response = await client.post(
+            f"/v1/merchant-migrations/{migration.id}/pan-transfer/steps/start_copy/complete"
+        )
+        assert response.status_code == 409
+
+
 async def _create_migration(
-    save_fixture: SaveFixture, organization: Organization
+    save_fixture: SaveFixture,
+    organization: Organization,
+    step: MerchantMigrationStep = MerchantMigrationStep.source_setup,
 ) -> MerchantMigration:
     migration = MerchantMigration(
         organization_id=organization.id,
         source_platform=MerchantMigrationSourcePlatform.stripe,
-        step=MerchantMigrationStep.source_setup,
+        step=step,
     )
     await save_fixture(migration)
     return migration

--- a/server/tests/merchant_migration/test_pan_transfer.py
+++ b/server/tests/merchant_migration/test_pan_transfer.py
@@ -1,0 +1,348 @@
+import pytest
+
+from polar.exceptions import PolarRequestValidationError
+from polar.merchant_migration import pan_transfer
+from polar.merchant_migration.pan_transfer import (
+    PanStepActor,
+    PanStepKind,
+    PanStepNotActionable,
+    PanStepNotFound,
+    PanStepNotOwned,
+    PanStepOwner,
+    PanStepStatus,
+    PanTransferMethod,
+    PanTransferStep,
+    PanTransferStepsType,
+)
+from polar.models import MerchantMigration
+from polar.models.merchant_migration import MerchantMigrationSourcePlatform
+
+
+def _copy_steps() -> list[PanTransferStep]:
+    return pan_transfer.build(PanTransferMethod.pan_copy)
+
+
+def _advance_to(
+    steps: list[PanTransferStep],
+    key: str,
+    *,
+    method: PanTransferMethod = PanTransferMethod.pan_copy,
+) -> list[PanTransferStep]:
+    """Complete every step ahead of `key` as whoever owns it. Ops stands in for
+    everyone but the app, which is what `_ACTOR_OWNERS` allows."""
+    while True:
+        step = pan_transfer.current(steps)
+        assert step is not None
+        if step.key == key:
+            return steps
+        actor = (
+            PanStepActor.system
+            if step.owner == PanStepOwner.polar_app
+            else PanStepActor.ops
+        )
+        template = pan_transfer._template(method, step.key)
+        steps = pan_transfer.complete(
+            method,
+            steps,
+            step.key,
+            actor=actor,
+            inputs={key: "value" for key in template.required_inputs},
+        )
+
+
+class TestPanTransferMethod:
+    def test_stripe_source_copies(self) -> None:
+        migration = MerchantMigration(
+            source_platform=MerchantMigrationSourcePlatform.stripe
+        )
+        assert migration.pan_transfer_method == PanTransferMethod.pan_copy
+
+    @pytest.mark.parametrize(
+        "platform",
+        [
+            MerchantMigrationSourcePlatform.paddle,
+            MerchantMigrationSourcePlatform.lemon_squeezy,
+        ],
+    )
+    def test_other_vaults_import(
+        self, platform: MerchantMigrationSourcePlatform
+    ) -> None:
+        migration = MerchantMigration(source_platform=platform)
+        assert migration.pan_transfer_method == PanTransferMethod.pan_import
+
+
+class TestBuild:
+    def test_only_one_step_is_actionable(self) -> None:
+        steps = _copy_steps()
+        actionable = [
+            step
+            for step in steps
+            if step.status in (PanStepStatus.pending, PanStepStatus.in_progress)
+        ]
+        assert len(actionable) == 1
+
+    def test_information_only_steps_complete_immediately(self) -> None:
+        steps = _copy_steps()
+
+        # Sharing Polar's destination account has nothing to wait on, so the
+        # merchant lands straight on the step they have to act on.
+        assert steps[0].key == "share_destination_account"
+        assert steps[0].status == PanStepStatus.completed
+        assert steps[0].completed_by == PanStepActor.system
+        current = pan_transfer.current(steps)
+        assert current is not None
+        assert current.key == "start_copy"
+
+    def test_remaining_steps_are_blocked(self) -> None:
+        steps = _copy_steps()
+        assert [step.status for step in steps[2:]] == [PanStepStatus.blocked] * (
+            len(steps) - 2
+        )
+
+    def test_import_starts_with_ops(self) -> None:
+        steps = pan_transfer.build(PanTransferMethod.pan_import)
+        current = pan_transfer.current(steps)
+        assert current is not None
+        assert current.key == "open_stripe_request"
+        assert current.owner == PanStepOwner.polar_ops
+
+    @pytest.mark.parametrize("method", list(PanTransferMethod))
+    def test_keys_are_unique(self, method: PanTransferMethod) -> None:
+        # Steps are addressed by key everywhere: the API path, the client copy,
+        # and the lookups here.
+        keys = [template.key for template in pan_transfer.templates_for(method)]
+        assert len(keys) == len(set(keys))
+
+    @pytest.mark.parametrize("method", list(PanTransferMethod))
+    def test_every_method_ends_on_the_merchant_then_us(
+        self, method: PanTransferMethod
+    ) -> None:
+        templates = pan_transfer.templates_for(method)
+        assert templates[-1].key == "move_subscriptions"
+        assert templates[-1].owner == PanStepOwner.polar_app
+        # Cutover is the last thing the merchant does before we take over billing.
+        assert templates[-2].key == "cutover"
+        assert templates[-2].owner == PanStepOwner.merchant
+
+
+class TestComplete:
+    def test_unblocks_the_next_step(self) -> None:
+        steps = pan_transfer.complete(
+            PanTransferMethod.pan_copy,
+            _copy_steps(),
+            "start_copy",
+            actor=PanStepActor.merchant,
+            inputs={},
+        )
+
+        assert steps[1].status == PanStepStatus.completed
+        assert steps[1].completed_at is not None
+        assert steps[1].completed_by == PanStepActor.merchant
+        current = pan_transfer.current(steps)
+        assert current is not None
+        assert current.key == "authorize_copy"
+        assert current.started_at is not None
+
+    def test_stores_optional_inputs(self) -> None:
+        steps = pan_transfer.complete(
+            PanTransferMethod.pan_copy,
+            _copy_steps(),
+            "start_copy",
+            actor=PanStepActor.merchant,
+            inputs={"stripe_migration_request_id": " mig_123 "},
+        )
+
+        assert steps[1].inputs == {"stripe_migration_request_id": "mig_123"}
+
+    def test_rejects_a_step_that_is_not_current(self) -> None:
+        with pytest.raises(PanStepNotActionable):
+            pan_transfer.complete(
+                PanTransferMethod.pan_copy,
+                _copy_steps(),
+                "cutover",
+                actor=PanStepActor.merchant,
+                inputs={},
+            )
+
+    def test_rejects_completing_twice(self) -> None:
+        steps = pan_transfer.complete(
+            PanTransferMethod.pan_copy,
+            _copy_steps(),
+            "start_copy",
+            actor=PanStepActor.merchant,
+            inputs={},
+        )
+
+        with pytest.raises(PanStepNotActionable):
+            pan_transfer.complete(
+                PanTransferMethod.pan_copy,
+                steps,
+                "start_copy",
+                actor=PanStepActor.merchant,
+                inputs={},
+            )
+
+    def test_rejects_an_unknown_step(self) -> None:
+        with pytest.raises(PanStepNotFound):
+            pan_transfer.complete(
+                PanTransferMethod.pan_copy,
+                _copy_steps(),
+                "nope",
+                actor=PanStepActor.merchant,
+                inputs={},
+            )
+
+    def test_merchant_cannot_complete_an_ops_step(self) -> None:
+        steps = _advance_to(_copy_steps(), "authorize_copy")
+
+        with pytest.raises(PanStepNotOwned):
+            pan_transfer.complete(
+                PanTransferMethod.pan_copy,
+                steps,
+                "authorize_copy",
+                actor=PanStepActor.merchant,
+                inputs={},
+            )
+
+    def test_ops_can_complete_a_merchant_step(self) -> None:
+        steps = pan_transfer.complete(
+            PanTransferMethod.pan_copy,
+            _copy_steps(),
+            "start_copy",
+            actor=PanStepActor.ops,
+            inputs={},
+        )
+
+        assert steps[1].completed_by == PanStepActor.ops
+
+    def test_ops_cannot_stand_in_for_the_app(self) -> None:
+        steps = _advance_to(_copy_steps(), "verify_cards")
+
+        # Completing this would skip linking the copied cards, not perform it.
+        with pytest.raises(PanStepNotOwned):
+            pan_transfer.complete(
+                PanTransferMethod.pan_copy,
+                steps,
+                "verify_cards",
+                actor=PanStepActor.ops,
+                inputs={},
+            )
+
+    def test_requires_declared_inputs(self) -> None:
+        steps = pan_transfer.build(PanTransferMethod.pan_import)
+
+        with pytest.raises(PolarRequestValidationError) as exc:
+            pan_transfer.complete(
+                PanTransferMethod.pan_import,
+                steps,
+                "open_stripe_request",
+                actor=PanStepActor.ops,
+                inputs={"stripe_migration_request_id": "   "},
+            )
+        errors = exc.value.errors()
+        assert [error["type"] for error in errors] == ["missing"]
+        assert errors[0]["loc"] == ("body", "inputs", "stripe_migration_request_id")
+
+    def test_rejects_undeclared_inputs(self) -> None:
+        with pytest.raises(PolarRequestValidationError) as exc:
+            pan_transfer.complete(
+                PanTransferMethod.pan_copy,
+                _copy_steps(),
+                "start_copy",
+                actor=PanStepActor.merchant,
+                inputs={"whatever": "x"},
+            )
+        errors = exc.value.errors()
+        assert [error["type"] for error in errors] == ["extra_forbidden"]
+        assert errors[0]["loc"] == ("body", "inputs", "whatever")
+
+    def test_walks_the_whole_checklist(self) -> None:
+        steps = _advance_to(_copy_steps(), "move_subscriptions")
+        steps = pan_transfer.complete(
+            PanTransferMethod.pan_copy,
+            steps,
+            "move_subscriptions",
+            actor=PanStepActor.system,
+            inputs={},
+        )
+
+        assert pan_transfer.current(steps) is None
+        assert all(step.status == PanStepStatus.completed for step in steps)
+
+
+class TestAnnotate:
+    def test_explains_a_step_we_are_waiting_on(self) -> None:
+        steps = _advance_to(_copy_steps(), "stripe_copy")
+        steps = pan_transfer.annotate(
+            steps, "stripe_copy", note="Stripe is copying.", in_progress=True
+        )
+
+        step = pan_transfer.current(steps)
+        assert step is not None
+        assert step.key == "stripe_copy"
+        assert step.status == PanStepStatus.in_progress
+        assert step.note == "Stripe is copying."
+
+    def test_an_in_progress_step_stays_current(self) -> None:
+        steps = pan_transfer.annotate(
+            _advance_to(_copy_steps(), "stripe_copy"), "stripe_copy", in_progress=True
+        )
+        steps = pan_transfer.complete(
+            PanTransferMethod.pan_copy,
+            steps,
+            "stripe_copy",
+            actor=PanStepActor.ops,
+            inputs={},
+        )
+
+        current = pan_transfer.current(steps)
+        assert current is not None
+        assert current.key == "verify_cards"
+
+    def test_can_annotate_a_step_that_is_still_blocked(self) -> None:
+        steps = pan_transfer.annotate(_copy_steps(), "cutover", note="Not yet.")
+
+        assert steps[-2].note == "Not yet."
+        assert steps[-2].status == PanStepStatus.blocked
+
+    def test_rejects_a_completed_step(self) -> None:
+        with pytest.raises(PanStepNotActionable):
+            pan_transfer.annotate(_copy_steps(), "share_destination_account", note="x")
+
+    def test_only_the_current_step_can_be_in_progress(self) -> None:
+        with pytest.raises(PanStepNotActionable):
+            pan_transfer.annotate(_copy_steps(), "cutover", in_progress=True)
+
+
+class TestPanTransferStepsType:
+    def test_round_trips_through_the_column(self) -> None:
+        steps = pan_transfer.complete(
+            PanTransferMethod.pan_copy,
+            _copy_steps(),
+            "start_copy",
+            actor=PanStepActor.merchant,
+            inputs={"stripe_migration_request_id": "mig_123"},
+        )
+        column = PanTransferStepsType()
+
+        stored = column.process_bind_param(steps, None)  # type: ignore[arg-type]
+        assert isinstance(stored[0], dict)
+        assert column.process_result_value(stored, None) == steps  # type: ignore[arg-type]
+
+    def test_passes_none_through(self) -> None:
+        column = PanTransferStepsType()
+
+        assert column.process_bind_param(None, None) is None  # type: ignore[arg-type]
+        assert column.process_result_value(None, None) is None  # type: ignore[arg-type]
+
+
+class TestKinds:
+    @pytest.mark.parametrize("method", list(PanTransferMethod))
+    def test_only_polar_and_third_parties_own_auto_steps(
+        self, method: PanTransferMethod
+    ) -> None:
+        # A step the merchant owns always has something to click, otherwise the
+        # checklist would stall waiting on them with no action to take.
+        for template in pan_transfer.templates_for(method):
+            if template.kind == PanStepKind.auto:
+                assert template.owner != PanStepOwner.merchant


### PR DESCRIPTION
## Summary

Moving a merchant's saved cards onto Polar's Stripe account is the slow part of a migration. It takes hours to 3 days for a Stripe source, and weeks for any other vault like Paddle. The work is split between the merchant, Polar Ops, Polar's own code, Stripe, and the old provider.

This adds a checklist to track it. One step is actionable at a time. Each step says who owns it, so the merchant can see they are waiting on Stripe and not on themselves.

## What

- New engine in `server/polar/merchant_migration/pan_transfer.py`: step templates, step state, and the rules for moving between steps.
- Two templates. `pan_copy` (8 steps) for Stripe sources. `pan_import` (11 steps) for every other vault. The method comes from `source_platform`.
- Three endpoints: read the checklist, start it, and complete a step the merchant owns.
- State is stored in the existing `merchant_migrations.pan_transfer_steps` JSONB column. No database migration.
- New setting `MERCHANT_MIGRATION_DESTINATION_STRIPE_ACCOUNT_ID`. This is the Stripe account cards are sent to.

## Why

The design doc (Appendix B of `handbook/engineering/design-documents/merchant-migrations.mdx`) asks for a guided checklist. A merchant should never have to ask support what is happening.

Some rules the engine enforces:

- Only one step can be acted on. Completing a later step raises instead of doing nothing, so a stale client cannot skip ahead.
- Merchants can only complete their own steps. Ops can also complete merchant, Stripe and provider steps. Nobody can complete a Polar step by hand, because those steps do real work (creating payment methods, moving subscriptions) that a manual complete would skip.
- Each step declares which inputs it takes. Unknown keys are rejected. Blank values count as missing.
- Ops can add a note and an expected date to a step. This is how "Stripe is copying, expect it Friday" reaches the merchant.

## How

Step titles and help text are **not** in the backend. They live in the client, keyed by the step `key`. So wording can change without touching stored data.

The step model is used both as the JSONB column type (through a `TypeDecorator`, same pattern as `polar/meter/aggregation.py`) and as the API response.

## Not in this PR

- No backoffice page yet, so Ops steps cannot be moved. A checklist stops at `authorize_copy` today. `annotate()` and Ops completion exist in the service, ready for that PR.
- The customer CSV, the card verification job, and the frontend checklist UI are separate follow-ups.
- `migration.step` still stops at `copy_cards`. The last two checklist steps (`cutover`, `move_subscriptions`) belong to the `activate_subscriptions` phase, so the checklist should drive `migration.step`. This is not a regression: nothing advanced it past this point before either. Left out because it is a design choice worth agreeing on first.

## Deploy note

`MERCHANT_MIGRATION_DESTINATION_STRIPE_ACCOUNT_ID` must be set, or starting a card transfer returns 409. This is on purpose: without it we would tell the merchant we shared an account and then show them nothing.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

