### PR TITLE
feat(backoffice): sync customer slug on organization slug update

### DIFF
--- a/server/polar/backoffice/organizations_v2/endpoints.py
+++ b/server/polar/backoffice/organizations_v2/endpoints.py
@@ -37,6 +37,7 @@ from polar.integrations.plain.service import (
     plain_thread_url,
 )
 from polar.integrations.plain.service import plain as plain_service
+from polar.integrations.polar.service import polar_self as polar_self_service
 from polar.integrations.stripe.service import StripeAccountRejectReason
 from polar.integrations.stripe.service import stripe as stripe_service
 from polar.kit.pagination import count_subquery
@@ -3162,7 +3163,8 @@ async def edit_organization(
         data = await request.form()
         try:
             form = UpdateOrganizationBasicForm.model_validate_form(data)
-            if form.slug != organization.slug:
+            slug_changed = form.slug != organization.slug
+            if slug_changed:
                 existing_slug = await repository.get_by_slug(
                     form.slug, include_deleted=True
                 )
@@ -3187,6 +3189,14 @@ async def edit_organization(
                 organization,
                 update_dict=form_dict,
             )
+
+            # Keep the Polar-for-Polar billing customer's slug in sync with the
+            # organization slug (the org slug is the customer's slug).
+            if slug_changed:
+                polar_self_service.enqueue_update_customer_slug(
+                    organization_id=organization.id, slug=organization.slug
+                )
+
             redirect_url = (
                 str(
                     request.url_for(

--- a/server/tests/backoffice/organizations_v2/test_endpoints.py
+++ b/server/tests/backoffice/organizations_v2/test_endpoints.py
@@ -457,3 +457,63 @@ class TestEditFeatures:
         assert response.status_code == 303
         assert organization.feature_settings["sso_enabled"] is True
         assert organization.sso_enforced is True
+
+
+class TestEditOrganization:
+    async def test_syncs_customer_slug_when_slug_changes(
+        self,
+        mocker: MockerFixture,
+        backoffice_client: httpx.AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        organization.slug = "existing-org-slug"
+        await save_fixture(organization)
+
+        enqueue_update_customer_slug_mock = mocker.patch(
+            "polar.backoffice.organizations_v2.endpoints"
+            ".polar_self_service.enqueue_update_customer_slug"
+        )
+
+        response = await backoffice_client.post(
+            f"/organizations/{organization.id}/edit",
+            data={
+                "name": organization.name,
+                "slug": "new-org-slug",
+                "customer_invoice_prefix": organization.customer_invoice_prefix,
+            },
+        )
+
+        assert response.status_code == 303
+        assert organization.slug == "new-org-slug"
+        enqueue_update_customer_slug_mock.assert_called_once_with(
+            organization_id=organization.id, slug="new-org-slug"
+        )
+
+    async def test_does_not_sync_customer_slug_when_slug_unchanged(
+        self,
+        mocker: MockerFixture,
+        backoffice_client: httpx.AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        organization.slug = "existing-org-slug"
+        await save_fixture(organization)
+
+        enqueue_update_customer_slug_mock = mocker.patch(
+            "polar.backoffice.organizations_v2.endpoints"
+            ".polar_self_service.enqueue_update_customer_slug"
+        )
+
+        response = await backoffice_client.post(
+            f"/organizations/{organization.id}/edit",
+            data={
+                "name": "A New Organization Name",
+                "slug": organization.slug,
+                "customer_invoice_prefix": organization.customer_invoice_prefix,
+            },
+        )
+
+        assert response.status_code == 303
+        assert organization.name == "A New Organization Name"
+        enqueue_update_customer_slug_mock.assert_not_called()

--- a/server/tests/backoffice/organizations_v2/test_endpoints.py
+++ b/server/tests/backoffice/organizations_v2/test_endpoints.py
@@ -459,6 +459,7 @@ class TestEditFeatures:
         assert organization.sso_enforced is True
 
 
+@pytest.mark.asyncio
 class TestEditOrganization:
     async def test_syncs_customer_slug_when_slug_changes(
         self,


### PR DESCRIPTION
## Summary

**Related Issue**: #N/A

Replaces #13558.

Rather than deleting `PolarSelfService.enqueue_update_customer_slug` and the `polar_self.update_customer_slug` task as dead code, this reinstates them as live code by wiring the customer-slug sync into the current (v2) backoffice organization edit flow — where it was missing.

## What

- Import `polar_self` service into `backoffice/organizations_v2/endpoints.py`.
- In the `edit_organization` endpoint, enqueue `enqueue_update_customer_slug` when the organization slug actually changes, after the organization is updated.
- Add backoffice endpoint tests covering both the slug-changed (syncs) and slug-unchanged (no sync) cases.

## Why

`enqueue_update_customer_slug` and the `polar_self.update_customer_slug` task became dead code when the classic backoffice organizations view was removed in #12429 (`refactor: remove classic backoffice organizations view`). The v2 backoffice that replaced it never reimplemented the slug-sync call, so the Polar-for-Polar billing customer's slug stopped tracking the organization slug on admin edits.

As confirmed on #13558, this is an oversight of the v2 backoffice, not genuinely dead code: an organization's slug is its customer's slug in Polar-for-Polar, so it should stay in sync. This PR restores that behavior instead of removing the pathway.

## How

- Capture whether the slug changed before applying the update, then enqueue the sync only when it did (avoiding a redundant job on name/invoice-prefix-only edits).
- The `enqueue_update_customer_slug` method already no-ops when Polar-for-Polar isn't configured (`POLAR_SELF_ENABLED`), so this is safe in all environments.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`) — ruff lint + format verified on the changed files; the full `uv run task` suite and mypy could not run in this environment (Python 3.14.6 interpreter and Postgres unavailable)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBfM3T63aem7jodasa8VjN

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBfM3T63aem7jodasa8VjN)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

