### PR TITLE
feat(orbit): DataTable and ListItem selection API

### DIFF
--- a/clients/apps/orbit/src/app/components/datatable/page.tsx
+++ b/clients/apps/orbit/src/app/components/datatable/page.tsx
@@ -109,9 +109,15 @@ const dataTableProps: PropRow[] = [
     description: 'Called when a row is clicked. Makes rows pointer targets.',
   },
   {
-    name: 'enableRowSelection',
-    type: 'boolean',
-    description: 'Enables single-row selection with selected styling.',
+    name: 'isRowActive',
+    type: '(row: Row<TData>) => boolean',
+    description: 'Marks rows as active, rendering them with selected styling.',
+  },
+  {
+    name: 'selection',
+    type: 'DataTableSelection<TData>',
+    description:
+      'Enables multi-row selection with a hover-revealed checkbox column.',
   },
   {
     name: 'getSubRows',

--- a/clients/apps/orbit/src/app/components/datatable/page.tsx
+++ b/clients/apps/orbit/src/app/components/datatable/page.tsx
@@ -117,7 +117,7 @@ const dataTableProps: PropRow[] = [
     name: 'selection',
     type: 'DataTableSelection<TData>',
     description:
-      'Enables multi-row selection with a hover-revealed checkbox column. Pass getItemLabel so row checkboxes announce a specific item.',
+      'Enables multi-row selection with a hover-revealed checkbox column.',
   },
   {
     name: 'getSubRows',

--- a/clients/apps/orbit/src/app/components/datatable/page.tsx
+++ b/clients/apps/orbit/src/app/components/datatable/page.tsx
@@ -117,7 +117,7 @@ const dataTableProps: PropRow[] = [
     name: 'selection',
     type: 'DataTableSelection<TData>',
     description:
-      'Enables multi-row selection with a hover-revealed checkbox column.',
+      'Enables multi-row selection with a hover-revealed checkbox column. Pass getItemLabel so row checkboxes announce a specific item.',
   },
   {
     name: 'getSubRows',

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/SalesPage.tsx
@@ -25,7 +25,6 @@ import {
 } from '@polar-sh/orbit'
 import { Status } from '@polar-sh/orbit'
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
-import { RowSelectionState } from '@tanstack/react-table'
 import { useRouter } from 'next/navigation'
 import {
   parseAsArrayOf,
@@ -33,7 +32,7 @@ import {
   parseAsStringLiteral,
   useQueryStates,
 } from 'nuqs'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import SalesFilters from './SalesFilters'
 
 const filterParsers = {
@@ -47,9 +46,6 @@ interface ClientPageProps {
 }
 
 const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
-  const [selectedOrderState, setSelectedOrderState] =
-    useState<RowSelectionState>({})
-
   const router = useRouter()
 
   const { pagination, setPagination, sorting, setSorting, resetPage } =
@@ -225,14 +221,6 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
       : []),
   ]
 
-  const selectedOrder = orders.find((order) => selectedOrderState[order.id])
-
-  useEffect(() => {
-    if (selectedOrder) {
-      router.push(`/dashboard/${organization.slug}/sales/${selectedOrder.id}`)
-    }
-  }, [selectedOrder, router, organization])
-
   const { data: metricsData } = useMetrics({
     organization_id: organization.id,
     startDate,
@@ -289,12 +277,12 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
             sorting={sorting}
             onSortingChange={setSorting}
             isLoading={ordersHook.isLoading}
-            onRowSelectionChange={(row) => {
-              setSelectedOrderState(row)
-            }}
-            rowSelection={selectedOrderState}
+            onRowClick={(row) =>
+              router.push(
+                `/dashboard/${organization.slug}/sales/${row.original.id}`,
+              )
+            }
             getRowId={(row) => row.id.toString()}
-            enableRowSelection
           />
         )}
       </div>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/subscriptions/SubscriptionsPage.tsx
@@ -25,11 +25,7 @@ import {
 import FormattedDateTime from '@polar-sh/ui/components/atoms/FormattedDateTime'
 import { Status } from '@polar-sh/orbit'
 import { Text } from '@polar-sh/orbit'
-import {
-  functionalUpdate,
-  OnChangeFn,
-  RowSelectionState,
-} from '@tanstack/react-table'
+import { functionalUpdate, OnChangeFn } from '@tanstack/react-table'
 import { useRouter } from 'next/navigation'
 import {
   parseAsArrayOf,
@@ -38,7 +34,7 @@ import {
   parseAsStringLiteral,
   useQueryStates,
 } from 'nuqs'
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import SubscriptionFilters from './SubscriptionFilters'
 
 const filterParsers = {
@@ -70,9 +66,6 @@ interface ClientPageProps {
 }
 
 const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
-  const [selectedSubscriptionState, setSelectedSubscriptionState] =
-    useState<RowSelectionState>({})
-
   const router = useRouter()
 
   const {
@@ -146,18 +139,6 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
   const subscriptions = subscriptionsHook.data?.items || []
   const rowCount = subscriptionsHook.data?.pagination.total_count ?? 0
   const pageCount = subscriptionsHook.data?.pagination.max_page ?? 1
-
-  const selectedSubscription = subscriptions.find(
-    (subscription) => selectedSubscriptionState[subscription.id],
-  )
-
-  useEffect(() => {
-    if (selectedSubscription) {
-      router.push(
-        `/dashboard/${organization.slug}/sales/subscriptions/${selectedSubscription.id}`,
-      )
-    }
-  }, [selectedSubscription, organization, router])
 
   const columns: DataTableColumnDef<schemas['Subscription']>[] = [
     {
@@ -301,12 +282,12 @@ const ClientPage: React.FC<ClientPageProps> = ({ organization }) => {
             sorting={sorting}
             onSortingChange={setSorting}
             isLoading={subscriptionsHook}
-            onRowSelectionChange={(row) => {
-              setSelectedSubscriptionState(row)
-            }}
-            rowSelection={selectedSubscriptionState}
+            onRowClick={(row) =>
+              router.push(
+                `/dashboard/${organization.slug}/sales/subscriptions/${row.original.id}`,
+              )
+            }
             getRowId={(row) => row.id.toString()}
-            enableRowSelection
           />
         ) : null}
       </div>

--- a/clients/apps/web/src/components/Benefit/LicenseKeys/LicenseKeysList.tsx
+++ b/clients/apps/web/src/components/Benefit/LicenseKeys/LicenseKeysList.tsx
@@ -10,7 +10,6 @@ import { Status } from '@polar-sh/orbit'
 import {
   OnChangeFn,
   PaginationState,
-  RowSelectionState,
   SortingState,
 } from '@tanstack/react-table'
 
@@ -23,8 +22,8 @@ export interface LicenseKeysListProps {
   setSorting: OnChangeFn<SortingState>
   sorting: DataTableSortingState
   isLoading: boolean
-  selectedLicenseKey: RowSelectionState
-  onSelectLicenseKeyChange?: OnChangeFn<RowSelectionState>
+  selectedLicenseKeyId: string | null
+  onSelectLicenseKey: (licenseKey: schemas['LicenseKeyRead']) => void
 }
 
 export const LicenseKeysList = ({
@@ -36,8 +35,8 @@ export const LicenseKeysList = ({
   setSorting,
   sorting,
   isLoading,
-  selectedLicenseKey,
-  onSelectLicenseKeyChange,
+  selectedLicenseKeyId,
+  onSelectLicenseKey,
 }: LicenseKeysListProps) => {
   const columns: DataTableColumnDef<schemas['LicenseKeyRead']>[] = [
     {
@@ -108,9 +107,8 @@ export const LicenseKeysList = ({
       sorting={sorting}
       onSortingChange={setSorting}
       isLoading={isLoading}
-      enableRowSelection={true}
-      onRowSelectionChange={onSelectLicenseKeyChange}
-      rowSelection={selectedLicenseKey}
+      onRowClick={(row) => onSelectLicenseKey(row.original)}
+      isRowActive={(row) => row.original.id === selectedLicenseKeyId}
       getRowId={(row) => row.id}
     />
   )

--- a/clients/apps/web/src/components/Benefit/LicenseKeysPage.tsx
+++ b/clients/apps/web/src/components/Benefit/LicenseKeysPage.tsx
@@ -24,7 +24,6 @@ import { Text } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import CopyToClipboardInput from '@polar-sh/ui/components/atoms/CopyToClipboardInput'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@polar-sh/orbit'
-import { RowSelectionState } from '@tanstack/react-table'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useCallback, useState } from 'react'
 import { InlineModal, InlineModalHeader } from '@polar-sh/orbit'
@@ -45,10 +44,9 @@ export const LicenseKeysPage = ({
   const deepLinkedLicenseKeyId = searchParams['license_key_id']
 
   const [statusLoading, setStatusLoading] = useState(false)
-  const [selectedLicenseKeys, setSelectedLicenseKeys] =
-    useState<RowSelectionState>(
-      deepLinkedLicenseKeyId ? { [deepLinkedLicenseKeyId]: true } : {},
-    )
+  const [selectedLicenseKeyId, setSelectedLicenseKeyId] = useState<
+    string | null
+  >(deepLinkedLicenseKeyId ?? null)
 
   const { data: licenseKeys, isLoading } = useOrganizationLicenseKeys({
     organization_id: organization.id,
@@ -60,7 +58,7 @@ export const LicenseKeysPage = ({
   })
 
   const { data: selectedLicenseKey } = useLicenseKey(
-    Object.keys(selectedLicenseKeys)[0],
+    selectedLicenseKeyId ?? undefined,
   )
 
   const getSearchParams = (
@@ -194,9 +192,9 @@ export const LicenseKeysPage = ({
 
   const closeLicenseKeyModal = useCallback(() => {
     hideLicenseKeyModal()
-    setSelectedLicenseKeys({})
+    setSelectedLicenseKeyId(null)
     setDeepLinkParam(null)
-  }, [hideLicenseKeyModal, setSelectedLicenseKeys, setDeepLinkParam])
+  }, [hideLicenseKeyModal, setSelectedLicenseKeyId, setDeepLinkParam])
 
   const LicenseKeyContextView = selectedLicenseKey ? (
     <Box flexDirection="column" overflowY="auto">
@@ -298,19 +296,12 @@ export const LicenseKeysPage = ({
             sorting={sorting}
             setPagination={setPagination}
             setSorting={setSorting}
-            onSelectLicenseKeyChange={(updaterOrValue) => {
-              const nextSelection =
-                typeof updaterOrValue === 'function'
-                  ? updaterOrValue(selectedLicenseKeys)
-                  : updaterOrValue
-              setSelectedLicenseKeys(nextSelection)
-              const nextId = Object.keys(nextSelection)[0] ?? null
-              setDeepLinkParam(nextId)
-              if (nextId) {
-                showLicenseKeyModal()
-              }
+            onSelectLicenseKey={(licenseKey) => {
+              setSelectedLicenseKeyId(licenseKey.id)
+              setDeepLinkParam(licenseKey.id)
+              showLicenseKeyModal()
             }}
-            selectedLicenseKey={selectedLicenseKeys}
+            selectedLicenseKeyId={selectedLicenseKeyId}
           />
           <InlineModal
             modalContent={LicenseKeyContextView ?? null}

--- a/clients/packages/orbit/src/components/List.tsx
+++ b/clients/packages/orbit/src/components/List.tsx
@@ -66,16 +66,20 @@ export const ListItem = ({
       onClick={onSelect}
     >
       {selectable && (
-        <Checkbox
-          aria-label="Select item"
-          checked={checked}
+        <div
+          className="-my-2 -mr-5 -ml-4 flex cursor-pointer items-center p-2"
           onClick={(event) => {
             event.preventDefault()
             event.stopPropagation()
             onCheckedChange?.(!checked, event)
           }}
-          className={selectionRevealClassName(!!checkboxVisible)}
-        />
+        >
+          <Checkbox
+            aria-label="Select item"
+            checked={checked}
+            className={selectionRevealClassName(!!checkboxVisible)}
+          />
+        </div>
       )}
       {children}
     </div>

--- a/clients/packages/orbit/src/components/List.tsx
+++ b/clients/packages/orbit/src/components/List.tsx
@@ -2,7 +2,6 @@
 
 import React, { PropsWithChildren } from 'react'
 import { twMerge } from 'tailwind-merge'
-import { selectionRevealClassName } from '../lib/selectionReveal'
 import { Checkbox } from './Checkbox'
 
 export interface ListProps extends PropsWithChildren {
@@ -32,7 +31,6 @@ export interface ListItemProps extends PropsWithChildren {
   selected?: boolean
   onSelect?: (e: React.MouseEvent) => void
   size?: 'small' | 'default'
-  selectable?: boolean
   checked?: boolean
   onCheckedChange?: (checked: boolean, event: React.MouseEvent) => void
   checkboxVisible?: boolean
@@ -46,38 +44,48 @@ export const ListItem = ({
   selected,
   onSelect,
   size = 'default',
-  selectable,
   checked,
   onCheckedChange,
   checkboxVisible,
 }: ListItemProps) => {
+  const hasCheckbox = !!onCheckedChange
+
   return (
     <div
       className={twMerge(
-        'group/row flex flex-row items-center justify-between gap-x-6',
+        'group/row flex flex-row items-center justify-between',
         selected
           ? 'dark:bg-polar-800 bg-gray-50'
           : 'dark:hover:bg-polar-800 hover:bg-gray-50',
         selected ? selectedClassName : inactiveClassName,
         onSelect && 'cursor-pointer',
-        size === 'default' ? 'px-6 py-4' : 'px-4 py-2',
+        size === 'default' ? 'py-4' : 'py-2',
+        hasCheckbox
+          ? 'pr-6 pl-4'
+          : size === 'default'
+            ? 'px-6'
+            : 'px-4',
+        !hasCheckbox && 'gap-x-6',
         className,
       )}
       onClick={onSelect}
     >
-      {selectable && (
+      {onCheckedChange && (
         <div
-          className="-my-2 -mr-5 -ml-4 flex cursor-pointer items-center p-2"
+          className="flex shrink-0 cursor-pointer items-center pr-4"
           onClick={(event) => {
             event.preventDefault()
             event.stopPropagation()
-            onCheckedChange?.(!checked, event)
+            onCheckedChange(!checked, event)
           }}
         >
           <Checkbox
             aria-label="Select item"
             checked={checked}
-            className={selectionRevealClassName(!!checkboxVisible)}
+            className={twMerge(
+              'opacity-0 transition-opacity group-hover/row:opacity-100 focus-visible:opacity-100 data-[state=checked]:opacity-100 data-[state=indeterminate]:opacity-100 pointer-coarse:opacity-100',
+              checkboxVisible && 'opacity-100',
+            )}
           />
         </div>
       )}

--- a/clients/packages/orbit/src/components/List.tsx
+++ b/clients/packages/orbit/src/components/List.tsx
@@ -34,6 +34,7 @@ export interface ListItemProps extends PropsWithChildren {
   checked?: boolean
   onCheckedChange?: (checked: boolean, event: React.MouseEvent) => void
   checkboxVisible?: boolean
+  checkboxLabel?: string
 }
 
 export const ListItem = ({
@@ -47,6 +48,7 @@ export const ListItem = ({
   checked,
   onCheckedChange,
   checkboxVisible,
+  checkboxLabel = 'Select item',
 }: ListItemProps) => {
   const hasCheckbox = !!onCheckedChange
 
@@ -80,7 +82,7 @@ export const ListItem = ({
           }}
         >
           <Checkbox
-            aria-label="Select item"
+            aria-label={checkboxLabel}
             checked={checked}
             className={twMerge(
               'opacity-0 transition-opacity group-hover/row:opacity-100 focus-visible:opacity-100 data-[state=checked]:opacity-100 data-[state=indeterminate]:opacity-100 pointer-coarse:opacity-100',

--- a/clients/packages/orbit/src/components/List.tsx
+++ b/clients/packages/orbit/src/components/List.tsx
@@ -1,5 +1,9 @@
+'use client'
+
 import React, { PropsWithChildren } from 'react'
 import { twMerge } from 'tailwind-merge'
+import { selectionRevealClassName } from '../lib/selectionReveal'
+import { Checkbox } from './Checkbox'
 
 export interface ListProps extends PropsWithChildren {
   className?: string
@@ -28,6 +32,10 @@ export interface ListItemProps extends PropsWithChildren {
   selected?: boolean
   onSelect?: (e: React.MouseEvent) => void
   size?: 'small' | 'default'
+  selectable?: boolean
+  checked?: boolean
+  onCheckedChange?: (checked: boolean, event: React.MouseEvent) => void
+  checkboxVisible?: boolean
 }
 
 export const ListItem = ({
@@ -38,11 +46,15 @@ export const ListItem = ({
   selected,
   onSelect,
   size = 'default',
+  selectable,
+  checked,
+  onCheckedChange,
+  checkboxVisible,
 }: ListItemProps) => {
   return (
     <div
       className={twMerge(
-        'flex flex-row items-center gap-x-6 justify-between',
+        'group/row flex flex-row items-center justify-between gap-x-6',
         selected
           ? 'dark:bg-polar-800 bg-gray-50'
           : 'dark:hover:bg-polar-800 hover:bg-gray-50',
@@ -53,6 +65,18 @@ export const ListItem = ({
       )}
       onClick={onSelect}
     >
+      {selectable && (
+        <Checkbox
+          aria-label="Select item"
+          checked={checked}
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            onCheckedChange?.(!checked, event)
+          }}
+          className={selectionRevealClassName(!!checkboxVisible)}
+        />
+      )}
       {children}
     </div>
   )

--- a/clients/packages/orbit/src/components/List.tsx
+++ b/clients/packages/orbit/src/components/List.tsx
@@ -62,11 +62,7 @@ export const ListItem = ({
         selected ? selectedClassName : inactiveClassName,
         onSelect && 'cursor-pointer',
         size === 'default' ? 'py-4' : 'py-2',
-        hasCheckbox
-          ? 'pr-6 pl-4'
-          : size === 'default'
-            ? 'px-6'
-            : 'px-4',
+        hasCheckbox ? 'pr-6 pl-4' : size === 'default' ? 'px-6' : 'px-4',
         !hasCheckbox && 'gap-x-6',
         className,
       )}

--- a/clients/packages/orbit/src/components/datatable/DataTable.tsx
+++ b/clients/packages/orbit/src/components/datatable/DataTable.tsx
@@ -6,7 +6,6 @@ import {
   OnChangeFn,
   PaginationState,
   Row,
-  RowSelectionState,
   SortingState,
   flexRender,
   getCoreRowModel,
@@ -28,6 +27,8 @@ import { DataTablePagination } from './DataTablePagination'
 import {
   createSelectionColumn,
   DataTableSelection,
+  SELECTION_COLUMN_ID,
+  SELECTION_COLUMN_WIDTH,
 } from './DataTableSelectionColumn'
 
 export interface ReactQueryLoading {
@@ -94,19 +95,6 @@ export function DataTable<TData, TValue>({
   onRowClick,
   isRowActive,
 }: DataTableProps<TData, TValue>) {
-  const rowSelection = React.useMemo(() => {
-    const state: RowSelectionState = {}
-    if (!selection) {
-      return state
-    }
-    data.forEach((item, index) => {
-      if (selection.isSelected(item)) {
-        state[getRowId ? getRowId(item, index) : String(index)] = true
-      }
-    })
-    return state
-  }, [selection, data, getRowId])
-
   const allColumns = React.useMemo(
     () =>
       selection
@@ -132,11 +120,9 @@ export function DataTable<TData, TValue>({
     getSubRows,
     getExpandedRowModel: getExpandedRowModel(),
     getRowId,
-    enableRowSelection: !!selection,
     state: {
       pagination,
       sorting,
-      rowSelection,
     },
   })
 
@@ -165,10 +151,20 @@ export function DataTable<TData, TValue>({
                 )}
               >
                 {headerGroup.headers.map((header) => {
+                  const isSelectColumn =
+                    header.column.id === SELECTION_COLUMN_ID
+
                   return (
                     <TableHead
                       key={header.id}
-                      style={{ width: header.column.getSize() }}
+                      className={isSelectColumn ? 'w-12' : undefined}
+                      style={
+                        isSelectColumn
+                          ? { width: SELECTION_COLUMN_WIDTH }
+                          : selection
+                            ? undefined
+                            : { width: header.column.getSize() }
+                      }
                     >
                       {header.isPlaceholder
                         ? null
@@ -203,7 +199,8 @@ export function DataTable<TData, TValue>({
                         onRowClick && 'cursor-pointer',
                       )}
                       data-state={
-                        isRowActive?.(row) || row.getIsSelected()
+                        isRowActive?.(row) ||
+                        selection?.isSelected(row.original)
                           ? 'selected'
                           : undefined
                       }
@@ -213,13 +210,22 @@ export function DataTable<TData, TValue>({
                         const colSpan = getCellColSpan
                           ? getCellColSpan(cell)
                           : 1
+                        const isSelectColumn =
+                          cell.column.id === SELECTION_COLUMN_ID
 
                         return (
                           <React.Fragment key={cell.id}>
                             {colSpan ? (
                               <TableCell
                                 colSpan={colSpan}
-                                style={{ width: cell.column.getSize() }}
+                                className={isSelectColumn ? 'w-12' : undefined}
+                                style={
+                                  isSelectColumn
+                                    ? { width: SELECTION_COLUMN_WIDTH }
+                                    : selection
+                                      ? undefined
+                                      : { width: cell.column.getSize() }
+                                }
                               >
                                 {flexRender(
                                   cell.column.columnDef.cell,

--- a/clients/packages/orbit/src/components/datatable/DataTable.tsx
+++ b/clients/packages/orbit/src/components/datatable/DataTable.tsx
@@ -161,9 +161,7 @@ export function DataTable<TData, TValue>({
                       style={
                         isSelectColumn
                           ? { width: SELECTION_COLUMN_WIDTH }
-                          : selection
-                            ? undefined
-                            : { width: header.column.getSize() }
+                          : { width: header.column.getSize() }
                       }
                     >
                       {header.isPlaceholder
@@ -222,9 +220,7 @@ export function DataTable<TData, TValue>({
                                 style={
                                   isSelectColumn
                                     ? { width: SELECTION_COLUMN_WIDTH }
-                                    : selection
-                                      ? undefined
-                                      : { width: cell.column.getSize() }
+                                    : { width: cell.column.getSize() }
                                 }
                               >
                                 {flexRender(

--- a/clients/packages/orbit/src/components/datatable/DataTable.tsx
+++ b/clients/packages/orbit/src/components/datatable/DataTable.tsx
@@ -54,6 +54,7 @@ interface DataTableProps<TData, TValue> {
   enableRowSelection?: boolean
   onRowSelectionChange?: OnChangeFn<RowSelectionState>
   onRowClick?: (row: Row<TData>) => void
+  isRowActive?: (row: Row<TData>) => boolean
 }
 
 export type DataTableColumnDef<TData, TValue = unknown> = ColumnDef<
@@ -91,6 +92,7 @@ export function DataTable<TData, TValue>({
   enableRowSelection,
   onRowSelectionChange,
   onRowClick,
+  isRowActive,
 }: DataTableProps<TData, TValue>) {
   // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
@@ -182,10 +184,9 @@ export function DataTable<TData, TValue>({
                           : undefined
                       }
                       data-state={
-                        enableRowSelection
-                          ? row.getIsSelected()
-                            ? 'selected'
-                            : undefined
+                        isRowActive?.(row) ||
+                        (enableRowSelection && row.getIsSelected())
+                          ? 'selected'
                           : undefined
                       }
                       onClick={

--- a/clients/packages/orbit/src/components/datatable/DataTable.tsx
+++ b/clients/packages/orbit/src/components/datatable/DataTable.tsx
@@ -25,6 +25,10 @@ import {
 import React from 'react'
 import { twMerge } from 'tailwind-merge'
 import { DataTablePagination } from './DataTablePagination'
+import {
+  createSelectionColumn,
+  DataTableSelection,
+} from './DataTableSelectionColumn'
 
 export interface ReactQueryLoading {
   isFetching: boolean
@@ -50,9 +54,7 @@ interface DataTableProps<TData, TValue> {
   isLoading: boolean | ReactQueryLoading
   getCellColSpan?: (cell: Cell<TData, unknown>) => number
   getRowId?: (originalRow: TData, index: number, parent?: Row<TData>) => string
-  rowSelection?: RowSelectionState
-  enableRowSelection?: boolean
-  onRowSelectionChange?: OnChangeFn<RowSelectionState>
+  selection?: DataTableSelection<TData>
   onRowClick?: (row: Row<TData>) => void
   isRowActive?: (row: Row<TData>) => boolean
 }
@@ -88,16 +90,38 @@ export function DataTable<TData, TValue>({
   isLoading,
   getCellColSpan,
   getRowId,
-  rowSelection,
-  enableRowSelection,
-  onRowSelectionChange,
+  selection,
   onRowClick,
   isRowActive,
 }: DataTableProps<TData, TValue>) {
+  const rowSelection = React.useMemo(() => {
+    const state: RowSelectionState = {}
+    if (!selection) {
+      return state
+    }
+    data.forEach((item, index) => {
+      if (selection.isSelected(item)) {
+        state[getRowId ? getRowId(item, index) : String(index)] = true
+      }
+    })
+    return state
+  }, [selection, data, getRowId])
+
+  const allColumns = React.useMemo(
+    () =>
+      selection
+        ? [
+            createSelectionColumn(selection) as ColumnDef<TData, TValue>,
+            ...columns,
+          ]
+        : columns,
+    [selection, columns],
+  )
+
   // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
     data,
-    columns,
+    columns: allColumns,
     getCoreRowModel: getCoreRowModel(),
     manualPagination: true,
     manualSorting: true,
@@ -108,9 +132,7 @@ export function DataTable<TData, TValue>({
     getSubRows,
     getExpandedRowModel: getExpandedRowModel(),
     getRowId,
-    enableRowSelection,
-    onRowSelectionChange,
-    enableMultiRowSelection: false,
+    enableRowSelection: !!selection,
     state: {
       pagination,
       sorting,
@@ -138,7 +160,7 @@ export function DataTable<TData, TValue>({
               <TableRow
                 key={headerGroup.id}
                 className={twMerge(
-                  'dark:bg-polar-800 bg-gray-50',
+                  'dark:bg-polar-800 group/row bg-gray-50',
                   headerClassName,
                 )}
               >
@@ -164,7 +186,7 @@ export function DataTable<TData, TValue>({
             {calcLoading ? (
               <TableRow>
                 <TableCell
-                  colSpan={columns.length}
+                  colSpan={allColumns.length}
                   className="h-24 text-center"
                 >
                   Loading...
@@ -176,26 +198,16 @@ export function DataTable<TData, TValue>({
                   table.getRowModel().rows.map((row) => (
                     <TableRow
                       key={row.id}
-                      className={
-                        enableRowSelection || onRowClick
-                          ? row.getCanSelect()
-                            ? 'cursor-pointer'
-                            : ''
-                          : undefined
-                      }
+                      className={twMerge(
+                        'group/row',
+                        onRowClick && 'cursor-pointer',
+                      )}
                       data-state={
-                        isRowActive?.(row) ||
-                        (enableRowSelection && row.getIsSelected())
+                        isRowActive?.(row) || row.getIsSelected()
                           ? 'selected'
                           : undefined
                       }
-                      onClick={
-                        onRowClick
-                          ? () => onRowClick(row)
-                          : enableRowSelection
-                            ? row.getToggleSelectedHandler()
-                            : undefined
-                      }
+                      onClick={onRowClick ? () => onRowClick(row) : undefined}
                     >
                       {row.getVisibleCells().map((cell) => {
                         const colSpan = getCellColSpan
@@ -223,7 +235,7 @@ export function DataTable<TData, TValue>({
                 ) : (
                   <TableRow>
                     <TableCell
-                      colSpan={columns.length}
+                      colSpan={allColumns.length}
                       className="h-24 text-center"
                     >
                       No Results

--- a/clients/packages/orbit/src/components/datatable/DataTableSelectionColumn.tsx
+++ b/clients/packages/orbit/src/components/datatable/DataTableSelectionColumn.tsx
@@ -1,8 +1,11 @@
 'use client'
 
 import { ColumnDef } from '@tanstack/react-table'
-import { selectionRevealClassName } from '../../lib/selectionReveal'
+import { twMerge } from 'tailwind-merge'
 import { Checkbox } from '../Checkbox'
+
+export const SELECTION_COLUMN_ID = 'select'
+export const SELECTION_COLUMN_WIDTH = 48
 
 export interface DataTableSelection<TData> {
   count: number
@@ -12,15 +15,21 @@ export interface DataTableSelection<TData> {
   setPageSelected: (selected: boolean) => void
 }
 
+const selectionRevealClassName = (alwaysVisible: boolean) =>
+  twMerge(
+    'opacity-0 transition-opacity group-hover/row:opacity-100 focus-visible:opacity-100 data-[state=checked]:opacity-100 data-[state=indeterminate]:opacity-100 pointer-coarse:opacity-100',
+    alwaysVisible && 'opacity-100',
+  )
+
 export const createSelectionColumn = <TData,>(
   selection: DataTableSelection<TData>,
 ): ColumnDef<TData, unknown> => ({
-  id: 'select',
-  size: 32,
+  id: SELECTION_COLUMN_ID,
+  size: SELECTION_COLUMN_WIDTH,
   enableSorting: false,
   header: () => (
     <div
-      className="-ml-4 flex h-12 w-8 cursor-pointer items-center pl-4"
+      className="flex h-12 cursor-pointer items-center pr-2 pl-4"
       onClick={() => selection.setPageSelected(selection.pageState !== 'all')}
     >
       <Checkbox
@@ -36,7 +45,7 @@ export const createSelectionColumn = <TData,>(
   ),
   cell: ({ row }) => (
     <div
-      className="-my-4 -ml-4 flex cursor-pointer items-center py-4 pl-4"
+      className="flex cursor-pointer items-center py-4 pr-2 pl-4"
       onClick={(event) => {
         event.stopPropagation()
         selection.toggle(row.original, { shiftKey: event.shiftKey })
@@ -44,7 +53,7 @@ export const createSelectionColumn = <TData,>(
     >
       <Checkbox
         aria-label="Select row"
-        checked={row.getIsSelected()}
+        checked={selection.isSelected(row.original)}
         className={selectionRevealClassName(selection.count > 0)}
       />
     </div>

--- a/clients/packages/orbit/src/components/datatable/DataTableSelectionColumn.tsx
+++ b/clients/packages/orbit/src/components/datatable/DataTableSelectionColumn.tsx
@@ -16,29 +16,37 @@ export const createSelectionColumn = <TData,>(
   selection: DataTableSelection<TData>,
 ): ColumnDef<TData, unknown> => ({
   id: 'select',
-  size: 44,
+  size: 32,
   enableSorting: false,
   header: () => (
-    <Checkbox
-      aria-label="Select all rows on this page"
-      checked={
-        selection.pageState === 'some'
-          ? 'indeterminate'
-          : selection.pageState === 'all'
-      }
-      onCheckedChange={(checked) => selection.setPageSelected(checked === true)}
-      className={selectionRevealClassName(selection.count > 0)}
-    />
+    <div
+      className="-ml-4 flex h-12 w-8 cursor-pointer items-center pl-4"
+      onClick={() => selection.setPageSelected(selection.pageState !== 'all')}
+    >
+      <Checkbox
+        aria-label="Select all rows on this page"
+        checked={
+          selection.pageState === 'some'
+            ? 'indeterminate'
+            : selection.pageState === 'all'
+        }
+        className={selectionRevealClassName(selection.count > 0)}
+      />
+    </div>
   ),
   cell: ({ row }) => (
-    <Checkbox
-      aria-label="Select row"
-      checked={row.getIsSelected()}
+    <div
+      className="-my-4 -ml-4 flex cursor-pointer items-center py-4 pl-4"
       onClick={(event) => {
         event.stopPropagation()
         selection.toggle(row.original, { shiftKey: event.shiftKey })
       }}
-      className={selectionRevealClassName(selection.count > 0)}
-    />
+    >
+      <Checkbox
+        aria-label="Select row"
+        checked={row.getIsSelected()}
+        className={selectionRevealClassName(selection.count > 0)}
+      />
+    </div>
   ),
 })

--- a/clients/packages/orbit/src/components/datatable/DataTableSelectionColumn.tsx
+++ b/clients/packages/orbit/src/components/datatable/DataTableSelectionColumn.tsx
@@ -5,7 +5,7 @@ import { twMerge } from 'tailwind-merge'
 import { Checkbox } from '../Checkbox'
 
 export const SELECTION_COLUMN_ID = 'select'
-export const SELECTION_COLUMN_WIDTH = 48
+export const SELECTION_COLUMN_WIDTH = 36
 
 export interface DataTableSelection<TData> {
   count: number
@@ -29,7 +29,7 @@ export const createSelectionColumn = <TData,>(
   enableSorting: false,
   header: () => (
     <div
-      className="flex h-12 cursor-pointer items-center pr-2 pl-4"
+      className="flex h-12 cursor-pointer items-center pl-4"
       onClick={() => selection.setPageSelected(selection.pageState !== 'all')}
     >
       <Checkbox
@@ -45,7 +45,7 @@ export const createSelectionColumn = <TData,>(
   ),
   cell: ({ row }) => (
     <div
-      className="flex cursor-pointer items-center py-4 pr-2 pl-4"
+      className="flex cursor-pointer items-center py-4 pl-4"
       onClick={(event) => {
         event.stopPropagation()
         selection.toggle(row.original, { shiftKey: event.shiftKey })

--- a/clients/packages/orbit/src/components/datatable/DataTableSelectionColumn.tsx
+++ b/clients/packages/orbit/src/components/datatable/DataTableSelectionColumn.tsx
@@ -13,6 +13,8 @@ export interface DataTableSelection<TData> {
   isSelected: (item: TData) => boolean
   toggle: (item: TData, options?: { shiftKey?: boolean }) => void
   setPageSelected: (selected: boolean) => void
+  /** Human-readable name for a row, used in checkbox accessible labels. */
+  getItemLabel?: (item: TData) => string
 }
 
 const selectionRevealClassName = (alwaysVisible: boolean) =>
@@ -20,6 +22,20 @@ const selectionRevealClassName = (alwaysVisible: boolean) =>
     'opacity-0 transition-opacity group-hover/row:opacity-100 focus-visible:opacity-100 data-[state=checked]:opacity-100 data-[state=indeterminate]:opacity-100 pointer-coarse:opacity-100',
     alwaysVisible && 'opacity-100',
   )
+
+const headerAriaLabel = (count: number) =>
+  count > 0
+    ? `Select all rows on this page, ${count} selected`
+    : 'Select all rows on this page'
+
+const rowAriaLabel = <TData,>(
+  selection: DataTableSelection<TData>,
+  item: TData,
+  rowIndex: number,
+) => {
+  const label = selection.getItemLabel?.(item)
+  return label ? `Select ${label}` : `Select row ${rowIndex + 1}`
+}
 
 export const createSelectionColumn = <TData,>(
   selection: DataTableSelection<TData>,
@@ -33,7 +49,7 @@ export const createSelectionColumn = <TData,>(
       onClick={() => selection.setPageSelected(selection.pageState !== 'all')}
     >
       <Checkbox
-        aria-label="Select all rows on this page"
+        aria-label={headerAriaLabel(selection.count)}
         checked={
           selection.pageState === 'some'
             ? 'indeterminate'
@@ -52,7 +68,7 @@ export const createSelectionColumn = <TData,>(
       }}
     >
       <Checkbox
-        aria-label="Select row"
+        aria-label={rowAriaLabel(selection, row.original, row.index)}
         checked={selection.isSelected(row.original)}
         className={selectionRevealClassName(selection.count > 0)}
       />

--- a/clients/packages/orbit/src/components/datatable/DataTableSelectionColumn.tsx
+++ b/clients/packages/orbit/src/components/datatable/DataTableSelectionColumn.tsx
@@ -13,8 +13,6 @@ export interface DataTableSelection<TData> {
   isSelected: (item: TData) => boolean
   toggle: (item: TData, options?: { shiftKey?: boolean }) => void
   setPageSelected: (selected: boolean) => void
-  /** Human-readable name for a row, used in checkbox accessible labels. */
-  getItemLabel?: (item: TData) => string
 }
 
 const selectionRevealClassName = (alwaysVisible: boolean) =>
@@ -22,20 +20,6 @@ const selectionRevealClassName = (alwaysVisible: boolean) =>
     'opacity-0 transition-opacity group-hover/row:opacity-100 focus-visible:opacity-100 data-[state=checked]:opacity-100 data-[state=indeterminate]:opacity-100 pointer-coarse:opacity-100',
     alwaysVisible && 'opacity-100',
   )
-
-const headerAriaLabel = (count: number) =>
-  count > 0
-    ? `Select all rows on this page, ${count} selected`
-    : 'Select all rows on this page'
-
-const rowAriaLabel = <TData,>(
-  selection: DataTableSelection<TData>,
-  item: TData,
-  rowIndex: number,
-) => {
-  const label = selection.getItemLabel?.(item)
-  return label ? `Select ${label}` : `Select row ${rowIndex + 1}`
-}
 
 export const createSelectionColumn = <TData,>(
   selection: DataTableSelection<TData>,
@@ -49,7 +33,11 @@ export const createSelectionColumn = <TData,>(
       onClick={() => selection.setPageSelected(selection.pageState !== 'all')}
     >
       <Checkbox
-        aria-label={headerAriaLabel(selection.count)}
+        aria-label={
+          selection.count > 0
+            ? `Select all rows on this page, ${selection.count} selected`
+            : 'Select all rows on this page'
+        }
         checked={
           selection.pageState === 'some'
             ? 'indeterminate'
@@ -68,7 +56,7 @@ export const createSelectionColumn = <TData,>(
       }}
     >
       <Checkbox
-        aria-label={rowAriaLabel(selection, row.original, row.index)}
+        aria-label={`Select row ${row.index + 1}`}
         checked={selection.isSelected(row.original)}
         className={selectionRevealClassName(selection.count > 0)}
       />

--- a/clients/packages/orbit/src/components/datatable/DataTableSelectionColumn.tsx
+++ b/clients/packages/orbit/src/components/datatable/DataTableSelectionColumn.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ColumnDef } from '@tanstack/react-table'
-import { twMerge } from 'tailwind-merge'
+import { selectionRevealClassName } from '../../lib/selectionReveal'
 import { Checkbox } from '../Checkbox'
 
 export interface DataTableSelection<TData> {
@@ -11,12 +11,6 @@ export interface DataTableSelection<TData> {
   toggle: (item: TData, options?: { shiftKey?: boolean }) => void
   setPageSelected: (selected: boolean) => void
 }
-
-const revealClassName = (alwaysVisible: boolean) =>
-  twMerge(
-    'opacity-0 transition-opacity group-hover/row:opacity-100 focus-visible:opacity-100 data-[state=checked]:opacity-100 data-[state=indeterminate]:opacity-100 pointer-coarse:opacity-100',
-    alwaysVisible && 'opacity-100',
-  )
 
 export const createSelectionColumn = <TData,>(
   selection: DataTableSelection<TData>,
@@ -33,7 +27,7 @@ export const createSelectionColumn = <TData,>(
           : selection.pageState === 'all'
       }
       onCheckedChange={(checked) => selection.setPageSelected(checked === true)}
-      className={revealClassName(selection.count > 0)}
+      className={selectionRevealClassName(selection.count > 0)}
     />
   ),
   cell: ({ row }) => (
@@ -44,7 +38,7 @@ export const createSelectionColumn = <TData,>(
         event.stopPropagation()
         selection.toggle(row.original, { shiftKey: event.shiftKey })
       }}
-      className={revealClassName(selection.count > 0)}
+      className={selectionRevealClassName(selection.count > 0)}
     />
   ),
 })

--- a/clients/packages/orbit/src/components/datatable/DataTableSelectionColumn.tsx
+++ b/clients/packages/orbit/src/components/datatable/DataTableSelectionColumn.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { ColumnDef } from '@tanstack/react-table'
+import { twMerge } from 'tailwind-merge'
+import { Checkbox } from '../Checkbox'
+
+export interface DataTableSelection<TData> {
+  count: number
+  pageState: 'none' | 'some' | 'all'
+  isSelected: (item: TData) => boolean
+  toggle: (item: TData, options?: { shiftKey?: boolean }) => void
+  setPageSelected: (selected: boolean) => void
+}
+
+const revealClassName = (alwaysVisible: boolean) =>
+  twMerge(
+    'opacity-0 transition-opacity group-hover/row:opacity-100 focus-visible:opacity-100 data-[state=checked]:opacity-100 data-[state=indeterminate]:opacity-100 pointer-coarse:opacity-100',
+    alwaysVisible && 'opacity-100',
+  )
+
+export const createSelectionColumn = <TData,>(
+  selection: DataTableSelection<TData>,
+): ColumnDef<TData, unknown> => ({
+  id: 'select',
+  size: 44,
+  enableSorting: false,
+  header: () => (
+    <Checkbox
+      aria-label="Select all rows on this page"
+      checked={
+        selection.pageState === 'some'
+          ? 'indeterminate'
+          : selection.pageState === 'all'
+      }
+      onCheckedChange={(checked) => selection.setPageSelected(checked === true)}
+      className={revealClassName(selection.count > 0)}
+    />
+  ),
+  cell: ({ row }) => (
+    <Checkbox
+      aria-label="Select row"
+      checked={row.getIsSelected()}
+      onClick={(event) => {
+        event.stopPropagation()
+        selection.toggle(row.original, { shiftKey: event.shiftKey })
+      }}
+      className={revealClassName(selection.count > 0)}
+    />
+  ),
+})

--- a/clients/packages/orbit/src/components/datatable/index.ts
+++ b/clients/packages/orbit/src/components/datatable/index.ts
@@ -6,3 +6,4 @@ export type {
   DataTableSortingState,
   ReactQueryLoading,
 } from './DataTable'
+export type { DataTableSelection } from './DataTableSelectionColumn'

--- a/clients/packages/orbit/src/components/ui/table.tsx
+++ b/clients/packages/orbit/src/components/ui/table.tsx
@@ -73,7 +73,7 @@ const TableHead = ({
   <th
     ref={ref}
     className={cn(
-      'text-muted-foreground h-12 px-4 text-left align-middle font-medium [&:has([role=checkbox])]:pr-0',
+      'text-muted-foreground h-12 px-4 text-left align-middle font-medium [&:has([role=checkbox])]:p-0',
       className,
     )}
     {...props}
@@ -90,7 +90,7 @@ const TableCell = ({
 }) => (
   <td
     ref={ref}
-    className={cn('p-4 align-middle [&:has([role=checkbox])]:pr-0', className)}
+    className={cn('p-4 align-middle [&:has([role=checkbox])]:p-0', className)}
     {...props}
   />
 )

--- a/clients/packages/orbit/src/index.ts
+++ b/clients/packages/orbit/src/index.ts
@@ -13,6 +13,7 @@ export type {
 } from './components/ButtonGroup'
 export { Checkbox } from './components/Checkbox'
 export { DataTable, DataTableColumnHeader } from './components/datatable'
+export type { DataTableSelection } from './components/datatable'
 export type {
   DataTableColumnDef,
   DataTablePaginationState,

--- a/clients/packages/orbit/src/lib/selectionReveal.ts
+++ b/clients/packages/orbit/src/lib/selectionReveal.ts
@@ -1,7 +1,0 @@
-import { twMerge } from 'tailwind-merge'
-
-export const selectionRevealClassName = (alwaysVisible: boolean) =>
-  twMerge(
-    'opacity-0 transition-opacity group-hover/row:opacity-100 focus-visible:opacity-100 data-[state=checked]:opacity-100 data-[state=indeterminate]:opacity-100 pointer-coarse:opacity-100',
-    alwaysVisible && 'opacity-100',
-  )

--- a/clients/packages/orbit/src/lib/selectionReveal.ts
+++ b/clients/packages/orbit/src/lib/selectionReveal.ts
@@ -1,0 +1,7 @@
+import { twMerge } from 'tailwind-merge'
+
+export const selectionRevealClassName = (alwaysVisible: boolean) =>
+  twMerge(
+    'opacity-0 transition-opacity group-hover/row:opacity-100 focus-visible:opacity-100 data-[state=checked]:opacity-100 data-[state=indeterminate]:opacity-100 pointer-coarse:opacity-100',
+    alwaysVisible && 'opacity-100',
+  )


### PR DESCRIPTION
## Summary

Related Issue: https://github.com/polarsource/feedback/issues/229

The goal is to add a reusable way for tables and lists to have multiselect capabilities. The idea is to not let the orbit table own the state, this is done by the component using it.

This PR is meant to separate row focus from multi-select in the datatable component in Orbit and to add UI for the selectable checkbox so that we can have a consistent look and behavior for selectable tables and lists. The checkboxes appears when hovering, unless one is selected then all is shown. If the table/list is not a multiselect one, it should now show the checkbox column

Open for feedback if this is not the way to do it. Upcoming PRs will have the actual web reusable multi-section logic. The padding around the checkbox column is a question to dig further to though.


- Untangle DataTable row focus (`isRowActive` / `onRowClick`) from multiselect, and add a `selection` prop with a hover-revealed checkbox column
- Add selectable `ListItem` checkbox affordance with matching reveal/hit-area spacing
- Update License Keys, Sales, and Subscriptions call sites for the new focus API (required by the DataTable change)

## Recordings of intended solution

https://github.com/user-attachments/assets/17841683-b3eb-40a0-9c13-2bf44da8baab


https://github.com/user-attachments/assets/7811b6bf-319d-4ec3-83ae-65b1fc6b2d85




<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

