### PR TITLE
feat(merchant-migration): decide and perform a subscription cutover

### DIFF
--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -184,13 +184,11 @@ class SubscriptionCutover:
     async def _reconcile_active(
         self, record: MerchantMigrationRecord
     ) -> CutoverOutcome:
-        """The Polar subscription is already live. Make sure the source isn't.
+        """The Polar subscription is already live, so make sure the source isn't.
 
-        Usually this is a previous run finishing twice, and the source is
-        already stopped. But a paused subscription can also be resumed by hand,
-        or by the customer from their portal, and then Polar and the source are
-        both billing the same person — so the source is stopped here rather than
-        taking "active on Polar" as proof that it isn't.
+        Usually a previous run finishing twice. But a paused subscription can
+        also be resumed by hand — by the customer, from their portal — and then
+        both sides are billing the same person.
         """
         source = await self.adapter.get_subscription(record.source_id)
         if source is not None and source.status != CanonicalSubscriptionStatus.canceled:

--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -1,0 +1,305 @@
+"""The cutover: Polar takes over billing for the imported subscriptions.
+
+Imported subscriptions sit paused so nothing bills while the cards move. Cutting
+over switches one on, and stops it on the old provider, in that order of checks:
+
+1. the subscription is still live on the source, on the same plan;
+2. its renewal is far enough out that the source can't bill the period first;
+3. the copied card is on Polar and can actually be charged;
+4. only then: stop it on the source, and unpause it on Polar.
+
+Everything before step 4 is read-only, so a subscription that fails any check is
+left exactly where it is — still billing on the source, still paused on Polar —
+with a reason the merchant can act on. The one irreversible act is fenced by all
+of them.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+import stripe as stripe_lib
+import structlog
+
+from polar.integrations.stripe.service import stripe as stripe_service
+from polar.kit.utils import utc_now
+from polar.logging import Logger
+from polar.models import (
+    Customer,
+    MerchantMigration,
+    MerchantMigrationRecord,
+    PaymentMethod,
+    Subscription,
+)
+from polar.models.merchant_migration_record import MerchantMigrationCutoverStatus
+from polar.models.subscription import SubscriptionStatus
+from polar.payment_method.repository import PaymentMethodRepository
+from polar.postgres import AsyncSession
+from polar.subscription.repository import SubscriptionRepository
+from polar.subscription.service import subscription as subscription_service
+
+from .adapters import SourceAdapter
+from .canonical import CanonicalSubscription, CanonicalSubscriptionStatus, deserialize
+from .cards import CARD_TYPE, link_payment_method
+from .precheck import subscription_import_reason
+
+log: Logger = structlog.get_logger()
+
+# The source must not get the chance to bill the period we're taking over. A
+# renewal landing inside this window stays where it is: once the source has
+# charged it, the next period opens up and the cutover can be retried.
+RENEWAL_SAFETY_WINDOW = timedelta(hours=24)
+
+# Source states we can hand over. Anything else means the customer isn't cleanly
+# subscribed there, so there is no healthy billing relationship to take on.
+MIGRATABLE_SOURCE_STATUSES = frozenset(
+    {CanonicalSubscriptionStatus.active, CanonicalSubscriptionStatus.trialing}
+)
+
+_GONE = "It no longer exists on the source, so there is nothing to take over."
+_SOURCE_CANCELED = (
+    "It was cancelled on the source after the import, so Polar won't start billing it."
+)
+_SOURCE_NOT_LIVE = (
+    "The source reports it as `{status}`, which isn't a healthy subscription "
+    "Polar can take billing over from."
+)
+_ENDING = (
+    "It's set to cancel at the end of the period on the source, so there is no "
+    "renewal for Polar to take over. It stays there until it ends."
+)
+_PLAN_CHANGED = (
+    "The plan changed on the source since the import, so the imported "
+    "subscription no longer matches. Re-run the import for this customer."
+)
+_NO_CARD = (
+    "No copied card has landed on Polar for this customer yet. They need to "
+    "enter their billing details again, or the copy has to pick them up."
+)
+_NOT_PAUSED = "It isn't paused in Polar any more, so the cutover left it alone."
+_CUSTOMER_DELETED = "The Polar customer was deleted, so it can't be billed."
+_SUBSCRIPTION_GONE = "The imported Polar subscription no longer exists."
+
+
+@dataclass(frozen=True)
+class CutoverOutcome:
+    status: MerchantMigrationCutoverStatus
+    reason: str | None = None
+
+
+_MOVED = CutoverOutcome(MerchantMigrationCutoverStatus.moved)
+
+
+def _skip(reason: str) -> CutoverOutcome:
+    return CutoverOutcome(MerchantMigrationCutoverStatus.skipped, reason)
+
+
+def _fail(reason: str) -> CutoverOutcome:
+    return CutoverOutcome(MerchantMigrationCutoverStatus.failed, reason)
+
+
+class SubscriptionCutover:
+    """Cuts one imported subscription over, or explains why it didn't."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        adapter: SourceAdapter,
+    ) -> None:
+        self.session = session
+        self.migration = migration
+        self.adapter = adapter
+        self.subscription_repository = SubscriptionRepository.from_session(session)
+
+    async def run(self, record: MerchantMigrationRecord) -> CutoverOutcome:
+        try:
+            return await self._run(record)
+        except stripe_lib.StripeError as e:
+            # Reaching Stripe is the one thing that fails for reasons that have
+            # nothing to do with this subscription, so it's recorded as failed
+            # (retryable) rather than skipped, and the run moves on.
+            log.warning(
+                "merchant_migration.cutover.stripe_error",
+                migration_id=self.migration.id,
+                record_id=record.id,
+                source_id=record.source_id,
+                error=str(e),
+            )
+            return _fail(e.user_message or str(e))
+
+    async def _run(self, record: MerchantMigrationRecord) -> CutoverOutcome:
+        subscription = await self._load_subscription(record)
+        if subscription is None:
+            return _fail(_SUBSCRIPTION_GONE)
+        if SubscriptionStatus.is_active(subscription.status):
+            # A previous run already moved it, or the merchant activated it by
+            # hand. Either way the source is no longer the one billing.
+            return _MOVED
+        if subscription.status != SubscriptionStatus.paused:
+            return _skip(_NOT_PAUSED)
+
+        customer = subscription.customer
+        if customer.is_deleted:
+            return _skip(_CUSTOMER_DELETED)
+
+        source = await self.adapter.get_subscription(record.source_id)
+        if source is None:
+            return _skip(_GONE)
+
+        # A previous attempt already stopped it on the source: the money side is
+        # committed, so the only safe move is to finish, not re-run the checks
+        # against the cancellation we made ourselves.
+        if not source.stopped_for_migration:
+            reason = self._source_reason(source, record)
+            if reason is not None:
+                return _skip(reason)
+
+        payment_method = await self._resolve_payment_method(subscription, customer)
+        if payment_method is None:
+            return _skip(_NO_CARD)
+        card_reason = await self._card_reason(customer, payment_method)
+        if card_reason is not None:
+            return _skip(card_reason)
+
+        if not source.stopped_for_migration:
+            await self.adapter.stop_source_subscription(
+                record.source_id, reference=str(self.migration.id)
+            )
+
+        current_period_start, current_period_end = self._period(source, subscription)
+        await subscription_service.activate_imported(
+            self.session,
+            subscription,
+            current_period_start=current_period_start,
+            current_period_end=current_period_end,
+            trial_end=self._trial_end(source),
+            payment_method=payment_method,
+        )
+        log.info(
+            "merchant_migration.cutover.moved",
+            migration_id=self.migration.id,
+            subscription_id=subscription.id,
+            source_id=record.source_id,
+        )
+        return _MOVED
+
+    async def _load_subscription(
+        self, record: MerchantMigrationRecord
+    ) -> Subscription | None:
+        if record.target_id is None:
+            return None
+        return await self.subscription_repository.get_by_id(
+            record.target_id,
+            options=self.subscription_repository.get_eager_options(),
+        )
+
+    def _source_reason(
+        self, source: CanonicalSubscription, record: MerchantMigrationRecord
+    ) -> str | None:
+        """Why the source says this subscription shouldn't move today."""
+        if source.status not in MIGRATABLE_SOURCE_STATUSES:
+            if source.status == CanonicalSubscriptionStatus.canceled:
+                return _SOURCE_CANCELED
+            reason = subscription_import_reason(source)
+            if reason is not None:
+                return reason.message
+            return _SOURCE_NOT_LIVE.format(status=source.status.value)
+        if source.cancel_at_period_end:
+            return _ENDING
+        # Everything the import refused to take, re-applied: the source has had
+        # weeks to grow a second line item, a coupon or a manual invoice.
+        reason = subscription_import_reason(source)
+        if reason is not None:
+            return reason.message
+        staged = deserialize(record.type, record.canonical)
+        if (
+            isinstance(staged, CanonicalSubscription)
+            and staged.price_source_id != source.price_source_id
+        ):
+            return _PLAN_CHANGED
+        return self._renewal_reason(source)
+
+    def _renewal_reason(self, source: CanonicalSubscription) -> str | None:
+        renewal = source.current_period_end
+        if renewal is None:
+            return (
+                "The source doesn't report a renewal date, so we can't tell "
+                "whether it's about to bill this subscription."
+            )
+        deadline = utc_now() + RENEWAL_SAFETY_WINDOW
+        if renewal > deadline:
+            return None
+        return (
+            f"It renews on the source at {renewal.isoformat()}, too soon to hand "
+            "over without risking a double charge. Retry once that renewal has "
+            "gone through."
+        )
+
+    async def _resolve_payment_method(
+        self, subscription: Subscription, customer: Customer
+    ) -> PaymentMethod | None:
+        """The card the first Polar renewal will charge.
+
+        A card linked by the `verify_cards` step wins; otherwise we look again,
+        because cards keep landing while the merchant walks the checklist.
+        """
+        if subscription.payment_method_id is not None:
+            payment_method = await PaymentMethodRepository.from_session(
+                self.session
+            ).get_by_id(subscription.payment_method_id)
+            if payment_method is not None:
+                return payment_method
+        return await link_payment_method(self.session, customer)
+
+    async def _card_reason(
+        self, customer: Customer, payment_method: PaymentMethod
+    ) -> str | None:
+        """Prove the card can be charged before anything is cancelled.
+
+        Only cards: a zero-amount confirmation says nothing useful about a bank
+        debit, and confirming one needs a mandate the copy doesn't carry.
+        """
+        if payment_method.type != CARD_TYPE or customer.stripe_customer_id is None:
+            return None
+        try:
+            setup_intent = await stripe_service.create_setup_intent(
+                customer=customer.stripe_customer_id,
+                payment_method=payment_method.processor_id,
+                payment_method_types=[CARD_TYPE],
+                usage="off_session",
+                confirm=True,
+                metadata={"merchant_migration_id": str(self.migration.id)},
+            )
+        except stripe_lib.CardError as e:
+            return f"The copied card was declined by the bank: {e.user_message}."
+        if setup_intent.status != "succeeded":
+            return (
+                "The copied card can't be charged without the customer "
+                "confirming it, so Polar can't bill it unattended. Ask them to "
+                "re-enter their billing details."
+            )
+        return None
+
+    def _period(
+        self, source: CanonicalSubscription, subscription: Subscription
+    ) -> tuple[datetime, datetime]:
+        """Where the source left the billing cycle.
+
+        Read at cutover, not at import: the source has kept renewing in between,
+        so the staged period is stale. The subscription's own period is the
+        fallback for a source that no longer reports one.
+        """
+        end = source.current_period_end or subscription.current_period_end
+        start = source.current_period_start or subscription.current_period_start
+        if start >= end:
+            # An inverted period would feed the renewal maths.
+            start = min(subscription.current_period_start, end)
+        return start, end
+
+    def _trial_end(self, source: CanonicalSubscription) -> datetime | None:
+        """Keep a running trial running: Polar bills at its end, not today."""
+        if source.status != CanonicalSubscriptionStatus.trialing:
+            return None
+        if source.trial_end is None or source.trial_end <= utc_now():
+            return None
+        return source.trial_end

--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -132,9 +132,7 @@ class SubscriptionCutover:
         if subscription is None:
             return _fail(_SUBSCRIPTION_GONE)
         if SubscriptionStatus.is_active(subscription.status):
-            # A previous run already moved it, or the merchant activated it by
-            # hand. Either way the source is no longer the one billing.
-            return _MOVED
+            return await self._reconcile_active(record)
         if subscription.status != SubscriptionStatus.paused:
             return _skip(_NOT_PAUSED)
 
@@ -181,6 +179,29 @@ class SubscriptionCutover:
             subscription_id=subscription.id,
             source_id=record.source_id,
         )
+        return _MOVED
+
+    async def _reconcile_active(
+        self, record: MerchantMigrationRecord
+    ) -> CutoverOutcome:
+        """The Polar subscription is already live. Make sure the source isn't.
+
+        Usually this is a previous run finishing twice, and the source is
+        already stopped. But a paused subscription can also be resumed by hand,
+        or by the customer from their portal, and then Polar and the source are
+        both billing the same person — so the source is stopped here rather than
+        taking "active on Polar" as proof that it isn't.
+        """
+        source = await self.adapter.get_subscription(record.source_id)
+        if source is not None and source.status != CanonicalSubscriptionStatus.canceled:
+            log.warning(
+                "merchant_migration.cutover.source_still_live",
+                migration_id=self.migration.id,
+                source_id=record.source_id,
+            )
+            await self.adapter.stop_source_subscription(
+                record.source_id, reference=str(self.migration.id)
+            )
         return _MOVED
 
     async def _load_subscription(

--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -38,7 +38,12 @@ from polar.subscription.repository import SubscriptionRepository
 from polar.subscription.service import subscription as subscription_service
 
 from .adapters import SourceAdapter
-from .canonical import CanonicalSubscription, CanonicalSubscriptionStatus, deserialize
+from .canonical import (
+    CanonicalPaymentMethod,
+    CanonicalSubscription,
+    CanonicalSubscriptionStatus,
+    deserialize,
+)
 from .cards import CARD_TYPE, link_payment_method
 from .precheck import subscription_import_reason
 
@@ -152,7 +157,9 @@ class SubscriptionCutover:
             if reason is not None:
                 return _skip(reason)
 
-        payment_method = await self._resolve_payment_method(subscription, customer)
+        payment_method = await self._resolve_payment_method(
+            subscription, customer, source.payment_method
+        )
         if payment_method is None:
             return _skip(_NO_CARD)
         card_reason = await self._card_reason(customer, payment_method)
@@ -255,12 +262,17 @@ class SubscriptionCutover:
         )
 
     async def _resolve_payment_method(
-        self, subscription: Subscription, customer: Customer
+        self,
+        subscription: Subscription,
+        customer: Customer,
+        source_method: CanonicalPaymentMethod | None,
     ) -> PaymentMethod | None:
         """The card the first Polar renewal will charge.
 
         A card linked by the `verify_cards` step wins; otherwise we look again,
-        because cards keep landing while the merchant walks the checklist.
+        because cards keep landing while the merchant walks the checklist. Read
+        from the source now, not from the staged copy: the customer may have
+        changed which card the subscription charges since the import.
         """
         if subscription.payment_method_id is not None:
             payment_method = await PaymentMethodRepository.from_session(
@@ -268,7 +280,9 @@ class SubscriptionCutover:
             ).get_by_id(subscription.payment_method_id)
             if payment_method is not None:
                 return payment_method
-        return await link_payment_method(self.session, customer)
+        return await link_payment_method(
+            self.session, customer, source_method=source_method
+        )
 
     async def _card_reason(
         self, customer: Customer, payment_method: PaymentMethod

--- a/server/polar/merchant_migration/cutover.py
+++ b/server/polar/merchant_migration/cutover.py
@@ -44,7 +44,7 @@ from .canonical import (
     CanonicalSubscriptionStatus,
     deserialize,
 )
-from .cards import CARD_TYPE, link_payment_method
+from .cards import CARD_TYPE, AmbiguousCopiedCard, link_payment_method
 from .precheck import subscription_import_reason
 
 log: Logger = structlog.get_logger()
@@ -119,6 +119,17 @@ class SubscriptionCutover:
     async def run(self, record: MerchantMigrationRecord) -> CutoverOutcome:
         try:
             return await self._run(record)
+        except AmbiguousCopiedCard as e:
+            # One customer nobody can pick a card for must not stop the run for
+            # everyone else. Recorded so it surfaces, and retryable once someone
+            # has removed the duplicate.
+            log.warning(
+                "merchant_migration.cutover.ambiguous_card",
+                migration_id=self.migration.id,
+                record_id=record.id,
+                customer_id=e.customer_id,
+            )
+            return _fail(str(e))
         except stripe_lib.StripeError as e:
             # Reaching Stripe is the one thing that fails for reasons that have
             # nothing to do with this subscription, so it's recorded as failed

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -715,6 +715,60 @@ class SubscriptionService:
         repository = SubscriptionRepository.from_session(session)
         return await repository.create(subscription, flush=True)
 
+    async def activate_imported(
+        self,
+        session: AsyncSession,
+        subscription: Subscription,
+        *,
+        current_period_start: datetime,
+        current_period_end: datetime,
+        trial_end: datetime | None,
+        payment_method: PaymentMethod,
+    ) -> Subscription:
+        """Hand billing of an imported subscription over to Polar (the cutover).
+
+        Unlike ``resume``, this doesn't start a fresh period or charge anything:
+        the customer already paid the old provider through ``current_period_end``,
+        so Polar picks the cycle up exactly there and first bills at the renewal
+        the customer is already expecting.
+
+        No resumed email either — from the customer's side nothing paused, and
+        nothing about their subscription is changing today.
+        """
+        assert subscription.status == SubscriptionStatus.paused
+
+        subscription.status = (
+            SubscriptionStatus.trialing if trial_end else SubscriptionStatus.active
+        )
+        subscription.paused_at = None
+        subscription.resumes_at = None
+        subscription.scheduler_locked_at = None
+        subscription.trial_start = current_period_start if trial_end else None
+        subscription.trial_end = trial_end
+        subscription.current_period_start = current_period_start
+        subscription.anchor_day = current_period_start.day
+        subscription.current_period_end = current_period_end
+        subscription.payment_method = payment_method
+        subscription.initialize_meter_period(
+            None if trial_end else current_period_start
+        )
+
+        repository = SubscriptionRepository.from_session(session)
+        # Flushed: the cutover settles its ledger and counts what moved in the
+        # same transaction, off the columns this writes.
+        subscription = await repository.update(subscription, flush=True)
+
+        await self.enqueue_benefits_grants(session, subscription)
+        await self._on_subscription_updated(session, subscription)
+        enqueue_job("customer.state_changed", subscription.customer_id)
+
+        log.info(
+            "subscription.imported_activated",
+            id=subscription.id,
+            current_period_end=subscription.current_period_end,
+        )
+        return subscription
+
     async def create_or_update_from_checkout(
         self,
         session: AsyncSession,

--- a/server/tests/merchant_migration/_helpers.py
+++ b/server/tests/merchant_migration/_helpers.py
@@ -4,6 +4,7 @@ from polar.kit.encryption import EncryptedString
 from polar.kit.utils import utc_now
 from polar.merchant_migration.canonical import (
     CanonicalCollectionMethod,
+    CanonicalPaymentMethod,
     CanonicalSubscription,
     CanonicalSubscriptionStatus,
     serialize,
@@ -99,6 +100,7 @@ def canonical_subscription(
     cancel_at_period_end: bool = False,
     trial_end: datetime | None = None,
     stopped_for_migration: bool = False,
+    payment_method: CanonicalPaymentMethod | None = None,
 ) -> CanonicalSubscription:
     """A source subscription that renews comfortably outside the safety window,
     so a test only states the field it's actually about."""
@@ -114,7 +116,7 @@ def canonical_subscription(
         paused_collection=status == CanonicalSubscriptionStatus.paused,
         line_item_count=line_item_count,
         quantity=quantity,
-        payment_method=None,
+        payment_method=payment_method,
         has_discount=has_discount,
         cancel_at_period_end=cancel_at_period_end,
         trial_end=trial_end,

--- a/server/tests/merchant_migration/_helpers.py
+++ b/server/tests/merchant_migration/_helpers.py
@@ -1,13 +1,31 @@
+from datetime import datetime, timedelta
+
 from polar.kit.encryption import EncryptedString
+from polar.kit.utils import utc_now
+from polar.merchant_migration.canonical import (
+    CanonicalCollectionMethod,
+    CanonicalSubscription,
+    CanonicalSubscriptionStatus,
+    serialize,
+)
 from polar.merchant_migration.repository import MerchantMigrationRepository
 from polar.merchant_migration.service import (
     SOURCE_CREDENTIALS_ENCRYPTION_CONTEXT,
     StripeSourceCredentials,
 )
-from polar.models import MerchantMigration, Organization
+from polar.models import (
+    MerchantMigration,
+    MerchantMigrationRecord,
+    Organization,
+    Subscription,
+)
 from polar.models.merchant_migration import (
     MerchantMigrationSourcePlatform,
     MerchantMigrationStep,
+)
+from polar.models.merchant_migration_record import (
+    MerchantMigrationRecordStatus,
+    MerchantMigrationRecordType,
 )
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
@@ -62,3 +80,69 @@ async def build_connected_migration(
     )
     await save_fixture(migration)
     return migration
+
+
+def canonical_subscription(
+    *,
+    source_id: str = "sub_1",
+    customer_source_id: str = "cus_1",
+    price_source_id: str = "price_1",
+    status: CanonicalSubscriptionStatus = CanonicalSubscriptionStatus.active,
+    collection_method: CanonicalCollectionMethod = (
+        CanonicalCollectionMethod.charge_automatically
+    ),
+    current_period_start: datetime | None = None,
+    current_period_end: datetime | None = None,
+    line_item_count: int = 1,
+    quantity: int = 1,
+    has_discount: bool = False,
+    cancel_at_period_end: bool = False,
+    trial_end: datetime | None = None,
+    stopped_for_migration: bool = False,
+) -> CanonicalSubscription:
+    """A source subscription that renews comfortably outside the safety window,
+    so a test only states the field it's actually about."""
+    return CanonicalSubscription(
+        source_id=source_id,
+        customer_source_id=customer_source_id,
+        price_source_id=price_source_id,
+        status=status,
+        collection_method=collection_method,
+        current_period_start=current_period_start or utc_now() - timedelta(days=10),
+        current_period_end=current_period_end or utc_now() + timedelta(days=20),
+        trialing=status == CanonicalSubscriptionStatus.trialing,
+        paused_collection=status == CanonicalSubscriptionStatus.paused,
+        line_item_count=line_item_count,
+        quantity=quantity,
+        payment_method=None,
+        has_discount=has_discount,
+        cancel_at_period_end=cancel_at_period_end,
+        trial_end=trial_end,
+        stopped_for_migration=stopped_for_migration,
+    )
+
+
+async def stage_subscription_record(
+    save_fixture: SaveFixture,
+    migration: MerchantMigration,
+    organization: Organization,
+    subscription: Subscription,
+    *,
+    source_id: str = "sub_1",
+    price_source_id: str = "price_1",
+) -> MerchantMigrationRecord:
+    """An imported subscription in the ledger, pointing at its Polar row: what
+    the cutover reads."""
+    record = MerchantMigrationRecord(
+        merchant_migration=migration,
+        organization=organization,
+        type=MerchantMigrationRecordType.subscription,
+        status=MerchantMigrationRecordStatus.imported,
+        source_id=source_id,
+        target_id=subscription.id,
+        canonical=serialize(
+            canonical_subscription(source_id=source_id, price_source_id=price_source_id)
+        ),
+    )
+    await save_fixture(record)
+    return record

--- a/server/tests/merchant_migration/test_cutover.py
+++ b/server/tests/merchant_migration/test_cutover.py
@@ -1,0 +1,536 @@
+from collections.abc import AsyncIterator
+from datetime import timedelta
+from typing import Any
+
+import pytest
+import pytest_asyncio
+import stripe as stripe_lib
+from pytest_mock import MockerFixture
+
+from polar.enums import PaymentProcessor
+from polar.kit.utils import utc_now
+from polar.merchant_migration.canonical import (
+    CanonicalCollectionMethod,
+    CanonicalSubscription,
+    CanonicalSubscriptionStatus,
+)
+from polar.merchant_migration.cutover import SubscriptionCutover
+from polar.models import (
+    Customer,
+    MerchantMigration,
+    MerchantMigrationRecord,
+    Organization,
+    PaymentMethod,
+    Product,
+    Subscription,
+)
+from polar.models.merchant_migration_record import MerchantMigrationCutoverStatus
+from polar.models.subscription import SubscriptionStatus
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_customer, create_subscription
+from tests.merchant_migration._helpers import (
+    build_connected_migration,
+    canonical_subscription,
+    stage_subscription_record,
+)
+
+
+async def _no_payment_methods() -> AsyncIterator[Any]:
+    """Nothing has landed on Polar's Stripe account for this customer yet."""
+    return
+    yield
+
+
+class _FakeSourceAdapter:
+    """Stands in for the merchant's Stripe account: what it reports back, and
+    whether anyone actually stopped a subscription on it."""
+
+    def __init__(
+        self,
+        subscription: CanonicalSubscription | None,
+        *,
+        error: Exception | None = None,
+    ) -> None:
+        self._subscription = subscription
+        self._error = error
+        self.stopped: list[str] = []
+
+    async def get_subscription(self, source_id: str) -> CanonicalSubscription | None:
+        if self._error is not None:
+            raise self._error
+        return self._subscription
+
+    async def stop_source_subscription(self, source_id: str, *, reference: str) -> None:
+        self.stopped.append(source_id)
+
+
+def _succeeded_setup_intent(mocker: MockerFixture, status: str = "succeeded") -> Any:
+    return mocker.patch(
+        "polar.merchant_migration.cutover.stripe_service.create_setup_intent",
+        new=mocker.AsyncMock(return_value=mocker.MagicMock(status=status)),
+    )
+
+
+async def _linked_card(save_fixture: SaveFixture, customer: Customer) -> PaymentMethod:
+    payment_method = PaymentMethod(
+        processor=PaymentProcessor.stripe,
+        processor_id="pm_copied",
+        type="card",
+        method_metadata={},
+        customer=customer,
+    )
+    await save_fixture(payment_method)
+    return payment_method
+
+
+@pytest_asyncio.fixture
+async def migration(
+    save_fixture: SaveFixture, organization: Organization
+) -> MerchantMigration:
+    return await build_connected_migration(save_fixture, organization)
+
+
+@pytest_asyncio.fixture
+async def imported_customer(
+    save_fixture: SaveFixture, organization: Organization
+) -> Customer:
+    return await create_customer(
+        save_fixture,
+        organization=organization,
+        email="imported@example.com",
+        stripe_customer_id="cus_1",
+    )
+
+
+@pytest_asyncio.fixture
+async def paused_subscription(
+    save_fixture: SaveFixture, product: Product, imported_customer: Customer
+) -> Subscription:
+    return await create_subscription(
+        save_fixture,
+        product=product,
+        customer=imported_customer,
+        status=SubscriptionStatus.paused,
+        current_period_start=utc_now() - timedelta(days=40),
+        current_period_end=utc_now() - timedelta(days=10),
+        user_metadata={"stripe_subscription_id": "sub_1"},
+    )
+
+
+@pytest_asyncio.fixture
+async def record(
+    save_fixture: SaveFixture,
+    migration: MerchantMigration,
+    organization: Organization,
+    paused_subscription: Subscription,
+) -> MerchantMigrationRecord:
+    return await stage_subscription_record(
+        save_fixture, migration, organization, paused_subscription
+    )
+
+
+@pytest.mark.asyncio
+class TestRun:
+    async def test_moves_and_stops_the_source(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        imported_customer: Customer,
+        paused_subscription: Subscription,
+    ) -> None:
+        payment_method = await _linked_card(save_fixture, imported_customer)
+        paused_subscription.payment_method = payment_method
+        await save_fixture(paused_subscription)
+        renewal = utc_now() + timedelta(days=20)
+        adapter = _FakeSourceAdapter(canonical_subscription(current_period_end=renewal))
+        _succeeded_setup_intent(mocker)
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        assert adapter.stopped == ["sub_1"]
+        assert paused_subscription.status == SubscriptionStatus.active
+        assert paused_subscription.paused_at is None
+        # Polar picks the cycle up where the source left it, so the customer's
+        # first Polar charge lands on the date they already expect.
+        assert paused_subscription.current_period_end == renewal
+        assert paused_subscription.payment_method_id == payment_method.id
+
+    async def test_keeps_a_running_trial_running(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        imported_customer: Customer,
+        paused_subscription: Subscription,
+    ) -> None:
+        payment_method = await _linked_card(save_fixture, imported_customer)
+        paused_subscription.payment_method = payment_method
+        await save_fixture(paused_subscription)
+        trial_end = utc_now() + timedelta(days=10)
+        adapter = _FakeSourceAdapter(
+            canonical_subscription(
+                status=CanonicalSubscriptionStatus.trialing,
+                current_period_end=trial_end,
+                trial_end=trial_end,
+            )
+        )
+        _succeeded_setup_intent(mocker)
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        assert paused_subscription.status == SubscriptionStatus.trialing
+        assert paused_subscription.trial_end == trial_end
+        assert paused_subscription.current_period_end == trial_end
+
+    async def test_finishes_a_move_that_already_stopped_the_source(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        imported_customer: Customer,
+        paused_subscription: Subscription,
+    ) -> None:
+        """A crash between the Stripe cancellation and the commit must not read
+        our own cancellation as the customer having churned."""
+        payment_method = await _linked_card(save_fixture, imported_customer)
+        paused_subscription.payment_method = payment_method
+        await save_fixture(paused_subscription)
+        adapter = _FakeSourceAdapter(
+            canonical_subscription(
+                status=CanonicalSubscriptionStatus.canceled,
+                # Cancelled, and its period has since lapsed: Polar takes over
+                # anyway, and bills on the next scheduler pass.
+                current_period_end=utc_now() - timedelta(days=1),
+                stopped_for_migration=True,
+            )
+        )
+        _succeeded_setup_intent(mocker)
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        assert adapter.stopped == []
+        assert paused_subscription.status == SubscriptionStatus.active
+
+    async def test_already_active_is_left_alone(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        paused_subscription.status = SubscriptionStatus.active
+        await save_fixture(paused_subscription)
+        adapter = _FakeSourceAdapter(canonical_subscription())
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        assert adapter.stopped == []
+
+
+@pytest.mark.asyncio
+class TestSkips:
+    """Every skip must leave the source billing: nothing is cancelled, and the
+    Polar subscription stays paused."""
+
+    def _assert_left_alone(
+        self,
+        adapter: _FakeSourceAdapter,
+        subscription: Subscription,
+    ) -> None:
+        assert adapter.stopped == []
+        assert subscription.status == SubscriptionStatus.paused
+
+    async def test_source_subscription_gone(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        adapter = _FakeSourceAdapter(None)
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        assert "no longer exists on the source" in (outcome.reason or "")
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_source_canceled_after_the_import(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        adapter = _FakeSourceAdapter(
+            canonical_subscription(status=CanonicalSubscriptionStatus.canceled)
+        )
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        assert "cancelled on the source" in (outcome.reason or "")
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_source_payment_failing(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        adapter = _FakeSourceAdapter(
+            canonical_subscription(status=CanonicalSubscriptionStatus.past_due)
+        )
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_source_already_ending(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        adapter = _FakeSourceAdapter(canonical_subscription(cancel_at_period_end=True))
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        assert "cancel at the end of the period" in (outcome.reason or "")
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_renewal_inside_the_safety_window(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        adapter = _FakeSourceAdapter(
+            canonical_subscription(current_period_end=utc_now() + timedelta(hours=6))
+        )
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        assert "too soon to hand over" in (outcome.reason or "")
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_renewal_already_past(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        adapter = _FakeSourceAdapter(
+            canonical_subscription(current_period_end=utc_now() - timedelta(days=2))
+        )
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_plan_changed_on_the_source(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        adapter = _FakeSourceAdapter(
+            canonical_subscription(price_source_id="price_upgraded")
+        )
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        assert "plan changed on the source" in (outcome.reason or "")
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_source_grew_a_second_line_item(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        adapter = _FakeSourceAdapter(canonical_subscription(line_item_count=2))
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_source_switched_to_manual_invoicing(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        adapter = _FakeSourceAdapter(
+            canonical_subscription(
+                collection_method=CanonicalCollectionMethod.send_invoice
+            )
+        )
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_no_card_landed_on_polar(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        mocker.patch(
+            "polar.merchant_migration.cards.stripe_service.list_payment_methods",
+            return_value=_no_payment_methods(),
+        )
+        adapter = _FakeSourceAdapter(canonical_subscription())
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        assert "No copied card" in (outcome.reason or "")
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_card_declined_when_validated(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        imported_customer: Customer,
+        paused_subscription: Subscription,
+    ) -> None:
+        payment_method = await _linked_card(save_fixture, imported_customer)
+        paused_subscription.payment_method = payment_method
+        await save_fixture(paused_subscription)
+        mocker.patch(
+            "polar.merchant_migration.cutover.stripe_service.create_setup_intent",
+            new=mocker.AsyncMock(
+                side_effect=stripe_lib.CardError("Your card was declined.", None, None)
+            ),
+        )
+        adapter = _FakeSourceAdapter(canonical_subscription())
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        assert "declined by the bank" in (outcome.reason or "")
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_card_needs_authentication(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        imported_customer: Customer,
+        paused_subscription: Subscription,
+    ) -> None:
+        payment_method = await _linked_card(save_fixture, imported_customer)
+        paused_subscription.payment_method = payment_method
+        await save_fixture(paused_subscription)
+        _succeeded_setup_intent(mocker, status="requires_action")
+        adapter = _FakeSourceAdapter(canonical_subscription())
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        assert "without the customer confirming" in (outcome.reason or "")
+        self._assert_left_alone(adapter, paused_subscription)
+
+    async def test_polar_subscription_canceled_by_the_merchant(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        paused_subscription.status = SubscriptionStatus.canceled
+        await save_fixture(paused_subscription)
+        adapter = _FakeSourceAdapter(canonical_subscription())
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        assert adapter.stopped == []
+
+    async def test_customer_deleted_on_polar(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        imported_customer: Customer,
+        paused_subscription: Subscription,
+    ) -> None:
+        imported_customer.deleted_at = utc_now()
+        await save_fixture(imported_customer)
+        adapter = _FakeSourceAdapter(canonical_subscription())
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.skipped
+        self._assert_left_alone(adapter, paused_subscription)
+
+
+@pytest.mark.asyncio
+class TestFailures:
+    async def test_stripe_error_is_retryable(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        adapter = _FakeSourceAdapter(
+            None, error=stripe_lib.APIConnectionError("Stripe is down")
+        )
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.failed
+        assert paused_subscription.status == SubscriptionStatus.paused
+
+    async def test_missing_polar_subscription(
+        self,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+    ) -> None:
+        record.target_id = None
+        adapter = _FakeSourceAdapter(canonical_subscription())
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.failed
+        assert adapter.stopped == []

--- a/server/tests/merchant_migration/test_cutover.py
+++ b/server/tests/merchant_migration/test_cutover.py
@@ -11,6 +11,8 @@ from polar.enums import PaymentProcessor
 from polar.kit.utils import utc_now
 from polar.merchant_migration.canonical import (
     CanonicalCollectionMethod,
+    CanonicalPaymentMethod,
+    CanonicalPaymentMethodType,
     CanonicalSubscription,
     CanonicalSubscriptionStatus,
 )
@@ -29,6 +31,7 @@ from polar.models.subscription import SubscriptionStatus
 from polar.postgres import AsyncSession
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import create_customer, create_subscription
+from tests.fixtures.stripe import build_stripe_payment_method
 from tests.merchant_migration._helpers import (
     build_connected_migration,
     canonical_subscription,
@@ -560,6 +563,45 @@ class TestFailures:
         outcome = await SubscriptionCutover(session, migration, adapter).run(record)
 
         assert outcome.status == MerchantMigrationCutoverStatus.failed
+        assert paused_subscription.status == SubscriptionStatus.paused
+
+    async def test_two_indistinguishable_cards_are_retryable(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        """One customer nobody can pick a card for must not stop the run for
+        everyone else, and must never be resolved by guessing."""
+        identical = {"last4": "4242", "brand": "visa", "exp_month": 4, "exp_year": 2030}
+
+        async def _two_copies(customer: str) -> AsyncIterator[Any]:
+            for id in ("pm_copy_a", "pm_copy_b"):
+                copy = build_stripe_payment_method(details=identical, customer=customer)
+                copy.id = id
+                yield copy
+
+        mocker.patch(
+            "polar.merchant_migration.cards.stripe_service.list_payment_methods",
+            new=_two_copies,
+        )
+        adapter = _FakeSourceAdapter(
+            canonical_subscription(
+                payment_method=CanonicalPaymentMethod(
+                    source_id="pm_on_the_source",
+                    type=CanonicalPaymentMethodType.card,
+                    **identical,  # type: ignore[arg-type]
+                )
+            )
+        )
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.failed
+        assert "can't tell which is which" in (outcome.reason or "")
+        assert adapter.stopped == []
         assert paused_subscription.status == SubscriptionStatus.paused
 
     async def test_missing_polar_subscription(

--- a/server/tests/merchant_migration/test_cutover.py
+++ b/server/tests/merchant_migration/test_cutover.py
@@ -222,7 +222,7 @@ class TestRun:
         assert adapter.stopped == []
         assert paused_subscription.status == SubscriptionStatus.active
 
-    async def test_already_active_is_left_alone(
+    async def test_a_second_run_stops_nothing_twice(
         self,
         session: AsyncSession,
         save_fixture: SaveFixture,
@@ -232,7 +232,48 @@ class TestRun:
     ) -> None:
         paused_subscription.status = SubscriptionStatus.active
         await save_fixture(paused_subscription)
+        adapter = _FakeSourceAdapter(
+            canonical_subscription(
+                status=CanonicalSubscriptionStatus.canceled,
+                stopped_for_migration=True,
+            )
+        )
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        assert adapter.stopped == []
+
+    async def test_resumed_by_hand_still_stops_the_source(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        """A customer can resume a paused subscription from their portal. Taking
+        "active on Polar" as proof the source stopped would bill them twice."""
+        paused_subscription.status = SubscriptionStatus.active
+        await save_fixture(paused_subscription)
         adapter = _FakeSourceAdapter(canonical_subscription())
+
+        outcome = await SubscriptionCutover(session, migration, adapter).run(record)
+
+        assert outcome.status == MerchantMigrationCutoverStatus.moved
+        assert adapter.stopped == ["sub_1"]
+
+    async def test_source_already_gone_needs_no_reconciling(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        migration: MerchantMigration,
+        record: MerchantMigrationRecord,
+        paused_subscription: Subscription,
+    ) -> None:
+        paused_subscription.status = SubscriptionStatus.active
+        await save_fixture(paused_subscription)
+        adapter = _FakeSourceAdapter(None)
 
         outcome = await SubscriptionCutover(session, migration, adapter).run(record)
 

--- a/server/tests/merchant_migration/test_cutover.py
+++ b/server/tests/merchant_migration/test_cutover.py
@@ -10,9 +10,11 @@ from pytest_mock import MockerFixture
 from polar.enums import PaymentProcessor
 from polar.kit.utils import utc_now
 from polar.merchant_migration.canonical import (
+    CanonicalAccount,
     CanonicalCollectionMethod,
     CanonicalPaymentMethod,
     CanonicalPaymentMethodType,
+    CanonicalRecord,
     CanonicalSubscription,
     CanonicalSubscriptionStatus,
 )
@@ -66,6 +68,15 @@ class _FakeSourceAdapter:
 
     async def stop_source_subscription(self, source_id: str, *, reference: str) -> None:
         self.stopped.append(source_id)
+
+    # The cutover never reads the catalog, but the protocol covers the whole
+    # adapter and a fake that only satisfies half of it isn't one.
+    async def extract(self) -> AsyncIterator[CanonicalRecord]:
+        return
+        yield
+
+    async def get_source_account(self) -> CanonicalAccount:
+        return CanonicalAccount(country="US", has_connected_accounts=False)
 
 
 def _succeeded_setup_intent(mocker: MockerFixture, status: str = "succeeded") -> Any:

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -3368,6 +3368,85 @@ class TestResume:
         assert cycle_entries[0].discount is None
 
 
+@pytest.mark.asyncio
+class TestActivateImported:
+    async def test_takes_over_the_cycle_without_charging(
+        self,
+        frozen_time: datetime,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        enqueue_job_mock: MagicMock,
+        enqueue_benefits_grants_mock: MagicMock,
+        subscription_hooks: Hooks,
+        product: Product,
+        customer: Customer,
+        payment_method: PaymentMethod,
+    ) -> None:
+        """Unlike a resume, the cutover keeps the period the customer already
+        paid the old provider for, and bills nothing today."""
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+        subscription.paused_at = frozen_time - timedelta(days=10)
+        await save_fixture(subscription)
+        reset_hooks(subscription_hooks)
+        period_start = frozen_time - timedelta(days=10)
+        period_end = frozen_time + timedelta(days=20)
+
+        updated = await subscription_service.activate_imported(
+            session,
+            subscription,
+            current_period_start=period_start,
+            current_period_end=period_end,
+            trial_end=None,
+            payment_method=payment_method,
+        )
+
+        assert updated.status == SubscriptionStatus.active
+        assert updated.paused_at is None
+        assert updated.current_period_start == period_start
+        assert updated.current_period_end == period_end
+        assert updated.payment_method_id == payment_method.id
+        enqueue_benefits_grants_mock.assert_called_once_with(session, updated)
+        # No order: the customer is not charged for a period they already paid.
+        enqueued = [call.args[0] for call in enqueue_job_mock.call_args_list]
+        assert "order.create_subscription_order" not in enqueued
+
+    async def test_does_not_tell_the_customer_anything_resumed(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        enqueue_benefits_grants_mock: MagicMock,
+        subscription_hooks: Hooks,
+        product: Product,
+        customer: Customer,
+        payment_method: PaymentMethod,
+    ) -> None:
+        """Nothing paused from the customer's side, so a resumed email would be
+        the first they hear of a migration they shouldn't notice."""
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+        reset_hooks(subscription_hooks)
+
+        await subscription_service.activate_imported(
+            session,
+            subscription,
+            current_period_start=utc_now(),
+            current_period_end=utc_now() + timedelta(days=30),
+            trial_end=None,
+            payment_method=payment_method,
+        )
+
+        assert_hooks_called_once(subscription_hooks, {"updated"})
+
+
 async def create_event_billing_entry(
     save_fixture: SaveFixture,
     *,


### PR DESCRIPTION
## Summary

**Related Issue**: n/a

> 📚 Stack 5/7 · base is #13625. Reviewable now; merge after its base. **This is the one to read slowly** — it decides whether real money moves.

The cutover decision engine, plus the subscription-side transition it drives. **Nothing schedules it yet.**

## What

- `subscription_service.activate_imported(...)` — hand billing of a paused imported subscription over to Polar.
- `SubscriptionCutover.run(record)` — decide whether one subscription may move, and move it. Returns `moved` / `skipped(reason)` / `failed(reason)`.

## Why

Cutting a subscription over is the only irreversible act in a migration: it cancels a live subscription on the merchant's own Stripe account. Everything that could go wrong has to be checked before that, and anything unclear has to leave the subscription where it is rather than guess.

`activate_imported` exists because `resume` is the wrong shape here. Resuming starts a fresh period and charges immediately; the customer already paid the old provider through the end of the current period, so Polar has to pick the cycle up exactly there.

## How

**Order of checks, all read-only, cancellation last.** Still live on the source, on the same price, single line item, no coupon, still charged automatically, not already set to cancel · renewal more than 24h out · copied card confirms a zero-amount `SetupIntent`. Only then stop the source and activate. A subscription that fails any check keeps billing on the source, stays paused on Polar, and carries a reason the merchant can act on.

**The period is read at cutover, not at import.** Weeks of source renewals have happened in between, so the staged period is stale; activating on it would bill the wrong date.

**24h window.** A renewal landing sooner risks the source charging the very period we're taking over. Skipping is retryable: once the source has charged, the next period opens up.

**`SetupIntent`, cards only.** A zero-amount confirmation is a real validity probe for a card and tells us whether it can be charged off-session, which is what the first renewal will do. It says nothing useful about a bank debit and confirming one needs a mandate the copy doesn't carry, so those are accepted as-is.

**Already stopped by us → skip the checks and finish.** That's the crash-retry path from #13624 landing here: re-running the checks against our own cancellation would read as churn.

**No resumed email, no order.** From the customer's side nothing paused and nothing is changing today; the first they should notice is the renewal they already expected, charged by Polar.

Edge cases covered by tests: source gone · cancelled after import · `past_due` · already ending · renewal too soon · renewal in the past · plan changed · second line item · manual invoicing · no card yet · card declined · card needs SCA · Polar subscription already active (idempotent) or cancelled by hand · customer deleted · Stripe unreachable (retryable, not skipped).

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests — 20 cases on the engine, and every skip asserts the source was **not** cancelled
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

---
_Generated by [Claude Code](https://claude.ai/code/session_011PzjzyWCvUEeXWuG4UGy8R)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

