### PR TITLE
fix(dashboard): start the customer date range at the first event

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/[customerId]/CustomersPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/[customerId]/CustomersPage.tsx
@@ -16,6 +16,7 @@ import { useDeleteCustomer } from '@/hooks/queries'
 import { extractApiErrorMessage } from '@/utils/api/errors'
 import { api } from '@/utils/client'
 import { CONFIG } from '@/utils/config'
+import { getCustomerActivityStart } from '@/utils/customer'
 import { useDateRange } from '@/utils/date'
 import { usePushRouteWithoutCache } from '@/utils/router'
 
@@ -247,7 +248,7 @@ interface ClientPageProps {
 
 const ClientPage: React.FC<ClientPageProps> = ({ organization, customer }) => {
   const { startDate, endDate, setStartDate, setEndDate } = useDateRange({
-    defaultStartDate: startOfDay(new Date(customer.created_at)),
+    defaultStartDate: startOfDay(getCustomerActivityStart(customer)),
     defaultEndDate: endOfToday(),
   })
 

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/[customerId]/meter/[meterId]/CustomerMeterPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/[customerId]/meter/[meterId]/CustomerMeterPage.tsx
@@ -16,6 +16,7 @@ import { useMeterQuantities } from '@/hooks/queries/meters'
 import { Events } from '@/components/Events/Events'
 import { ParsedMetricPeriod } from '@/hooks/queries/metrics'
 import { useSubscriptions } from '@/hooks/queries/subscriptions'
+import { getCustomerActivityStart } from '@/utils/customer'
 import ArrowBackOutlined from '@mui/icons-material/ArrowBackOutlined'
 import { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
@@ -322,10 +323,10 @@ const CustomerMeterActivityCards = ({
       currentMonthEnd: endOfMonth(new UTCDate()),
       lastMonthStart: startOfMonth(subMonths(new UTCDate(), 1)),
       lastMonthEnd: endOfMonth(subMonths(new UTCDate(), 1)),
-      allTimeStart: new UTCDate(customer.created_at),
+      allTimeStart: new UTCDate(getCustomerActivityStart(customer).getTime()),
       allTimeEnd: new UTCDate(),
     }),
-    [customer.created_at],
+    [customer],
   )
 
   const { data: figuresQuantities } = useMeterQuantities(meter.id, {

--- a/clients/apps/web/src/utils/customer.ts
+++ b/clients/apps/web/src/utils/customer.ts
@@ -1,3 +1,16 @@
+/** A minimum, not a fallback: `first_user_event_at` can fall either side of `created_at`. */
+export const getCustomerActivityStart = (customer: {
+  created_at: string
+  first_user_event_at?: string | null
+}): Date => {
+  const createdAt = new Date(customer.created_at)
+  if (!customer.first_user_event_at) {
+    return createdAt
+  }
+  const firstUserEventAt = new Date(customer.first_user_event_at)
+  return firstUserEventAt < createdAt ? firstUserEventAt : createdAt
+}
+
 export const buildCustomerDashboardPath = (
   organizationSlug: string,
   customer: { id: string; email?: string | null; name?: string | null },

--- a/clients/apps/web/src/utils/customer.ts
+++ b/clients/apps/web/src/utils/customer.ts
@@ -1,4 +1,3 @@
-/** A minimum, not a fallback: `first_user_event_at` can fall either side of `created_at`. */
 export const getCustomerActivityStart = (customer: {
   created_at: string
   first_user_event_at?: string | null


### PR DESCRIPTION
## Summary

"All Time" on a customer started at `created_at`, which hid events ingested against an `external_customer_id` before the customer row existed.

It now starts at the earlier of `created_at` and `first_user_event_at`, on both the customer page and the customer meter page.

A minimum, not a fallback — a first event can land after signup, and the range must still start at signup then.

The column shipped in #13481 and prod is backfilled.

Closes polarsource/feedback#38

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

