### PR TITLE
feat: merchant-migration card transfer checklist UI

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/MigrationStepper.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/MigrationStepper.tsx
@@ -1,12 +1,8 @@
 import { schemas } from '@polar-sh/client'
 import { Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
-import { Check, Circle } from 'lucide-react'
+import { STATE_COLORS, STATE_LABELS, StepMarker, StepState } from './stepMarker'
 import { currentPosition, MIGRATION_STEPS } from './steps'
-
-type StepState = 'done' | 'current' | 'upcoming'
-
-const MARKER_SIZE = 16
 
 // One derived control: every segment carries the same 2px top track, and the
 // filled length of that track is the only dimension encoding progress. Position
@@ -33,33 +29,8 @@ export function MigrationStepper({
   )
 }
 
-function Marker({ state }: { state: StepState }) {
-  if (state === 'done') {
-    return <Check size={MARKER_SIZE} strokeWidth={2.5} aria-hidden="true" />
-  }
-  return (
-    <Circle
-      size={MARKER_SIZE}
-      fill={state === 'current' ? 'currentColor' : 'none'}
-      aria-hidden="true"
-    />
-  )
-}
-
-const STATE_LABELS: Record<StepState, string> = {
-  done: 'completed',
-  current: 'current step',
-  upcoming: 'not started',
-}
-
 function Segment({ label, state }: { label: string; state: StepState }) {
   const reached = state !== 'upcoming'
-  const color =
-    state === 'current'
-      ? 'text-accent'
-      : state === 'done'
-        ? 'text-secondary'
-        : 'text-tertiary'
   return (
     <Box
       as="li"
@@ -75,9 +46,9 @@ function Segment({ label, state }: { label: string; state: StepState }) {
       borderStyle="solid"
       borderColor={reached ? 'border-primary' : 'border-secondary'}
     >
-      <Box alignItems="center" columnGap="xs" color={color}>
-        <Marker state={state} />
-        <Text variant="caption" color="inherit" truncate>
+      <Box alignItems="center" columnGap="xs">
+        <StepMarker state={state} />
+        <Text variant="caption" color={STATE_COLORS[state]} truncate>
           {label}
         </Text>
       </Box>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/[id]/MigrationDetailPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/[id]/MigrationDetailPage.tsx
@@ -7,6 +7,8 @@ import { Alert, Spinner, Status, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { ChevronLeft } from 'lucide-react'
 import Link from 'next/link'
+import { PanTransferPanel } from '../cards/PanTransferPanel'
+import { StartPanTransfer } from '../cards/StartPanTransfer'
 import { MigrationStepper } from '../MigrationStepper'
 import { PrecheckPanel } from '../PrecheckPanel'
 import { ReviewTable } from '../review/ReviewTable'
@@ -125,7 +127,25 @@ function StepContent({
   }
   // `steps.ts` owns which backend steps the assessment covers.
   if (def?.key === 'assessment') {
-    return <ReviewTable migrationId={migration.id} />
+    return (
+      <Box flexDirection="column" rowGap="xl">
+        <ReviewTable migrationId={migration.id} />
+        {/* Gated on the catalog existing, since the cards are verified
+            against it. Moving on stays the merchant's call. */}
+        {migration.step === 'create_catalog' && (
+          <StartPanTransfer migrationId={migration.id} />
+        )}
+      </Box>
+    )
+  }
+
+  if (def?.key === 'cards') {
+    return (
+      <Box flexDirection="column" rowGap="l">
+        <StepHeading def={def} />
+        <PanTransferPanel migrationId={migration.id} />
+      </Box>
+    )
   }
 
   return (

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferPanel.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferPanel.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import { usePanTransfer } from '@/hooks/queries/merchantMigrations'
+import { schemas } from '@polar-sh/client'
+import { Alert, Spinner, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { PanTransferStepItem } from './PanTransferStepItem'
+
+const METHOD_INTRO: Record<schemas['PanTransferMethod'], string> = {
+  pan_copy:
+    "Stripe copies your customers' saved cards onto Polar's Stripe account. Nothing changes for your customers.",
+  pan_import:
+    "Your provider sends the saved cards to Stripe, and Stripe imports them onto Polar's account. This runs over a few weeks.",
+}
+
+export function PanTransferPanel({ migrationId }: { migrationId: string }) {
+  const { data: checklist, isLoading, isError } = usePanTransfer(migrationId)
+
+  if (isLoading) {
+    return (
+      <Box padding="2xl" alignItems="center" justifyContent="center">
+        <Spinner />
+      </Box>
+    )
+  }
+
+  if (isError || !checklist) {
+    return (
+      <Alert
+        variant="danger"
+        title="We couldn't load the card transfer"
+        description="Something went wrong. Please refresh and try again."
+      />
+    )
+  }
+
+  if (!checklist.started) {
+    return (
+      <Text variant="caption" color="muted">
+        The card transfer hasn&apos;t started yet.
+      </Text>
+    )
+  }
+
+  const done = checklist.steps.filter(
+    (step) => step.status === 'completed',
+  ).length
+  // Off the steps, not a null `current_step_key`: a checklist stuck with
+  // nothing actionable would report that too.
+  const finished = done === checklist.steps.length
+
+  return (
+    <Box flexDirection="column" rowGap="xl">
+      {finished ? (
+        <Alert
+          variant="success"
+          title="Every step is done"
+          description="Your customers' cards are on Polar and their subscriptions have moved over."
+        />
+      ) : (
+        <Box flexDirection="column" rowGap="xs">
+          <Text variant="caption" color="muted">
+            {METHOD_INTRO[checklist.method]}
+          </Text>
+          <Text variant="caption" color="muted">
+            {done} of {checklist.steps.length} steps done
+          </Text>
+        </Box>
+      )}
+
+      <Box as="ol" flexDirection="column" rowGap="xl">
+        {checklist.steps.map((step) => (
+          <PanTransferStepItem
+            // Migration-scoped: another migration lands on the same step key,
+            // and a bare key would keep its unsaved form values alive.
+            key={`${migrationId}:${step.key}`}
+            step={step}
+            current={step.key === checklist.current_step_key}
+            destinationAccountId={checklist.destination_account_id}
+            migrationId={migrationId}
+          />
+        ))}
+      </Box>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepBody.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepBody.tsx
@@ -1,0 +1,114 @@
+'use client'
+
+import { schemas } from '@polar-sh/client'
+import { Alert, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import CopyToClipboardInput from '@polar-sh/ui/components/atoms/CopyToClipboardInput'
+import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
+import { StepCopy } from './panTransferCopy'
+import { PanTransferStepForm } from './PanTransferStepForm'
+
+interface Props {
+  step: schemas['PanTransferStep']
+  copy: StepCopy
+  destinationAccountId: string | null
+  migrationId: string
+}
+
+export function PanTransferStepBody({
+  step,
+  copy,
+  destinationAccountId,
+  migrationId,
+}: Props) {
+  const submittable = step.owner === 'merchant' && step.kind !== 'auto'
+  // A newer backend: submitting would 422 on a field we never rendered, because
+  // the accepted-input contract isn't on the wire.
+  const fieldsUnknown = step.kind === 'input' && !copy.inputs?.length
+
+  return (
+    <Box flexDirection="column" rowGap="l">
+      <Text variant="caption" color="muted">
+        {copy.description}
+      </Text>
+
+      {copy.showsDestinationAccount &&
+        (destinationAccountId ? (
+          <Box flexDirection="column" rowGap="xs" maxWidth={380}>
+            <Text variant="caption" color="muted">
+              Polar account ID
+            </Text>
+            <CopyToClipboardInput value={destinationAccountId} variant="mono" />
+          </Box>
+        ) : (
+          // The guidance below says to paste an ID we would not be showing.
+          <Alert
+            variant="danger"
+            title="We can't show the Polar account ID right now"
+            description="Please contact support before you start the copy in Stripe."
+          />
+        ))}
+
+      {copy.guidance && (
+        <Box as="ol" flexDirection="column" rowGap="xs">
+          {copy.guidance.map((line, index) => (
+            <Box as="li" key={index} display="flex" columnGap="s">
+              {/* The list marker is reset away, so spell the order out. */}
+              <Text variant="caption" color="muted" tabularNums>
+                {index + 1}.
+              </Text>
+              <Text variant="caption" color="muted">
+                {line}
+              </Text>
+            </Box>
+          ))}
+        </Box>
+      )}
+
+      {copy.warning && <Alert variant="warning" title={copy.warning} />}
+
+      <OpsUpdate step={step} />
+
+      {submittable &&
+        (fieldsUnknown || !copy.action ? (
+          <Text variant="caption" color="muted">
+            This step needs a newer version of this page. Please refresh.
+          </Text>
+        ) : (
+          <PanTransferStepForm
+            copy={copy}
+            migrationId={migrationId}
+            stepKey={step.key}
+          />
+        ))}
+    </Box>
+  )
+}
+
+export function OpsUpdate({ step }: { step: schemas['PanTransferStep'] }) {
+  if (!step.note && !step.expected_at) {
+    return null
+  }
+
+  return (
+    <Box
+      flexDirection="column"
+      rowGap="xs"
+      padding="l"
+      borderRadius="m"
+      backgroundColor="background-secondary"
+    >
+      {/* Prose wraps on its own; a pasted link does not. */}
+      {step.note && (
+        <Box overflowX="auto" maxWidth="100%">
+          <Text variant="caption">{step.note}</Text>
+        </Box>
+      )}
+      {step.expected_at && (
+        <Text variant="caption" color="muted">
+          Expected by <FormattedDateTime datetime={step.expected_at} />
+        </Text>
+      )}
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepForm.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepForm.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { useCompletePanTransferStep } from '@/hooks/queries/merchantMigrations'
+import { Button, Input, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { useState } from 'react'
+import { StepCopy } from './panTransferCopy'
+
+interface Props {
+  copy: StepCopy
+  migrationId: string
+  stepKey: string
+}
+
+// The mutation lives here, not in the panel, so a failure stays attached to the
+// step that caused it. A shared one keeps showing the last error after a
+// refetch moves the checklist on.
+export function PanTransferStepForm({ copy, migrationId, stepKey }: Props) {
+  const complete = useCompletePanTransferStep(migrationId)
+  const [values, setValues] = useState<Record<string, string>>({})
+  const fields = copy.inputs ?? []
+  const missingRequired = fields.some(
+    (field) => field.required && !values[field.name]?.trim(),
+  )
+
+  return (
+    <Box
+      as="form"
+      flexDirection="column"
+      rowGap="m"
+      onSubmit={(event) => {
+        event.preventDefault()
+        complete.mutate({ key: stepKey, inputs: values })
+      }}
+    >
+      {fields.map((field) => (
+        <Box key={field.name} flexDirection="column" rowGap="xs" maxWidth={380}>
+          <Text as="label" htmlFor={field.name} variant="caption" color="muted">
+            {field.label}
+            {field.required ? '' : ' (optional)'}
+          </Text>
+          <Input
+            id={field.name}
+            value={values[field.name] ?? ''}
+            placeholder={field.placeholder}
+            onChange={(event) =>
+              setValues((current) => ({
+                ...current,
+                [field.name]: event.target.value,
+              }))
+            }
+          />
+        </Box>
+      ))}
+
+      {complete.error && (
+        <Text variant="caption" color="danger" role="alert">
+          {complete.error.message}
+        </Text>
+      )}
+
+      <Box>
+        <Button
+          type="submit"
+          size="sm"
+          disabled={complete.isPending || missingRequired}
+        >
+          {complete.isPending ? 'Saving…' : copy.action}
+        </Button>
+      </Box>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepItem.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/PanTransferStepItem.tsx
@@ -1,0 +1,122 @@
+'use client'
+
+import { schemas } from '@polar-sh/client'
+import { Status, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
+import {
+  ownerLabel,
+  STEP_COPY,
+  StepInputField,
+  waitingLabel,
+} from './panTransferCopy'
+import { OpsUpdate, PanTransferStepBody } from './PanTransferStepBody'
+import { STATE_LABELS, StepMarker, StepState } from '../stepMarker'
+
+interface Props {
+  step: schemas['PanTransferStep']
+  current: boolean
+  destinationAccountId: string | null
+  migrationId: string
+}
+
+export function PanTransferStepItem({
+  step,
+  current,
+  destinationAccountId,
+  migrationId,
+}: Props) {
+  const copy = STEP_COPY[step.key]
+  // Keep the row on an unknown key so the count and order still line up.
+  const title = copy?.title ?? step.key
+  const done = step.status === 'completed'
+  const state: StepState = done ? 'done' : current ? 'current' : 'upcoming'
+
+  return (
+    <Box
+      as="li"
+      display="flex"
+      columnGap="m"
+      alignItems="start"
+      aria-current={current ? 'step' : undefined}
+    >
+      <Box role="img" aria-label={STATE_LABELS[state]} paddingTop="xs">
+        <StepMarker state={state} />
+      </Box>
+
+      <Box flex={1} minWidth={0} flexDirection="column" rowGap="m">
+        <Box alignItems="center" columnGap="s" flexWrap="wrap">
+          <Text
+            variant={current ? 'label' : 'caption'}
+            color={current ? 'default' : 'muted'}
+          >
+            {title}
+          </Text>
+          {current ? (
+            <Status
+              status={waitingLabel(step.owner)}
+              color={step.owner === 'merchant' ? 'blue' : 'gray'}
+              size="small"
+            />
+          ) : (
+            !done && (
+              <Text variant="caption" color="muted">
+                {ownerLabel(step.owner)}
+              </Text>
+            )
+          )}
+        </Box>
+
+        {done && <CompletedSummary step={step} fields={copy?.inputs ?? []} />}
+
+        {/* Ops can annotate a step before it comes up; the current one gets
+            its update from the body instead. */}
+        {!done && !current && <OpsUpdate step={step} />}
+
+        {current &&
+          (copy ? (
+            <PanTransferStepBody
+              step={step}
+              copy={copy}
+              destinationAccountId={destinationAccountId}
+              migrationId={migrationId}
+            />
+          ) : (
+            <Text variant="caption" color="muted">
+              This step needs a newer version of this page. Please refresh.
+            </Text>
+          ))}
+      </Box>
+    </Box>
+  )
+}
+
+// The merchant may need to quote a reference back to their provider weeks
+// later, so it outlives the open step.
+function CompletedSummary({
+  step,
+  fields,
+}: {
+  step: schemas['PanTransferStep']
+  fields: StepInputField[]
+}) {
+  const entered = fields.filter((field) => step.inputs[field.name])
+
+  return (
+    <Box flexDirection="column" rowGap="xs">
+      {step.completed_at && (
+        <Text variant="caption" color="muted">
+          Done on <FormattedDateTime datetime={step.completed_at} />
+        </Text>
+      )}
+      {/* Scroll rather than clip: the value has to stay readable in full. */}
+      {entered.map((field) => (
+        <Box key={field.name} overflowX="auto" maxWidth="100%">
+          <Text variant="caption" color="muted" wrap="nowrap">
+            {field.label}: {step.inputs[field.name]}
+          </Text>
+        </Box>
+      ))}
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/StartPanTransfer.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/StartPanTransfer.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useStartPanTransfer } from '@/hooks/queries/merchantMigrations'
+import { Button, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+
+export function StartPanTransfer({ migrationId }: { migrationId: string }) {
+  const start = useStartPanTransfer(migrationId)
+
+  return (
+    <Box
+      flexDirection="column"
+      rowGap="m"
+      padding="xl"
+      borderRadius="l"
+      borderWidth={1}
+      borderStyle="solid"
+      borderColor="border-primary"
+      backgroundColor="background-card"
+    >
+      <Text variant="heading-xs" as="h3">
+        Move saved cards
+      </Text>
+      <Text variant="caption" color="muted">
+        Your catalog is imported. Next we move the cards your customers already
+        saved, so Polar can charge them. This is a checklist you can leave and
+        come back to. You can still import more records until you start.
+      </Text>
+
+      {start.error && (
+        <Text variant="caption" color="danger" role="alert">
+          {start.error.message}
+        </Text>
+      )}
+
+      <Box>
+        {/* In-flight only. Disabling on success strands the merchant if the
+            refetch that unmounts this card never lands; a second click is
+            merely a recoverable "already started". */}
+        <Button
+          size="sm"
+          onClick={() => start.mutate()}
+          disabled={start.isPending}
+        >
+          {start.isPending ? 'Starting…' : 'Start moving cards'}
+        </Button>
+      </Box>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/cards/panTransferCopy.ts
@@ -1,0 +1,177 @@
+import { schemas } from '@polar-sh/client'
+
+// The backend checklist stores state only. All wording lives here, keyed by
+// step key, so we can reword a step without a data migration.
+
+export interface StepInputField {
+  name: string
+  label: string
+  placeholder?: string
+  required: boolean
+}
+
+export interface StepCopy {
+  title: string
+  description: string
+  guidance?: string[]
+  warning?: string
+  inputs?: StepInputField[]
+  action?: string
+  showsDestinationAccount?: boolean
+}
+
+export const STEP_COPY: Record<string, StepCopy> = {
+  share_destination_account: {
+    title: 'Get the Polar account ID',
+    description:
+      'This is the Stripe account your cards move into. You need it for the next step.',
+  },
+  start_copy: {
+    title: 'Start the copy in Stripe',
+    description: 'Ask Stripe to copy your saved cards over to Polar.',
+    guidance: [
+      'Open your Stripe Dashboard and go to Customers.',
+      'Click Copy customers, then pick a copy method.',
+      'Paste the Polar account ID above as the recipient.',
+      'Confirm the copy.',
+    ],
+    warning:
+      'Only the account owner can start a copy. Wallet cards, Bacs and old SEPA mandates do not copy.',
+    inputs: [
+      {
+        name: 'stripe_migration_request_id',
+        label: 'Stripe request ID',
+        placeholder: 'From the Stripe copy status page',
+        required: false,
+      },
+    ],
+    action: 'I started the copy',
+    showsDestinationAccount: true,
+  },
+  authorize_copy: {
+    title: 'Polar accepts the copy',
+    description:
+      'We accept the incoming copy on our Stripe account. This usually takes one business day.',
+  },
+  stripe_copy: {
+    title: 'Stripe copies the cards',
+    description:
+      'Stripe moves the card data. This takes a few hours, and up to 72 hours.',
+  },
+  open_stripe_request: {
+    title: 'Polar opens the Stripe request',
+    description:
+      'We open a migration request with Stripe and share our PCI documents.',
+    // Ops fills this in, but the merchant is the one who has to quote it to
+    // their provider on the next step, so it has to stay readable afterwards.
+    inputs: [
+      {
+        name: 'stripe_migration_request_id',
+        label: 'Stripe request ID',
+        required: true,
+      },
+    ],
+  },
+  request_provider_export: {
+    title: 'Ask your provider for the card export',
+    description:
+      'Your provider sends the encrypted card data to Stripe. Only you can ask them for it.',
+    guidance: [
+      'Open a ticket with your provider and ask for a PCI card data migration to Stripe.',
+      'Give them the Stripe recipient details from our migration request.',
+      'Ask them to include the network transaction IDs and the full billing address.',
+    ],
+    warning:
+      'Most providers allow only two exports. Keep the second one for the cutover.',
+    inputs: [
+      {
+        name: 'provider_reference',
+        label: 'Ticket or request reference',
+        placeholder: 'The reference your provider gave you',
+        required: true,
+      },
+      {
+        name: 'provider_contact',
+        label: 'Contact at your provider',
+        placeholder: 'Email address',
+        required: false,
+      },
+    ],
+    action: 'I asked my provider',
+  },
+  provider_export: {
+    title: 'Your provider prepares the export',
+    description:
+      'This takes around two weeks. Your provider sends the encrypted file straight to Stripe.',
+  },
+  map_customers: {
+    title: 'Polar maps your customers',
+    description:
+      'We send Stripe a map of your old customer IDs, so every card lands on the right customer.',
+  },
+  stripe_review: {
+    title: 'Stripe reviews the file',
+    description:
+      'Stripe checks the file and sends back a summary. Errors come back here if something needs fixing.',
+  },
+  approve_import: {
+    title: 'Polar approves the import',
+    description: 'We review the summary from Stripe and approve it.',
+  },
+  stripe_import: {
+    title: 'Stripe imports the cards',
+    description:
+      'This takes around ten business days once Stripe has correct data.',
+  },
+  verify_cards: {
+    title: 'Polar checks the cards',
+    description:
+      'We check that every imported subscription has a card it can charge, and tell you which ones do not.',
+  },
+  resolve_uncovered: {
+    title: 'Handle customers without a card',
+    description:
+      'Some customers have to add a card again. Ask them to do it, or run the copy again to pick up new cards.',
+    action: 'I handled these customers',
+  },
+  cutover: {
+    title: 'Cut over billing',
+    description:
+      'Polar takes over billing. Stop billing these subscriptions on your old provider first.',
+    warning: 'You cannot undo this. Charges start on Polar from now on.',
+    action: 'Cut over billing',
+  },
+  move_subscriptions: {
+    title: 'Polar moves your subscriptions',
+    description:
+      'We activate the imported subscriptions. They are charged on their next renewal date.',
+  },
+}
+
+type Owner = schemas['PanStepOwner']
+
+// Polar Ops and the Polar app are the same party to a merchant. The split only
+// matters to us.
+const OWNER_LABEL: Record<Owner, string> = {
+  merchant: 'You',
+  polar_ops: 'Polar',
+  polar_app: 'Polar',
+  stripe: 'Stripe',
+  provider: 'Your provider',
+}
+
+const WAITING_LABEL: Record<Owner, string> = {
+  merchant: 'Your turn',
+  polar_ops: 'With Polar',
+  polar_app: 'With Polar',
+  stripe: 'With Stripe',
+  provider: 'With your provider',
+}
+
+// An owner the backend added but this build doesn't know yet still has to read
+// as something, the same way an unknown step key does.
+export const ownerLabel = (owner: Owner): string =>
+  OWNER_LABEL[owner] ?? 'Polar'
+
+export const waitingLabel = (owner: Owner): string =>
+  WAITING_LABEL[owner] ?? 'In progress'

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/stepMarker.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/stepMarker.tsx
@@ -1,0 +1,41 @@
+import { Text, TextColor } from '@polar-sh/orbit'
+import { Check, Circle } from 'lucide-react'
+
+// Shared by the top-level stepper and the card-transfer checklist so the two
+// stay one visual language.
+
+export type StepState = 'done' | 'current' | 'upcoming'
+
+const MARKER_SIZE = 16
+
+export const STATE_LABELS: Record<StepState, string> = {
+  done: 'completed',
+  current: 'current step',
+  upcoming: 'not started',
+}
+
+// Named for `Text`, not `Box`: Box's `color` prop has no accent entry, so
+// setting it there typechecks and then silently does nothing.
+export const STATE_COLORS: Record<StepState, TextColor> = {
+  done: 'muted',
+  current: 'accent',
+  upcoming: 'disabled',
+}
+
+// The icons draw with `currentColor`, so wrapping them in a coloured Text is
+// what actually tints them.
+export function StepMarker({ state }: { state: StepState }) {
+  return (
+    <Text as="span" color={STATE_COLORS[state]}>
+      {state === 'done' ? (
+        <Check size={MARKER_SIZE} strokeWidth={2.5} aria-hidden="true" />
+      ) : (
+        <Circle
+          size={MARKER_SIZE}
+          fill={state === 'current' ? 'currentColor' : 'none'}
+          aria-hidden="true"
+        />
+      )}
+    </Text>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/steps.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/steps.ts
@@ -5,7 +5,7 @@ type Step = schemas['MerchantMigrationStep']
 // Who moves a step forward. `you` (the merchant) is implicit and never badged;
 // `polar` and `stripe` are surfaced so the merchant knows they're waiting on
 // someone else.
-export type StepOwner = 'you' | 'polar' | 'stripe'
+export type StepOwner = 'you' | 'polar' | 'stripe' | 'varies'
 
 export interface MigrationStepDef {
   key: string
@@ -41,10 +41,11 @@ export const MIGRATION_STEPS: MigrationStepDef[] = [
   {
     key: 'cards',
     short: 'Card movement',
-    owner: 'stripe',
+    // No single party owns this step; the checklist inside it badges per step.
+    owner: 'varies',
     title: 'Move saved cards',
     description:
-      "Stripe copies your customers' saved cards onto Polar's account.",
+      "Follow the checklist to move your customers' saved cards onto Polar.",
     steps: ['copy_cards'],
   },
   {
@@ -60,6 +61,7 @@ export const MIGRATION_STEPS: MigrationStepDef[] = [
 
 export const OWNER_LABELS: Record<StepOwner, string | null> = {
   you: null,
+  varies: null,
   polar: 'Polar',
   stripe: 'Stripe',
 }

--- a/clients/apps/web/src/hooks/queries/merchantMigrations.ts
+++ b/clients/apps/web/src/hooks/queries/merchantMigrations.ts
@@ -1,3 +1,4 @@
+import { extractApiErrorMessage } from '@/utils/api/errors'
 import { getQueryClient } from '@/utils/api/query'
 import { api } from '@/utils/client'
 import { schemas, unwrap } from '@polar-sh/client'
@@ -89,6 +90,98 @@ export const useImportMerchantMigrationCatalog = (id: string) =>
         queryKey: ['merchantMigrationRecords'],
       })
     },
+  })
+
+const panTransferKey = (id: string) => ['merchantMigrationPanTransfer', { id }]
+
+export const usePanTransfer = (id: string) =>
+  useQuery({
+    queryKey: panTransferKey(id),
+    queryFn: () =>
+      unwrap(
+        api.GET('/v1/merchant-migrations/{id}/pan-transfer', {
+          params: { path: { id } },
+        }),
+      ),
+    retry: defaultRetry,
+    enabled: !!id,
+  })
+
+// The list card draws its own position from the migration, so it goes stale
+// alongside the detail view on every write.
+const invalidateMigration = (id: string) => {
+  getQueryClient().invalidateQueries({
+    queryKey: ['merchantMigration', { id }],
+  })
+  getQueryClient().invalidateQueries({ queryKey: ['merchantMigrations'] })
+}
+
+// Written straight into the cache: waiting for a refetch leaves the finished
+// step on screen with its button live, long enough to submit it twice.
+const syncPanTransfer = (
+  id: string,
+  checklist: schemas['PanTransferChecklist'],
+) => {
+  getQueryClient().setQueryData(panTransferKey(id), checklist)
+  invalidateMigration(id)
+}
+
+// Not `unwrap` like its neighbours: that reads `message`, the API reports
+// `detail`, and these two surface the server's wording to the merchant.
+const checklistOrThrow = (
+  result: {
+    data?: schemas['PanTransferChecklist']
+    error?: { detail?: unknown }
+  },
+  fallback: string,
+): schemas['PanTransferChecklist'] => {
+  if (result.error || !result.data) {
+    throw new Error(extractApiErrorMessage(result.error ?? {}, fallback))
+  }
+  return result.data
+}
+
+// A step can move from the backoffice or another tab, so a conflict means our
+// view is stale. Refetch the migration too: the page picks its view from it,
+// and otherwise the start button stays live and keeps failing the same way.
+const panTransferHandlers = (id: string) => ({
+  onSuccess: (checklist: schemas['PanTransferChecklist']) =>
+    syncPanTransfer(id, checklist),
+  onError: () => {
+    getQueryClient().invalidateQueries({ queryKey: panTransferKey(id) })
+    invalidateMigration(id)
+  },
+})
+
+export const useStartPanTransfer = (id: string) =>
+  useMutation({
+    mutationFn: async () =>
+      checklistOrThrow(
+        await api.POST('/v1/merchant-migrations/{id}/pan-transfer', {
+          params: { path: { id } },
+        }),
+        "We couldn't start the card transfer.",
+      ),
+    ...panTransferHandlers(id),
+  })
+
+export const useCompletePanTransferStep = (id: string) =>
+  useMutation({
+    mutationFn: async ({
+      key,
+      inputs,
+    }: {
+      key: string
+      inputs: Record<string, string>
+    }) =>
+      checklistOrThrow(
+        await api.POST(
+          '/v1/merchant-migrations/{id}/pan-transfer/steps/{key}/complete',
+          { params: { path: { id, key } }, body: { inputs } },
+        ),
+        "We couldn't save this step.",
+      ),
+    ...panTransferHandlers(id),
   })
 
 export const useMigrationRecords = (


### PR DESCRIPTION
## Summary

Adds the merchant-facing UI for moving saved cards. This is the last phase of a merchant migration. The backend checklist engine landed in #13564; this renders it.

## What

- A "Move saved cards" checklist on the migration detail page.
- One step is open at a time. Finished steps collapse and keep what the merchant typed.
- Steps the merchant does not own show who we are waiting on, plus a note and a date from Polar when there is one.
- Merchant steps have one action: fill a field, or confirm the work is done.
- A card at the end of the assessment step to start the card move.
- All step wording lives in one file, keyed by step key. The backend stores no text, so we can reword a step without a data migration.
- The progress marker used by the top stepper moved to a shared module, so the stepper and the checklist stay one visual language.

## Why

Moving cards takes days for a Stripe source and weeks for any other provider. The work is split between the merchant, Polar, Stripe and the old provider. Merchants need to see what is done, what is next, and who they are waiting on, without asking support.

## How

- `usePanTransfer` reads the checklist. Both mutations write their response straight into the query cache, so the list is right as soon as the click lands.
- A step can also move from the backoffice or another tab. A failed submit refetches, so the list corrects itself instead of showing a step that is already gone.
- Errors show the message the API sent. Some failures cannot be fixed by trying again, so a generic "please try again" would be wrong.

## Screenshots

**Starting the card move.** Offered under the imported catalog, so the merchant can keep importing until they choose to move on.

![The imported catalog, with the card move offered underneath](https://raw.githubusercontent.com/polarsource/polar/pr-13575-screenshots/01-assessment.png)

**Working the checklist.** One step open at a time. The Polar account ID they need is right where the instructions tell them to paste it.

![The card transfer checklist with the merchant step open](https://raw.githubusercontent.com/polarsource/polar/pr-13575-screenshots/02-checklist.png)

**Waiting on someone else.** A finished step keeps the reference the merchant entered. A step sitting with Polar says so, with a note and a date instead of silence.

![A step waiting on Polar, with a note and an expected date](https://raw.githubusercontent.com/polarsource/polar/pr-13575-screenshots/03-waiting.png)

## Notes

- `MERCHANT_MIGRATION_DESTINATION_STRIPE_ACCOUNT_ID` must be set, or starting a transfer returns 409.
- Polar-owned steps still need the backoffice pages before a transfer can run end to end.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (`pnpm lint` and `tsc --noEmit`; backend `lint` and `lint_types` also run clean)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->




