### PR TITLE
feat(email): dedup reminders on deduplication_key instead of email_props

### DIFF
--- a/server/polar/email/deduplication.py
+++ b/server/polar/email/deduplication.py
@@ -8,7 +8,10 @@ human-formatted date — so the format can't drift and silently re-send.
 """
 
 from datetime import date
+from typing import Any
 from uuid import UUID
+
+from sqlalchemy import ColumnElement, ColumnExpressionArgument, String, cast, func
 
 from .schemas import EmailTemplate
 
@@ -35,4 +38,50 @@ def subscription_trial_conversion_reminder_key(
     return (
         f"{EmailTemplate.subscription_trial_conversion_reminder}"
         f":{subscription_id}:{trial_end.isoformat()}"
+    )
+
+
+def payment_method_expiration_reminder_key_sql(
+    payment_method_id: ColumnExpressionArgument[Any],
+    exp_year: ColumnExpressionArgument[Any],
+    exp_month: ColumnExpressionArgument[Any],
+) -> ColumnElement[str]:
+    return func.concat(
+        f"{EmailTemplate.payment_method_expiration_reminder}:",
+        cast(payment_method_id, String),
+        ":",
+        cast(exp_year, String),
+        "-",
+        cast(exp_month, String),
+    )
+
+
+def subscription_renewal_reminder_key_sql(
+    subscription_id: ColumnExpressionArgument[Any],
+    period_end: ColumnExpressionArgument[Any],
+) -> ColumnElement[str]:
+    return _subscription_date_key_sql(
+        EmailTemplate.subscription_renewal_reminder, subscription_id, period_end
+    )
+
+
+def subscription_trial_conversion_reminder_key_sql(
+    subscription_id: ColumnExpressionArgument[Any],
+    trial_end: ColumnExpressionArgument[Any],
+) -> ColumnElement[str]:
+    return _subscription_date_key_sql(
+        EmailTemplate.subscription_trial_conversion_reminder, subscription_id, trial_end
+    )
+
+
+def _subscription_date_key_sql(
+    template: EmailTemplate,
+    subscription_id: ColumnExpressionArgument[Any],
+    date_column: ColumnExpressionArgument[Any],
+) -> ColumnElement[str]:
+    return func.concat(
+        f"{template}:",
+        cast(subscription_id, String),
+        ":",
+        func.to_char(func.timezone("UTC", date_column), "YYYY-MM-DD"),
     )

--- a/server/polar/payment_method/repository.py
+++ b/server/polar/payment_method/repository.py
@@ -2,9 +2,10 @@ from collections.abc import Sequence
 from datetime import UTC, datetime
 from uuid import UUID
 
-from sqlalchemy import Select, String, and_, cast, or_, select, update
+from sqlalchemy import Select, and_, or_, select, update
 from sqlalchemy.orm import joinedload
 
+from polar.email.deduplication import payment_method_expiration_reminder_key_sql
 from polar.enums import PaymentProcessor
 from polar.kit.repository import (
     Options,
@@ -146,18 +147,15 @@ class PaymentMethodRepository(
             .exists()
         )
 
-        logged_payment_method = EmailLog.email_props["payment_method"]
         already_sent_subquery = (
             select(EmailLog.id)
             .where(
                 EmailLog.email_template == "payment_method_expiration_reminder",
                 EmailLog.status == EmailLogStatus.sent,
-                logged_payment_method["id"].as_string()
-                == cast(PaymentMethod.id, String),
-                logged_payment_method["method_metadata"]["exp_year"].as_integer()
-                == exp_year,
-                logged_payment_method["method_metadata"]["exp_month"].as_integer()
-                == exp_month,
+                EmailLog.deduplication_key
+                == payment_method_expiration_reminder_key_sql(
+                    PaymentMethod.id, exp_year, exp_month
+                ),
             )
             .correlate(PaymentMethod)
             .exists()

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from uuid import UUID
 
 import sqlalchemy as sa
-from sqlalchemy import ColumnElement, Select, and_, case, cast, func, or_, select
+from sqlalchemy import ColumnElement, Select, and_, case, func, or_, select
 from sqlalchemy.orm import contains_eager
 from sqlalchemy.orm.attributes import set_committed_value
 from sqlalchemy.orm.strategy_options import joinedload, raiseload, selectinload
@@ -25,6 +25,10 @@ from polar.auth.models import (
 )
 from polar.auth.permission import OrganizationPermission
 from polar.authz.repository import select_accessible_org_ids
+from polar.email.deduplication import (
+    subscription_renewal_reminder_key_sql,
+    subscription_trial_conversion_reminder_key_sql,
+)
 from polar.enums import SubscriptionRecurringInterval
 from polar.kit.repository import (
     Options,
@@ -424,11 +428,9 @@ class SubscriptionRepository(
             .where(
                 EmailLog.email_template == "subscription_renewal_reminder",
                 EmailLog.status == EmailLogStatus.sent,
-                EmailLog.email_props["subscription"]["id"].as_string()
-                == cast(Subscription.id, sa.String),
-                EmailLog.email_props["renewal_date"].as_string()
-                == sa.func.to_char(
-                    Subscription.current_period_end, "FMMonth FMDD, YYYY"
+                EmailLog.deduplication_key
+                == subscription_renewal_reminder_key_sql(
+                    Subscription.id, Subscription.current_period_end
                 ),
             )
             .correlate(Subscription)
@@ -474,10 +476,10 @@ class SubscriptionRepository(
             .where(
                 EmailLog.email_template == "subscription_trial_conversion_reminder",
                 EmailLog.status == EmailLogStatus.sent,
-                EmailLog.email_props["subscription"]["id"].as_string()
-                == cast(Subscription.id, sa.String),
-                EmailLog.email_props["conversion_date"].as_string()
-                == sa.func.to_char(Subscription.trial_end, "FMMonth FMDD, YYYY"),
+                EmailLog.deduplication_key
+                == subscription_trial_conversion_reminder_key_sql(
+                    Subscription.id, Subscription.trial_end
+                ),
             )
             .correlate(Subscription)
             .exists()

--- a/server/tests/payment_method/test_repository.py
+++ b/server/tests/payment_method/test_repository.py
@@ -6,6 +6,7 @@ import pytest
 from pytest_mock import MockerFixture
 from sqlalchemy import select
 
+from polar.email.deduplication import payment_method_expiration_reminder_key
 from polar.email.react import serialize_email_props
 from polar.enums import EmailSender
 from polar.kit.utils import utc_now
@@ -123,6 +124,9 @@ async def create_sent_log(
         subject="Your card ending in 4242 expires soon",
         email_template=email_template,
         email_props=props,
+        deduplication_key=payment_method_expiration_reminder_key(
+            payment_method.id, exp_year, exp_month
+        ),
     )
     await save_fixture(email_log)
     return email_log
@@ -313,7 +317,7 @@ class TestDedupRoundTrip:
         product: Product,
         mocker: MockerFixture,
     ) -> None:
-        """The dedup query must read the props the sender actually writes."""
+        """The dedup query must match the key the sender actually writes."""
         payment_method = await create_expiring_card(save_fixture, customer, product)
         enqueue_mock = mocker.patch(
             "polar.payment_method.service.enqueue_email_template", autospec=True
@@ -335,6 +339,7 @@ class TestDedupRoundTrip:
             subject=enqueue_mock.call_args.kwargs["subject"],
             email_template=email.template,
             email_props=email_props,
+            deduplication_key=enqueue_mock.call_args.kwargs["deduplication_key"],
         )
         await save_fixture(email_log)
 

--- a/server/tests/subscription/test_repository.py
+++ b/server/tests/subscription/test_repository.py
@@ -1,20 +1,30 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 from decimal import Decimal
 
 import pytest
 
-from polar.enums import SubscriptionRecurringInterval
+from polar.email.deduplication import (
+    subscription_renewal_reminder_key,
+    subscription_trial_conversion_reminder_key,
+)
+from polar.enums import EmailSender, SubscriptionRecurringInterval
 from polar.kit.utils import utc_now
-from polar.models import Customer, Meter, Organization
+from polar.models import Customer, Meter, Organization, Product
 from polar.models.customer_seat import SeatStatus
+from polar.models.email_log import EmailLog, EmailLogStatus
+from polar.models.subscription import Subscription, SubscriptionStatus
 from polar.postgres import AsyncSession
-from polar.subscription.repository import SubscriptionProductPriceRepository
+from polar.subscription.repository import (
+    SubscriptionProductPriceRepository,
+    SubscriptionRepository,
+)
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_active_subscription,
     create_customer,
     create_customer_seat,
     create_product,
+    create_subscription,
 )
 
 
@@ -198,3 +208,197 @@ class TestSubscriptionProductPriceRepository:
             == seat_subscription.id
         )
         assert result[customer_without_subscription.id] is None
+
+
+async def _create_sent_reminder_log(
+    save_fixture: SaveFixture,
+    *,
+    email_template: str,
+    deduplication_key: str,
+    status: EmailLogStatus = EmailLogStatus.sent,
+) -> EmailLog:
+    email_log = EmailLog(
+        status=status,
+        processor=EmailSender.resend,
+        to_email_addr="customer@example.com",
+        from_email_addr="acme@polar.sh",
+        from_name="Acme",
+        subject="Reminder",
+        email_template=email_template,
+        email_props={},
+        deduplication_key=deduplication_key,
+    )
+    await save_fixture(email_log)
+    return email_log
+
+
+@pytest.mark.asyncio
+class TestGetSubscriptionsNeedingRenewalReminder:
+    async def _yearly_subscription(
+        self,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        customer: Customer,
+        current_period_end: datetime,
+    ) -> Subscription:
+        product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.year,
+        )
+        return await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            current_period_end=current_period_end,
+        )
+
+    async def test_returns_subscription_in_window(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        now = utc_now()
+        subscription = await self._yearly_subscription(
+            save_fixture, organization, customer, now + timedelta(days=3)
+        )
+
+        repository = SubscriptionRepository.from_session(session)
+        result = await repository.get_subscriptions_needing_renewal_reminder(
+            now, now + timedelta(days=7)
+        )
+
+        assert [s.id for s in result] == [subscription.id]
+
+    async def test_excludes_subscription_already_reminded(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        now = utc_now()
+        current_period_end = now + timedelta(days=3)
+        subscription = await self._yearly_subscription(
+            save_fixture, organization, customer, current_period_end
+        )
+        await _create_sent_reminder_log(
+            save_fixture,
+            email_template="subscription_renewal_reminder",
+            deduplication_key=subscription_renewal_reminder_key(
+                subscription.id, current_period_end.date()
+            ),
+        )
+
+        repository = SubscriptionRepository.from_session(session)
+        result = await repository.get_subscriptions_needing_renewal_reminder(
+            now, now + timedelta(days=7)
+        )
+
+        assert result == []
+
+    async def test_returns_subscription_reminded_for_a_previous_period(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        customer: Customer,
+    ) -> None:
+        now = utc_now()
+        current_period_end = now + timedelta(days=3)
+        subscription = await self._yearly_subscription(
+            save_fixture, organization, customer, current_period_end
+        )
+        await _create_sent_reminder_log(
+            save_fixture,
+            email_template="subscription_renewal_reminder",
+            deduplication_key=subscription_renewal_reminder_key(
+                subscription.id, (current_period_end - timedelta(days=365)).date()
+            ),
+        )
+
+        repository = SubscriptionRepository.from_session(session)
+        result = await repository.get_subscriptions_needing_renewal_reminder(
+            now, now + timedelta(days=7)
+        )
+
+        assert [s.id for s in result] == [subscription.id]
+
+
+@pytest.mark.asyncio
+class TestGetSubscriptionsNeedingTrialConversionReminder:
+    async def _trialing_subscription(
+        self,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+        *,
+        trial_start: datetime,
+        trial_end: datetime,
+    ) -> Subscription:
+        return await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.trialing,
+            trial_start=trial_start,
+            trial_end=trial_end,
+            current_period_start=trial_start,
+            current_period_end=trial_end,
+        )
+
+    async def test_returns_subscription_in_window(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        now = utc_now()
+        subscription = await self._trialing_subscription(
+            save_fixture,
+            product,
+            customer,
+            trial_start=now - timedelta(days=10),
+            trial_end=now + timedelta(days=2),
+        )
+
+        repository = SubscriptionRepository.from_session(session)
+        result = await repository.get_subscriptions_needing_trial_conversion_reminder(
+            now
+        )
+
+        assert [s.id for s in result] == [subscription.id]
+
+    async def test_excludes_subscription_already_reminded(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        now = utc_now()
+        trial_end = now + timedelta(days=2)
+        subscription = await self._trialing_subscription(
+            save_fixture,
+            product,
+            customer,
+            trial_start=now - timedelta(days=10),
+            trial_end=trial_end,
+        )
+        await _create_sent_reminder_log(
+            save_fixture,
+            email_template="subscription_trial_conversion_reminder",
+            deduplication_key=subscription_trial_conversion_reminder_key(
+                subscription.id, trial_end.date()
+            ),
+        )
+
+        repository = SubscriptionRepository.from_session(session)
+        result = await repository.get_subscriptions_needing_trial_conversion_reminder(
+            now
+        )
+
+        assert result == []


### PR DESCRIPTION
Follow up to #13456
Waiting for #13633

Backfill has been applied already, in sandbox and production


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch reminder email deduplication to `EmailLog.deduplication_key` and add a partial unique index to prevent duplicates per recipient. Stable SQL-generated keys keep repo queries aligned with the sender and avoid dupes when props change.

- **Refactors**
  - Use `deduplication_key` comparisons in `payment_method` and `subscription` repositories via new SQL helpers.
  - Added `payment_method_expiration_reminder_key_sql`, `subscription_renewal_reminder_key_sql`, and `subscription_trial_conversion_reminder_key_sql`.
  - Updated tests to match sender-written keys and verify suppression for already-reminded periods, including renewal/trial windows and prior-period behavior.

- **Migration**
  - Add partial unique index `ix_email_logs_deduplication_key` on (`deduplication_key`, `to_email_addr`) where the key is not null, allowing multiple nulls but enforcing one reminder per key+recipient.

<sup>Written for commit f1914146c0a572e31e70ee27421d2715d30367b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



