### PR TITLE
org: Make benefit-grants readable without a write token

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -1270,7 +1270,7 @@ export interface paths {
      * Get Organization Billing Details
      * @description Get the billing name, address, and tax ID used on Polar invoices.
      *
-     *     **Scopes**: `organizations:write`
+     *     **Scopes**: `organizations:read` `organizations:write`
      */
     get: operations['organizations:get_billing_details']
     put?: never
@@ -1298,7 +1298,7 @@ export interface paths {
      * List Organization Payment Methods
      * @description List the saved payment methods used to pay Polar invoices.
      *
-     *     **Scopes**: `organizations:write`
+     *     **Scopes**: `organizations:read` `organizations:write`
      */
     get: operations['organizations:list_payment_methods']
     put?: never
@@ -1411,7 +1411,7 @@ export interface paths {
      * @description List Slack shared channel benefit grants attached to this org's Polar
      *     subscription.
      *
-     *     **Scopes**: `organizations:write`
+     *     **Scopes**: `organizations:read` `organizations:write`
      */
     get: operations['organizations:list_benefit_grants']
     put?: never

--- a/server/polar/authz/dependencies.py
+++ b/server/polar/authz/dependencies.py
@@ -188,6 +188,20 @@ AuthorizeOrgManageUser = Annotated[
         )
     ),
 ]
+# User-only counterpart to `AuthorizeOrgManageRead`.
+AuthorizeOrgManageUserRead = Annotated[
+    AuthzContext[User],
+    Depends(
+        OrgPolicyGuard(
+            org_policy.can_manage,
+            allowed_subjects={User},
+            required_scopes={
+                Scope.organizations_read,
+                Scope.organizations_write,
+            },
+        )
+    ),
+]
 AuthorizeOrgAccess = Annotated[
     AuthzContext[User | Organization], Depends(OrgPolicyGuard())
 ]

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -17,6 +17,7 @@ from polar.authz.dependencies import (
     AuthorizeOrgManage,
     AuthorizeOrgManageRead,
     AuthorizeOrgManageUser,
+    AuthorizeOrgManageUserRead,
 )
 from polar.checkout.repository import CheckoutRepository
 from polar.config import settings
@@ -1173,7 +1174,7 @@ async def list_orders(
     tags=[APITag.private],
 )
 async def get_billing_details(
-    authz: AuthorizeOrgManageUser,
+    authz: AuthorizeOrgManageUserRead,
 ) -> OrganizationBillingDetails:
     """Get the billing name, address, and tax ID used on Polar invoices."""
     customer = await polar_self_service.get_billing_details(
@@ -1211,7 +1212,7 @@ async def update_billing_details(
     tags=[APITag.private],
 )
 async def list_payment_methods(
-    authz: AuthorizeOrgManageUser,
+    authz: AuthorizeOrgManageUserRead,
 ) -> ListResource[OrganizationPaymentMethod]:
     """List the saved payment methods used to pay Polar invoices."""
     methods, default_payment_method_id = await polar_self_service.list_payment_methods(
@@ -1338,7 +1339,7 @@ async def get_order_invoice(
     tags=[APITag.private],
 )
 async def list_benefit_grants(
-    authz: AuthorizeOrgManageUser,
+    authz: AuthorizeOrgManageUserRead,
 ) -> ListResource[OrganizationBenefitGrant]:
     """List Slack shared channel benefit grants attached to this org's Polar
     subscription."""

--- a/server/tests/authz/test_endpoints.py
+++ b/server/tests/authz/test_endpoints.py
@@ -2,10 +2,13 @@ import uuid
 
 import pytest
 from httpx import AsyncClient
+from pytest_mock import MockerFixture
 
+from polar.auth.scope import READ_ONLY_SCOPES
 from polar.models import Organization, User
 from polar.models.organization import OrganizationStatus
 from polar.models.user_organization import OrganizationRole, UserOrganization
+from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_account
 
@@ -189,6 +192,62 @@ class TestPolicyGuardInviteMember:
         assert (
             response.json()["detail"] == "You don't have permission to manage members"
         )
+
+
+@pytest.mark.asyncio
+class TestPolicyGuardListBenefitGrants:
+    """Test AuthorizeOrgManageUserRead on GET /organizations/{id}/benefit-grants."""
+
+    async def test_anonymous_returns_401(self, client: AsyncClient) -> None:
+        response = await client.get(f"/v1/organizations/{uuid.uuid4()}/benefit-grants")
+        assert response.status_code == 401
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes=READ_ONLY_SCOPES))
+    async def test_read_only_session_returns_200(
+        self,
+        mocker: MockerFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        mocker.patch(
+            "polar.organization.endpoints.polar_self_service.list_benefit_grants",
+            return_value=[],
+        )
+
+        response = await client.get(
+            f"/v1/organizations/{organization.id}/benefit-grants"
+        )
+        assert response.status_code == 200
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes=READ_ONLY_SCOPES))
+    async def test_read_only_session_non_admin_returns_403(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        user_organization.role = OrganizationRole.member
+        await save_fixture(user_organization)
+
+        response = await client.get(
+            f"/v1/organizations/{organization.id}/benefit-grants"
+        )
+        assert response.status_code == 403
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes=READ_ONLY_SCOPES))
+    async def test_read_only_session_update_returns_403(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}/benefit-grants/{uuid.uuid4()}",
+            json={"invited_email": "admin@example.com"},
+        )
+        assert response.status_code == 403
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Without this it is not possible to do e.g. /benefit-grants as a user with only read only permissions (impersonation)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow org admins with read-only sessions to view benefit grants, billing details, and payment methods. Adds a user-only auth guard so GET works without a write token; write actions remain blocked.

- New Features
  - Added `AuthorizeOrgManageUserRead` (user-only; allows `organizations:read` or `organizations:write`).
  - Switched GET to use it: GET /organizations/{id}/benefit-grants, /billing, /payment-methods; updated client schema to list `organizations:read`.
  - Tests (benefit-grants): 200 for read-only admin; 401 anonymous; 403 for non-admin member and for PATCH updates.

<sup>Written for commit be90cb8a9f7e8a82152cff944dda179d37f8f8d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

