### PR TITLE
feat: add index on email_template to email_logs

### DIFF
--- a/server/migrations/versions/2026-08-11-0830_add_index_on_email_template_to_email_.py
+++ b/server/migrations/versions/2026-08-11-0830_add_index_on_email_template_to_email_.py
@@ -1,0 +1,48 @@
+"""Add index on email_template to email_logs
+
+Revision ID: 565c75e65f2d
+Revises: c1a7e4b93f2d
+Create Date: 2026-08-11 08:30:35.506229
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "565c75e65f2d"
+down_revision = "c1a7e4b93f2d"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+INDEX = "ix_email_logs_email_template"
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        # Drop any INVALID leftover from an interrupted concurrent build first.
+        op.drop_index(
+            INDEX,
+            table_name="email_logs",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            INDEX,
+            "email_logs",
+            ["email_template"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            INDEX,
+            table_name="email_logs",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )

--- a/server/polar/models/email_log.py
+++ b/server/polar/models/email_log.py
@@ -28,7 +28,9 @@ class EmailLog(RecordModel):
     from_email_addr: Mapped[str] = mapped_column(String, nullable=False)
     from_name: Mapped[str] = mapped_column(String, nullable=False)
     subject: Mapped[str] = mapped_column(String, nullable=False)
-    email_template: Mapped[str | None] = mapped_column(String, nullable=True)
+    email_template: Mapped[str | None] = mapped_column(
+        String, nullable=True, index=True
+    )
     email_props: Mapped[dict[str, Any]] = mapped_column(
         JSONB, nullable=False, default=dict
     )


### PR DESCRIPTION
This is a temporary index needed to backfill email deduplication keys. Once that backfill is done this can be dropped again.

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a concurrent index on email_logs.email_template to speed up queries that filter by template and reduce table scans. Also marks the `EmailLog.email_template` column as indexed to keep the model in sync.

<sup>Written for commit 801e2bb21dc536f68a0a8c436516593246fc0f61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

