### PR TITLE
fix(customer): only backfill organizations that have events

### DIFF
--- a/server/scripts/backfill_customer_first_user_event_at.py
+++ b/server/scripts/backfill_customer_first_user_event_at.py
@@ -72,6 +72,31 @@ CHUNK_SIZE = 1000
 PAGE_SIZE = 50_000
 
 
+async def organization_ids_with_user_events() -> set[UUID]:
+    """
+    Organizations that appear in either view, in two queries rather than two per org.
+
+    Production has ~90k organizations and almost none of them ingest events. Iterating
+    all of them costs two Tinybird round trips each, which is hours before any writes.
+    """
+    organization_ids: set[UUID] = set()
+
+    for table in (
+        event_types_by_customer_id_table,
+        event_types_by_external_customer_id_table,
+    ):
+        statement = (
+            select(table.c.organization_id)
+            .where(table.c.source == EventSource.user)
+            .group_by(table.c.organization_id)
+        )
+        sql, template = _compile(statement)
+        rows = await tinybird_client.query(sql, db_statement=template)
+        organization_ids.update(_parse_uuid(row["organization_id"]) for row in rows)
+
+    return organization_ids
+
+
 async def _pages_by_key(
     table: Table, key: str, organization_id: UUID, *, uuid_key: bool
 ) -> AsyncIterator[dict[str, datetime]]:
@@ -198,12 +223,20 @@ async def backfill(
     sessionmaker = create_async_sessionmaker(engine)
 
     try:
-        async with sessionmaker() as session:
-            statement = select(Organization.id).order_by(Organization.id)
-            if organization_id is not None:
-                statement = statement.where(Organization.id == organization_id)
-            result = await session.execute(statement)
-            organization_ids = list(result.scalars().all())
+        if organization_id is not None:
+            organization_ids = [organization_id]
+        else:
+            console.print("[cyan]Listing organizations with events…")
+            with_events = await organization_ids_with_user_events()
+            async with sessionmaker() as session:
+                result = await session.execute(
+                    select(Organization.id)
+                    .where(Organization.id.in_(with_events))
+                    .order_by(Organization.id)
+                )
+                organization_ids = list(result.scalars().all())
+
+        console.print(f"[cyan]{len(organization_ids)} organization(s) to process.")
 
         total_rows = 0
         with Progress(console=console) as progress:


### PR DESCRIPTION
## Summary

Was taking ages with the previous approach

**Related Issue**: #<!-- issue number -->

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->

## Why

<!-- Explain why this change is needed -->

## How

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up the backfill script by processing only organizations that have user events. We pre-fetch org IDs from Tinybird across `event_types_by_customer_id_table` and `event_types_by_external_customer_id_table`, and still allow an explicit organization ID to target a single org.

<sup>Written for commit b1a73a78ad951ccd53ead4457b207b308221b0fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

