### PR TITLE
tf: Add Render access to AWS Redis via PrivateLink

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -4,3 +4,4 @@
 **/.terraform/
 **/.terraform.lock.hcl
 
+*.zip

--- a/terraform/modules/aws_redis/main.tf
+++ b/terraform/modules/aws_redis/main.tf
@@ -11,14 +11,18 @@ resource "aws_security_group" "this" {
   tags        = var.tags
 }
 
-resource "aws_elasticache_cluster" "this" {
-  cluster_id         = var.name
-  engine             = "redis"
-  engine_version     = var.engine_version
-  node_type          = var.node_type
-  num_cache_nodes    = 1
-  port               = var.port
-  subnet_group_name  = aws_elasticache_subnet_group.this.name
-  security_group_ids = [aws_security_group.this.id]
-  tags               = var.tags
+resource "aws_elasticache_replication_group" "this" {
+  replication_group_id       = var.name
+  description                = "${var.name} Redis"
+  engine                     = "redis"
+  engine_version             = var.engine_version
+  node_type                  = var.node_type
+  num_cache_clusters         = var.num_cache_clusters
+  multi_az_enabled           = var.num_cache_clusters > 1
+  automatic_failover_enabled = var.num_cache_clusters > 1
+  port                       = var.port
+  snapshot_retention_limit   = var.snapshot_retention_days
+  subnet_group_name          = aws_elasticache_subnet_group.this.name
+  security_group_ids         = [aws_security_group.this.id]
+  tags                       = var.tags
 }

--- a/terraform/modules/aws_redis/outputs.tf
+++ b/terraform/modules/aws_redis/outputs.tf
@@ -1,11 +1,11 @@
 output "host" {
-  description = "Primary endpoint host for the Redis node."
-  value       = aws_elasticache_cluster.this.cache_nodes[0].address
+  description = "Primary endpoint host for the Redis replication group."
+  value       = aws_elasticache_replication_group.this.primary_endpoint_address
 }
 
 output "port" {
   description = "Redis port."
-  value       = aws_elasticache_cluster.this.port
+  value       = aws_elasticache_replication_group.this.port
 }
 
 output "security_group_id" {

--- a/terraform/modules/aws_redis/outputs.tf
+++ b/terraform/modules/aws_redis/outputs.tf
@@ -8,6 +8,11 @@ output "port" {
   value       = aws_elasticache_replication_group.this.port
 }
 
+output "arn" {
+  description = "ARN of the replication group."
+  value       = aws_elasticache_replication_group.this.arn
+}
+
 output "security_group_id" {
   description = "Security group attached to the cache."
   value       = aws_security_group.this.id

--- a/terraform/modules/aws_redis/variables.tf
+++ b/terraform/modules/aws_redis/variables.tf
@@ -13,6 +13,18 @@ variable "subnet_ids" {
   type        = list(string)
 }
 
+variable "snapshot_retention_days" {
+  description = "Days to retain automatic daily snapshots. 0 disables backups."
+  type        = number
+  default     = 7
+}
+
+variable "num_cache_clusters" {
+  description = "Number of nodes (primary + replicas). More than one enables multi-AZ with automatic failover."
+  type        = number
+  default     = 1
+}
+
 variable "node_type" {
   description = "ElastiCache node type."
   type        = string

--- a/terraform/modules/redis_private_link/main.tf
+++ b/terraform/modules/redis_private_link/main.tf
@@ -1,0 +1,83 @@
+# Resolved at plan time; a node replacement changes the IP until re-apply.
+data "dns_a_record_set" "redis" {
+  host = var.redis_host
+}
+
+resource "aws_security_group" "nlb" {
+  name        = "${var.name}-nlb"
+  description = "Security group for the ${var.name} private link NLB."
+  vpc_id      = var.vpc_id
+  tags        = var.tags
+}
+
+resource "aws_vpc_security_group_ingress_rule" "clients" {
+  security_group_id = aws_security_group.nlb.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = var.redis_port
+  to_port           = var.redis_port
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "redis" {
+  security_group_id = aws_security_group.nlb.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = var.redis_port
+  to_port           = var.redis_port
+  ip_protocol       = "tcp"
+}
+
+resource "aws_lb" "this" {
+  name                             = var.name
+  internal                         = true
+  load_balancer_type               = "network"
+  subnets                          = var.subnet_ids
+  security_groups                  = [aws_security_group.nlb.id]
+  enable_cross_zone_load_balancing = true
+
+  enforce_security_group_inbound_rules_on_private_link_traffic = "off"
+
+  tags = var.tags
+}
+
+resource "aws_lb_target_group" "redis" {
+  name        = var.name
+  port        = var.redis_port
+  protocol    = "TCP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    protocol = "TCP"
+    port     = "traffic-port"
+  }
+
+  tags = var.tags
+}
+
+resource "aws_lb_target_group_attachment" "redis" {
+  for_each = toset(data.dns_a_record_set.redis.addrs)
+
+  target_group_arn = aws_lb_target_group.redis.arn
+  target_id        = each.value
+  port             = var.redis_port
+}
+
+resource "aws_lb_listener" "redis" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = var.redis_port
+  protocol          = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.redis.arn
+  }
+
+  tags = var.tags
+}
+
+resource "aws_vpc_endpoint_service" "this" {
+  acceptance_required        = true
+  network_load_balancer_arns = [aws_lb.this.arn]
+  allowed_principals         = var.allowed_principals
+  tags                       = merge(var.tags, { Name = var.name })
+}

--- a/terraform/modules/redis_private_link/main.tf
+++ b/terraform/modules/redis_private_link/main.tf
@@ -1,21 +1,8 @@
-# Resolved at plan time; a node replacement changes the IP until re-apply.
-data "dns_a_record_set" "redis" {
-  host = var.redis_host
-}
-
 resource "aws_security_group" "nlb" {
   name        = "${var.name}-nlb"
   description = "Security group for the ${var.name} private link NLB."
   vpc_id      = var.vpc_id
   tags        = var.tags
-}
-
-resource "aws_vpc_security_group_ingress_rule" "clients" {
-  security_group_id = aws_security_group.nlb.id
-  cidr_ipv4         = "0.0.0.0/0"
-  from_port         = var.redis_port
-  to_port           = var.redis_port
-  ip_protocol       = "tcp"
 }
 
 resource "aws_vpc_security_group_egress_rule" "redis" {
@@ -54,14 +41,6 @@ resource "aws_lb_target_group" "redis" {
   tags = var.tags
 }
 
-resource "aws_lb_target_group_attachment" "redis" {
-  for_each = toset(data.dns_a_record_set.redis.addrs)
-
-  target_group_arn = aws_lb_target_group.redis.arn
-  target_id        = each.value
-  port             = var.redis_port
-}
-
 resource "aws_lb_listener" "redis" {
   load_balancer_arn = aws_lb.this.arn
   port              = var.redis_port
@@ -80,4 +59,99 @@ resource "aws_vpc_endpoint_service" "this" {
   network_load_balancer_arns = [aws_lb.this.arn]
   allowed_principals         = var.allowed_principals
   tags                       = merge(var.tags, { Name = var.name })
+}
+
+# Exclusively owns target registration; the Redis primary IP moves on failover.
+data "archive_file" "refresh" {
+  type        = "zip"
+  source_file = "${path.module}/refresh.py"
+  output_path = "${path.module}/refresh.zip"
+}
+
+resource "aws_iam_role" "refresh" {
+  name                 = "${var.name}-target-refresh"
+  permissions_boundary = var.permissions_boundary_arn
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy" "refresh" {
+  name = "${var.name}-target-refresh"
+  role = aws_iam_role.refresh.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["elasticloadbalancing:DescribeTargetHealth"]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "elasticloadbalancing:RegisterTargets",
+          "elasticloadbalancing:DeregisterTargets",
+        ]
+        Resource = aws_lb_target_group.redis.arn
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+        ]
+        Resource = "arn:aws:logs:*:*:*"
+      },
+    ]
+  })
+}
+
+resource "aws_lambda_function" "refresh" {
+  function_name    = "${var.name}-target-refresh"
+  role             = aws_iam_role.refresh.arn
+  runtime          = "python3.13"
+  handler          = "refresh.handler"
+  filename         = data.archive_file.refresh.output_path
+  source_code_hash = data.archive_file.refresh.output_base64sha256
+  timeout          = 30
+
+  environment {
+    variables = {
+      TARGET_GROUP_ARN = aws_lb_target_group.redis.arn
+      REDIS_HOST       = var.redis_host
+      REDIS_PORT       = tostring(var.redis_port)
+    }
+  }
+
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_event_rule" "refresh" {
+  name                = "${var.name}-target-refresh"
+  schedule_expression = "rate(1 minute)"
+  tags                = var.tags
+}
+
+resource "aws_cloudwatch_event_target" "refresh" {
+  rule = aws_cloudwatch_event_rule.refresh.name
+  arn  = aws_lambda_function.refresh.arn
+}
+
+resource "aws_lambda_permission" "refresh" {
+  statement_id  = "AllowEventBridge"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.refresh.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.refresh.arn
 }

--- a/terraform/modules/redis_private_link/main.tf
+++ b/terraform/modules/redis_private_link/main.tf
@@ -34,8 +34,11 @@ resource "aws_lb_target_group" "redis" {
   target_type = "ip"
 
   health_check {
-    protocol = "TCP"
-    port     = "traffic-port"
+    protocol            = "TCP"
+    port                = "traffic-port"
+    interval            = 10
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
   }
 
   tags = var.tags
@@ -118,13 +121,14 @@ resource "aws_iam_role_policy" "refresh" {
 }
 
 resource "aws_lambda_function" "refresh" {
-  function_name    = "${var.name}-target-refresh"
-  role             = aws_iam_role.refresh.arn
-  runtime          = "python3.13"
-  handler          = "refresh.handler"
-  filename         = data.archive_file.refresh.output_path
-  source_code_hash = data.archive_file.refresh.output_base64sha256
-  timeout          = 30
+  function_name                  = "${var.name}-target-refresh"
+  role                           = aws_iam_role.refresh.arn
+  runtime                        = "python3.13"
+  handler                        = "refresh.handler"
+  filename                       = data.archive_file.refresh.output_path
+  source_code_hash               = data.archive_file.refresh.output_base64sha256
+  timeout                        = 30
+  reserved_concurrent_executions = 1
 
   environment {
     variables = {
@@ -154,4 +158,31 @@ resource "aws_lambda_permission" "refresh" {
   function_name = aws_lambda_function.refresh.function_name
   principal     = "events.amazonaws.com"
   source_arn    = aws_cloudwatch_event_rule.refresh.arn
+}
+
+resource "aws_cloudwatch_event_rule" "elasticache_events" {
+  name = "${var.name}-elasticache-events"
+
+  event_pattern = jsonencode({
+    source = ["aws.elasticache"]
+    resources = [
+      { prefix = var.redis_arn },
+      { prefix = replace(var.redis_arn, ":replicationgroup:", ":cluster:") },
+    ]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_event_target" "elasticache_events" {
+  rule = aws_cloudwatch_event_rule.elasticache_events.name
+  arn  = aws_lambda_function.refresh.arn
+}
+
+resource "aws_lambda_permission" "elasticache_events" {
+  statement_id  = "AllowElastiCacheEvents"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.refresh.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.elasticache_events.arn
 }

--- a/terraform/modules/redis_private_link/outputs.tf
+++ b/terraform/modules/redis_private_link/outputs.tf
@@ -1,0 +1,14 @@
+output "service_name" {
+  description = "Endpoint service name to provide to Render when creating the private link."
+  value       = aws_vpc_endpoint_service.this.service_name
+}
+
+output "nlb_security_group_id" {
+  description = "Security group attached to the NLB, for ingress rules on the Redis side."
+  value       = aws_security_group.nlb.id
+}
+
+output "target_ips" {
+  description = "Redis node IPs currently registered on the target group."
+  value       = data.dns_a_record_set.redis.addrs
+}

--- a/terraform/modules/redis_private_link/outputs.tf
+++ b/terraform/modules/redis_private_link/outputs.tf
@@ -7,8 +7,3 @@ output "nlb_security_group_id" {
   description = "Security group attached to the NLB, for ingress rules on the Redis side."
   value       = aws_security_group.nlb.id
 }
-
-output "target_ips" {
-  description = "Redis node IPs currently registered on the target group."
-  value       = data.dns_a_record_set.redis.addrs
-}

--- a/terraform/modules/redis_private_link/refresh.py
+++ b/terraform/modules/redis_private_link/refresh.py
@@ -1,0 +1,40 @@
+import os
+import socket
+
+import boto3
+
+elbv2 = boto3.client("elbv2")
+
+
+def handler(event, context):
+    target_group_arn = os.environ["TARGET_GROUP_ARN"]
+    host = os.environ["REDIS_HOST"]
+    port = int(os.environ["REDIS_PORT"])
+
+    resolved = {
+        info[4][0] for info in socket.getaddrinfo(host, port, socket.AF_INET)
+    }
+    descriptions = elbv2.describe_target_health(TargetGroupArn=target_group_arn)
+    registered = {
+        description["Target"]["Id"]
+        for description in descriptions["TargetHealthDescriptions"]
+    }
+
+    to_register = resolved - registered
+    to_deregister = registered - resolved
+    if to_register:
+        elbv2.register_targets(
+            TargetGroupArn=target_group_arn,
+            Targets=[{"Id": ip, "Port": port} for ip in sorted(to_register)],
+        )
+    if to_deregister:
+        elbv2.deregister_targets(
+            TargetGroupArn=target_group_arn,
+            Targets=[{"Id": ip, "Port": port} for ip in sorted(to_deregister)],
+        )
+
+    return {
+        "resolved": sorted(resolved),
+        "registered": sorted(to_register),
+        "deregistered": sorted(to_deregister),
+    }

--- a/terraform/modules/redis_private_link/refresh.py
+++ b/terraform/modules/redis_private_link/refresh.py
@@ -1,9 +1,22 @@
 import os
 import socket
+import time
 
 import boto3
 
 elbv2 = boto3.client("elbv2")
+
+
+def resolve(host, port):
+    for attempt in range(3):
+        try:
+            return {
+                info[4][0] for info in socket.getaddrinfo(host, port, socket.AF_INET)
+            }
+        except OSError:
+            if attempt == 2:
+                raise
+            time.sleep(2)
 
 
 def handler(event, context):
@@ -11,9 +24,7 @@ def handler(event, context):
     host = os.environ["REDIS_HOST"]
     port = int(os.environ["REDIS_PORT"])
 
-    resolved = {
-        info[4][0] for info in socket.getaddrinfo(host, port, socket.AF_INET)
-    }
+    resolved = resolve(host, port)
     descriptions = elbv2.describe_target_health(TargetGroupArn=target_group_arn)
     registered = {
         description["Target"]["Id"]

--- a/terraform/modules/redis_private_link/terraform.tf
+++ b/terraform/modules/redis_private_link/terraform.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    dns = {
+      source  = "hashicorp/dns"
+      version = ">= 3.0"
+    }
+  }
+}

--- a/terraform/modules/redis_private_link/terraform.tf
+++ b/terraform/modules/redis_private_link/terraform.tf
@@ -2,13 +2,13 @@ terraform {
   required_version = ">= 1.2"
 
   required_providers {
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">= 2.0"
+    }
     aws = {
       source  = "hashicorp/aws"
       version = ">= 5.0"
-    }
-    dns = {
-      source  = "hashicorp/dns"
-      version = ">= 3.0"
     }
   }
 }

--- a/terraform/modules/redis_private_link/variables.tf
+++ b/terraform/modules/redis_private_link/variables.tf
@@ -24,6 +24,11 @@ variable "redis_port" {
   default     = 6379
 }
 
+variable "permissions_boundary_arn" {
+  description = "Permissions boundary applied to the target-refresh Lambda role."
+  type        = string
+}
+
 variable "allowed_principals" {
   description = "AWS principal ARNs allowed to connect to the endpoint service (Render's, from the private link dialog)."
   type        = list(string)

--- a/terraform/modules/redis_private_link/variables.tf
+++ b/terraform/modules/redis_private_link/variables.tf
@@ -1,0 +1,37 @@
+variable "name" {
+  description = "Name used for the NLB, target group, and endpoint service."
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC the NLB and its security group live in."
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Private subnets for the NLB."
+  type        = list(string)
+}
+
+variable "redis_host" {
+  description = "ElastiCache endpoint hostname to expose through the endpoint service."
+  type        = string
+}
+
+variable "redis_port" {
+  description = "Redis port."
+  type        = number
+  default     = 6379
+}
+
+variable "allowed_principals" {
+  description = "AWS principal ARNs allowed to connect to the endpoint service (Render's, from the private link dialog)."
+  type        = list(string)
+  default     = []
+}
+
+variable "tags" {
+  description = "Tags applied to all created resources."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/redis_private_link/variables.tf
+++ b/terraform/modules/redis_private_link/variables.tf
@@ -18,6 +18,11 @@ variable "redis_host" {
   type        = string
 }
 
+variable "redis_arn" {
+  description = "Replication group ARN, used to scope the ElastiCache event trigger."
+  type        = string
+}
+
 variable "redis_port" {
   description = "Redis port."
   type        = number

--- a/terraform/production/aws.tf
+++ b/terraform/production/aws.tf
@@ -20,9 +20,11 @@ module "lambda_worker_ecr" {
 module "redis" {
   source = "../modules/aws_redis"
 
-  name       = "polar-production-worker"
-  vpc_id     = module.vpc.vpc_id
-  subnet_ids = module.vpc.private_subnet_ids
+  name               = "polar-production-worker"
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = module.vpc.private_subnet_ids
+  node_type          = "cache.t4g.small"
+  num_cache_clusters = 2
 }
 
 resource "aws_vpc_security_group_ingress_rule" "redis_lambda" {

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -20,9 +20,11 @@ module "lambda_worker_ecr" {
 module "redis" {
   source = "../modules/aws_redis"
 
-  name       = "polar-sandbox-worker"
-  vpc_id     = module.vpc.vpc_id
-  subnet_ids = module.vpc.private_subnet_ids
+  name               = "polar-sandbox-worker"
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = module.vpc.private_subnet_ids
+  node_type          = "cache.t4g.small"
+  num_cache_clusters = 2
 }
 
 resource "aws_vpc_security_group_ingress_rule" "redis_lambda" {

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -43,6 +43,7 @@ module "redis_private_link" {
   subnet_ids               = module.vpc.private_subnet_ids
   redis_host               = module.redis.host
   redis_port               = module.redis.port
+  redis_arn                = module.redis.arn
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
 }
 

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -36,11 +36,12 @@ resource "aws_vpc_security_group_ingress_rule" "redis_lambda" {
 module "redis_private_link" {
   source = "../modules/redis_private_link"
 
-  name       = "polar-sandbox-worker-redis"
-  vpc_id     = module.vpc.vpc_id
-  subnet_ids = module.vpc.private_subnet_ids
-  redis_host = module.redis.host
-  redis_port = module.redis.port
+  name                     = "polar-sandbox-worker-redis"
+  vpc_id                   = module.vpc.vpc_id
+  subnet_ids               = module.vpc.private_subnet_ids
+  redis_host               = module.redis.host
+  redis_port               = module.redis.port
+  permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
 }
 
 resource "aws_vpc_security_group_ingress_rule" "redis_nlb" {

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -33,6 +33,24 @@ resource "aws_vpc_security_group_ingress_rule" "redis_lambda" {
   ip_protocol                  = "tcp"
 }
 
+module "redis_private_link" {
+  source = "../modules/redis_private_link"
+
+  name       = "polar-sandbox-worker-redis"
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnet_ids
+  redis_host = module.redis.host
+  redis_port = module.redis.port
+}
+
+resource "aws_vpc_security_group_ingress_rule" "redis_nlb" {
+  security_group_id            = module.redis.security_group_id
+  referenced_security_group_id = module.redis_private_link.nlb_security_group_id
+  from_port                    = module.redis.port
+  to_port                      = module.redis.port
+  ip_protocol                  = "tcp"
+}
+
 locals {
   files_bucket_name        = "polar-sandbox-files"
   files_public_bucket_name = "polar-public-sandbox-files"

--- a/terraform/sandbox/outputs.tf
+++ b/terraform/sandbox/outputs.tf
@@ -22,3 +22,8 @@ output "redis_sandbox_id" {
   description = "The sandbox Redis ID. Used for the render_redis data source."
   value       = render_redis.redis_sandbox.id
 }
+
+output "redis_endpoint_service_name" {
+  description = "VPC endpoint service name for the worker Redis. Provide to Render when creating the private link."
+  value       = module.redis_private_link.service_name
+}


### PR DESCRIPTION
This sets up a PrivateLink between Render and AWS and an NLB for Redis. This should give us access to the Redis instance running in AWS in Render, which can unify our Redis usage.

This in turn will allow us to write debounce keys for the lambda workers, and run the customer state change tasks in lambda.

This also adds a small lambda that runs on a schedule (1/minute) to update the DNS of the NLB that points to ElastiCache. This is part of the best practices recommended by [AWS](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/elasticache-vpc-accessing.html#elasticache-vpc-accessing-using-transit-gateway).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

