### PR TITLE
fix(checkout): store contact details before confirmation

### DIFF
--- a/clients/packages/checkout/src/components/CheckoutForm.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.test.tsx
@@ -1,6 +1,6 @@
 import type { schemas } from '@polar-sh/client'
 import type { ThemingPresetProps } from '@polar-sh/ui/hooks/theming'
-import { act, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { useEffect } from 'react'
 import type { UseFormReturn } from 'react-hook-form'
 import { useForm } from 'react-hook-form'
@@ -615,6 +615,63 @@ describe('CheckoutForm', () => {
       expect(lastElementsOptions()).toMatchObject({
         customerSessionClientSecret: 'cs_secret_abc',
       })
+    })
+  })
+
+  describe('contact capture', () => {
+    const renderForm = () => {
+      const update = vi.fn(async () => createCheckout())
+      render(
+        <FormWrapper
+          checkout={createCheckout()}
+          {...defaultProps}
+          update={update}
+          themePreset={{ stripe: {} } as ThemingPresetProps}
+          locale="en"
+        />,
+      )
+      return update
+    }
+
+    const fill = (label: string, value: string) => {
+      const input = screen.getByLabelText(label)
+      fireEvent.change(input, { target: { value } })
+      fireEvent.blur(input)
+    }
+
+    it('stores the email once the buyer leaves the field', () => {
+      const update = renderForm()
+
+      fill('Email', 'buyer@example.com')
+
+      expect(update).toHaveBeenCalledWith({
+        customer_email: 'buyer@example.com',
+      })
+    })
+
+    it('stores the cardholder name once the buyer leaves the field', () => {
+      const update = renderForm()
+
+      fill('Cardholder name', 'Buyer Example')
+
+      expect(update).toHaveBeenCalledWith({ customer_name: 'Buyer Example' })
+    })
+
+    it('waits for an address the browser reads as one', () => {
+      const update = renderForm()
+
+      fill('Email', 'buyer@')
+
+      expect(update).not.toHaveBeenCalled()
+    })
+
+    it('stores an unchanged value once', () => {
+      const update = renderForm()
+
+      fill('Email', 'buyer@example.com')
+      fireEvent.blur(screen.getByLabelText('Email'))
+
+      expect(update).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/clients/packages/checkout/src/components/CheckoutForm.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.test.tsx
@@ -619,18 +619,31 @@ describe('CheckoutForm', () => {
   })
 
   describe('contact capture', () => {
-    const renderForm = (checkout: ProductCheckoutPublic = createCheckout()) => {
-      const update = vi.fn(async () => createCheckout())
+    const rejectingUpdate = () =>
+      vi.fn(async () => {
+        throw new Error('rejected')
+      })
+
+    const renderForm = (
+      checkout: ProductCheckoutPublic = createCheckout(),
+      update: () => Promise<schemas['CheckoutPublic']> = vi.fn(async () =>
+        createCheckout(),
+      ),
+    ) => {
+      let form!: UseFormReturn<schemas['CheckoutUpdatePublic']>
       render(
         <FormWrapper
           checkout={checkout}
           {...defaultProps}
           update={update}
+          onForm={(f) => {
+            form = f
+          }}
           themePreset={{ stripe: {} } as ThemingPresetProps}
           locale="en"
         />,
       )
-      return update
+      return { update, form }
     }
 
     const fill = (label: string, value: string) => {
@@ -640,7 +653,7 @@ describe('CheckoutForm', () => {
     }
 
     it('stores the email once the buyer leaves the field', () => {
-      const update = renderForm()
+      const { update } = renderForm()
 
       fill('Email', 'buyer@example.com')
 
@@ -650,7 +663,7 @@ describe('CheckoutForm', () => {
     })
 
     it('stores the cardholder name once the buyer leaves the field', () => {
-      const update = renderForm()
+      const { update } = renderForm()
 
       fill('Cardholder name', 'Buyer Example')
 
@@ -658,7 +671,7 @@ describe('CheckoutForm', () => {
     })
 
     it('waits for an address the browser reads as one', () => {
-      const update = renderForm()
+      const { update } = renderForm()
 
       fill('Email', 'buyer@')
 
@@ -666,13 +679,38 @@ describe('CheckoutForm', () => {
     })
 
     it('skips a value the checkout already holds', () => {
-      const update = renderForm(
+      const { update } = renderForm(
         createCheckout({ customer_email: 'buyer@example.com' }),
       )
 
       fill('Email', 'buyer@example.com')
 
       expect(update).not.toHaveBeenCalled()
+    })
+
+    it('clears the error left by a rejected write', async () => {
+      const { form } = renderForm(createCheckout(), rejectingUpdate())
+      act(() => form.setError('customer_email', { message: 'Server said no' }))
+      expect(screen.getByText('Server said no')).toBeInTheDocument()
+
+      await act(async () => {
+        fill('Email', 'buyer@example.com')
+      })
+
+      expect(screen.queryByText('Server said no')).not.toBeInTheDocument()
+    })
+
+    it('stores the value again after a rejected write', async () => {
+      const { update } = renderForm(createCheckout(), rejectingUpdate())
+
+      await act(async () => {
+        fill('Email', 'buyer@example.com')
+      })
+      await act(async () => {
+        fireEvent.blur(screen.getByLabelText('Email'))
+      })
+
+      expect(update).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/clients/packages/checkout/src/components/CheckoutForm.test.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.test.tsx
@@ -619,11 +619,11 @@ describe('CheckoutForm', () => {
   })
 
   describe('contact capture', () => {
-    const renderForm = () => {
+    const renderForm = (checkout: ProductCheckoutPublic = createCheckout()) => {
       const update = vi.fn(async () => createCheckout())
       render(
         <FormWrapper
-          checkout={createCheckout()}
+          checkout={checkout}
           {...defaultProps}
           update={update}
           themePreset={{ stripe: {} } as ThemingPresetProps}
@@ -665,13 +665,14 @@ describe('CheckoutForm', () => {
       expect(update).not.toHaveBeenCalled()
     })
 
-    it('stores an unchanged value once', () => {
-      const update = renderForm()
+    it('skips a value the checkout already holds', () => {
+      const update = renderForm(
+        createCheckout({ customer_email: 'buyer@example.com' }),
+      )
 
       fill('Email', 'buyer@example.com')
-      fireEvent.blur(screen.getByLabelText('Email'))
 
-      expect(update).toHaveBeenCalledTimes(1)
+      expect(update).not.toHaveBeenCalled()
     })
   })
 })

--- a/clients/packages/checkout/src/components/CheckoutForm.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.tsx
@@ -33,7 +33,7 @@ import {
   StripeElementsOptions,
   StripePaymentElementChangeEvent,
 } from '@stripe/stripe-js'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { UseFormReturn, WatchObserver } from 'react-hook-form'
 import { hasProductCheckout, isLegacyRecurringProductPrice } from '../guards'
 import { useDebouncedCallback } from '../hooks/debounce'
@@ -45,6 +45,8 @@ import PolarLogo from './PolarLogo'
 import { CheckoutBanner } from './CheckoutBanner'
 
 const WALLET_PAYMENT_METHODS = ['apple_pay', 'google_pay', 'link']
+
+type ContactField = 'customer_email' | 'customer_name'
 
 const XIcon = ({ className }: { className?: string }) => {
   return (
@@ -185,6 +187,19 @@ const BaseCheckoutForm = ({
   )
   const debouncedWatcher = useDebouncedCallback(watcher, 500, [watcher])
 
+  const capturedContact = useRef<Partial<Record<ContactField, string>>>({})
+  const captureContact = useCallback(
+    (name: ContactField, value: string) => {
+      const contact = value.trim()
+      if (!contact || capturedContact.current[name] === contact) {
+        return
+      }
+      capturedContact.current[name] = contact
+      update({ [name]: contact }).catch(() => clearErrors(name))
+    },
+    [update, clearErrors],
+  )
+
   const discountCode = watch('discount_code')
 
   useEffect(() => {
@@ -308,6 +323,12 @@ const BaseCheckoutForm = ({
                         autoComplete="email"
                         {...field}
                         value={field.value || ''}
+                        onBlur={(e) => {
+                          field.onBlur()
+                          if (e.target.validity.valid) {
+                            captureContact('customer_email', e.target.value)
+                          }
+                        }}
                         disabled={checkout.customer_id !== null}
                       />
                     </FormControl>
@@ -334,6 +355,10 @@ const BaseCheckoutForm = ({
                           autoComplete="name"
                           {...field}
                           value={field.value || ''}
+                          onBlur={(e) => {
+                            field.onBlur()
+                            captureContact('customer_name', e.target.value)
+                          }}
                         />
                       </FormControl>
                       <FormMessage />

--- a/clients/packages/checkout/src/components/CheckoutForm.tsx
+++ b/clients/packages/checkout/src/components/CheckoutForm.tsx
@@ -33,7 +33,7 @@ import {
   StripeElementsOptions,
   StripePaymentElementChangeEvent,
 } from '@stripe/stripe-js'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { UseFormReturn, WatchObserver } from 'react-hook-form'
 import { hasProductCheckout, isLegacyRecurringProductPrice } from '../guards'
 import { useDebouncedCallback } from '../hooks/debounce'
@@ -187,17 +187,15 @@ const BaseCheckoutForm = ({
   )
   const debouncedWatcher = useDebouncedCallback(watcher, 500, [watcher])
 
-  const capturedContact = useRef<Partial<Record<ContactField, string>>>({})
   const captureContact = useCallback(
     (name: ContactField, value: string) => {
       const contact = value.trim()
-      if (!contact || capturedContact.current[name] === contact) {
+      if (!contact || checkout[name] === contact) {
         return
       }
-      capturedContact.current[name] = contact
       update({ [name]: contact }).catch(() => clearErrors(name))
     },
-    [update, clearErrors],
+    [checkout, update, clearErrors],
   )
 
   const discountCode = watch('discount_code')


### PR DESCRIPTION
## Summary

The form only sent customer_email and customer_name at confirmation, so an abandoned checkout expired without them and checkout.expired carried no address. They are now stored as the buyer leaves each field.

A rejected write clears the error it raised: the buyer is still filling the form, and confirmation is what validates it.

Closes polarsource/feedback#236

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

