### PR TITLE
fix: fix `useDebounceCallback` race condition

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/ProductsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/ProductsPage.tsx
@@ -105,19 +105,15 @@ export default function ClientPage({
       ? `${sorting[0].desc ? '-' : ''}${sorting[0].id}`
       : 'name'
 
-  const debouncedQueryChange = useDebouncedCallback(
-    (query: string) => {
-      const searchParams = serializeSearchParams(pagination, sorting)
-      if (query) {
-        searchParams.set('query', query)
-      } else {
-        searchParams.delete('query')
-      }
-      router.replace(`${pathname}?${searchParams}`)
-    },
-    500,
-    [pagination, sorting, query, router, pathname],
-  )
+  const debouncedQueryChange = useDebouncedCallback((query: string) => {
+    const searchParams = serializeSearchParams(pagination, sorting)
+    if (query) {
+      searchParams.set('query', query)
+    } else {
+      searchParams.delete('query')
+    }
+    router.replace(`${pathname}?${searchParams}`)
+  }, 500)
 
   const onQueryChange = useCallback(
     (query: string) => {

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/discounts/DiscountsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/discounts/DiscountsPage.tsx
@@ -107,19 +107,15 @@ const ClientPage: React.FC<ClientPageProps> = ({
     )
   }
 
-  const debouncedQueryChange = useDebouncedCallback(
-    (query: string) => {
-      router.push(
-        `/dashboard/${organization.slug}/products/discounts?${getSearchParams(
-          { ...pagination, pageIndex: 0 },
-          sorting,
-          query,
-        )}`,
-      )
-    },
-    500,
-    [pagination, sorting, query, router],
-  )
+  const debouncedQueryChange = useDebouncedCallback((query: string) => {
+    router.push(
+      `/dashboard/${organization.slug}/products/discounts?${getSearchParams(
+        { ...pagination, pageIndex: 0 },
+        sorting,
+        query,
+      )}`,
+    )
+  }, 500)
 
   const onQueryChange = useCallback(
     (query: string) => {

--- a/clients/apps/web/src/hooks/utils.test.ts
+++ b/clients/apps/web/src/hooks/utils.test.ts
@@ -1,0 +1,89 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useDebouncedCallback } from './utils'
+
+describe('useDebouncedCallback', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('calls the callback after the delay', () => {
+    const callback = vi.fn()
+    const { result } = renderHook(() => useDebouncedCallback(callback, 300))
+
+    act(() => {
+      result.current('query')
+    })
+
+    expect(callback).not.toHaveBeenCalled()
+
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+
+    expect(callback).toHaveBeenCalledOnce()
+    expect(callback).toHaveBeenCalledWith('query')
+  })
+
+  it('debounces multiple calls', () => {
+    const callback = vi.fn()
+    const { result } = renderHook(() => useDebouncedCallback(callback, 300))
+
+    act(() => {
+      result.current('first')
+      result.current('second')
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+
+    expect(callback).toHaveBeenCalledOnce()
+    expect(callback).toHaveBeenCalledWith('second')
+  })
+
+  it('uses the latest callback after a rerender', () => {
+    const onSearch = vi.fn()
+    const { result, rerender } = renderHook(
+      ({ sorting }) =>
+        useDebouncedCallback((query: string) => onSearch(query, sorting), 300),
+      { initialProps: { sorting: 'name' } },
+    )
+
+    act(() => {
+      result.current('query')
+    })
+
+    rerender({ sorting: 'created_at' })
+
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+
+    expect(onSearch).toHaveBeenCalledOnce()
+    expect(onSearch).toHaveBeenCalledWith('query', 'created_at')
+  })
+
+  it('clears the pending callback on unmount', () => {
+    const callback = vi.fn()
+    const { result, unmount } = renderHook(() =>
+      useDebouncedCallback(callback, 300),
+    )
+
+    act(() => {
+      result.current()
+    })
+
+    unmount()
+
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+})

--- a/clients/apps/web/src/hooks/utils.ts
+++ b/clients/apps/web/src/hooks/utils.ts
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const useDebouncedCallback = <T extends (...args: any[]) => any>(
@@ -8,7 +14,7 @@ export const useDebouncedCallback = <T extends (...args: any[]) => any>(
   const timeout = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
   const callbackRef = useRef(callback)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     callbackRef.current = callback
   }, [callback])
 
@@ -16,9 +22,10 @@ export const useDebouncedCallback = <T extends (...args: any[]) => any>(
     () => () => {
       if (timeout.current != null) {
         clearTimeout(timeout.current)
+        timeout.current = undefined
       }
     },
-    [delay],
+    [],
   )
 
   return useCallback(

--- a/clients/apps/web/src/hooks/utils.ts
+++ b/clients/apps/web/src/hooks/utils.ts
@@ -1,25 +1,38 @@
-import React, { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const useDebouncedCallback = <T extends (...args: any[]) => any>(
   callback: T,
   delay: number,
-  dependencies?: unknown[],
 ) => {
-  const timeout = React.useRef<NodeJS.Timeout>(undefined)
+  const timeout = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  const callbackRef = useRef(callback)
 
-  return React.useCallback(
+  useEffect(() => {
+    callbackRef.current = callback
+  }, [callback])
+
+  useEffect(
+    () => () => {
+      if (timeout.current != null) {
+        clearTimeout(timeout.current)
+      }
+    },
+    [delay],
+  )
+
+  return useCallback(
     (...args: Parameters<T>): ReturnType<T> | void => {
       if (timeout.current != null) {
         clearTimeout(timeout.current)
       }
 
       timeout.current = setTimeout(() => {
-        callback(...args)
+        timeout.current = undefined
+        callbackRef.current(...args)
       }, delay)
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [callback, delay, ...(dependencies ? dependencies : [])],
+    [delay],
   )
 }
 


### PR DESCRIPTION
## Summary

**Related Issue**: polarsource/feedback#350

PR fixes the `useDebounceCallback` hook so there are no race condition when user does a second action within the 500ms debounce time.

## Why

Users could accidentally overwrite their filtering/pagination if they set their preferences really fast.

<!-- Explain why this change is needed -->

## How

Hook now stores the latest callback in a ref and that ref is updated when sorting or pagination changes. This means that when the debounce timer expires in always has access to the latest change.

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included
