### PR TITLE
feat(customers): add top customers and growth endpoints

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -3642,6 +3642,50 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/customers/growth': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Customer Growth
+     * @description Get new and cumulative customer counts over time.
+     *
+     *     **Scopes**: `customers:read` `customers:write`
+     */
+    get: operations['customers:growth']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v1/customers/top': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Top Customers
+     * @description Rank the organization's customers by paid net revenue.
+     *
+     *     **Scopes**: `customers:read` `customers:write`
+     */
+    get: operations['customers:top']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/customers/{id}': {
     parameters: {
       query?: never
@@ -16790,6 +16834,25 @@ export interface components {
     CustomerEmailUpdateVerifyResponse: {
       /** Token */
       token: string
+    }
+    /** CustomerGrowthPeriod */
+    CustomerGrowthPeriod: {
+      /**
+       * Timestamp
+       * Format: date-time
+       * @description The start of the period.
+       */
+      timestamp: string
+      /**
+       * New Customers
+       * @description The number of customers created during the period.
+       */
+      new_customers: number
+      /**
+       * Total Customers
+       * @description The cumulative number of customers at the end of the period.
+       */
+      total_customers: number
     }
     /**
      * CustomerIndividual
@@ -35430,6 +35493,43 @@ export interface components {
       /** Id Token */
       id_token?: string | null
     }
+    /** TopCustomer */
+    TopCustomer: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the customer.
+       * @example 992fae2a-2a17-4b7a-8d9e-e287cf90131b
+       */
+      id: string
+      /**
+       * Email
+       * @description The email address of the customer. This must be unique within the organization.
+       * @example customer@example.com
+       */
+      email: string | null
+      /**
+       * Name
+       * @description The name of the customer.
+       * @example John Doe
+       */
+      name: string | null
+      /**
+       * Avatar Url
+       * @example https://www.gravatar.com/avatar/xxx?d=404
+       */
+      avatar_url: string | null
+      /**
+       * Order Count
+       * @description The number of paid orders in the period.
+       */
+      order_count: number
+      /**
+       * Net Revenue
+       * @description The net revenue from this customer in the period, in cents, with refunded amounts subtracted.
+       */
+      net_revenue: number
+    }
     /** Transaction */
     Transaction: {
       /**
@@ -48211,6 +48311,82 @@ export interface operations {
         }
         content: {
           'text/csv': string
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'customers:growth': {
+    parameters: {
+      query: {
+        /** @description The organization ID to compute growth for. */
+        organization_id: string
+        /** @description The start of the period. */
+        start: string
+        /** @description The end of the period. */
+        end: string
+        /** @description The interval between each period. */
+        interval: components['schemas']['TimeInterval']
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['CustomerGrowthPeriod'][]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'customers:top': {
+    parameters: {
+      query: {
+        /** @description The organization ID to rank customers for. */
+        organization_id: string
+        /** @description Only count orders created at or after this timestamp. */
+        start?: string | null
+        /** @description Only count orders created before this timestamp. */
+        end?: string | null
+        /** @description How many customers to rank. */
+        limit?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['TopCustomer'][]
         }
       }
       /** @description Validation Error */

--- a/server/polar/customer/endpoints.py
+++ b/server/polar/customer/endpoints.py
@@ -1,5 +1,6 @@
 import json
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Sequence
+from datetime import datetime
 
 from fastapi import Depends, Query
 from pydantic import TypeAdapter
@@ -14,7 +15,9 @@ from polar.kit.csv import CSVStreamingResponse, IterableCSVWriter
 from polar.kit.metadata import MetadataQuery, get_metadata_query_openapi_schema
 from polar.kit.pagination import ListResource, PaginationParamsQuery
 from polar.kit.schemas import MultipleQueryFilter
+from polar.kit.time_queries import TimeInterval
 from polar.models import Customer, PaymentMethod
+from polar.models.customer import _avatar_url_for_email
 from polar.openapi import APITag
 from polar.organization.schemas import OrganizationID
 from polar.payment_method.schemas import PaymentMethodTypeAdapter
@@ -31,12 +34,14 @@ from . import auth, sorting
 from .repository import CustomerRepository
 from .schemas.customer import (
     CustomerCreate,
+    CustomerGrowthPeriod,
     CustomerID,
     CustomerPaymentMethod,
     CustomerPaymentMethodTypeAdapter,
     CustomerUpdate,
     CustomerUpdateExternalID,
     ExternalCustomerID,
+    TopCustomer,
 )
 from .schemas.customer import (
     CustomerResponse as CustomerSchema,
@@ -45,6 +50,10 @@ from .schemas.state import CustomerState
 from .service import customer as customer_service
 
 _CustomerAdapter: TypeAdapter[CustomerSchema] = TypeAdapter(CustomerSchema)
+
+# Bound before the `list` endpoint function below shadows the builtin
+TopCustomerList = list[TopCustomer]
+CustomerGrowthPeriodList = list[CustomerGrowthPeriod]
 
 router = APIRouter(
     prefix="/customers",
@@ -169,6 +178,83 @@ async def export(
             )
 
     return CSVStreamingResponse(create_csv(), "polar-customers.csv")
+
+
+@router.get(
+    "/growth",
+    summary="Customer Growth",
+    response_model=CustomerGrowthPeriodList,
+    tags=[APITag.private],
+)
+async def growth(
+    auth_subject: auth.CustomerRead,
+    organization_id: OrganizationID = Query(
+        description="The organization ID to compute growth for."
+    ),
+    start: datetime = Query(description="The start of the period."),
+    end: datetime = Query(description="The end of the period."),
+    interval: TimeInterval = Query(description="The interval between each period."),
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> Sequence[CustomerGrowthPeriod]:
+    """Get new and cumulative customer counts over time."""
+    periods = await customer_service.get_growth(
+        session,
+        auth_subject,
+        organization_id=organization_id,
+        start=start,
+        end=end,
+        interval=interval,
+    )
+    return [
+        CustomerGrowthPeriod(
+            timestamp=timestamp,
+            new_customers=new_customers,
+            total_customers=total_customers,
+        )
+        for timestamp, new_customers, total_customers in periods
+    ]
+
+
+@router.get(
+    "/top",
+    summary="Top Customers",
+    response_model=TopCustomerList,
+    tags=[APITag.private],
+)
+async def top(
+    auth_subject: auth.CustomerRead,
+    organization_id: OrganizationID = Query(
+        description="The organization ID to rank customers for."
+    ),
+    start: datetime | None = Query(
+        None, description="Only count orders created at or after this timestamp."
+    ),
+    end: datetime | None = Query(
+        None, description="Only count orders created before this timestamp."
+    ),
+    limit: int = Query(10, ge=1, le=50, description="How many customers to rank."),
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> TopCustomerList:
+    """Rank the organization's customers by paid net revenue."""
+    ranked = await customer_service.get_top_by_revenue(
+        session,
+        auth_subject,
+        organization_id=organization_id,
+        start=start,
+        end=end,
+        limit=limit,
+    )
+    return [
+        TopCustomer(
+            id=customer_id,
+            email=email,
+            name=name,
+            avatar_url=_avatar_url_for_email(email) if email else None,
+            order_count=order_count,
+            net_revenue=net_revenue,
+        )
+        for customer_id, email, name, order_count, net_revenue in ranked
+    ]
 
 
 @router.get(

--- a/server/polar/customer/repository.py
+++ b/server/polar/customer/repository.py
@@ -325,27 +325,35 @@ class CustomerRepository(
     ) -> Sequence[tuple[datetime, int, int]]:
         """New and cumulative customer counts per interval bucket, zero-filled.
 
-        Buckets cover whole intervals: the first bucket counts every customer
-        created within it, even before `start`, matching the metrics layer.
+        Both bounds are truncated to the interval before generating the
+        series, so the buckets containing `start` and `end` are always
+        included even when the raw bounds are not interval-aligned. Buckets
+        cover whole intervals: the first bucket counts every customer created
+        within it, even before `start`, matching the metrics layer.
         """
-        timestamp_series = get_timestamp_series_cte(start, end, interval)
+        timestamp_series = get_timestamp_series_cte(
+            interval.sql_date_trunc(start), interval.sql_date_trunc(end), interval
+        )
+        # Stepping one interval from a truncated start yields bucket starts,
+        # so the series values need no further truncation.
         timestamp_column = timestamp_series.c.timestamp
 
-        bucket = interval.sql_date_trunc(timestamp_column).label("timestamp")
         grouped = (
-            select(bucket, func.count(Customer.id).label("new_customers"))
+            select(
+                timestamp_column.label("timestamp"),
+                func.count(Customer.id).label("new_customers"),
+            )
             .select_from(timestamp_series)
             .join(
                 Customer,
                 isouter=True,
                 onclause=and_(
-                    interval.sql_date_trunc(Customer.created_at)
-                    == interval.sql_date_trunc(timestamp_column),
+                    interval.sql_date_trunc(Customer.created_at) == timestamp_column,
                     Customer.organization_id == organization_id,
                     Customer.deleted_at.is_(None),
                 ),
             )
-            .group_by(bucket)
+            .group_by(timestamp_column)
             .subquery("customer_growth")
         )
 

--- a/server/polar/customer/repository.py
+++ b/server/polar/customer/repository.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
     Select,
     String,
     Uuid,
+    and_,
     cast,
     column,
     func,
@@ -30,6 +31,7 @@ from polar.kit.repository import (
     RepositorySoftDeletionIDMixin,
     RepositorySoftDeletionMixin,
 )
+from polar.kit.time_queries import TimeInterval, get_timestamp_series_cte
 from polar.models import Customer, Subscription
 from polar.models.customer import EXTERNAL_ID_METADATA_KEY
 from polar.models.subscription import SubscriptionStatus
@@ -312,6 +314,62 @@ class CustomerRepository(
         customer_ids = [r.id for r in rows]
         external_ids = [r.external_id for r in rows if r.external_id is not None]
         return customer_ids, external_ids
+
+    async def get_growth_per_period(
+        self,
+        organization_id: UUID,
+        *,
+        start: datetime,
+        end: datetime,
+        interval: TimeInterval,
+    ) -> Sequence[tuple[datetime, int, int]]:
+        """New and cumulative customer counts per interval bucket, zero-filled.
+
+        Buckets cover whole intervals: the first bucket counts every customer
+        created within it, even before `start`, matching the metrics layer.
+        """
+        timestamp_series = get_timestamp_series_cte(start, end, interval)
+        timestamp_column = timestamp_series.c.timestamp
+
+        bucket = interval.sql_date_trunc(timestamp_column).label("timestamp")
+        grouped = (
+            select(bucket, func.count(Customer.id).label("new_customers"))
+            .select_from(timestamp_series)
+            .join(
+                Customer,
+                isouter=True,
+                onclause=and_(
+                    interval.sql_date_trunc(Customer.created_at)
+                    == interval.sql_date_trunc(timestamp_column),
+                    Customer.organization_id == organization_id,
+                    Customer.deleted_at.is_(None),
+                ),
+            )
+            .group_by(bucket)
+            .subquery("customer_growth")
+        )
+
+        customers_before_start = (
+            select(func.count(Customer.id))
+            .where(
+                Customer.organization_id == organization_id,
+                Customer.deleted_at.is_(None),
+                Customer.created_at < interval.sql_date_trunc(start),
+            )
+            .scalar_subquery()
+        )
+
+        statement = select(
+            grouped.c.timestamp,
+            grouped.c.new_customers,
+            (
+                customers_before_start
+                + func.sum(grouped.c.new_customers).over(order_by=grouped.c.timestamp)
+            ).label("total_customers"),
+        ).order_by(grouped.c.timestamp)
+
+        result = await self.session.execute(statement)
+        return [(row[0], int(row[1]), int(row[2])) for row in result.all()]
 
     def get_statement_by_org_ids(
         self, org_ids: set[AccessibleOrganizationID]

--- a/server/polar/customer/schemas/customer.py
+++ b/server/polar/customer/schemas/customer.py
@@ -268,6 +268,34 @@ CustomerResponse = Annotated[
 ]
 
 
+class CustomerGrowthPeriod(Schema):
+    timestamp: datetime = Field(description="The start of the period.")
+    new_customers: int = Field(
+        description="The number of customers created during the period."
+    )
+    total_customers: int = Field(
+        description="The cumulative number of customers at the end of the period."
+    )
+
+
+class TopCustomer(Schema):
+    id: UUID4 = Field(
+        description="The ID of the customer.", examples=[CUSTOMER_ID_EXAMPLE]
+    )
+    email: str | None = Field(description=_email_description, examples=[_email_example])
+    name: str | None = Field(description=_name_description, examples=[_name_example])
+    avatar_url: str | None = Field(
+        examples=["https://www.gravatar.com/avatar/xxx?d=404"],
+    )
+    order_count: int = Field(description="The number of paid orders in the period.")
+    net_revenue: int = Field(
+        description=(
+            "The net revenue from this customer in the period, in cents, "
+            "with refunded amounts subtracted."
+        )
+    )
+
+
 _is_default_description = (
     "Whether this payment method is the customer's default payment method."
 )

--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -30,6 +30,7 @@ from polar.kit.email import EmailNotValidError, unalias_email
 from polar.kit.metadata import MetadataQuery, apply_metadata_clause
 from polar.kit.pagination import PaginationParams
 from polar.kit.sorting import Sorting
+from polar.kit.time_queries import TimeInterval, is_under_limits
 from polar.kit.utils import utc_now
 from polar.member.repository import MemberRepository
 from polar.member.service import member_service
@@ -132,6 +133,61 @@ class CustomerService:
 
         return await repository.paginate(
             statement, limit=pagination.limit, page=pagination.page
+        )
+
+    async def get_growth(
+        self,
+        session: AsyncReadSession,
+        auth_subject: AuthSubject[User | Organization],
+        *,
+        organization_id: uuid.UUID,
+        start: datetime,
+        end: datetime,
+        interval: TimeInterval,
+    ) -> Sequence[tuple[datetime, int, int]]:
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization_id,
+            OrganizationPermission.customers_read,
+        )
+
+        if not is_under_limits(start.date(), end.date(), interval):
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("query", "interval"),
+                        "msg": "The interval is too small for the given date range.",
+                        "input": interval,
+                    }
+                ]
+            )
+
+        repository = CustomerRepository.from_session(session)
+        return await repository.get_growth_per_period(
+            organization_id, start=start, end=end, interval=interval
+        )
+
+    async def get_top_by_revenue(
+        self,
+        session: AsyncReadSession,
+        auth_subject: AuthSubject[User | Organization],
+        *,
+        organization_id: uuid.UUID,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        limit: int = 10,
+    ) -> Sequence[tuple[uuid.UUID, str | None, str | None, int, int]]:
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization_id,
+            OrganizationPermission.customers_read,
+        )
+        order_repository = OrderRepository.from_session(session)
+        return await order_repository.get_revenue_by_customer(
+            organization_id, start=start, end=end, limit=limit
         )
 
     async def get(

--- a/server/polar/kit/time_queries.py
+++ b/server/polar/kit/time_queries.py
@@ -30,7 +30,9 @@ class TimeInterval(StrEnum):
 
 
 def get_timestamp_series_cte(
-    start_timestamp: datetime, end_timestamp: datetime, interval: TimeInterval
+    start_timestamp: datetime | SQLColumnExpression[datetime],
+    end_timestamp: datetime | SQLColumnExpression[datetime],
+    interval: TimeInterval,
 ) -> CTE:
     return cte(
         select(

--- a/server/tests/customer/test_endpoints.py
+++ b/server/tests/customer/test_endpoints.py
@@ -1,18 +1,22 @@
 import uuid
+from datetime import timedelta
 
 import pytest
 from httpx import AsyncClient
 
+from polar.kit.utils import utc_now
 from polar.member.repository import MemberRepository
 from polar.models import (
     Benefit,
     Customer,
     Organization,
     Product,
+    User,
     UserOrganization,
 )
 from polar.models.customer import _avatar_url_for_email
 from polar.models.subscription import SubscriptionStatus
+from polar.models.user_organization import OrganizationRole
 from polar.postgres import AsyncSession
 from polar.tax.tax_id import TaxIDFormat
 from tests.fixtures.auth import AuthSubjectFixture
@@ -21,6 +25,7 @@ from tests.fixtures.random_objects import (
     create_active_subscription,
     create_benefit_grant,
     create_customer,
+    create_order,
     create_payment_method,
     create_subscription,
 )
@@ -228,6 +233,228 @@ class TestListCustomers:
             str(customer_past_due.id),
             str(customer_inactive.id),
         } <= ids
+
+
+@pytest.mark.asyncio
+class TestCustomerGrowth:
+    async def test_anonymous(
+        self, client: AsyncClient, organization: Organization
+    ) -> None:
+        response = await client.get(
+            "/v1/customers/growth",
+            params={
+                "organization_id": str(organization.id),
+                "start": utc_now().isoformat(),
+                "end": utc_now().isoformat(),
+                "interval": "day",
+            },
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_not_member(
+        self,
+        client: AsyncClient,
+        organization_second: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.get(
+            "/v1/customers/growth",
+            params={
+                "organization_id": str(organization_second.id),
+                "start": utc_now().isoformat(),
+                "end": utc_now().isoformat(),
+                "interval": "day",
+            },
+        )
+
+        assert response.status_code == 403
+
+    @pytest.mark.auth
+    async def test_interval_too_small_for_range(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.get(
+            "/v1/customers/growth",
+            params={
+                "organization_id": str(organization.id),
+                "start": (utc_now() - timedelta(days=30)).isoformat(),
+                "end": utc_now().isoformat(),
+                "interval": "hour",
+            },
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.auth
+    async def test_valid(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization_second: Organization,
+        user: User,
+    ) -> None:
+        # `organization_second` is used because the authenticated client's
+        # fixture chain seeds a customer in the default `organization`.
+        await save_fixture(
+            UserOrganization(
+                user=user,
+                organization=organization_second,
+                role=OrganizationRole.owner,
+            )
+        )
+        now = utc_now()
+        await create_customer(
+            save_fixture,
+            organization=organization_second,
+            email="old@example.com",
+            created_at=now - timedelta(days=10),
+        )
+        await create_customer(
+            save_fixture,
+            organization=organization_second,
+            email="yesterday1@example.com",
+            created_at=now - timedelta(days=1),
+        )
+        await create_customer(
+            save_fixture,
+            organization=organization_second,
+            email="yesterday2@example.com",
+            created_at=now - timedelta(days=1),
+        )
+        await create_customer(
+            save_fixture,
+            organization=organization_second,
+            email="today@example.com",
+            created_at=now,
+        )
+
+        response = await client.get(
+            "/v1/customers/growth",
+            params={
+                "organization_id": str(organization_second.id),
+                "start": (now - timedelta(days=2)).isoformat(),
+                "end": now.isoformat(),
+                "interval": "day",
+            },
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+        assert len(json) == 3
+        assert [period["new_customers"] for period in json] == [0, 2, 1]
+        assert [period["total_customers"] for period in json] == [1, 3, 4]
+
+
+@pytest.mark.asyncio
+class TestTopCustomers:
+    async def test_anonymous(
+        self, client: AsyncClient, organization: Organization
+    ) -> None:
+        response = await client.get(
+            "/v1/customers/top", params={"organization_id": str(organization.id)}
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_not_member(
+        self,
+        client: AsyncClient,
+        organization_second: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.get(
+            "/v1/customers/top",
+            params={"organization_id": str(organization_second.id)},
+        )
+
+        assert response.status_code == 403
+
+    @pytest.mark.auth
+    async def test_ranked_by_net_revenue(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+        product: Product,
+    ) -> None:
+        best = await create_customer(
+            save_fixture, organization=organization, email="best@example.com"
+        )
+        runner_up = await create_customer(
+            save_fixture, organization=organization, email="runner.up@example.com"
+        )
+        await create_customer(
+            save_fixture, organization=organization, email="no.orders@example.com"
+        )
+        await create_order(
+            save_fixture, customer=best, product=product, subtotal_amount=10_000
+        )
+        await create_order(
+            save_fixture,
+            customer=best,
+            product=product,
+            subtotal_amount=5_000,
+            refunded_amount=2_000,
+        )
+        await create_order(
+            save_fixture, customer=runner_up, product=product, subtotal_amount=4_000
+        )
+
+        response = await client.get(
+            "/v1/customers/top", params={"organization_id": str(organization.id)}
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+        assert [item["id"] for item in json] == [str(best.id), str(runner_up.id)]
+        assert json[0]["net_revenue"] == 13_000
+        assert json[0]["order_count"] == 2
+        assert json[0]["email"] == "best@example.com"
+        assert json[0]["avatar_url"] == _avatar_url_for_email("best@example.com")
+        assert json[1]["net_revenue"] == 4_000
+        assert json[1]["order_count"] == 1
+
+    @pytest.mark.auth
+    async def test_start_filter(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+        product: Product,
+    ) -> None:
+        customer = await create_customer(save_fixture, organization=organization)
+        await create_order(
+            save_fixture,
+            customer=customer,
+            product=product,
+            subtotal_amount=10_000,
+            created_at=utc_now() - timedelta(days=30),
+        )
+        await create_order(
+            save_fixture, customer=customer, product=product, subtotal_amount=500
+        )
+
+        response = await client.get(
+            "/v1/customers/top",
+            params={
+                "organization_id": str(organization.id),
+                "start": (utc_now() - timedelta(days=7)).isoformat(),
+            },
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+        assert len(json) == 1
+        assert json[0]["net_revenue"] == 500
+        assert json[0]["order_count"] == 1
 
 
 @pytest.mark.asyncio

--- a/server/tests/customer/test_endpoints.py
+++ b/server/tests/customer/test_endpoints.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from httpx import AsyncClient
@@ -348,6 +348,52 @@ class TestCustomerGrowth:
         assert len(json) == 3
         assert [period["new_customers"] for period in json] == [0, 2, 1]
         assert [period["total_customers"] for period in json] == [1, 3, 4]
+
+    @pytest.mark.auth
+    async def test_unaligned_bounds_include_boundary_buckets(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization_second: Organization,
+        user: User,
+    ) -> None:
+        await save_fixture(
+            UserOrganization(
+                user=user,
+                organization=organization_second,
+                role=OrganizationRole.owner,
+            )
+        )
+        await create_customer(
+            save_fixture,
+            organization=organization_second,
+            email="june@example.com",
+            created_at=datetime(2026, 6, 25, tzinfo=UTC),
+        )
+        await create_customer(
+            save_fixture,
+            organization=organization_second,
+            email="august@example.com",
+            created_at=datetime(2026, 8, 3, tzinfo=UTC),
+        )
+
+        # Bounds deliberately not aligned to month starts: the buckets
+        # containing both `start` and `end` must still be present.
+        response = await client.get(
+            "/v1/customers/growth",
+            params={
+                "organization_id": str(organization_second.id),
+                "start": datetime(2026, 6, 20, tzinfo=UTC).isoformat(),
+                "end": datetime(2026, 8, 5, tzinfo=UTC).isoformat(),
+                "interval": "month",
+            },
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+        assert len(json) == 3
+        assert [period["new_customers"] for period in json] == [1, 0, 1]
+        assert [period["total_customers"] for period in json] == [1, 1, 2]
 
 
 @pytest.mark.asyncio

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -939,8 +939,10 @@ async def create_customer(
     billing_address: Address | None = None,
     tax_id: TaxID | None = None,
     user_metadata: dict[str, Any] = {},
+    created_at: datetime | None = None,
 ) -> Customer:
     customer = Customer(
+        created_at=created_at or utc_now(),
         external_id=external_id,
         email=email,
         email_verified=email_verified,


### PR DESCRIPTION
Two private endpoints backing the customers overview page:

- GET /v1/customers/top ranks customers by paid net revenue,
  reusing the refund-aware aggregation Compass already uses.
- GET /v1/customers/growth returns per-interval new and cumulative
  customer counts, zero-filled via generate_series and truncated on
  both sides of the bucket join to match the metrics layer.

Both assert customers_read on the target organization. The
create_customer test fixture gains a created_at parameter.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

