### PR TITLE
fix(merchant-migration): reject non-migratable Stripe sources when connecting

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/CreateMigrationModal.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/CreateMigrationModal.tsx
@@ -95,7 +95,7 @@ export function CreateMigrationModal({
         {error && (
           <Alert
             variant="danger"
-            title="Couldn't validate the key"
+            title="We couldn't connect this account"
             description={error}
           />
         )}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
@@ -117,7 +117,7 @@ export function ReviewTable({ migrationId }: { migrationId: string }) {
       }}
       importing={importCatalog.isPending}
       importResult={importCatalog.data}
-      importError={importCatalog.isError}
+      importError={importCatalog.error?.message}
       onRerunPrecheck={() => rerunPrecheck.mutate()}
       rerunning={rerunPrecheck.isPending}
       blockers={rerunPrecheck.data?.issues.filter(

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTable.tsx
@@ -117,7 +117,12 @@ export function ReviewTable({ migrationId }: { migrationId: string }) {
       }}
       importing={importCatalog.isPending}
       importResult={importCatalog.data}
-      importError={importCatalog.error?.message}
+      importError={
+        importCatalog.isError
+          ? importCatalog.error?.message ||
+            'Something went wrong. Please try again.'
+          : undefined
+      }
       onRerunPrecheck={() => rerunPrecheck.mutate()}
       rerunning={rerunPrecheck.isPending}
       blockers={rerunPrecheck.data?.issues.filter(

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/migrations/review/ReviewTableView.tsx
@@ -44,7 +44,7 @@ interface Props {
   onImport: () => void
   importing?: boolean
   importResult?: ImportSummary | null
-  importError?: boolean
+  importError?: string
   onRerunPrecheck?: () => void
   rerunning?: boolean
   blockers?: schemas['PrecheckIssue'][]
@@ -70,7 +70,7 @@ export function ReviewTableView({
   onImport,
   importing = false,
   importResult,
-  importError = false,
+  importError,
   onRerunPrecheck,
   rerunning = false,
   blockers = [],
@@ -186,7 +186,7 @@ export function ReviewTableView({
         <Alert
           variant="danger"
           title="We couldn't import the catalog"
-          description="Something went wrong. Please try again."
+          description={importError}
         />
       )}
 

--- a/clients/apps/web/src/hooks/queries/merchantMigrations.ts
+++ b/clients/apps/web/src/hooks/queries/merchantMigrations.ts
@@ -68,10 +68,30 @@ interface ImportOptions {
   excludeRecordIds?: string[]
 }
 
+// Not `unwrap` like its neighbours: that reads `message`, the API reports
+// `detail`, and these surface the server's wording to the merchant. Takes the
+// request, not its result: a rejected fetch (offline, DNS) would otherwise put
+// the browser's own wording on screen instead of the fallback.
+const dataOrThrow = async <T>(
+  request: Promise<{ data?: T; error?: { detail?: unknown } }>,
+  fallback: string,
+): Promise<T> => {
+  let result
+  try {
+    result = await request
+  } catch {
+    throw new Error(fallback)
+  }
+  if (result.error || result.data === undefined) {
+    throw new Error(extractApiErrorMessage(result.error ?? {}, fallback))
+  }
+  return result.data
+}
+
 export const useImportMerchantMigrationCatalog = (id: string) =>
   useMutation({
     mutationFn: (options: ImportOptions = {}) =>
-      unwrap(
+      dataOrThrow(
         api.POST('/v1/merchant-migrations/{id}/import', {
           params: { path: { id } },
           body: {
@@ -81,6 +101,7 @@ export const useImportMerchantMigrationCatalog = (id: string) =>
               : {}),
           },
         }),
+        "We couldn't import the catalog.",
       ),
     onSuccess: () => {
       getQueryClient().invalidateQueries({
@@ -126,21 +147,6 @@ const syncPanTransfer = (
   invalidateMigration(id)
 }
 
-// Not `unwrap` like its neighbours: that reads `message`, the API reports
-// `detail`, and these two surface the server's wording to the merchant.
-const checklistOrThrow = (
-  result: {
-    data?: schemas['PanTransferChecklist']
-    error?: { detail?: unknown }
-  },
-  fallback: string,
-): schemas['PanTransferChecklist'] => {
-  if (result.error || !result.data) {
-    throw new Error(extractApiErrorMessage(result.error ?? {}, fallback))
-  }
-  return result.data
-}
-
 // A step can move from the backoffice or another tab, so a conflict means our
 // view is stale. Refetch the migration too: the page picks its view from it,
 // and otherwise the start button stays live and keeps failing the same way.
@@ -155,9 +161,9 @@ const panTransferHandlers = (id: string) => ({
 
 export const useStartPanTransfer = (id: string) =>
   useMutation({
-    mutationFn: async () =>
-      checklistOrThrow(
-        await api.POST('/v1/merchant-migrations/{id}/pan-transfer', {
+    mutationFn: () =>
+      dataOrThrow(
+        api.POST('/v1/merchant-migrations/{id}/pan-transfer', {
           params: { path: { id } },
         }),
         "We couldn't start the card transfer.",
@@ -167,15 +173,15 @@ export const useStartPanTransfer = (id: string) =>
 
 export const useCompletePanTransferStep = (id: string) =>
   useMutation({
-    mutationFn: async ({
+    mutationFn: ({
       key,
       inputs,
     }: {
       key: string
       inputs: Record<string, string>
     }) =>
-      checklistOrThrow(
-        await api.POST(
+      dataOrThrow(
+        api.POST(
           '/v1/merchant-migrations/{id}/pan-transfer/steps/{key}/complete',
           { params: { path: { id, key } }, body: { inputs } },
         ),

--- a/clients/apps/web/src/hooks/queries/merchantMigrations.ts
+++ b/clients/apps/web/src/hooks/queries/merchantMigrations.ts
@@ -76,14 +76,9 @@ const dataOrThrow = async <T>(
   request: Promise<{ data?: T; error?: { detail?: unknown } }>,
   fallback: string,
 ): Promise<T> => {
-  let result
-  try {
-    result = await request
-  } catch {
-    throw new Error(fallback)
-  }
-  if (result.error || result.data === undefined) {
-    throw new Error(extractApiErrorMessage(result.error ?? {}, fallback))
+  const result = await request.catch(() => null)
+  if (!result || result.error || result.data === undefined) {
+    throw new Error(extractApiErrorMessage(result?.error ?? {}, fallback))
   }
   return result.data
 }
@@ -101,7 +96,7 @@ export const useImportMerchantMigrationCatalog = (id: string) =>
               : {}),
           },
         }),
-        "We couldn't import the catalog.",
+        'Something went wrong. Please try again.',
       ),
     onSuccess: () => {
       getQueryClient().invalidateQueries({

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -32414,6 +32414,17 @@ export interface components {
        */
       users: components['schemas']['SlackWorkspaceUser'][]
     }
+    /** SourceAccountNotMigratable */
+    SourceAccountNotMigratable: {
+      /**
+       * Error
+       * @example SourceAccountNotMigratable
+       * @constant
+       */
+      error: 'SourceAccountNotMigratable'
+      /** Detail */
+      detail: string
+    }
     /** SourceKeyModeMismatch */
     SourceKeyModeMismatch: {
       /**
@@ -52081,7 +52092,7 @@ export interface operations {
           'application/json': components['schemas']['MerchantMigration']
         }
       }
-      /** @description The Stripe API key is invalid, wrong mode, or missing permissions. */
+      /** @description The Stripe API key is invalid, wrong mode, or missing permissions, or the account it belongs to can't be migrated. */
       400: {
         headers: {
           [name: string]: unknown
@@ -52090,6 +52101,7 @@ export interface operations {
           'application/json':
             | components['schemas']['InvalidSourceCredentials']
             | components['schemas']['MissingStripeScopes']
+            | components['schemas']['SourceAccountNotMigratable']
             | components['schemas']['SourceKeyModeMismatch']
             | components['schemas']['UnsupportedMigrationSource']
         }

--- a/server/polar/merchant_migration/adapters/stripe.py
+++ b/server/polar/merchant_migration/adapters/stripe.py
@@ -36,6 +36,8 @@ class StripeAdapter:
         self._client = stripe_lib.StripeClient(
             access_token, stripe_version=STRIPE_API_VERSION
         )
+        self._account: stripe_lib.Account | None = None
+        self._account_read = False
 
     async def verify_scopes(self) -> list[str]:
         """Probe every permission the migration needs, concurrently, and return the
@@ -87,11 +89,15 @@ class StripeAdapter:
             pass
 
     async def _current_account(self) -> stripe_lib.Account | None:
-        # Best-effort: a restricted key may lack account read scope.
-        try:
-            return await self._client.v1.accounts.retrieve_current_async()
-        except stripe_lib.StripeError:
-            return None
+        # Best-effort: a restricted key may lack account read scope. Read once:
+        # creating a migration needs both the account id and its country.
+        if not self._account_read:
+            try:
+                self._account = await self._client.v1.accounts.retrieve_current_async()
+            except stripe_lib.StripeError:
+                self._account = None
+            self._account_read = True
+        return self._account
 
     async def get_account_id(self) -> str | None:
         account = await self._current_account()

--- a/server/polar/merchant_migration/adapters/stripe.py
+++ b/server/polar/merchant_migration/adapters/stripe.py
@@ -122,10 +122,12 @@ class StripeAdapter:
         return bool(accounts.data)
 
     async def get_source_account(self) -> CanonicalAccount:
-        account = await self._current_account()
+        account, has_connected_accounts = await asyncio.gather(
+            self._current_account(), self._has_connected_accounts()
+        )
         return CanonicalAccount(
             country=account.country if account else None,
-            has_connected_accounts=await self._has_connected_accounts(),
+            has_connected_accounts=has_connected_accounts,
         )
 
     async def _extract_products(self) -> AsyncIterator[CanonicalProduct]:

--- a/server/polar/merchant_migration/adapters/stripe.py
+++ b/server/polar/merchant_migration/adapters/stripe.py
@@ -37,7 +37,6 @@ class StripeAdapter:
             access_token, stripe_version=STRIPE_API_VERSION
         )
         self._account: stripe_lib.Account | None = None
-        self._account_read = False
 
     async def verify_scopes(self) -> list[str]:
         """Probe every permission the migration needs, concurrently, and return the
@@ -89,14 +88,15 @@ class StripeAdapter:
             pass
 
     async def _current_account(self) -> stripe_lib.Account | None:
-        # Best-effort: a restricted key may lack account read scope. Read once:
-        # creating a migration needs both the account id and its country.
-        if not self._account_read:
+        # Best-effort: a restricted key may lack account read scope. Only a
+        # successful read is cached — creating a migration needs both the account
+        # id and its country, but a rate-limited read must not stick and cost the
+        # id we would otherwise have stored.
+        if self._account is None:
             try:
                 self._account = await self._client.v1.accounts.retrieve_current_async()
             except stripe_lib.StripeError:
-                self._account = None
-            self._account_read = True
+                return None
         return self._account
 
     async def get_account_id(self) -> str | None:

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -42,6 +42,7 @@ from .service import (
     MerchantMigrationNotEnabled,
     MerchantMigrationNotFound,
     MissingStripeScopes,
+    SourceAccountNotMigratable,
     SourceKeyModeMismatch,
     SourceNotConnected,
     SourceVerificationUnavailable,
@@ -87,9 +88,10 @@ async def list(
     responses={
         400: {
             "description": "The Stripe API key is invalid, wrong mode, or missing "
-            "permissions.",
+            "permissions, or the account it belongs to can't be migrated.",
             "model": InvalidSourceCredentials.schema()
             | MissingStripeScopes.schema()
+            | SourceAccountNotMigratable.schema()
             | SourceKeyModeMismatch.schema()
             | UnsupportedMigrationSource.schema(),
         },

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -769,16 +769,26 @@ class SplitRecords:
         return split
 
 
+def _blockers(issues: Iterable[PrecheckIssue]) -> list[PrecheckIssue]:
+    return [issue for issue in issues if issue.level == PrecheckIssueLevel.blocker]
+
+
+def account_blockers(source_account: CanonicalAccount) -> list[PrecheckIssue]:
+    """Blockers that come from the source account itself. They hold for every
+    catalog that account could ever have, so the caller can reject the source as
+    soon as it's connected rather than at the import."""
+    return _blockers(precheck_engine._check_account(source_account))
+
+
 def import_blockers(
     organization: Organization, source_account: CanonicalAccount
 ) -> list[PrecheckIssue]:
     """Blockers that don't depend on the catalog, so the import can re-check them
     without re-reading the whole source."""
-    issues = [
-        *precheck_engine._check_organization(organization),
-        *precheck_engine._check_account(source_account),
+    return [
+        *_blockers(precheck_engine._check_organization(organization)),
+        *account_blockers(source_account),
     ]
-    return [issue for issue in issues if issue.level == PrecheckIssueLevel.blocker]
 
 
 def classify_records(

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -774,9 +774,9 @@ def _blockers(issues: Iterable[PrecheckIssue]) -> list[PrecheckIssue]:
 
 
 def account_blockers(source_account: CanonicalAccount) -> list[PrecheckIssue]:
-    """Blockers that come from the source account itself. They hold for every
-    catalog that account could ever have, so the caller can reject the source as
-    soon as it's connected rather than at the import."""
+    """Blockers that come from the source account itself rather than its catalog,
+    so the caller can reject the source as soon as it's connected instead of at
+    the import."""
     return _blockers(precheck_engine._check_account(source_account))
 
 

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -145,23 +145,27 @@ class CatalogImportNotReady(MerchantMigrationError):
         )
 
 
-class CatalogImportBlocked(MerchantMigrationError):
-    def __init__(self, blockers: list[PrecheckIssue]) -> None:
+class BlockedByPrecheck(MerchantMigrationError):
+    """Precheck blockers as an API error: the codes stay machine-readable while
+    the merchant reads the joined messages."""
+
+    def __init__(
+        self, summary: str, blockers: list[PrecheckIssue], status_code: int
+    ) -> None:
         self.blockers = [issue.code for issue in blockers]
         super().__init__(
-            "The migration can't be imported: " + " ".join(i.message for i in blockers),
-            409,
+            f"{summary} " + " ".join(issue.message for issue in blockers), status_code
         )
 
 
-class SourceAccountNotMigratable(MerchantMigrationError):
+class CatalogImportBlocked(BlockedByPrecheck):
     def __init__(self, blockers: list[PrecheckIssue]) -> None:
-        self.blockers = [issue.code for issue in blockers]
-        super().__init__(
-            "This account can't be migrated: "
-            + " ".join(issue.message for issue in blockers),
-            400,
-        )
+        super().__init__("The migration can't be imported:", blockers, 409)
+
+
+class SourceAccountNotMigratable(BlockedByPrecheck):
+    def __init__(self, blockers: list[PrecheckIssue]) -> None:
+        super().__init__("This account can't be migrated:", blockers, 400)
 
 
 class SourceKeyModeMismatch(MerchantMigrationError):

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -34,7 +34,12 @@ from .pan_transfer import (
     PanTransferStep,
     PanTransferUnavailable,
 )
-from .precheck import classify_records, import_blockers, precheck_engine
+from .precheck import (
+    account_blockers,
+    classify_records,
+    import_blockers,
+    precheck_engine,
+)
 from .repository import (
     MerchantMigrationRecordRepository,
     MerchantMigrationRepository,
@@ -149,6 +154,16 @@ class CatalogImportBlocked(MerchantMigrationError):
         )
 
 
+class SourceAccountNotMigratable(MerchantMigrationError):
+    def __init__(self, blockers: list[PrecheckIssue]) -> None:
+        self.blockers = [issue.code for issue in blockers]
+        super().__init__(
+            "This account can't be migrated: "
+            + " ".join(issue.message for issue in blockers),
+            400,
+        )
+
+
 class SourceKeyModeMismatch(MerchantMigrationError):
     def __init__(self, *, expect_live: bool) -> None:
         mode = "live" if expect_live else "test"
@@ -231,6 +246,12 @@ class MerchantMigrationService:
             raise SourceVerificationUnavailable() from e
         if missing_scopes:
             raise MissingStripeScopes(missing_scopes)
+
+        # An account we can never migrate is rejected here rather than at the
+        # import, so the merchant hears it while they're still connecting the key.
+        blockers = account_blockers(await adapter.get_source_account())
+        if blockers:
+            raise SourceAccountNotMigratable(blockers)
 
         # Pre-generate the id so the credentials (encrypted with it as context) can
         # be set before the row is inserted — one INSERT instead of INSERT+UPDATE.

--- a/server/tests/merchant_migration/_helpers.py
+++ b/server/tests/merchant_migration/_helpers.py
@@ -1,4 +1,5 @@
 from polar.kit.encryption import EncryptedString
+from polar.merchant_migration.repository import MerchantMigrationRepository
 from polar.merchant_migration.service import (
     SOURCE_CREDENTIALS_ENCRYPTION_CONTEXT,
     StripeSourceCredentials,
@@ -8,7 +9,21 @@ from polar.models.merchant_migration import (
     MerchantMigrationSourcePlatform,
     MerchantMigrationStep,
 )
+from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
+
+
+async def assert_no_migrations(
+    session: AsyncSession, organization: Organization
+) -> None:
+    """A rejected create must leave nothing behind, not even an unusable row."""
+    repository = MerchantMigrationRepository.from_session(session)
+    migrations = await repository.get_all(
+        repository.get_base_statement().where(
+            MerchantMigration.organization_id == organization.id
+        )
+    )
+    assert len(migrations) == 0
 
 
 async def build_stripe_credentials(

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -24,7 +24,10 @@ from polar.models.merchant_migration import (
 from polar.postgres import AsyncSession
 from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
-from tests.merchant_migration._helpers import build_connected_migration
+from tests.merchant_migration._helpers import (
+    assert_no_migrations,
+    build_connected_migration,
+)
 
 VALID_BODY = {
     "source_platform": "stripe",
@@ -131,13 +134,7 @@ class TestCreate:
         assert response.status_code == 400
         assert "Subscriptions (write)" in response.text
 
-        repository = MerchantMigrationRepository.from_session(session)
-        migrations = await repository.get_all(
-            repository.get_base_statement().where(
-                MerchantMigration.organization_id == organization.id
-            )
-        )
-        assert len(migrations) == 0
+        await assert_no_migrations(session, organization)
 
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
     async def test_invalid_key_returns_400(
@@ -177,13 +174,7 @@ class TestCreate:
         assert response.status_code == 400
         assert "Connect accounts" in response.text
 
-        repository = MerchantMigrationRepository.from_session(session)
-        migrations = await repository.get_all(
-            repository.get_base_statement().where(
-                MerchantMigration.organization_id == organization.id
-            )
-        )
-        assert len(migrations) == 0
+        await assert_no_migrations(session, organization)
 
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
     async def test_creates_connected_migration(

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -51,6 +51,7 @@ def _mock_stripe_adapter(
     *,
     missing_scopes: list[str] | None = None,
     auth_error: Exception | None = None,
+    has_connected_accounts: bool = False,
 ) -> None:
     adapter = mocker.MagicMock()
     if auth_error is not None:
@@ -58,6 +59,11 @@ def _mock_stripe_adapter(
     else:
         adapter.verify_scopes = mocker.AsyncMock(return_value=missing_scopes or [])
     adapter.get_account_id = mocker.AsyncMock(return_value="acct_test")
+    adapter.get_source_account = mocker.AsyncMock(
+        return_value=CanonicalAccount(
+            country="US", has_connected_accounts=has_connected_accounts
+        )
+    )
     mocker.patch("polar.merchant_migration.service.StripeAdapter", return_value=adapter)
 
 
@@ -151,6 +157,33 @@ class TestCreate:
             "/v1/merchant-migrations/", json=_body(organization)
         )
         assert response.status_code == 400
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_source_with_connected_accounts_returns_400(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+        mocker: MockerFixture,
+    ) -> None:
+        await _enable_feature(save_fixture, organization)
+        _mock_stripe_adapter(mocker, has_connected_accounts=True)
+
+        response = await client.post(
+            "/v1/merchant-migrations/", json=_body(organization)
+        )
+        assert response.status_code == 400
+        assert "Connect accounts" in response.text
+
+        repository = MerchantMigrationRepository.from_session(session)
+        migrations = await repository.get_all(
+            repository.get_base_statement().where(
+                MerchantMigration.organization_id == organization.id
+            )
+        )
+        assert len(migrations) == 0
 
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
     async def test_creates_connected_migration(

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -68,7 +68,10 @@ from polar.models.subscription import SubscriptionStatus
 from polar.postgres import AsyncSession
 from polar.product.service import product as product_service
 from tests.fixtures.database import SaveFixture
-from tests.merchant_migration._helpers import build_connected_migration
+from tests.merchant_migration._helpers import (
+    assert_no_migrations,
+    build_connected_migration,
+)
 
 
 class _FakeAdapter:
@@ -176,13 +179,7 @@ class TestCreate:
             await service.create(session, auth_subject, _create_schema(organization))
 
         assert exc_info.value.missing == ["Payment methods", "Subscriptions (write)"]
-        repository = MerchantMigrationRepository.from_session(session)
-        migrations = await repository.get_all(
-            repository.get_base_statement().where(
-                MerchantMigration.organization_id == organization.id
-            )
-        )
-        assert len(migrations) == 0
+        await assert_no_migrations(session, organization)
 
     @pytest.mark.auth
     async def test_source_with_connected_accounts_raises_and_persists_nothing(
@@ -198,7 +195,9 @@ class TestCreate:
         mocker.patch(
             "polar.merchant_migration.service.StripeAdapter",
             return_value=_FakeAdapter(
-                source_account=CanonicalAccount(country="US", has_connected_accounts=True)
+                source_account=CanonicalAccount(
+                    country="US", has_connected_accounts=True
+                )
             ),
         )
 
@@ -206,13 +205,7 @@ class TestCreate:
             await service.create(session, auth_subject, _create_schema(organization))
 
         assert exc_info.value.blockers == ["source_has_connected_accounts"]
-        repository = MerchantMigrationRepository.from_session(session)
-        migrations = await repository.get_all(
-            repository.get_base_statement().where(
-                MerchantMigration.organization_id == organization.id
-            )
-        )
-        assert len(migrations) == 0
+        await assert_no_migrations(session, organization)
 
     @pytest.mark.auth
     async def test_invalid_key_raises(
@@ -257,13 +250,7 @@ class TestCreate:
         with pytest.raises(SourceVerificationUnavailable):
             await service.create(session, auth_subject, _create_schema(organization))
 
-        repository = MerchantMigrationRepository.from_session(session)
-        migrations = await repository.get_all(
-            repository.get_base_statement().where(
-                MerchantMigration.organization_id == organization.id
-            )
-        )
-        assert len(migrations) == 0
+        await assert_no_migrations(session, organization)
 
     @pytest.mark.auth
     async def test_sandbox_rejects_a_live_key(
@@ -747,7 +734,9 @@ class TestImportCatalog:
         mocker.patch(
             "polar.merchant_migration.service.StripeAdapter",
             return_value=_FakeAdapter(
-                source_account=CanonicalAccount(country="US", has_connected_accounts=True)
+                source_account=CanonicalAccount(
+                    country="US", has_connected_accounts=True
+                )
             ),
         )
 

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -38,6 +38,7 @@ from polar.merchant_migration.service import (
     CatalogImportNotReady,
     InvalidSourceCredentials,
     MissingStripeScopes,
+    SourceAccountNotMigratable,
     SourceKeyModeMismatch,
     SourceNotConnected,
     SourceVerificationUnavailable,
@@ -78,11 +79,15 @@ class _FakeAdapter:
         missing_scopes: list[str] | None = None,
         verify_error: Exception | None = None,
         account_id: str | None = "acct_test",
+        source_account: CanonicalAccount | None = None,
     ) -> None:
         self._records = records or []
         self._missing_scopes = missing_scopes or []
         self._verify_error = verify_error
         self._account_id = account_id
+        self._source_account = source_account or CanonicalAccount(
+            country="US", has_connected_accounts=False
+        )
 
     async def verify_scopes(self) -> list[str]:
         if self._verify_error is not None:
@@ -97,7 +102,7 @@ class _FakeAdapter:
             yield record
 
     async def get_source_account(self) -> CanonicalAccount:
-        return CanonicalAccount(country="US", has_connected_accounts=False)
+        return self._source_account
 
 
 async def _enable_feature(
@@ -171,6 +176,36 @@ class TestCreate:
             await service.create(session, auth_subject, _create_schema(organization))
 
         assert exc_info.value.missing == ["Payment methods", "Subscriptions (write)"]
+        repository = MerchantMigrationRepository.from_session(session)
+        migrations = await repository.get_all(
+            repository.get_base_statement().where(
+                MerchantMigration.organization_id == organization.id
+            )
+        )
+        assert len(migrations) == 0
+
+    @pytest.mark.auth
+    async def test_source_with_connected_accounts_raises_and_persists_nothing(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await _enable_feature(save_fixture, organization)
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter",
+            return_value=_FakeAdapter(
+                source_account=CanonicalAccount(country="US", has_connected_accounts=True)
+            ),
+        )
+
+        with pytest.raises(SourceAccountNotMigratable) as exc_info:
+            await service.create(session, auth_subject, _create_schema(organization))
+
+        assert exc_info.value.blockers == ["source_has_connected_accounts"]
         repository = MerchantMigrationRepository.from_session(session)
         migrations = await repository.get_all(
             repository.get_base_statement().where(
@@ -692,6 +727,34 @@ class TestImportCatalog:
         with pytest.raises(CatalogImportBlocked):
             await service.import_catalog(session, auth_subject, migration.id)
 
+        assert await _products(session, organization) == []
+
+    @pytest.mark.auth
+    async def test_blocked_source_account_cannot_import(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        # Migrations created before the source account grew a blocker, or before
+        # `create` started rejecting them, still have to be caught here.
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter",
+            return_value=_FakeAdapter(
+                source_account=CanonicalAccount(country="US", has_connected_accounts=True)
+            ),
+        )
+
+        with pytest.raises(CatalogImportBlocked) as exc_info:
+            await service.import_catalog(session, auth_subject, migration.id)
+
+        assert exc_info.value.blockers == ["source_has_connected_accounts"]
         assert await _products(session, organization) == []
 
     @pytest.mark.auth

--- a/server/tests/merchant_migration/test_stripe_adapter.py
+++ b/server/tests/merchant_migration/test_stripe_adapter.py
@@ -115,6 +115,20 @@ class TestGetAccountId:
 
         client.v1.accounts.retrieve_current_async.assert_awaited_once()
 
+    async def test_failed_read_is_not_cached(self, mocker: MockerFixture) -> None:
+        # A rate limit on the first read must not cost the account id for the
+        # rest of the adapter's life.
+        adapter, client = _adapter(mocker)
+        client.v1.accounts.retrieve_current_async = mocker.AsyncMock(
+            side_effect=[
+                stripe_lib.RateLimitError("rate limited"),
+                mocker.MagicMock(id="acct_123"),
+            ]
+        )
+
+        assert await adapter.get_account_id() is None
+        assert await adapter.get_account_id() == "acct_123"
+
 
 @pytest.mark.asyncio
 class TestGetSourceAccount:

--- a/server/tests/merchant_migration/test_stripe_adapter.py
+++ b/server/tests/merchant_migration/test_stripe_adapter.py
@@ -99,6 +99,22 @@ class TestGetAccountId:
 
         assert await adapter.get_account_id() is None
 
+    async def test_account_is_read_once(self, mocker: MockerFixture) -> None:
+        # Creating a migration needs both the id and the country; one read serves
+        # both.
+        adapter, client = _adapter(mocker)
+        client.v1.accounts.retrieve_current_async = mocker.AsyncMock(
+            return_value=mocker.MagicMock(id="acct_123", country="US")
+        )
+        client.v1.accounts.list_async = mocker.AsyncMock(
+            side_effect=stripe_lib.PermissionError("not a platform")
+        )
+
+        assert (await adapter.get_source_account()).country == "US"
+        assert await adapter.get_account_id() == "acct_123"
+
+        client.v1.accounts.retrieve_current_async.assert_awaited_once()
+
 
 @pytest.mark.asyncio
 class TestGetSourceAccount:


### PR DESCRIPTION
## Summary

Some Stripe sources can never be migrated. A source with Connect accounts is one: only data on
the platform account can be copied. We only said so when the merchant clicked Import, and the
dashboard showed "Something went wrong" instead of the reason.

Now we reject the source while the key is being connected, and nothing is saved. The import still
re-checks, for migrations made before this change, and it now shows the reason.

Rebased on #13582, so it uses that PR's rule: the source is blocked only when it really has
connected accounts.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

Last box: three existing tests moved to a new `assert_no_migrations` helper, because this PR would
have added two more copies of the same block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
