### PR TITLE
feat(compass): thread history UI for the assistant 

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/compass/CompassPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/compass/CompassPage.tsx
@@ -1,12 +1,16 @@
 'use client'
 
 import { CompassConversation } from '@/components/Compass/CompassConversation'
+import { CompassHistoryMenu } from '@/components/Compass/CompassHistoryMenu'
+import { CompassIconAction } from '@/components/Compass/CompassIconAction'
 import { CompassTabs } from '@/components/Compass/CompassTabs'
 import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import { useCompassAssistant } from '@/hooks/useCompassAssistant'
+import AddRounded from '@mui/icons-material/AddRounded'
 import { schemas } from '@polar-sh/client'
+import { Box } from '@polar-sh/orbit/Box'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 interface CompassPageProps {
   organization: schemas['Organization']
@@ -14,12 +18,34 @@ interface CompassPageProps {
 
 export default function CompassPage({ organization }: CompassPageProps) {
   const [value, setValue] = useState('')
-  const { messages, send, isStreaming } = useCompassAssistant(organization.id)
-  const inputRef = useRef<HTMLTextAreaElement | null>(null)
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
+  const inputRef = useRef<HTMLTextAreaElement | null>(null)
   const askedRef = useRef(false)
+
+  const showThreadUrl = useCallback(
+    (id: string | null) => {
+      router.replace(id ? `${pathname}?thread=${id}` : pathname, {
+        scroll: false,
+      })
+    },
+    [router, pathname],
+  )
+
+  // Captured once on mount: the deep-linked thread this page opened with.
+  const [initialThreadId] = useState(() => searchParams.get('thread'))
+  const { messages, send, isStreaming, threadId, selectThread, newChat } =
+    useCompassAssistant({
+      organizationId: organization.id,
+      initialThreadId,
+      onThreadChange: showThreadUrl,
+    })
+
+  const startNewChat = useCallback(() => {
+    newChat()
+    inputRef.current?.focus()
+  }, [newChat])
 
   // The overview's idle box hands its question over via `?ask=`. Send it
   // once, then strip the param so refresh and back don't re-ask.
@@ -59,7 +85,36 @@ export default function CompassPage({ organization }: CompassPageProps) {
   return (
     <DashboardBody
       title="Compass"
-      header={<CompassTabs organization={organization} active="assistant" />}
+      header={
+        <Box alignItems="center" columnGap="xs">
+          {messages.length > 0 && (
+            <CompassIconAction label="New chat" onClick={startNewChat}>
+              <AddRounded style={{ fontSize: '1.125rem' }} />
+            </CompassIconAction>
+          )}
+          <CompassHistoryMenu
+            organization={organization}
+            activeThreadId={threadId}
+            onSelect={selectThread}
+            onDeleted={(deletedId) => {
+              if (deletedId === threadId) {
+                startNewChat()
+              }
+            }}
+          />
+          <Box
+            as="span"
+            display="block"
+            width={0}
+            height={20}
+            marginHorizontal="s"
+            borderLeftWidth={1}
+            borderStyle="solid"
+            borderColor="border-primary"
+          />
+          <CompassTabs organization={organization} active="assistant" />
+        </Box>
+      }
       className="h-full"
       wrapperClassName="max-w-3xl!"
     >

--- a/clients/apps/web/src/components/Chat/time.ts
+++ b/clients/apps/web/src/components/Chat/time.ts
@@ -12,3 +12,5 @@ export const relativeTime = (iso: string): string => {
 }
 
 export const exactTime = (iso: string): string => format(new Date(iso), 'PPpp')
+
+export const messageTime = (iso: string): string => format(new Date(iso), 'PPp')

--- a/clients/apps/web/src/components/Compass/AssistantBlocks.tsx
+++ b/clients/apps/web/src/components/Compass/AssistantBlocks.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { relativeTime } from '@/components/Chat/time'
 import { ParsedMetricPeriod } from '@/hooks/queries'
 import { AssistantBlock, AssistantPart } from '@/hooks/useCompassAssistant'
 import { getFormattedMetricValue } from '@/utils/metrics'
@@ -94,12 +95,14 @@ const ParagraphsText = ({ text }: { text: string }) => {
  * reviewed component. The model can only pick block types from the closed
  * union — unknown types render nothing.
  */
-export const AssistantBlockView = ({
+const BlockBody = ({
   block,
   organization,
+  answeredAt,
 }: {
   block: AssistantBlock
   organization: schemas['Organization']
+  answeredAt?: string
 }) => {
   switch (block.type) {
     case 'text':
@@ -130,9 +133,9 @@ export const AssistantBlockView = ({
         </Grid>
       )
     case 'entity_list':
-      return <EntityListView block={block} />
+      return <EntityListView block={block} answeredAt={answeredAt} />
     case 'data_table':
-      return <EntityTableView block={block} />
+      return <EntityTableView block={block} answeredAt={answeredAt} />
     case 'customer_card':
       return <CustomerCardView block={block} />
     default:
@@ -140,15 +143,55 @@ export const AssistantBlockView = ({
   }
 }
 
+export const AssistantBlockView = ({
+  block,
+  organization,
+  answeredAt,
+}: {
+  block: AssistantBlock
+  organization: schemas['Organization']
+  answeredAt?: string
+}) => {
+  const body = (
+    <BlockBody
+      block={block}
+      organization={organization}
+      answeredAt={answeredAt}
+    />
+  )
+  // The entity presentations carry the fetch time in their own caption row.
+  const ownsFetchedCaption =
+    block.type === 'entity_list' || block.type === 'data_table'
+  if (block.type === 'text' || ownsFetchedCaption || !answeredAt) {
+    return body
+  }
+  return (
+    <Box display="flex" flexDirection="column" rowGap="xs">
+      {body}
+      <Text variant="caption" color="muted">
+        Fetched {relativeTime(answeredAt)}
+      </Text>
+    </Box>
+  )
+}
+
 export const AssistantPartView = ({
   part,
   organization,
+  answeredAt,
 }: {
   part: AssistantPart
   organization: schemas['Organization']
+  answeredAt?: string
 }) => {
   if (part.kind === 'text') {
     return <ParagraphsText text={part.text} />
   }
-  return <AssistantBlockView block={part.block} organization={organization} />
+  return (
+    <AssistantBlockView
+      block={part.block}
+      organization={organization}
+      answeredAt={answeredAt}
+    />
+  )
 }

--- a/clients/apps/web/src/components/Compass/AssistantBlocks.tsx
+++ b/clients/apps/web/src/components/Compass/AssistantBlocks.tsx
@@ -159,10 +159,15 @@ export const AssistantBlockView = ({
       answeredAt={answeredAt}
     />
   )
-  // The entity presentations carry the fetch time in their own caption row.
-  const ownsFetchedCaption =
-    block.type === 'entity_list' || block.type === 'data_table'
-  if (block.type === 'text' || ownsFetchedCaption || !answeredAt) {
+  // Only the blocks that render a surface of their own get the caption: text
+  // reads as prose, the entity presentations carry the fetch time in their own
+  // caption row, and an unknown type renders nothing — a bare caption would be
+  // worse than none. Keep in sync with BlockBody.
+  const wantsFetchedCaption =
+    block.type === 'metric_chart' ||
+    block.type === 'insight_cards' ||
+    block.type === 'customer_card'
+  if (!wantsFetchedCaption || !answeredAt) {
     return body
   }
   return (

--- a/clients/apps/web/src/components/Compass/AssistantEntities.tsx
+++ b/clients/apps/web/src/components/Compass/AssistantEntities.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { relativeTime } from '@/components/Chat/time'
 import {
   AssistantBlock,
   DataTableColumn,
@@ -38,10 +39,45 @@ const formatCell = (
   return String(value)
 }
 
+/**
+ * The caption under the entity presentations: how much of the result is shown,
+ * and when it was fetched. One line, so a restored answer's staleness sits with
+ * its data rather than adding a caption of its own.
+ */
+const BlockFooter = ({
+  shown,
+  total,
+  entity,
+  answeredAt,
+}: {
+  shown: number
+  total: number
+  entity: string
+  answeredAt?: string
+}) => {
+  const parts: string[] = []
+  if (total > shown) {
+    parts.push(`Showing ${shown} of ${total} ${entity}`)
+  }
+  if (answeredAt) {
+    parts.push(`Fetched ${relativeTime(answeredAt)}`)
+  }
+  if (parts.length === 0) {
+    return null
+  }
+  return (
+    <Text variant="caption" color="muted">
+      {parts.join(' · ')}
+    </Text>
+  )
+}
+
 export const EntityListView = ({
   block,
+  answeredAt,
 }: {
   block: Extract<AssistantBlock, { type: 'entity_list' }>
+  answeredAt?: string
 }) => {
   // Same columns/rows shape as the table, so currency and dates format
   // identically in both presentations. First column is the title, the last
@@ -110,11 +146,12 @@ export const EntityListView = ({
           </ListItem>
         ))}
       </List>
-      {block.total_count > block.rows.length ? (
-        <Text variant="caption" color="muted">
-          Showing {block.rows.length} of {block.total_count} {block.entity}
-        </Text>
-      ) : null}
+      <BlockFooter
+        shown={block.rows.length}
+        total={block.total_count}
+        entity={block.entity}
+        answeredAt={answeredAt}
+      />
     </Box>
   )
 }
@@ -152,8 +189,10 @@ export const CustomerCardView = ({
 
 export const EntityTableView = ({
   block,
+  answeredAt,
 }: {
   block: Extract<AssistantBlock, { type: 'data_table' }>
+  answeredAt?: string
 }) => {
   const columns = useMemo(
     (): DataTableColumnDef<DataTableRow>[] =>
@@ -188,11 +227,12 @@ export const EntityTableView = ({
         </Text>
       ) : null}
       <DataTable columns={columns} data={block.rows} isLoading={false} />
-      {block.total_count > block.rows.length ? (
-        <Text variant="caption" color="muted">
-          Showing {block.rows.length} of {block.total_count} {block.entity}
-        </Text>
-      ) : null}
+      <BlockFooter
+        shown={block.rows.length}
+        total={block.total_count}
+        entity={block.entity}
+        answeredAt={answeredAt}
+      />
     </Box>
   )
 }

--- a/clients/apps/web/src/components/Compass/CompassConversation.tsx
+++ b/clients/apps/web/src/components/Compass/CompassConversation.tsx
@@ -13,10 +13,10 @@ import { Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { ChevronRight } from 'lucide-react'
 import Link from 'next/link'
-import { AnimatePresence, motion } from 'motion/react'
+import { motion } from 'motion/react'
 import { ComponentType, RefObject, useEffect } from 'react'
-import { AssistantPartView } from './AssistantBlocks'
 import { CompassInputBar } from './CompassInputBar'
+import { CompassMessageList } from './CompassMessageList'
 import { CompassWidget } from './CompassWidget'
 
 interface CompassConversationProps {
@@ -122,12 +122,12 @@ export const CompassConversation = ({
 
   // Sending always re-follows the bottom, even if the user had scrolled up
   // in the previous answer. Streamed growth is handled by the hook itself.
-  const lastMessage = messages[messages.length - 1]
+  const lastMessageId = messages[messages.length - 1]?.id
   useEffect(() => {
-    if (lastMessage?.role === 'user') {
+    if (lastMessageId !== undefined) {
       scrollToBottom()
     }
-  }, [lastMessage, scrollToBottom])
+  }, [lastMessageId, scrollToBottom])
 
   return (
     <motion.div
@@ -209,59 +209,12 @@ export const CompassConversation = ({
             )}
           </Box>
         ) : (
-          <Box display="flex" flexDirection="column" rowGap="2xl">
-            <AnimatePresence initial={false}>
-              {messages.map((message) => (
-                <motion.div
-                  key={message.id}
-                  initial={{ opacity: 0, y: 6 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.2, ease: 'easeOut' }}
-                  className="flex"
-                >
-                  {message.role === 'user' ? (
-                    <Box
-                      marginLeft="auto"
-                      maxWidth="85%"
-                      paddingHorizontal="l"
-                      paddingVertical="m"
-                      borderRadius="l"
-                      backgroundColor="background-card"
-                    >
-                      {message.parts.map((part, i) => (
-                        <AssistantPartView
-                          key={i}
-                          part={part}
-                          organization={organization}
-                        />
-                      ))}
-                    </Box>
-                  ) : (
-                    <Box
-                      display="flex"
-                      flexDirection="column"
-                      rowGap="2xl"
-                      maxWidth="85%"
-                    >
-                      {message.parts.length === 0 && isStreaming ? (
-                        <span className="dark:from-polar-500 dark:via-polar-100 dark:to-polar-500 w-fit [animation:shimmer_2s_linear_infinite] bg-linear-to-r from-gray-400 via-gray-800 to-gray-400 bg-size-[200%_100%] bg-clip-text text-transparent">
-                          Thinking...
-                        </span>
-                      ) : (
-                        message.parts.map((part, i) => (
-                          <AssistantPartView
-                            key={i}
-                            part={part}
-                            organization={organization}
-                          />
-                        ))
-                      )}
-                    </Box>
-                  )}
-                </motion.div>
-              ))}
-            </AnimatePresence>
-          </Box>
+          <CompassMessageList
+            organization={organization}
+            messages={messages}
+            isStreaming={isStreaming}
+            onAsk={onAsk}
+          />
         )}
       </div>
 
@@ -273,6 +226,7 @@ export const CompassConversation = ({
             value={value}
             onValueChange={onValueChange}
             onSubmit={onSubmit}
+            isStreaming={isStreaming}
             autoFocus
           />
         </div>

--- a/clients/apps/web/src/components/Compass/CompassHistoryMenu.tsx
+++ b/clients/apps/web/src/components/Compass/CompassHistoryMenu.tsx
@@ -1,0 +1,109 @@
+'use client'
+
+import HistoryRounded from '@mui/icons-material/HistoryRounded'
+import { schemas } from '@polar-sh/client'
+import { Box } from '@polar-sh/orbit/Box'
+import { AnimatePresence, motion } from 'motion/react'
+import { useEffect, useRef, useState } from 'react'
+import { CompassIconAction } from './CompassIconAction'
+import { CompassThreadList } from './CompassThreadList'
+
+interface CompassHistoryMenuProps {
+  organization: schemas['Organization']
+  activeThreadId: string | null
+  onSelect: (threadId: string) => void
+  onDeleted: (threadId: string) => void
+}
+
+export const CompassHistoryMenu = ({
+  organization,
+  activeThreadId,
+  onSelect,
+  onDeleted,
+}: CompassHistoryMenuProps) => {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (e: PointerEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    // Capture phase so closing the panel wins over the page-level Escape
+    // handler, which would otherwise navigate back.
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !e.isComposing) {
+        e.stopPropagation()
+        setOpen(false)
+      }
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    window.addEventListener('keydown', onKeyDown, true)
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown)
+      window.removeEventListener('keydown', onKeyDown, true)
+    }
+  }, [open])
+
+  return (
+    <div ref={containerRef} className="relative">
+      <CompassIconAction
+        label="History"
+        expanded={open}
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        <HistoryRounded style={{ fontSize: '1.125rem' }} />
+      </CompassIconAction>
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ opacity: 0, scale: 0.97, y: -4 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{
+              opacity: 0,
+              scale: 0.97,
+              y: -4,
+              transition: { duration: 0.12 },
+            }}
+            transition={{ duration: 0.18, ease: [0.23, 1, 0.32, 1] }}
+            style={{ transformOrigin: 'top right' }}
+            className="absolute top-full right-0 z-40 mt-2 w-80"
+          >
+            <Box
+              role="group"
+              aria-label="Conversation history"
+              flexDirection="column"
+              backgroundColor="background-primary"
+              borderWidth={1}
+              borderStyle="solid"
+              borderColor="border-primary"
+              borderRadius="l"
+              boxShadow="xl"
+              maxHeight={400}
+              overflow="hidden"
+            >
+              <Box
+                flexDirection="column"
+                paddingHorizontal="s"
+                paddingBottom="s"
+                overflowY="auto"
+              >
+                <CompassThreadList
+                  organization={organization}
+                  activeThreadId={activeThreadId}
+                  onSelect={(threadId) => {
+                    setOpen(false)
+                    onSelect(threadId)
+                  }}
+                  onDeleted={onDeleted}
+                />
+              </Box>
+            </Box>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  )
+}

--- a/clients/apps/web/src/components/Compass/CompassIconAction.tsx
+++ b/clients/apps/web/src/components/Compass/CompassIconAction.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { Box } from '@polar-sh/orbit/Box'
+import { ReactNode } from 'react'
+
+interface CompassIconActionProps {
+  label: string
+  onClick: () => void
+  expanded?: boolean
+  children: ReactNode
+}
+
+export const CompassIconAction = ({
+  label,
+  onClick,
+  expanded,
+  children,
+}: CompassIconActionProps) => (
+  <button
+    type="button"
+    aria-label={label}
+    title={label}
+    aria-expanded={expanded}
+    onClick={onClick}
+    className="cursor-pointer transition-transform duration-150 ease-[cubic-bezier(0.23,1,0.32,1)] active:scale-[0.97]"
+  >
+    <Box
+      as="span"
+      display="inline-flex"
+      width={32}
+      height={32}
+      borderRadius="full"
+      alignItems="center"
+      justifyContent="center"
+      color={
+        expanded
+          ? { base: 'text-primary' }
+          : { base: 'text-tertiary', hover: 'text-primary' }
+      }
+      backgroundColor={
+        expanded
+          ? { base: 'background-card', hover: 'background-card' }
+          : { hover: 'background-card' }
+      }
+      transitionProperty="colors"
+      transitionDuration="fast"
+    >
+      {children}
+    </Box>
+  </button>
+)

--- a/clients/apps/web/src/components/Compass/CompassInputBar.tsx
+++ b/clients/apps/web/src/components/Compass/CompassInputBar.tsx
@@ -13,6 +13,7 @@ interface CompassInputBarProps {
   onFocus?: () => void
   placeholder?: string
   autoFocus?: boolean
+  isStreaming?: boolean
 }
 
 /**
@@ -20,6 +21,9 @@ interface CompassInputBarProps {
  * attach / expand / send controls. The idle bottom box and the conversation
  * overlay render this same component, so the surface cannot drift between
  * the two again.
+ *
+ * While a turn streams the next question can still be typed, but sending
+ * waits: the assistant answers one turn at a time.
  */
 export const CompassInputBar = forwardRef<
   HTMLTextAreaElement,
@@ -32,10 +36,11 @@ export const CompassInputBar = forwardRef<
     onFocus,
     placeholder = 'Ask Compass...',
     autoFocus,
+    isStreaming = false,
   },
   ref,
 ) {
-  const canSend = value.trim().length > 0
+  const canSend = value.trim().length > 0 && !isStreaming
 
   return (
     <Box

--- a/clients/apps/web/src/components/Compass/CompassMessageList.tsx
+++ b/clients/apps/web/src/components/Compass/CompassMessageList.tsx
@@ -1,0 +1,173 @@
+'use client'
+
+import { messageTime, relativeTime } from '@/components/Chat/time'
+import { AssistantMessage } from '@/hooks/useCompassAssistant'
+import RefreshRounded from '@mui/icons-material/RefreshRounded'
+import { schemas } from '@polar-sh/client'
+import { Button, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { AnimatePresence, motion } from 'motion/react'
+import { Fragment } from 'react'
+import { AssistantPartView } from './AssistantBlocks'
+
+const STALE_AFTER_MS = 60 * 60 * 1000
+const isStale = (iso: string) =>
+  Date.now() - new Date(iso).getTime() > STALE_AFTER_MS
+
+interface CompassMessageListProps {
+  organization: schemas['Organization']
+  messages: AssistantMessage[]
+  isStreaming: boolean
+  onAsk: (question: string) => void
+}
+
+const MessageTimestamp = ({ at }: { at: string }) => (
+  <div className="opacity-0 transition-opacity duration-150 group-hover:opacity-100">
+    <Text variant="caption" color="muted">
+      {messageTime(at)}
+    </Text>
+  </div>
+)
+
+const ResumeDivider = ({ answeredAt }: { answeredAt: string }) => (
+  <Box role="separator" alignItems="center" columnGap="m">
+    <Box
+      flexGrow={1}
+      borderTopWidth={1}
+      borderStyle="solid"
+      borderColor="border-primary"
+    />
+    <Text variant="caption" color="muted">
+      Continuing from {relativeTime(answeredAt)}
+    </Text>
+    <Box
+      flexGrow={1}
+      borderTopWidth={1}
+      borderStyle="solid"
+      borderColor="border-primary"
+    />
+  </Box>
+)
+
+const RerunAction = ({
+  prompt,
+  disabled,
+  onAsk,
+}: {
+  prompt: string
+  disabled: boolean
+  onAsk: (question: string) => void
+}) => (
+  <Box>
+    <Button
+      variant="secondary"
+      size="sm"
+      disabled={disabled}
+      onClick={() => onAsk(prompt)}
+    >
+      <Box alignItems="center" columnGap="xs">
+        <RefreshRounded style={{ fontSize: '1rem' }} />
+        Ask again with current data
+      </Box>
+    </Button>
+  </Box>
+)
+
+export const CompassMessageList = ({
+  organization,
+  messages,
+  isStreaming,
+  onAsk,
+}: CompassMessageListProps) => {
+  const showsGapAfter = (message: AssistantMessage, index: number) => {
+    const next = messages[index + 1]
+    if (next) {
+      const gap =
+        new Date(next.answeredAt).getTime() -
+        new Date(message.answeredAt).getTime()
+      return gap > STALE_AFTER_MS
+    }
+    return Boolean(message.restored) && isStale(message.answeredAt)
+  }
+
+  return (
+    <Box display="flex" flexDirection="column" rowGap="2xl">
+      <AnimatePresence initial={false}>
+        {messages.map((message, index) => (
+          <Fragment key={message.id}>
+            <motion.div
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.2, ease: 'easeOut' }}
+              className="group flex"
+            >
+              {message.role === 'user' ? (
+                <Box
+                  marginLeft="auto"
+                  maxWidth="85%"
+                  flexDirection="column"
+                  rowGap="xs"
+                  alignItems="end"
+                >
+                  <Box
+                    paddingHorizontal="l"
+                    paddingVertical="m"
+                    borderRadius="l"
+                    backgroundColor="background-card"
+                  >
+                    {message.parts.map((part, i) => (
+                      <AssistantPartView
+                        key={i}
+                        part={part}
+                        organization={organization}
+                      />
+                    ))}
+                  </Box>
+                  <MessageTimestamp at={message.answeredAt} />
+                </Box>
+              ) : (
+                <Box
+                  display="flex"
+                  flexDirection="column"
+                  rowGap="m"
+                  maxWidth="100%"
+                >
+                  <Box display="flex" flexDirection="column" rowGap="2xl">
+                    {message.parts.length === 0 && isStreaming ? (
+                      <span className="dark:from-polar-500 dark:via-polar-100 dark:to-polar-500 w-fit [animation:shimmer_2s_linear_infinite] bg-linear-to-r from-gray-400 via-gray-800 to-gray-400 bg-size-[200%_100%] bg-clip-text text-transparent">
+                        Thinking...
+                      </span>
+                    ) : (
+                      message.parts.map((part, i) => (
+                        <AssistantPartView
+                          key={i}
+                          part={part}
+                          organization={organization}
+                          answeredAt={message.answeredAt}
+                        />
+                      ))
+                    )}
+                  </Box>
+                  {message.restored &&
+                    message.prompt &&
+                    isStale(message.answeredAt) &&
+                    message.parts.some((part) => part.kind === 'block') && (
+                      <RerunAction
+                        prompt={message.prompt}
+                        disabled={isStreaming}
+                        onAsk={onAsk}
+                      />
+                    )}
+                  <MessageTimestamp at={message.answeredAt} />
+                </Box>
+              )}
+            </motion.div>
+            {showsGapAfter(message, index) && (
+              <ResumeDivider answeredAt={message.answeredAt} />
+            )}
+          </Fragment>
+        ))}
+      </AnimatePresence>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/components/Compass/CompassThreadList.tsx
+++ b/clients/apps/web/src/components/Compass/CompassThreadList.tsx
@@ -1,0 +1,181 @@
+'use client'
+
+import { useCompassThreads, useDeleteCompassThread } from '@/hooks/queries'
+import DeleteOutlineRounded from '@mui/icons-material/DeleteOutlineRounded'
+import { schemas } from '@polar-sh/client'
+import { Button, Spinner, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { differenceInCalendarDays, isToday, isYesterday } from 'date-fns'
+
+type CompassThread = schemas['CompassThreadSchema']
+
+const BUCKETS = ['Today', 'Yesterday', 'Previous 7 days', 'Earlier'] as const
+
+type Bucket = (typeof BUCKETS)[number]
+
+const bucketOf = (thread: CompassThread): Bucket => {
+  const date = new Date(thread.modified_at ?? thread.created_at)
+  if (isToday(date)) return 'Today'
+  if (isYesterday(date)) return 'Yesterday'
+  return differenceInCalendarDays(new Date(), date) <= 7
+    ? 'Previous 7 days'
+    : 'Earlier'
+}
+
+interface ThreadRowProps {
+  thread: CompassThread
+  active: boolean
+  onSelect: (threadId: string) => void
+  onDelete: (threadId: string) => void
+}
+
+const ThreadRow = ({ thread, active, onSelect, onDelete }: ThreadRowProps) => (
+  // `group` marks the row for the delete button's reveal; Box pseudo-states
+  // are self-scoped, so there is no typed equivalent.
+  <div className="group">
+    <Box
+      alignItems="center"
+      columnGap="s"
+      paddingLeft="m"
+      paddingRight="s"
+      paddingVertical="s"
+      borderRadius="m"
+      backgroundColor={
+        active
+          ? { base: 'background-card', hover: 'background-card' }
+          : { hover: 'background-secondary' }
+      }
+      transitionProperty="colors"
+      transitionDuration="fast"
+    >
+      <button
+        type="button"
+        className="min-w-0 flex-1 text-left"
+        onClick={() => onSelect(thread.id)}
+      >
+        <Text truncate>{thread.title}</Text>
+      </button>
+      <button
+        type="button"
+        aria-label={`Delete ${thread.title}`}
+        onClick={() => onDelete(thread.id)}
+        className="flex shrink-0 items-center justify-center leading-none opacity-0 transition-opacity duration-150 ease-out group-focus-within:opacity-100 group-hover:opacity-100"
+      >
+        <Box
+          as="span"
+          display="inline-flex"
+          color={{ base: 'text-tertiary', hover: 'text-danger' }}
+          transitionProperty="colors"
+          transitionDuration="fast"
+          cursor={{ hover: 'pointer' }}
+        >
+          <DeleteOutlineRounded
+            style={{ fontSize: '1rem', display: 'block' }}
+          />
+        </Box>
+      </button>
+    </Box>
+  </div>
+)
+
+interface CompassThreadListProps {
+  organization: schemas['Organization']
+  activeThreadId: string | null
+  onSelect: (threadId: string) => void
+  onDeleted: (threadId: string) => void
+}
+
+export const CompassThreadList = ({
+  organization,
+  activeThreadId,
+  onSelect,
+  onDeleted,
+}: CompassThreadListProps) => {
+  const {
+    data: threads,
+    isLoading,
+    isError,
+    refetch,
+  } = useCompassThreads(organization.id)
+  const deleteThread = useDeleteCompassThread(organization.id)
+  const items = threads?.items ?? []
+
+  const removeThread = async (threadId: string) => {
+    const { error } = await deleteThread.mutateAsync(threadId)
+    if (error) {
+      return
+    }
+    onDeleted(threadId)
+  }
+
+  if (isLoading) {
+    return (
+      <Box alignItems="center" justifyContent="center" paddingVertical="xl">
+        <Spinner />
+      </Box>
+    )
+  }
+
+  if (isError) {
+    return (
+      <Box
+        flexDirection="column"
+        alignItems="center"
+        rowGap="s"
+        paddingVertical="xl"
+      >
+        <Text variant="caption" color="muted">
+          Conversations could not be loaded
+        </Text>
+        <Button variant="ghost" size="sm" onClick={() => refetch()}>
+          Try again
+        </Button>
+      </Box>
+    )
+  }
+
+  if (items.length === 0) {
+    return (
+      <Box flexDirection="column" alignItems="center" paddingVertical="xl">
+        <Text variant="caption" color="muted">
+          No conversations yet
+        </Text>
+      </Box>
+    )
+  }
+
+  return (
+    <>
+      {BUCKETS.map((bucket) => {
+        const bucketItems = items.filter((item) => bucketOf(item) === bucket)
+        if (bucketItems.length === 0) return null
+        return (
+          <Box key={bucket} flexDirection="column">
+            <Box
+              position="sticky"
+              top={0}
+              zIndex={1}
+              backgroundColor="background-primary"
+              paddingLeft="m"
+              paddingTop="m"
+              paddingBottom="xs"
+            >
+              <Text variant="caption" color="muted">
+                {bucket}
+              </Text>
+            </Box>
+            {bucketItems.map((thread) => (
+              <ThreadRow
+                key={thread.id}
+                thread={thread}
+                active={thread.id === activeThreadId}
+                onSelect={onSelect}
+                onDelete={removeThread}
+              />
+            ))}
+          </Box>
+        )
+      })}
+    </>
+  )
+}

--- a/clients/apps/web/src/components/Compass/CompassThreadList.tsx
+++ b/clients/apps/web/src/components/Compass/CompassThreadList.tsx
@@ -1,11 +1,13 @@
 'use client'
 
 import { useCompassThreads, useDeleteCompassThread } from '@/hooks/queries'
+import { useInViewport } from '@/hooks/utils'
 import DeleteOutlineRounded from '@mui/icons-material/DeleteOutlineRounded'
 import { schemas } from '@polar-sh/client'
 import { Button, Spinner, Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { differenceInCalendarDays, isToday, isYesterday } from 'date-fns'
+import { useEffect, useMemo } from 'react'
 
 type CompassThread = schemas['CompassThreadSchema']
 
@@ -96,9 +98,23 @@ export const CompassThreadList = ({
     isLoading,
     isError,
     refetch,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
   } = useCompassThreads(organization.id)
   const deleteThread = useDeleteCompassThread(organization.id)
-  const items = threads?.items ?? []
+  const items = useMemo(
+    () => threads?.pages.flatMap((page) => page.items) ?? [],
+    [threads],
+  )
+
+  const { ref: loadingRef, inViewport } = useInViewport<HTMLElement>()
+
+  useEffect(() => {
+    if (inViewport && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage()
+    }
+  }, [inViewport, hasNextPage, isFetchingNextPage, fetchNextPage])
 
   const removeThread = async (threadId: string) => {
     const { error } = await deleteThread.mutateAsync(threadId)
@@ -176,6 +192,16 @@ export const CompassThreadList = ({
           </Box>
         )
       })}
+      {hasNextPage && (
+        <Box
+          ref={loadingRef}
+          alignItems="center"
+          justifyContent="center"
+          paddingVertical="l"
+        >
+          <Spinner />
+        </Box>
+      )}
     </>
   )
 }

--- a/clients/apps/web/src/hooks/queries/compass.ts
+++ b/clients/apps/web/src/hooks/queries/compass.ts
@@ -1,5 +1,5 @@
 import { api } from '@/utils/client'
-import { paths, unwrap } from '@polar-sh/client'
+import { paths, schemas, unwrap } from '@polar-sh/client'
 import {
   QueryClient,
   useMutation,
@@ -51,23 +51,44 @@ export const useCompassThreads = (organizationId: string, enabled = true) => {
   })
 }
 
+const THREAD_MESSAGES_PAGE_SIZE = 50
+
+export type CompassThreadDetail = schemas['CompassThreadSchema'] & {
+  messages: schemas['CompassThreadMessageSchema'][]
+}
+
 /**
- * Imperative fetch of a thread's rendered messages. Use for explicit
+ * Imperative fetch of a thread and its most recent turns. Use for explicit
  * hydration (deep link, history pick). A mounted query would re-hydrate on
  * cache/focus updates and clobber a live conversation.
+ *
+ * Messages are their own paginated resource; this takes the first page, which
+ * the API serves newest-first, so it's the tail of the conversation.
  */
 export const fetchCompassThread = (
   queryClient: QueryClient,
   threadId: string,
-) =>
+): Promise<CompassThreadDetail> =>
   queryClient.fetchQuery({
     queryKey: ['compass_threads', 'detail', threadId],
-    queryFn: () =>
-      unwrap(
-        api.GET('/v1/compass/threads/{id}', {
-          params: { path: { id: threadId } },
-        }),
-      ),
+    queryFn: async () => {
+      const [thread, messages] = await Promise.all([
+        unwrap(
+          api.GET('/v1/compass/threads/{id}', {
+            params: { path: { id: threadId } },
+          }),
+        ),
+        unwrap(
+          api.GET('/v1/compass/threads/{id}/messages', {
+            params: {
+              path: { id: threadId },
+              query: { limit: THREAD_MESSAGES_PAGE_SIZE },
+            },
+          }),
+        ),
+      ])
+      return { ...thread, messages: messages.items }
+    },
     staleTime: 0,
   })
 

--- a/clients/apps/web/src/hooks/queries/compass.ts
+++ b/clients/apps/web/src/hooks/queries/compass.ts
@@ -2,6 +2,7 @@ import { api } from '@/utils/client'
 import { paths, schemas, unwrap } from '@polar-sh/client'
 import {
   QueryClient,
+  useInfiniteQuery,
   useMutation,
   useQuery,
   useQueryClient,
@@ -37,17 +38,35 @@ export const useCompassInsights = (organizationId: string, enabled = true) => {
   })
 }
 
+const THREADS_PAGE_SIZE = 50
+
 export const useCompassThreads = (organizationId: string, enabled = true) => {
-  return useQuery({
+  return useInfiniteQuery({
     queryKey: ['compass_threads', { organizationId }],
     enabled,
-    queryFn: () =>
+    queryFn: ({ pageParam }) =>
       unwrap(
         api.GET('/v1/compass/threads', {
-          params: { query: { organization_id: organizationId, limit: 50 } },
+          params: {
+            query: {
+              organization_id: organizationId,
+              limit: THREADS_PAGE_SIZE,
+              page: pageParam,
+            },
+          },
         }),
       ),
     retry: defaultRetry,
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, _allPages, lastPageParam) => {
+      if (
+        lastPageParam === lastPage.pagination.max_page ||
+        lastPage.items.length === 0
+      ) {
+        return null
+      }
+      return lastPageParam + 1
+    },
   })
 }
 

--- a/clients/apps/web/src/hooks/queries/compass.ts
+++ b/clients/apps/web/src/hooks/queries/compass.ts
@@ -1,6 +1,11 @@
 import { api } from '@/utils/client'
 import { paths, unwrap } from '@polar-sh/client'
-import { useQuery } from '@tanstack/react-query'
+import {
+  QueryClient,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query'
 import { defaultRetry } from './retry'
 
 type CompassTimezone = NonNullable<
@@ -29,5 +34,57 @@ export const useCompassInsights = (organizationId: string, enabled = true) => {
         }),
       ),
     retry: defaultRetry,
+  })
+}
+
+export const useCompassThreads = (organizationId: string, enabled = true) => {
+  return useQuery({
+    queryKey: ['compass_threads', { organizationId }],
+    enabled,
+    queryFn: () =>
+      unwrap(
+        api.GET('/v1/compass/threads', {
+          params: { query: { organization_id: organizationId, limit: 50 } },
+        }),
+      ),
+    retry: defaultRetry,
+  })
+}
+
+/**
+ * Imperative fetch of a thread's rendered messages. Use for explicit
+ * hydration (deep link, history pick). A mounted query would re-hydrate on
+ * cache/focus updates and clobber a live conversation.
+ */
+export const fetchCompassThread = (
+  queryClient: QueryClient,
+  threadId: string,
+) =>
+  queryClient.fetchQuery({
+    queryKey: ['compass_threads', 'detail', threadId],
+    queryFn: () =>
+      unwrap(
+        api.GET('/v1/compass/threads/{id}', {
+          params: { path: { id: threadId } },
+        }),
+      ),
+    staleTime: 0,
+  })
+
+export const useDeleteCompassThread = (organizationId: string) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (threadId: string) =>
+      api.DELETE('/v1/compass/threads/{id}', {
+        params: { path: { id: threadId } },
+      }),
+    onSuccess: (result) => {
+      if (result.error) {
+        return
+      }
+      queryClient.invalidateQueries({
+        queryKey: ['compass_threads', { organizationId }],
+      })
+    },
   })
 }

--- a/clients/apps/web/src/hooks/useCompassAssistant.ts
+++ b/clients/apps/web/src/hooks/useCompassAssistant.ts
@@ -1,69 +1,31 @@
 'use client'
 
+import { fetchCompassThread } from '@/hooks/queries'
 import { getServerURL } from '@/utils/api'
-import { schemas } from '@polar-sh/client'
+import { NotFoundResponseError, schemas } from '@polar-sh/client'
+import { useQueryClient } from '@tanstack/react-query'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-export interface MetricChartPoint {
-  timestamp: string
-  value: number
-}
-
+export type AssistantPart =
+  | schemas['AssistantTextPart']
+  | schemas['AssistantBlockPart']
 /**
  * The closed set of renderable blocks the assistant can produce. Mirrors the
  * backend `AssistantBlock` union; anything outside it is ignored by the
  * registry rather than rendered.
  */
-export interface DataTableColumn {
-  key: string
-  label: string
-  format: 'text' | 'currency' | 'datetime' | 'badge' | 'avatar'
-}
-
-export type DataTableRow = Record<string, string | number | null>
-
-export type AssistantBlock =
-  | { type: 'text'; text: string }
-  | {
-      type: 'metric_chart'
-      metric: string
-      label: string
-      unit: string
-      points: MetricChartPoint[]
-    }
-  | { type: 'insight_cards'; insights: schemas['Insight'][] }
-  | {
-      type: 'entity_list'
-      entity: string
-      title: string | null
-      columns: DataTableColumn[]
-      rows: DataTableRow[]
-      total_count: number
-    }
-  | {
-      type: 'data_table'
-      entity: string
-      title: string | null
-      columns: DataTableColumn[]
-      rows: DataTableRow[]
-      total_count: number
-    }
-  | {
-      type: 'customer_card'
-      email: string
-      name: string | null
-      avatar_url: string | null
-      created_at: string
-    }
-
-export type AssistantPart =
-  | { kind: 'text'; text: string }
-  | { kind: 'block'; block: AssistantBlock }
+export type AssistantBlock = schemas['AssistantBlockPart']['block']
+export type MetricChartPoint = schemas['MetricChartPoint']
+export type DataTableColumn = schemas['DataTableColumn']
+export type DataTableRow = schemas['DataTableBlock']['rows'][number]
 
 export interface AssistantMessage {
   id: string
   role: 'user' | 'assistant'
   parts: AssistantPart[]
+  answeredAt: string
+  restored?: boolean
+  prompt?: string
 }
 
 const appendDelta = (
@@ -77,23 +39,51 @@ const appendDelta = (
   return [...parts, { kind: 'text', text: delta }]
 }
 
+interface UseCompassAssistantOptions {
+  organizationId: string
+  initialThreadId?: string | null
+  onThreadChange?: (threadId: string | null) => void
+}
+
 /**
  * Client for the Compass assistant SSE endpoint. Streams one turn at a time:
- * `text` deltas and `block` events append to the pending assistant message,
- * `done` carries opaque conversation state we replay on the next turn.
+ * `text` deltas and `block` events append to the pending assistant message.
+ * Conversation state lives server-side on a thread: `thread` / `done` carry
+ * the thread id we send back on the next turn, and `hydrate` replays a
+ * stored thread into the message list.
  */
-export const useCompassAssistant = (organizationId: string) => {
+export const useCompassAssistant = ({
+  organizationId,
+  initialThreadId = null,
+  onThreadChange,
+}: UseCompassAssistantOptions) => {
+  const queryClient = useQueryClient()
   const [messages, setMessages] = useState<AssistantMessage[]>([])
   const [isStreaming, setIsStreaming] = useState(false)
-  const historyRef = useRef<string | null>(null)
+  // Ref for send (updated mid-stream), state for consumers. Seeded from
+  // initialThreadId so early prompts continue a deep-linked thread.
+  const [threadId, setThreadId] = useState<string | null>(initialThreadId)
+  const threadIdRef = useRef<string | null>(initialThreadId)
   const idRef = useRef(0)
   const controllerRef = useRef<AbortController | null>(null)
+  const loadRef = useRef(0)
+  const onThreadChangeRef = useRef(onThreadChange)
+  onThreadChangeRef.current = onThreadChange
 
   useEffect(() => {
     // Abort the in-flight stream on unmount so the SSE connection closes and
     // no further state updates fire.
     return () => controllerRef.current?.abort()
   }, [])
+
+  const setThread = useCallback((id: string | null) => {
+    threadIdRef.current = id
+    setThreadId(id)
+  }, [])
+
+  // Invalidate in-flight thread loads. Call whenever the on-screen conversation
+  // changes so a slow fetch can't resurrect what the user moved on from.
+  const claimConversation = useCallback(() => (loadRef.current += 1), [])
 
   const appendToAssistant = useCallback(
     (
@@ -113,18 +103,27 @@ export const useCompassAssistant = (organizationId: string) => {
 
   const send = useCallback(
     async (prompt: string) => {
+      // One turn at a time. A send during a live stream used to abort it, and
+      // an aborted turn is never recorded server-side: the conversation would
+      // silently lose the turn the user just watched.
+      if (controllerRef.current) return
+      const claim = claimConversation()
+
       const userId = `m${(idRef.current += 1)}`
       const assistantId = `m${(idRef.current += 1)}`
+      const answeredAt = new Date().toISOString()
       setMessages((prev) => [
         ...prev,
-        { id: userId, role: 'user', parts: [{ kind: 'text', text: prompt }] },
-        { id: assistantId, role: 'assistant', parts: [] },
+        {
+          id: userId,
+          role: 'user',
+          parts: [{ kind: 'text', text: prompt }],
+          answeredAt,
+        },
+        { id: assistantId, role: 'assistant', parts: [], answeredAt, prompt },
       ])
       setIsStreaming(true)
 
-      // One live stream at a time: a new send supersedes the previous one,
-      // which would otherwise race it for historyRef and isStreaming.
-      controllerRef.current?.abort()
       const controller = new AbortController()
       controllerRef.current = controller
 
@@ -137,7 +136,7 @@ export const useCompassAssistant = (organizationId: string) => {
           body: JSON.stringify({
             organization_id: organizationId,
             prompt,
-            message_history: historyRef.current,
+            thread_id: threadIdRef.current,
           }),
         })
         if (!response.ok || !response.body) {
@@ -149,6 +148,9 @@ export const useCompassAssistant = (organizationId: string) => {
         let buffer = ''
 
         const handle = (rawEvent: string) => {
+          // A history selection claims the conversation before its fetch
+          // resolves and aborts us.
+          if (claim !== loadRef.current) return
           let event = 'message'
           let data = ''
           for (const line of rawEvent.split(/\r?\n/)) {
@@ -166,8 +168,15 @@ export const useCompassAssistant = (organizationId: string) => {
               ...parts,
               { kind: 'block', block: payload as AssistantBlock },
             ])
+          } else if (event === 'thread') {
+            // Adopt the new thread so a mid-stream refresh can recover it
+            setThread(payload.thread_id)
+            onThreadChangeRef.current?.(payload.thread_id)
+            void queryClient.invalidateQueries({
+              queryKey: ['compass_threads'],
+            })
           } else if (event === 'done') {
-            historyRef.current = payload.message_history
+            setThread(payload.thread_id)
           } else if (event === 'error') {
             appendToAssistant(assistantId, (parts) =>
               appendDelta(parts, payload.message),
@@ -187,28 +196,109 @@ export const useCompassAssistant = (organizationId: string) => {
           }
         }
       } catch (error) {
-        // An aborted stream (unmount or superseding send) is not a failure.
+        // An aborted stream (unmount, or a thread switch that supersedes it)
+        // is not a failure.
         if (!(error instanceof DOMException && error.name === 'AbortError')) {
           appendToAssistant(assistantId, (parts) =>
             appendDelta(parts, 'Something went wrong. Please try again.'),
           )
         }
       } finally {
-        // A superseding send owns isStreaming now; only the current stream
-        // may clear it.
+        // Hydrating another thread already cleared isStreaming and dropped
+        // this controller; only the stream still in charge may clear it.
         if (controllerRef.current === controller) {
           setIsStreaming(false)
           controllerRef.current = null
         }
       }
     },
-    [appendToAssistant, organizationId],
+    [
+      appendToAssistant,
+      claimConversation,
+      organizationId,
+      queryClient,
+      setThread,
+    ],
   )
 
-  const reset = useCallback(() => {
-    setMessages([])
-    historyRef.current = null
-  }, [])
+  const hydrate = useCallback(
+    (thread: schemas['CompassThreadWithMessages']) => {
+      // Replaying a stored thread supersedes whatever was on screen,
+      // including a live stream.
+      controllerRef.current?.abort()
+      controllerRef.current = null
+      setIsStreaming(false)
+      setThread(thread.id)
+      setMessages(
+        thread.messages.flatMap((message) => [
+          {
+            id: `${message.id}-prompt`,
+            role: 'user' as const,
+            parts: [{ kind: 'text' as const, text: message.prompt }],
+            answeredAt: message.created_at,
+            restored: true,
+          },
+          {
+            id: message.id,
+            role: 'assistant' as const,
+            parts: message.parts,
+            answeredAt: message.created_at,
+            restored: true,
+            prompt: message.prompt,
+          },
+        ]),
+      )
+    },
+    [setThread],
+  )
 
-  return { messages, send, isStreaming, reset }
+  const newChat = useCallback(() => {
+    controllerRef.current?.abort()
+    controllerRef.current = null
+    claimConversation()
+    setIsStreaming(false)
+    setMessages([])
+    setThread(null)
+    onThreadChangeRef.current?.(null)
+  }, [claimConversation, setThread])
+
+  const loadThread = useCallback(
+    async (id: string) => {
+      const claim = claimConversation()
+      try {
+        const detail = await fetchCompassThread(queryClient, id)
+        if (claim !== loadRef.current) return
+        hydrate(detail)
+        onThreadChangeRef.current?.(detail.id)
+      } catch (error) {
+        if (claim !== loadRef.current) return
+        // Only a thread that is gone justifies clearing the screen, a
+        // transient failure keeps what's on it.
+        if (error instanceof NotFoundResponseError) {
+          newChat()
+        }
+      }
+    },
+    [claimConversation, queryClient, hydrate, newChat],
+  )
+
+  const selectThread = useCallback(
+    (id: string) => {
+      if (id === threadIdRef.current) return
+      void loadThread(id)
+    },
+    [loadThread],
+  )
+
+  // Hydration is imperative — once on mount for a `?thread=` deep link, and
+  // on an explicit history selection. Reactive URL/cache hydration races
+  // router.replace and resurrects conversations the user just left.
+  const initialLoadedRef = useRef(false)
+  useEffect(() => {
+    if (!initialThreadId || initialLoadedRef.current) return
+    initialLoadedRef.current = true
+    void loadThread(initialThreadId)
+  }, [initialThreadId, loadThread])
+
+  return { messages, send, isStreaming, threadId, selectThread, newChat }
 }

--- a/clients/apps/web/src/hooks/useCompassAssistant.ts
+++ b/clients/apps/web/src/hooks/useCompassAssistant.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { fetchCompassThread } from '@/hooks/queries'
+import { CompassThreadDetail, fetchCompassThread } from '@/hooks/queries'
 import { getServerURL } from '@/utils/api'
 import { NotFoundResponseError, schemas } from '@polar-sh/client'
 import { useQueryClient } from '@tanstack/react-query'
@@ -222,7 +222,7 @@ export const useCompassAssistant = ({
   )
 
   const hydrate = useCallback(
-    (thread: schemas['CompassThreadWithMessages']) => {
+    (thread: CompassThreadDetail) => {
       // Replaying a stored thread supersedes whatever was on screen,
       // including a live stream.
       controllerRef.current?.abort()

--- a/clients/apps/web/src/hooks/useCompassAssistant.ts
+++ b/clients/apps/web/src/hooks/useCompassAssistant.ts
@@ -177,6 +177,11 @@ export const useCompassAssistant = ({
             })
           } else if (event === 'done') {
             setThread(payload.thread_id)
+            // The recorded turn bumps the thread's recency, which reorders and
+            // re-buckets the history list.
+            void queryClient.invalidateQueries({
+              queryKey: ['compass_threads'],
+            })
           } else if (event === 'error') {
             appendToAssistant(assistantId, (parts) =>
               appendDelta(parts, payload.message),


### PR DESCRIPTION
PR 3 of 3 in the threads to compass POC

For more context, see the draft https://github.com/polarsource/polar/pull/13550

Wires the dashboard to the thread API. Sending a turn now posts thread_id instead of the sealed history blob, and the thread / done events carry the id back, new conversations get theirs before the first token, so the URL can point at the thread while it is still streaming. Threads are deep-linkable as ?thread=<id>, opening one replays its stored messages rather than re-running the model.

Adds a history popover to the page header: threads bucketed by Today / Yesterday / Previous 7 days / Earlier, each row selectable, with delete on hover. Plus a new-chat action that appears once a conversation has started.

In future PR this will be refactored a bunch I think. For example with better state management now that threads are introduced and fix the edge cases of failed messages or stream interrupts etc.


PR 1:  https://github.com/polarsource/polar/pull/13568

PR 2: https://github.com/polarsource/polar/pull/13574

This PR is dependent on those.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

