### PR TITLE
feat(merchant-migration): cut over on the merchant's confirmation

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -5338,6 +5338,30 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/merchant-migrations/{id}/cutover': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get Merchant Migration Cutover
+     * @description **Scopes**: `organizations:write`
+     */
+    get: operations['merchant-migrations:cutover']
+    put?: never
+    /**
+     * Retry Merchant Migration Cutover
+     * @description **Scopes**: `organizations:write`
+     */
+    post: operations['merchant-migrations:retry_cutover']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/merchant-migrations/{id}/records/summary': {
     parameters: {
       query?: never
@@ -19748,6 +19772,17 @@ export interface components {
       | '-created_at'
       | 'balance'
       | '-balance'
+    /** CutoverNotStarted */
+    CutoverNotStarted: {
+      /**
+       * Error
+       * @example CutoverNotStarted
+       * @constant
+       */
+      error: 'CutoverNotStarted'
+      /** Detail */
+      detail: string
+    }
     /**
      * DataTableBlock
      * @description Tabular entities (orders, subscriptions, customers, ...).
@@ -23683,6 +23718,57 @@ export interface components {
        */
       api_key: string
     }
+    /**
+     * MerchantMigrationCutoverReport
+     * @description Where the cutover has got to, for the imported subscriptions.
+     */
+    MerchantMigrationCutoverReport: {
+      /**
+       * Started
+       * @description Whether the merchant has triggered the cutover.
+       */
+      started: boolean
+      /**
+       * Completed
+       * @description Whether Polar has finished going through every subscription.
+       */
+      completed: boolean
+      /**
+       * Total
+       * @description Imported subscriptions the cutover looks at.
+       */
+      total: number
+      /**
+       * Pending
+       * @description Not looked at yet.
+       */
+      pending: number
+      /**
+       * Moved
+       * @description Now billed by Polar, and stopped on the source.
+       */
+      moved: number
+      /**
+       * Skipped
+       * @description Left on the source, each with a reason on its record. Retryable once the merchant has dealt with the reason.
+       */
+      skipped: number
+      /**
+       * Failed
+       * @description Hit an unexpected error. Safe to retry as-is.
+       */
+      failed: number
+    }
+    /**
+     * MerchantMigrationCutoverStatus
+     * @description What the cutover did with an imported subscription.
+     *
+     *     Only subscription records ever carry one, and only once the cutover has
+     *     looked at them: ``None`` means "not attempted", which is also what every
+     *     other record type keeps forever.
+     * @enum {string}
+     */
+    MerchantMigrationCutoverStatus: 'moved' | 'skipped' | 'failed'
     /** MerchantMigrationImportReport */
     MerchantMigrationImportReport: {
       /** @description The migration step after the import. */
@@ -23800,6 +23886,15 @@ export interface components {
       reason_code: string | null
       /** @description How urgent `reason` is: `action_required` when the merchant has to fix something, `info` when there is nothing to fix. Null without a reason. */
       reason_level: components['schemas']['PrecheckReasonLevel'] | null
+      /** @description What the cutover did with this subscription: `moved` (Polar bills it now), `skipped` (left on the source, see `cutover_error`) or `failed` (retryable). Null when the cutover hasn't reached it, and for every entity other than subscriptions. */
+      cutover_status:
+        | components['schemas']['MerchantMigrationCutoverStatus']
+        | null
+      /**
+       * Cutover Error
+       * @description Why the cutover skipped or failed this subscription.
+       */
+      cutover_error: string | null
     }
     /**
      * MerchantMigrationRecordStatus
@@ -52910,6 +53005,113 @@ export interface operations {
       }
     }
   }
+  'merchant-migrations:cutover': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationCutoverReport']
+        }
+      }
+      /** @description Not allowed to manage this organization. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['NotPermitted']
+        }
+      }
+      /** @description Merchant migration not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'merchant-migrations:retry_cutover': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationCutoverReport']
+        }
+      }
+      /** @description Not allowed to manage this organization. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['NotPermitted']
+        }
+      }
+      /** @description Merchant migration not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationNotFound']
+        }
+      }
+      /** @description The cutover step hasn't been confirmed yet. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['CutoverNotStarted']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
   'merchant-migrations:records_summary': {
     parameters: {
       query?: never
@@ -52978,6 +53180,9 @@ export interface operations {
         reason_level?: components['schemas']['PrecheckReasonLevel'] | null
         import_status?:
           | components['schemas']['MerchantMigrationRecordStatus']
+          | null
+        cutover_status?:
+          | components['schemas']['MerchantMigrationCutoverStatus']
           | null
         /** @description Page number, defaults to 1. */
         page?: number
@@ -65690,6 +65895,9 @@ export const memberRoleValues: ReadonlyArray<
 export const memberSortPropertyValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['MemberSortProperty']
 > = ['created_at', '-created_at']
+export const merchantMigrationCutoverStatusValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['MerchantMigrationCutoverStatus']
+> = ['moved', 'skipped', 'failed']
 export const merchantMigrationRecordStatusValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['MerchantMigrationRecordStatus']
 > = ['pending', 'imported', 'skipped', 'failed']

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -5338,6 +5338,30 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/merchant-migrations/{id}/cutover': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /**
+     * Get Merchant Migration Cutover
+     * @description **Scopes**: `organizations:write`
+     */
+    get: operations['merchant-migrations:cutover']
+    put?: never
+    /**
+     * Retry Merchant Migration Cutover
+     * @description **Scopes**: `organizations:write`
+     */
+    post: operations['merchant-migrations:retry_cutover']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/merchant-migrations/{id}/records/summary': {
     parameters: {
       query?: never
@@ -19748,6 +19772,17 @@ export interface components {
       | '-created_at'
       | 'balance'
       | '-balance'
+    /** CutoverNotStarted */
+    CutoverNotStarted: {
+      /**
+       * Error
+       * @example CutoverNotStarted
+       * @constant
+       */
+      error: 'CutoverNotStarted'
+      /** Detail */
+      detail: string
+    }
     /**
      * DataTableBlock
      * @description Tabular entities (orders, subscriptions, customers, ...).
@@ -23630,6 +23665,57 @@ export interface components {
        */
       api_key: string
     }
+    /**
+     * MerchantMigrationCutoverReport
+     * @description Where the cutover has got to, for the imported subscriptions.
+     */
+    MerchantMigrationCutoverReport: {
+      /**
+       * Started
+       * @description Whether the merchant has triggered the cutover.
+       */
+      started: boolean
+      /**
+       * Completed
+       * @description Whether Polar has finished going through every subscription.
+       */
+      completed: boolean
+      /**
+       * Total
+       * @description Imported subscriptions the cutover looks at.
+       */
+      total: number
+      /**
+       * Pending
+       * @description Not looked at yet.
+       */
+      pending: number
+      /**
+       * Moved
+       * @description Now billed by Polar, and stopped on the source.
+       */
+      moved: number
+      /**
+       * Skipped
+       * @description Left on the source, each with a reason on its record. Retryable once the merchant has dealt with the reason.
+       */
+      skipped: number
+      /**
+       * Failed
+       * @description Hit an unexpected error. Safe to retry as-is.
+       */
+      failed: number
+    }
+    /**
+     * MerchantMigrationCutoverStatus
+     * @description What the cutover did with an imported subscription.
+     *
+     *     Only subscription records ever carry one, and only once the cutover has
+     *     looked at them: ``None`` means "not attempted", which is also what every
+     *     other record type keeps forever.
+     * @enum {string}
+     */
+    MerchantMigrationCutoverStatus: 'moved' | 'skipped' | 'failed'
     /** MerchantMigrationImportReport */
     MerchantMigrationImportReport: {
       /** @description The migration step after the import. */
@@ -23747,6 +23833,15 @@ export interface components {
       reason_code: string | null
       /** @description How urgent `reason` is: `action_required` when the merchant has to fix something, `info` when there is nothing to fix. Null without a reason. */
       reason_level: components['schemas']['PrecheckReasonLevel'] | null
+      /** @description What the cutover did with this subscription: `moved` (Polar bills it now), `skipped` (left on the source, see `cutover_error`) or `failed` (retryable). Null when the cutover hasn't reached it, and for every entity other than subscriptions. */
+      cutover_status:
+        | components['schemas']['MerchantMigrationCutoverStatus']
+        | null
+      /**
+       * Cutover Error
+       * @description Why the cutover skipped or failed this subscription.
+       */
+      cutover_error: string | null
     }
     /**
      * MerchantMigrationRecordStatus
@@ -52854,6 +52949,113 @@ export interface operations {
       }
     }
   }
+  'merchant-migrations:cutover': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationCutoverReport']
+        }
+      }
+      /** @description Not allowed to manage this organization. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['NotPermitted']
+        }
+      }
+      /** @description Merchant migration not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationNotFound']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
+  'merchant-migrations:retry_cutover': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        id: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationCutoverReport']
+        }
+      }
+      /** @description Not allowed to manage this organization. */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['NotPermitted']
+        }
+      }
+      /** @description Merchant migration not found. */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['MerchantMigrationNotFound']
+        }
+      }
+      /** @description The cutover step hasn't been confirmed yet. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['CutoverNotStarted']
+        }
+      }
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['HTTPValidationError']
+        }
+      }
+    }
+  }
   'merchant-migrations:records_summary': {
     parameters: {
       query?: never
@@ -52922,6 +53124,9 @@ export interface operations {
         reason_level?: components['schemas']['PrecheckReasonLevel'] | null
         import_status?:
           | components['schemas']['MerchantMigrationRecordStatus']
+          | null
+        cutover_status?:
+          | components['schemas']['MerchantMigrationCutoverStatus']
           | null
         /** @description Page number, defaults to 1. */
         page?: number
@@ -65631,6 +65836,9 @@ export const memberRoleValues: ReadonlyArray<
 export const memberSortPropertyValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['MemberSortProperty']
 > = ['created_at', '-created_at']
+export const merchantMigrationCutoverStatusValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['MerchantMigrationCutoverStatus']
+> = ['moved', 'skipped', 'failed']
 export const merchantMigrationRecordStatusValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['MerchantMigrationRecordStatus']
 > = ['pending', 'imported', 'skipped', 'failed']

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -7,7 +7,10 @@ from polar.exceptions import NotPermitted, ResourceNotFound
 from polar.kit.db.postgres import AsyncSession
 from polar.kit.pagination import ListResource, PaginationParamsQuery
 from polar.models import MerchantMigration
-from polar.models.merchant_migration_record import MerchantMigrationRecordStatus
+from polar.models.merchant_migration_record import (
+    MerchantMigrationCutoverStatus,
+    MerchantMigrationRecordStatus,
+)
 from polar.openapi import APITag
 from polar.organization.schemas import OrganizationID
 from polar.postgres import AsyncReadSession, get_db_read_session, get_db_session
@@ -26,6 +29,7 @@ from .pan_transfer import (
 from .schemas import MerchantMigration as MerchantMigrationSchema
 from .schemas import (
     MerchantMigrationCreate,
+    MerchantMigrationCutoverReport,
     MerchantMigrationImportReport,
     MerchantMigrationImportRequest,
     MerchantMigrationRecordItem,
@@ -40,6 +44,7 @@ from .schemas import (
 from .service import (
     CatalogImportBlocked,
     CatalogImportNotReady,
+    CutoverNotStarted,
     InvalidSourceCredentials,
     MerchantMigrationNotEnabled,
     MerchantMigrationNotFound,
@@ -293,6 +298,60 @@ async def complete_pan_transfer_step(
 
 
 @router.get(
+    "/{id}/cutover",
+    response_model=MerchantMigrationCutoverReport,
+    summary="Get Merchant Migration Cutover",
+    responses={
+        403: {
+            "description": "Not allowed to manage this organization.",
+            "model": NotPermitted.schema(),
+        },
+        404: {
+            "description": "Merchant migration not found.",
+            "model": MerchantMigrationNotFound.schema(),
+        },
+    },
+)
+async def cutover(
+    id: UUID4,
+    auth_subject: MerchantMigrationWrite,
+    # The primary: the client polls this as the cutover runs, and replica lag
+    # would report subscriptions as still pending after they've moved.
+    session: AsyncSession = Depends(get_db_session),
+) -> MerchantMigrationCutoverReport:
+    return await merchant_migration_service.get_cutover_report(
+        session, auth_subject, id
+    )
+
+
+@router.post(
+    "/{id}/cutover",
+    response_model=MerchantMigrationCutoverReport,
+    summary="Retry Merchant Migration Cutover",
+    responses={
+        403: {
+            "description": "Not allowed to manage this organization.",
+            "model": NotPermitted.schema(),
+        },
+        404: {
+            "description": "Merchant migration not found.",
+            "model": MerchantMigrationNotFound.schema(),
+        },
+        409: {
+            "description": "The cutover step hasn't been confirmed yet.",
+            "model": CutoverNotStarted.schema(),
+        },
+    },
+)
+async def retry_cutover(
+    id: UUID4,
+    auth_subject: MerchantMigrationWrite,
+    session: AsyncSession = Depends(get_db_session),
+) -> MerchantMigrationCutoverReport:
+    return await merchant_migration_service.retry_cutover(session, auth_subject, id)
+
+
+@router.get(
     "/{id}/records/summary",
     response_model=MerchantMigrationRecordSummary,
     summary="Summarize Merchant Migration Records",
@@ -349,6 +408,7 @@ async def records(
     status: Annotated[PrecheckRecordStatus | None, Query()] = None,
     reason_level: Annotated[PrecheckReasonLevel | None, Query()] = None,
     import_status: Annotated[MerchantMigrationRecordStatus | None, Query()] = None,
+    cutover_status: Annotated[MerchantMigrationCutoverStatus | None, Query()] = None,
     # The primary, like the summary above: it supplies the selection ceiling
     # and these rows supply the checkboxes, so a split would let replica lag
     # show a tickable row the count doesn't include.
@@ -362,6 +422,7 @@ async def records(
         status=status,
         reason_level=reason_level,
         import_status=import_status,
+        cutover_status=cutover_status,
         pagination=pagination,
     )
     return ListResource.from_paginated_results(items, count, pagination)

--- a/server/polar/merchant_migration/precheck.py
+++ b/server/polar/merchant_migration/precheck.py
@@ -636,10 +636,12 @@ def _item(
     reason = skip or note
     price = price or PriceDisplay()
     return MerchantMigrationRecordItem(
-        # record_id and import_status come from the ledger via
-        # `_attach_record_ids`; the classifier itself has none.
+        # record_id, import_status and the cutover outcome come from the ledger
+        # via `_attach_record_ids`; the classifier itself has none.
         record_id=None,
         import_status=None,
+        cutover_status=None,
+        cutover_error=None,
         entity=entity,
         source_id=source_id,
         title=title,

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -12,6 +12,7 @@ from polar.kit.repository import (
 )
 from polar.models import MerchantMigration, MerchantMigrationRecord, Subscription
 from polar.models.merchant_migration_record import (
+    MerchantMigrationCutoverStatus,
     MerchantMigrationRecordStatus,
     MerchantMigrationRecordType,
 )
@@ -109,6 +110,40 @@ class MerchantMigrationRecordRepository(
             statement = statement.limit(limit)
         return await self.get_all(statement)
 
+    async def get_next_cutover_candidate(
+        self, migration_id: UUID
+    ) -> MerchantMigrationRecord | None:
+        """Claim the next subscription the cutover hasn't settled yet.
+
+        Locked and skipping locked rows, so a second run started by an impatient
+        merchant works alongside the first instead of moving the same
+        subscription twice.
+        """
+        statement = (
+            self._imported_subscriptions_statement(migration_id)
+            .where(MerchantMigrationRecord.cutover_status.is_(None))
+            .limit(1)
+            .with_for_update(of=MerchantMigrationRecord, skip_locked=True)
+        )
+        return await self.get_one_or_none(statement)
+
+    async def count_cutover_statuses(
+        self, migration_id: UUID
+    ) -> dict[MerchantMigrationCutoverStatus | None, int]:
+        """How the cutover has settled the imported subscriptions so far, with
+        ``None`` counting the ones it hasn't reached."""
+        statement = (
+            self._imported_subscriptions_statement(migration_id)
+            .with_only_columns(
+                MerchantMigrationRecord.cutover_status,
+                func.count(MerchantMigrationRecord.id),
+            )
+            .order_by(None)
+            .group_by(MerchantMigrationRecord.cutover_status)
+        )
+        result = await self.session.execute(statement)
+        return {status: count for status, count in result.all()}
+
     async def count_linked_cards(self, migration_id: UUID) -> tuple[int, int]:
         """``(with a card, total)`` over the imported subscriptions: what the
         card check reports back to the merchant."""
@@ -127,6 +162,26 @@ class MerchantMigrationRecordRepository(
         )
         linked, total = (await self.session.execute(statement)).one()
         return linked, total
+
+    async def reset_cutover(self, migration_id: UUID) -> None:
+        """Clear the settled-but-not-moved outcomes so a retry looks at them
+        again. What moved stays moved."""
+        statement = (
+            self._imported_subscriptions_statement(migration_id)
+            .where(
+                MerchantMigrationRecord.cutover_status.in_(
+                    (
+                        MerchantMigrationCutoverStatus.skipped,
+                        MerchantMigrationCutoverStatus.failed,
+                    )
+                )
+            )
+            .order_by(None)
+        )
+        for record in await self.get_all(statement):
+            await self.update(
+                record, update_dict={"cutover_status": None, "cutover_error": None}
+            )
 
     async def upsert(
         self,

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -14,6 +14,7 @@ from polar.kit.repository import (
 )
 from polar.models import MerchantMigration, MerchantMigrationRecord, Subscription
 from polar.models.merchant_migration_record import (
+    MerchantMigrationCutoverStatus,
     MerchantMigrationRecordStatus,
     MerchantMigrationRecordType,
 )
@@ -272,6 +273,40 @@ class MerchantMigrationRecordRepository(
             statement = statement.limit(limit)
         return await self.get_all(statement)
 
+    async def get_next_cutover_candidate(
+        self, migration_id: UUID
+    ) -> MerchantMigrationRecord | None:
+        """Claim the next subscription the cutover hasn't settled yet.
+
+        Locked and skipping locked rows, so a second run started by an impatient
+        merchant works alongside the first instead of moving the same
+        subscription twice.
+        """
+        statement = (
+            self._imported_subscriptions_statement(migration_id)
+            .where(MerchantMigrationRecord.cutover_status.is_(None))
+            .limit(1)
+            .with_for_update(of=MerchantMigrationRecord, skip_locked=True)
+        )
+        return await self.get_one_or_none(statement)
+
+    async def count_cutover_statuses(
+        self, migration_id: UUID
+    ) -> dict[MerchantMigrationCutoverStatus | None, int]:
+        """How the cutover has settled the imported subscriptions so far, with
+        ``None`` counting the ones it hasn't reached."""
+        statement = (
+            self._imported_subscriptions_statement(migration_id)
+            .with_only_columns(
+                MerchantMigrationRecord.cutover_status,
+                func.count(MerchantMigrationRecord.id),
+            )
+            .order_by(None)
+            .group_by(MerchantMigrationRecord.cutover_status)
+        )
+        result = await self.session.execute(statement)
+        return {status: count for status, count in result.all()}
+
     async def count_linked_payment_methods(self, migration_id: UUID) -> tuple[int, int]:
         """``(with a method to charge, total)`` over the imported subscriptions.
 
@@ -294,6 +329,26 @@ class MerchantMigrationRecordRepository(
         )
         linked, total = (await self.session.execute(statement)).one()
         return linked, total
+
+    async def reset_cutover(self, migration_id: UUID) -> None:
+        """Clear the settled-but-not-moved outcomes so a retry looks at them
+        again. What moved stays moved."""
+        statement = (
+            self._imported_subscriptions_statement(migration_id)
+            .where(
+                MerchantMigrationRecord.cutover_status.in_(
+                    (
+                        MerchantMigrationCutoverStatus.skipped,
+                        MerchantMigrationCutoverStatus.failed,
+                    )
+                )
+            )
+            .order_by(None)
+        )
+        for record in await self.get_all(statement):
+            await self.update(
+                record, update_dict={"cutover_status": None, "cutover_error": None}
+            )
 
     async def upsert(
         self,

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -9,7 +9,10 @@ from polar.models.merchant_migration import (
     MerchantMigrationSourcePlatform,
     MerchantMigrationStep,
 )
-from polar.models.merchant_migration_record import MerchantMigrationRecordStatus
+from polar.models.merchant_migration_record import (
+    MerchantMigrationCutoverStatus,
+    MerchantMigrationRecordStatus,
+)
 
 from .pan_transfer import PanTransferMethod, PanTransferStep
 
@@ -122,6 +125,17 @@ class MerchantMigrationRecordItem(Schema):
             "reason."
         )
     )
+    cutover_status: MerchantMigrationCutoverStatus | None = Field(
+        description=(
+            "What the cutover did with this subscription: `moved` (Polar bills "
+            "it now), `skipped` (left on the source, see `cutover_error`) or "
+            "`failed` (retryable). Null when the cutover hasn't reached it, and "
+            "for every entity other than subscriptions."
+        )
+    )
+    cutover_error: str | None = Field(
+        description="Why the cutover skipped or failed this subscription."
+    )
 
 
 class MerchantMigrationRecordSummaryEntity(PrecheckEntitySummary):
@@ -182,6 +196,25 @@ class MerchantMigrationImportReport(Schema):
     results: list[MerchantMigrationImportResult] = Field(
         description="Per-entity counts of what was imported vs skipped."
     )
+
+
+class MerchantMigrationCutoverReport(Schema):
+    """Where the cutover has got to, for the imported subscriptions."""
+
+    started: bool = Field(description="Whether the merchant has triggered the cutover.")
+    completed: bool = Field(
+        description="Whether Polar has finished going through every subscription."
+    )
+    total: int = Field(description="Imported subscriptions the cutover looks at.")
+    pending: int = Field(description="Not looked at yet.")
+    moved: int = Field(description="Now billed by Polar, and stopped on the source.")
+    skipped: int = Field(
+        description=(
+            "Left on the source, each with a reason on its record. Retryable "
+            "once the merchant has dealt with the reason."
+        )
+    )
+    failed: int = Field(description="Hit an unexpected error. Safe to retry as-is.")
 
 
 class PanTransferStepComplete(Schema):

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -21,6 +21,7 @@ from polar.models.merchant_migration import (
     MerchantMigrationStep,
 )
 from polar.models.merchant_migration_record import (
+    MerchantMigrationCutoverStatus,
     MerchantMigrationRecordStatus,
     MerchantMigrationRecordType,
 )
@@ -34,9 +35,12 @@ from . import pan_transfer
 from .adapters import SourceAdapter, StripeAdapter
 from .canonical import CanonicalRecord, deserialize
 from .cards import link_payment_method
+from .cutover import SubscriptionCutover
 from .errors import MerchantMigrationError
 from .importer import CatalogImporter
 from .pan_transfer import (
+    STEP_CUTOVER,
+    STEP_MOVE_SUBSCRIPTIONS,
     STEP_RESOLVE_UNCOVERED,
     STEP_VERIFY_CARDS,
     PanStepActor,
@@ -59,6 +63,7 @@ from .repository import (
 )
 from .schemas import (
     MerchantMigrationCreate,
+    MerchantMigrationCutoverReport,
     MerchantMigrationImportReport,
     MerchantMigrationRecordItem,
     MerchantMigrationRecordSummary,
@@ -96,6 +101,14 @@ SOURCE_CREDENTIALS_ENCRYPTION_CONTEXT = {
 # schedules the work, and the work is what completes it.
 POLAR_APP_STEP_TASKS = {
     STEP_VERIFY_CARDS: "merchant_migration.verify_cards",
+    STEP_MOVE_SUBSCRIPTIONS: "merchant_migration.cutover",
+}
+
+# Where the checklist sits maps onto the migration's coarse step. Everything up
+# to the move is card movement; the move is its own phase, and finishing it hands
+# the merchant back the last job — switching their own billing off.
+_MIGRATION_STEP_BY_PAN_STEP = {
+    STEP_MOVE_SUBSCRIPTIONS: MerchantMigrationStep.activate_subscriptions,
 }
 
 # How many subscriptions one card-check run looks at before handing over to the
@@ -163,6 +176,13 @@ class SourceVerificationUnavailable(MerchantMigrationError):
         super().__init__(
             "We couldn't verify the Stripe key right now. Please try again.",
             502,
+        )
+
+
+class CutoverNotStarted(MerchantMigrationError):
+    def __init__(self) -> None:
+        super().__init__(
+            "Confirm the cutover step before moving subscriptions over.", 409
         )
 
 
@@ -533,12 +553,17 @@ class MerchantMigrationService:
         migration: MerchantMigration,
         steps: Sequence[PanTransferStep],
     ) -> None:
-        """Persist the checklist and schedule the job for a Polar-owned step."""
+        """Persist the checklist and set whatever the new current step implies
+        going: the migration's own step, and the job that runs a Polar-owned one.
+        """
         current = pan_transfer.current(steps)
+        update_dict: dict[str, object] = {"pan_transfer_steps": list(steps)}
+        if current is not None:
+            migration_step = _MIGRATION_STEP_BY_PAN_STEP.get(current.key)
+            if migration_step is not None:
+                update_dict["step"] = migration_step
         repository = MerchantMigrationRepository.from_session(session)
-        await repository.update(
-            migration, update_dict={"pan_transfer_steps": list(steps)}
-        )
+        await repository.update(migration, update_dict=update_dict)
 
         if current is None or current.owner != PanStepOwner.polar_app:
             return
@@ -665,6 +690,100 @@ class MerchantMigrationService:
             "Subscriptions without one stay on your old provider at cutover."
         )
 
+    async def run_cutover(self, session: AsyncSession, migration_id: UUID) -> None:
+        """Cut one subscription over, then hand off to the next run.
+
+        One subscription per run, each in its own transaction: the irreversible
+        half of a cutover is a cancellation on the merchant's own provider, and
+        a batch that dies halfway would replay it for everything it had already
+        done.
+        """
+        migration = await self._load(session, migration_id)
+        if migration is None:
+            return
+        if not self._cutover_started(migration):
+            # The merchant hasn't confirmed. Nothing may touch their source.
+            log.warning(
+                "merchant_migration.cutover.not_confirmed",
+                merchant_migration_id=migration.id,
+            )
+            return
+        organization = await self._get_organization(session, migration)
+        if not organization.can_renew_subscriptions:
+            # Activating subscriptions the organization can't bill would leave
+            # them live and uncollected. Stopping keeps them on the source.
+            log.warning(
+                "merchant_migration.cutover.renewals_disabled",
+                merchant_migration_id=migration.id,
+                organization_id=organization.id,
+            )
+            return
+
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        record = await record_repository.get_next_cutover_candidate(migration.id)
+        if record is None:
+            await self._finish_cutover(session, migration)
+            return
+
+        outcome = await SubscriptionCutover(
+            session, migration, await self._build_adapter(migration)
+        ).run(record)
+        await record_repository.update(
+            record,
+            update_dict={
+                "cutover_status": outcome.status,
+                "cutover_error": outcome.reason,
+            },
+        )
+        enqueue_job("merchant_migration.cutover", merchant_migration_id=migration.id)
+
+    async def _finish_cutover(
+        self, session: AsyncSession, migration: MerchantMigration
+    ) -> None:
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        counts = await record_repository.count_cutover_statuses(migration.id)
+        if counts.get(None, 0) > 0:
+            # Another run holds the rows we skipped over; it finishes the step.
+            return
+        completed = await self._complete_polar_app_step(
+            session, migration, STEP_MOVE_SUBSCRIPTIONS
+        )
+        if completed is None:
+            return
+        # `annotate` refuses a completed step, so the note goes on before the
+        # completion is persisted — it's the receipt the merchant reads after.
+        steps = list(completed)
+        note = self._cutover_note(counts)
+        for step in steps:
+            if step.key == STEP_MOVE_SUBSCRIPTIONS:
+                step.note = note
+        # Nothing follows the last step, so there is no next job to dispatch:
+        # what's left is the merchant turning their own billing off.
+        await MerchantMigrationRepository.from_session(session).update(
+            migration,
+            update_dict={
+                "pan_transfer_steps": steps,
+                "step": MerchantMigrationStep.cleanup,
+            },
+        )
+
+    def _cutover_note(
+        self, counts: dict[MerchantMigrationCutoverStatus | None, int]
+    ) -> str:
+        moved = counts.get(MerchantMigrationCutoverStatus.moved, 0)
+        left = counts.get(MerchantMigrationCutoverStatus.skipped, 0) + counts.get(
+            MerchantMigrationCutoverStatus.failed, 0
+        )
+        note = (
+            f"Polar now bills {moved} subscription(s), and stopped them on your source."
+        )
+        if left:
+            note += (
+                f" {left} stayed on your source; open the subscriptions list to see "
+                "why, and run the cutover again once they're sorted."
+            )
+        return note
+
     async def _complete_polar_app_step(
         self,
         session: AsyncSession,
@@ -684,6 +803,64 @@ class MerchantMigrationService:
             key,
             actor=PanStepActor.system,
             inputs={},
+        )
+
+    async def get_cutover_report(
+        self,
+        session: AsyncReadSession,
+        auth_subject: AuthSubject[User | Organization],
+        migration_id: UUID,
+    ) -> MerchantMigrationCutoverReport:
+        migration = await self._get_manageable(session, auth_subject, migration_id)
+        return await self._cutover_report(session, migration)
+
+    async def retry_cutover(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        migration_id: UUID,
+    ) -> MerchantMigrationCutoverReport:
+        """Look again at every subscription the cutover left on the source.
+
+        The reasons it recorded are mostly things the merchant can fix — a card
+        re-entered, a renewal that has since gone through — so a retry re-runs
+        the checks rather than trusting the last verdict.
+        """
+        migration = await self._get_manageable(
+            session, auth_subject, migration_id, for_update=True
+        )
+        if not self._cutover_started(migration):
+            raise CutoverNotStarted()
+
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        await record_repository.reset_cutover(migration.id)
+        enqueue_job("merchant_migration.cutover", merchant_migration_id=migration.id)
+        return await self._cutover_report(session, migration)
+
+    async def _cutover_report(
+        self, session: AsyncReadSession, migration: MerchantMigration
+    ) -> MerchantMigrationCutoverReport:
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        counts = await record_repository.count_cutover_statuses(migration.id)
+        return MerchantMigrationCutoverReport(
+            started=self._cutover_started(migration),
+            completed=self._step_completed(migration, STEP_MOVE_SUBSCRIPTIONS),
+            total=sum(counts.values()),
+            pending=counts.get(None, 0),
+            moved=counts.get(MerchantMigrationCutoverStatus.moved, 0),
+            skipped=counts.get(MerchantMigrationCutoverStatus.skipped, 0),
+            failed=counts.get(MerchantMigrationCutoverStatus.failed, 0),
+        )
+
+    def _cutover_started(self, migration: MerchantMigration) -> bool:
+        """The merchant has confirmed the cutover step, so Polar is allowed to
+        stop subscriptions on their source."""
+        return self._step_completed(migration, STEP_CUTOVER)
+
+    def _step_completed(self, migration: MerchantMigration, key: str) -> bool:
+        return any(
+            step.key == key and step.status == pan_transfer.PanStepStatus.completed
+            for step in migration.pan_transfer_steps
         )
 
     async def _load(
@@ -768,6 +945,7 @@ class MerchantMigrationService:
         status: PrecheckRecordStatus | None,
         reason_level: PrecheckReasonLevel | None = None,
         import_status: MerchantMigrationRecordStatus | None = None,
+        cutover_status: MerchantMigrationCutoverStatus | None = None,
         pagination: PaginationParams,
     ) -> tuple[Sequence[MerchantMigrationRecordItem], int]:
         """Return staged records classified importable/skipped and paginated in
@@ -776,7 +954,9 @@ class MerchantMigrationService:
         ``reason_level`` filters to rows the merchant has to act on
         (`action_required`) or only needs to know about (`info`);
         ``import_status`` filters on the ledger outcome, which excludes price rows
-        since they have none. Reads what ``run_precheck`` persisted."""
+        since they have none; ``cutover_status`` narrows to what the cutover did
+        with a subscription, which is how the merchant finds the ones it left on
+        the source. Reads what ``run_precheck`` persisted."""
         migration = await self._get_manageable(session, auth_subject, migration_id)
         entities = [entity] if entity is not None else list(_ENTITY_RECORD_TYPE)
         items = await self._classify_staged(session, migration, entities)
@@ -787,6 +967,8 @@ class MerchantMigrationService:
             items = [item for item in items if item.reason_level == reason_level]
         if import_status is not None:
             items = [item for item in items if item.import_status == import_status]
+        if cutover_status is not None:
+            items = [item for item in items if item.cutover_status == cutover_status]
 
         start = (pagination.page - 1) * pagination.limit
         return items[start : start + pagination.limit], len(items)
@@ -867,6 +1049,8 @@ class MerchantMigrationService:
         for item, record in zip(items, staged_of_type, strict=True):
             item.record_id = record.id
             item.import_status = record.status
+            item.cutover_status = record.cutover_status
+            item.cutover_error = record.cutover_error
 
     async def _stage_records(
         self,

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -20,6 +20,7 @@ from polar.models.merchant_migration import (
     MerchantMigrationStep,
 )
 from polar.models.merchant_migration_record import (
+    MerchantMigrationCutoverStatus,
     MerchantMigrationRecordStatus,
     MerchantMigrationRecordType,
 )
@@ -33,9 +34,12 @@ from . import pan_transfer
 from .adapters import SourceAdapter, StripeAdapter
 from .canonical import CanonicalRecord, deserialize
 from .cards import link_payment_method
+from .cutover import SubscriptionCutover
 from .errors import MerchantMigrationError
 from .importer import CatalogImporter
 from .pan_transfer import (
+    STEP_CUTOVER,
+    STEP_MOVE_SUBSCRIPTIONS,
     STEP_RESOLVE_UNCOVERED,
     STEP_VERIFY_CARDS,
     PanStepActor,
@@ -58,6 +62,7 @@ from .repository import (
 )
 from .schemas import (
     MerchantMigrationCreate,
+    MerchantMigrationCutoverReport,
     MerchantMigrationImportReport,
     MerchantMigrationRecordItem,
     MerchantMigrationRecordSummary,
@@ -95,6 +100,14 @@ SOURCE_CREDENTIALS_ENCRYPTION_CONTEXT = {
 # schedules the work, and the work is what completes it.
 POLAR_APP_STEP_TASKS = {
     STEP_VERIFY_CARDS: "merchant_migration.verify_cards",
+    STEP_MOVE_SUBSCRIPTIONS: "merchant_migration.cutover",
+}
+
+# Where the checklist sits maps onto the migration's coarse step. Everything up
+# to the move is card movement; the move is its own phase, and finishing it hands
+# the merchant back the last job — switching their own billing off.
+_MIGRATION_STEP_BY_PAN_STEP = {
+    STEP_MOVE_SUBSCRIPTIONS: MerchantMigrationStep.activate_subscriptions,
 }
 
 # How many subscriptions one card-check run looks at before handing over to the
@@ -162,6 +175,13 @@ class SourceVerificationUnavailable(MerchantMigrationError):
         super().__init__(
             "We couldn't verify the Stripe key right now. Please try again.",
             502,
+        )
+
+
+class CutoverNotStarted(MerchantMigrationError):
+    def __init__(self) -> None:
+        super().__init__(
+            "Confirm the cutover step before moving subscriptions over.", 409
         )
 
 
@@ -497,12 +517,17 @@ class MerchantMigrationService:
         migration: MerchantMigration,
         steps: Sequence[PanTransferStep],
     ) -> None:
-        """Persist the checklist and schedule the job for a Polar-owned step."""
+        """Persist the checklist and set whatever the new current step implies
+        going: the migration's own step, and the job that runs a Polar-owned one.
+        """
         current = pan_transfer.current(steps)
+        update_dict: dict[str, object] = {"pan_transfer_steps": list(steps)}
+        if current is not None:
+            migration_step = _MIGRATION_STEP_BY_PAN_STEP.get(current.key)
+            if migration_step is not None:
+                update_dict["step"] = migration_step
         repository = MerchantMigrationRepository.from_session(session)
-        await repository.update(
-            migration, update_dict={"pan_transfer_steps": list(steps)}
-        )
+        await repository.update(migration, update_dict=update_dict)
 
         if current is None or current.owner != PanStepOwner.polar_app:
             return
@@ -596,6 +621,100 @@ class MerchantMigrationService:
             "Subscriptions without a card stay on your old provider at cutover."
         )
 
+    async def run_cutover(self, session: AsyncSession, migration_id: UUID) -> None:
+        """Cut one subscription over, then hand off to the next run.
+
+        One subscription per run, each in its own transaction: the irreversible
+        half of a cutover is a cancellation on the merchant's own provider, and
+        a batch that dies halfway would replay it for everything it had already
+        done.
+        """
+        migration = await self._load(session, migration_id)
+        if migration is None:
+            return
+        if not self._cutover_started(migration):
+            # The merchant hasn't confirmed. Nothing may touch their source.
+            log.warning(
+                "merchant_migration.cutover.not_confirmed",
+                merchant_migration_id=migration.id,
+            )
+            return
+        organization = await self._get_organization(session, migration)
+        if not organization.can_renew_subscriptions:
+            # Activating subscriptions the organization can't bill would leave
+            # them live and uncollected. Stopping keeps them on the source.
+            log.warning(
+                "merchant_migration.cutover.renewals_disabled",
+                merchant_migration_id=migration.id,
+                organization_id=organization.id,
+            )
+            return
+
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        record = await record_repository.get_next_cutover_candidate(migration.id)
+        if record is None:
+            await self._finish_cutover(session, migration)
+            return
+
+        outcome = await SubscriptionCutover(
+            session, migration, await self._build_adapter(migration)
+        ).run(record)
+        await record_repository.update(
+            record,
+            update_dict={
+                "cutover_status": outcome.status,
+                "cutover_error": outcome.reason,
+            },
+        )
+        enqueue_job("merchant_migration.cutover", merchant_migration_id=migration.id)
+
+    async def _finish_cutover(
+        self, session: AsyncSession, migration: MerchantMigration
+    ) -> None:
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        counts = await record_repository.count_cutover_statuses(migration.id)
+        if counts.get(None, 0) > 0:
+            # Another run holds the rows we skipped over; it finishes the step.
+            return
+        completed = await self._complete_polar_app_step(
+            session, migration, STEP_MOVE_SUBSCRIPTIONS
+        )
+        if completed is None:
+            return
+        # `annotate` refuses a completed step, so the note goes on before the
+        # completion is persisted — it's the receipt the merchant reads after.
+        steps = list(completed)
+        note = self._cutover_note(counts)
+        for step in steps:
+            if step.key == STEP_MOVE_SUBSCRIPTIONS:
+                step.note = note
+        # Nothing follows the last step, so there is no next job to dispatch:
+        # what's left is the merchant turning their own billing off.
+        await MerchantMigrationRepository.from_session(session).update(
+            migration,
+            update_dict={
+                "pan_transfer_steps": steps,
+                "step": MerchantMigrationStep.cleanup,
+            },
+        )
+
+    def _cutover_note(
+        self, counts: dict[MerchantMigrationCutoverStatus | None, int]
+    ) -> str:
+        moved = counts.get(MerchantMigrationCutoverStatus.moved, 0)
+        left = counts.get(MerchantMigrationCutoverStatus.skipped, 0) + counts.get(
+            MerchantMigrationCutoverStatus.failed, 0
+        )
+        note = (
+            f"Polar now bills {moved} subscription(s), and stopped them on your source."
+        )
+        if left:
+            note += (
+                f" {left} stayed on your source; open the subscriptions list to see "
+                "why, and run the cutover again once they're sorted."
+            )
+        return note
+
     async def _complete_polar_app_step(
         self,
         session: AsyncSession,
@@ -615,6 +734,64 @@ class MerchantMigrationService:
             key,
             actor=PanStepActor.system,
             inputs={},
+        )
+
+    async def get_cutover_report(
+        self,
+        session: AsyncReadSession,
+        auth_subject: AuthSubject[User | Organization],
+        migration_id: UUID,
+    ) -> MerchantMigrationCutoverReport:
+        migration = await self._get_manageable(session, auth_subject, migration_id)
+        return await self._cutover_report(session, migration)
+
+    async def retry_cutover(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User | Organization],
+        migration_id: UUID,
+    ) -> MerchantMigrationCutoverReport:
+        """Look again at every subscription the cutover left on the source.
+
+        The reasons it recorded are mostly things the merchant can fix — a card
+        re-entered, a renewal that has since gone through — so a retry re-runs
+        the checks rather than trusting the last verdict.
+        """
+        migration = await self._get_manageable(
+            session, auth_subject, migration_id, for_update=True
+        )
+        if not self._cutover_started(migration):
+            raise CutoverNotStarted()
+
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        await record_repository.reset_cutover(migration.id)
+        enqueue_job("merchant_migration.cutover", merchant_migration_id=migration.id)
+        return await self._cutover_report(session, migration)
+
+    async def _cutover_report(
+        self, session: AsyncReadSession, migration: MerchantMigration
+    ) -> MerchantMigrationCutoverReport:
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        counts = await record_repository.count_cutover_statuses(migration.id)
+        return MerchantMigrationCutoverReport(
+            started=self._cutover_started(migration),
+            completed=self._step_completed(migration, STEP_MOVE_SUBSCRIPTIONS),
+            total=sum(counts.values()),
+            pending=counts.get(None, 0),
+            moved=counts.get(MerchantMigrationCutoverStatus.moved, 0),
+            skipped=counts.get(MerchantMigrationCutoverStatus.skipped, 0),
+            failed=counts.get(MerchantMigrationCutoverStatus.failed, 0),
+        )
+
+    def _cutover_started(self, migration: MerchantMigration) -> bool:
+        """The merchant has confirmed the cutover step, so Polar is allowed to
+        stop subscriptions on their source."""
+        return self._step_completed(migration, STEP_CUTOVER)
+
+    def _step_completed(self, migration: MerchantMigration, key: str) -> bool:
+        return any(
+            step.key == key and step.status == pan_transfer.PanStepStatus.completed
+            for step in migration.pan_transfer_steps
         )
 
     async def _load(
@@ -699,6 +876,7 @@ class MerchantMigrationService:
         status: PrecheckRecordStatus | None,
         reason_level: PrecheckReasonLevel | None = None,
         import_status: MerchantMigrationRecordStatus | None = None,
+        cutover_status: MerchantMigrationCutoverStatus | None = None,
         pagination: PaginationParams,
     ) -> tuple[Sequence[MerchantMigrationRecordItem], int]:
         """Return staged records classified importable/skipped and paginated in
@@ -707,7 +885,9 @@ class MerchantMigrationService:
         ``reason_level`` filters to rows the merchant has to act on
         (`action_required`) or only needs to know about (`info`);
         ``import_status`` filters on the ledger outcome, which excludes price rows
-        since they have none. Reads what ``run_precheck`` persisted."""
+        since they have none; ``cutover_status`` narrows to what the cutover did
+        with a subscription, which is how the merchant finds the ones it left on
+        the source. Reads what ``run_precheck`` persisted."""
         migration = await self._get_manageable(session, auth_subject, migration_id)
         entities = [entity] if entity is not None else list(_ENTITY_RECORD_TYPE)
         items = await self._classify_staged(session, migration, entities)
@@ -718,6 +898,8 @@ class MerchantMigrationService:
             items = [item for item in items if item.reason_level == reason_level]
         if import_status is not None:
             items = [item for item in items if item.import_status == import_status]
+        if cutover_status is not None:
+            items = [item for item in items if item.cutover_status == cutover_status]
 
         start = (pagination.page - 1) * pagination.limit
         return items[start : start + pagination.limit], len(items)
@@ -798,6 +980,8 @@ class MerchantMigrationService:
         for item, record in zip(items, staged_of_type, strict=True):
             item.record_id = record.id
             item.import_status = record.status
+            item.cutover_status = record.cutover_status
+            item.cutover_error = record.cutover_error
 
     async def _stage_records(
         self,

--- a/server/polar/merchant_migration/tasks.py
+++ b/server/polar/merchant_migration/tasks.py
@@ -14,3 +14,15 @@ async def merchant_migration_verify_cards(
         await merchant_migration_service.run_card_verification(
             session, merchant_migration_id, offset=offset
         )
+
+
+@actor(actor_name="merchant_migration.cutover", priority=TaskPriority.LOW)
+async def merchant_migration_cutover(merchant_migration_id: UUID) -> None:
+    """Hand billing over to Polar, one subscription per run.
+
+    Each run is its own transaction because the run cancels a subscription on the
+    merchant's provider: work already done must never be replayed by a retry of
+    work that came after it.
+    """
+    async with AsyncSessionMaker() as session:
+        await merchant_migration_service.run_cutover(session, merchant_migration_id)

--- a/server/tests/merchant_migration/_helpers.py
+++ b/server/tests/merchant_migration/_helpers.py
@@ -10,6 +10,7 @@ from polar.merchant_migration.canonical import (
     serialize,
 )
 from polar.merchant_migration.pan_transfer import (
+    STEP_MOVE_SUBSCRIPTIONS,
     PanStepActor,
     PanStepOwner,
     PanTransferMethod,
@@ -167,6 +168,11 @@ def steps_at(key: str) -> list[PanTransferStep]:
         steps = pan_transfer.complete(
             method, steps, current.key, actor=_actor_for(current.owner), inputs={}
         )
+
+
+def cutover_ready_steps() -> list[PanTransferStep]:
+    """Everything the merchant and Ops have to do is done; the move is next."""
+    return steps_at(STEP_MOVE_SUBSCRIPTIONS)
 
 
 def _actor_for(owner: PanStepOwner) -> PanStepActor:

--- a/server/tests/merchant_migration/_helpers.py
+++ b/server/tests/merchant_migration/_helpers.py
@@ -11,6 +11,7 @@ from polar.merchant_migration.canonical import (
     serialize,
 )
 from polar.merchant_migration.pan_transfer import (
+    STEP_MOVE_SUBSCRIPTIONS,
     PanStepActor,
     PanStepOwner,
     PanTransferMethod,
@@ -169,6 +170,11 @@ def steps_at(key: str) -> list[PanTransferStep]:
         steps = pan_transfer.complete(
             method, steps, current.key, actor=_actor_for(current.owner), inputs={}
         )
+
+
+def cutover_ready_steps() -> list[PanTransferStep]:
+    """Everything the merchant and Ops have to do is done; the move is next."""
+    return steps_at(STEP_MOVE_SUBSCRIPTIONS)
 
 
 def _actor_for(owner: PanStepOwner) -> PanStepActor:

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -27,6 +27,7 @@ from tests.fixtures.database import SaveFixture
 from tests.merchant_migration._helpers import (
     assert_no_migrations,
     build_connected_migration,
+    cutover_ready_steps,
 )
 
 VALID_BODY = {
@@ -736,6 +737,67 @@ class TestCompletePanTransferStep:
             f"/v1/merchant-migrations/{migration.id}/pan-transfer/steps/start_copy/complete"
         )
         assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+class TestCutover:
+    async def test_anonymous(
+        self, client: AsyncClient, save_fixture: SaveFixture, organization: Organization
+    ) -> None:
+        migration = await _create_migration(save_fixture, organization)
+        response = await client.get(f"/v1/merchant-migrations/{migration.id}/cutover")
+        assert response.status_code == 401
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_reports_nothing_before_the_checklist_reaches_it(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _create_migration(save_fixture, organization)
+
+        response = await client.get(f"/v1/merchant-migrations/{migration.id}/cutover")
+
+        assert response.status_code == 200
+        json_body = response.json()
+        assert json_body["started"] is False
+        assert json_body["completed"] is False
+        assert json_body["total"] == 0
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_retry_refused_before_the_merchant_confirms(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _create_migration(save_fixture, organization)
+
+        response = await client.post(f"/v1/merchant-migrations/{migration.id}/cutover")
+
+        assert response.status_code == 409
+
+    @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
+    async def test_retry_reopens_what_stayed_behind(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _create_migration(
+            save_fixture, organization, MerchantMigrationStep.activate_subscriptions
+        )
+        migration.pan_transfer_steps = cutover_ready_steps()
+        await save_fixture(migration)
+
+        response = await client.post(f"/v1/merchant-migrations/{migration.id}/cutover")
+
+        assert response.status_code == 200
+        assert response.json()["started"] is True
 
 
 async def _create_migration(

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -17,6 +17,7 @@ from polar.kit import encryption
 from polar.kit.encryption import LocalKeyProvider
 from polar.kit.pagination import PaginationParams
 from polar.kit.utils import utc_now
+from polar.merchant_migration import pan_transfer
 from polar.merchant_migration.canonical import (
     CanonicalAccount,
     CanonicalCollectionMethod,
@@ -29,6 +30,7 @@ from polar.merchant_migration.canonical import (
     CanonicalSubscriptionStatus,
 )
 from polar.merchant_migration.pan_transfer import (
+    PanTransferMethod,
     PanTransferStep,
 )
 from polar.merchant_migration.repository import (
@@ -44,6 +46,7 @@ from polar.merchant_migration.schemas import (
 from polar.merchant_migration.service import (
     CatalogImportBlocked,
     CatalogImportNotReady,
+    CutoverNotStarted,
     InvalidSourceCredentials,
     MissingStripeScopes,
     SourceAccountNotMigratable,
@@ -68,6 +71,7 @@ from polar.models.merchant_migration import (
     MerchantMigrationStep,
 )
 from polar.models.merchant_migration_record import (
+    MerchantMigrationCutoverStatus,
     MerchantMigrationRecordStatus,
     MerchantMigrationRecordType,
 )
@@ -82,6 +86,8 @@ from tests.fixtures.stripe import build_stripe_payment_method
 from tests.merchant_migration._helpers import (
     assert_no_migrations,
     build_connected_migration,
+    canonical_subscription,
+    cutover_ready_steps,
     stage_subscription_record,
     steps_at,
 )
@@ -1435,12 +1441,12 @@ async def _migration_at(
     save_fixture: SaveFixture,
     organization: Organization,
     *,
-    steps: list[PanTransferStep],
-    step: MerchantMigrationStep,
+    steps: list[PanTransferStep] | None = None,
+    step: MerchantMigrationStep = MerchantMigrationStep.activate_subscriptions,
 ) -> MerchantMigration:
     """A migration whose checklist sits at a given step."""
     migration = await build_connected_migration(save_fixture, organization)
-    migration.pan_transfer_steps = steps
+    migration.pan_transfer_steps = steps if steps is not None else cutover_ready_steps()
     migration.step = step
     await save_fixture(migration)
     return migration
@@ -1484,6 +1490,192 @@ async def _importable_subscription(
 
 def _step(migration: MerchantMigration, key: str) -> PanTransferStep:
     return next(step for step in migration.pan_transfer_steps if step.key == key)
+
+
+@pytest.mark.asyncio
+class TestRunCutover:
+    async def test_moves_each_subscription_then_finishes(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        migration = await _migration_at(save_fixture, organization)
+        subscriptions = [
+            await _importable_subscription(
+                save_fixture,
+                organization,
+                product,
+                email=f"imported{index}@example.com",
+                stripe_customer_id=f"cus_{index}",
+            )
+            for index in range(2)
+        ]
+        records = [
+            await stage_subscription_record(
+                save_fixture,
+                migration,
+                organization,
+                subscription,
+                source_id=f"sub_{index}",
+            )
+            for index, subscription in enumerate(subscriptions)
+        ]
+        adapter = _FakeAdapter(source_subscription=canonical_subscription())
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
+        )
+        mocker.patch(
+            "polar.merchant_migration.cutover.stripe_service.create_setup_intent",
+            new=mocker.AsyncMock(return_value=mocker.MagicMock(status="succeeded")),
+        )
+
+        # One subscription per run: the chain hands over rather than batching an
+        # irreversible operation.
+        for _ in range(3):
+            await service.run_cutover(session, migration.id)
+
+        assert all(
+            record.cutover_status == MerchantMigrationCutoverStatus.moved
+            for record in records
+        )
+        assert len(adapter.stopped) == 2
+        assert all(
+            subscription.status == SubscriptionStatus.active
+            for subscription in subscriptions
+        )
+        assert _step(migration, "move_subscriptions").status == "completed"
+        assert migration.step == MerchantMigrationStep.cleanup
+
+    async def test_records_the_reason_a_subscription_stayed(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        migration = await _migration_at(save_fixture, organization)
+        subscription = await _importable_subscription(
+            save_fixture, organization, product
+        )
+        record = await stage_subscription_record(
+            save_fixture, migration, organization, subscription
+        )
+        adapter = _FakeAdapter(source_subscription=None)
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
+        )
+
+        await service.run_cutover(session, migration.id)
+        await service.run_cutover(session, migration.id)
+
+        assert record.cutover_status == MerchantMigrationCutoverStatus.skipped
+        assert record.cutover_error is not None
+        assert subscription.status == SubscriptionStatus.paused
+        # The run is over even though a subscription stayed behind; the note
+        # tells the merchant so they can retry.
+        assert _step(migration, "move_subscriptions").status == "completed"
+        assert "stayed on your source" in (
+            _step(migration, "move_subscriptions").note or ""
+        )
+
+    async def test_refuses_before_the_merchant_confirms(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        """A stale job must never reach the merchant's own provider."""
+        migration = await _migration_at(
+            save_fixture,
+            organization,
+            steps=pan_transfer.build(PanTransferMethod.pan_copy),
+            step=MerchantMigrationStep.copy_cards,
+        )
+        subscription = await _importable_subscription(
+            save_fixture, organization, product
+        )
+        record = await stage_subscription_record(
+            save_fixture, migration, organization, subscription
+        )
+        adapter = _FakeAdapter(source_subscription=canonical_subscription())
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
+        )
+
+        await service.run_cutover(session, migration.id)
+
+        assert record.cutover_status is None
+        assert adapter.stopped == []
+
+    async def test_refuses_when_the_organization_cannot_renew(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        """Activating what the organization can't bill would leave subscriptions
+        live and uncollected."""
+        organization.capabilities = {
+            **organization.capabilities,
+            "subscription_renewals": False,
+        }
+        await save_fixture(organization)
+        migration = await _migration_at(save_fixture, organization)
+        subscription = await _importable_subscription(
+            save_fixture, organization, product
+        )
+        record = await stage_subscription_record(
+            save_fixture, migration, organization, subscription
+        )
+        adapter = _FakeAdapter(source_subscription=canonical_subscription())
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
+        )
+
+        await service.run_cutover(session, migration.id)
+
+        assert record.cutover_status is None
+        assert adapter.stopped == []
+
+
+@pytest.mark.asyncio
+class TestCompletePanStep:
+    @pytest.mark.auth
+    async def test_confirming_the_cutover_schedules_the_move(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        """The merchant's confirmation is the trigger; nothing else starts it."""
+        migration = await _migration_at(
+            save_fixture,
+            organization,
+            steps=steps_at("cutover"),
+            step=MerchantMigrationStep.copy_cards,
+        )
+        enqueue_job_mock = mocker.patch("polar.merchant_migration.service.enqueue_job")
+
+        checklist = await service.complete_pan_step(
+            session, auth_subject, migration.id, "cutover", inputs={}
+        )
+
+        assert checklist.current_step_key == "move_subscriptions"
+        assert migration.step == MerchantMigrationStep.activate_subscriptions
+        enqueue_job_mock.assert_called_once_with(
+            "merchant_migration.cutover", merchant_migration_id=migration.id
+        )
 
 
 @pytest.mark.asyncio
@@ -1541,3 +1733,118 @@ class TestRunCardVerification:
         assert uncovered.payment_method_id is None
         assert _step(migration, "verify_cards").status == "completed"
         assert "1 of 2" in (_step(migration, "resolve_uncovered").note or "")
+
+
+@pytest.mark.asyncio
+class TestCutoverReport:
+    @pytest.mark.auth
+    async def test_counts_by_outcome(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+        product: Product,
+    ) -> None:
+        migration = await _migration_at(save_fixture, organization)
+        for index, status in enumerate(
+            (
+                MerchantMigrationCutoverStatus.moved,
+                MerchantMigrationCutoverStatus.skipped,
+                None,
+            )
+        ):
+            subscription = await _importable_subscription(
+                save_fixture,
+                organization,
+                product,
+                email=f"imported{index}@example.com",
+                stripe_customer_id=f"cus_{index}",
+            )
+            record = await stage_subscription_record(
+                save_fixture,
+                migration,
+                organization,
+                subscription,
+                source_id=f"sub_{index}",
+            )
+            record.cutover_status = status
+            await save_fixture(record)
+
+        report = await service.get_cutover_report(session, auth_subject, migration.id)
+
+        assert report.started is True
+        assert report.completed is False
+        assert report.total == 3
+        assert report.moved == 1
+        assert report.skipped == 1
+        assert report.pending == 1
+
+    @pytest.mark.auth
+    async def test_retry_looks_at_what_stayed_behind(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+        product: Product,
+    ) -> None:
+        migration = await _migration_at(save_fixture, organization)
+        moved_subscription = await _importable_subscription(
+            save_fixture, organization, product, stripe_customer_id="cus_moved"
+        )
+        skipped_subscription = await _importable_subscription(
+            save_fixture,
+            organization,
+            product,
+            email="skipped@example.com",
+            stripe_customer_id="cus_skipped",
+        )
+        moved = await stage_subscription_record(
+            save_fixture,
+            migration,
+            organization,
+            moved_subscription,
+            source_id="sub_moved",
+        )
+        moved.cutover_status = MerchantMigrationCutoverStatus.moved
+        await save_fixture(moved)
+        skipped = await stage_subscription_record(
+            save_fixture,
+            migration,
+            organization,
+            skipped_subscription,
+            source_id="sub_skipped",
+        )
+        skipped.cutover_status = MerchantMigrationCutoverStatus.skipped
+        skipped.cutover_error = "No copied card has landed yet."
+        await save_fixture(skipped)
+
+        report = await service.retry_cutover(session, auth_subject, migration.id)
+
+        assert skipped.cutover_status is None
+        assert skipped.cutover_error is None
+        # What already moved stays moved: it must never be cut over twice.
+        assert moved.cutover_status == MerchantMigrationCutoverStatus.moved
+        assert report.pending == 1
+
+    @pytest.mark.auth
+    async def test_retry_refused_before_the_cutover_step(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _migration_at(
+            save_fixture,
+            organization,
+            steps=pan_transfer.build(PanTransferMethod.pan_copy),
+            step=MerchantMigrationStep.copy_cards,
+        )
+
+        with pytest.raises(CutoverNotStarted):
+            await service.retry_cutover(session, auth_subject, migration.id)

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -17,6 +17,7 @@ from polar.kit import encryption
 from polar.kit.encryption import LocalKeyProvider
 from polar.kit.pagination import PaginationParams
 from polar.kit.utils import utc_now
+from polar.merchant_migration import pan_transfer
 from polar.merchant_migration.canonical import (
     CanonicalAccount,
     CanonicalCollectionMethod,
@@ -29,6 +30,7 @@ from polar.merchant_migration.canonical import (
     CanonicalSubscriptionStatus,
 )
 from polar.merchant_migration.pan_transfer import (
+    PanTransferMethod,
     PanTransferStep,
 )
 from polar.merchant_migration.repository import (
@@ -44,6 +46,7 @@ from polar.merchant_migration.schemas import (
 from polar.merchant_migration.service import (
     CatalogImportBlocked,
     CatalogImportNotReady,
+    CutoverNotStarted,
     InvalidSourceCredentials,
     MissingStripeScopes,
     SourceAccountNotMigratable,
@@ -68,6 +71,7 @@ from polar.models.merchant_migration import (
     MerchantMigrationStep,
 )
 from polar.models.merchant_migration_record import (
+    MerchantMigrationCutoverStatus,
     MerchantMigrationRecordStatus,
     MerchantMigrationRecordType,
 )
@@ -82,6 +86,8 @@ from tests.fixtures.stripe import build_stripe_payment_method
 from tests.merchant_migration._helpers import (
     assert_no_migrations,
     build_connected_migration,
+    canonical_subscription,
+    cutover_ready_steps,
     stage_subscription_record,
     steps_at,
 )
@@ -1441,12 +1447,12 @@ async def _migration_at(
     save_fixture: SaveFixture,
     organization: Organization,
     *,
-    steps: list[PanTransferStep],
-    step: MerchantMigrationStep,
+    steps: list[PanTransferStep] | None = None,
+    step: MerchantMigrationStep = MerchantMigrationStep.activate_subscriptions,
 ) -> MerchantMigration:
     """A migration whose checklist sits at a given step."""
     migration = await build_connected_migration(save_fixture, organization)
-    migration.pan_transfer_steps = steps
+    migration.pan_transfer_steps = steps if steps is not None else cutover_ready_steps()
     migration.step = step
     await save_fixture(migration)
     return migration
@@ -1490,6 +1496,192 @@ async def _importable_subscription(
 
 def _step(migration: MerchantMigration, key: str) -> PanTransferStep:
     return next(step for step in migration.pan_transfer_steps if step.key == key)
+
+
+@pytest.mark.asyncio
+class TestRunCutover:
+    async def test_moves_each_subscription_then_finishes(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        migration = await _migration_at(save_fixture, organization)
+        subscriptions = [
+            await _importable_subscription(
+                save_fixture,
+                organization,
+                product,
+                email=f"imported{index}@example.com",
+                stripe_customer_id=f"cus_{index}",
+            )
+            for index in range(2)
+        ]
+        records = [
+            await stage_subscription_record(
+                save_fixture,
+                migration,
+                organization,
+                subscription,
+                source_id=f"sub_{index}",
+            )
+            for index, subscription in enumerate(subscriptions)
+        ]
+        adapter = _FakeAdapter(source_subscription=canonical_subscription())
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
+        )
+        mocker.patch(
+            "polar.merchant_migration.cutover.stripe_service.create_setup_intent",
+            new=mocker.AsyncMock(return_value=mocker.MagicMock(status="succeeded")),
+        )
+
+        # One subscription per run: the chain hands over rather than batching an
+        # irreversible operation.
+        for _ in range(3):
+            await service.run_cutover(session, migration.id)
+
+        assert all(
+            record.cutover_status == MerchantMigrationCutoverStatus.moved
+            for record in records
+        )
+        assert len(adapter.stopped) == 2
+        assert all(
+            subscription.status == SubscriptionStatus.active
+            for subscription in subscriptions
+        )
+        assert _step(migration, "move_subscriptions").status == "completed"
+        assert migration.step == MerchantMigrationStep.cleanup
+
+    async def test_records_the_reason_a_subscription_stayed(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        migration = await _migration_at(save_fixture, organization)
+        subscription = await _importable_subscription(
+            save_fixture, organization, product
+        )
+        record = await stage_subscription_record(
+            save_fixture, migration, organization, subscription
+        )
+        adapter = _FakeAdapter(source_subscription=None)
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
+        )
+
+        await service.run_cutover(session, migration.id)
+        await service.run_cutover(session, migration.id)
+
+        assert record.cutover_status == MerchantMigrationCutoverStatus.skipped
+        assert record.cutover_error is not None
+        assert subscription.status == SubscriptionStatus.paused
+        # The run is over even though a subscription stayed behind; the note
+        # tells the merchant so they can retry.
+        assert _step(migration, "move_subscriptions").status == "completed"
+        assert "stayed on your source" in (
+            _step(migration, "move_subscriptions").note or ""
+        )
+
+    async def test_refuses_before_the_merchant_confirms(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        """A stale job must never reach the merchant's own provider."""
+        migration = await _migration_at(
+            save_fixture,
+            organization,
+            steps=pan_transfer.build(PanTransferMethod.pan_copy),
+            step=MerchantMigrationStep.copy_cards,
+        )
+        subscription = await _importable_subscription(
+            save_fixture, organization, product
+        )
+        record = await stage_subscription_record(
+            save_fixture, migration, organization, subscription
+        )
+        adapter = _FakeAdapter(source_subscription=canonical_subscription())
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
+        )
+
+        await service.run_cutover(session, migration.id)
+
+        assert record.cutover_status is None
+        assert adapter.stopped == []
+
+    async def test_refuses_when_the_organization_cannot_renew(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        """Activating what the organization can't bill would leave subscriptions
+        live and uncollected."""
+        organization.capabilities = {
+            **organization.capabilities,
+            "subscription_renewals": False,
+        }
+        await save_fixture(organization)
+        migration = await _migration_at(save_fixture, organization)
+        subscription = await _importable_subscription(
+            save_fixture, organization, product
+        )
+        record = await stage_subscription_record(
+            save_fixture, migration, organization, subscription
+        )
+        adapter = _FakeAdapter(source_subscription=canonical_subscription())
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
+        )
+
+        await service.run_cutover(session, migration.id)
+
+        assert record.cutover_status is None
+        assert adapter.stopped == []
+
+
+@pytest.mark.asyncio
+class TestCompletePanStep:
+    @pytest.mark.auth
+    async def test_confirming_the_cutover_schedules_the_move(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        """The merchant's confirmation is the trigger; nothing else starts it."""
+        migration = await _migration_at(
+            save_fixture,
+            organization,
+            steps=steps_at("cutover"),
+            step=MerchantMigrationStep.copy_cards,
+        )
+        enqueue_job_mock = mocker.patch("polar.merchant_migration.service.enqueue_job")
+
+        checklist = await service.complete_pan_step(
+            session, auth_subject, migration.id, "cutover", inputs={}
+        )
+
+        assert checklist.current_step_key == "move_subscriptions"
+        assert migration.step == MerchantMigrationStep.activate_subscriptions
+        enqueue_job_mock.assert_called_once_with(
+            "merchant_migration.cutover", merchant_migration_id=migration.id
+        )
 
 
 @pytest.mark.asyncio
@@ -1627,3 +1819,118 @@ class TestRunCardVerification:
 
         listing.assert_not_called()
         assert _step(migration, "verify_cards").status == "completed"
+
+
+@pytest.mark.asyncio
+class TestCutoverReport:
+    @pytest.mark.auth
+    async def test_counts_by_outcome(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+        product: Product,
+    ) -> None:
+        migration = await _migration_at(save_fixture, organization)
+        for index, status in enumerate(
+            (
+                MerchantMigrationCutoverStatus.moved,
+                MerchantMigrationCutoverStatus.skipped,
+                None,
+            )
+        ):
+            subscription = await _importable_subscription(
+                save_fixture,
+                organization,
+                product,
+                email=f"imported{index}@example.com",
+                stripe_customer_id=f"cus_{index}",
+            )
+            record = await stage_subscription_record(
+                save_fixture,
+                migration,
+                organization,
+                subscription,
+                source_id=f"sub_{index}",
+            )
+            record.cutover_status = status
+            await save_fixture(record)
+
+        report = await service.get_cutover_report(session, auth_subject, migration.id)
+
+        assert report.started is True
+        assert report.completed is False
+        assert report.total == 3
+        assert report.moved == 1
+        assert report.skipped == 1
+        assert report.pending == 1
+
+    @pytest.mark.auth
+    async def test_retry_looks_at_what_stayed_behind(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+        product: Product,
+    ) -> None:
+        migration = await _migration_at(save_fixture, organization)
+        moved_subscription = await _importable_subscription(
+            save_fixture, organization, product, stripe_customer_id="cus_moved"
+        )
+        skipped_subscription = await _importable_subscription(
+            save_fixture,
+            organization,
+            product,
+            email="skipped@example.com",
+            stripe_customer_id="cus_skipped",
+        )
+        moved = await stage_subscription_record(
+            save_fixture,
+            migration,
+            organization,
+            moved_subscription,
+            source_id="sub_moved",
+        )
+        moved.cutover_status = MerchantMigrationCutoverStatus.moved
+        await save_fixture(moved)
+        skipped = await stage_subscription_record(
+            save_fixture,
+            migration,
+            organization,
+            skipped_subscription,
+            source_id="sub_skipped",
+        )
+        skipped.cutover_status = MerchantMigrationCutoverStatus.skipped
+        skipped.cutover_error = "No copied card has landed yet."
+        await save_fixture(skipped)
+
+        report = await service.retry_cutover(session, auth_subject, migration.id)
+
+        assert skipped.cutover_status is None
+        assert skipped.cutover_error is None
+        # What already moved stays moved: it must never be cut over twice.
+        assert moved.cutover_status == MerchantMigrationCutoverStatus.moved
+        assert report.pending == 1
+
+    @pytest.mark.auth
+    async def test_retry_refused_before_the_cutover_step(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await _migration_at(
+            save_fixture,
+            organization,
+            steps=pan_transfer.build(PanTransferMethod.pan_copy),
+            step=MerchantMigrationStep.copy_cards,
+        )
+
+        with pytest.raises(CutoverNotStarted):
+            await service.retry_cutover(session, auth_subject, migration.id)


### PR DESCRIPTION
## Summary

**Related Issue**: n/a

> 📚 Stack 7/7 · base is #13627. Merge last — **this is the PR that turns the cutover on.**

> ♻️ Restacked on 13 Aug: the branches below merged to `main`, so this one and #13627 were rebuilt on the squashed history. Content is unchanged.

Confirming the `cutover` step now schedules the move, and the merchant can see and retry what it did.

## What

- `run_cutover` — takes one subscription per run and hands over to the next.
- `merchant_migration.cutover` actor; `move_subscriptions` added to the dispatcher.
- `GET /v1/merchant-migrations/{id}/cutover` — counts; `POST` — retry.
- `cutover_status` / `cutover_error` on the records listing, plus a filter.
- Repository: `get_next_cutover_candidate`, `count_cutover_statuses`, `reset_cutover`.
- Regenerated `v1.ts` (+208, generated — skip it).

## Why

Everything below this in the stack is inert. This is the wiring, and the guard rails around it.

## How

**The merchant's confirmation is the only trigger.** The job refuses to touch their provider unless the `cutover` step is completed, so a stale or duplicated message can't start one. It also stops if the organization can't renew subscriptions — activating what Polar can't bill leaves subscriptions live and uncollected, which is worse than leaving them on the source.

**One subscription per run, each in its own transaction.** A batch that died halfway would replay cancellations it had already made on the merchant's account; one per run means a retry re-reads a single subscription and converges on it (with the marker from #13624). Candidates are claimed `FOR UPDATE SKIP LOCKED`, so an impatient second run works alongside the first rather than moving the same subscription twice, and the run only finalises the step once nothing is left pending — including rows another run holds uncommitted.

**Retry re-opens everything that isn't `moved`.** Most recorded reasons are exactly the things that change — a card re-entered, a renewal since gone through — so a retry re-runs the checks rather than trusting the last verdict. What already moved is never re-opened.

**Reporting reuses the records listing** rather than adding a parallel surface: the merchant filters to the subscriptions still on their old provider and reads the reason on each. Both cutover endpoints read the primary, not the replica — the client polls them while the run is in flight, and replica lag would show moved subscriptions as still pending.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

---
_Generated by [Claude Code](https://claude.ai/code/session_011PzjzyWCvUEeXWuG4UGy8R)_


<a href="https://cubic.dev/pr/polarsource/polar/pull/13629?utm_source=github" rel="nofollow noreferrer noopener" target="_blank">``&lt;img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"&gt;``</a>
