### PR TITLE
feat(merchant-migration): read and stop a subscription on the source

### DIFF
--- a/server/polar/merchant_migration/adapters/base.py
+++ b/server/polar/merchant_migration/adapters/base.py
@@ -1,7 +1,7 @@
 from collections.abc import AsyncIterator
 from typing import Protocol
 
-from ..canonical import CanonicalAccount, CanonicalRecord
+from ..canonical import CanonicalAccount, CanonicalRecord, CanonicalSubscription
 
 
 class SourceAdapter(Protocol):
@@ -10,8 +10,28 @@ class SourceAdapter(Protocol):
     ``extract`` is an async iterator because source data can be huge and must be
     streamed, not materialized. Credential validation is provider-specific and
     lives on the concrete adapter (e.g. ``StripeAdapter.verify_scopes``), not here.
+
+    Everything here reads, except ``stop_source_subscription``: the one write the
+    migration makes on the merchant's own provider, at cutover.
     """
 
     def extract(self) -> AsyncIterator[CanonicalRecord]: ...
 
     async def get_source_account(self) -> CanonicalAccount: ...
+
+    async def get_subscription(self, source_id: str) -> CanonicalSubscription | None:
+        """The source subscription as it stands now, or None if it's gone.
+
+        Weeks can pass between the import and the cutover, so the cutover reads
+        the source again rather than trusting the staged copy.
+        """
+        ...
+
+    async def stop_source_subscription(self, source_id: str, *, reference: str) -> None:
+        """Stop billing this subscription on the source, for good.
+
+        ``reference`` identifies the migration and is recorded on the source, so
+        a later read can tell our own cancellation apart from the customer
+        having churned (see ``CanonicalSubscription.stopped_for_migration``).
+        """
+        ...

--- a/server/polar/merchant_migration/adapters/stripe.py
+++ b/server/polar/merchant_migration/adapters/stripe.py
@@ -30,6 +30,20 @@ SKIPPED_SUBSCRIPTION_STATUSES = frozenset(
     {"canceled", "incomplete", "incomplete_expired"}
 )
 
+# Written to `cancellation_details.comment` when the cutover stops a source
+# subscription, and matched when reading one back. A cutover that crashes
+# between the Stripe cancellation and its own commit retries against a
+# subscription it already cancelled; without this marker the retry would read
+# that as the customer having churned and strand the subscription unbilled.
+CANCELLATION_COMMENT_PREFIX = "Migrated to Polar"
+
+# Expansions the cutover needs on a single subscription read.
+_SUBSCRIPTION_EXPAND = [
+    "default_payment_method",
+    "customer.invoice_settings.default_payment_method",
+    "customer.default_source",
+]
+
 
 class StripeAdapter:
     def __init__(self, access_token: str) -> None:
@@ -178,11 +192,7 @@ class StripeAdapter:
             params={
                 "status": "all",
                 "limit": PAGE_SIZE,
-                "expand": [
-                    "data.default_payment_method",
-                    "data.customer.invoice_settings.default_payment_method",
-                    "data.customer.default_source",
-                ],
+                "expand": [f"data.{path}" for path in _SUBSCRIPTION_EXPAND],
             }
         )
         async for subscription in subscriptions.auto_paging_iter():
@@ -191,6 +201,47 @@ class StripeAdapter:
             if not subscription["items"]["data"]:
                 continue
             yield self._map_subscription(subscription)
+
+    async def get_subscription(self, source_id: str) -> CanonicalSubscription | None:
+        try:
+            subscription = await self._client.v1.subscriptions.retrieve_async(
+                source_id, params={"expand": _SUBSCRIPTION_EXPAND}
+            )
+        except stripe_lib.InvalidRequestError as e:
+            # The merchant deleted it on Stripe since the import.
+            if e.code == "resource_missing":
+                return None
+            raise
+        if not subscription["items"]["data"]:
+            return None
+        return self._map_subscription(subscription)
+
+    async def stop_source_subscription(self, source_id: str, *, reference: str) -> None:
+        """Cancel the subscription on Stripe, right now.
+
+        No proration and no final invoice: the customer already paid the source
+        through the end of the period, and Polar picks the billing up from there.
+        Cancelling one Stripe has already cancelled is treated as done, so a
+        retry converges instead of failing.
+        """
+        comment = f"{CANCELLATION_COMMENT_PREFIX} (migration {reference})"
+        try:
+            await self._client.v1.subscriptions.cancel_async(
+                source_id,
+                params={"cancellation_details": {"comment": comment}},
+            )
+        except stripe_lib.InvalidRequestError:
+            if await self._is_stopped(source_id):
+                return
+            raise
+
+    async def _is_stopped(self, source_id: str) -> bool:
+        try:
+            subscription = await self._client.v1.subscriptions.retrieve_async(source_id)
+        except stripe_lib.InvalidRequestError as e:
+            # Gone entirely: it certainly isn't billing anyone.
+            return e.code == "resource_missing"
+        return subscription.status == "canceled"
 
     def _map_price(self, price: stripe_lib.Price) -> CanonicalPrice:
         return CanonicalPrice(
@@ -232,7 +283,17 @@ class StripeAdapter:
             payment_method=self._resolve_payment_method(subscription),
             has_discount=bool(subscription.get("discounts"))
             or subscription.get("discount") is not None,
+            cancel_at_period_end=bool(subscription.cancel_at_period_end),
+            trial_end=self._to_datetime(subscription.trial_end),
+            stopped_for_migration=self._stopped_for_migration(subscription),
         )
+
+    def _stopped_for_migration(self, subscription: stripe_lib.Subscription) -> bool:
+        if subscription.status != "canceled":
+            return False
+        details = subscription.cancellation_details
+        comment = details.comment if details is not None else None
+        return bool(comment and comment.startswith(CANCELLATION_COMMENT_PREFIX))
 
     def _map_customer(self, customer: stripe_lib.Customer) -> CanonicalCustomer:
         address = customer.address

--- a/server/polar/merchant_migration/adapters/stripe.py
+++ b/server/polar/merchant_migration/adapters/stripe.py
@@ -219,8 +219,12 @@ class StripeAdapter:
     async def stop_source_subscription(self, source_id: str, *, reference: str) -> None:
         """Cancel the subscription on Stripe, right now.
 
-        No proration and no final invoice: the customer already paid the source
-        through the end of the period, and Polar picks the billing up from there.
+        No proration and no final invoice, so the customer keeps the period they
+        already paid the source for and gets no surprise charge or refund out of
+        the move. That only holds because the caller takes the subscription on
+        with the source's own period end, and bills nothing before it — cancel
+        at period end instead if that ever stops being true.
+
         Cancelling one Stripe has already cancelled is treated as done, so a
         retry converges instead of failing.
         """
@@ -289,6 +293,16 @@ class StripeAdapter:
         )
 
     def _stopped_for_migration(self, subscription: stripe_lib.Subscription) -> bool:
+        """The prefix, deliberately, and not the per-migration reference.
+
+        The two ways to be wrong here are not symmetric. Failing to recognise
+        our own cancellation strands a customer billed by nobody, so the match
+        stays as loose as it can be. Recognising someone else's — a second
+        migration on the same account, a hand-written comment — only means we
+        take over a subscription whose source billing is provably already
+        stopped, which is the outcome we were driving at anyway. The reference
+        is there for a human reading the Stripe dashboard.
+        """
         if subscription.status != "canceled":
             return False
         details = subscription.cancellation_details

--- a/server/polar/merchant_migration/adapters/stripe.py
+++ b/server/polar/merchant_migration/adapters/stripe.py
@@ -219,14 +219,10 @@ class StripeAdapter:
     async def stop_source_subscription(self, source_id: str, *, reference: str) -> None:
         """Cancel the subscription on Stripe, right now.
 
-        No proration and no final invoice, so the customer keeps the period they
-        already paid the source for and gets no surprise charge or refund out of
-        the move. That only holds because the caller takes the subscription on
-        with the source's own period end, and bills nothing before it — cancel
-        at period end instead if that ever stops being true.
-
-        Cancelling one Stripe has already cancelled is treated as done, so a
-        retry converges instead of failing.
+        No proration and no final invoice: the customer already paid the source
+        through the end of the period, and the caller takes the subscription on
+        with that same period end. Cancelling one Stripe has already cancelled
+        is treated as done, so a retry converges instead of failing.
         """
         comment = f"{CANCELLATION_COMMENT_PREFIX} (migration {reference})"
         try:
@@ -293,16 +289,9 @@ class StripeAdapter:
         )
 
     def _stopped_for_migration(self, subscription: stripe_lib.Subscription) -> bool:
-        """The prefix, deliberately, and not the per-migration reference.
-
-        The two ways to be wrong here are not symmetric. Failing to recognise
-        our own cancellation strands a customer billed by nobody, so the match
-        stays as loose as it can be. Recognising someone else's — a second
-        migration on the same account, a hand-written comment — only means we
-        take over a subscription whose source billing is provably already
-        stopped, which is the outcome we were driving at anyway. The reference
-        is there for a human reading the Stripe dashboard.
-        """
+        """Prefix, not the full reference: missing our own cancellation strands a
+        customer billed by nobody, while matching someone else's only takes over a
+        subscription whose source billing is already stopped."""
         if subscription.status != "canceled":
             return False
         details = subscription.cancellation_details

--- a/server/polar/merchant_migration/canonical.py
+++ b/server/polar/merchant_migration/canonical.py
@@ -109,6 +109,16 @@ class CanonicalSubscription:
     # A discount/coupon on the source. Its amount isn't migrated yet, so importing
     # at list price would overcharge; such subscriptions are skipped for now.
     has_discount: bool = False
+    # The customer already asked to stop: the source won't renew it. Nothing left
+    # for Polar to take over, so the cutover leaves it where it is.
+    cancel_at_period_end: bool = False
+    # When the source trial ends, so the cutover can keep the subscription
+    # trialing on Polar until then instead of billing it early.
+    trial_end: datetime | None = None
+    # This migration already stopped it on the source. Set when re-reading at
+    # cutover, so a retry after a crash finishes the move instead of reading its
+    # own cancellation as the customer having churned.
+    stopped_for_migration: bool = False
 
     type = MerchantMigrationRecordType.subscription
 
@@ -188,6 +198,9 @@ def deserialize(
                 if payment_method is not None
                 else None,
                 has_discount=data.get("has_discount", False),
+                cancel_at_period_end=data.get("cancel_at_period_end", False),
+                trial_end=_parse_datetime(data.get("trial_end")),
+                stopped_for_migration=data.get("stopped_for_migration", False),
             )
         case _:
             raise ValueError(f"Cannot deserialize record of type {type}")

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -594,6 +594,17 @@ class PriceDisplay:
         return cls(price.amount, price.currency, product.recurring_interval)
 
 
+def subscription_import_reason(
+    subscription: CanonicalSubscription,
+) -> Reason | None:
+    """Why a subscription can't be taken on its own terms, ignoring what its
+    product and customer do. The cutover re-reads the source weeks later and
+    holds it to the same bar as the import did."""
+    return _drop_reason(
+        precheck_engine._check_subscription(subscription), SUBSCRIPTION_DROP_CODES
+    )
+
+
 def _drop_reason(issues: Iterable[PrecheckIssue], codes: set[str]) -> Reason | None:
     for issue in issues:
         if issue.code in codes:
@@ -992,9 +1003,7 @@ def plan_subscription_imports(
     }
     plans: dict[str, Reason | None] = {}
     for subscription in subscriptions:
-        skip = _drop_reason(
-            precheck_engine._check_subscription(subscription), SUBSCRIPTION_DROP_CODES
-        )
+        skip = subscription_import_reason(subscription)
         if skip is None and subscription.price_source_id not in importable_prices:
             skip = Reason(
                 "subscription_product_not_importable", _SUBSCRIPTION_PRODUCT_REASON

--- a/server/tests/merchant_migration/test_stripe_adapter.py
+++ b/server/tests/merchant_migration/test_stripe_adapter.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -251,6 +252,22 @@ class TestGetSubscription:
         assert subscription.status == CanonicalSubscriptionStatus.active
         assert subscription.cancel_at_period_end is True
         assert subscription.current_period_end is not None
+
+    async def test_reads_a_running_trial(self, mocker: MockerFixture) -> None:
+        """The cutover keeps the trial running rather than billing at once, so
+        it needs the end date back as an aware datetime."""
+        adapter, client = _adapter(mocker)
+        client.v1.subscriptions.retrieve_async = mocker.AsyncMock(
+            return_value=_stripe_subscription(
+                status="trialing", trial_end=1_702_000_000
+            )
+        )
+
+        subscription = await adapter.get_subscription("sub_1")
+
+        assert subscription is not None
+        assert subscription.status == CanonicalSubscriptionStatus.trialing
+        assert subscription.trial_end == datetime(2023, 12, 8, 1, 46, 40, tzinfo=UTC)
 
     async def test_deleted_subscription_is_gone(self, mocker: MockerFixture) -> None:
         adapter, client = _adapter(mocker)

--- a/server/tests/merchant_migration/test_stripe_adapter.py
+++ b/server/tests/merchant_migration/test_stripe_adapter.py
@@ -4,7 +4,11 @@ import pytest
 import stripe as stripe_lib
 from pytest_mock import MockerFixture
 
-from polar.merchant_migration.adapters.stripe import StripeAdapter
+from polar.merchant_migration.adapters.stripe import (
+    CANCELLATION_COMMENT_PREFIX,
+    StripeAdapter,
+)
+from polar.merchant_migration.canonical import CanonicalSubscriptionStatus
 
 
 def _adapter(mocker: MockerFixture) -> tuple[StripeAdapter, Any]:
@@ -192,3 +196,147 @@ class TestGetSourceAccount:
 
         assert account.country is None
         assert account.has_connected_accounts is False
+
+
+def _stripe_subscription(
+    *,
+    status: str = "active",
+    cancel_at_period_end: bool = False,
+    trial_end: int | None = None,
+    cancellation_comment: str | None = None,
+    items: list[dict[str, Any]] | None = None,
+) -> stripe_lib.Subscription:
+    return stripe_lib.Subscription.construct_from(
+        {
+            "id": "sub_1",
+            "customer": "cus_1",
+            "status": status,
+            "collection_method": "charge_automatically",
+            "cancel_at_period_end": cancel_at_period_end,
+            "pause_collection": None,
+            "trial_end": trial_end,
+            "default_payment_method": None,
+            "discounts": [],
+            "cancellation_details": (
+                {"comment": cancellation_comment} if cancellation_comment else None
+            ),
+            "items": {
+                "data": items
+                if items is not None
+                else [
+                    {
+                        "price": {"id": "price_1"},
+                        "quantity": 1,
+                        "current_period_start": 1_700_000_000,
+                        "current_period_end": 1_702_000_000,
+                    }
+                ]
+            },
+        },
+        None,
+    )
+
+
+@pytest.mark.asyncio
+class TestGetSubscription:
+    async def test_reads_the_current_state(self, mocker: MockerFixture) -> None:
+        adapter, client = _adapter(mocker)
+        client.v1.subscriptions.retrieve_async = mocker.AsyncMock(
+            return_value=_stripe_subscription(cancel_at_period_end=True)
+        )
+
+        subscription = await adapter.get_subscription("sub_1")
+
+        assert subscription is not None
+        assert subscription.status == CanonicalSubscriptionStatus.active
+        assert subscription.cancel_at_period_end is True
+        assert subscription.current_period_end is not None
+
+    async def test_deleted_subscription_is_gone(self, mocker: MockerFixture) -> None:
+        adapter, client = _adapter(mocker)
+        client.v1.subscriptions.retrieve_async = mocker.AsyncMock(
+            side_effect=stripe_lib.InvalidRequestError(
+                "No such subscription", "id", code="resource_missing"
+            )
+        )
+
+        assert await adapter.get_subscription("sub_1") is None
+
+    async def test_other_errors_propagate(self, mocker: MockerFixture) -> None:
+        adapter, client = _adapter(mocker)
+        client.v1.subscriptions.retrieve_async = mocker.AsyncMock(
+            side_effect=stripe_lib.InvalidRequestError("nope", "id", code="other")
+        )
+
+        with pytest.raises(stripe_lib.InvalidRequestError):
+            await adapter.get_subscription("sub_1")
+
+    async def test_our_own_cancellation_is_recognised(
+        self, mocker: MockerFixture
+    ) -> None:
+        """Otherwise a retry would read it as the customer having churned."""
+        adapter, client = _adapter(mocker)
+        client.v1.subscriptions.retrieve_async = mocker.AsyncMock(
+            return_value=_stripe_subscription(
+                status="canceled",
+                cancellation_comment="Migrated to Polar (migration abc)",
+            )
+        )
+
+        subscription = await adapter.get_subscription("sub_1")
+
+        assert subscription is not None
+        assert subscription.stopped_for_migration is True
+
+    async def test_a_customer_cancellation_is_not(self, mocker: MockerFixture) -> None:
+        adapter, client = _adapter(mocker)
+        client.v1.subscriptions.retrieve_async = mocker.AsyncMock(
+            return_value=_stripe_subscription(
+                status="canceled", cancellation_comment="Too expensive"
+            )
+        )
+
+        subscription = await adapter.get_subscription("sub_1")
+
+        assert subscription is not None
+        assert subscription.stopped_for_migration is False
+
+
+@pytest.mark.asyncio
+class TestStopSourceSubscription:
+    async def test_cancels_with_a_traceable_comment(
+        self, mocker: MockerFixture
+    ) -> None:
+        adapter, client = _adapter(mocker)
+        client.v1.subscriptions.cancel_async = mocker.AsyncMock()
+
+        await adapter.stop_source_subscription("sub_1", reference="abc")
+
+        _, kwargs = client.v1.subscriptions.cancel_async.call_args
+        comment = kwargs["params"]["cancellation_details"]["comment"]
+        assert comment.startswith(CANCELLATION_COMMENT_PREFIX)
+        assert "abc" in comment
+
+    async def test_already_cancelled_is_done(self, mocker: MockerFixture) -> None:
+        adapter, client = _adapter(mocker)
+        client.v1.subscriptions.cancel_async = mocker.AsyncMock(
+            side_effect=stripe_lib.InvalidRequestError("already canceled", "id")
+        )
+        client.v1.subscriptions.retrieve_async = mocker.AsyncMock(
+            return_value=_stripe_subscription(status="canceled")
+        )
+
+        await adapter.stop_source_subscription("sub_1", reference="abc")
+
+    async def test_a_real_failure_propagates(self, mocker: MockerFixture) -> None:
+        """The caller must not activate on Polar while the source keeps billing."""
+        adapter, client = _adapter(mocker)
+        client.v1.subscriptions.cancel_async = mocker.AsyncMock(
+            side_effect=stripe_lib.InvalidRequestError("bad request", "id")
+        )
+        client.v1.subscriptions.retrieve_async = mocker.AsyncMock(
+            return_value=_stripe_subscription(status="active")
+        )
+
+        with pytest.raises(stripe_lib.InvalidRequestError):
+            await adapter.stop_source_subscription("sub_1", reference="abc")


### PR DESCRIPTION
## Summary

**Related Issue**: n/a

> 📚 Stack 3/7 · base is #13623. Reviewable now; merge after its base.

Two capabilities the cutover will need from a source adapter, plus the canonical fields that carry them. **Nothing calls them yet** — this is the Stripe-semantics half of the cutover, isolated so it can be read on its own.

## What

- `SourceAdapter.get_subscription(source_id)` — re-read one subscription as it stands now; `None` when it's gone.
- `SourceAdapter.stop_source_subscription(source_id, reference)` — the adapter's only write.
- `CanonicalSubscription` gains `cancel_at_period_end`, `trial_end` and `stopped_for_migration`.
- `subscription_import_reason` extracted out of `plan_subscription_imports`.

## Why

Weeks pass between the catalog import and the cutover, so the staged copy of a subscription is stale by the time we'd act on it. Every cutover check has to read the source again, and the cutover's last act is to stop billing there.


## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

---
_Generated by [Claude Code](https://claude.ai/code/session_011PzjzyWCvUEeXWuG4UGy8R)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

