### PR TITLE
orbit: add emphasized prop to checkbox

### DIFF
--- a/clients/apps/orbit/src/app/components/checkbox/page.tsx
+++ b/clients/apps/orbit/src/app/components/checkbox/page.tsx
@@ -25,10 +25,21 @@ function BasicDemo() {
 function StatesDemo() {
   return (
     <Box alignItems="center" columnGap="xl">
-      <Checkbox checked={false} />
-      <Checkbox checked />
-      <Checkbox checked="indeterminate" />
-      <Checkbox checked disabled />
+      <Checkbox />
+      <Checkbox defaultChecked />
+      <Checkbox defaultChecked="indeterminate" />
+      <Checkbox defaultChecked disabled />
+    </Box>
+  )
+}
+
+function EmphasizedDemo() {
+  return (
+    <Box alignItems="center" columnGap="xl">
+      <Checkbox emphasized />
+      <Checkbox emphasized defaultChecked />
+      <Checkbox emphasized defaultChecked="indeterminate" />
+      <Checkbox emphasized defaultChecked disabled />
     </Box>
   )
 }
@@ -36,15 +47,11 @@ function StatesDemo() {
 function LabelDemo() {
   const [checked, setChecked] = useState(false)
   return (
-    <Box as="label" alignItems="center" columnGap="s" cursor="pointer">
-      <Checkbox
-        checked={checked}
-        onCheckedChange={(c) => setChecked(c === true)}
-      />
-      <Text variant="label" as="span">
-        Send me product updates
-      </Text>
-    </Box>
+    <Checkbox
+      label="Send me product updates"
+      checked={checked}
+      onCheckedChange={(c) => setChecked(c === true)}
+    />
   )
 }
 
@@ -52,15 +59,21 @@ const basicCode = `const [checked, setChecked] = useState(true)
 
 <Checkbox checked={checked} onCheckedChange={setChecked} />`
 
-const statesCode = `<Checkbox checked={false} />
-<Checkbox checked />
-<Checkbox checked="indeterminate" />
-<Checkbox checked disabled />`
+const statesCode = `<Checkbox />
+<Checkbox defaultChecked />
+<Checkbox defaultChecked="indeterminate" />
+<Checkbox defaultChecked disabled />`
 
-const labelCode = `<Box as="label" alignItems="center" columnGap="s">
-  <Checkbox checked={checked} onCheckedChange={setChecked} />
-  <Text variant="label" as="span">Send me product updates</Text>
-</Box>`
+const emphasizedCode = `<Checkbox emphasized />
+<Checkbox emphasized defaultChecked />
+<Checkbox emphasized defaultChecked="indeterminate" />
+<Checkbox emphasized defaultChecked disabled />`
+
+const labelCode = `<Checkbox
+  label="Send me product updates"
+  checked={checked}
+  onCheckedChange={setChecked}
+/>`
 
 const checkboxProps: PropRow[] = [
   {
@@ -78,6 +91,19 @@ const checkboxProps: PropRow[] = [
     name: 'onCheckedChange',
     type: "(checked: boolean | 'indeterminate') => void",
     description: 'Called when the checked state changes.',
+  },
+  {
+    name: 'label',
+    type: 'string',
+    description:
+      'Renders the checkbox inside a clickable label with the given content, handling layout and spacing internally.',
+  },
+  {
+    name: 'emphasized',
+    type: 'boolean',
+    default: 'false',
+    description:
+      'Renders the checkbox in the accent color instead of the monochromatic default.',
   },
   {
     name: 'disabled',
@@ -148,8 +174,17 @@ export default function CheckboxPage() {
       </Section>
 
       <Section
+        title="Emphasized"
+        description="Pass emphasized to render the checkbox in the accent color. Use it sparingly, when the selection deserves extra attention."
+      >
+        <Example code={emphasizedCode}>
+          <EmphasizedDemo />
+        </Example>
+      </Section>
+
+      <Section
         title="With a label"
-        description="Wrap the control and its Text in a Box rendered as a label so the whole row is clickable."
+        description="Pass label to render the control inside a clickable label. Layout and spacing are handled by the component."
       >
         <Example code={labelCode} align="start">
           <LabelDemo />

--- a/clients/packages/orbit/src/components/Checkbox.tsx
+++ b/clients/packages/orbit/src/components/Checkbox.tsx
@@ -5,33 +5,69 @@ import { Check, Minus } from 'lucide-react'
 import * as React from 'react'
 
 import { cn } from '../lib/utils'
+import { Box } from './Box'
+import { Text } from './Text'
+
+export interface CheckboxProps extends React.ComponentProps<
+  typeof CheckboxPrimitive.Root
+> {
+  emphasized?: boolean
+  label?: string
+}
 
 const Checkbox = ({
   ref,
   className,
+  emphasized,
+  label,
   ...props
-}: React.ComponentProps<typeof CheckboxPrimitive.Root>) => (
-  <CheckboxPrimitive.Root
-    ref={ref}
-    className={cn(
-      'border-primary ring-offset-background focus-visible:ring-ring data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground peer h-4 w-4 shrink-0 rounded-xs border focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
-      className,
-    )}
-    {...props}
-  >
-    <CheckboxPrimitive.Indicator
+}: CheckboxProps) => {
+  const checkbox = (
+    <CheckboxPrimitive.Root
+      ref={ref}
       className={cn(
-        'group flex h-full w-full items-center justify-center text-current',
+        'ring-offset-background focus-visible:ring-ring peer h-4 w-4 shrink-0 rounded-xs border focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+        emphasized
+          ? 'border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground'
+          : 'dark:border-polar-600 border-gray-300 data-[state=checked]:border-black data-[state=checked]:bg-black data-[state=checked]:text-white dark:data-[state=checked]:border-white dark:data-[state=checked]:bg-white dark:data-[state=checked]:text-black',
+        className,
       )}
+      {...props}
     >
-      <Check className="h-4 w-4 group-data-[state=indeterminate]:hidden" />
-      <Minus
-        className="text-primary hidden h-3 w-3 group-data-[state=indeterminate]:block"
-        strokeWidth={3}
-      />
-    </CheckboxPrimitive.Indicator>
-  </CheckboxPrimitive.Root>
-)
+      <CheckboxPrimitive.Indicator
+        className={cn(
+          'group flex h-full w-full items-center justify-center text-current',
+        )}
+      >
+        <Check className="h-4 w-4 group-data-[state=indeterminate]:hidden" />
+        <Minus
+          className={cn(
+            'hidden h-3 w-3 group-data-[state=indeterminate]:block',
+            emphasized ? 'text-primary' : 'text-black dark:text-white',
+          )}
+          strokeWidth={3}
+        />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+
+  if (!label) {
+    return checkbox
+  }
+
+  return (
+    <Box
+      as="label"
+      display="inline-flex"
+      alignItems="center"
+      columnGap="s"
+      cursor={props.disabled ? 'not-allowed' : 'pointer'}
+    >
+      {checkbox}
+      <Text as="span">{label}</Text>
+    </Box>
+  )
+}
 Checkbox.displayName = CheckboxPrimitive.Root.displayName
 
 export { Checkbox }


### PR DESCRIPTION

<img width="949" height="884" alt="image" src="https://github.com/user-attachments/assets/682124c3-f03b-4167-baed-bc168dbc8faa" />


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an emphasized option to Checkbox for accent-colored styling and a label prop to render a clickable label with built-in layout. The default Checkbox style is now monochrome; use emphasized when you need accent.

- **New Features**
  - emphasized prop renders the checkbox in the accent color.
  - label prop wraps the control in a clickable label with spacing and cursor handling.
  - Docs/examples updated with states, emphasized, and label demos.

- **Migration**
  - The default checkbox is now monochrome. Use emphasized to restore accent styling.
  - If you manually wrapped Checkbox and Text in a label, pass label to Checkbox instead.

<sup>Written for commit 011681f3c9f39c1737a8958381256423c3d2212a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

