### PR TITLE
feat(web): customers overview page

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/page.tsx
@@ -1,6 +1,8 @@
-import { MasterDetailIndex } from '@/components/Layout/MasterDetailIndex'
+import { CustomersOverview } from '@/components/Customer/CustomersOverview'
+import { EmptyState } from '@/components/Shared/EmptyState'
 import { getServerSideAPI } from '@/utils/client/serverside'
 import { getOrganizationBySlugOrNotFound } from '@/utils/organization'
+import { Users } from 'lucide-react'
 import { Metadata } from 'next'
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -11,43 +13,34 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function Page(props: {
   params: Promise<{ organization: string }>
-  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
 }) {
   const params = await props.params
-  const searchParams = await props.searchParams
   const api = await getServerSideAPI()
   const organization = await getOrganizationBySlugOrNotFound(
     api,
     params.organization,
   )
 
-  // Fetch the newest customer
   const { data } = await api.GET('/v1/customers/', {
     params: {
       query: {
         organization_id: organization.id,
         limit: 1,
-        sorting: ['-created_at'],
       },
     },
   })
 
-  // If there's a newest customer, redirect to it on desktop (on mobile, show the list)
-  if (data?.items && data.items.length > 0) {
-    const queryString = new URLSearchParams(
-      searchParams as Record<string, string>,
-    ).toString()
-    const redirectUrl = `/dashboard/${organization.slug}/customers/${data.items[0].id}${queryString ? `?${queryString}` : ''}`
-    return <MasterDetailIndex redirectTo={redirectUrl} />
+  if (!data?.items || data.items.length === 0) {
+    return (
+      <div className="flex h-full w-full flex-col justify-center">
+        <EmptyState
+          icon={<Users />}
+          title="No Customers"
+          description="Create a customer to get started."
+        />
+      </div>
+    )
   }
 
-  // Otherwise show empty state
-  return (
-    <div className="mt-96 flex w-full flex-col items-center justify-center gap-4">
-      <h1 className="text-2xl">No Customers</h1>
-      <p className="dark:text-polar-500 text-gray-500">
-        Create a customer to get started
-      </p>
-    </div>
-  )
+  return <CustomersOverview organization={organization} />
 }

--- a/clients/apps/web/src/components/Customer/AtRiskList.tsx
+++ b/clients/apps/web/src/components/Customer/AtRiskList.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { EmptyState } from '@/components/Shared/EmptyState'
+import {
+  Toplist,
+  ToplistItem,
+  ToplistSkeleton,
+  ToplistText,
+  ToplistValue,
+} from '@/components/Shared/Toplist'
+import { useSubscriptions } from '@/hooks/queries'
+import { schemas } from '@polar-sh/client'
+import { formatCurrency } from '@polar-sh/currency'
+import { Avatar } from '@polar-sh/orbit'
+import { ShieldCheck } from 'lucide-react'
+import { useMemo } from 'react'
+
+type RiskReason = 'past_due' | 'canceling'
+
+interface AtRiskItem {
+  subscription: schemas['Subscription']
+  reason: RiskReason
+}
+
+const cancelDate = (subscription: schemas['Subscription']) =>
+  new Date(
+    subscription.ends_at ?? subscription.current_period_end,
+  ).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+
+interface AtRiskListProps {
+  organization: schemas['Organization']
+}
+
+export const AtRiskList = ({ organization }: AtRiskListProps) => {
+  const { data: pastDue, isLoading: pastDueLoading } = useSubscriptions(
+    organization.id,
+    { status: ['past_due'], limit: 10, sorting: ['-amount'] },
+  )
+  const { data: canceling, isLoading: cancelingLoading } = useSubscriptions(
+    organization.id,
+    {
+      status: ['active', 'trialing'],
+      cancel_at_period_end: true,
+      limit: 10,
+      sorting: ['current_period_end'],
+    },
+  )
+
+  const atRisk = useMemo<AtRiskItem[]>(() => {
+    const pastDueItems = (pastDue?.items ?? []).map((subscription) => ({
+      subscription,
+      reason: 'past_due' as const,
+    }))
+    const pastDueIds = new Set(pastDueItems.map((item) => item.subscription.id))
+    const cancelingItems = (canceling?.items ?? [])
+      .filter((subscription) => !pastDueIds.has(subscription.id))
+      .map((subscription) => ({
+        subscription,
+        reason: 'canceling' as const,
+      }))
+    return [...pastDueItems, ...cancelingItems].slice(0, 5)
+  }, [pastDue, canceling])
+
+  if (pastDueLoading || cancelingLoading) {
+    return <ToplistSkeleton rows={3} />
+  }
+
+  if (atRisk.length === 0) {
+    return (
+      <EmptyState
+        icon={<ShieldCheck />}
+        title="Nothing at risk"
+        description="No payment issues or scheduled cancellations."
+        fill
+      />
+    )
+  }
+
+  return (
+    <Toplist>
+      {atRisk.map(({ subscription, reason }) => (
+        <ToplistItem
+          key={subscription.id}
+          href={`/dashboard/${organization.slug}/customers/${subscription.customer_id}`}
+        >
+          <Avatar
+            className="h-8 w-8"
+            avatar_url={subscription.customer.avatar_url}
+            name={
+              subscription.customer.name ?? subscription.customer.email ?? '-'
+            }
+          />
+          <ToplistText
+            primary={
+              subscription.customer.name ?? subscription.customer.email ?? '-'
+            }
+            secondary={subscription.product.name}
+          />
+          <ToplistValue
+            value={formatCurrency('statistics')(
+              subscription.amount,
+              subscription.currency,
+            )}
+            caption={
+              reason === 'past_due'
+                ? 'Past due'
+                : `Cancels ${cancelDate(subscription)}`
+            }
+            captionColor={reason === 'past_due' ? 'danger' : 'warning'}
+          />
+        </ToplistItem>
+      ))}
+    </Toplist>
+  )
+}

--- a/clients/apps/web/src/components/Customer/AtRiskList.tsx
+++ b/clients/apps/web/src/components/Customer/AtRiskList.tsx
@@ -11,7 +11,7 @@ import {
 import { useSubscriptions } from '@/hooks/queries'
 import { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
-import { Avatar } from '@polar-sh/orbit'
+import { Alert, Avatar } from '@polar-sh/orbit'
 import { ShieldCheck } from 'lucide-react'
 import { useMemo } from 'react'
 
@@ -32,19 +32,27 @@ interface AtRiskListProps {
 }
 
 export const AtRiskList = ({ organization }: AtRiskListProps) => {
-  const { data: pastDue, isLoading: pastDueLoading } = useSubscriptions(
-    organization.id,
-    { status: ['past_due'], limit: 10, sorting: ['-amount'] },
-  )
-  const { data: canceling, isLoading: cancelingLoading } = useSubscriptions(
-    organization.id,
-    {
-      status: ['active', 'trialing'],
-      cancel_at_period_end: true,
-      limit: 10,
-      sorting: ['current_period_end'],
-    },
-  )
+  const {
+    data: pastDue,
+    isLoading: pastDueLoading,
+    isError: pastDueError,
+    refetch: refetchPastDue,
+  } = useSubscriptions(organization.id, {
+    status: ['past_due'],
+    limit: 10,
+    sorting: ['-amount'],
+  })
+  const {
+    data: canceling,
+    isLoading: cancelingLoading,
+    isError: cancelingError,
+    refetch: refetchCanceling,
+  } = useSubscriptions(organization.id, {
+    status: ['active', 'trialing'],
+    cancel_at_period_end: true,
+    limit: 10,
+    sorting: ['current_period_end'],
+  })
 
   const atRisk = useMemo<AtRiskItem[]>(() => {
     const pastDueItems = (pastDue?.items ?? []).map((subscription) => ({
@@ -63,6 +71,24 @@ export const AtRiskList = ({ organization }: AtRiskListProps) => {
 
   if (pastDueLoading || cancelingLoading) {
     return <ToplistSkeleton rows={3} />
+  }
+
+  if (pastDueError || cancelingError) {
+    return (
+      <Alert
+        variant="danger"
+        title="Could not load at-risk subscriptions"
+        actions={[
+          {
+            text: 'Retry',
+            onClick: () => {
+              refetchPastDue()
+              refetchCanceling()
+            },
+          },
+        ]}
+      />
+    )
   }
 
   if (atRisk.length === 0) {

--- a/clients/apps/web/src/components/Customer/CustomerGrowthChart.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerGrowthChart.tsx
@@ -1,0 +1,117 @@
+'use client'
+
+import MetricChart from '@/components/Metrics/MetricChart'
+import { ParsedMetricPeriod, useCustomerGrowth } from '@/hooks/queries'
+import { formatHumanFriendlyScalar } from '@/utils/formatters'
+import { schemas } from '@polar-sh/client'
+import { SegmentedControl, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { useMemo, useState } from 'react'
+
+type GrowthView = 'new_customers' | 'total_customers'
+
+const GROWTH_METRICS: Record<GrowthView, schemas['Metric']> = {
+  new_customers: {
+    slug: 'new_customers',
+    display_name: 'New Customers',
+    type: 'scalar',
+  },
+  total_customers: {
+    slug: 'total_customers',
+    display_name: 'Total Customers',
+    type: 'scalar',
+  },
+}
+
+interface CustomerGrowthChartProps {
+  organization: schemas['Organization']
+  start: Date
+  end: Date
+  interval: schemas['TimeInterval']
+}
+
+export const CustomerGrowthChart = ({
+  organization,
+  start,
+  end,
+  interval,
+}: CustomerGrowthChartProps) => {
+  const [view, setView] = useState<GrowthView>('new_customers')
+  const { data: growth, isLoading } = useCustomerGrowth(organization.id, {
+    start,
+    end,
+    interval,
+  })
+
+  const periods = useMemo(
+    () =>
+      (growth ?? []).map((period) => ({
+        timestamp: new Date(period.timestamp),
+        new_customers: period.new_customers,
+        total_customers: period.total_customers,
+      })) as unknown as ParsedMetricPeriod[],
+    [growth],
+  )
+
+  const headlineValue = useMemo(() => {
+    if (!growth || growth.length === 0) {
+      return 0
+    }
+    return view === 'new_customers'
+      ? growth.reduce((sum, period) => sum + period.new_customers, 0)
+      : growth[growth.length - 1].total_customers
+  }, [growth, view])
+
+  return (
+    <Box
+      flexDirection="column"
+      rowGap="xl"
+      padding="xl"
+      borderRadius="l"
+      borderWidth={1}
+      borderStyle="solid"
+      borderColor="border-primary"
+    >
+      <Box
+        flexDirection={{ base: 'column', md: 'row' }}
+        justifyContent="between"
+        gap="l"
+      >
+        <Box flexDirection="column" rowGap="xs">
+          <Text color="muted">{GROWTH_METRICS[view].display_name}</Text>
+          <Text variant="heading-xs" as="p">
+            {formatHumanFriendlyScalar(headlineValue)}
+          </Text>
+        </Box>
+        <Box alignItems="start">
+          <SegmentedControl<GrowthView>
+            options={[
+              { value: 'new_customers', label: 'New' },
+              { value: 'total_customers', label: 'Total' },
+            ]}
+            value={view}
+            onChange={setView}
+          />
+        </Box>
+      </Box>
+      {isLoading ? (
+        <div className="animate-pulse">
+          <Box
+            height={240}
+            borderRadius="m"
+            backgroundColor="background-card"
+          />
+        </div>
+      ) : (
+        <MetricChart
+          data={periods}
+          interval={interval}
+          metric={GROWTH_METRICS[view]}
+          chartType={view === 'new_customers' ? 'bar' : 'line'}
+          height={240}
+          showYAxis
+        />
+      )}
+    </Box>
+  )
+}

--- a/clients/apps/web/src/components/Customer/CustomerListSidebar.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerListSidebar.tsx
@@ -128,7 +128,11 @@ export const CustomerListSidebar: React.FC<CustomerListSidebarProps> = ({
     <>
       <div className="dark:divide-polar-800 flex h-full flex-col divide-y divide-gray-200">
         <div className="flex flex-row items-center justify-between gap-6 px-4 py-4">
-          <div>Customers</div>
+          <Link
+            href={withQuerystring(`/dashboard/${organization.slug}/customers`)}
+          >
+            Customers
+          </Link>
           <div className="flex flex-row items-center gap-4">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>

--- a/clients/apps/web/src/components/Customer/CustomersOverview.tsx
+++ b/clients/apps/web/src/components/Customer/CustomersOverview.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { MasterDetailLayoutContent } from '@/components/Layout/MasterDetailLayout'
+import { ToplistHeader } from '@/components/Shared/Toplist'
+import { CHART_RANGES, ChartRange, getChartRangeParams } from '@/utils/metrics'
+import { schemas } from '@polar-sh/client'
+import { Grid, SegmentedControl, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { useMemo, useState } from 'react'
+import { AtRiskList } from './AtRiskList'
+import { CustomerGrowthChart } from './CustomerGrowthChart'
+import { TopCostCustomersList } from './TopCostCustomersList'
+import { TopCustomersList } from './TopCustomersList'
+
+interface CustomersOverviewProps {
+  organization: schemas['Organization']
+}
+
+export const CustomersOverview = ({ organization }: CustomersOverviewProps) => {
+  const [range, setRange] = useState<ChartRange>('30d')
+  const [startDate, endDate, interval] = useMemo(
+    () => getChartRangeParams(range, organization.created_at),
+    [range, organization.created_at],
+  )
+
+  return (
+    <MasterDetailLayoutContent
+      header={
+        <>
+          <Text variant="heading-xxs" as="h1">
+            Customers
+          </Text>
+          <SegmentedControl
+            options={(
+              Object.entries(CHART_RANGES) as [ChartRange, string][]
+            ).map(([value, label]) => ({ value, label }))}
+            value={range}
+            onChange={setRange}
+          />
+        </>
+      }
+    >
+      <Box flexDirection="column" rowGap="4xl">
+        <CustomerGrowthChart
+          organization={organization}
+          start={startDate}
+          end={endDate}
+          interval={interval}
+        />
+        <Grid
+          templateColumns={{ base: '1fr', md: '1fr', xl: '1fr 1fr 1fr' }}
+          gap="3xl"
+        >
+          <Box flexDirection="column" rowGap="l">
+            <ToplistHeader title="Top Customers" caption="By net revenue" />
+            <TopCustomersList
+              organization={organization}
+              start={startDate}
+              end={endDate}
+            />
+          </Box>
+          <Box flexDirection="column" rowGap="l">
+            <ToplistHeader title="At Risk" caption="Past due & canceling" />
+            <AtRiskList organization={organization} />
+          </Box>
+          <Box flexDirection="column" rowGap="l">
+            <ToplistHeader
+              title="Cost Drivers"
+              caption="Ingested cost events"
+            />
+            <TopCostCustomersList
+              organization={organization}
+              start={startDate}
+              end={endDate}
+            />
+          </Box>
+        </Grid>
+      </Box>
+    </MasterDetailLayoutContent>
+  )
+}

--- a/clients/apps/web/src/components/Customer/CustomersOverview.tsx
+++ b/clients/apps/web/src/components/Customer/CustomersOverview.tsx
@@ -2,6 +2,7 @@
 
 import { MasterDetailLayoutContent } from '@/components/Layout/MasterDetailLayout'
 import { ToplistHeader } from '@/components/Shared/Toplist'
+import { useHasPermission } from '@/hooks/permissions'
 import { CHART_RANGES, ChartRange, getChartRangeParams } from '@/utils/metrics'
 import { schemas } from '@polar-sh/client'
 import { Grid, SegmentedControl, Text } from '@polar-sh/orbit'
@@ -22,6 +23,7 @@ export const CustomersOverview = ({ organization }: CustomersOverviewProps) => {
     () => getChartRangeParams(range, organization.created_at),
     [range, organization.created_at],
   )
+  const canReadAnalytics = useHasPermission(organization.id, 'analytics:read')
 
   return (
     <MasterDetailLayoutContent
@@ -48,7 +50,11 @@ export const CustomersOverview = ({ organization }: CustomersOverviewProps) => {
           interval={interval}
         />
         <Grid
-          templateColumns={{ base: '1fr', md: '1fr', xl: '1fr 1fr 1fr' }}
+          templateColumns={{
+            base: '1fr',
+            md: '1fr',
+            xl: canReadAnalytics ? '1fr 1fr 1fr' : '1fr 1fr',
+          }}
           gap="3xl"
         >
           <Box flexDirection="column" rowGap="l">
@@ -63,17 +69,19 @@ export const CustomersOverview = ({ organization }: CustomersOverviewProps) => {
             <ToplistHeader title="At Risk" caption="Past due & canceling" />
             <AtRiskList organization={organization} />
           </Box>
-          <Box flexDirection="column" rowGap="l">
-            <ToplistHeader
-              title="Cost Drivers"
-              caption="Ingested cost events"
-            />
-            <TopCostCustomersList
-              organization={organization}
-              start={startDate}
-              end={endDate}
-            />
-          </Box>
+          {canReadAnalytics && (
+            <Box flexDirection="column" rowGap="l">
+              <ToplistHeader
+                title="Cost Drivers"
+                caption="Ingested cost events"
+              />
+              <TopCostCustomersList
+                organization={organization}
+                start={startDate}
+                end={endDate}
+              />
+            </Box>
+          )}
         </Grid>
       </Box>
     </MasterDetailLayoutContent>

--- a/clients/apps/web/src/components/Customer/TopCostCustomersList.tsx
+++ b/clients/apps/web/src/components/Customer/TopCostCustomersList.tsx
@@ -9,13 +9,12 @@ import {
   ToplistValue,
 } from '@/components/Shared/Toplist'
 import { CustomerStatItem, useEventCustomerStats } from '@/hooks/queries/events'
+import { toISODate } from '@/utils/metrics'
 import { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
-import { Avatar } from '@polar-sh/orbit'
+import { Alert, Avatar } from '@polar-sh/orbit'
 import { Coins } from 'lucide-react'
 import { useMemo } from 'react'
-
-const isoDate = (date: Date) => date.toISOString().slice(0, 10)
 
 const cost = (stat: CustomerStatItem) =>
   parseFloat(String(stat.totals?.['_cost_amount'] ?? '0'))
@@ -31,12 +30,15 @@ export const TopCostCustomersList = ({
   start,
   end,
 }: TopCostCustomersListProps) => {
-  const { data, isLoading } = useEventCustomerStats(organization.id, {
-    start_date: isoDate(start),
-    end_date: isoDate(end),
-    aggregate_fields: ['_cost.amount'],
-    limit: 5,
-  })
+  const { data, isLoading, isError, refetch } = useEventCustomerStats(
+    organization.id,
+    {
+      start_date: toISODate(start),
+      end_date: toISODate(end),
+      aggregate_fields: ['_cost.amount'],
+      limit: 5,
+    },
+  )
 
   const stats = useMemo(
     () => (data?.items ?? []).filter((stat) => cost(stat) > 0).slice(0, 5),
@@ -45,6 +47,16 @@ export const TopCostCustomersList = ({
 
   if (isLoading) {
     return <ToplistSkeleton rows={3} />
+  }
+
+  if (isError) {
+    return (
+      <Alert
+        variant="danger"
+        title="Could not load cost statistics"
+        actions={[{ text: 'Retry', onClick: () => refetch() }]}
+      />
+    )
   }
 
   if (stats.length === 0) {

--- a/clients/apps/web/src/components/Customer/TopCostCustomersList.tsx
+++ b/clients/apps/web/src/components/Customer/TopCostCustomersList.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { EmptyState } from '@/components/Shared/EmptyState'
+import {
+  Toplist,
+  ToplistItem,
+  ToplistSkeleton,
+  ToplistText,
+  ToplistValue,
+} from '@/components/Shared/Toplist'
+import { CustomerStatItem, useEventCustomerStats } from '@/hooks/queries/events'
+import { schemas } from '@polar-sh/client'
+import { formatCurrency } from '@polar-sh/currency'
+import { Avatar } from '@polar-sh/orbit'
+import { Coins } from 'lucide-react'
+import { useMemo } from 'react'
+
+const isoDate = (date: Date) => date.toISOString().slice(0, 10)
+
+const cost = (stat: CustomerStatItem) =>
+  parseFloat(String(stat.totals?.['_cost_amount'] ?? '0'))
+
+interface TopCostCustomersListProps {
+  organization: schemas['Organization']
+  start: Date
+  end: Date
+}
+
+export const TopCostCustomersList = ({
+  organization,
+  start,
+  end,
+}: TopCostCustomersListProps) => {
+  const { data, isLoading } = useEventCustomerStats(organization.id, {
+    start_date: isoDate(start),
+    end_date: isoDate(end),
+    aggregate_fields: ['_cost.amount'],
+    limit: 5,
+  })
+
+  const stats = useMemo(
+    () => (data?.items ?? []).filter((stat) => cost(stat) > 0).slice(0, 5),
+    [data],
+  )
+
+  if (isLoading) {
+    return <ToplistSkeleton rows={3} />
+  }
+
+  if (stats.length === 0) {
+    return (
+      <EmptyState
+        icon={<Coins />}
+        title="No cost data"
+        description="Costs come from _cost metadata on ingested events."
+        fill
+      />
+    )
+  }
+
+  return (
+    <Toplist>
+      {stats.map((stat) => (
+        <ToplistItem
+          key={stat.customer_id ?? stat.external_customer_id}
+          href={
+            stat.customer_id
+              ? `/dashboard/${organization.slug}/customers/${stat.customer_id}`
+              : undefined
+          }
+        >
+          <Avatar
+            className="h-8 w-8"
+            avatar_url={null}
+            name={stat.name ?? stat.email ?? stat.external_customer_id ?? '-'}
+          />
+          <ToplistText
+            primary={
+              stat.name ?? stat.email ?? stat.external_customer_id ?? '-'
+            }
+            secondary={`${stat.occurrences.toLocaleString()} ${
+              stat.occurrences === 1 ? 'event' : 'events'
+            }`}
+          />
+          <ToplistValue
+            value={formatCurrency('subcent')(cost(stat), 'usd')}
+            caption={`${Math.round(stat.share * 100)}% of costs`}
+          />
+        </ToplistItem>
+      ))}
+    </Toplist>
+  )
+}

--- a/clients/apps/web/src/components/Customer/TopCustomersList.tsx
+++ b/clients/apps/web/src/components/Customer/TopCustomersList.tsx
@@ -11,7 +11,7 @@ import {
 import { useTopCustomers } from '@/hooks/queries'
 import { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
-import { Avatar } from '@polar-sh/orbit'
+import { Alert, Avatar } from '@polar-sh/orbit'
 import { TrendingUp } from 'lucide-react'
 
 interface TopCustomersListProps {
@@ -25,7 +25,12 @@ export const TopCustomersList = ({
   start,
   end,
 }: TopCustomersListProps) => {
-  const { data: topCustomers, isLoading } = useTopCustomers(organization.id, {
+  const {
+    data: topCustomers,
+    isLoading,
+    isError,
+    refetch,
+  } = useTopCustomers(organization.id, {
     start,
     end,
     limit: 5,
@@ -33,6 +38,16 @@ export const TopCustomersList = ({
 
   if (isLoading) {
     return <ToplistSkeleton rows={5} />
+  }
+
+  if (isError) {
+    return (
+      <Alert
+        variant="danger"
+        title="Could not load top customers"
+        actions={[{ text: 'Retry', onClick: () => refetch() }]}
+      />
+    )
   }
 
   if (!topCustomers || topCustomers.length === 0) {

--- a/clients/apps/web/src/components/Customer/TopCustomersList.tsx
+++ b/clients/apps/web/src/components/Customer/TopCustomersList.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { EmptyState } from '@/components/Shared/EmptyState'
+import {
+  Toplist,
+  ToplistItem,
+  ToplistSkeleton,
+  ToplistText,
+  ToplistValue,
+} from '@/components/Shared/Toplist'
+import { useTopCustomers } from '@/hooks/queries'
+import { schemas } from '@polar-sh/client'
+import { formatCurrency } from '@polar-sh/currency'
+import { Avatar } from '@polar-sh/orbit'
+import { TrendingUp } from 'lucide-react'
+
+interface TopCustomersListProps {
+  organization: schemas['Organization']
+  start: Date
+  end: Date
+}
+
+export const TopCustomersList = ({
+  organization,
+  start,
+  end,
+}: TopCustomersListProps) => {
+  const { data: topCustomers, isLoading } = useTopCustomers(organization.id, {
+    start,
+    end,
+    limit: 5,
+  })
+
+  if (isLoading) {
+    return <ToplistSkeleton rows={5} />
+  }
+
+  if (!topCustomers || topCustomers.length === 0) {
+    return (
+      <EmptyState
+        icon={<TrendingUp />}
+        title="No revenue yet"
+        description="No paid orders were recorded in this period."
+        fill
+      />
+    )
+  }
+
+  return (
+    <Toplist>
+      {topCustomers.map((customer) => (
+        <ToplistItem
+          key={customer.id}
+          href={`/dashboard/${organization.slug}/customers/${customer.id}`}
+        >
+          <Avatar
+            className="h-8 w-8"
+            avatar_url={customer.avatar_url}
+            name={customer.name ?? customer.email ?? '-'}
+          />
+          <ToplistText
+            primary={customer.name ?? customer.email ?? '-'}
+            secondary={
+              customer.name && customer.email ? customer.email : undefined
+            }
+          />
+          <ToplistValue
+            value={formatCurrency('statistics')(customer.net_revenue, 'usd')}
+            caption={`${customer.order_count} ${
+              customer.order_count === 1 ? 'order' : 'orders'
+            }`}
+          />
+        </ToplistItem>
+      ))}
+    </Toplist>
+  )
+}

--- a/clients/apps/web/src/components/Shared/EmptyState.tsx
+++ b/clients/apps/web/src/components/Shared/EmptyState.tsx
@@ -8,6 +8,8 @@ interface EmptyStateProps {
   title: string
   description: string
   actions?: ButtonProps[]
+  /** Grow to fill the parent's remaining space, e.g. to match sibling list heights. */
+  fill?: boolean
 }
 
 export const EmptyState = ({
@@ -15,22 +17,24 @@ export const EmptyState = ({
   title,
   description,
   actions,
+  fill = false,
 }: EmptyStateProps) => {
   return (
     <Box
       flexDirection="column"
       alignItems="center"
       justifyContent="center"
-      gap="s"
+      gap="m"
       borderRadius="m"
       borderWidth={1}
       borderStyle="solid"
       borderColor="border-primary"
       padding="3xl"
+      flexGrow={fill ? 1 : undefined}
     >
       <div className="dark:text-polar-500 text-5xl text-gray-500">{icon}</div>
       <Box flexDirection="column" alignItems="center" textAlign="center">
-        <Text variant="heading-xxs" as="h3">
+        <Text variant="body" as="h3">
           {title}
         </Text>
         <Text color="muted">{description}</Text>

--- a/clients/apps/web/src/components/Shared/Toplist.tsx
+++ b/clients/apps/web/src/components/Shared/Toplist.tsx
@@ -1,0 +1,154 @@
+import { Text, TextColor } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import Link from 'next/link'
+import { PropsWithChildren, ReactNode } from 'react'
+
+export const ToplistHeader = ({
+  title,
+  caption,
+}: {
+  title: ReactNode
+  caption?: ReactNode
+}) => (
+  <Box
+    alignItems="baseline"
+    columnGap="m"
+    paddingBottom="l"
+    borderBottomWidth={1}
+    borderStyle="solid"
+    borderColor="border-primary"
+  >
+    <Text variant="body" as="h2">
+      {title}
+    </Text>
+    {caption ? (
+      <Text color="muted" variant="body">
+        {caption}
+      </Text>
+    ) : null}
+  </Box>
+)
+
+// Rows carry `m` horizontal padding for their hover surface; the negative
+// margin offsets it so row content aligns with the section title above.
+export const Toplist = ({ children }: PropsWithChildren) => (
+  <div className="-mx-3">
+    <Box as="ul" flexDirection="column">
+      {children}
+    </Box>
+  </div>
+)
+
+export interface ToplistItemProps extends PropsWithChildren {
+  href?: string
+}
+
+export const ToplistItem = ({ href, children }: ToplistItemProps) => {
+  const row = (
+    <Box
+      alignItems="center"
+      columnGap="m"
+      paddingHorizontal="m"
+      paddingVertical="s"
+      borderRadius="s"
+      backgroundColor={{ hover: 'background-card' }}
+      transitionProperty="colors"
+      transitionDuration="instant"
+    >
+      {children}
+    </Box>
+  )
+  return (
+    <Box as="li" flexDirection="column">
+      {href ? <Link href={href}>{row}</Link> : row}
+    </Box>
+  )
+}
+
+export const ToplistText = ({
+  primary,
+  secondary,
+}: {
+  primary: ReactNode
+  secondary?: ReactNode
+}) => (
+  <Box flexDirection="column" flex={1} minWidth={0}>
+    <Text truncate>{primary}</Text>
+    {secondary ? (
+      <Text truncate color="muted" variant="caption">
+        {secondary}
+      </Text>
+    ) : null}
+  </Box>
+)
+
+export const ToplistValue = ({
+  value,
+  caption,
+  captionColor = 'muted',
+}: {
+  value: ReactNode
+  caption?: ReactNode
+  captionColor?: TextColor
+}) => (
+  <Box flexDirection="column" alignItems="end">
+    <Text>{value}</Text>
+    {caption ? (
+      <Text color={captionColor} variant="caption">
+        {caption}
+      </Text>
+    ) : null}
+  </Box>
+)
+
+export const ToplistSkeleton = ({ rows = 3 }: { rows?: number }) => (
+  <div className="-mx-3 animate-pulse">
+    <Box flexDirection="column">
+      {Array.from({ length: rows }).map((_, index) => (
+        <Box
+          key={index}
+          alignItems="center"
+          columnGap="m"
+          paddingHorizontal="m"
+          paddingVertical="m"
+        >
+          <Box
+            width={32}
+            height={32}
+            borderRadius="full"
+            backgroundColor="background-card"
+            flexShrink={0}
+          />
+          <Box flexDirection="column" rowGap="xs" flex={1}>
+            <Box
+              height={14}
+              width="40%"
+              borderRadius="s"
+              backgroundColor="background-card"
+            />
+            <Box
+              height={10}
+              width="55%"
+              borderRadius="s"
+              backgroundColor="background-card"
+            />
+          </Box>
+          <Box flexDirection="column" rowGap="xs" alignItems="end">
+            <Box
+              height={14}
+              width={56}
+              borderRadius="s"
+              backgroundColor="background-card"
+            />
+            <Box
+              height={10}
+              width={40}
+              borderRadius="s"
+              backgroundColor="background-card"
+            />
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  </div>
+)

--- a/clients/apps/web/src/hooks/queries/customers.ts
+++ b/clients/apps/web/src/hooks/queries/customers.ts
@@ -44,6 +44,64 @@ export const useCustomers = (
     },
   })
 
+export const useTopCustomers = (
+  organizationId: string,
+  parameters?: { start?: Date; end?: Date; limit?: number },
+) =>
+  useQuery({
+    queryKey: [
+      'customers',
+      'top',
+      organizationId,
+      parameters?.start?.toISOString(),
+      parameters?.end?.toISOString(),
+      parameters?.limit,
+    ],
+    queryFn: () =>
+      unwrap(
+        api.GET('/v1/customers/top', {
+          params: {
+            query: {
+              organization_id: organizationId,
+              start: parameters?.start?.toISOString(),
+              end: parameters?.end?.toISOString(),
+              limit: parameters?.limit,
+            },
+          },
+        }),
+      ),
+    retry: defaultRetry,
+  })
+
+export const useCustomerGrowth = (
+  organizationId: string,
+  parameters: { start: Date; end: Date; interval: schemas['TimeInterval'] },
+) =>
+  useQuery({
+    queryKey: [
+      'customers',
+      'growth',
+      organizationId,
+      parameters.start.toISOString(),
+      parameters.end.toISOString(),
+      parameters.interval,
+    ],
+    queryFn: () =>
+      unwrap(
+        api.GET('/v1/customers/growth', {
+          params: {
+            query: {
+              organization_id: organizationId,
+              start: parameters.start.toISOString(),
+              end: parameters.end.toISOString(),
+              interval: parameters.interval,
+            },
+          },
+        }),
+      ),
+    retry: defaultRetry,
+  })
+
 export const useCustomer = (id: string | null) =>
   useQuery({
     queryKey: ['customers', 'id', id],

--- a/clients/apps/web/src/hooks/queries/customers.ts
+++ b/clients/apps/web/src/hooks/queries/customers.ts
@@ -51,8 +51,8 @@ export const useTopCustomers = (
   useQuery({
     queryKey: [
       'customers',
-      'top',
       organizationId,
+      'top',
       parameters?.start?.toISOString(),
       parameters?.end?.toISOString(),
       parameters?.limit,
@@ -80,8 +80,8 @@ export const useCustomerGrowth = (
   useQuery({
     queryKey: [
       'customers',
-      'growth',
       organizationId,
+      'growth',
       parameters.start.toISOString(),
       parameters.end.toISOString(),
       parameters.interval,

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -3642,6 +3642,50 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/customers/growth': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Customer Growth
+     * @description Get new and cumulative customer counts over time.
+     *
+     *     **Scopes**: `customers:read` `customers:write`
+     */
+    get: operations['customers:growth']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/v1/customers/top': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Top Customers
+     * @description Rank the organization's customers by paid net revenue.
+     *
+     *     **Scopes**: `customers:read` `customers:write`
+     */
+    get: operations['customers:top']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/customers/{id}': {
     parameters: {
       query?: never
@@ -16790,6 +16834,25 @@ export interface components {
     CustomerEmailUpdateVerifyResponse: {
       /** Token */
       token: string
+    }
+    /** CustomerGrowthPeriod */
+    CustomerGrowthPeriod: {
+      /**
+       * Timestamp
+       * Format: date-time
+       * @description The start of the period.
+       */
+      timestamp: string
+      /**
+       * New Customers
+       * @description The number of customers created during the period.
+       */
+      new_customers: number
+      /**
+       * Total Customers
+       * @description The cumulative number of customers at the end of the period.
+       */
+      total_customers: number
     }
     /**
      * CustomerIndividual
@@ -35430,6 +35493,43 @@ export interface components {
       /** Id Token */
       id_token?: string | null
     }
+    /** TopCustomer */
+    TopCustomer: {
+      /**
+       * Id
+       * Format: uuid4
+       * @description The ID of the customer.
+       * @example 992fae2a-2a17-4b7a-8d9e-e287cf90131b
+       */
+      id: string
+      /**
+       * Email
+       * @description The email address of the customer. This must be unique within the organization.
+       * @example customer@example.com
+       */
+      email: string | null
+      /**
+       * Name
+       * @description The name of the customer.
+       * @example John Doe
+       */
+      name: string | null
+      /**
+       * Avatar Url
+       * @example https://www.gravatar.com/avatar/xxx?d=404
+       */
+      avatar_url: string | null
+      /**
+       * Order Count
+       * @description The number of paid orders in the period.
+       */
+      order_count: number
+      /**
+       * Net Revenue
+       * @description The net revenue from this customer in the period, in cents, with refunded amounts subtracted.
+       */
+      net_revenue: number
+    }
     /** Transaction */
     Transaction: {
       /**
@@ -48211,6 +48311,82 @@ export interface operations {
         }
         content: {
           'text/csv': string
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'customers:growth': {
+    parameters: {
+      query: {
+        /** @description The organization ID to compute growth for. */
+        organization_id: string
+        /** @description The start of the period. */
+        start: string
+        /** @description The end of the period. */
+        end: string
+        /** @description The interval between each period. */
+        interval: components['schemas']['TimeInterval']
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['CustomerGrowthPeriod'][]
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'customers:top': {
+    parameters: {
+      query: {
+        /** @description The organization ID to rank customers for. */
+        organization_id: string
+        /** @description Only count orders created at or after this timestamp. */
+        start?: string | null
+        /** @description Only count orders created before this timestamp. */
+        end?: string | null
+        /** @description How many customers to rank. */
+        limit?: number
+      }
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['TopCustomer'][]
         }
       }
       /** @description Validation Error */

--- a/server/polar/customer/endpoints.py
+++ b/server/polar/customer/endpoints.py
@@ -1,5 +1,6 @@
 import json
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Sequence
+from datetime import datetime
 
 from fastapi import Depends, Query
 from pydantic import TypeAdapter
@@ -14,7 +15,9 @@ from polar.kit.csv import CSVStreamingResponse, IterableCSVWriter
 from polar.kit.metadata import MetadataQuery, get_metadata_query_openapi_schema
 from polar.kit.pagination import ListResource, PaginationParamsQuery
 from polar.kit.schemas import MultipleQueryFilter
+from polar.kit.time_queries import TimeInterval
 from polar.models import Customer, PaymentMethod
+from polar.models.customer import _avatar_url_for_email
 from polar.openapi import APITag
 from polar.organization.schemas import OrganizationID
 from polar.payment_method.schemas import PaymentMethodTypeAdapter
@@ -31,12 +34,14 @@ from . import auth, sorting
 from .repository import CustomerRepository
 from .schemas.customer import (
     CustomerCreate,
+    CustomerGrowthPeriod,
     CustomerID,
     CustomerPaymentMethod,
     CustomerPaymentMethodTypeAdapter,
     CustomerUpdate,
     CustomerUpdateExternalID,
     ExternalCustomerID,
+    TopCustomer,
 )
 from .schemas.customer import (
     CustomerResponse as CustomerSchema,
@@ -45,6 +50,10 @@ from .schemas.state import CustomerState
 from .service import customer as customer_service
 
 _CustomerAdapter: TypeAdapter[CustomerSchema] = TypeAdapter(CustomerSchema)
+
+# Bound before the `list` endpoint function below shadows the builtin
+TopCustomerList = list[TopCustomer]
+CustomerGrowthPeriodList = list[CustomerGrowthPeriod]
 
 router = APIRouter(
     prefix="/customers",
@@ -169,6 +178,83 @@ async def export(
             )
 
     return CSVStreamingResponse(create_csv(), "polar-customers.csv")
+
+
+@router.get(
+    "/growth",
+    summary="Customer Growth",
+    response_model=CustomerGrowthPeriodList,
+    tags=[APITag.private],
+)
+async def growth(
+    auth_subject: auth.CustomerRead,
+    organization_id: OrganizationID = Query(
+        description="The organization ID to compute growth for."
+    ),
+    start: datetime = Query(description="The start of the period."),
+    end: datetime = Query(description="The end of the period."),
+    interval: TimeInterval = Query(description="The interval between each period."),
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> Sequence[CustomerGrowthPeriod]:
+    """Get new and cumulative customer counts over time."""
+    periods = await customer_service.get_growth(
+        session,
+        auth_subject,
+        organization_id=organization_id,
+        start=start,
+        end=end,
+        interval=interval,
+    )
+    return [
+        CustomerGrowthPeriod(
+            timestamp=timestamp,
+            new_customers=new_customers,
+            total_customers=total_customers,
+        )
+        for timestamp, new_customers, total_customers in periods
+    ]
+
+
+@router.get(
+    "/top",
+    summary="Top Customers",
+    response_model=TopCustomerList,
+    tags=[APITag.private],
+)
+async def top(
+    auth_subject: auth.CustomerRead,
+    organization_id: OrganizationID = Query(
+        description="The organization ID to rank customers for."
+    ),
+    start: datetime | None = Query(
+        None, description="Only count orders created at or after this timestamp."
+    ),
+    end: datetime | None = Query(
+        None, description="Only count orders created before this timestamp."
+    ),
+    limit: int = Query(10, ge=1, le=50, description="How many customers to rank."),
+    session: AsyncReadSession = Depends(get_db_read_session),
+) -> TopCustomerList:
+    """Rank the organization's customers by paid net revenue."""
+    ranked = await customer_service.get_top_by_revenue(
+        session,
+        auth_subject,
+        organization_id=organization_id,
+        start=start,
+        end=end,
+        limit=limit,
+    )
+    return [
+        TopCustomer(
+            id=customer_id,
+            email=email,
+            name=name,
+            avatar_url=_avatar_url_for_email(email) if email else None,
+            order_count=order_count,
+            net_revenue=net_revenue,
+        )
+        for customer_id, email, name, order_count, net_revenue in ranked
+    ]
 
 
 @router.get(

--- a/server/polar/customer/repository.py
+++ b/server/polar/customer/repository.py
@@ -325,27 +325,35 @@ class CustomerRepository(
     ) -> Sequence[tuple[datetime, int, int]]:
         """New and cumulative customer counts per interval bucket, zero-filled.
 
-        Buckets cover whole intervals: the first bucket counts every customer
-        created within it, even before `start`, matching the metrics layer.
+        Both bounds are truncated to the interval before generating the
+        series, so the buckets containing `start` and `end` are always
+        included even when the raw bounds are not interval-aligned. Buckets
+        cover whole intervals: the first bucket counts every customer created
+        within it, even before `start`, matching the metrics layer.
         """
-        timestamp_series = get_timestamp_series_cte(start, end, interval)
+        timestamp_series = get_timestamp_series_cte(
+            interval.sql_date_trunc(start), interval.sql_date_trunc(end), interval
+        )
+        # Stepping one interval from a truncated start yields bucket starts,
+        # so the series values need no further truncation.
         timestamp_column = timestamp_series.c.timestamp
 
-        bucket = interval.sql_date_trunc(timestamp_column).label("timestamp")
         grouped = (
-            select(bucket, func.count(Customer.id).label("new_customers"))
+            select(
+                timestamp_column.label("timestamp"),
+                func.count(Customer.id).label("new_customers"),
+            )
             .select_from(timestamp_series)
             .join(
                 Customer,
                 isouter=True,
                 onclause=and_(
-                    interval.sql_date_trunc(Customer.created_at)
-                    == interval.sql_date_trunc(timestamp_column),
+                    interval.sql_date_trunc(Customer.created_at) == timestamp_column,
                     Customer.organization_id == organization_id,
                     Customer.deleted_at.is_(None),
                 ),
             )
-            .group_by(bucket)
+            .group_by(timestamp_column)
             .subquery("customer_growth")
         )
 

--- a/server/polar/customer/repository.py
+++ b/server/polar/customer/repository.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
     Select,
     String,
     Uuid,
+    and_,
     cast,
     column,
     func,
@@ -30,6 +31,7 @@ from polar.kit.repository import (
     RepositorySoftDeletionIDMixin,
     RepositorySoftDeletionMixin,
 )
+from polar.kit.time_queries import TimeInterval, get_timestamp_series_cte
 from polar.models import Customer, Subscription
 from polar.models.customer import EXTERNAL_ID_METADATA_KEY
 from polar.models.subscription import SubscriptionStatus
@@ -312,6 +314,62 @@ class CustomerRepository(
         customer_ids = [r.id for r in rows]
         external_ids = [r.external_id for r in rows if r.external_id is not None]
         return customer_ids, external_ids
+
+    async def get_growth_per_period(
+        self,
+        organization_id: UUID,
+        *,
+        start: datetime,
+        end: datetime,
+        interval: TimeInterval,
+    ) -> Sequence[tuple[datetime, int, int]]:
+        """New and cumulative customer counts per interval bucket, zero-filled.
+
+        Buckets cover whole intervals: the first bucket counts every customer
+        created within it, even before `start`, matching the metrics layer.
+        """
+        timestamp_series = get_timestamp_series_cte(start, end, interval)
+        timestamp_column = timestamp_series.c.timestamp
+
+        bucket = interval.sql_date_trunc(timestamp_column).label("timestamp")
+        grouped = (
+            select(bucket, func.count(Customer.id).label("new_customers"))
+            .select_from(timestamp_series)
+            .join(
+                Customer,
+                isouter=True,
+                onclause=and_(
+                    interval.sql_date_trunc(Customer.created_at)
+                    == interval.sql_date_trunc(timestamp_column),
+                    Customer.organization_id == organization_id,
+                    Customer.deleted_at.is_(None),
+                ),
+            )
+            .group_by(bucket)
+            .subquery("customer_growth")
+        )
+
+        customers_before_start = (
+            select(func.count(Customer.id))
+            .where(
+                Customer.organization_id == organization_id,
+                Customer.deleted_at.is_(None),
+                Customer.created_at < interval.sql_date_trunc(start),
+            )
+            .scalar_subquery()
+        )
+
+        statement = select(
+            grouped.c.timestamp,
+            grouped.c.new_customers,
+            (
+                customers_before_start
+                + func.sum(grouped.c.new_customers).over(order_by=grouped.c.timestamp)
+            ).label("total_customers"),
+        ).order_by(grouped.c.timestamp)
+
+        result = await self.session.execute(statement)
+        return [(row[0], int(row[1]), int(row[2])) for row in result.all()]
 
     def get_statement_by_org_ids(
         self, org_ids: set[AccessibleOrganizationID]

--- a/server/polar/customer/schemas/customer.py
+++ b/server/polar/customer/schemas/customer.py
@@ -268,6 +268,34 @@ CustomerResponse = Annotated[
 ]
 
 
+class CustomerGrowthPeriod(Schema):
+    timestamp: datetime = Field(description="The start of the period.")
+    new_customers: int = Field(
+        description="The number of customers created during the period."
+    )
+    total_customers: int = Field(
+        description="The cumulative number of customers at the end of the period."
+    )
+
+
+class TopCustomer(Schema):
+    id: UUID4 = Field(
+        description="The ID of the customer.", examples=[CUSTOMER_ID_EXAMPLE]
+    )
+    email: str | None = Field(description=_email_description, examples=[_email_example])
+    name: str | None = Field(description=_name_description, examples=[_name_example])
+    avatar_url: str | None = Field(
+        examples=["https://www.gravatar.com/avatar/xxx?d=404"],
+    )
+    order_count: int = Field(description="The number of paid orders in the period.")
+    net_revenue: int = Field(
+        description=(
+            "The net revenue from this customer in the period, in cents, "
+            "with refunded amounts subtracted."
+        )
+    )
+
+
 _is_default_description = (
     "Whether this payment method is the customer's default payment method."
 )

--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -30,6 +30,7 @@ from polar.kit.email import EmailNotValidError, unalias_email
 from polar.kit.metadata import MetadataQuery, apply_metadata_clause
 from polar.kit.pagination import PaginationParams
 from polar.kit.sorting import Sorting
+from polar.kit.time_queries import TimeInterval, is_under_limits
 from polar.kit.utils import utc_now
 from polar.member.repository import MemberRepository
 from polar.member.service import member_service
@@ -132,6 +133,61 @@ class CustomerService:
 
         return await repository.paginate(
             statement, limit=pagination.limit, page=pagination.page
+        )
+
+    async def get_growth(
+        self,
+        session: AsyncReadSession,
+        auth_subject: AuthSubject[User | Organization],
+        *,
+        organization_id: uuid.UUID,
+        start: datetime,
+        end: datetime,
+        interval: TimeInterval,
+    ) -> Sequence[tuple[datetime, int, int]]:
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization_id,
+            OrganizationPermission.customers_read,
+        )
+
+        if not is_under_limits(start.date(), end.date(), interval):
+            raise PolarRequestValidationError(
+                [
+                    {
+                        "type": "value_error",
+                        "loc": ("query", "interval"),
+                        "msg": "The interval is too small for the given date range.",
+                        "input": interval,
+                    }
+                ]
+            )
+
+        repository = CustomerRepository.from_session(session)
+        return await repository.get_growth_per_period(
+            organization_id, start=start, end=end, interval=interval
+        )
+
+    async def get_top_by_revenue(
+        self,
+        session: AsyncReadSession,
+        auth_subject: AuthSubject[User | Organization],
+        *,
+        organization_id: uuid.UUID,
+        start: datetime | None = None,
+        end: datetime | None = None,
+        limit: int = 10,
+    ) -> Sequence[tuple[uuid.UUID, str | None, str | None, int, int]]:
+        await assert_organization_permission(
+            session,
+            auth_subject,
+            organization_id,
+            OrganizationPermission.customers_read,
+        )
+        order_repository = OrderRepository.from_session(session)
+        return await order_repository.get_revenue_by_customer(
+            organization_id, start=start, end=end, limit=limit
         )
 
     async def get(

--- a/server/polar/kit/time_queries.py
+++ b/server/polar/kit/time_queries.py
@@ -30,7 +30,9 @@ class TimeInterval(StrEnum):
 
 
 def get_timestamp_series_cte(
-    start_timestamp: datetime, end_timestamp: datetime, interval: TimeInterval
+    start_timestamp: datetime | SQLColumnExpression[datetime],
+    end_timestamp: datetime | SQLColumnExpression[datetime],
+    interval: TimeInterval,
 ) -> CTE:
     return cte(
         select(

--- a/server/tests/customer/test_endpoints.py
+++ b/server/tests/customer/test_endpoints.py
@@ -1,18 +1,22 @@
 import uuid
+from datetime import timedelta
 
 import pytest
 from httpx import AsyncClient
 
+from polar.kit.utils import utc_now
 from polar.member.repository import MemberRepository
 from polar.models import (
     Benefit,
     Customer,
     Organization,
     Product,
+    User,
     UserOrganization,
 )
 from polar.models.customer import _avatar_url_for_email
 from polar.models.subscription import SubscriptionStatus
+from polar.models.user_organization import OrganizationRole
 from polar.postgres import AsyncSession
 from polar.tax.tax_id import TaxIDFormat
 from tests.fixtures.auth import AuthSubjectFixture
@@ -21,6 +25,7 @@ from tests.fixtures.random_objects import (
     create_active_subscription,
     create_benefit_grant,
     create_customer,
+    create_order,
     create_payment_method,
     create_subscription,
 )
@@ -228,6 +233,228 @@ class TestListCustomers:
             str(customer_past_due.id),
             str(customer_inactive.id),
         } <= ids
+
+
+@pytest.mark.asyncio
+class TestCustomerGrowth:
+    async def test_anonymous(
+        self, client: AsyncClient, organization: Organization
+    ) -> None:
+        response = await client.get(
+            "/v1/customers/growth",
+            params={
+                "organization_id": str(organization.id),
+                "start": utc_now().isoformat(),
+                "end": utc_now().isoformat(),
+                "interval": "day",
+            },
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_not_member(
+        self,
+        client: AsyncClient,
+        organization_second: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.get(
+            "/v1/customers/growth",
+            params={
+                "organization_id": str(organization_second.id),
+                "start": utc_now().isoformat(),
+                "end": utc_now().isoformat(),
+                "interval": "day",
+            },
+        )
+
+        assert response.status_code == 403
+
+    @pytest.mark.auth
+    async def test_interval_too_small_for_range(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.get(
+            "/v1/customers/growth",
+            params={
+                "organization_id": str(organization.id),
+                "start": (utc_now() - timedelta(days=30)).isoformat(),
+                "end": utc_now().isoformat(),
+                "interval": "hour",
+            },
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.auth
+    async def test_valid(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization_second: Organization,
+        user: User,
+    ) -> None:
+        # `organization_second` is used because the authenticated client's
+        # fixture chain seeds a customer in the default `organization`.
+        await save_fixture(
+            UserOrganization(
+                user=user,
+                organization=organization_second,
+                role=OrganizationRole.owner,
+            )
+        )
+        now = utc_now()
+        await create_customer(
+            save_fixture,
+            organization=organization_second,
+            email="old@example.com",
+            created_at=now - timedelta(days=10),
+        )
+        await create_customer(
+            save_fixture,
+            organization=organization_second,
+            email="yesterday1@example.com",
+            created_at=now - timedelta(days=1),
+        )
+        await create_customer(
+            save_fixture,
+            organization=organization_second,
+            email="yesterday2@example.com",
+            created_at=now - timedelta(days=1),
+        )
+        await create_customer(
+            save_fixture,
+            organization=organization_second,
+            email="today@example.com",
+            created_at=now,
+        )
+
+        response = await client.get(
+            "/v1/customers/growth",
+            params={
+                "organization_id": str(organization_second.id),
+                "start": (now - timedelta(days=2)).isoformat(),
+                "end": now.isoformat(),
+                "interval": "day",
+            },
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+        assert len(json) == 3
+        assert [period["new_customers"] for period in json] == [0, 2, 1]
+        assert [period["total_customers"] for period in json] == [1, 3, 4]
+
+
+@pytest.mark.asyncio
+class TestTopCustomers:
+    async def test_anonymous(
+        self, client: AsyncClient, organization: Organization
+    ) -> None:
+        response = await client.get(
+            "/v1/customers/top", params={"organization_id": str(organization.id)}
+        )
+
+        assert response.status_code == 401
+
+    @pytest.mark.auth
+    async def test_not_member(
+        self,
+        client: AsyncClient,
+        organization_second: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        response = await client.get(
+            "/v1/customers/top",
+            params={"organization_id": str(organization_second.id)},
+        )
+
+        assert response.status_code == 403
+
+    @pytest.mark.auth
+    async def test_ranked_by_net_revenue(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+        product: Product,
+    ) -> None:
+        best = await create_customer(
+            save_fixture, organization=organization, email="best@example.com"
+        )
+        runner_up = await create_customer(
+            save_fixture, organization=organization, email="runner.up@example.com"
+        )
+        await create_customer(
+            save_fixture, organization=organization, email="no.orders@example.com"
+        )
+        await create_order(
+            save_fixture, customer=best, product=product, subtotal_amount=10_000
+        )
+        await create_order(
+            save_fixture,
+            customer=best,
+            product=product,
+            subtotal_amount=5_000,
+            refunded_amount=2_000,
+        )
+        await create_order(
+            save_fixture, customer=runner_up, product=product, subtotal_amount=4_000
+        )
+
+        response = await client.get(
+            "/v1/customers/top", params={"organization_id": str(organization.id)}
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+        assert [item["id"] for item in json] == [str(best.id), str(runner_up.id)]
+        assert json[0]["net_revenue"] == 13_000
+        assert json[0]["order_count"] == 2
+        assert json[0]["email"] == "best@example.com"
+        assert json[0]["avatar_url"] == _avatar_url_for_email("best@example.com")
+        assert json[1]["net_revenue"] == 4_000
+        assert json[1]["order_count"] == 1
+
+    @pytest.mark.auth
+    async def test_start_filter(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+        product: Product,
+    ) -> None:
+        customer = await create_customer(save_fixture, organization=organization)
+        await create_order(
+            save_fixture,
+            customer=customer,
+            product=product,
+            subtotal_amount=10_000,
+            created_at=utc_now() - timedelta(days=30),
+        )
+        await create_order(
+            save_fixture, customer=customer, product=product, subtotal_amount=500
+        )
+
+        response = await client.get(
+            "/v1/customers/top",
+            params={
+                "organization_id": str(organization.id),
+                "start": (utc_now() - timedelta(days=7)).isoformat(),
+            },
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+        assert len(json) == 1
+        assert json[0]["net_revenue"] == 500
+        assert json[0]["order_count"] == 1
 
 
 @pytest.mark.asyncio

--- a/server/tests/customer/test_endpoints.py
+++ b/server/tests/customer/test_endpoints.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from httpx import AsyncClient
@@ -348,6 +348,52 @@ class TestCustomerGrowth:
         assert len(json) == 3
         assert [period["new_customers"] for period in json] == [0, 2, 1]
         assert [period["total_customers"] for period in json] == [1, 3, 4]
+
+    @pytest.mark.auth
+    async def test_unaligned_bounds_include_boundary_buckets(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization_second: Organization,
+        user: User,
+    ) -> None:
+        await save_fixture(
+            UserOrganization(
+                user=user,
+                organization=organization_second,
+                role=OrganizationRole.owner,
+            )
+        )
+        await create_customer(
+            save_fixture,
+            organization=organization_second,
+            email="june@example.com",
+            created_at=datetime(2026, 6, 25, tzinfo=UTC),
+        )
+        await create_customer(
+            save_fixture,
+            organization=organization_second,
+            email="august@example.com",
+            created_at=datetime(2026, 8, 3, tzinfo=UTC),
+        )
+
+        # Bounds deliberately not aligned to month starts: the buckets
+        # containing both `start` and `end` must still be present.
+        response = await client.get(
+            "/v1/customers/growth",
+            params={
+                "organization_id": str(organization_second.id),
+                "start": datetime(2026, 6, 20, tzinfo=UTC).isoformat(),
+                "end": datetime(2026, 8, 5, tzinfo=UTC).isoformat(),
+                "interval": "month",
+            },
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+        assert len(json) == 3
+        assert [period["new_customers"] for period in json] == [1, 0, 1]
+        assert [period["total_customers"] for period in json] == [1, 1, 2]
 
 
 @pytest.mark.asyncio

--- a/server/tests/fixtures/random_objects.py
+++ b/server/tests/fixtures/random_objects.py
@@ -939,8 +939,10 @@ async def create_customer(
     billing_address: Address | None = None,
     tax_id: TaxID | None = None,
     user_metadata: dict[str, Any] = {},
+    created_at: datetime | None = None,
 ) -> Customer:
     customer = Customer(
+        created_at=created_at or utc_now(),
         external_id=external_id,
         email=email,
         email_verified=email_verified,


### PR DESCRIPTION

<img width="3596" height="2016" alt="image" src="https://github.com/user-attachments/assets/edfe0756-0830-41b1-be90-eb12a59efa9b" />


Replace the auto-redirect to the newest customer with an overview:

- Customer growth chart with a New/Total toggle and range control
- Top Customers by net revenue, At Risk (past due and canceling
  subscriptions), and Cost Drivers (ingested cost events) toplists
- Composable shared Toplist component (header with divider, linkable
  items, text/value slots, structured skeleton) used by all three
- EmptyState gains a fill prop so empty sections match sibling heights
- Sidebar title links back to the overview root

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

