### PR TITLE
tf/ecs: Set up ECS cluster and service module

### DIFF
--- a/terraform/modules/ecs_cluster/main.tf
+++ b/terraform/modules/ecs_cluster/main.tf
@@ -1,0 +1,18 @@
+resource "aws_ecs_cluster" "this" {
+  name = "polar-${var.environment}"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+}
+
+resource "aws_ecs_cluster_capacity_providers" "this" {
+  cluster_name       = aws_ecs_cluster.this.name
+  capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+
+  default_capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = 1
+  }
+}

--- a/terraform/modules/ecs_cluster/main.tf
+++ b/terraform/modules/ecs_cluster/main.tf
@@ -1,5 +1,6 @@
 resource "aws_ecs_cluster" "this" {
   name = "polar-${var.environment}"
+  tags = var.tags
 
   setting {
     name  = "containerInsights"

--- a/terraform/modules/ecs_cluster/outputs.tf
+++ b/terraform/modules/ecs_cluster/outputs.tf
@@ -1,0 +1,9 @@
+output "cluster_arn" {
+  description = "ECS cluster ARN."
+  value       = aws_ecs_cluster.this.arn
+}
+
+output "cluster_name" {
+  description = "ECS cluster name."
+  value       = aws_ecs_cluster.this.name
+}

--- a/terraform/modules/ecs_cluster/terraform.tf
+++ b/terraform/modules/ecs_cluster/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/terraform/modules/ecs_cluster/variables.tf
+++ b/terraform/modules/ecs_cluster/variables.tf
@@ -1,0 +1,9 @@
+variable "environment" {
+  description = "Environment name"
+  type        = string
+
+  validation {
+    condition     = contains(["production", "sandbox", "test"], var.environment)
+    error_message = "Must be either \"production\", \"sandbox\" or \"test\"."
+  }
+}

--- a/terraform/modules/ecs_cluster/variables.tf
+++ b/terraform/modules/ecs_cluster/variables.tf
@@ -7,3 +7,9 @@ variable "environment" {
     error_message = "Must be either \"production\", \"sandbox\" or \"test\"."
   }
 }
+
+variable "tags" {
+  description = "Tags applied to all created resources."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/ecs_service/main.tf
+++ b/terraform/modules/ecs_service/main.tf
@@ -1,0 +1,78 @@
+data "aws_region" "current" {}
+
+locals {
+  full_name = "polar-${var.environment}-${var.name}"
+}
+
+resource "aws_cloudwatch_log_group" "this" {
+  name              = "/ecs/${local.full_name}"
+  retention_in_days = var.log_retention_days
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "execution" {
+  name                 = "${local.full_name}-execution"
+  assume_role_policy   = data.aws_iam_policy_document.assume_role.json
+  permissions_boundary = var.permissions_boundary_arn
+}
+
+resource "aws_iam_role_policy_attachment" "execution" {
+  role       = aws_iam_role.execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = local.full_name
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = aws_iam_role.execution.arn
+  task_role_arn            = var.task_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name      = local.full_name
+      image     = var.image
+      essential = true
+      command   = var.command
+      environment = [
+        for key, value in var.environment_variables : { name = key, value = value }
+      ]
+      portMappings = var.container_port == null ? [] : [
+        { containerPort = var.container_port, protocol = "tcp" }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.this.name
+          "awslogs-region"        = data.aws_region.current.name
+          "awslogs-stream-prefix" = local.full_name
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_service" "this" {
+  name            = local.full_name
+  cluster         = var.cluster_arn
+  task_definition = aws_ecs_task_definition.this.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = var.subnet_ids
+    security_groups = var.security_group_ids
+  }
+}

--- a/terraform/modules/ecs_service/main.tf
+++ b/terraform/modules/ecs_service/main.tf
@@ -2,11 +2,39 @@ data "aws_region" "current" {}
 
 locals {
   full_name = "polar-${var.environment}-${var.name}"
+
+  aws_names = {
+    log_group      = { value = "/ecs/${local.full_name}", max = 512 }
+    execution_role = { value = "${local.full_name}-execution", max = 64 }
+    task_family    = { value = local.full_name, max = 255 }
+    service        = { value = local.full_name, max = 255 }
+  }
+
+  profiles = {
+    tiny   = { cpu = 256, memory = 512 }
+    small  = { cpu = 512, memory = 1024 }
+    medium = { cpu = 1024, memory = 2048 }
+    big    = { cpu = 2048, memory = 4096 }
+  }
+
+  cpu    = var.profile != null ? local.profiles[var.profile].cpu : var.cpu
+  memory = var.profile != null ? local.profiles[var.profile].memory : var.memory
+
+  fargate_memory_by_cpu = {
+    "256"   = [512, 1024, 2048]
+    "512"   = range(1024, 4097, 1024)
+    "1024"  = range(2048, 8193, 1024)
+    "2048"  = range(4096, 16385, 1024)
+    "4096"  = range(8192, 30721, 1024)
+    "8192"  = range(16384, 61441, 4096)
+    "16384" = range(32768, 122881, 8192)
+  }
 }
 
 resource "aws_cloudwatch_log_group" "this" {
-  name              = "/ecs/${local.full_name}"
+  name              = local.aws_names.log_group.value
   retention_in_days = var.log_retention_days
+  tags              = var.tags
 }
 
 data "aws_iam_policy_document" "assume_role" {
@@ -21,9 +49,10 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 resource "aws_iam_role" "execution" {
-  name                 = "${local.full_name}-execution"
+  name                 = local.aws_names.execution_role.value
   assume_role_policy   = data.aws_iam_policy_document.assume_role.json
   permissions_boundary = var.permissions_boundary_arn
+  tags                 = var.tags
 }
 
 resource "aws_iam_role_policy_attachment" "execution" {
@@ -32,13 +61,14 @@ resource "aws_iam_role_policy_attachment" "execution" {
 }
 
 resource "aws_ecs_task_definition" "this" {
-  family                   = local.full_name
+  family                   = local.aws_names.task_family.value
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = var.cpu
-  memory                   = var.memory
+  cpu                      = local.cpu
+  memory                   = local.memory
   execution_role_arn       = aws_iam_role.execution.arn
   task_role_arn            = var.task_role_arn
+  tags                     = var.tags
 
   container_definitions = jsonencode([
     {
@@ -62,17 +92,37 @@ resource "aws_ecs_task_definition" "this" {
       }
     }
   ])
+
+  lifecycle {
+    precondition {
+      condition     = alltrue([for n in local.aws_names : length(n.value) <= n.max])
+      error_message = "Name over its AWS length limit: ${join(", ", [for key, n in local.aws_names : "${key} \"${n.value}\" (${length(n.value)} > ${n.max})" if length(n.value) > n.max])}."
+    }
+
+    precondition {
+      condition     = var.profile != null ? var.cpu == null && var.memory == null : var.cpu != null && var.memory != null
+      error_message = "Set either profile or both cpu and memory, not both."
+    }
+
+    precondition {
+      condition     = local.cpu == null || local.memory == null || contains(keys(local.fargate_memory_by_cpu), tostring(local.cpu)) && contains(local.fargate_memory_by_cpu[tostring(local.cpu)], local.memory)
+      error_message = "Invalid Fargate combination: ${jsonencode(local.cpu)} CPU units with ${jsonencode(local.memory)} MiB."
+    }
+  }
 }
 
 resource "aws_ecs_service" "this" {
-  name            = local.full_name
+  name            = local.aws_names.service.value
   cluster         = var.cluster_arn
   task_definition = aws_ecs_task_definition.this.arn
   desired_count   = var.desired_count
   launch_type     = "FARGATE"
+  tags            = var.tags
 
   network_configuration {
     subnets         = var.subnet_ids
     security_groups = var.security_group_ids
   }
+
+  depends_on = [aws_iam_role_policy_attachment.execution]
 }

--- a/terraform/modules/ecs_service/outputs.tf
+++ b/terraform/modules/ecs_service/outputs.tf
@@ -1,0 +1,19 @@
+output "service_name" {
+  description = "ECS service name."
+  value       = aws_ecs_service.this.name
+}
+
+output "task_definition_arn" {
+  description = "Task definition ARN."
+  value       = aws_ecs_task_definition.this.arn
+}
+
+output "execution_role_arn" {
+  description = "Task execution role ARN."
+  value       = aws_iam_role.execution.arn
+}
+
+output "log_group_name" {
+  description = "CloudWatch log group name."
+  value       = aws_cloudwatch_log_group.this.name
+}

--- a/terraform/modules/ecs_service/terraform.tf
+++ b/terraform/modules/ecs_service/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/terraform/modules/ecs_service/variables.tf
+++ b/terraform/modules/ecs_service/variables.tf
@@ -1,0 +1,87 @@
+variable "environment" {
+  description = "Environment name"
+  type        = string
+
+  validation {
+    condition     = contains(["production", "sandbox", "test"], var.environment)
+    error_message = "Must be either \"production\", \"sandbox\" or \"test\"."
+  }
+}
+
+variable "name" {
+  description = "Short service name, combined into polar-{environment}-{name}."
+  type        = string
+}
+
+variable "cluster_arn" {
+  description = "ECS cluster the service runs in."
+  type        = string
+}
+
+variable "image" {
+  description = "Container image."
+  type        = string
+}
+
+variable "command" {
+  description = "Container command override."
+  type        = list(string)
+  default     = null
+}
+
+variable "cpu" {
+  description = "Task CPU units."
+  type        = number
+  default     = 256
+}
+
+variable "memory" {
+  description = "Task memory in MiB."
+  type        = number
+  default     = 512
+}
+
+variable "desired_count" {
+  description = "Number of tasks to run."
+  type        = number
+  default     = 1
+}
+
+variable "container_port" {
+  description = "Container port to expose, if any."
+  type        = number
+  default     = null
+}
+
+variable "environment_variables" {
+  description = "Environment variables for the container."
+  type        = map(string)
+  default     = {}
+}
+
+variable "subnet_ids" {
+  description = "Subnets the tasks run in."
+  type        = list(string)
+}
+
+variable "security_group_ids" {
+  description = "Security groups attached to the tasks."
+  type        = list(string)
+}
+
+variable "task_role_arn" {
+  description = "IAM role assumed by the running task, if any."
+  type        = string
+  default     = null
+}
+
+variable "permissions_boundary_arn" {
+  description = "Permissions boundary for the execution role."
+  type        = string
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch log retention in days."
+  type        = number
+  default     = 30
+}

--- a/terraform/modules/ecs_service/variables.tf
+++ b/terraform/modules/ecs_service/variables.tf
@@ -11,6 +11,11 @@ variable "environment" {
 variable "name" {
   description = "Short service name, combined into polar-{environment}-{name}."
   type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9-]+$", var.name))
+    error_message = "Must contain only lowercase letters, digits and hyphens."
+  }
 }
 
 variable "cluster_arn" {
@@ -29,16 +34,27 @@ variable "command" {
   default     = null
 }
 
+variable "profile" {
+  description = "Preconfigured task size: tiny (256/512), small (512/1024), medium (1024/2048) or big (2048/4096). Mutually exclusive with cpu/memory."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.profile == null ? true : contains(["tiny", "small", "medium", "big"], var.profile)
+    error_message = "Must be either \"tiny\", \"small\", \"medium\" or \"big\"."
+  }
+}
+
 variable "cpu" {
-  description = "Task CPU units."
+  description = "Task CPU units, set together with memory when profile is unset."
   type        = number
-  default     = 256
+  default     = null
 }
 
 variable "memory" {
-  description = "Task memory in MiB."
+  description = "Task memory in MiB, set together with cpu when profile is unset."
   type        = number
-  default     = 512
+  default     = null
 }
 
 variable "desired_count" {
@@ -84,4 +100,10 @@ variable "log_retention_days" {
   description = "CloudWatch log retention in days."
   type        = number
   default     = 30
+}
+
+variable "tags" {
+  description = "Tags applied to all created resources."
+  type        = map(string)
+  default     = {}
 }

--- a/terraform/production/ecs.tf
+++ b/terraform/production/ecs.tf
@@ -1,0 +1,5 @@
+module "ecs_cluster" {
+  source = "../modules/ecs_cluster"
+
+  environment = "production"
+}

--- a/terraform/sandbox/ecs.tf
+++ b/terraform/sandbox/ecs.tf
@@ -1,0 +1,5 @@
+module "ecs_cluster" {
+  source = "../modules/ecs_cluster"
+
+  environment = "sandbox"
+}

--- a/terraform/test/ecs.tf
+++ b/terraform/test/ecs.tf
@@ -1,0 +1,5 @@
+module "ecs_cluster" {
+  source = "../modules/ecs_cluster"
+
+  environment = "test"
+}


### PR DESCRIPTION
This spins up an ECS cluster in each environment, and adds a module to spin up ECS/Fargate services inside those clusters.

This is an alternative place to run Docker services.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

