### PR TITLE
fix(email): robust date derivation + single-pass dedup for backfill

### DIFF
--- a/server/scripts/backfill_email_log_deduplication_key.py
+++ b/server/scripts/backfill_email_log_deduplication_key.py
@@ -2,8 +2,7 @@ from collections.abc import Callable
 from typing import Any
 
 import typer
-from sqlalchemy import ColumnElement, and_, func, or_, select, update
-from sqlalchemy.orm import aliased
+from sqlalchemy import ColumnElement, Select, and_, func, select, update
 
 from polar.email.schemas import EmailTemplate
 from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
@@ -87,6 +86,43 @@ CONFIGS: list[tuple[EmailTemplate, KeyExpr, ValidExpr]] = [
 ]
 
 
+def _canonical_ids(
+    template: EmailTemplate, key: KeyExpr, valid: ValidExpr
+) -> Select[tuple[Any]]:
+    """Select the id of the row to key per (computed key, recipient) group.
+
+    A single window pass over the template's sent rows (no correlated subquery,
+    so it scales to a large `email_logs`): pick the earliest row in each group
+    (`rn == 1`), but only when the group has no already-keyed row — that row
+    occupies the target key (from the new send path or a previous run), so the
+    rest stay NULL and are excluded from the partial unique index PR2 builds.
+    """
+    partition = (key(EmailLog), EmailLog.to_email_addr)
+    ranked = (
+        select(
+            EmailLog.id.label("id"),
+            func.row_number()
+            .over(partition_by=partition, order_by=(EmailLog.created_at, EmailLog.id))
+            .label("rank"),
+            func.bool_or(EmailLog.deduplication_key.isnot(None))
+            .over(partition_by=partition)
+            .label("group_keyed"),
+        )
+        .where(
+            EmailLog.status == EmailLogStatus.sent,
+            EmailLog.email_template == template,
+            valid(EmailLog),
+        )
+        .subquery()
+    )
+    # rank == 1 is the earliest row in the group; group_keyed is false only when
+    # no row in the group is keyed, so that earliest row is guaranteed NULL.
+    return select(ranked.c.id).where(
+        ranked.c.rank == 1,
+        ranked.c.group_keyed.is_(False),
+    )
+
+
 async def run_backfill(
     *,
     batch_size: int = 5000,
@@ -96,45 +132,11 @@ async def run_backfill(
 ) -> int:
     total = 0
     for template, key, valid in CONFIGS:
-        src = aliased(EmailLog)
-        other = aliased(EmailLog)
-
-        # Only key the earliest not-yet-keyed row per (computed key, recipient)
-        # group so any historical duplicate leaves the others NULL — excluded from
-        # the partial unique index PR2 builds. A row is skipped if another row in
-        # the group is already keyed (it occupies the target key, e.g. via the
-        # new send path or a previous run) or is earlier. Membership is defined
-        # over ALL sent rows in the group, so it stays stable as batches fill in.
-        is_canonical = ~(
-            select(other.id)
-            .where(
-                other.status == EmailLogStatus.sent,
-                other.email_template == template,
-                key(other) == key(src),
-                other.to_email_addr == src.to_email_addr,
-                or_(
-                    other.deduplication_key.isnot(None),
-                    other.created_at < src.created_at,
-                    and_(
-                        other.created_at == src.created_at,
-                        other.id < src.id,
-                    ),
-                ),
-            )
-            .exists()
-        )
-
-        candidate_statement = select(src.id).where(
-            src.status == EmailLogStatus.sent,
-            src.email_template == template,
-            src.deduplication_key.is_(None),
-            valid(src),
-            is_canonical,
-        )
+        canonical_ids = _canonical_ids(template, key, valid)
 
         if dry_run:
             count = await _count(
-                select(func.count()).select_from(candidate_statement.subquery()),
+                select(func.count()).select_from(canonical_ids.subquery()),
                 session,
             )
             typer.echo(f"[dry-run] {template}: {count} rows would be updated")
@@ -144,7 +146,7 @@ async def run_backfill(
         total += await run_batched_update(
             update(EmailLog)
             .values(deduplication_key=key(EmailLog))
-            .where(EmailLog.id.in_(candidate_statement.limit(limit_bindparam()))),
+            .where(EmailLog.id.in_(canonical_ids.limit(limit_bindparam()))),
             batch_size=batch_size,
             sleep_seconds=sleep_seconds,
             session=session,

--- a/server/scripts/backfill_email_log_deduplication_key.py
+++ b/server/scripts/backfill_email_log_deduplication_key.py
@@ -24,12 +24,6 @@ KeyExpr = Callable[[Any], ColumnElement[str]]
 ValidExpr = Callable[[Any], ColumnElement[bool]]
 
 
-def _iso_date(value: ColumnElement[str]) -> ColumnElement[str]:
-    """Reconstruct the ISO date from the legacy localized string (e.g.
-    "July 30, 2026") that the reminder builders now emit as YYYY-MM-DD."""
-    return func.to_char(func.to_date(value, "FMMonth FMDD, YYYY"), "YYYY-MM-DD")
-
-
 def _card_key(model: Any) -> ColumnElement[str]:
     metadata = model.email_props["payment_method"]["method_metadata"]
     return func.concat(
@@ -52,30 +46,38 @@ def _card_valid(model: Any) -> ColumnElement[bool]:
 
 
 def _subscription_date_key(
-    template: EmailTemplate, date_prop: str
+    template: EmailTemplate, date_field: str
 ) -> tuple[KeyExpr, ValidExpr]:
+    # The date comes from the serialized subscription's ISO datetime (the same
+    # value the send-path key builder uses), so we take its YYYY-MM-DD prefix
+    # rather than parsing the localized `renewal_date`/`conversion_date` string.
+    def _iso_date(model: Any) -> ColumnElement[str]:
+        return func.substring(
+            model.email_props["subscription"][date_field].as_string(), 1, 10
+        )
+
     def key(model: Any) -> ColumnElement[str]:
         return func.concat(
             f"{template}:",
             model.email_props["subscription"]["id"].as_string(),
             ":",
-            _iso_date(model.email_props[date_prop].as_string()),
+            _iso_date(model),
         )
 
     def valid(model: Any) -> ColumnElement[bool]:
         return and_(
             model.email_props["subscription"]["id"].as_string().isnot(None),
-            model.email_props[date_prop].as_string().isnot(None),
+            model.email_props["subscription"][date_field].as_string().isnot(None),
         )
 
     return key, valid
 
 
 _renewal_key, _renewal_valid = _subscription_date_key(
-    EmailTemplate.subscription_renewal_reminder, "renewal_date"
+    EmailTemplate.subscription_renewal_reminder, "current_period_end"
 )
 _trial_key, _trial_valid = _subscription_date_key(
-    EmailTemplate.subscription_trial_conversion_reminder, "conversion_date"
+    EmailTemplate.subscription_trial_conversion_reminder, "trial_end"
 )
 
 CONFIGS: list[tuple[EmailTemplate, KeyExpr, ValidExpr]] = [

--- a/server/tests/scripts/test_backfill_email_log_deduplication_key.py
+++ b/server/tests/scripts/test_backfill_email_log_deduplication_key.py
@@ -83,16 +83,20 @@ class TestBackfillEmailLogDeduplicationKey:
             save_fixture,
             template="subscription_renewal_reminder",
             email_props={
-                "subscription": {"id": subscription_id},
-                "renewal_date": "November 7, 2026",
+                "subscription": {
+                    "id": subscription_id,
+                    "current_period_end": "2026-11-07T00:00:00Z",
+                },
             },
         )
         trial = await _create_email_log(
             save_fixture,
             template="subscription_trial_conversion_reminder",
             email_props={
-                "subscription": {"id": subscription_id},
-                "conversion_date": "March 17, 2026",
+                "subscription": {
+                    "id": subscription_id,
+                    "trial_end": "2026-03-17T12:34:56Z",
+                },
             },
         )
 


### PR DESCRIPTION
```
% uv run python -m scripts.backfill_email_log_deduplication_key
```

Crashed in sandbox because of poor date format matching and in production because of sql timeouts. This hopefully fixes both issues.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Makes the email log backfill reliable and faster. Subscription reminder keys now use ISO datetimes from the subscription, and canonical rows are chosen in a single windowed query to avoid timeouts on large datasets.

- **Bug Fixes**
  - Derive reminder date from `subscription.current_period_end` and `subscription.trial_end` (take YYYY-MM-DD) instead of parsing localized strings, preventing format-related crashes.

- **Refactors**
  - Replace correlated self-join with a single window query (`row_number` + `bool_or`) to select the earliest unkeyed row per (computed key, recipient), improving performance on large `email_logs`.

<sup>Written for commit d0fafab7eb409ad1c1b1b5d3efe2ae694b535f1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

