### PR TITLE
fix(checkout): merge metadata into the subscription on upgrade

### DIFF
--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -811,7 +811,11 @@ class SubscriptionService:
         if checkout.discount is not None and trial_end is None:
             subscription.discount_applied_at = current_period_start
         subscription.checkout = checkout
-        subscription.user_metadata = checkout.user_metadata
+        # Upgrading an existing subscription keeps the keys the checkout doesn't carry
+        subscription.user_metadata = {
+            **(subscription.user_metadata or {}),
+            **checkout.user_metadata,
+        }
         subscription.custom_field_data = checkout.custom_field_data
         subscription.seats = checkout.seats
 

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -931,6 +931,108 @@ class TestCreateOrUpdateFromCheckout:
             session, updated_subscription
         )
 
+    async def test_new_sets_metadata(
+        self,
+        enqueue_benefits_grants_mock: MagicMock,
+        publish_checkout_event_mock: AsyncMock,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+        payment_method: PaymentMethod,
+    ) -> None:
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product],
+            status=CheckoutStatus.confirmed,
+            customer=customer,
+            user_metadata={"utm_source": "youtube"},
+        )
+
+        (
+            subscription,
+            created,
+        ) = await subscription_service.create_or_update_from_checkout(
+            session, checkout, payment_method
+        )
+
+        assert created is True
+        assert subscription.user_metadata == {"utm_source": "youtube"}
+
+    async def test_upgrade_keeps_metadata_absent_from_checkout(
+        self,
+        enqueue_benefits_grants_mock: MagicMock,
+        publish_checkout_event_mock: AsyncMock,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product_recurring_free_price: Product,
+        product: Product,
+        customer: Customer,
+        payment_method: PaymentMethod,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product_recurring_free_price,
+            customer=customer,
+            status=SubscriptionStatus.active,
+            user_metadata={"utm_source": "youtube"},
+        )
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product],
+            status=CheckoutStatus.confirmed,
+            customer=customer,
+            subscription=subscription,
+        )
+
+        (
+            updated_subscription,
+            _,
+        ) = await subscription_service.create_or_update_from_checkout(
+            session, checkout, payment_method
+        )
+
+        assert updated_subscription.user_metadata == {"utm_source": "youtube"}
+
+    async def test_upgrade_overwrites_metadata_set_on_checkout(
+        self,
+        enqueue_benefits_grants_mock: MagicMock,
+        publish_checkout_event_mock: AsyncMock,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product_recurring_free_price: Product,
+        product: Product,
+        customer: Customer,
+        payment_method: PaymentMethod,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product_recurring_free_price,
+            customer=customer,
+            status=SubscriptionStatus.active,
+            user_metadata={"utm_source": "youtube", "plan": "free"},
+        )
+        checkout = await create_checkout(
+            save_fixture,
+            products=[product],
+            status=CheckoutStatus.confirmed,
+            customer=customer,
+            subscription=subscription,
+            user_metadata={"plan": "paid"},
+        )
+
+        (
+            updated_subscription,
+            _,
+        ) = await subscription_service.create_or_update_from_checkout(
+            session, checkout, payment_method
+        )
+
+        assert updated_subscription.user_metadata == {
+            "utm_source": "youtube",
+            "plan": "paid",
+        }
+
     async def test_trial(
         self,
         enqueue_benefits_grants_mock: MagicMock,


### PR DESCRIPTION
## Summary

[Documentation](https://polar.sh/docs/api-reference/checkouts/create-checkout-session#body-subscription-id-one-of-0) says: "If checkout is successful, metadata set on this checkout will be copied to the subscription, and existing keys will be overwritten." 

this was initially the case and seems to have regressed in https://github.com/polarsource/polar/pull/5247

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix metadata handling on subscription upgrades to match docs. Checkout `user_metadata` is merged into the subscription—missing keys are kept and provided keys overwrite.

- **Bug Fixes**
  - Merge `user_metadata` from checkout into existing subscriptions instead of replacing it.
  - Added tests for new subscriptions, upgrades that preserve absent keys, and upgrades that overwrite provided keys.

<sup>Written for commit 86b467cd0297ad1a99a88e25b2da590b10f01a97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

