### PR TITLE
fix(merchant-migration): only block sources that have Connect accounts

### DIFF
--- a/handbook/engineering/design-documents/merchant-migrations.mdx
+++ b/handbook/engineering/design-documents/merchant-migrations.mdx
@@ -286,7 +286,7 @@ We can't reuse Polar's platform Stripe service (it's bound to the global platfor
 
 On top of the generic ones in Appendix A. What's unique to Stripe:
 
-- **Manual:** source account is a Connect platform - only platform-account customers/PMs are copyable; anything on connected accounts is excluded.
+- **Manual:** source account has Connect accounts - only platform-account customers/PMs are copyable; anything on connected accounts is excluded. A platform with no connected accounts is not flagged: Stripe answers the list call with an empty list for a non-platform, so the call succeeding proves nothing.
 - **Blocker:** India / RBI account - card data can't cross the border, so the PAN copy can't run (bidirectional).
 - **Blocker:** tiered/graduated pricing (`billing_scheme=tiered`) can't be represented.
 - **Blocker:** metered pricing (`usage_type=metered`) - to be implemented later (Stripe now requires a Billing Meter; legacy usage records are gone).

--- a/server/polar/merchant_migration/adapters/stripe.py
+++ b/server/polar/merchant_migration/adapters/stripe.py
@@ -105,23 +105,21 @@ class StripeAdapter:
         async for subscription in self._extract_subscriptions():
             yield subscription
 
-    async def get_source_account(self) -> CanonicalAccount:
-        # Best-effort: the restricted key may lack account/Connect read scope, in
-        # which case we can't determine these and don't block.
-        account = await self._current_account()
-        is_connect_platform = False
+    async def _has_connected_accounts(self) -> bool:
+        # Best-effort: a restricted key may lack Connect read scope. Stripe
+        # answers with an empty list for a non-platform rather than an error, so
+        # only an actual connected account counts.
         try:
-            # Only Connect platforms may list connected accounts; a non-platform
-            # gets a permission error. So the call *succeeding* — not the number
-            # of accounts returned — is what identifies a platform (a platform
-            # with zero connected accounts still succeeds here).
-            await self._client.v1.accounts.list_async(params={"limit": 1})
-            is_connect_platform = True
+            accounts = await self._client.v1.accounts.list_async(params={"limit": 1})
         except stripe_lib.StripeError:
-            pass
+            return False
+        return bool(accounts.data)
+
+    async def get_source_account(self) -> CanonicalAccount:
+        account = await self._current_account()
         return CanonicalAccount(
             country=account.country if account else None,
-            is_connect_platform=is_connect_platform,
+            has_connected_accounts=await self._has_connected_accounts(),
         )
 
     async def _extract_products(self) -> AsyncIterator[CanonicalProduct]:

--- a/server/polar/merchant_migration/canonical.py
+++ b/server/polar/merchant_migration/canonical.py
@@ -118,7 +118,9 @@ class CanonicalAccount:
     """Source-account-level facts the precheck needs but that aren't per-record."""
 
     country: str | None
-    is_connect_platform: bool
+    # The source is a Connect platform *and* has connected accounts, whose data
+    # can't be copied. A platform with none has nothing to leave behind.
+    has_connected_accounts: bool
 
 
 CanonicalRecord = CanonicalProduct | CanonicalCustomer | CanonicalSubscription

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -206,13 +206,13 @@ class PrecheckEngine:
                 ),
                 source_id=None,
             )
-        if account.is_connect_platform:
+        if account.has_connected_accounts:
             yield PrecheckIssue(
                 level=PrecheckIssueLevel.blocker,
-                code="connect_platform_account",
+                code="source_has_connected_accounts",
                 message=(
-                    "The source is a Connect platform; only platform-account data "
-                    "is copyable, so it can't be migrated automatically."
+                    "The source has Connect accounts. Only data on the platform "
+                    "account can be copied, so it can't be migrated automatically."
                 ),
                 source_id=None,
             )

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -279,7 +279,7 @@ class TestPrecheck:
         adapter = mocker.MagicMock()
         adapter.extract.return_value = _empty_extract()
         adapter.get_source_account = mocker.AsyncMock(
-            return_value=CanonicalAccount(country="US", is_connect_platform=False)
+            return_value=CanonicalAccount(country="US", has_connected_accounts=False)
         )
         mocker.patch(
             "polar.merchant_migration.service.StripeAdapter", return_value=adapter
@@ -341,7 +341,7 @@ class TestRecords:
         adapter = mocker.MagicMock()
         adapter.extract.return_value = _catalog_extract()
         adapter.get_source_account = mocker.AsyncMock(
-            return_value=CanonicalAccount(country="US", is_connect_platform=False)
+            return_value=CanonicalAccount(country="US", has_connected_accounts=False)
         )
         mocker.patch(
             "polar.merchant_migration.service.StripeAdapter", return_value=adapter
@@ -406,7 +406,7 @@ class TestImport:
         adapter = mocker.MagicMock()
         adapter.extract.return_value = _catalog_with_customer_extract()
         adapter.get_source_account = mocker.AsyncMock(
-            return_value=CanonicalAccount(country="US", is_connect_platform=False)
+            return_value=CanonicalAccount(country="US", has_connected_accounts=False)
         )
         mocker.patch(
             "polar.merchant_migration.service.StripeAdapter", return_value=adapter
@@ -436,7 +436,7 @@ class TestImport:
         adapter = mocker.MagicMock()
         adapter.extract.return_value = _catalog_with_customer_extract()
         adapter.get_source_account = mocker.AsyncMock(
-            return_value=CanonicalAccount(country="US", is_connect_platform=False)
+            return_value=CanonicalAccount(country="US", has_connected_accounts=False)
         )
         mocker.patch(
             "polar.merchant_migration.service.StripeAdapter", return_value=adapter

--- a/server/tests/merchant_migration/test_precheck.py
+++ b/server/tests/merchant_migration/test_precheck.py
@@ -48,9 +48,11 @@ def build_organization(
 
 
 def build_account(
-    *, country: str | None = "US", is_connect_platform: bool = False
+    *, country: str | None = "US", has_connected_accounts: bool = False
 ) -> CanonicalAccount:
-    return CanonicalAccount(country=country, is_connect_platform=is_connect_platform)
+    return CanonicalAccount(
+        country=country, has_connected_accounts=has_connected_accounts
+    )
 
 
 def build_customer(
@@ -192,11 +194,13 @@ class TestPrecheckEngine:
         report = await run([build_product()], account=build_account(country="IN"))
         assert "india_account" in codes(report, PrecheckIssueLevel.blocker)
 
-    async def test_connect_platform_account_blocks(self) -> None:
+    async def test_connected_accounts_block(self) -> None:
         report = await run(
-            [build_product()], account=build_account(is_connect_platform=True)
+            [build_product()], account=build_account(has_connected_accounts=True)
         )
-        assert "connect_platform_account" in codes(report, PrecheckIssueLevel.blocker)
+        assert "source_has_connected_accounts" in codes(
+            report, PrecheckIssueLevel.blocker
+        )
 
     async def test_non_fixed_pricing_warns_and_can_start(self) -> None:
         report = await run(

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -97,7 +97,7 @@ class _FakeAdapter:
             yield record
 
     async def get_source_account(self) -> CanonicalAccount:
-        return CanonicalAccount(country="US", is_connect_platform=False)
+        return CanonicalAccount(country="US", has_connected_accounts=False)
 
 
 async def _enable_feature(

--- a/server/tests/merchant_migration/test_stripe_adapter.py
+++ b/server/tests/merchant_migration/test_stripe_adapter.py
@@ -102,35 +102,51 @@ class TestGetAccountId:
 
 @pytest.mark.asyncio
 class TestGetSourceAccount:
-    async def test_platform_with_zero_connected_accounts_is_flagged(
+    async def test_platform_with_connected_accounts_is_flagged(
         self, mocker: MockerFixture
     ) -> None:
         adapter, client = _adapter(mocker)
         client.v1.accounts.retrieve_current_async = mocker.AsyncMock(
             return_value=mocker.MagicMock(country="US")
         )
-        # A platform with no connected accounts still lists successfully.
+        client.v1.accounts.list_async = mocker.AsyncMock(
+            return_value=mocker.MagicMock(data=[mocker.MagicMock(id="acct_123")])
+        )
+
+        account = await adapter.get_source_account()
+
+        assert account.has_connected_accounts is True
+
+    async def test_empty_account_list_is_not_flagged(
+        self, mocker: MockerFixture
+    ) -> None:
+        adapter, client = _adapter(mocker)
+        client.v1.accounts.retrieve_current_async = mocker.AsyncMock(
+            return_value=mocker.MagicMock(country="US")
+        )
         client.v1.accounts.list_async = mocker.AsyncMock(
             return_value=mocker.MagicMock(data=[])
         )
 
         account = await adapter.get_source_account()
 
-        assert account.is_connect_platform is True
+        assert account.has_connected_accounts is False
+        assert account.country == "US"
 
-    async def test_non_platform_is_not_flagged(self, mocker: MockerFixture) -> None:
+    async def test_missing_connect_scope_is_not_flagged(
+        self, mocker: MockerFixture
+    ) -> None:
         adapter, client = _adapter(mocker)
         client.v1.accounts.retrieve_current_async = mocker.AsyncMock(
             return_value=mocker.MagicMock(country="US")
         )
-        # Non-platforms get a permission error when listing connected accounts.
         client.v1.accounts.list_async = mocker.AsyncMock(
-            side_effect=stripe_lib.PermissionError("not a platform")
+            side_effect=stripe_lib.PermissionError("no connect access")
         )
 
         account = await adapter.get_source_account()
 
-        assert account.is_connect_platform is False
+        assert account.has_connected_accounts is False
         assert account.country == "US"
 
     async def test_scope_gap_is_tolerated(self, mocker: MockerFixture) -> None:
@@ -145,4 +161,4 @@ class TestGetSourceAccount:
         account = await adapter.get_source_account()
 
         assert account.country is None
-        assert account.is_connect_platform is False
+        assert account.has_connected_accounts is False


### PR DESCRIPTION
## Summary

The migration pre-check blocked any Stripe source it thought was a Connect platform. It was wrong about which sources those are, so sandbox sources could not be migrated.

## What

- Flag the source only when Stripe returns at least one connected account.
- Rename `CanonicalAccount.is_connect_platform` to `has_connected_accounts`, and the blocker code to `source_has_connected_accounts`, so the names match the check.
- Update the blocker message and the design doc.

## Why

The old check set the flag whenever `GET /v1/accounts` succeeded. Stripe returns an empty list for a non-platform instead of an error, so the call succeeding proves nothing. Any key with Connect read access was blocked, even on a plain account.

A platform with no connected accounts is also fine to migrate. There is no connected-account data it would leave behind.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

