### PR TITLE
fix(events): render subscription event cards from event metadata

### DIFF
--- a/clients/apps/web/src/components/Events/EventCard/SubscriptionEventCard.tsx
+++ b/clients/apps/web/src/components/Events/EventCard/SubscriptionEventCard.tsx
@@ -1,11 +1,12 @@
-import ProductPriceLabel from '@/components/Products/ProductPriceLabel'
-import { useSubscription } from '@/hooks/queries'
+import AmountLabel from '@/components/Shared/AmountLabel'
+import { useProduct } from '@/hooks/queries'
 import { OrganizationContext } from '@/providers/maintainerOrganization'
 import AllInclusiveOutlined from '@mui/icons-material/AllInclusiveOutlined'
+import ArrowForwardOutlined from '@mui/icons-material/ArrowForwardOutlined'
 import { schemas } from '@polar-sh/client'
 import { Status, type StatusColor } from '@polar-sh/orbit'
 import Link from 'next/link'
-import { useContext, useMemo } from 'react'
+import { useContext } from 'react'
 import { EventCardBase } from './EventCardBase'
 
 export interface SubscriptionEventCardProps {
@@ -15,50 +16,112 @@ export interface SubscriptionEventCardProps {
     | schemas['SubscriptionProductUpdatedEvent']
 }
 
+const subscriptionHref = (organizationSlug: string, subscriptionId: string) =>
+  `/dashboard/${organizationSlug}/subscriptions?subscriptionId=${subscriptionId}`
+
+const SubscriptionBillingEventCard = ({
+  event,
+  status,
+}: {
+  event:
+    | schemas['SubscriptionCycledEvent']
+    | schemas['SubscriptionRevokedEvent']
+  status: [string, StatusColor]
+}) => {
+  const { organization } = useContext(OrganizationContext)
+  const { data: product, isLoading } = useProduct(event.metadata.product_id)
+
+  const { amount, currency, recurring_interval, recurring_interval_count } =
+    event.metadata
+
+  return (
+    <EventCardBase loading={isLoading}>
+      <Link
+        href={subscriptionHref(
+          organization.slug,
+          event.metadata.subscription_id,
+        )}
+        className="flex grow flex-row items-center justify-between gap-x-12"
+      >
+        <div className="flex flex-row items-center gap-x-4 p-2">
+          <div className="flex flex-row items-center gap-x-4">
+            <AllInclusiveOutlined fontSize="inherit" />
+            {product ? <span>{product.name}</span> : null}
+          </div>
+          {typeof amount === 'number' && currency ? (
+            <span className="dark:text-polar-500 text-gray-500">
+              <AmountLabel
+                amount={amount}
+                currency={currency}
+                interval={
+                  recurring_interval as schemas['RecurringInterval'] | undefined
+                }
+                intervalCount={recurring_interval_count}
+              />
+            </span>
+          ) : null}
+        </div>
+        <Status status={status[0]} color={status[1]} size="small" />
+      </Link>
+    </EventCardBase>
+  )
+}
+
+const SubscriptionProductUpdatedEventCard = ({
+  event,
+}: {
+  event: schemas['SubscriptionProductUpdatedEvent']
+}) => {
+  const { organization } = useContext(OrganizationContext)
+  const { data: oldProduct, isLoading: isLoadingOldProduct } = useProduct(
+    event.metadata.old_product_id,
+  )
+  const { data: newProduct, isLoading: isLoadingNewProduct } = useProduct(
+    event.metadata.new_product_id,
+  )
+
+  return (
+    <EventCardBase loading={isLoadingOldProduct || isLoadingNewProduct}>
+      <Link
+        href={subscriptionHref(
+          organization.slug,
+          event.metadata.subscription_id,
+        )}
+        className="flex grow flex-row items-center justify-between gap-x-12"
+      >
+        <div className="flex flex-row items-center gap-x-4 p-2">
+          <AllInclusiveOutlined fontSize="inherit" />
+          <div className="flex flex-row items-center gap-x-2">
+            <span>{oldProduct?.name ?? '—'}</span>
+            <ArrowForwardOutlined fontSize="inherit" />
+            <span>{newProduct?.name ?? '—'}</span>
+          </div>
+        </div>
+        <Status status="Product Updated" color="blue" size="small" />
+      </Link>
+    </EventCardBase>
+  )
+}
+
 export const SubscriptionEventCard = ({
   event,
 }: SubscriptionEventCardProps) => {
-  const { organization } = useContext(OrganizationContext)
-  const { data: subscription, isLoading: isLoadingSubscription } =
-    useSubscription(event.metadata.subscription_id)
-
-  const status = useMemo((): [string, StatusColor] | null => {
-    switch (event.name) {
-      case 'subscription.cycled':
-        return ['Cycled', 'green']
-      case 'subscription.revoked':
-        return ['Revoked', 'red']
-      case 'subscription.product_updated':
-        return ['Product Updated', 'blue']
-      default:
-        return null
-    }
-  }, [event.name])
-
-  return (
-    <EventCardBase loading={isLoadingSubscription}>
-      {subscription ? (
-        <Link
-          href={`/dashboard/${organization.slug}/subscriptions?subscriptionId=${subscription.id}`}
-          className="flex grow flex-row items-center justify-between gap-x-12"
-        >
-          <div className="flex flex-row items-center gap-x-4 p-2">
-            <div className="flex flex-row items-center gap-x-4">
-              <AllInclusiveOutlined fontSize="inherit" />
-              <span className="">{subscription.product.name}</span>
-            </div>
-            <span className="dark:text-polar-500 text-gray-500">
-              <ProductPriceLabel
-                product={subscription.product}
-                currency={subscription.currency}
-              />
-            </span>
-          </div>
-          {status ? (
-            <Status status={status[0]} color={status[1]} size="small" />
-          ) : null}
-        </Link>
-      ) : null}
-    </EventCardBase>
-  )
+  switch (event.name) {
+    case 'subscription.cycled':
+      return (
+        <SubscriptionBillingEventCard
+          event={event}
+          status={['Cycled', 'green']}
+        />
+      )
+    case 'subscription.revoked':
+      return (
+        <SubscriptionBillingEventCard
+          event={event}
+          status={['Revoked', 'red']}
+        />
+      )
+    case 'subscription.product_updated':
+      return <SubscriptionProductUpdatedEventCard event={event} />
+  }
 }


### PR DESCRIPTION
## Summary

`SubscriptionEventCard` rendered the **live** subscription's product name and current price, which doesn't reflect what each event was actually about. This sources the card's content from `event.metadata` instead — the data recorded at the time of the event.

## What

- Split `SubscriptionEventCard` into two sub-cards dispatched on `event.name`, dropping the `useSubscription` fetch.
- **`subscription.cycled` / `subscription.revoked`**: show the event's own product (`metadata.product_id`) and the `amount` / `currency` / `recurring_interval` / `recurring_interval_count` **as recorded on the event** (via `AmountLabel`), instead of the subscription's current price.
- **`subscription.product_updated`**: show the **old → new** product transition (`old_product_id` → `new_product_id`) instead of the current product.
- The subscription-detail link is preserved via `metadata.subscription_id` (always present).

## Why

For an event log, the current subscription state is the wrong source of truth — it describes the subscription *as it is now*, not the event. This was especially misleading for `subscription.product_updated`: the event exists because the product *changed*, yet the card showed only the current product, hiding the transition entirely. `cycled` / `revoked` similarly showed a re-derived current price rather than the amount actually billed/revoked.

## How

Each event type already carries the relevant snapshot in its metadata, so the card reads from there. Optional metadata fields (`product_id`, `amount`, `currency`, …) are rendered only when present, so a `cycled`/`revoked` event without a product id renders immediately (the disabled `useProduct(undefined)` query never enters a loading state) rather than showing a perpetual "Loading…".

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests — this is a presentational fix to an existing component; the `EventCard` family has no unit tests, and none were added.
- [x] Linting and type checking pass — frontend change: `pnpm typecheck` (tsc --noEmit), `eslint --max-warnings 0`, and `oxfmt --check` all pass.
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015X8ZNhNTaS1LYQtheCwEik

---
_Generated by [Claude Code](https://claude.ai/code/session_015X8ZNhNTaS1LYQtheCwEik)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

