### PR TITLE
fix(license-key): drive the benefit grant when key status changes

### DIFF
--- a/server/polar/license_key/service.py
+++ b/server/polar/license_key/service.py
@@ -183,13 +183,7 @@ class LicenseKeyService:
         if already_applied:
             return
 
-        enqueue_job(
-            "benefit.revoke" if revoke else "benefit.grant",
-            customer_id=grant.customer_id,
-            benefit_id=grant.benefit_id,
-            member_id=grant.member_id,
-            **grant.scope,
-        )
+        enqueue_job("license_key.sync_benefit_grant", license_key_id=license_key.id)
 
     async def validate(
         self,

--- a/server/polar/license_key/service.py
+++ b/server/polar/license_key/service.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import joinedload
 from polar.auth.models import AuthSubject, Customer, Member
 from polar.auth.permission import OrganizationPermission
 from polar.authz.service import get_accessible_org_ids
+from polar.benefit.grant.repository import BenefitGrantRepository
 from polar.benefit.strategies.license_keys.properties import (
     BenefitLicenseKeysProperties,
 )
@@ -24,6 +25,7 @@ from polar.models import (
 )
 from polar.models.license_key import LicenseKeyStatus
 from polar.postgres import AsyncReadSession, AsyncSession
+from polar.worker import enqueue_job
 
 from .repository import LicenseKeyRepository
 from .schemas import (
@@ -148,12 +150,46 @@ class LicenseKeyService:
         updates: LicenseKeyUpdate,
     ) -> LicenseKey:
         update_dict = updates.model_dump(exclude_unset=True)
+
+        status = update_dict.get("status")
+        if status is not None and status != license_key.status:
+            await self._enqueue_grant_lifecycle(session, license_key, status)
+
         for key, value in update_dict.items():
             setattr(license_key, key, value)
 
         session.add(license_key)
         await session.flush()
         return license_key
+
+    async def _enqueue_grant_lifecycle(
+        self,
+        session: AsyncSession,
+        license_key: LicenseKey,
+        status: LicenseKeyStatus,
+    ) -> None:
+        grant_repository = BenefitGrantRepository.from_session(session)
+        grant = await grant_repository.get_by_property_and_organization(
+            license_key.organization_id,
+            "license_key_id",
+            str(license_key.id),
+            benefit_id=license_key.benefit_id,
+        )
+        if grant is None:
+            return
+
+        revoke = status == LicenseKeyStatus.revoked
+        already_applied = grant.is_revoked if revoke else grant.is_granted
+        if already_applied:
+            return
+
+        enqueue_job(
+            "benefit.revoke" if revoke else "benefit.grant",
+            customer_id=grant.customer_id,
+            benefit_id=grant.benefit_id,
+            member_id=grant.member_id,
+            **grant.scope,
+        )
 
     async def validate(
         self,

--- a/server/polar/license_key/tasks.py
+++ b/server/polar/license_key/tasks.py
@@ -53,18 +53,25 @@ async def sync_benefit_grant(license_key_id: uuid.UUID) -> None:
 
         benefit_repository = BenefitRepository.from_session(session)
         benefit = await benefit_repository.get_by_id(
-            grant.benefit_id, options=benefit_repository.get_eager_options()
+            grant.benefit_id,
+            options=benefit_repository.get_eager_options(),
+            include_deleted=True,
         )
         assert benefit is not None
 
         customer_repository = CustomerRepository.from_session(session)
-        customer = await customer_repository.get_by_id(grant.customer_id)
+        customer = await customer_repository.get_by_id(
+            grant.customer_id, include_deleted=True
+        )
         assert customer is not None
 
         member = None
         if grant.member_id is not None:
             member_repository = MemberRepository.from_session(session)
-            member = await member_repository.get_by_id(grant.member_id)
+            member = await member_repository.get_by_id(
+                grant.member_id, include_deleted=True
+            )
+            assert member is not None
 
         scope = await resolve_scope(session, grant.scope)
         apply = (

--- a/server/polar/license_key/tasks.py
+++ b/server/polar/license_key/tasks.py
@@ -55,15 +55,14 @@ async def sync_benefit_grant(license_key_id: uuid.UUID) -> None:
         benefit = await benefit_repository.get_by_id(
             grant.benefit_id,
             options=benefit_repository.get_eager_options(),
-            include_deleted=True,
+            include_deleted=revoke,
         )
-        assert benefit is not None
-
         customer_repository = CustomerRepository.from_session(session)
         customer = await customer_repository.get_by_id(
-            grant.customer_id, include_deleted=True
+            grant.customer_id, include_deleted=revoke
         )
-        assert customer is not None
+        if benefit is None or customer is None:
+            return
 
         member = None
         if grant.member_id is not None:

--- a/server/polar/license_key/tasks.py
+++ b/server/polar/license_key/tasks.py
@@ -1,0 +1,82 @@
+import uuid
+
+import structlog
+
+from polar.benefit.grant.repository import BenefitGrantRepository
+from polar.benefit.grant.scope import resolve_scope
+from polar.benefit.grant.service import benefit_grant as benefit_grant_service
+from polar.benefit.repository import BenefitRepository
+from polar.customer.repository import CustomerRepository
+from polar.exceptions import PolarTaskError
+from polar.logging import Logger
+from polar.member.repository import MemberRepository
+from polar.models.license_key import LicenseKeyStatus
+from polar.worker import AsyncSessionMaker, RedisMiddleware, TaskPriority, actor
+
+from .repository import LicenseKeyRepository
+
+log: Logger = structlog.get_logger()
+
+
+class LicenseKeyTaskError(PolarTaskError): ...
+
+
+class LicenseKeyDoesNotExist(LicenseKeyTaskError):
+    def __init__(self, license_key_id: uuid.UUID) -> None:
+        self.license_key_id = license_key_id
+        message = f"The license key with id {license_key_id} does not exist."
+        super().__init__(message)
+
+
+@actor(actor_name="license_key.sync_benefit_grant", priority=TaskPriority.MEDIUM)
+async def sync_benefit_grant(license_key_id: uuid.UUID) -> None:
+    async with AsyncSessionMaker() as session:
+        license_key_repository = LicenseKeyRepository.from_session(session)
+        license_key = await license_key_repository.get_by_id(license_key_id)
+        if license_key is None:
+            raise LicenseKeyDoesNotExist(license_key_id)
+
+        grant_repository = BenefitGrantRepository.from_session(session)
+        grant = await grant_repository.get_by_property_and_organization(
+            license_key.organization_id,
+            "license_key_id",
+            str(license_key.id),
+            benefit_id=license_key.benefit_id,
+        )
+        if grant is None:
+            return
+
+        revoke = license_key.status == LicenseKeyStatus.revoked
+        already_applied = grant.is_revoked if revoke else grant.is_granted
+        if already_applied:
+            return
+
+        benefit_repository = BenefitRepository.from_session(session)
+        benefit = await benefit_repository.get_by_id(
+            grant.benefit_id, options=benefit_repository.get_eager_options()
+        )
+        assert benefit is not None
+
+        customer_repository = CustomerRepository.from_session(session)
+        customer = await customer_repository.get_by_id(grant.customer_id)
+        assert customer is not None
+
+        member = None
+        if grant.member_id is not None:
+            member_repository = MemberRepository.from_session(session)
+            member = await member_repository.get_by_id(grant.member_id)
+
+        scope = await resolve_scope(session, grant.scope)
+        apply = (
+            benefit_grant_service.revoke_benefit
+            if revoke
+            else benefit_grant_service.grant_benefit
+        )
+        await apply(
+            session,
+            RedisMiddleware.get(),
+            customer,
+            benefit,
+            member=member,
+            **scope,
+        )

--- a/server/polar/tasks.py
+++ b/server/polar/tasks.py
@@ -19,6 +19,7 @@ from polar.integrations.chargeback_stop import tasks as chargeback_stop
 from polar.integrations.polar import tasks as polar_self
 from polar.integrations.stripe import tasks as stripe
 from polar.integrations.tinybird import tasks as tinybird
+from polar.license_key import tasks as license_key
 from polar.meter import tasks as meter
 from polar.notifications import tasks as notifications
 from polar.oauth2 import tasks as oauth2
@@ -61,6 +62,7 @@ __all__ = [
     "feedback",
     "file",
     "invariants",
+    "license_key",
     "meter",
     "notifications",
     "oauth2",

--- a/server/scripts/backfill_license_key_grant_state.py
+++ b/server/scripts/backfill_license_key_grant_state.py
@@ -1,0 +1,160 @@
+"""
+Realign benefit grants with the status of their license key.
+
+Changing a license key's status from the dashboard used to write only the key,
+leaving the parent grant on its previous state: a live key hidden from the
+customer portal, or a revoked key still advertised as an active benefit.
+
+The invariant is that a grant is revoked exactly when its key is revoked, so
+`granted` and `disabled` keys both keep the entitlement. Only grants that
+positively assert the opposite state are touched — grants still pending or
+holding a grant error are left alone.
+
+Timestamps are set to now: this records when the two sides were reconciled, not
+when the merchant changed the key.
+
+No webhook or event is emitted. Some of these rows diverged over a year ago and
+replaying them as fresh grant activity would misinform every subscriber.
+
+Usage:
+    cd server
+
+    # Dry-run (default) — show how many grants are out of line:
+    uv run python -m scripts.backfill_license_key_grant_state
+
+    # Execute the backfill (batched):
+    uv run python -m scripts.backfill_license_key_grant_state --execute
+"""
+
+import structlog
+import typer
+from rich.console import Console
+from sqlalchemy import (
+    ColumnElement,
+    Select,
+    Text,
+    Update,
+    and_,
+    cast,
+    func,
+    select,
+    update,
+)
+
+from polar.kit.db.postgres import create_async_sessionmaker
+from polar.models import BenefitGrant, LicenseKey
+from polar.models.license_key import LicenseKeyStatus
+from polar.postgres import create_async_engine
+from scripts.helper import (
+    configure_script_console_logging,
+    limit_bindparam,
+    run_batched_update,
+    typer_async,
+)
+
+cli = typer.Typer()
+console = Console()
+log = structlog.get_logger()
+
+configure_script_console_logging()
+
+
+def _diverged(revoke: bool) -> ColumnElement[bool]:
+    key_status = (
+        LicenseKey.status == LicenseKeyStatus.revoked
+        if revoke
+        else LicenseKey.status != LicenseKeyStatus.revoked
+    )
+    stale_state = (
+        BenefitGrant.granted_at.is_not(None)
+        if revoke
+        else BenefitGrant.revoked_at.is_not(None)
+    )
+    return and_(
+        BenefitGrant.deleted_at.is_(None),
+        stale_state,
+        BenefitGrant.properties.has_key("license_key_id"),
+        select(1)
+        .where(
+            cast(LicenseKey.id, Text)
+            == BenefitGrant.properties["license_key_id"].as_string(),
+            LicenseKey.deleted_at.is_(None),
+            key_status,
+        )
+        .exists(),
+    )
+
+
+def diverged_count_statement(*, revoke: bool) -> Select[tuple[int]]:
+    return select(func.count()).select_from(BenefitGrant).where(_diverged(revoke))
+
+
+def realign_statement(*, revoke: bool) -> Update:
+    subquery = (
+        select(BenefitGrant.id)
+        .where(_diverged(revoke))
+        .order_by(BenefitGrant.id)
+        .limit(limit_bindparam())
+        .scalar_subquery()
+    )
+    values = (
+        {"granted_at": None, "revoked_at": func.now()}
+        if revoke
+        else {"granted_at": func.now(), "revoked_at": None}
+    )
+    return update(BenefitGrant).where(BenefitGrant.id.in_(subquery)).values(**values)
+
+
+@cli.command()
+@typer_async
+async def backfill(
+    execute: bool = typer.Option(
+        False, help="Actually run the backfill (default: dry-run)"
+    ),
+    batch_size: int = typer.Option(
+        5000, min=1, help="Number of rows to process per batch"
+    ),
+    sleep_seconds: float = typer.Option(0.1, help="Seconds to sleep between batches"),
+) -> None:
+    engine = create_async_engine("script")
+    sessionmaker = create_async_sessionmaker(engine)
+
+    try:
+        totals = {}
+        async with sessionmaker() as session:
+            for revoke in (True, False):
+                result = await session.execute(diverged_count_statement(revoke=revoke))
+                totals[revoke] = result.scalar_one()
+
+        console.print(
+            f"[bold]{totals[True]}[/bold] grant(s) to revoke, "
+            f"[bold]{totals[False]}[/bold] grant(s) to grant."
+        )
+
+        if totals[True] == 0 and totals[False] == 0:
+            console.print("[green]Every grant already matches its license key.")
+            return
+
+        if not execute:
+            console.print("[yellow]Dry-run — use --execute to realign them.")
+            return
+
+        console.rule("[bold]Executing backfill")
+        for revoke in (True, False):
+            rows_updated = await run_batched_update(
+                realign_statement(revoke=revoke),
+                batch_size=batch_size,
+                sleep_seconds=sleep_seconds,
+            )
+            log.info("backfill.complete", revoke=revoke, rowcount=rows_updated)
+            console.print(
+                f"[green]{'Revoked' if revoke else 'Granted'} "
+                f"{rows_updated} benefit grant(s)."
+            )
+
+    finally:
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/tests/fixtures/license_key.py
+++ b/server/tests/fixtures/license_key.py
@@ -63,13 +63,17 @@ class TestLicenseKey:
             customer=customer,
             status=SubscriptionStatus.active,
         )
-        await create_benefit_grant(
+        grant = await create_benefit_grant(
             save_fixture,
             customer,
             benefit,
             subscription=subscription,
         )
-        return await cls.run_grant_task(session, redis, benefit, customer)
+        benefit, granted = await cls.run_grant_task(session, redis, benefit, customer)
+        grant.properties = granted
+        grant.set_granted()
+        await save_fixture(grant)
+        return benefit, granted
 
     @classmethod
     async def run_grant_task(

--- a/server/tests/license_key/test_service.py
+++ b/server/tests/license_key/test_service.py
@@ -2,8 +2,13 @@ import asyncio
 from uuid import UUID
 
 import pytest
+from pytest_mock import MockerFixture
 from sqlalchemy import delete, func, select
 
+from polar.benefit.grant.repository import BenefitGrantRepository
+from polar.benefit.strategies.license_keys.schemas import (
+    BenefitLicenseKeysCreateProperties,
+)
 from polar.config import settings
 from polar.exceptions import NotPermitted
 from polar.kit.db.postgres import (
@@ -12,11 +17,23 @@ from polar.kit.db.postgres import (
     create_async_sessionmaker,
 )
 from polar.license_key.repository import LicenseKeyRepository
-from polar.license_key.schemas import LicenseKeyActivate
+from polar.license_key.schemas import LicenseKeyActivate, LicenseKeyUpdate
 from polar.license_key.service import license_key as license_key_service
-from polar.models import Account, LicenseKey, LicenseKeyActivation, Organization, User
+from polar.models import (
+    Account,
+    BenefitGrant,
+    Customer,
+    LicenseKey,
+    LicenseKeyActivation,
+    Organization,
+    Product,
+    User,
+)
 from polar.models.license_key import LicenseKeyStatus
-from tests.fixtures.database import get_database_url, save_fixture_factory
+from polar.postgres import AsyncSession
+from polar.redis import Redis
+from tests.fixtures.database import SaveFixture, get_database_url, save_fixture_factory
+from tests.fixtures.license_key import TestLicenseKey
 from tests.fixtures.random_objects import (
     create_account,
     create_benefit,
@@ -111,3 +128,155 @@ class TestConcurrentActivation:
                 await cleanup_session.execute(delete(User).where(User.id == user.id))
                 await cleanup_session.commit()
             await engine.dispose()
+
+
+async def _license_key_and_grant(
+    session: AsyncSession,
+    redis: Redis,
+    save_fixture: SaveFixture,
+    customer: Customer,
+    organization: Organization,
+    product: Product,
+) -> tuple[LicenseKey, BenefitGrant]:
+    benefit, granted = await TestLicenseKey.create_benefit_and_grant(
+        session,
+        redis,
+        save_fixture,
+        customer=customer,
+        organization=organization,
+        product=product,
+        properties=BenefitLicenseKeysCreateProperties(prefix="testing"),
+    )
+    license_key_repository = LicenseKeyRepository.from_session(session)
+    license_key = await license_key_repository.get_by_id(
+        UUID(granted["license_key_id"])
+    )
+    assert license_key is not None
+
+    grant_repository = BenefitGrantRepository.from_session(session)
+    grant = await grant_repository.get_by_property_and_organization(
+        organization.id,
+        "license_key_id",
+        str(license_key.id),
+        benefit_id=benefit.id,
+    )
+    assert grant is not None
+    return license_key, grant
+
+
+@pytest.mark.asyncio
+class TestUpdate:
+    @pytest.mark.parametrize(
+        "status", [LicenseKeyStatus.granted, LicenseKeyStatus.disabled]
+    )
+    async def test_non_revoked_status_enqueues_grant(
+        self,
+        status: LicenseKeyStatus,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.license_key.service.enqueue_job")
+        license_key, grant = await _license_key_and_grant(
+            session, redis, save_fixture, customer, organization, product
+        )
+        license_key.status = LicenseKeyStatus.revoked
+        grant.set_revoked()
+        await save_fixture(grant)
+
+        await license_key_service.update(
+            session,
+            license_key=license_key,
+            updates=LicenseKeyUpdate(status=status),
+        )
+
+        assert license_key.status == status
+        enqueue_job_mock.assert_called_once_with(
+            "benefit.grant",
+            customer_id=grant.customer_id,
+            benefit_id=grant.benefit_id,
+            member_id=grant.member_id,
+            subscription_id=grant.subscription_id,
+        )
+
+    async def test_revoked_status_enqueues_revoke(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.license_key.service.enqueue_job")
+        license_key, grant = await _license_key_and_grant(
+            session, redis, save_fixture, customer, organization, product
+        )
+
+        await license_key_service.update(
+            session,
+            license_key=license_key,
+            updates=LicenseKeyUpdate(status=LicenseKeyStatus.revoked),
+        )
+
+        assert license_key.status == LicenseKeyStatus.revoked
+        enqueue_job_mock.assert_called_once_with(
+            "benefit.revoke",
+            customer_id=grant.customer_id,
+            benefit_id=grant.benefit_id,
+            member_id=grant.member_id,
+            subscription_id=grant.subscription_id,
+        )
+
+    async def test_status_already_matching_grant_does_not_enqueue(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.license_key.service.enqueue_job")
+        license_key, _ = await _license_key_and_grant(
+            session, redis, save_fixture, customer, organization, product
+        )
+
+        await license_key_service.update(
+            session,
+            license_key=license_key,
+            updates=LicenseKeyUpdate(status=LicenseKeyStatus.disabled),
+        )
+
+        assert license_key.status == LicenseKeyStatus.disabled
+        enqueue_job_mock.assert_not_called()
+
+    async def test_update_without_status_does_not_enqueue(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        enqueue_job_mock = mocker.patch("polar.license_key.service.enqueue_job")
+        license_key, _ = await _license_key_and_grant(
+            session, redis, save_fixture, customer, organization, product
+        )
+
+        await license_key_service.update(
+            session,
+            license_key=license_key,
+            updates=LicenseKeyUpdate(limit_activations=5),
+        )
+
+        assert license_key.limit_activations == 5
+        enqueue_job_mock.assert_not_called()

--- a/server/tests/license_key/test_service.py
+++ b/server/tests/license_key/test_service.py
@@ -169,7 +169,7 @@ class TestUpdate:
     @pytest.mark.parametrize(
         "status", [LicenseKeyStatus.granted, LicenseKeyStatus.disabled]
     )
-    async def test_non_revoked_status_enqueues_grant(
+    async def test_non_revoked_status_enqueues_sync(
         self,
         status: LicenseKeyStatus,
         mocker: MockerFixture,
@@ -196,14 +196,10 @@ class TestUpdate:
 
         assert license_key.status == status
         enqueue_job_mock.assert_called_once_with(
-            "benefit.grant",
-            customer_id=grant.customer_id,
-            benefit_id=grant.benefit_id,
-            member_id=grant.member_id,
-            subscription_id=grant.subscription_id,
+            "license_key.sync_benefit_grant", license_key_id=license_key.id
         )
 
-    async def test_revoked_status_enqueues_revoke(
+    async def test_revoked_status_enqueues_sync(
         self,
         mocker: MockerFixture,
         session: AsyncSession,
@@ -214,7 +210,7 @@ class TestUpdate:
         customer: Customer,
     ) -> None:
         enqueue_job_mock = mocker.patch("polar.license_key.service.enqueue_job")
-        license_key, grant = await _license_key_and_grant(
+        license_key, _ = await _license_key_and_grant(
             session, redis, save_fixture, customer, organization, product
         )
 
@@ -226,11 +222,7 @@ class TestUpdate:
 
         assert license_key.status == LicenseKeyStatus.revoked
         enqueue_job_mock.assert_called_once_with(
-            "benefit.revoke",
-            customer_id=grant.customer_id,
-            benefit_id=grant.benefit_id,
-            member_id=grant.member_id,
-            subscription_id=grant.subscription_id,
+            "license_key.sync_benefit_grant", license_key_id=license_key.id
         )
 
     async def test_status_already_matching_grant_does_not_enqueue(

--- a/server/tests/license_key/test_tasks.py
+++ b/server/tests/license_key/test_tasks.py
@@ -213,3 +213,55 @@ class TestSyncBenefitGrant:
 
         revoke_benefit_mock.assert_called_once()
         assert revoke_benefit_mock.call_args.kwargs["member"].id == member.id
+
+    async def test_deleted_customer_is_not_re_granted(
+        self,
+        grant_benefit_mock: AsyncMock,
+        revoke_benefit_mock: AsyncMock,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        license_key, grant = await _license_key_and_grant(
+            session, redis, save_fixture, customer, organization, product
+        )
+        grant.set_revoked()
+        await save_fixture(grant)
+        customer.set_deleted_at()
+        await save_fixture(customer)
+
+        session.expunge_all()
+
+        await sync_benefit_grant(license_key.id)
+
+        grant_benefit_mock.assert_not_called()
+        revoke_benefit_mock.assert_not_called()
+
+    async def test_deleted_customer_is_still_revoked(
+        self,
+        grant_benefit_mock: AsyncMock,
+        revoke_benefit_mock: AsyncMock,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        license_key, _ = await _license_key_and_grant(
+            session, redis, save_fixture, customer, organization, product
+        )
+        license_key.status = LicenseKeyStatus.revoked
+        await save_fixture(license_key)
+        customer.set_deleted_at()
+        await save_fixture(customer)
+
+        session.expunge_all()
+
+        await sync_benefit_grant(license_key.id)
+
+        revoke_benefit_mock.assert_called_once()
+        grant_benefit_mock.assert_not_called()

--- a/server/tests/license_key/test_tasks.py
+++ b/server/tests/license_key/test_tasks.py
@@ -22,6 +22,7 @@ from polar.postgres import AsyncSession
 from polar.redis import Redis
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.license_key import TestLicenseKey
+from tests.fixtures.random_objects import create_member
 
 
 async def _license_key_and_grant(
@@ -134,7 +135,7 @@ class TestSyncBenefitGrant:
         grant_benefit_mock.assert_called_once()
         revoke_benefit_mock.assert_not_called()
 
-    async def test_does_not_resurrect_a_key_revoked_after_enqueue(
+    async def test_revoked_key_with_revoked_grant_is_left_alone(
         self,
         grant_benefit_mock: AsyncMock,
         revoke_benefit_mock: AsyncMock,
@@ -181,3 +182,34 @@ class TestSyncBenefitGrant:
 
         grant_benefit_mock.assert_not_called()
         revoke_benefit_mock.assert_not_called()
+
+    async def test_soft_deleted_member_still_targets_the_same_grant(
+        self,
+        grant_benefit_mock: AsyncMock,
+        revoke_benefit_mock: AsyncMock,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        license_key, grant = await _license_key_and_grant(
+            session, redis, save_fixture, customer, organization, product
+        )
+        member = await create_member(
+            save_fixture, customer=customer, organization=organization
+        )
+        grant.member_id = member.id
+        await save_fixture(grant)
+        license_key.status = LicenseKeyStatus.revoked
+        await save_fixture(license_key)
+        member.set_deleted_at()
+        await save_fixture(member)
+
+        session.expunge_all()
+
+        await sync_benefit_grant(license_key.id)
+
+        revoke_benefit_mock.assert_called_once()
+        assert revoke_benefit_mock.call_args.kwargs["member"].id == member.id

--- a/server/tests/license_key/test_tasks.py
+++ b/server/tests/license_key/test_tasks.py
@@ -1,0 +1,183 @@
+import uuid
+from unittest.mock import AsyncMock
+from uuid import UUID
+
+import pytest
+from pytest_mock import MockerFixture
+
+from polar.benefit.grant.repository import BenefitGrantRepository
+from polar.benefit.grant.service import BenefitGrantService
+from polar.benefit.grant.service import benefit_grant as benefit_grant_service
+from polar.benefit.strategies.license_keys.schemas import (
+    BenefitLicenseKeysCreateProperties,
+)
+from polar.license_key.repository import LicenseKeyRepository
+from polar.license_key.tasks import (
+    LicenseKeyDoesNotExist,
+    sync_benefit_grant,
+)
+from polar.models import BenefitGrant, Customer, LicenseKey, Organization, Product
+from polar.models.license_key import LicenseKeyStatus
+from polar.postgres import AsyncSession
+from polar.redis import Redis
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.license_key import TestLicenseKey
+
+
+async def _license_key_and_grant(
+    session: AsyncSession,
+    redis: Redis,
+    save_fixture: SaveFixture,
+    customer: Customer,
+    organization: Organization,
+    product: Product,
+) -> tuple[LicenseKey, BenefitGrant]:
+    benefit, granted = await TestLicenseKey.create_benefit_and_grant(
+        session,
+        redis,
+        save_fixture,
+        customer=customer,
+        organization=organization,
+        product=product,
+        properties=BenefitLicenseKeysCreateProperties(prefix="testing"),
+    )
+    license_key_repository = LicenseKeyRepository.from_session(session)
+    license_key = await license_key_repository.get_by_id(
+        UUID(granted["license_key_id"])
+    )
+    assert license_key is not None
+
+    grant_repository = BenefitGrantRepository.from_session(session)
+    grant = await grant_repository.get_by_property_and_organization(
+        organization.id,
+        "license_key_id",
+        str(license_key.id),
+        benefit_id=benefit.id,
+    )
+    assert grant is not None
+    return license_key, grant
+
+
+@pytest.fixture
+def grant_benefit_mock(mocker: MockerFixture) -> AsyncMock:
+    return mocker.patch.object(
+        benefit_grant_service, "grant_benefit", spec=BenefitGrantService.grant_benefit
+    )
+
+
+@pytest.fixture
+def revoke_benefit_mock(mocker: MockerFixture) -> AsyncMock:
+    return mocker.patch.object(
+        benefit_grant_service, "revoke_benefit", spec=BenefitGrantService.revoke_benefit
+    )
+
+
+@pytest.mark.asyncio
+class TestSyncBenefitGrant:
+    async def test_not_existing_license_key(self, session: AsyncSession) -> None:
+        session.expunge_all()
+
+        with pytest.raises(LicenseKeyDoesNotExist):
+            await sync_benefit_grant(uuid.uuid4())
+
+    async def test_revoked_key_revokes_the_grant(
+        self,
+        grant_benefit_mock: AsyncMock,
+        revoke_benefit_mock: AsyncMock,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        license_key, _ = await _license_key_and_grant(
+            session, redis, save_fixture, customer, organization, product
+        )
+        license_key.status = LicenseKeyStatus.revoked
+        await save_fixture(license_key)
+
+        session.expunge_all()
+
+        await sync_benefit_grant(license_key.id)
+
+        revoke_benefit_mock.assert_called_once()
+        grant_benefit_mock.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "status", [LicenseKeyStatus.granted, LicenseKeyStatus.disabled]
+    )
+    async def test_non_revoked_key_grants_the_grant(
+        self,
+        status: LicenseKeyStatus,
+        grant_benefit_mock: AsyncMock,
+        revoke_benefit_mock: AsyncMock,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        license_key, grant = await _license_key_and_grant(
+            session, redis, save_fixture, customer, organization, product
+        )
+        license_key.status = status
+        await save_fixture(license_key)
+        grant.set_revoked()
+        await save_fixture(grant)
+
+        session.expunge_all()
+
+        await sync_benefit_grant(license_key.id)
+
+        grant_benefit_mock.assert_called_once()
+        revoke_benefit_mock.assert_not_called()
+
+    async def test_does_not_resurrect_a_key_revoked_after_enqueue(
+        self,
+        grant_benefit_mock: AsyncMock,
+        revoke_benefit_mock: AsyncMock,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        license_key, grant = await _license_key_and_grant(
+            session, redis, save_fixture, customer, organization, product
+        )
+        grant.set_revoked()
+        await save_fixture(grant)
+        license_key.status = LicenseKeyStatus.revoked
+        await save_fixture(license_key)
+
+        session.expunge_all()
+
+        await sync_benefit_grant(license_key.id)
+
+        grant_benefit_mock.assert_not_called()
+        revoke_benefit_mock.assert_not_called()
+
+    async def test_grant_already_matching_the_key_is_left_alone(
+        self,
+        grant_benefit_mock: AsyncMock,
+        revoke_benefit_mock: AsyncMock,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        license_key, _ = await _license_key_and_grant(
+            session, redis, save_fixture, customer, organization, product
+        )
+
+        session.expunge_all()
+
+        await sync_benefit_grant(license_key.id)
+
+        grant_benefit_mock.assert_not_called()
+        revoke_benefit_mock.assert_not_called()

--- a/server/tests/scripts/test_backfill_license_key_grant_state.py
+++ b/server/tests/scripts/test_backfill_license_key_grant_state.py
@@ -1,0 +1,194 @@
+from uuid import UUID
+
+import pytest
+
+from polar.benefit.grant.repository import BenefitGrantRepository
+from polar.benefit.strategies.license_keys.schemas import (
+    BenefitLicenseKeysCreateProperties,
+)
+from polar.kit.db.postgres import AsyncSession
+from polar.license_key.repository import LicenseKeyRepository
+from polar.models import BenefitGrant, Customer, LicenseKey, Organization, Product
+from polar.models.license_key import LicenseKeyStatus
+from polar.redis import Redis
+from scripts.backfill_license_key_grant_state import (
+    diverged_count_statement,
+    realign_statement,
+)
+from scripts.helper import run_batched_update
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.license_key import TestLicenseKey
+
+
+async def _license_key_and_grant(
+    session: AsyncSession,
+    redis: Redis,
+    save_fixture: SaveFixture,
+    customer: Customer,
+    organization: Organization,
+    product: Product,
+) -> tuple[LicenseKey, BenefitGrant]:
+    benefit, granted = await TestLicenseKey.create_benefit_and_grant(
+        session,
+        redis,
+        save_fixture,
+        customer=customer,
+        organization=organization,
+        product=product,
+        properties=BenefitLicenseKeysCreateProperties(prefix="testing"),
+    )
+    license_key_repository = LicenseKeyRepository.from_session(session)
+    license_key = await license_key_repository.get_by_id(
+        UUID(granted["license_key_id"])
+    )
+    assert license_key is not None
+
+    grant_repository = BenefitGrantRepository.from_session(session)
+    grant = await grant_repository.get_by_property_and_organization(
+        organization.id,
+        "license_key_id",
+        str(license_key.id),
+        benefit_id=benefit.id,
+    )
+    assert grant is not None
+    return license_key, grant
+
+
+async def _realign(session: AsyncSession, *, revoke: bool) -> int:
+    return await run_batched_update(
+        realign_statement(revoke=revoke),
+        batch_size=5000,
+        sleep_seconds=0,
+        session=session,
+    )
+
+
+async def _count(session: AsyncSession, *, revoke: bool) -> int:
+    result = await session.execute(diverged_count_statement(revoke=revoke))
+    return result.scalar_one()
+
+
+@pytest.mark.asyncio
+class TestBackfillLicenseKeyGrantState:
+    async def test_revoked_key_revokes_the_grant(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        license_key, grant = await _license_key_and_grant(
+            session, redis, save_fixture, customer, organization, product
+        )
+        license_key.status = LicenseKeyStatus.revoked
+        await save_fixture(license_key)
+
+        assert await _count(session, revoke=True) == 1
+        assert await _realign(session, revoke=True) == 1
+
+        await session.refresh(grant)
+        assert grant.is_revoked is True
+        assert grant.is_granted is False
+
+    @pytest.mark.parametrize(
+        "status", [LicenseKeyStatus.granted, LicenseKeyStatus.disabled]
+    )
+    async def test_non_revoked_key_grants_the_grant(
+        self,
+        status: LicenseKeyStatus,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        license_key, grant = await _license_key_and_grant(
+            session, redis, save_fixture, customer, organization, product
+        )
+        license_key.status = status
+        await save_fixture(license_key)
+        grant.set_revoked()
+        await save_fixture(grant)
+
+        assert await _count(session, revoke=False) == 1
+        assert await _realign(session, revoke=False) == 1
+
+        await session.refresh(grant)
+        assert grant.is_granted is True
+        assert grant.is_revoked is False
+
+    @pytest.mark.parametrize(
+        "status", [LicenseKeyStatus.granted, LicenseKeyStatus.disabled]
+    )
+    async def test_aligned_grant_is_left_alone(
+        self,
+        status: LicenseKeyStatus,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        license_key, grant = await _license_key_and_grant(
+            session, redis, save_fixture, customer, organization, product
+        )
+        license_key.status = status
+        await save_fixture(license_key)
+        granted_at = grant.granted_at
+
+        assert await _count(session, revoke=True) == 0
+        assert await _count(session, revoke=False) == 0
+        assert await _realign(session, revoke=True) == 0
+        assert await _realign(session, revoke=False) == 0
+
+        await session.refresh(grant)
+        assert grant.granted_at == granted_at
+
+    async def test_pending_grant_is_left_alone(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        license_key, grant = await _license_key_and_grant(
+            session, redis, save_fixture, customer, organization, product
+        )
+        license_key.status = LicenseKeyStatus.revoked
+        await save_fixture(license_key)
+        grant.granted_at = None
+        grant.revoked_at = None
+        await save_fixture(grant)
+
+        assert await _count(session, revoke=True) == 0
+        assert await _realign(session, revoke=True) == 0
+
+        await session.refresh(grant)
+        assert grant.granted_at is None
+        assert grant.revoked_at is None
+
+    async def test_soft_deleted_grant_is_left_alone(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        license_key, grant = await _license_key_and_grant(
+            session, redis, save_fixture, customer, organization, product
+        )
+        license_key.status = LicenseKeyStatus.revoked
+        await save_fixture(license_key)
+        grant.set_deleted_at()
+        await save_fixture(grant)
+
+        assert await _count(session, revoke=True) == 0
+        assert await _realign(session, revoke=True) == 0


### PR DESCRIPTION
Superseeds https://github.com/polarsource/polar/pull/12659


## Problem

Changing a license key's status from the dashboard wrote only the key. The parent benefit grant kept its old state.

Two symptoms:

- Key re-enabled, grant still revoked — the key validates, but the customer portal hides it.
- Key revoked, grant still granted — the portal advertises a benefit that fails validation.

Just over 400 grants in production disagree with their key, across more than 120 organizations. The oldest dates to December 2024 and new ones are still accruing.

## Fix

A status change now enqueues `benefit.grant` or `benefit.revoke`, so the grant follows the key through the normal lifecycle.

A grant is revoked exactly when its key is revoked. `granted` and `disabled` both keep the entitlement — the portal already renders a disabled key.

## Backfill

`scripts.backfill_license_key_grant_state` realigns the existing rows: 307 to revoke, 96 to grant. Dry-run by default.

It writes the timestamps directly and emits no webhooks. Some of these rows diverged over a year ago; replaying them as fresh grant activity would misinform every subscriber.



## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

