### PR TITLE
docs(merchant-migration): correct how imported subscriptions are held

### DIFF
--- a/handbook/engineering/design-documents/merchant-migrations.mdx
+++ b/handbook/engineering/design-documents/merchant-migrations.mdx
@@ -70,13 +70,17 @@ In this phase, some actions are done by the merchant, their billing provider, St
 
 Once we have the catalog and payment methods, we should be able to start moving subscriptions. Cutover only becomes available once the PAN checklist prep steps are complete; triggering it runs the final steps below.
 
-Subscriptions keep their real status (`active`/`trialing`) but are held from billing with a `migration_billing_paused` flag, so the renewal scheduler skips them. The org must be in a renewal-enabled status (REVIEW or ACTIVE). Before activating each subscription we run some checks to prevent double charging the customer:
+Imported subscriptions are created `paused` (we considered a separate `migration_billing_paused` flag alongside the real status, but reusing `paused` means the renewal scheduler already skips them for free). The org must be in a renewal-enabled status (REVIEW or ACTIVE). Weeks can pass between the import and the cutover, so every check reads the source again rather than trusting what was staged. Per subscription:
 
-1. Check the subscription is still active on the current billing provider.
-2. Confirm the renewal date is far enough out (24h safety window), so we don't clash with the old billing provider renewal.
-3. Confirm the card is valid on Polar (with a SetupIntent).
+1. Re-read it on the source. It must still be `active`/`trialing`, on the same price, single line item, no coupon, still charged automatically, and not already set to cancel at period end.
+2. Confirm the renewal date is far enough out (24h safety window), so we don't clash with the old billing provider renewal. The period we activate with is the one the source reports now, not the one captured at import.
+3. Confirm the card is valid on Polar (a zero-amount `SetupIntent`, cards only — a bank debit needs a mandate the copy doesn't carry, so we accept it as-is).
 4. Cancel the subscription on the old billing provider.
-5. Clear the `migration_billing_paused` flag (the status stays as-is).
+5. Activate on Polar, keeping the source's period so the first Polar charge lands on the renewal the customer already expects.
+
+Only step 4 is irreversible, and every check is read-only, so a subscription that fails one is left billing on the source and paused on Polar, with a reason on its ledger row. A trial carries over as `trialing` until its end date.
+
+**Retries.** One subscription per job, each in its own transaction. The cancellation is stamped with a marker (Stripe: `cancellation_details.comment`) so a run that dies between cancelling on the source and committing finishes the move on retry instead of reading its own cancellation as the customer having churned. `MerchantMigrationRecord.cutover_status` (`moved`/`skipped`/`failed`, null = not reached) is the ledger; retrying re-opens everything that isn't `moved`.
 
 Polar will bill the next billing cycle. If for some reason the payment fails on the next billing cycle, the subscription will enter the normal dunning state where we send an email to the customer.
 


### PR DESCRIPTION
## Summary

**Related Issue**: n/a

> 📚 Stack 2/7 · base is #13620. Reviewable now; merge after its base.

The merchant-migrations design doc describes a mechanism that was never built. Corrects it, and writes down what the cutover actually does, so the PRs stacked above this one can be reviewed against an accurate spec.

## What

- Imported subscriptions are created `paused` — not "real status plus a `migration_billing_paused` flag", which is what the doc claimed.
- Spells out the cutover's checks and their order, and that everything before the source cancellation is read-only.
- Documents the retry story: one subscription per job, and the cancellation marker that lets a crashed run converge.

## Why

The flag never existed; `create_imported` has always used `SubscriptionStatus.paused`, which the renewal scheduler already skips without a second concept. Anyone reading the doc to review the cutover would be checking the code against a design that isn't the one in the repo.

## How

Doc only, no code. Kept the rejected alternative in one clause rather than deleting it, so the next person doesn't re-propose the flag.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests — documentation only
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

---
_Generated by [Claude Code](https://claude.ai/code/session_011PzjzyWCvUEeXWuG4UGy8R)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

