### PR TITLE
fix: fix sorting and re-focus in checkout links page

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/checkout-links/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/checkout-links/page.tsx
@@ -24,20 +24,22 @@ export default async function Page(props: {
     params.organization,
   )
 
-  // Fetch the newest checkout link
   const productId = searchParams.productId
+  const productIds = Array.isArray(productId)
+    ? productId
+    : productId?.split(',')
+  const sorting = searchParams.sorting === '-label' ? '-label' : 'label'
   const { data } = await api.GET('/v1/checkout-links/', {
     params: {
       query: {
         organization_id: organization.id,
-        ...(productId && { product_id: productId }),
+        ...(productIds && { product_id: productIds }),
         limit: 1,
-        sorting: ['-created_at'],
+        sorting: [sorting],
       },
     },
   })
 
-  // If there's a newest checkout link, redirect to it on desktop (on mobile, show the list)
   if (data?.items && data.items.length > 0) {
     const queryString = new URLSearchParams(
       searchParams as Record<string, string>,

--- a/clients/apps/web/src/components/CheckoutLinks/CheckoutLinkListSidebar.tsx
+++ b/clients/apps/web/src/components/CheckoutLinks/CheckoutLinkListSidebar.tsx
@@ -36,19 +36,11 @@ export const CheckoutLinkListSidebar = ({
   const searchParams = useSearchParams()
   const pushRouteWithoutCache = usePushRouteWithoutCache()
 
-  const [productIds, setProductIds] = useQueryState(
-    'productId',
-    parseAsArrayOf(parseAsString),
-  )
+  const [productIds] = useQueryState('productId', parseAsArrayOf(parseAsString))
 
   const [sorting, setSorting] = useQueryState(
     'sorting',
-    parseAsStringLiteral([
-      '-created_at',
-      'created_at',
-      'label',
-      '-label',
-    ] as const).withDefault('-created_at'),
+    parseAsStringLiteral(['label', '-label'] as const).withDefault('label'),
   )
 
   const [createCheckoutLinkQuerystring, setCreateCheckoutLinkQuerystring] =
@@ -96,6 +88,23 @@ export const CheckoutLinkListSidebar = ({
     return null
   }, [pathname])
 
+  const handleProductIdsChange = useCallback(
+    (productIds: string[]) => {
+      const params = new URLSearchParams(searchParams.toString())
+      if (productIds.length > 0) {
+        params.set('productId', productIds.join(','))
+      } else {
+        params.delete('productId')
+      }
+      const queryString = params.toString()
+
+      pushRouteWithoutCache(
+        `/dashboard/${organization.slug}/products/checkout-links${queryString ? `?${queryString}` : ''}`,
+      )
+    },
+    [searchParams, pushRouteWithoutCache, organization.slug],
+  )
+
   const handleCreateCheckoutLinkClose = useCallback(
     (checkoutLink: schemas['CheckoutLink']) => {
       hideCreateCheckoutLinkModal()
@@ -127,12 +136,10 @@ export const CheckoutLinkListSidebar = ({
               size="icon"
               className="h-6 w-6"
               onClick={() =>
-                setSorting(
-                  sorting === '-created_at' ? 'created_at' : '-created_at',
-                )
+                setSorting(sorting === 'label' ? '-label' : 'label')
               }
             >
-              {sorting === 'created_at' ? (
+              {sorting === 'label' ? (
                 <ArrowUpward fontSize="small" />
               ) : (
                 <ArrowDownward fontSize="small" />
@@ -151,7 +158,7 @@ export const CheckoutLinkListSidebar = ({
           <ProductSelect
             organization={organization}
             value={productIds ?? []}
-            onChange={(productIds) => setProductIds(productIds)}
+            onChange={handleProductIdsChange}
           />
         </div>
         <div className="dark:divide-polar-800 flex h-full grow flex-col divide-y divide-gray-50 overflow-y-auto">


### PR DESCRIPTION
## Summary

**Related Issue**: polarsource/feedback#352

Adresses two customer issues with the checkout links page:

- Checkout links were not alphabetically sorted so it was hard to find one when you have lots (50)
- When changing the product filter in the sidebar, the main panel did not change and displayed a stale checkout link so customer could end up editing one that they did not intend.

## How

- Changed sidebar list to be alphabetically sorted instead of creation order
- On product filter change recalculate which checkout link detail to show


<details>
<summary>Video showing checkout link details change</summary>


https://github.com/user-attachments/assets/81df837c-2a47-40f1-9541-1813c7f8fa02


</details>

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included
