### PR TITLE
feat(merchant-migration): link the moved cards to imported customers

### DIFF
--- a/server/polar/merchant_migration/adapters/stripe.py
+++ b/server/polar/merchant_migration/adapters/stripe.py
@@ -351,7 +351,15 @@ class StripeAdapter:
             type = CanonicalPaymentMethodType(payment_method.type)
         except ValueError:
             type = CanonicalPaymentMethodType.other
-        return CanonicalPaymentMethod(source_id=payment_method.id, type=type)
+        details = payment_method.get(payment_method.type) or {}
+        return CanonicalPaymentMethod(
+            source_id=payment_method.id,
+            type=type,
+            last4=details.get("last4"),
+            brand=details.get("brand"),
+            exp_month=details.get("exp_month"),
+            exp_year=details.get("exp_year"),
+        )
 
     def _id_of(self, value: Any) -> str:
         if isinstance(value, str):

--- a/server/polar/merchant_migration/canonical.py
+++ b/server/polar/merchant_migration/canonical.py
@@ -53,6 +53,12 @@ class CanonicalPaymentMethodType(StrEnum):
 class CanonicalPaymentMethod:
     source_id: str
     type: CanonicalPaymentMethodType
+    # A copy re-mints the id but not the card, so these are the only join key
+    # left between the method the source charged and the one that lands on ours.
+    last4: str | None = None
+    brand: str | None = None
+    exp_month: int | None = None
+    exp_year: int | None = None
 
 
 @dataclass
@@ -194,6 +200,10 @@ def deserialize(
                 payment_method=CanonicalPaymentMethod(
                     source_id=payment_method["source_id"],
                     type=CanonicalPaymentMethodType(payment_method["type"]),
+                    last4=payment_method.get("last4"),
+                    brand=payment_method.get("brand"),
+                    exp_month=payment_method.get("exp_month"),
+                    exp_year=payment_method.get("exp_year"),
                 )
                 if payment_method is not None
                 else None,

--- a/server/polar/merchant_migration/canonical.py
+++ b/server/polar/merchant_migration/canonical.py
@@ -53,8 +53,7 @@ class CanonicalPaymentMethodType(StrEnum):
 class CanonicalPaymentMethod:
     source_id: str
     type: CanonicalPaymentMethodType
-    # A copy re-mints the id but not the card, so these are the only join key
-    # left between the method the source charged and the one that lands on ours.
+    # What a copy preserves, and so all there is to re-identify it by.
     last4: str | None = None
     brand: str | None = None
     exp_month: int | None = None

--- a/server/polar/merchant_migration/cards.py
+++ b/server/polar/merchant_migration/cards.py
@@ -19,13 +19,22 @@ from polar.models import Customer, PaymentMethod
 from polar.payment_method.service import payment_method as payment_method_service
 from polar.postgres import AsyncSession
 
+from .canonical import CanonicalPaymentMethod
+
 CARD_TYPE = "card"
 
 
 async def link_payment_method(
-    session: AsyncSession, customer: Customer
+    session: AsyncSession,
+    customer: Customer,
+    *,
+    source_method: CanonicalPaymentMethod | None = None,
 ) -> PaymentMethod | None:
     """Mirror the cards on Polar's Stripe account onto the Polar customer.
+
+    ``source_method`` is the method the source subscription was charging; the
+    copy of it wins, so a customer with several stored cards keeps being charged
+    on the one they were already being charged on.
 
     Returns the payment method to charge, or None while nothing has landed for
     this customer yet. Idempotent: re-running picks up cards that arrived since,
@@ -56,7 +65,9 @@ async def link_payment_method(
     if not payment_methods:
         return None
 
-    preferred = _preferred(payment_methods, customer.default_payment_method_id)
+    preferred = _preferred(
+        payment_methods, customer.default_payment_method_id, source_method
+    )
     # The renewal falls back to the customer default when a subscription has no
     # method of its own, so an imported customer should have one.
     if customer.default_payment_method_id is None:
@@ -67,12 +78,19 @@ async def link_payment_method(
 
 
 def _preferred(
-    payment_methods: Sequence[PaymentMethod], default_id: UUID | None
+    payment_methods: Sequence[PaymentMethod],
+    default_id: UUID | None,
+    source_method: CanonicalPaymentMethod | None,
 ) -> PaymentMethod:
-    """Keep an existing default; otherwise the newest card, which Stripe lists
-    first. Falls back to any other method rather than nothing — ACH and SEPA are
-    chargeable and migratable, per `CanonicalPaymentMethodType.requires_reentry`.
+    """The copy of what the source was charging, else an existing default, else
+    the newest card, which Stripe lists first. Falls back to any other method
+    rather than nothing — ACH and SEPA are chargeable and migratable, per
+    `CanonicalPaymentMethodType.requires_reentry`.
     """
+    if source_method is not None:
+        for payment_method in payment_methods:
+            if _is_copy_of(payment_method, source_method):
+                return payment_method
     for payment_method in payment_methods:
         if payment_method.id == default_id:
             return payment_method
@@ -80,3 +98,22 @@ def _preferred(
         if payment_method.type == CARD_TYPE:
             return payment_method
     return payment_methods[0]
+
+
+def _is_copy_of(
+    payment_method: PaymentMethod, source_method: CanonicalPaymentMethod
+) -> bool:
+    """A copy keeps the card but not its id, so match on what survives. Within
+    one customer's handful of cards, brand + last4 + expiry doesn't collide."""
+    details = {
+        "last4": source_method.last4,
+        "brand": source_method.brand,
+        "exp_month": source_method.exp_month,
+        "exp_year": source_method.exp_year,
+    }
+    known = {key: value for key, value in details.items() if value is not None}
+    if not known or payment_method.type != source_method.type.value:
+        return False
+    return all(
+        payment_method.method_metadata.get(key) == value for key, value in known.items()
+    )

--- a/server/polar/merchant_migration/cards.py
+++ b/server/polar/merchant_migration/cards.py
@@ -1,0 +1,81 @@
+"""Linking the moved cards back to the imported customers and subscriptions.
+
+PAN copy (and PAN import) land the cards on Polar's own Stripe account under the
+source's `cus_…` id, but with fresh `pm_…` ids. Until those are read back and
+stored as Polar payment methods, an imported subscription has nothing to charge.
+
+This is the `verify_cards` checklist step, and the same check the cutover runs
+again per subscription before it stops billing on the source.
+"""
+
+from collections.abc import Sequence
+from uuid import UUID
+
+import stripe as stripe_lib
+
+from polar.customer.repository import CustomerRepository
+from polar.integrations.stripe.service import stripe as stripe_service
+from polar.models import Customer, PaymentMethod
+from polar.payment_method.service import payment_method as payment_method_service
+from polar.postgres import AsyncSession
+
+CARD_TYPE = "card"
+
+
+async def link_payment_method(
+    session: AsyncSession, customer: Customer
+) -> PaymentMethod | None:
+    """Mirror the cards on Polar's Stripe account onto the Polar customer.
+
+    Returns the payment method to charge, or None while nothing has landed for
+    this customer yet. Idempotent: re-running picks up cards that arrived since,
+    which is what makes it safe to run once per checklist step and again at
+    cutover.
+    """
+    if customer.stripe_customer_id is None:
+        return None
+
+    try:
+        stripe_payment_methods = [
+            stripe_payment_method
+            async for stripe_payment_method in stripe_service.list_payment_methods(
+                customer.stripe_customer_id
+            )
+        ]
+    except stripe_lib.InvalidRequestError:
+        # The customer isn't on Polar's Stripe account: the copy hasn't reached
+        # them. Not an error — it's the answer the checklist is asking for.
+        return None
+
+    payment_methods = [
+        await payment_method_service.upsert_from_stripe(
+            session, customer, stripe_payment_method, flush=True
+        )
+        for stripe_payment_method in stripe_payment_methods
+    ]
+    if not payment_methods:
+        return None
+
+    preferred = _preferred(payment_methods, customer.default_payment_method_id)
+    # The renewal falls back to the customer default when a subscription has no
+    # method of its own, so an imported customer should have one.
+    if customer.default_payment_method_id is None:
+        await CustomerRepository.from_session(session).update(
+            customer, update_dict={"default_payment_method_id": preferred.id}
+        )
+    return preferred
+
+
+def _preferred(
+    payment_methods: Sequence[PaymentMethod], default_id: UUID | None
+) -> PaymentMethod:
+    """Never move a customer off a default they already have. Otherwise take the
+    newest card: Stripe lists newest first, and a card is the only type every
+    renewal path can charge off-session without a mandate."""
+    for payment_method in payment_methods:
+        if payment_method.id == default_id:
+            return payment_method
+    for payment_method in payment_methods:
+        if payment_method.type == CARD_TYPE:
+            return payment_method
+    return payment_methods[0]

--- a/server/polar/merchant_migration/cards.py
+++ b/server/polar/merchant_migration/cards.py
@@ -1,11 +1,7 @@
-"""Linking the moved cards back to the imported customers and subscriptions.
+"""Reading the moved cards back onto the imported customers.
 
-PAN copy (and PAN import) land the cards on Polar's own Stripe account under the
-source's `cus_…` id, but with fresh `pm_…` ids. Until those are read back and
-stored as Polar payment methods, an imported subscription has nothing to charge.
-
-This is the `verify_cards` checklist step, and the same check the cutover runs
-again per subscription before it stops billing on the source.
+A copy lands them under the source's `cus_…` id but with fresh `pm_…` ids, so
+they stay invisible to Polar until stored as payment methods of our own.
 """
 
 from collections.abc import Sequence
@@ -30,16 +26,10 @@ async def link_payment_method(
     *,
     source_method: CanonicalPaymentMethod | None = None,
 ) -> PaymentMethod | None:
-    """Mirror the cards on Polar's Stripe account onto the Polar customer.
+    """The method to charge, or None while nothing has landed for this customer.
 
-    ``source_method`` is the method the source subscription was charging; the
-    copy of it wins, so a customer with several stored cards keeps being charged
-    on the one they were already being charged on.
-
-    Returns the payment method to charge, or None while nothing has landed for
-    this customer yet. Idempotent: re-running picks up cards that arrived since,
-    which is what makes it safe to run once per checklist step and again at
-    cutover.
+    ``source_method`` is what the source subscription was charging; its copy
+    wins. Idempotent, so it can run again as more cards arrive.
     """
     if customer.stripe_customer_id is None:
         return None
@@ -52,8 +42,7 @@ async def link_payment_method(
             )
         ]
     except stripe_lib.InvalidRequestError:
-        # The customer isn't on Polar's Stripe account: the copy hasn't reached
-        # them. Not an error — it's the answer the checklist is asking for.
+        # No such customer on our account: the copy hasn't reached them.
         return None
 
     payment_methods = [
@@ -68,8 +57,7 @@ async def link_payment_method(
     preferred = _preferred(
         payment_methods, customer.default_payment_method_id, source_method
     )
-    # The renewal falls back to the customer default when a subscription has no
-    # method of its own, so an imported customer should have one.
+    # What the renewal charges when a subscription has no method of its own.
     if customer.default_payment_method_id is None:
         await CustomerRepository.from_session(session).update(
             customer, update_dict={"default_payment_method_id": preferred.id}
@@ -82,11 +70,8 @@ def _preferred(
     default_id: UUID | None,
     source_method: CanonicalPaymentMethod | None,
 ) -> PaymentMethod:
-    """The copy of what the source was charging, else an existing default, else
-    the newest card, which Stripe lists first. Falls back to any other method
-    rather than nothing — ACH and SEPA are chargeable and migratable, per
-    `CanonicalPaymentMethodType.requires_reentry`.
-    """
+    """Ordered by how much each candidate says about what to charge. Any stored
+    method beats nothing: ACH and SEPA migrate too, per `requires_reentry`."""
     if source_method is not None:
         for payment_method in payment_methods:
             if _is_copy_of(payment_method, source_method):
@@ -103,8 +88,7 @@ def _preferred(
 def _is_copy_of(
     payment_method: PaymentMethod, source_method: CanonicalPaymentMethod
 ) -> bool:
-    """A copy keeps the card but not its id, so match on what survives. Within
-    one customer's handful of cards, brand + last4 + expiry doesn't collide."""
+    """A copy keeps the card but not its id, so match on what survives."""
     details = {
         "last4": source_method.last4,
         "brand": source_method.brand,

--- a/server/polar/merchant_migration/cards.py
+++ b/server/polar/merchant_migration/cards.py
@@ -69,14 +69,9 @@ async def link_payment_method(
 def _preferred(
     payment_methods: Sequence[PaymentMethod], default_id: UUID | None
 ) -> PaymentMethod:
-    """Never move a customer off a default they already have. Otherwise take the
-    newest card — Stripe lists newest first, and a card is the one type every
-    renewal path can charge off-session without a mandate.
-
-    A customer with no copied card still gets one of their other methods rather
-    than nothing: ACH and SEPA are migratable by design (only Bacs, Link and
-    legacy sources need re-entry, per `CanonicalPaymentMethodType`), so refusing
-    them here would strand those subscriptions on the old provider forever.
+    """Keep an existing default; otherwise the newest card, which Stripe lists
+    first. Falls back to any other method rather than nothing — ACH and SEPA are
+    chargeable and migratable, per `CanonicalPaymentMethodType.requires_reentry`.
     """
     for payment_method in payment_methods:
         if payment_method.id == default_id:

--- a/server/polar/merchant_migration/cards.py
+++ b/server/polar/merchant_migration/cards.py
@@ -16,8 +16,22 @@ from polar.payment_method.service import payment_method as payment_method_servic
 from polar.postgres import AsyncSession
 
 from .canonical import CanonicalPaymentMethod
+from .errors import MerchantMigrationError
 
 CARD_TYPE = "card"
+
+
+class AmbiguousCopiedCard(MerchantMigrationError):
+    """Deliberately unhandled at the top: charging the wrong card is worse than
+    not charging, and there is nothing sensible to guess. Pages so a human can
+    look at the account."""
+
+    def __init__(self, customer_id: UUID, matches: int) -> None:
+        self.customer_id = customer_id
+        super().__init__(
+            f"{matches} copied methods look like the one the source was charging "
+            f"for customer {customer_id}; can't tell which is which."
+        )
 
 
 async def link_payment_method(
@@ -54,9 +68,7 @@ async def link_payment_method(
     if not payment_methods:
         return None
 
-    preferred = _preferred(
-        payment_methods, customer.default_payment_method_id, source_method
-    )
+    preferred = _preferred(payment_methods, customer, source_method)
     # What the renewal charges when a subscription has no method of its own.
     if customer.default_payment_method_id is None:
         await CustomerRepository.from_session(session).update(
@@ -67,17 +79,23 @@ async def link_payment_method(
 
 def _preferred(
     payment_methods: Sequence[PaymentMethod],
-    default_id: UUID | None,
+    customer: Customer,
     source_method: CanonicalPaymentMethod | None,
 ) -> PaymentMethod:
     """Ordered by how much each candidate says about what to charge. Any stored
     method beats nothing: ACH and SEPA migrate too, per `requires_reentry`."""
     if source_method is not None:
-        for payment_method in payment_methods:
-            if _is_copy_of(payment_method, source_method):
-                return payment_method
+        copies = [
+            payment_method
+            for payment_method in payment_methods
+            if _is_copy_of(payment_method, source_method)
+        ]
+        if len(copies) > 1:
+            raise AmbiguousCopiedCard(customer.id, len(copies))
+        if copies:
+            return copies[0]
     for payment_method in payment_methods:
-        if payment_method.id == default_id:
+        if payment_method.id == customer.default_payment_method_id:
             return payment_method
     for payment_method in payment_methods:
         if payment_method.type == CARD_TYPE:
@@ -88,7 +106,8 @@ def _preferred(
 def _is_copy_of(
     payment_method: PaymentMethod, source_method: CanonicalPaymentMethod
 ) -> bool:
-    """A copy keeps the card but not its id, so match on what survives."""
+    """A copy keeps the card but not its id, and not its fingerprint either —
+    that is per-account. Brand, last4 and expiry are what is left."""
     details = {
         "last4": source_method.last4,
         "brand": source_method.brand,

--- a/server/polar/merchant_migration/cards.py
+++ b/server/polar/merchant_migration/cards.py
@@ -70,8 +70,14 @@ def _preferred(
     payment_methods: Sequence[PaymentMethod], default_id: UUID | None
 ) -> PaymentMethod:
     """Never move a customer off a default they already have. Otherwise take the
-    newest card: Stripe lists newest first, and a card is the only type every
-    renewal path can charge off-session without a mandate."""
+    newest card — Stripe lists newest first, and a card is the one type every
+    renewal path can charge off-session without a mandate.
+
+    A customer with no copied card still gets one of their other methods rather
+    than nothing: ACH and SEPA are migratable by design (only Bacs, Link and
+    legacy sources need re-entry, per `CanonicalPaymentMethodType`), so refusing
+    them here would strand those subscriptions on the old provider forever.
+    """
     for payment_method in payment_methods:
         if payment_method.id == default_id:
             return payment_method

--- a/server/tests/merchant_migration/test_canonical.py
+++ b/server/tests/merchant_migration/test_canonical.py
@@ -77,7 +77,14 @@ class TestSerialize:
         assert result["current_period_start"] == "2026-01-01T00:00:00+00:00"
         assert result["current_period_end"] == "2026-02-01T00:00:00+00:00"
         assert result["status"] == "active"
-        assert result["payment_method"] == {"source_id": "pm_1", "type": "card"}
+        assert result["payment_method"] == {
+            "source_id": "pm_1",
+            "type": "card",
+            "last4": None,
+            "brand": None,
+            "exp_month": None,
+            "exp_year": None,
+        }
 
     def test_optional_fields_stay_none(self) -> None:
         customer = CanonicalCustomer(

--- a/server/tests/merchant_migration/test_cards.py
+++ b/server/tests/merchant_migration/test_cards.py
@@ -1,4 +1,5 @@
 from collections.abc import AsyncIterator, Sequence
+from typing import Any
 
 import pytest
 import pytest_asyncio
@@ -20,16 +21,16 @@ from tests.fixtures.stripe import build_stripe_payment_method
 
 
 def _stripe_payment_method(
-    id: str, type: str = "card", **details: object
+    id: str, type: str = "card", details: dict[str, Any] | None = None
 ) -> stripe_lib.PaymentMethod:
     payment_method = build_stripe_payment_method(
-        type=type, details=details, customer="cus_1"
+        type=type, details=details or {}, customer="cus_1"
     )
     payment_method.id = id
     return payment_method
 
 
-def _card(last4: str) -> dict[str, object]:
+def _card(last4: str) -> dict[str, Any]:
     return {"last4": last4, "brand": "visa", "exp_month": 4, "exp_year": 2030}
 
 
@@ -208,14 +209,14 @@ class TestKeepsTheCardTheSourceCharged:
         _listing(
             mocker,
             [
-                _stripe_payment_method("pm_copy_of_c1", **_card("1111")),
-                _stripe_payment_method("pm_copy_of_c2", **_card("2222")),
+                _stripe_payment_method("pm_copy_of_c1", details=_card("1111")),
+                _stripe_payment_method("pm_copy_of_c2", details=_card("2222")),
             ],
         )
         charged_on_the_source = CanonicalPaymentMethod(
             source_id="pm_c2_on_the_source",
             type=CanonicalPaymentMethodType.card,
-            **_card("2222"),  # type: ignore[arg-type]
+            **_card("2222"),
         )
 
         payment_method = await link_payment_method(
@@ -246,8 +247,8 @@ class TestKeepsTheCardTheSourceCharged:
         _listing(
             mocker,
             [
-                _stripe_payment_method("pm_copy_of_c1", **_card("1111")),
-                _stripe_payment_method("pm_copy_of_c2", **_card("2222")),
+                _stripe_payment_method("pm_copy_of_c1", details=_card("1111")),
+                _stripe_payment_method("pm_copy_of_c2", details=_card("2222")),
             ],
         )
 
@@ -257,7 +258,7 @@ class TestKeepsTheCardTheSourceCharged:
             source_method=CanonicalPaymentMethod(
                 source_id="pm_c2_on_the_source",
                 type=CanonicalPaymentMethodType.card,
-                **_card("2222"),  # type: ignore[arg-type]
+                **_card("2222"),
             ),
         )
 
@@ -272,7 +273,9 @@ class TestKeepsTheCardTheSourceCharged:
     ) -> None:
         """Only C1 copied. Better the card we have than nothing — the cutover's
         SetupIntent is what decides whether it can actually be charged."""
-        _listing(mocker, [_stripe_payment_method("pm_copy_of_c1", **_card("1111"))])
+        _listing(
+            mocker, [_stripe_payment_method("pm_copy_of_c1", details=_card("1111"))]
+        )
 
         payment_method = await link_payment_method(
             session,
@@ -280,7 +283,7 @@ class TestKeepsTheCardTheSourceCharged:
             source_method=CanonicalPaymentMethod(
                 source_id="pm_c2_on_the_source",
                 type=CanonicalPaymentMethodType.card,
-                **_card("2222"),  # type: ignore[arg-type]
+                **_card("2222"),
             ),
         )
 
@@ -294,7 +297,7 @@ class TestKeepsTheCardTheSourceCharged:
         imported_customer: Customer,
     ) -> None:
         """A legacy `src_` object gives us an id and nothing else."""
-        _listing(mocker, [_stripe_payment_method("pm_copied", **_card("1111"))])
+        _listing(mocker, [_stripe_payment_method("pm_copied", details=_card("1111"))])
 
         payment_method = await link_payment_method(
             session,
@@ -318,8 +321,8 @@ class TestKeepsTheCardTheSourceCharged:
         _listing(
             mocker,
             [
-                _stripe_payment_method("pm_copy_a", **_card("2222")),
-                _stripe_payment_method("pm_copy_b", **_card("2222")),
+                _stripe_payment_method("pm_copy_a", details=_card("2222")),
+                _stripe_payment_method("pm_copy_b", details=_card("2222")),
             ],
         )
 
@@ -330,6 +333,6 @@ class TestKeepsTheCardTheSourceCharged:
                 source_method=CanonicalPaymentMethod(
                     source_id="pm_on_the_source",
                     type=CanonicalPaymentMethodType.card,
-                    **_card("2222"),  # type: ignore[arg-type]
+                    **_card("2222"),
                 ),
             )

--- a/server/tests/merchant_migration/test_cards.py
+++ b/server/tests/merchant_migration/test_cards.py
@@ -11,7 +11,7 @@ from polar.merchant_migration.canonical import (
     CanonicalPaymentMethod,
     CanonicalPaymentMethodType,
 )
-from polar.merchant_migration.cards import link_payment_method
+from polar.merchant_migration.cards import AmbiguousCopiedCard, link_payment_method
 from polar.models import Customer, Organization, PaymentMethod
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
@@ -306,3 +306,30 @@ class TestKeepsTheCardTheSourceCharged:
 
         assert payment_method is not None
         assert payment_method.processor_id == "pm_copied"
+
+    async def test_two_indistinguishable_copies_raise(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        imported_customer: Customer,
+    ) -> None:
+        """Same brand, last4 and expiry on both copies. Nothing left to tell them
+        apart, and charging the wrong one is worse than not charging."""
+        _listing(
+            mocker,
+            [
+                _stripe_payment_method("pm_copy_a", **_card("2222")),
+                _stripe_payment_method("pm_copy_b", **_card("2222")),
+            ],
+        )
+
+        with pytest.raises(AmbiguousCopiedCard):
+            await link_payment_method(
+                session,
+                imported_customer,
+                source_method=CanonicalPaymentMethod(
+                    source_id="pm_on_the_source",
+                    type=CanonicalPaymentMethodType.card,
+                    **_card("2222"),  # type: ignore[arg-type]
+                ),
+            )

--- a/server/tests/merchant_migration/test_cards.py
+++ b/server/tests/merchant_migration/test_cards.py
@@ -1,0 +1,180 @@
+from collections.abc import AsyncIterator, Sequence
+
+import pytest
+import pytest_asyncio
+import stripe as stripe_lib
+from pytest_mock import MockerFixture
+from sqlalchemy import select
+
+from polar.merchant_migration.cards import link_payment_method
+from polar.models import Customer, Organization, PaymentMethod
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_customer
+from tests.fixtures.stripe import build_stripe_payment_method
+
+
+def _stripe_payment_method(id: str, type: str = "card") -> stripe_lib.PaymentMethod:
+    payment_method = build_stripe_payment_method(type=type, customer="cus_1")
+    payment_method.id = id
+    return payment_method
+
+
+def _listing(
+    mocker: MockerFixture,
+    payment_methods: Sequence[stripe_lib.PaymentMethod] | None = None,
+    *,
+    error: Exception | None = None,
+) -> None:
+    async def _list(customer: str) -> AsyncIterator[stripe_lib.PaymentMethod]:
+        if error is not None:
+            raise error
+        for payment_method in payment_methods or []:
+            yield payment_method
+
+    mocker.patch(
+        "polar.merchant_migration.cards.stripe_service.list_payment_methods", new=_list
+    )
+
+
+async def _payment_methods(
+    session: AsyncSession, customer: Customer
+) -> Sequence[PaymentMethod]:
+    result = await session.execute(
+        select(PaymentMethod).where(PaymentMethod.customer_id == customer.id)
+    )
+    return list(result.scalars().all())
+
+
+@pytest_asyncio.fixture
+async def imported_customer(
+    save_fixture: SaveFixture, organization: Organization
+) -> Customer:
+    return await create_customer(
+        save_fixture,
+        organization=organization,
+        email="imported@example.com",
+        stripe_customer_id="cus_1",
+    )
+
+
+@pytest.mark.asyncio
+class TestLinkPaymentMethod:
+    async def test_no_source_customer_id(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+    ) -> None:
+        customer = await create_customer(
+            save_fixture,
+            organization=organization,
+            email="nocard@example.com",
+            stripe_customer_id=None,
+        )
+
+        assert await link_payment_method(session, customer) is None
+
+    async def test_customer_not_on_polars_account_yet(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        imported_customer: Customer,
+    ) -> None:
+        """The copy hasn't reached this customer: an answer, not an error."""
+        _listing(
+            mocker,
+            error=stripe_lib.InvalidRequestError("No such customer", "customer"),
+        )
+
+        assert await link_payment_method(session, imported_customer) is None
+
+    async def test_no_card_copied_yet(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        imported_customer: Customer,
+    ) -> None:
+        _listing(mocker, [])
+
+        assert await link_payment_method(session, imported_customer) is None
+
+    async def test_stores_the_copied_card_and_defaults_to_it(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        imported_customer: Customer,
+    ) -> None:
+        _listing(mocker, [_stripe_payment_method("pm_copied")])
+
+        payment_method = await link_payment_method(session, imported_customer)
+
+        assert payment_method is not None
+        assert payment_method.processor_id == "pm_copied"
+        assert imported_customer.default_payment_method_id == payment_method.id
+
+    async def test_prefers_a_card_over_a_bank_account(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        imported_customer: Customer,
+    ) -> None:
+        _listing(
+            mocker,
+            [
+                _stripe_payment_method("pm_bank", type="us_bank_account"),
+                _stripe_payment_method("pm_card"),
+            ],
+        )
+
+        payment_method = await link_payment_method(session, imported_customer)
+
+        assert payment_method is not None
+        assert payment_method.processor_id == "pm_card"
+        # Both are stored: the merchant may want either one later.
+        assert len(await _payment_methods(session, imported_customer)) == 2
+
+    async def test_keeps_an_existing_default(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        imported_customer: Customer,
+    ) -> None:
+        existing = PaymentMethod(
+            processor="stripe",
+            processor_id="pm_chosen",
+            type="card",
+            method_metadata={},
+            customer=imported_customer,
+        )
+        await save_fixture(existing)
+        imported_customer.default_payment_method_id = existing.id
+        await save_fixture(imported_customer)
+        _listing(
+            mocker,
+            [_stripe_payment_method("pm_newer"), _stripe_payment_method("pm_chosen")],
+        )
+
+        payment_method = await link_payment_method(session, imported_customer)
+
+        assert payment_method is not None
+        assert payment_method.id == existing.id
+
+    async def test_rerun_does_not_duplicate(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        imported_customer: Customer,
+    ) -> None:
+        """Cards keep landing while the merchant walks the checklist, so this
+        runs more than once per customer."""
+        _listing(mocker, [_stripe_payment_method("pm_copied")])
+
+        first = await link_payment_method(session, imported_customer)
+        second = await link_payment_method(session, imported_customer)
+
+        assert first is not None
+        assert second is not None
+        assert first.id == second.id
+        assert len(await _payment_methods(session, imported_customer)) == 1

--- a/server/tests/merchant_migration/test_cards.py
+++ b/server/tests/merchant_migration/test_cards.py
@@ -6,6 +6,11 @@ import stripe as stripe_lib
 from pytest_mock import MockerFixture
 from sqlalchemy import select
 
+from polar.enums import PaymentProcessor
+from polar.merchant_migration.canonical import (
+    CanonicalPaymentMethod,
+    CanonicalPaymentMethodType,
+)
 from polar.merchant_migration.cards import link_payment_method
 from polar.models import Customer, Organization, PaymentMethod
 from polar.postgres import AsyncSession
@@ -14,10 +19,18 @@ from tests.fixtures.random_objects import create_customer
 from tests.fixtures.stripe import build_stripe_payment_method
 
 
-def _stripe_payment_method(id: str, type: str = "card") -> stripe_lib.PaymentMethod:
-    payment_method = build_stripe_payment_method(type=type, customer="cus_1")
+def _stripe_payment_method(
+    id: str, type: str = "card", **details: object
+) -> stripe_lib.PaymentMethod:
+    payment_method = build_stripe_payment_method(
+        type=type, details=details, customer="cus_1"
+    )
     payment_method.id = id
     return payment_method
+
+
+def _card(last4: str) -> dict[str, object]:
+    return {"last4": last4, "brand": "visa", "exp_month": 4, "exp_year": 2030}
 
 
 def _listing(
@@ -178,3 +191,118 @@ class TestLinkPaymentMethod:
         assert second is not None
         assert first.id == second.id
         assert len(await _payment_methods(session, imported_customer)) == 1
+
+
+@pytest.mark.asyncio
+class TestKeepsTheCardTheSourceCharged:
+    """The customer has two cards stored but the subscription only ever charged
+    one of them. The copy re-mints both ids, so the details are what tells them
+    apart — and the one that was being charged has to keep being charged."""
+
+    async def test_picks_the_copy_of_the_source_method(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        imported_customer: Customer,
+    ) -> None:
+        _listing(
+            mocker,
+            [
+                _stripe_payment_method("pm_copy_of_c1", **_card("1111")),
+                _stripe_payment_method("pm_copy_of_c2", **_card("2222")),
+            ],
+        )
+        charged_on_the_source = CanonicalPaymentMethod(
+            source_id="pm_c2_on_the_source",
+            type=CanonicalPaymentMethodType.card,
+            **_card("2222"),  # type: ignore[arg-type]
+        )
+
+        payment_method = await link_payment_method(
+            session, imported_customer, source_method=charged_on_the_source
+        )
+
+        assert payment_method is not None
+        assert payment_method.processor_id == "pm_copy_of_c2"
+
+    async def test_beats_an_existing_default(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        imported_customer: Customer,
+    ) -> None:
+        """The default is a guess; what the subscription charged is the answer."""
+        existing = PaymentMethod(
+            processor=PaymentProcessor.stripe,
+            processor_id="pm_copy_of_c1",
+            type="card",
+            method_metadata=_card("1111"),
+            customer=imported_customer,
+        )
+        await save_fixture(existing)
+        imported_customer.default_payment_method_id = existing.id
+        await save_fixture(imported_customer)
+        _listing(
+            mocker,
+            [
+                _stripe_payment_method("pm_copy_of_c1", **_card("1111")),
+                _stripe_payment_method("pm_copy_of_c2", **_card("2222")),
+            ],
+        )
+
+        payment_method = await link_payment_method(
+            session,
+            imported_customer,
+            source_method=CanonicalPaymentMethod(
+                source_id="pm_c2_on_the_source",
+                type=CanonicalPaymentMethodType.card,
+                **_card("2222"),  # type: ignore[arg-type]
+            ),
+        )
+
+        assert payment_method is not None
+        assert payment_method.processor_id == "pm_copy_of_c2"
+
+    async def test_falls_back_when_the_card_did_not_land(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        imported_customer: Customer,
+    ) -> None:
+        """Only C1 copied. Better the card we have than nothing — the cutover's
+        SetupIntent is what decides whether it can actually be charged."""
+        _listing(mocker, [_stripe_payment_method("pm_copy_of_c1", **_card("1111"))])
+
+        payment_method = await link_payment_method(
+            session,
+            imported_customer,
+            source_method=CanonicalPaymentMethod(
+                source_id="pm_c2_on_the_source",
+                type=CanonicalPaymentMethodType.card,
+                **_card("2222"),  # type: ignore[arg-type]
+            ),
+        )
+
+        assert payment_method is not None
+        assert payment_method.processor_id == "pm_copy_of_c1"
+
+    async def test_a_source_method_with_no_details_cannot_match(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        imported_customer: Customer,
+    ) -> None:
+        """A legacy `src_` object gives us an id and nothing else."""
+        _listing(mocker, [_stripe_payment_method("pm_copied", **_card("1111"))])
+
+        payment_method = await link_payment_method(
+            session,
+            imported_customer,
+            source_method=CanonicalPaymentMethod(
+                source_id="src_legacy", type=CanonicalPaymentMethodType.card
+            ),
+        )
+
+        assert payment_method is not None
+        assert payment_method.processor_id == "pm_copied"

--- a/server/tests/merchant_migration/test_stripe_adapter.py
+++ b/server/tests/merchant_migration/test_stripe_adapter.py
@@ -9,7 +9,11 @@ from polar.merchant_migration.adapters.stripe import (
     CANCELLATION_COMMENT_PREFIX,
     StripeAdapter,
 )
-from polar.merchant_migration.canonical import CanonicalSubscriptionStatus
+from polar.merchant_migration.canonical import (
+    CanonicalPaymentMethod,
+    CanonicalPaymentMethodType,
+    CanonicalSubscriptionStatus,
+)
 
 
 def _adapter(mocker: MockerFixture) -> tuple[StripeAdapter, Any]:
@@ -206,6 +210,7 @@ def _stripe_subscription(
     trial_end: int | None = None,
     cancellation_comment: str | None = None,
     items: list[dict[str, Any]] | None = None,
+    payment_method: dict[str, Any] | None = None,
 ) -> stripe_lib.Subscription:
     return stripe_lib.Subscription.construct_from(
         {
@@ -216,7 +221,7 @@ def _stripe_subscription(
             "cancel_at_period_end": cancel_at_period_end,
             "pause_collection": None,
             "trial_end": trial_end,
-            "default_payment_method": None,
+            "default_payment_method": payment_method,
             "discounts": [],
             "cancellation_details": (
                 {"comment": cancellation_comment} if cancellation_comment else None
@@ -252,6 +257,40 @@ class TestGetSubscription:
         assert subscription.status == CanonicalSubscriptionStatus.active
         assert subscription.cancel_at_period_end is True
         assert subscription.current_period_end is not None
+
+    async def test_carries_the_card_details_the_copy_keeps(
+        self, mocker: MockerFixture
+    ) -> None:
+        """A copy re-mints the `pm_…` id, so these are what identifies the card
+        the subscription was actually charging once it lands on our account."""
+        adapter, client = _adapter(mocker)
+        client.v1.subscriptions.retrieve_async = mocker.AsyncMock(
+            return_value=_stripe_subscription(
+                payment_method={
+                    "id": "pm_source",
+                    "object": "payment_method",
+                    "type": "card",
+                    "card": {
+                        "last4": "4242",
+                        "brand": "visa",
+                        "exp_month": 4,
+                        "exp_year": 2030,
+                    },
+                }
+            )
+        )
+
+        subscription = await adapter.get_subscription("sub_1")
+
+        assert subscription is not None
+        assert subscription.payment_method == CanonicalPaymentMethod(
+            source_id="pm_source",
+            type=CanonicalPaymentMethodType.card,
+            last4="4242",
+            brand="visa",
+            exp_month=4,
+            exp_year=2030,
+        )
 
     async def test_reads_a_running_trial(self, mocker: MockerFixture) -> None:
         """The cutover keeps the trial running rather than billing at once, so


### PR DESCRIPTION
## Summary

Read the cards that have landed on Polar's Stripe account for an imported customer, store them, and return the one their subscription was already being charged on.


## Why

PAN copy preserves the source `cus_…` id but creates new `pm_…` ids, so a card can be on Polar's Stripe account and still be invisible to Polar: the renewal path charges `subscription.payment_method_id or customer.default_payment_method_id`, and neither exists until we do this.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

---
_Generated by [Claude Code](https://claude.ai/code/session_011PzjzyWCvUEeXWuG4UGy8R)_


<a href="https://cubic.dev/pr/polarsource/polar/pull/13625?utm_source=github" rel="nofollow noreferrer noopener" target="_blank">``&lt;img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;``</a>