### PR TITLE
fix(dashboard): hide empty email line for team customers in grant/order/subscription tables

### DIFF
--- a/clients/apps/web/src/components/Benefit/BenefitPage.tsx
+++ b/clients/apps/web/src/components/Benefit/BenefitPage.tsx
@@ -130,10 +130,8 @@ export const BenefitPage = ({ benefit, organization }: BenefitPageProps) => {
               />
               <Box minWidth={0} flexDirection="column">
                 <Text truncate>{grant.customer.name ?? '—'}</Text>
-                {!(
-                  grant.customer.type === 'team' &&
-                  grant.customer.email == null
-                ) && (
+                {(grant.customer.email ||
+                  grant.customer.type === 'individual') && (
                   <Text variant="caption" color="muted" truncate>
                     {grant.customer.email ?? '—'}
                   </Text>

--- a/clients/apps/web/src/components/Benefit/BenefitPage.tsx
+++ b/clients/apps/web/src/components/Benefit/BenefitPage.tsx
@@ -130,9 +130,14 @@ export const BenefitPage = ({ benefit, organization }: BenefitPageProps) => {
               />
               <Box minWidth={0} flexDirection="column">
                 <Text truncate>{grant.customer.name ?? '—'}</Text>
-                <Text variant="caption" color="muted" truncate>
-                  {grant.customer.email ?? '—'}
-                </Text>
+                {!(
+                  grant.customer.type === 'team' &&
+                  grant.customer.email == null
+                ) && (
+                  <Text variant="caption" color="muted" truncate>
+                    {grant.customer.email ?? '—'}
+                  </Text>
+                )}
               </Box>
             </Box>
           </Link>

--- a/clients/apps/web/src/components/Meter/MeterCustomersTab.tsx
+++ b/clients/apps/web/src/components/Meter/MeterCustomersTab.tsx
@@ -73,9 +73,11 @@ const MeterCustomersTab = ({
               />
               <div className="flex flex-col">
                 <span className="text-xs">{customer.name ?? '—'}</span>
-                <span className="dark:text-polar-500 text-xxs text-gray-500">
-                  {customer.email ?? '—'}
-                </span>
+                {(customer.email || customer.type === 'individual') && (
+                  <span className="dark:text-polar-500 text-xxs text-gray-500">
+                    {customer.email ?? '—'}
+                  </span>
+                )}
               </div>
             </Link>
           ),

--- a/clients/apps/web/src/components/Products/ProductPage/ProductOrders.tsx
+++ b/clients/apps/web/src/components/Products/ProductPage/ProductOrders.tsx
@@ -60,9 +60,11 @@ export const ProductOrders = ({
                   />
                   <div className="flex flex-col overflow-hidden">
                     <span className="truncate">{customer.name ?? '—'}</span>
-                    <span className="dark:text-polar-500 truncate text-xs text-gray-500">
-                      {customer.email ?? '—'}
-                    </span>
+                    {(customer.email || customer.type === 'individual') && (
+                      <span className="dark:text-polar-500 truncate text-xs text-gray-500">
+                        {customer.email ?? '—'}
+                      </span>
+                    )}
                   </div>
                 </div>
               )

--- a/clients/apps/web/src/components/Products/ProductPage/ProductSubscriptions.tsx
+++ b/clients/apps/web/src/components/Products/ProductPage/ProductSubscriptions.tsx
@@ -58,9 +58,11 @@ export const ProductSubscriptions = ({
                   />
                   <div className="flex flex-col overflow-hidden">
                     <span className="truncate">{customer.name ?? '—'}</span>
-                    <span className="dark:text-polar-500 truncate text-xs text-gray-500">
-                      {customer.email ?? '—'}
-                    </span>
+                    {(customer.email || customer.type === 'individual') && (
+                      <span className="dark:text-polar-500 truncate text-xs text-gray-500">
+                        {customer.email ?? '—'}
+                      </span>
+                    )}
                   </div>
                 </div>
               )


### PR DESCRIPTION
## Summary

Team customers can have no email. In the two-line customer displays (name over email), a team customer without an email rendered a dangling `—` on the second line. This hides that second line entirely for team customers with no email, while keeping the existing `—` fallback for individual customers.

## What

Guards the secondary email line in the customer cell of four dashboard tables so it's omitted when the customer is a `team` with no email:

- `components/Benefit/BenefitPage.tsx` — benefit grants table (`products/benefits/:id`)
- `components/Products/ProductPage/ProductSubscriptions.tsx` — product → Subscriptions tab
- `components/Products/ProductPage/ProductOrders.tsx` — product → Orders tab
- `components/Meter/MeterCustomersTab.tsx` — meter → Customers tab

## Why

For a `team` customer, an email is optional, so the muted second line just showed `—` under the name — visual noise with no meaning. Individual customers keep the `—` fallback (they always have an email conceptually, and an empty cell there would be more confusing than a placeholder).

## How

Wraps the email line in the same guard already used in `CustomerListSidebar.tsx`:

```tsx
{(customer.email || customer.type === 'individual') && (
  <span …>{customer.email ?? '—'}</span>
)}
```

The benefit grants table (authored with Orbit `<Box>`/`<Text>`) uses the equivalent inverse condition `!(customer.type === 'team' && customer.email == null)`. The other three are legacy Tailwind files and were left in their existing style to keep the diff minimal.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [x] Linting and type checking pass (verified `eslint` + `tsc` on the changed files)
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BfP59bzPkbBaWNnNtT6kah)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

