### PR TITLE
feat(compass): back the assistant with server-side threads

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -3186,6 +3186,62 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/compass/threads': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * List Assistant Threads
+     * @description List the caller's assistant conversation threads, most recent first.
+     *
+     *     **Scopes**: `metrics:read`
+     */
+    get: operations['compass:list_threads']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v1/compass/threads/{id}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get Assistant Thread
+     * @description Get a thread with its rendered messages, for rehydrating the UI.
+     *
+     *     **Scopes**: `metrics:read`
+     */
+    get: operations['compass:get_thread']
+    put?: never
+    post?: never
+    /**
+     * Delete Assistant Thread
+     * @description Delete a thread and its conversation history.
+     *
+     *     **Scopes**: `metrics:write`
+     */
+    delete: operations['compass:delete_thread']
+    options?: never
+    head?: never
+    /**
+     * Update Assistant Thread
+     * @description Rename a thread.
+     *
+     *     **Scopes**: `metrics:write`
+     */
+    patch: operations['compass:update_thread']
+    trace?: never
+  }
   '/v1/license-keys/': {
     parameters: {
       query?: never
@@ -7761,6 +7817,38 @@ export interface components {
       error: 'AppealNotRejectedError'
       /** Detail */
       detail: string
+    }
+    /**
+     * AssistantBlockPart
+     * @description A renderable block, at the position the model placed it.
+     */
+    AssistantBlockPart: {
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      kind: 'block'
+      /** Block */
+      block:
+        | components['schemas']['TextBlock']
+        | components['schemas']['MetricChartBlock']
+        | components['schemas']['InsightCardsBlock']
+        | components['schemas']['EntityListBlock']
+        | components['schemas']['DataTableBlock']
+        | components['schemas']['CustomerCardBlock']
+    }
+    /**
+     * AssistantTextPart
+     * @description A run of assistant prose, as it was streamed.
+     */
+    AssistantTextPart: {
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      kind: 'text'
+      /** Text */
+      text: string
     }
     /**
      * AttachedCustomField
@@ -14475,6 +14563,113 @@ export interface components {
       allow_trial?: false | null
     }
     /**
+     * ColumnFormat
+     * @enum {string}
+     */
+    ColumnFormat: 'text' | 'currency' | 'datetime' | 'badge' | 'avatar'
+    /**
+     * CompassThreadMessageSchema
+     * @description One completed turn: the user's prompt and the rendered answer.
+     */
+    CompassThreadMessageSchema: {
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the object.
+       */
+      id: string
+      /** Prompt */
+      prompt: string
+      /** Parts */
+      parts: (
+        | components['schemas']['AssistantTextPart']
+        | components['schemas']['AssistantBlockPart']
+      )[]
+    }
+    /**
+     * CompassThreadSchema
+     * @description An assistant conversation thread.
+     */
+    CompassThreadSchema: {
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the object.
+       */
+      id: string
+      /**
+       * Organization Id
+       * Format: uuid4
+       */
+      organization_id: string
+      /** Title */
+      title: string
+    }
+    /** CompassThreadUpdate */
+    CompassThreadUpdate: {
+      /** Title */
+      title?: string | null
+    }
+    /** CompassThreadWithMessages */
+    CompassThreadWithMessages: {
+      /**
+       * Created At
+       * Format: date-time
+       * @description Creation timestamp of the object.
+       */
+      created_at: string
+      /**
+       * Modified At
+       * @description Last modification timestamp of the object.
+       */
+      modified_at: string | null
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the object.
+       */
+      id: string
+      /**
+       * Organization Id
+       * Format: uuid4
+       */
+      organization_id: string
+      /** Title */
+      title: string
+      /**
+       * Messages
+       * @description Most recent turns, oldest first.
+       */
+      messages: components['schemas']['CompassThreadMessageSchema'][]
+      /**
+       * Has More
+       * @description Whether older turns exist beyond the ones returned.
+       */
+      has_more: boolean
+    }
+    /**
      * ConfidenceLevel
      * @description How much we trust an insight, derived from sample size and baseline variance.
      *
@@ -16265,6 +16460,28 @@ export interface components {
       | 'too_expensive'
       | 'unused'
       | 'other'
+    /**
+     * CustomerCardBlock
+     * @description A single customer's identity header, above their orders/subscriptions.
+     */
+    CustomerCardBlock: {
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'customer_card'
+      /** Email */
+      email: string
+      /** Name */
+      name: string | null
+      /** Avatar Url */
+      avatar_url: string | null
+      /**
+       * Created At
+       * Format: date-time
+       */
+      created_at: string
+    }
     CustomerCreate:
       | components['schemas']['CustomerIndividualCreate']
       | components['schemas']['CustomerTeamCreate']
@@ -19439,6 +19656,44 @@ export interface components {
       | '-created_at'
       | 'balance'
       | '-balance'
+    /**
+     * DataTableBlock
+     * @description Tabular entities (orders, subscriptions, customers, ...).
+     */
+    DataTableBlock: {
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'data_table'
+      /**
+       * Entity
+       * @description What the rows are, e.g. `subscriptions`.
+       */
+      entity: string
+      /**
+       * Title
+       * @description Heading rendered above the table.
+       */
+      title: string | null
+      /** Columns */
+      columns: components['schemas']['DataTableColumn'][]
+      /** Rows */
+      rows: {
+        [key: string]: string | number | null
+      }[]
+      /** Total Count */
+      total_count: number
+    }
+    /** DataTableColumn */
+    DataTableColumn: {
+      /** Key */
+      key: string
+      /** Label */
+      label: string
+      /** @default text */
+      format: components['schemas']['ColumnFormat']
+    }
     /** DiscordGuild */
     DiscordGuild: {
       /** Name */
@@ -20876,6 +21131,36 @@ export interface components {
       /** Return To */
       return_to?: string | null
     }
+    /**
+     * EntityListBlock
+     * @description A few entities as a compact list; same shape as the table so the
+     *     client formats values (currency, dates) identically in both.
+     */
+    EntityListBlock: {
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'entity_list'
+      /**
+       * Entity
+       * @description What the items are, e.g. `orders`.
+       */
+      entity: string
+      /**
+       * Title
+       * @description Heading rendered above the list.
+       */
+      title: string | null
+      /** Columns */
+      columns: components['schemas']['DataTableColumn'][]
+      /** Rows */
+      rows: {
+        [key: string]: string | number | null
+      }[]
+      /** Total Count */
+      total_count: number
+    }
     Event:
       | components['schemas']['SystemEvent']
       | components['schemas']['UserEvent']
@@ -21718,6 +22003,19 @@ export interface components {
       drivers?: components['schemas']['InsightDriver'][]
     }
     /**
+     * InsightCardsBlock
+     * @description Compass insights, rendered with the same card as the feed.
+     */
+    InsightCardsBlock: {
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'insight_cards'
+      /** Insights */
+      insights: components['schemas']['Insight'][]
+    }
+    /**
      * InsightCategory
      * @description Buckets an insight by which aspect of the business it speaks to.
      * @enum {string}
@@ -22467,6 +22765,12 @@ export interface components {
     ListResource_Checkout_: {
       /** Items */
       items: components['schemas']['Checkout'][]
+      pagination: components['schemas']['Pagination']
+    }
+    /** ListResource[CompassThreadSchema] */
+    ListResource_CompassThreadSchema_: {
+      /** Items */
+      items: components['schemas']['CompassThreadSchema'][]
       pagination: components['schemas']['Pagination']
     }
     /** ListResource[CustomField] */
@@ -23708,6 +24012,44 @@ export interface components {
       display_name: string
       /** @description Type of the metric, useful to know the unit or format of the value. */
       type: components['schemas']['MetricType']
+    }
+    /**
+     * MetricChartBlock
+     * @description A single metric's series over the requested window.
+     */
+    MetricChartBlock: {
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'metric_chart'
+      /**
+       * Metric
+       * @description Metric slug, e.g. `monthly_recurring_revenue`.
+       */
+      metric: string
+      /**
+       * Label
+       * @description Human-readable metric name.
+       */
+      label: string
+      /**
+       * Unit
+       * @description Metric unit type, e.g. `currency` or `scalar`.
+       */
+      unit: string
+      /** Points */
+      points: components['schemas']['MetricChartPoint'][]
+    }
+    /** MetricChartPoint */
+    MetricChartPoint: {
+      /**
+       * Timestamp
+       * Format: date-time
+       */
+      timestamp: string
+      /** Value */
+      value: number
     }
     /**
      * MetricDashboardCreate
@@ -34862,6 +35204,19 @@ export interface components {
        * @description Number of distinct jurisdictions tax was remitted in.
        */
       jurisdiction_count: number
+    }
+    /**
+     * TextBlock
+     * @description Plain narrated text.
+     */
+    TextBlock: {
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'text'
+      /** Text */
+      text: string
     }
     /**
      * TimeInterval
@@ -46402,6 +46757,167 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['Insight'][]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'compass:list_threads': {
+    parameters: {
+      query: {
+        /** @description Organization whose threads to list. */
+        organization_id: string
+        /** @description Page number, defaults to 1. */
+        page?: number
+        /** @description Size of a page, defaults to 10. Maximum is 100. */
+        limit?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ListResource_CompassThreadSchema_']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'compass:get_thread': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description The thread ID. */
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['CompassThreadWithMessages']
+        }
+      }
+      /** @description Thread not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'compass:delete_thread': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description The thread ID. */
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Thread deleted. */
+      204: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Thread not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'compass:update_thread': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description The thread ID. */
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CompassThreadUpdate']
+      }
+    }
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['CompassThreadSchema']
+        }
+      }
+      /** @description Thread not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
         }
       }
       /** @description Validation Error */
@@ -63482,6 +63998,12 @@ export const aggregationFunctionValues: ReadonlyArray<
 export const appealDecisionValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['AppealDecision']
 > = ['approved', 'rejected']
+export const assistantBlockPartKindValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['AssistantBlockPart']['kind']
+> = ['block']
+export const assistantTextPartKindValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['AssistantTextPart']['kind']
+> = ['text']
 export const authorizeResponseOrganizationSub_typeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['AuthorizeResponseOrganization']['sub_type']
 > = ['organization']
@@ -63717,6 +64239,9 @@ export const checkoutSortPropertyValues: ReadonlyArray<
 export const checkoutStatusValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['CheckoutStatus']
 > = ['open', 'expired', 'confirmed', 'succeeded', 'failed']
+export const columnFormatValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['ColumnFormat']
+> = ['text', 'currency', 'datetime', 'badge', 'avatar']
 export const confidenceLevelValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['ConfidenceLevel']
 > = ['low', 'medium', 'high']
@@ -64332,6 +64857,9 @@ export const customerCancellationReasonValues: ReadonlyArray<
   'unused',
   'other',
 ]
+export const customerCardBlockTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['CustomerCardBlock']['type']
+> = ['customer_card']
 export const customerCreatedEventNameValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['CustomerCreatedEvent']['name']
 > = ['customer.created']
@@ -64442,6 +64970,9 @@ export const customerUpdatedEventNameValues: ReadonlyArray<
 export const customerWalletSortPropertyValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['CustomerWalletSortProperty']
 > = ['created_at', '-created_at', 'balance', '-balance']
+export const dataTableBlockTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['DataTableBlock']['type']
+> = ['data_table']
 export const discountDurationValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['DiscountDuration']
 > = ['once', 'forever', 'repeating']
@@ -64501,6 +65032,9 @@ export const downloadableFileCreateServiceValues: ReadonlyArray<
 export const downloadableFileReadServiceValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['DownloadableFileRead']['service']
 > = ['downloadable']
+export const entityListBlockTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['EntityListBlock']['type']
+> = ['entity_list']
 export const eventNamesSortPropertyValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['EventNamesSortProperty']
 > = [
@@ -64572,6 +65106,9 @@ export const filterOperatorValues: ReadonlyArray<
 export const identityVerificationStatusValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['IdentityVerificationStatus']
 > = ['unverified', 'pending', 'verified', 'failed']
+export const insightCardsBlockTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['InsightCardsBlock']['type']
+> = ['insight_cards']
 export const insightCategoryValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['InsightCategory']
 > = ['revenue', 'retention', 'growth', 'risk', 'cost', 'product']
@@ -64643,6 +65180,9 @@ export const meterSortPropertyValues: ReadonlyArray<
 export const meterUnitValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['MeterUnit']
 > = ['scalar', 'token', 'custom']
+export const metricChartBlockTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['MetricChartBlock']['type']
+> = ['metric_chart']
 export const metricTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['MetricType']
 > = ['scalar', 'currency', 'currency_sub_cent', 'percentage']
@@ -66937,6 +67477,9 @@ export const taxJurisdictionSortPropertyValues: ReadonlyArray<
   'country',
   '-country',
 ]
+export const textBlockTypeValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['TextBlock']['type']
+> = ['text']
 export const timeIntervalValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['TimeInterval']
 > = ['year', 'month', 'week', 'day', 'hour']

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -3217,7 +3217,7 @@ export interface paths {
     }
     /**
      * Get Assistant Thread
-     * @description Get a thread with its rendered messages, for rehydrating the UI.
+     * @description Get a thread. Its messages are fetched separately, page by page.
      *
      *     **Scopes**: `metrics:read`
      */
@@ -3240,6 +3240,32 @@ export interface paths {
      *     **Scopes**: `metrics:write`
      */
     patch: operations['compass:update_thread']
+    trace?: never
+  }
+  '/v1/compass/threads/{id}/messages': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * List Assistant Thread Messages
+     * @description List a thread's turns, for rehydrating the UI.
+     *
+     *     Paged newest-first: page 1 is the tail of the conversation and higher
+     *     pages walk back through it. Within a page, turns read oldest-first the
+     *     way they're rendered.
+     *
+     *     **Scopes**: `metrics:read`
+     */
+    get: operations['compass:list_thread_messages']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
     trace?: never
   }
   '/v1/license-keys/': {
@@ -14632,43 +14658,6 @@ export interface components {
       /** Title */
       title?: string | null
     }
-    /** CompassThreadWithMessages */
-    CompassThreadWithMessages: {
-      /**
-       * Created At
-       * Format: date-time
-       * @description Creation timestamp of the object.
-       */
-      created_at: string
-      /**
-       * Modified At
-       * @description Last modification timestamp of the object.
-       */
-      modified_at: string | null
-      /**
-       * Id
-       * Format: uuid4
-       * @description The ID of the object.
-       */
-      id: string
-      /**
-       * Organization Id
-       * Format: uuid4
-       */
-      organization_id: string
-      /** Title */
-      title: string
-      /**
-       * Messages
-       * @description Most recent turns, oldest first.
-       */
-      messages: components['schemas']['CompassThreadMessageSchema'][]
-      /**
-       * Has More
-       * @description Whether older turns exist beyond the ones returned.
-       */
-      has_more: boolean
-    }
     /**
      * ConfidenceLevel
      * @description How much we trust an insight, derived from sample size and baseline variance.
@@ -22765,6 +22754,12 @@ export interface components {
     ListResource_Checkout_: {
       /** Items */
       items: components['schemas']['Checkout'][]
+      pagination: components['schemas']['Pagination']
+    }
+    /** ListResource[CompassThreadMessageSchema] */
+    ListResource_CompassThreadMessageSchema_: {
+      /** Items */
+      items: components['schemas']['CompassThreadMessageSchema'][]
       pagination: components['schemas']['Pagination']
     }
     /** ListResource[CompassThreadSchema] */
@@ -46824,7 +46819,7 @@ export interface operations {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['CompassThreadWithMessages']
+          'application/json': components['schemas']['CompassThreadSchema']
         }
       }
       /** @description Thread not found. */
@@ -46909,6 +46904,52 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['CompassThreadSchema']
+        }
+      }
+      /** @description Thread not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'compass:list_thread_messages': {
+    parameters: {
+      query?: {
+        /** @description Page number, defaults to 1. */
+        page?: number
+        /** @description Size of a page, defaults to 10. Maximum is 100. */
+        limit?: number
+      }
+      header?: never
+      path: {
+        /** @description The thread ID. */
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ListResource_CompassThreadMessageSchema_']
         }
       }
       /** @description Thread not found. */

--- a/server/polar/compass/assistant/agent.py
+++ b/server/polar/compass/assistant/agent.py
@@ -66,8 +66,13 @@ Follow-ups and judgment questions:
 - Never map words in the question onto tool or category names literally.
   "Risk" in a follow-up usually means the downside of the prior
   recommendation, not the risk insight category.
-- Tool results from earlier turns remain valid context; do not re-fetch to
-  re-answer.
+- Tool results from earlier turns show the data as it was when fetched, not
+  as it is now. Each replayed result starts with the date it was fetched, as
+  `[fetched YYYY-MM-DD]`. For judgment and analysis follow-ups, reason from
+  them directly without re-fetching. But when the user asks about current
+  numbers and the relevant result was fetched before today's date, fetch
+  fresh data instead of quoting the remembered figure. Never repeat a
+  `[fetched ...]` marker in your answer.
 - When your answer is analysis rather than measurement, frame it that way
   (e.g. "the main trade-off is..."), and say what data would confirm it.
 
@@ -134,19 +139,38 @@ def build_assistant_agent(
     agent: Agent[AssistantDeps, str] = Agent(
         model_instance,
         deps_type=AssistantDeps,
-        system_prompt=SYSTEM_PROMPT,
+        # Use `instructions`, not `system_prompt`. System prompts only go out
+        # on a history-less first turn, so a resumed thread would keep the
+        # original date forever. Instructions rebuild every turn.
+        instructions=SYSTEM_PROMPT,
         tools=tools,
         # gpt-5.5+ reasoning models reject any non-default temperature.
         model_settings=({} if model_name.startswith("gpt-5.5") else {"temperature": 0}),
     )
 
     # Relative dates ("yesterday", "last month") are resolvable only if the
-    # model knows what today is; the static prompt can't carry it.
-    @agent.system_prompt
-    async def _current_date(ctx: RunContext[AssistantDeps]) -> str:
-        return (
+    # model knows what today is; the static prompt can't carry it. On resumed
+    # threads, this also anchors the per-result `[fetched <date>]` stamps that
+    # replayed tool results carry, so the staleness rule is applicable.
+    @agent.instructions
+    async def _run_context(ctx: RunContext[AssistantDeps]) -> str:
+        lines = [
             f"Today's date is {ctx.deps.today.isoformat()} in the merchant's "
             f"timezone ({ctx.deps.timezone})."
-        )
+        ]
+        if ctx.deps.history_last_at is not None:
+            last_turn_on = (
+                ctx.deps.history_last_at.astimezone(ctx.deps.timezone)
+                .date()
+                .isoformat()
+            )
+            lines.append(
+                "This conversation is being continued: its most recent earlier "
+                f"turn ran on {last_turn_on}. Every tool result replayed from an "
+                "earlier turn is prefixed with `[fetched <date>]`, the date it "
+                "was fetched in this same timezone; it shows the data as of "
+                "that date, not as it is now."
+            )
+        return "\n".join(lines)
 
     return agent, model_provider, model_name

--- a/server/polar/compass/assistant/deps.py
+++ b/server/polar/compass/assistant/deps.py
@@ -1,6 +1,6 @@
 import uuid
 from dataclasses import dataclass, field
-from datetime import date
+from datetime import date, datetime
 from zoneinfo import ZoneInfo
 
 from polar.auth.models import AuthSubject, User
@@ -26,6 +26,7 @@ class AssistantDeps:
     timezone: ZoneInfo
     today: date
     redis: Redis | None = None
+    history_last_at: datetime | None = None
     blocks: list[AssistantBlock] = field(default_factory=list)
     """Renderable blocks produced by tools during the run, in order. The
     endpoint streams them to the client interleaved with the model's text."""

--- a/server/polar/compass/assistant/schemas.py
+++ b/server/polar/compass/assistant/schemas.py
@@ -8,14 +8,13 @@ class AssistantChatRequest(Schema):
 
     organization_id: UUID4 = Field(
         description="Organization the conversation is about. Must be accessible "
-        "to the caller; tools are always scoped to it."
+        "to the caller. Tools are always scoped to it."
     )
     prompt: str = Field(min_length=1, max_length=4000)
-    message_history: str | None = Field(
+    thread_id: UUID4 | None = Field(
         default=None,
         description=(
-            "Opaque conversation state from the previous turn's `done` event. "
-            "Send it back verbatim to continue the conversation; omit to start "
-            "a new one."
+            "Thread to continue, from a previous turn's `done` event or the "
+            "thread list. Omit to start a new thread."
         ),
     )

--- a/server/polar/compass/assistant/stream.py
+++ b/server/polar/compass/assistant/stream.py
@@ -195,11 +195,13 @@ async def stream_assistant_run(
                         yield text_event(tail)
 
             # Fallback: blocks the model never placed still reach the user,
-            # after the text.
+            # after the text. Collected rather than yielded here — they add to
+            # `recorder.parts`, so they belong in the turn persisted below.
+            fallback: list[dict[str, str]] = []
             for index in range(1, len(deps.blocks) + 1):
                 unplaced = block_event(index)
                 if unplaced is not None:
-                    yield unplaced
+                    fallback.append(unplaced)
 
             result = run.result
             assert result is not None
@@ -209,7 +211,12 @@ async def stream_assistant_run(
             )
             # Persist only completed turns: a turn that errored mid-stream is
             # never recorded, so replay history can't be poisoned by it.
+            # Written before the yields below — a client disconnecting at a
+            # yield closes this generator, losing a turn the model finished.
             await record_turn(recorder.parts, new_messages)
+
+            for fallback_event in fallback:
+                yield fallback_event
             yield sse_event("done", {"thread_id": thread_id})
     except Exception:
         log.exception(

--- a/server/polar/compass/assistant/stream.py
+++ b/server/polar/compass/assistant/stream.py
@@ -2,14 +2,12 @@
 Run the assistant agent and turn it into an SSE event stream.
 
 Events, in order of appearance:
-- `text`   {"delta": str}         — model output, streamed as it generates
-- `block`  {<AssistantBlock>}     — a renderable block, placed by the model
-- `done`   {"message_history": str} — opaque state to send back next turn
+- `text`   {"delta": str}         model output, streamed as it generates
+- `block`  {<AssistantBlock>}     a renderable block, placed by the model
+- `done`   {"thread_id": str}     the thread to continue on the next turn
 - `error`  {"message": str}
 """
 
-import hashlib
-import hmac
 import json
 import re
 import uuid
@@ -19,6 +17,7 @@ from typing import Any
 import structlog
 from pydantic_ai import Agent
 from pydantic_ai.messages import (
+    ModelMessage,
     ModelMessagesTypeAdapter,
     PartDeltaEvent,
     PartStartEvent,
@@ -26,17 +25,17 @@ from pydantic_ai.messages import (
     TextPartDelta,
 )
 
-from polar.config import settings
 from polar.integrations.polar.service import polar_self
 from polar.logging import Logger
 from polar.organization_review.schemas import UsageInfo
 
+from ..threads.service import RecordTurn
 from .deps import AssistantDeps
 
 log: Logger = structlog.get_logger()
 
 
-def _event(event: str, data: Any) -> dict[str, str]:
+def sse_event(event: str, data: Any) -> dict[str, str]:
     return {"event": event, "data": json.dumps(data)}
 
 
@@ -64,55 +63,6 @@ def _track_usage(
             "compass.assistant_usage_tracking_error",
             organization_id=str(deps.organization_id),
         )
-
-
-def _scopes_digest(deps: AssistantDeps) -> str:
-    joined = ",".join(sorted(scope.value for scope in deps.auth_subject.scopes))
-    return hashlib.sha256(joined.encode()).hexdigest()
-
-
-def _history_mac(organization_id: str, scopes: str, messages: str) -> str:
-    payload = f"{organization_id}|{scopes}|{messages}".encode()
-    return hmac.new(settings.SECRET.encode(), payload, hashlib.sha256).hexdigest()
-
-
-def seal_history(deps: AssistantDeps, messages_json: str) -> str:
-    """Bind conversation state to the caller's organization and scopes.
-
-    The state round-trips through the client, so it is signed with claims:
-    replaying it against another organization, or after the token's scopes
-    changed, fails verification instead of leaking prior context (including
-    old tool results) into a conversation it does not belong to.
-    """
-    organization_id = str(deps.organization_id)
-    scopes = _scopes_digest(deps)
-    return json.dumps(
-        {
-            "org": organization_id,
-            "scopes": scopes,
-            "messages": messages_json,
-            "mac": _history_mac(organization_id, scopes, messages_json),
-        }
-    )
-
-
-def open_history(deps: AssistantDeps, sealed: str) -> str | None:
-    """The messages JSON if the seal verifies for this caller, else None."""
-    try:
-        envelope = json.loads(sealed)
-        organization_id = envelope["org"]
-        scopes = envelope["scopes"]
-        messages = envelope["messages"]
-        mac = envelope["mac"]
-    except (ValueError, TypeError, KeyError):
-        return None
-    if not hmac.compare_digest(mac, _history_mac(organization_id, scopes, messages)):
-        return None
-    if organization_id != str(deps.organization_id):
-        return None
-    if scopes != _scopes_digest(deps):
-        return None
-    return str(messages)
 
 
 _MARKER_RE = re.compile(r"\s*\[block:(\d+)\]\s*")
@@ -164,48 +114,57 @@ class _BlockPlacer:
         return tail
 
 
+class _PartsRecorder:
+    """Accumulates the streamed turn as renderable parts: the exact
+    interleaving of text and blocks the client displayed, so the turn can be
+    rehydrated later without re-running the model."""
+
+    def __init__(self) -> None:
+        self.parts: list[dict[str, Any]] = []
+
+    def add_text(self, delta: str) -> None:
+        if self.parts and self.parts[-1]["kind"] == "text":
+            self.parts[-1]["text"] += delta
+        else:
+            self.parts.append({"kind": "text", "text": delta})
+
+    def add_block(self, block: dict[str, Any]) -> None:
+        self.parts.append({"kind": "block", "block": block})
+
+
 async def stream_assistant_run(
     agent: Agent[AssistantDeps, str],
     deps: AssistantDeps,
     prompt: str,
-    message_history_json: str | None,
+    message_history: list[ModelMessage] | None,
     *,
     model_provider: str,
     model_name: str,
+    record_turn: RecordTurn,
+    thread_id: str,
 ) -> AsyncGenerator[dict[str, str]]:
-    history = None
-    if message_history_json:
-        messages_json = open_history(deps, message_history_json)
-        if messages_json is None:
-            yield _event(
-                "error",
-                {
-                    "message": "This conversation state is invalid or from a "
-                    "different context. Start a new conversation."
-                },
-            )
-            return
-        try:
-            history = ModelMessagesTypeAdapter.validate_json(messages_json)
-        except ValueError:
-            yield _event("error", {"message": "Invalid message history."})
-            return
-
+    recorder = _PartsRecorder()
     placer = _BlockPlacer()
     placed: set[int] = set()
+
+    def text_event(delta: str) -> dict[str, str]:
+        recorder.add_text(delta)
+        return sse_event("text", {"delta": delta})
 
     def block_event(index: int) -> dict[str, str] | None:
         # Markers are 1-based indexes into the run's prepared blocks.
         if index in placed or not (1 <= index <= len(deps.blocks)):
             return None
         placed.add(index)
-        return _event("block", deps.blocks[index - 1].model_dump(mode="json"))
+        dumped = deps.blocks[index - 1].model_dump(mode="json")
+        recorder.add_block(dumped)
+        return sse_event("block", dumped)
 
     def placed_events(delta: str) -> list[dict[str, str]]:
         events: list[dict[str, str]] = []
         for kind, value in placer.feed(delta):
             if kind == "text":
-                events.append(_event("text", {"delta": str(value)}))
+                events.append(text_event(str(value)))
             else:
                 placed_block = block_event(int(value))
                 if placed_block is not None:
@@ -213,7 +172,9 @@ async def stream_assistant_run(
         return events
 
     try:
-        async with agent.iter(prompt, deps=deps, message_history=history) as run:
+        async with agent.iter(
+            prompt, deps=deps, message_history=message_history
+        ) as run:
             async for node in run:
                 if Agent.is_model_request_node(node):
                     async with node.stream(run.ctx) as request_stream:
@@ -231,7 +192,7 @@ async def stream_assistant_run(
                                     for out in placed_events(event.delta.content_delta):
                                         yield out
                     if tail := placer.flush():
-                        yield _event("text", {"delta": tail})
+                        yield text_event(tail)
 
             # Fallback: blocks the model never placed still reach the user,
             # after the text.
@@ -243,22 +204,18 @@ async def stream_assistant_run(
             result = run.result
             assert result is not None
             _track_usage(deps, result.usage, model_provider, model_name)
-            yield _event(
-                "done",
-                {
-                    "message_history": seal_history(
-                        deps,
-                        ModelMessagesTypeAdapter.dump_json(
-                            result.all_messages()
-                        ).decode(),
-                    )
-                },
+            new_messages = ModelMessagesTypeAdapter.dump_python(
+                result.new_messages(), mode="json"
             )
+            # Persist only completed turns: a turn that errored mid-stream is
+            # never recorded, so replay history can't be poisoned by it.
+            await record_turn(recorder.parts, new_messages)
+            yield sse_event("done", {"thread_id": thread_id})
     except Exception:
         log.exception(
             "compass.assistant_error", organization_id=str(deps.organization_id)
         )
-        yield _event(
+        yield sse_event(
             "error",
             {"message": "The assistant hit an unexpected error. Try again."},
         )

--- a/server/polar/compass/auth.py
+++ b/server/polar/compass/auth.py
@@ -15,3 +15,11 @@ _CompassRead = Authenticator(
     allowed_subjects={User},
 )
 CompassRead = Annotated[AuthSubject[User], Depends(_CompassRead)]
+
+# Renaming or deleting a thread is a write, so it must not pass on a read-only
+# credential (an impersonation session holds read scopes only).
+_CompassWrite = Authenticator(
+    required_scopes={Scope.metrics_write},
+    allowed_subjects={User},
+)
+CompassWrite = Annotated[AuthSubject[User], Depends(_CompassWrite)]

--- a/server/polar/compass/endpoints.py
+++ b/server/polar/compass/endpoints.py
@@ -1,18 +1,30 @@
+from collections.abc import AsyncGenerator
 from datetime import datetime
+from typing import Annotated
 from zoneinfo import ZoneInfo
 
-from fastapi import Depends, Query, Request
+from fastapi import Depends, Path, Query, Request
+from pydantic import UUID4
 from pydantic_extra_types.timezone_name import TimeZoneName
 from sse_starlette.sse import EventSourceResponse
 
 from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
 from polar.exceptions import ResourceNotFound
+from polar.kit.db.postgres import AsyncSessionMaker
+from polar.kit.pagination import ListResource, PaginationParamsQuery
 from polar.kit.schemas import MultipleQueryFilter
+from polar.models import CompassThread
 from polar.openapi import APITag
 from polar.organization.repository import OrganizationRepository
 from polar.organization.schemas import OrganizationID
-from polar.postgres import AsyncReadSession, get_db_read_session
+from polar.postgres import (
+    AsyncReadSession,
+    AsyncSession,
+    get_db_read_session,
+    get_db_session,
+    get_db_sessionmaker,
+)
 from polar.redis import Redis, get_redis
 from polar.routing import APIRouter
 
@@ -20,11 +32,23 @@ from . import auth
 from .assistant.agent import build_assistant_agent
 from .assistant.deps import AssistantDeps
 from .assistant.schemas import AssistantChatRequest
-from .assistant.stream import stream_assistant_run
+from .assistant.stream import sse_event, stream_assistant_run
 from .schemas import Insight, InsightCategory
 from .service import compass as compass_service
+from .threads.schemas import (
+    CompassThreadSchema,
+    CompassThreadUpdate,
+    CompassThreadWithMessages,
+)
+from .threads.service import compass_thread as compass_thread_service
 
 router = APIRouter(prefix="/compass", tags=["compass", APITag.private])
+
+CompassThreadID = Annotated[UUID4, Path(description="The thread ID.")]
+CompassThreadNotFound = {
+    "description": "Thread not found.",
+    "model": ResourceNotFound.schema(),
+}
 
 
 @router.get("/insights", summary="List Insights", response_model=list[Insight])
@@ -59,6 +83,97 @@ async def list_insights(
     )
 
 
+@router.get(
+    "/threads",
+    summary="List Assistant Threads",
+    response_model=ListResource[CompassThreadSchema],
+)
+async def list_threads(
+    auth_subject: auth.CompassRead,
+    pagination: PaginationParamsQuery,
+    organization_id: OrganizationID = Query(
+        description="Organization whose threads to list."
+    ),
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> ListResource[CompassThreadSchema]:
+    """List the caller's assistant conversation threads, most recent first."""
+    results, count = await compass_thread_service.list(
+        session, auth_subject, organization_id=organization_id, pagination=pagination
+    )
+    return ListResource.from_paginated_results(
+        [CompassThreadSchema.model_validate(t) for t in results], count, pagination
+    )
+
+
+@router.get(
+    "/threads/{id}",
+    summary="Get Assistant Thread",
+    response_model=CompassThreadWithMessages,
+    responses={404: CompassThreadNotFound},
+)
+async def get_thread(
+    auth_subject: auth.CompassRead,
+    id: CompassThreadID,
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> CompassThreadWithMessages:
+    """Get a thread with its rendered messages, for rehydrating the UI."""
+    thread = await compass_thread_service.get(session, auth_subject, id)
+    if thread is None:
+        raise ResourceNotFound()
+    messages, has_more = await compass_thread_service.list_messages(session, thread)
+    return CompassThreadWithMessages.model_validate(
+        {
+            "id": thread.id,
+            "created_at": thread.created_at,
+            "modified_at": thread.modified_at,
+            "organization_id": thread.organization_id,
+            "title": thread.title,
+            "messages": messages,
+            "has_more": has_more,
+        }
+    )
+
+
+@router.patch(
+    "/threads/{id}",
+    summary="Update Assistant Thread",
+    response_model=CompassThreadSchema,
+    responses={404: CompassThreadNotFound},
+)
+async def update_thread(
+    auth_subject: auth.CompassWrite,
+    id: CompassThreadID,
+    body: CompassThreadUpdate,
+    session: AsyncSession = Depends(get_db_session),
+) -> CompassThread:
+    """Rename a thread."""
+    thread = await compass_thread_service.get(session, auth_subject, id)
+    if thread is None:
+        raise ResourceNotFound()
+    return await compass_thread_service.update(session, thread, body)
+
+
+@router.delete(
+    "/threads/{id}",
+    summary="Delete Assistant Thread",
+    status_code=204,
+    responses={
+        204: {"description": "Thread deleted."},
+        404: CompassThreadNotFound,
+    },
+)
+async def delete_thread(
+    auth_subject: auth.CompassWrite,
+    id: CompassThreadID,
+    session: AsyncSession = Depends(get_db_session),
+) -> None:
+    """Delete a thread and its conversation history."""
+    thread = await compass_thread_service.get(session, auth_subject, id)
+    if thread is None:
+        raise ResourceNotFound()
+    await compass_thread_service.delete(session, thread)
+
+
 @router.post(
     "/assistant",
     summary="Ask the Compass Assistant",
@@ -73,14 +188,17 @@ async def assistant_chat(
         description="Timezone used to resolve metric windows. Default is UTC.",
     ),
     session: AsyncReadSession = Depends(get_db_read_session),
+    # Write sessionmaker for turn persistence; the SSE generator outlives the
+    # request-scoped session, so tool calls open their own read sessions below.
+    write_sessionmaker: AsyncSessionMaker = Depends(get_db_sessionmaker),
     redis: Redis | None = Depends(get_redis),
 ) -> EventSourceResponse:
     """Stream one assistant turn as SSE: `text` deltas, renderable `block`
-    events, then `done` with opaque conversation state for the next turn.
+    events, then `thread` (new conversations) and `done` with the thread id.
 
     The agent runs under the caller's auth subject: its toolset is derived
     from the token's granted scopes, so a restricted token can only reach the
-    data those scopes allow.
+    data those scopes allow. Conversation state lives server-side on a thread.
     """
     org_ids = await get_accessible_org_ids(
         session, auth_subject, permission=OrganizationPermission.analytics_read
@@ -93,12 +211,34 @@ async def assistant_chat(
         raise ResourceNotFound()
 
     tz = ZoneInfo(timezone)
+    turn = await compass_thread_service.begin_turn(
+        session,
+        write_sessionmaker,
+        auth_subject,
+        organization_id=organization.id,
+        prompt=body.prompt,
+        thread_id=body.thread_id,
+        timezone=tz,
+    )
+    if turn is None:
+        raise ResourceNotFound()
+
     agent, model_provider, model_name = build_assistant_agent(auth_subject.scopes)
+    record_turn = compass_thread_service.turn_recorder(
+        write_sessionmaker, turn.thread.id, body.prompt
+    )
     # The request-scoped session closes when this handler returns, before the
     # response streams — the generator opens its own session for tool calls.
     read_sessionmaker = request.state.async_read_sessionmaker
 
-    async def event_stream():  # type: ignore[no-untyped-def]
+    async def event_stream() -> AsyncGenerator[dict[str, str]]:
+        if turn.is_new:
+            # Announced up-front so the client can point its URL at the
+            # thread before the first token arrives.
+            yield sse_event(
+                "thread",
+                {"thread_id": str(turn.thread.id), "title": turn.thread.title},
+            )
         async with read_sessionmaker() as stream_session:
             deps = AssistantDeps(
                 session=stream_session,
@@ -107,14 +247,17 @@ async def assistant_chat(
                 timezone=tz,
                 today=datetime.now(tz=tz).date(),
                 redis=redis,
+                history_last_at=turn.history_last_at,
             )
             async for event in stream_assistant_run(
                 agent,
                 deps,
                 body.prompt,
-                body.message_history,
+                turn.history,
                 model_provider=model_provider,
                 model_name=model_name,
+                record_turn=record_turn,
+                thread_id=str(turn.thread.id),
             ):
                 yield event
 

--- a/server/polar/compass/endpoints.py
+++ b/server/polar/compass/endpoints.py
@@ -36,9 +36,9 @@ from .assistant.stream import sse_event, stream_assistant_run
 from .schemas import Insight, InsightCategory
 from .service import compass as compass_service
 from .threads.schemas import (
+    CompassThreadMessageSchema,
     CompassThreadSchema,
     CompassThreadUpdate,
-    CompassThreadWithMessages,
 )
 from .threads.service import compass_thread as compass_thread_service
 
@@ -108,29 +108,49 @@ async def list_threads(
 @router.get(
     "/threads/{id}",
     summary="Get Assistant Thread",
-    response_model=CompassThreadWithMessages,
+    response_model=CompassThreadSchema,
     responses={404: CompassThreadNotFound},
 )
 async def get_thread(
     auth_subject: auth.CompassRead,
     id: CompassThreadID,
     session: AsyncReadSession = Depends(get_db_read_session),
-) -> CompassThreadWithMessages:
-    """Get a thread with its rendered messages, for rehydrating the UI."""
+) -> CompassThread:
+    """Get a thread. Its messages are fetched separately, page by page."""
     thread = await compass_thread_service.get(session, auth_subject, id)
     if thread is None:
         raise ResourceNotFound()
-    messages, has_more = await compass_thread_service.list_messages(session, thread)
-    return CompassThreadWithMessages.model_validate(
-        {
-            "id": thread.id,
-            "created_at": thread.created_at,
-            "modified_at": thread.modified_at,
-            "organization_id": thread.organization_id,
-            "title": thread.title,
-            "messages": messages,
-            "has_more": has_more,
-        }
+    return thread
+
+
+@router.get(
+    "/threads/{id}/messages",
+    summary="List Assistant Thread Messages",
+    response_model=ListResource[CompassThreadMessageSchema],
+    responses={404: CompassThreadNotFound},
+)
+async def list_thread_messages(
+    auth_subject: auth.CompassRead,
+    id: CompassThreadID,
+    pagination: PaginationParamsQuery,
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> ListResource[CompassThreadMessageSchema]:
+    """List a thread's turns, for rehydrating the UI.
+
+    Paged newest-first: page 1 is the tail of the conversation and higher
+    pages walk back through it. Within a page, turns read oldest-first the
+    way they're rendered.
+    """
+    thread = await compass_thread_service.get(session, auth_subject, id)
+    if thread is None:
+        raise ResourceNotFound()
+    messages, count = await compass_thread_service.list_messages(
+        session, thread, pagination=pagination
+    )
+    return ListResource.from_paginated_results(
+        [CompassThreadMessageSchema.model_validate(m) for m in messages],
+        count,
+        pagination,
     )
 
 

--- a/server/polar/rate_limit.py
+++ b/server/polar/rate_limit.py
@@ -256,6 +256,27 @@ _BASE_RULES: dict[str, Sequence[Rule]] = {
             zone="feedback-submit",
         ),
     ],
+    # Each call is an LLM run Polar pays for, so it's capped well below the
+    # catch-all. All groups listed — an unmatched one falls through to `api`.
+    "^/v1/compass/assistant": [
+        Rule(minute=60, hour=500, zone="compass-assistant"),
+        Rule(group=RateLimitGroup.web, minute=60, hour=500, zone="compass-assistant"),
+        Rule(
+            group=RateLimitGroup.elevated, minute=60, hour=500, zone="compass-assistant"
+        ),
+        Rule(
+            group=RateLimitGroup.restricted,
+            minute=60,
+            hour=500,
+            zone="compass-assistant",
+        ),
+        Rule(
+            group=RateLimitGroup.pending_auth,
+            minute=60,
+            hour=500,
+            zone="compass-assistant",
+        ),
+    ],
 }
 
 _SANDBOX_RULES: dict[str, Sequence[Rule]] = {

--- a/server/tests/compass/test_assistant.py
+++ b/server/tests/compass/test_assistant.py
@@ -578,3 +578,66 @@ class TestPartsRecorder:
             {"kind": "block", "block": {"type": "text", "text": "block"}},
             {"kind": "text", "text": "After"},
         ]
+
+
+class _FinishedRun:
+    """A run whose model has already completed, producing no nodes."""
+
+    def __init__(self) -> None:
+        self.ctx = None
+        self.result = SimpleNamespace(usage=SimpleNamespace(), new_messages=list)
+
+    def __aiter__(self) -> "_FinishedRun":
+        return self
+
+    async def __anext__(self) -> Any:
+        raise StopAsyncIteration
+
+    async def __aenter__(self) -> "_FinishedRun":
+        return self
+
+    async def __aexit__(self, *args: Any) -> bool:
+        return False
+
+
+class _FinishedAgent:
+    def iter(self, prompt: str, **kwargs: Any) -> _FinishedRun:
+        return _FinishedRun()
+
+
+@pytest.mark.asyncio
+class TestStreamAssistantRun:
+    async def test_completed_turn_is_persisted_before_the_client_can_drop(
+        self,
+    ) -> None:
+        """A disconnect parks the generator at a yield and closes it. Any yield
+        between the model finishing and the write would lose the whole turn."""
+        from polar.compass.assistant.stream import stream_assistant_run
+
+        deps = _deps(set(Scope))
+        deps.emit(TextBlock(text="unplaced"))
+        recorded: list[list[dict[str, Any]]] = []
+
+        async def record_turn(
+            parts: list[dict[str, Any]], model_messages: list[dict[str, Any]]
+        ) -> None:
+            recorded.append(parts)
+
+        stream = stream_assistant_run(
+            _FinishedAgent(),  # type: ignore[arg-type]
+            deps,
+            "hi",
+            None,
+            model_provider="openai",
+            model_name="gpt-5.5",
+            record_turn=record_turn,
+            thread_id=str(uuid.uuid4()),
+        )
+
+        # The client takes one event, then goes away mid-stream.
+        await anext(stream)
+        await stream.aclose()
+
+        assert recorded == [
+            [{"kind": "block", "block": {"type": "text", "text": "unplaced"}}]
+        ]

--- a/server/tests/compass/test_assistant.py
+++ b/server/tests/compass/test_assistant.py
@@ -555,48 +555,26 @@ class TestBlockPlacer:
         assert placer.flush() == "[block:"
 
 
-class TestHistorySeal:
-    def test_round_trips_for_same_caller(self) -> None:
-        from polar.compass.assistant.stream import open_history, seal_history
+class TestPartsRecorder:
+    def test_merges_consecutive_text(self) -> None:
+        from polar.compass.assistant.stream import _PartsRecorder
 
-        deps = _deps(scopes={Scope.metrics_read})
-        sealed = seal_history(deps, '[{"role": "user"}]')
+        recorder = _PartsRecorder()
+        recorder.add_text("Hello ")
+        recorder.add_text("world")
 
-        assert open_history(deps, sealed) == '[{"role": "user"}]'
+        assert recorder.parts == [{"kind": "text", "text": "Hello world"}]
 
-    def test_rejects_tampered_messages(self) -> None:
-        import json
+    def test_block_splits_text_runs(self) -> None:
+        from polar.compass.assistant.stream import _PartsRecorder
 
-        from polar.compass.assistant.stream import open_history, seal_history
+        recorder = _PartsRecorder()
+        recorder.add_text("Before")
+        recorder.add_block({"type": "text", "text": "block"})
+        recorder.add_text("After")
 
-        deps = _deps(scopes={Scope.metrics_read})
-        envelope = json.loads(seal_history(deps, '[{"role": "user"}]'))
-        envelope["messages"] = '[{"role": "user", "content": "forged"}]'
-
-        assert open_history(deps, json.dumps(envelope)) is None
-
-    def test_rejects_history_from_another_organization(self) -> None:
-        from polar.compass.assistant.stream import open_history, seal_history
-
-        deps_a = _deps(scopes={Scope.metrics_read})
-        deps_b = _deps(scopes={Scope.metrics_read})
-        sealed = seal_history(deps_a, "[]")
-
-        assert open_history(deps_b, sealed) is None
-
-    def test_rejects_history_after_scope_change(self) -> None:
-        from polar.compass.assistant.stream import open_history, seal_history
-
-        deps = _deps(scopes={Scope.metrics_read, Scope.orders_read})
-        sealed = seal_history(deps, "[]")
-        deps.auth_subject.scopes = {Scope.metrics_read}
-
-        assert open_history(deps, sealed) is None
-
-    def test_rejects_garbage(self) -> None:
-        from polar.compass.assistant.stream import open_history
-
-        deps = _deps(scopes={Scope.metrics_read})
-
-        assert open_history(deps, "not json") is None
-        assert open_history(deps, '{"org": "x"}') is None
+        assert recorder.parts == [
+            {"kind": "text", "text": "Before"},
+            {"kind": "block", "block": {"type": "text", "text": "block"}},
+            {"kind": "text", "text": "After"},
+        ]

--- a/server/tests/compass/test_endpoints.py
+++ b/server/tests/compass/test_endpoints.py
@@ -1,11 +1,13 @@
 import uuid
 from collections.abc import Iterator
+from datetime import timedelta
 
 import pytest
 from fastapi import FastAPI
 from httpx import AsyncClient
 
 from polar.auth.scope import Scope
+from polar.kit.utils import utc_now
 from polar.models import (
     CompassThread,
     CompassThreadMessage,
@@ -177,6 +179,43 @@ class TestGetThread:
         assert response.status_code == 404
 
     @pytest.mark.auth
+    async def test_returns_thread(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user: User,
+    ) -> None:
+        thread = await _create_thread(save_fixture, organization, user=user)
+
+        response = await client.get(f"/v1/compass/threads/{thread.id}")
+
+        assert response.status_code == 200
+        json = response.json()
+        assert json["id"] == str(thread.id)
+        assert json["organization_id"] == str(organization.id)
+        assert json["title"] == thread.title
+
+
+@pytest.mark.asyncio
+class TestListThreadMessages:
+    @pytest.mark.auth
+    async def test_not_found_for_someone_elses_thread(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user_second: User,
+    ) -> None:
+        thread = await _create_thread(save_fixture, organization, user=user_second)
+
+        response = await client.get(f"/v1/compass/threads/{thread.id}/messages")
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth
     async def test_returns_messages_with_parts(
         self,
         client: AsyncClient,
@@ -195,17 +234,47 @@ class TestGetThread:
             )
         )
 
-        response = await client.get(f"/v1/compass/threads/{thread.id}")
+        response = await client.get(f"/v1/compass/threads/{thread.id}/messages")
 
         assert response.status_code == 200
         json = response.json()
-        assert json["id"] == str(thread.id)
-        assert len(json["messages"]) == 1
-        message = json["messages"][0]
+        assert json["pagination"]["total_count"] == 1
+        message = json["items"][0]
         assert message["prompt"] == "How is my MRR?"
         assert message["parts"] == [{"kind": "text", "text": "MRR is up 12%."}]
-        assert json["has_more"] is False
         assert "model_messages" not in message
+
+    @pytest.mark.auth
+    async def test_first_page_is_the_most_recent_turns(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user: User,
+    ) -> None:
+        thread = await _create_thread(save_fixture, organization, user=user)
+        now = utc_now()
+        for turn in range(5):
+            await save_fixture(
+                CompassThreadMessage(
+                    thread=thread,
+                    prompt=f"q{turn}",
+                    parts=[],
+                    model_messages=[],
+                    created_at=now + timedelta(seconds=turn),
+                )
+            )
+
+        response = await client.get(
+            f"/v1/compass/threads/{thread.id}/messages",
+            params={"page": 1, "limit": 2},
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+        assert [item["prompt"] for item in json["items"]] == ["q3", "q4"]
+        assert json["pagination"]["total_count"] == 5
 
 
 @pytest.mark.asyncio

--- a/server/tests/compass/test_endpoints.py
+++ b/server/tests/compass/test_endpoints.py
@@ -1,14 +1,52 @@
 import uuid
+from collections.abc import Iterator
 
 import pytest
+from fastapi import FastAPI
 from httpx import AsyncClient
 
-from polar.models import Organization, UserOrganization
+from polar.auth.scope import Scope
+from polar.models import (
+    CompassThread,
+    CompassThreadMessage,
+    Organization,
+    User,
+    UserOrganization,
+)
+from polar.postgres import get_db_sessionmaker
+from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
+
+
+async def _create_thread(
+    save_fixture: SaveFixture,
+    organization: Organization,
+    *,
+    user: User,
+    title: str = "Thread",
+) -> CompassThread:
+    thread = CompassThread(
+        organization_id=organization.id,
+        user_id=user.id,
+        title=title,
+    )
+    await save_fixture(thread)
+    return thread
 
 
 @pytest.mark.asyncio
 class TestAssistantChat:
+    @pytest.fixture(autouse=True)
+    def stub_sessionmakers(self, app: FastAPI) -> Iterator[None]:
+        # The chat endpoint depends on the write sessionmaker, which the test
+        # harness doesn't provide. Every scenario here 4xxs before it is used,
+        # so a stub override is enough to let the dependency resolve.
+        app.dependency_overrides[get_db_sessionmaker] = lambda: None
+        try:
+            yield
+        finally:
+            app.dependency_overrides.pop(get_db_sessionmaker)
+
     async def test_anonymous(
         self, client: AsyncClient, organization: Organization
     ) -> None:
@@ -45,3 +83,232 @@ class TestAssistantChat:
         )
 
         assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_someone_elses_thread(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user_second: User,
+    ) -> None:
+        organization.feature_settings = {"compass_enabled": True}
+        await save_fixture(organization)
+        thread = await _create_thread(save_fixture, organization, user=user_second)
+
+        response = await client.post(
+            "/v1/compass/assistant",
+            json={
+                "organization_id": str(organization.id),
+                "prompt": "hi",
+                "thread_id": str(thread.id),
+            },
+        )
+
+        assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestListThreads:
+    async def test_anonymous(
+        self, client: AsyncClient, organization: Organization
+    ) -> None:
+        response = await client.get(
+            "/v1/compass/threads",
+            params={"organization_id": str(organization.id)},
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_lists_only_own_threads(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user: User,
+        user_second: User,
+    ) -> None:
+        mine = await _create_thread(save_fixture, organization, user=user, title="Mine")
+        await _create_thread(save_fixture, organization, user=user_second)
+
+        response = await client.get(
+            "/v1/compass/threads",
+            params={"organization_id": str(organization.id)},
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+        assert json["pagination"]["total_count"] == 1
+        assert json["items"][0]["id"] == str(mine.id)
+        assert json["items"][0]["title"] == "Mine"
+
+    @pytest.mark.auth(AuthSubjectFixture(subject="organization"))
+    async def test_organization_token_is_rejected(
+        self, client: AsyncClient, organization: Organization
+    ) -> None:
+        """A thread belongs to a user, so an organization token has none to
+        list."""
+        response = await client.get(
+            "/v1/compass/threads",
+            params={"organization_id": str(organization.id)},
+        )
+
+        assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+class TestGetThread:
+    @pytest.mark.auth
+    async def test_not_found_for_someone_elses_thread(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user_second: User,
+    ) -> None:
+        thread = await _create_thread(save_fixture, organization, user=user_second)
+
+        response = await client.get(f"/v1/compass/threads/{thread.id}")
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_returns_messages_with_parts(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user: User,
+    ) -> None:
+        thread = await _create_thread(save_fixture, organization, user=user)
+        await save_fixture(
+            CompassThreadMessage(
+                thread=thread,
+                prompt="How is my MRR?",
+                parts=[{"kind": "text", "text": "MRR is up 12%."}],
+                model_messages=[],
+            )
+        )
+
+        response = await client.get(f"/v1/compass/threads/{thread.id}")
+
+        assert response.status_code == 200
+        json = response.json()
+        assert json["id"] == str(thread.id)
+        assert len(json["messages"]) == 1
+        message = json["messages"][0]
+        assert message["prompt"] == "How is my MRR?"
+        assert message["parts"] == [{"kind": "text", "text": "MRR is up 12%."}]
+        assert json["has_more"] is False
+        assert "model_messages" not in message
+
+
+@pytest.mark.asyncio
+class TestUpdateThread:
+    @pytest.mark.auth
+    async def test_rename(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user: User,
+    ) -> None:
+        thread = await _create_thread(save_fixture, organization, user=user)
+
+        response = await client.patch(
+            f"/v1/compass/threads/{thread.id}",
+            json={"title": "Churn investigation"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["title"] == "Churn investigation"
+
+    @pytest.mark.auth
+    async def test_not_found_for_someone_elses_thread(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user_second: User,
+    ) -> None:
+        thread = await _create_thread(save_fixture, organization, user=user_second)
+
+        response = await client.patch(
+            f"/v1/compass/threads/{thread.id}", json={"title": "Hijacked"}
+        )
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.metrics_read}))
+    async def test_read_only_token_cannot_rename(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user: User,
+    ) -> None:
+        thread = await _create_thread(save_fixture, organization, user=user)
+
+        response = await client.patch(
+            f"/v1/compass/threads/{thread.id}", json={"title": "Renamed"}
+        )
+
+        assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+class TestDeleteThread:
+    @pytest.mark.auth
+    async def test_deleted_thread_disappears(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user: User,
+    ) -> None:
+        thread = await _create_thread(save_fixture, organization, user=user)
+
+        response = await client.delete(f"/v1/compass/threads/{thread.id}")
+        assert response.status_code == 204
+
+        response = await client.get(f"/v1/compass/threads/{thread.id}")
+        assert response.status_code == 404
+
+    @pytest.mark.auth
+    async def test_not_found_for_someone_elses_thread(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user_second: User,
+    ) -> None:
+        thread = await _create_thread(save_fixture, organization, user=user_second)
+
+        response = await client.delete(f"/v1/compass/threads/{thread.id}")
+
+        assert response.status_code == 404
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.metrics_read}))
+    async def test_read_only_token_cannot_delete(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        user: User,
+    ) -> None:
+        thread = await _create_thread(save_fixture, organization, user=user)
+
+        response = await client.delete(f"/v1/compass/threads/{thread.id}")
+
+        assert response.status_code == 403

--- a/server/tests/test_rate_limit.py
+++ b/server/tests/test_rate_limit.py
@@ -302,3 +302,22 @@ class TestEmailUpdateZone:
         rule = _select_rule(rules, path, group)
         assert rule is not None
         assert rule.zone == "email-update"
+
+
+@pytest.mark.parametrize("rules", [_PRODUCTION_RULES, _SANDBOX_RULES])
+@pytest.mark.parametrize("group", list(RateLimitGroup))
+class TestCompassAssistantZone:
+    """Every call costs an LLM run, so no caller may reach the catch-all "api"
+    zone. Rules are selected by exact group match and an unmatched group falls
+    through rather than being denied, so every group needs its own rule."""
+
+    def test_resolves_to_compass_zone(
+        self, rules: dict[str, Sequence[Rule]], group: RateLimitGroup
+    ) -> None:
+        rule = _select_rule(rules, "/v1/compass/assistant", group)
+
+        assert rule is not None, f"No rule selected for group={group.value!r}"
+        assert rule.zone == "compass-assistant", (
+            f"Group {group.value!r} resolved to zone {rule.zone!r} — it would "
+            f"fall through to the catch-all allowance"
+        )


### PR DESCRIPTION
PR 2 of 3 in the threads to compass POC

For more context, see the draft https://github.com/polarsource/polar/pull/13550


Replaces current conversation blob solkution with a server-side thread. Now clients sends a thread_id, the endpoint loads history from the thread, records the completed turn, and emits the thread id back. The scope logic is rethought since we now persist the data server side

Stacked on the persistence PR, nothing calls this yet, the frontend lands in the follow-up.

PR 1:  https://github.com/polarsource/polar/pull/13568


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

