### PR TITLE
tf: Ignore changes to masked variables

### DIFF
--- a/terraform/identity/ssosync.tf
+++ b/terraform/identity/ssosync.tf
@@ -79,4 +79,14 @@ resource "aws_serverlessapplicationrepository_cloudformation_stack" "ssosync" {
     LogFormat               = "json"
     ScheduleExpression      = var.ssosync_schedule_expression
   }
+
+  lifecycle {
+    ignore_changes = [
+      parameters["GoogleCredentials"],
+      parameters["GoogleAdminEmail"],
+      parameters["SCIMEndpointAccessToken"],
+      parameters["SyncMethod"],
+      parameters["LogFormat"],
+    ]
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add lifecycle ignore_changes for sensitive ssosync parameters to prevent endless Terraform diffs and accidental redeploys when AWS returns masked values. No functional changes; stabilizes plans by ignoring GoogleCredentials, GoogleAdminEmail, SCIMEndpointAccessToken, SyncMethod, and LogFormat.

<sup>Written for commit 6b195154737e082c56217a5e58fb978de1774e0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

