### PR TITLE
fix(migrations): skip products with no price in the default currency

### DIFF
--- a/server/polar/merchant_migration/importer.py
+++ b/server/polar/merchant_migration/importer.py
@@ -184,7 +184,9 @@ class CatalogImporter:
             self._as(deserialize(record.type, record.canonical), CanonicalProduct)
             for record in records
         ]
-        plans = plan_product_imports(products)
+        plans = plan_product_imports(
+            products, self.organization.default_presentment_currency
+        )
 
         counts = ImportCounts()
         for record, product in zip(records, products, strict=True):
@@ -343,7 +345,12 @@ class CatalogImporter:
             self._as(deserialize(record.type, record.canonical), CanonicalCustomer)
             for record in customer_records
         ]
-        plans = plan_subscription_imports(subscriptions, products, customers)
+        plans = plan_subscription_imports(
+            subscriptions,
+            products,
+            customers,
+            self.organization.default_presentment_currency,
+        )
         product_by_price = {
             price.source_id: product for product in products for price in product.prices
         }

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -59,6 +59,7 @@ PRODUCT_DROP_CODES = {
     "one_time_product",
     "unsupported_recurring_interval",
     "multiple_prices_same_currency",
+    "missing_default_currency_price",
 }
 PRICE_DROP_CODES = {
     "unsupported_pricing_scheme",
@@ -80,6 +81,7 @@ ACTION_REQUIRED_CODES = {
     "customer_missing_country",
     "customer_missing_email",
     "duplicate_customer_email",
+    "missing_default_currency_price",
     "multiple_prices_same_currency",
     "subscription_has_discount",
     "send_invoice_collection",
@@ -138,10 +140,12 @@ class PrecheckEngine:
         existing_product_names: set[str] | None = None,
     ) -> PrecheckReport:
         record_list = [record async for record in records]
+        default_currency = organization.default_presentment_currency
 
         issues: list[PrecheckIssue] = list(self._check_organization(organization))
         issues.extend(self._check_account(source_account))
 
+        products: list[CanonicalProduct] = []
         products_by_name: dict[str, set[str]] = {}
         email_counts: Counter[str] = Counter()
         customers_without_country = 0
@@ -149,10 +153,11 @@ class PrecheckEngine:
 
         for record in record_list:
             if isinstance(record, CanonicalProduct):
+                products.append(record)
                 products_by_name.setdefault(record.name, set()).add(
                     record.product_source_id
                 )
-                issues.extend(self._check_product(record))
+                issues.extend(self._check_product(record, default_currency))
             elif isinstance(record, CanonicalCustomer):
                 if record.email:
                     email_counts[record.email.lower()] += 1
@@ -163,6 +168,7 @@ class PrecheckEngine:
             elif isinstance(record, CanonicalSubscription):
                 issues.extend(self._check_subscription(record))
 
+        issues.extend(self._check_default_currency(products, default_currency))
         issues.extend(self._check_duplicate_names(products_by_name))
         issues.extend(
             self._check_existing_products(
@@ -178,7 +184,7 @@ class PrecheckEngine:
             can_start=not any(
                 issue.level == PrecheckIssueLevel.blocker for issue in issues
             ),
-            entities=summarize_records(record_list),
+            entities=summarize_records(record_list, default_currency),
         )
 
     def _check_organization(
@@ -217,7 +223,51 @@ class PrecheckEngine:
                 source_id=None,
             )
 
-    def _check_product(self, product: CanonicalProduct) -> Iterable[PrecheckIssue]:
+    def _check_default_currency(
+        self, products: Sequence[CanonicalProduct], default_currency: str
+    ) -> Iterable[PrecheckIssue]:
+        """A catalog priced entirely in another currency imports nothing: every
+        product is dropped for the same reason. Say it once, up front, with the
+        two ways out, instead of leaving the merchant to read it off every row.
+        """
+        plans = plan_product_imports(products, default_currency)
+        skips = [plans[product.source_id].skip for product in products]
+        dropped_for_currency = [
+            product
+            for product, skip in zip(products, skips, strict=True)
+            if skip is not None and skip.code == "missing_default_currency_price"
+        ]
+        if not dropped_for_currency:
+            return
+        # Some products still import, so their rows carry the reason on their own.
+        if any(skip is None for skip in skips):
+            return
+
+        # Only the currencies Polar would have taken: naming a price it drops
+        # anyway would send the merchant after a currency it can't switch to.
+        currencies = sorted(
+            {
+                currency.upper()
+                for product in dropped_for_currency
+                for currency in self._importable_price_currencies(product)
+            }
+        )
+        yield PrecheckIssue(
+            level=PrecheckIssueLevel.blocker,
+            code="no_default_currency_prices",
+            message=(
+                "No product can be imported. The ones that could be are priced "
+                f"in {', '.join(currencies)}, and your organization's default "
+                f"currency is {default_currency.upper()}. Change the default "
+                "currency in your organization's payment settings, or add "
+                f"{default_currency.upper()} prices at the source, then refresh."
+            ),
+            source_id=None,
+        )
+
+    def _check_product(
+        self, product: CanonicalProduct, default_currency: str
+    ) -> Iterable[PrecheckIssue]:
         # A product Polar can't represent is skipped along with its subscriptions,
         # rather than blocking the whole migration.
         dropped = False
@@ -248,15 +298,12 @@ class PrecheckEngine:
                 source_id=product.source_id,
             )
             dropped = True
-        importable_currencies: Counter[str] = Counter()
         for price in product.prices:
-            price_issues = list(self._check_price(product, price))
-            yield from price_issues
-            if not any(issue.code in PRICE_DROP_CODES for issue in price_issues):
-                importable_currencies[price.currency.lower()] += 1
+            yield from self._check_price(product, price)
         # Only worth reporting on a product that would otherwise import.
         if dropped:
             return
+        importable_currencies = self._importable_price_currencies(product)
         for currency, count in importable_currencies.items():
             if count > 1:
                 yield PrecheckIssue(
@@ -269,6 +316,33 @@ class PrecheckEngine:
                     ),
                     source_id=product.source_id,
                 )
+        # A Polar product must price in the organization's default currency: it's
+        # the fallback for every checkout that has no local price. A product with
+        # no importable price at all is reported as such instead.
+        if importable_currencies and default_currency not in importable_currencies:
+            yield PrecheckIssue(
+                level=PrecheckIssueLevel.warning,
+                code="missing_default_currency_price",
+                message=(
+                    f"Product '{product.name}' has no price in "
+                    f"{default_currency.upper()}, your organization's default "
+                    "currency, so it and its subscriptions won't be imported. "
+                    f"Add a {default_currency.upper()} price at the source, then "
+                    "refresh."
+                ),
+                source_id=product.source_id,
+            )
+
+    def _importable_price_currencies(self, product: CanonicalProduct) -> Counter[str]:
+        """How many prices Polar would take, per currency."""
+        currencies: Counter[str] = Counter()
+        for price in product.prices:
+            if (
+                _drop_reason(self._check_price(product, price), PRICE_DROP_CODES)
+                is None
+            ):
+                currencies[price.currency.lower()] += 1
+        return currencies
 
     def _check_price(
         self, product: CanonicalProduct, price: CanonicalPrice
@@ -624,9 +698,10 @@ def _duplicate_customer_source_ids(
 def _product_items(
     products: Sequence[CanonicalProduct],
     existing_product_names: set[str],
+    default_currency: str,
 ) -> list[MerchantMigrationRecordItem]:
     # Use the importer's plan, so the report can't promise a product it will skip.
-    plans = plan_product_imports(products)
+    plans = plan_product_imports(products, default_currency)
     duplicate_names = _duplicate_product_names(products)
     items: list[MerchantMigrationRecordItem] = []
     for product in products:
@@ -656,12 +731,14 @@ def _product_items(
 
 def _price_items(
     products: Sequence[CanonicalProduct],
+    default_currency: str,
 ) -> list[MerchantMigrationRecordItem]:
     items: list[MerchantMigrationRecordItem] = []
     for product in products:
         # A price under a product that won't import can't import either.
         product_skip = _drop_reason(
-            precheck_engine._check_product(product), PRODUCT_DROP_CODES
+            precheck_engine._check_product(product, default_currency),
+            PRODUCT_DROP_CODES,
         )
         for price in product.prices:
             skip = product_skip or _drop_reason(
@@ -715,9 +792,12 @@ def _subscription_items(
     subscriptions: Sequence[CanonicalSubscription],
     products: Sequence[CanonicalProduct],
     customers: Sequence[CanonicalCustomer],
+    default_currency: str,
 ) -> list[MerchantMigrationRecordItem]:
     # Use the importer's plan; the notes on top are display-only.
-    plans = plan_subscription_imports(subscriptions, products, customers)
+    plans = plan_subscription_imports(
+        subscriptions, products, customers, default_currency
+    )
     email_by_source = {c.source_id: c.email for c in customers if c.email}
     price_by_source = _price_display_by_source_id(products)
     items: list[MerchantMigrationRecordItem] = []
@@ -784,18 +864,23 @@ def import_blockers(
 def classify_records(
     records: Sequence[CanonicalRecord],
     entity: PrecheckEntity,
+    default_currency: str,
     existing_product_names: set[str] | None = None,
 ) -> list[MerchantMigrationRecordItem]:
     """Classify the source catalog into per-record rows of one entity type,
     each marked importable or skipped with a reason."""
     split = SplitRecords.of(records)
     if entity == PrecheckEntity.products:
-        return _product_items(split.products, existing_product_names or set())
+        return _product_items(
+            split.products, existing_product_names or set(), default_currency
+        )
     if entity == PrecheckEntity.prices:
-        return _price_items(split.products)
+        return _price_items(split.products, default_currency)
     if entity == PrecheckEntity.customers:
         return _customer_items(split.customers)
-    return _subscription_items(split.subscriptions, split.products, split.customers)
+    return _subscription_items(
+        split.subscriptions, split.products, split.customers, default_currency
+    )
 
 
 @dataclass
@@ -815,18 +900,23 @@ class ProductImportPlan:
 
 def plan_product_imports(
     products: Sequence[CanonicalProduct],
+    default_currency: str,
 ) -> dict[str, ProductImportPlan]:
     """What the catalog importer should do with each canonical product, using the
     exact same predicates as the precheck report so imported == report-importable.
 
-    A product is skipped when its own checks fail (one-time, unsupported interval)
-    or when none of its prices can be imported (a product with no price is
-    unsellable). Otherwise it imports with the prices that pass. Sharing a name
-    with another product is fine: Polar doesn't require unique names.
+    A product is skipped when its own checks fail (one-time, unsupported interval,
+    no price in the organization's default currency) or when none of its prices
+    can be imported (a product with no price is unsellable). Otherwise it imports
+    with the prices that pass. Sharing a name with another product is fine: Polar
+    doesn't require unique names.
     """
     plans: dict[str, ProductImportPlan] = {}
     for product in products:
-        skip = _drop_reason(precheck_engine._check_product(product), PRODUCT_DROP_CODES)
+        skip = _drop_reason(
+            precheck_engine._check_product(product, default_currency),
+            PRODUCT_DROP_CODES,
+        )
         if skip is not None:
             plans[product.source_id] = ProductImportPlan(skip, set())
             continue
@@ -874,6 +964,7 @@ def plan_subscription_imports(
     subscriptions: Sequence[CanonicalSubscription],
     products: Sequence[CanonicalProduct],
     customers: Sequence[CanonicalCustomer],
+    default_currency: str,
 ) -> dict[str, Reason | None]:
     """Per subscription ``source_id``, the skip reason or ``None`` when
     importable. Mirrors the review drawer's per-subscription classification: a
@@ -881,7 +972,7 @@ def plan_subscription_imports(
     customer it depends on won't import."""
     importable_prices = {
         price_id
-        for plan in plan_product_imports(products).values()
+        for plan in plan_product_imports(products, default_currency).values()
         for price_id in plan.importable_price_ids
     }
     importable_customers = {
@@ -910,12 +1001,13 @@ def plan_subscription_imports(
 
 def summarize_records(
     records: Sequence[CanonicalRecord],
+    default_currency: str,
 ) -> list[PrecheckEntitySummary]:
     """Per-entity counts of total/importable/skipped, computed from the same
     classification the review drawer shows."""
     summaries: list[PrecheckEntitySummary] = []
     for entity in PrecheckEntity:
-        items = classify_records(records, entity)
+        items = classify_records(records, entity, default_currency)
         importable = sum(
             1 for item in items if item.status == PrecheckRecordStatus.importable
         )

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -261,11 +261,7 @@ class MerchantMigrationService:
             session, auth_subject, migration_id, for_update=True
         )
 
-        organization = await OrganizationRepository.from_session(session).get_by_id(
-            migration.organization_id
-        )
-        if organization is None:
-            raise MerchantMigrationNotFound()
+        organization = await self._get_organization(session, migration)
 
         adapter = await self._build_adapter(migration)
         source_account = await adapter.get_source_account()
@@ -309,11 +305,7 @@ class MerchantMigrationService:
         if migration.step not in IMPORTABLE_STEPS:
             raise CatalogImportNotReady()
 
-        organization = await OrganizationRepository.from_session(session).get_by_id(
-            migration.organization_id
-        )
-        if organization is None:
-            raise MerchantMigrationNotFound()
+        organization = await self._get_organization(session, migration)
 
         # The pre-check reports blockers but doesn't stop the import, and both the
         # org and the source account can change after it ran.
@@ -460,6 +452,16 @@ class MerchantMigrationService:
         )
         return migration
 
+    async def _get_organization(
+        self, session: AsyncReadSession, migration: MerchantMigration
+    ) -> Organization:
+        organization = await OrganizationRepository.from_session(session).get_by_id(
+            migration.organization_id
+        )
+        if organization is None:
+            raise MerchantMigrationNotFound()
+        return organization
+
     async def list_records(
         self,
         session: AsyncSession,
@@ -479,6 +481,8 @@ class MerchantMigrationService:
         ``run_precheck`` persisted."""
         migration = await self._get_manageable(session, auth_subject, migration_id)
 
+        organization = await self._get_organization(session, migration)
+
         record_repository = MerchantMigrationRecordRepository.from_session(session)
         staged = await record_repository.list_by_migration(migration.id)
         records = [deserialize(record.type, record.canonical) for record in staged]
@@ -490,7 +494,10 @@ class MerchantMigrationService:
         items: list[MerchantMigrationRecordItem] = []
         for entity_type in entities:
             entity_items = classify_records(
-                records, entity_type, existing_product_names
+                records,
+                entity_type,
+                organization.default_presentment_currency,
+                existing_product_names,
             )
             self._attach_record_ids(entity_items, staged, entity_type)
             items.extend(entity_items)

--- a/server/tests/merchant_migration/test_precheck.py
+++ b/server/tests/merchant_migration/test_precheck.py
@@ -43,8 +43,12 @@ async def aiter_records(
 
 def build_organization(
     status: OrganizationStatus = OrganizationStatus.ACTIVE,
+    *,
+    default_presentment_currency: str = "usd",
 ) -> Organization:
-    return Organization(status=status)
+    return Organization(
+        status=status, default_presentment_currency=default_presentment_currency
+    )
 
 
 def build_account(
@@ -223,6 +227,103 @@ class TestPrecheckEngine:
         report = await run([build_product(prices=[build_price(currency="xyz")])])
         assert "unsupported_currency" in codes(report, PrecheckIssueLevel.warning)
 
+    async def test_product_without_default_currency_price_warns(self) -> None:
+        report = await run(
+            [
+                build_product(product_source_id="prod_1", name="Pro"),
+                build_product(
+                    product_source_id="prod_2",
+                    name="Team",
+                    prices=[build_price(source_id="price_eur", currency="eur")],
+                ),
+            ]
+        )
+        assert "missing_default_currency_price" in codes(
+            report, PrecheckIssueLevel.warning
+        )
+        # One product still imports, so the catalog is worth importing.
+        assert report.can_start is True
+
+    async def test_catalog_priced_in_another_currency_blocks(self) -> None:
+        report = await run(
+            [build_product(prices=[build_price(currency="eur")])],
+        )
+        assert "no_default_currency_prices" in codes(report, PrecheckIssueLevel.blocker)
+        assert report.can_start is False
+
+    async def test_blocker_names_only_the_currencies_polar_would_take(self) -> None:
+        # A price Polar drops anyway isn't a currency the merchant can switch to.
+        report = await run(
+            [
+                build_product(
+                    prices=[
+                        build_price(source_id="price_eur", currency="eur"),
+                        build_price(source_id="price_bad", currency="xyz"),
+                    ]
+                )
+            ]
+        )
+        blocker = next(
+            issue
+            for issue in report.issues
+            if issue.code == "no_default_currency_prices"
+        )
+        assert "EUR" in blocker.message
+        assert "XYZ" not in blocker.message
+
+    async def test_blocker_does_not_claim_dropped_products_lack_the_currency(
+        self,
+    ) -> None:
+        # The one-time product does have a USD price; it just can't be imported.
+        report = await run(
+            [
+                build_product(
+                    product_source_id="prod_1", name="Legacy", recurring_interval=None
+                ),
+                build_product(
+                    product_source_id="prod_2",
+                    name="Pro",
+                    prices=[build_price(source_id="price_eur", currency="eur")],
+                ),
+            ]
+        )
+        blocker = next(
+            issue
+            for issue in report.issues
+            if issue.code == "no_default_currency_prices"
+        )
+        assert "No product can be imported." in blocker.message
+        assert "EUR" in blocker.message
+
+    async def test_default_currency_matching_the_catalog_does_not_warn(self) -> None:
+        report = await run(
+            [build_product(prices=[build_price(currency="eur")])],
+            organization=build_organization(default_presentment_currency="eur"),
+        )
+        assert report.issues == []
+        assert report.can_start is True
+
+    async def test_product_with_a_price_in_each_currency_does_not_warn(self) -> None:
+        report = await run(
+            [
+                build_product(
+                    prices=[
+                        build_price(source_id="price_usd", currency="usd"),
+                        build_price(source_id="price_eur", currency="eur"),
+                    ]
+                )
+            ]
+        )
+        assert report.issues == []
+
+    async def test_product_without_importable_price_keeps_its_own_reason(self) -> None:
+        report = await run(
+            [build_product(prices=[build_price(currency="eur", amount=None)])]
+        )
+        warnings = codes(report, PrecheckIssueLevel.warning)
+        assert "unsupported_price_amount" in warnings
+        assert "missing_default_currency_price" not in warnings
+
     async def test_price_below_minimum_warns(self) -> None:
         report = await run([build_product(prices=[build_price(amount=1)])])
         assert "price_out_of_bounds" in codes(report, PrecheckIssueLevel.warning)
@@ -365,7 +466,7 @@ class TestClassifyRecords:
             ),
         ]
 
-        items = classify_records(records, PrecheckEntity.products)
+        items = classify_records(records, PrecheckEntity.products, "usd")
 
         by_id = {item.source_id: item for item in items}
         assert by_id["prod_1"].status == PrecheckRecordStatus.importable
@@ -384,7 +485,7 @@ class TestClassifyRecords:
             ),
         ]
 
-        items = classify_records(records, PrecheckEntity.products)
+        items = classify_records(records, PrecheckEntity.products, "usd")
 
         assert items[0].status == PrecheckRecordStatus.skipped
         assert items[0].reason_code == "no_importable_price"
@@ -398,7 +499,7 @@ class TestClassifyRecords:
             build_subscription(source_id="sub_1", has_discount=True),
         ]
 
-        items = classify_records(records, PrecheckEntity.subscriptions)
+        items = classify_records(records, PrecheckEntity.subscriptions, "usd")
 
         assert items[0].status == PrecheckRecordStatus.skipped
         assert items[0].reason_code == "subscription_has_discount"
@@ -421,7 +522,7 @@ class TestClassifyRecords:
             ),
         ]
 
-        items = classify_records(records, PrecheckEntity.prices)
+        items = classify_records(records, PrecheckEntity.prices, "usd")
 
         by_id = {item.source_id: item for item in items}
         assert by_id["price_ok"].status == PrecheckRecordStatus.importable
@@ -433,7 +534,7 @@ class TestClassifyRecords:
             build_customer(source_id="cus_1", email="a@example.com", country=None)
         ]
 
-        items = classify_records(records, PrecheckEntity.customers)
+        items = classify_records(records, PrecheckEntity.customers, "usd")
 
         assert items[0].status == PrecheckRecordStatus.importable
         assert items[0].reason_code == "customer_missing_country"
@@ -448,7 +549,7 @@ class TestClassifyRecords:
             build_subscription(source_id="sub_1", trialing=True),
         ]
 
-        items = classify_records(records, PrecheckEntity.subscriptions)
+        items = classify_records(records, PrecheckEntity.subscriptions, "usd")
 
         assert items[0].status == PrecheckRecordStatus.importable
         assert items[0].reason_code == "subscription_trialing"
@@ -468,7 +569,7 @@ class TestClassifyRecords:
             ),
         ]
 
-        items = classify_records(records, PrecheckEntity.subscriptions)
+        items = classify_records(records, PrecheckEntity.subscriptions, "usd")
 
         assert items[0].status == PrecheckRecordStatus.importable
         assert items[0].reason_code == "payment_method_requires_reentry"
@@ -483,7 +584,7 @@ class TestClassifyRecords:
             build_subscription(source_id="sub_1", has_discount=True),
         ]
 
-        items = classify_records(records, PrecheckEntity.subscriptions)
+        items = classify_records(records, PrecheckEntity.subscriptions, "usd")
 
         assert items[0].status == PrecheckRecordStatus.skipped
         assert items[0].reason_level == PrecheckReasonLevel.action_required
@@ -499,7 +600,7 @@ class TestClassifyRecords:
             )
         ]
 
-        items = classify_records(records, PrecheckEntity.products)
+        items = classify_records(records, PrecheckEntity.products, "usd")
 
         assert items[0].status == PrecheckRecordStatus.skipped
         assert items[0].reason_code == "multiple_prices_same_currency"
@@ -516,7 +617,7 @@ class TestClassifyRecords:
             )
         ]
 
-        items = classify_records(records, PrecheckEntity.products)
+        items = classify_records(records, PrecheckEntity.products, "usd")
 
         assert items[0].status == PrecheckRecordStatus.importable
 
@@ -535,7 +636,7 @@ class TestClassifyRecords:
             )
         ]
 
-        items = classify_records(records, PrecheckEntity.products)
+        items = classify_records(records, PrecheckEntity.products, "usd")
 
         assert items[0].status == PrecheckRecordStatus.importable
 
@@ -554,7 +655,7 @@ class TestClassifyRecords:
             )
         ]
 
-        items = classify_records(records, PrecheckEntity.products)
+        items = classify_records(records, PrecheckEntity.products, "usd")
 
         assert items[0].status == PrecheckRecordStatus.importable
         assert items[0].amount == 1000
@@ -570,17 +671,50 @@ class TestClassifyRecords:
             subscription,
         ]
 
-        items = classify_records(records, PrecheckEntity.subscriptions)
+        items = classify_records(records, PrecheckEntity.subscriptions, "usd")
 
         assert items[0].status == PrecheckRecordStatus.skipped
         assert items[0].reason_code == "subscription_customer_not_importable"
+
+    def test_product_without_default_currency_price_skipped(self) -> None:
+        # Polar requires a price in the organization's default currency, so the
+        # classifier must not promise a product the importer would reject.
+        records: list[CanonicalRecord] = [
+            build_product(
+                product_source_id="prod_1",
+                prices=[build_price(source_id="price_eur", currency="eur")],
+            )
+        ]
+
+        items = classify_records(records, PrecheckEntity.products, "usd")
+
+        assert items[0].status == PrecheckRecordStatus.skipped
+        assert items[0].reason_code == "missing_default_currency_price"
+        assert items[0].reason_level == PrecheckReasonLevel.action_required
+
+    def test_subscription_of_product_without_default_currency_price_skipped(
+        self,
+    ) -> None:
+        records: list[CanonicalRecord] = [
+            build_product(
+                product_source_id="prod_1",
+                prices=[build_price(source_id="price_1", currency="eur")],
+            ),
+            build_customer(source_id="cus_1", email="a@example.com"),
+            build_subscription(source_id="sub_1"),
+        ]
+
+        items = classify_records(records, PrecheckEntity.subscriptions, "usd")
+
+        assert items[0].status == PrecheckRecordStatus.skipped
+        assert items[0].reason_code == "subscription_product_not_importable"
 
     def test_product_matching_an_existing_polar_name_gets_a_note(self) -> None:
         records: list[CanonicalRecord] = [
             build_product(product_source_id="prod_1", name="Pro")
         ]
 
-        items = classify_records(records, PrecheckEntity.products, {"pro"})
+        items = classify_records(records, PrecheckEntity.products, "usd", {"pro"})
 
         assert items[0].status == PrecheckRecordStatus.importable
         assert items[0].reason_code == "product_exists_in_polar"
@@ -592,7 +726,7 @@ class TestClassifyRecords:
             build_customer(source_id="cus_2", email="same@example.com"),
         ]
 
-        items = classify_records(records, PrecheckEntity.customers)
+        items = classify_records(records, PrecheckEntity.customers, "usd")
 
         by_id = {item.source_id: item for item in items}
         assert by_id["cus_1"].status == PrecheckRecordStatus.importable
@@ -605,7 +739,7 @@ class TestClassifyRecords:
         # is skipped, not promised as importable.
         records: list[CanonicalRecord] = [build_customer(source_id="cus_1", email="")]
 
-        items = classify_records(records, PrecheckEntity.customers)
+        items = classify_records(records, PrecheckEntity.customers, "usd")
 
         assert items[0].status == PrecheckRecordStatus.skipped
         assert items[0].reason_code == "customer_missing_email"
@@ -622,7 +756,7 @@ class TestClassifyRecords:
             ),
         ]
 
-        items = classify_records(records, PrecheckEntity.subscriptions)
+        items = classify_records(records, PrecheckEntity.subscriptions, "usd")
 
         by_id = {item.source_id: item for item in items}
         assert by_id["sub_1"].status == PrecheckRecordStatus.importable
@@ -641,7 +775,7 @@ class TestSummarizeRecords:
             build_customer(source_id="cus_1", email="a@example.com"),
         ]
 
-        summaries = {s.entity: s for s in summarize_records(records)}
+        summaries = {s.entity: s for s in summarize_records(records, "usd")}
 
         assert summaries[PrecheckEntity.products].total == 2
         assert summaries[PrecheckEntity.products].importable == 1
@@ -650,7 +784,7 @@ class TestSummarizeRecords:
         assert summaries[PrecheckEntity.subscriptions].total == 0
 
         for entity, summary in summaries.items():
-            items = classify_records(records, entity)
+            items = classify_records(records, entity, "usd")
             importable = sum(
                 1 for i in items if i.status == PrecheckRecordStatus.importable
             )
@@ -678,7 +812,7 @@ class TestClassifyCascade:
             ),
         ]
 
-        items = classify_records(records, PrecheckEntity.products)
+        items = classify_records(records, PrecheckEntity.products, "usd")
 
         assert len(items) == 2
         assert all(i.status == PrecheckRecordStatus.importable for i in items)
@@ -689,7 +823,7 @@ class TestClassifyCascade:
             build_product(product_source_id="prod_2", name="Pro"),
         ]
 
-        items = classify_records(records, PrecheckEntity.products)
+        items = classify_records(records, PrecheckEntity.products, "usd")
 
         by_id = {item.source_id: item for item in items}
         for source_id in ("prod_1", "prod_2"):
@@ -707,7 +841,7 @@ class TestClassifyCascade:
             ),
         ]
 
-        items = classify_records(records, PrecheckEntity.prices)
+        items = classify_records(records, PrecheckEntity.prices, "usd")
 
         assert items[0].status == PrecheckRecordStatus.skipped
         assert items[0].reason_code == "one_time_product"
@@ -724,7 +858,7 @@ class TestClassifyCascade:
             build_subscription(source_id="sub_1"),
         ]
 
-        items = classify_records(records, PrecheckEntity.subscriptions)
+        items = classify_records(records, PrecheckEntity.subscriptions, "usd")
 
         assert items[0].status == PrecheckRecordStatus.skipped
         assert items[0].reason_code == "subscription_product_not_importable"
@@ -742,7 +876,7 @@ class TestClassifyCascade:
             duplicate_customer_subscription,
         ]
 
-        items = classify_records(records, PrecheckEntity.subscriptions)
+        items = classify_records(records, PrecheckEntity.subscriptions, "usd")
 
         assert items[0].status == PrecheckRecordStatus.skipped
         assert items[0].reason_code == "subscription_customer_not_importable"
@@ -768,7 +902,7 @@ class TestClassifyCascade:
             subscription,
         ]
 
-        items = classify_records(records, PrecheckEntity.subscriptions)
+        items = classify_records(records, PrecheckEntity.subscriptions, "usd")
 
         assert items[0].status == PrecheckRecordStatus.importable
 
@@ -787,7 +921,7 @@ class TestClassifyCascade:
             subscription,
         ]
 
-        items = classify_records(records, PrecheckEntity.subscriptions)
+        items = classify_records(records, PrecheckEntity.subscriptions, "usd")
 
         assert items[0].status == PrecheckRecordStatus.skipped
         assert items[0].reason_code == "subscription_product_not_importable"
@@ -797,7 +931,7 @@ class TestPlanProductImports:
     def test_importable_product_lists_its_prices(self) -> None:
         product = build_product(prices=[build_price(source_id="price_1")])
 
-        plans = plan_product_imports([product])
+        plans = plan_product_imports([product], "usd")
 
         plan = plans[product.source_id]
         assert plan.importable is True
@@ -806,7 +940,7 @@ class TestPlanProductImports:
     def test_one_time_product_is_skipped(self) -> None:
         product = build_product(source_id="prod_1:one_time", recurring_interval=None)
 
-        plan = plan_product_imports([product])[product.source_id]
+        plan = plan_product_imports([product], "usd")[product.source_id]
 
         assert plan.importable is False
         assert plan.skip is not None
@@ -823,7 +957,7 @@ class TestPlanProductImports:
             ]
         )
 
-        plan = plan_product_imports([product])[product.source_id]
+        plan = plan_product_imports([product], "usd")[product.source_id]
 
         assert plan.importable is True
         assert plan.importable_price_ids == {"price_ok"}
@@ -838,17 +972,41 @@ class TestPlanProductImports:
             ]
         )
 
-        plan = plan_product_imports([product])[product.source_id]
+        plan = plan_product_imports([product], "usd")[product.source_id]
 
         assert plan.importable is False
         assert plan.skip is not None
         assert plan.skip.code == "no_importable_price"
 
+    def test_product_without_default_currency_price_is_skipped(self) -> None:
+        product = build_product(
+            prices=[build_price(source_id="price_eur", currency="eur")]
+        )
+
+        plan = plan_product_imports([product], "usd")[product.source_id]
+
+        assert plan.importable is False
+        assert plan.skip is not None
+        assert plan.skip.code == "missing_default_currency_price"
+
+    def test_default_currency_price_keeps_the_other_currencies(self) -> None:
+        product = build_product(
+            prices=[
+                build_price(source_id="price_usd", currency="usd"),
+                build_price(source_id="price_eur", currency="eur"),
+            ]
+        )
+
+        plan = plan_product_imports([product], "usd")[product.source_id]
+
+        assert plan.importable is True
+        assert plan.importable_price_ids == {"price_usd", "price_eur"}
+
     def test_products_sharing_a_name_both_import(self) -> None:
         first = build_product(source_id="prod_1:month:1", product_source_id="prod_1")
         second = build_product(source_id="prod_2:month:1", product_source_id="prod_2")
 
-        plans = plan_product_imports([first, second])
+        plans = plan_product_imports([first, second], "usd")
 
         assert plans[first.source_id].importable is True
         assert plans[second.source_id].importable is True

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -560,6 +560,27 @@ class TestListRecords:
         assert prod_1.id in {item.record_id for item in items}
 
 
+def _catalog_priced_in(currency: str) -> list[CanonicalRecord]:
+    """A single recurring product priced in one currency."""
+    return [
+        CanonicalProduct(
+            source_id="prod_1:month:1",
+            product_source_id="prod_1",
+            name="Pro",
+            recurring_interval="month",
+            recurring_interval_count=1,
+            prices=[
+                CanonicalPrice(
+                    source_id="price_1",
+                    currency=currency,
+                    amount=1000,
+                    pricing_scheme=CanonicalPricingScheme.fixed,
+                )
+            ],
+        )
+    ]
+
+
 def _importable_catalog() -> list[CanonicalRecord]:
     """An importable recurring product, a one-time product that's skipped, and
     a customer."""
@@ -1194,3 +1215,42 @@ class TestImportCatalog:
 
         with pytest.raises(CatalogImportNotReady):
             await service.import_catalog(session, auth_subject, migration.id)
+
+    @pytest.mark.auth
+    async def test_product_priced_in_another_currency_is_skipped(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        # Polar rejects a product with no price in the organization's default
+        # currency, so the importer must skip it instead of failing the run.
+        migration = await _staged_migration(
+            mocker,
+            session,
+            save_fixture,
+            auth_subject,
+            organization,
+            records=_catalog_priced_in("eur"),
+        )
+
+        report = await service.import_catalog(session, auth_subject, migration.id)
+
+        results = {result.entity: result for result in report.results}
+        assert results[PrecheckEntity.products].imported == 0
+        assert results[PrecheckEntity.products].skipped == 1
+        assert await _products(session, organization) == []
+
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        record = await record_repository.get_by_source(
+            organization_id=organization.id,
+            type=MerchantMigrationRecordType.product,
+            source_id="prod_1:month:1",
+        )
+        assert record is not None
+        assert record.status == MerchantMigrationRecordStatus.skipped
+        assert record.error is not None
+        assert "USD" in record.error


### PR DESCRIPTION
## Summary

Importing a Stripe catalog failed with a generic error when the products were priced in a currency that weren't including the default one. So if the organization had the default currency to USD, and the product had only EUR this fails. The pre-check now catches this and explains it.

## What

- A product with no importable price in the organization's default currency is skipped. The reason shows on its row, and its subscriptions are skipped with it.
- When that leaves nothing to import, the assessment reports a blocker. The message names the currencies the catalog uses and the two ways out.

## Why

Polar requires every product to have a price in the organization's default currency. The import copied the source currency as-is, so a catalog priced only in EUR while the organization was set to USD made product creation fail. The whole import stopped, and the dashboard only said "Something went wrong".

## How

The pre-check takes the organization's default currency and applies the same rule as product creation, before anything is written. 

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

