### PR TITLE
Allow regenerating invoice from backoffice

### DIFF
--- a/server/polar/backoffice/orders/endpoints.py
+++ b/server/polar/backoffice/orders/endpoints.py
@@ -347,6 +347,18 @@ async def get(
                         ):
                             text("Unvoid")
 
+                    if order.invoice_path is not None:
+                        with button(
+                            hx_get=str(
+                                request.url_for(
+                                    "orders:regenerate_invoice", id=order.id
+                                )
+                            ),
+                            hx_target="#modal",
+                            outline=True,
+                        ):
+                            text("Regenerate Invoice")
+
             with tag.div(classes="grid grid-cols-1 lg:grid-cols-2 gap-4"):
                 # Order Details
                 with tag.div(classes="card card-border w-full shadow-sm"):
@@ -1047,3 +1059,64 @@ async def unvoid(
                     variant="primary",
                 ):
                     text("Unvoid Order")
+
+
+@router.api_route(
+    "/{id}/regenerate-invoice",
+    name="orders:regenerate_invoice",
+    methods=["GET", "POST"],
+)
+async def regenerate_invoice(
+    request: Request,
+    id: UUID4,
+    session: AsyncSession = Depends(get_db_session),
+) -> Any:
+    order_repository = OrderRepository.from_session(session)
+    order = await order_repository.get_by_id(
+        id,
+        options=order_repository.get_eager_options(),
+    )
+
+    if order is None:
+        raise HTTPException(status_code=404)
+
+    if order.invoice_path is None:
+        await add_toast(request, "This order has no invoice to regenerate.", "error")
+        return HXRedirectResponse(
+            request, str(request.url_for("orders:get", id=id)), 303
+        )
+
+    if request.method == "POST":
+        try:
+            await order_service.trigger_invoice_generation(session, order, force=True)
+            await add_toast(
+                request,
+                "Invoice regeneration scheduled. "
+                "The PDF will refresh in a few seconds.",
+                "success",
+            )
+            return HXRedirectResponse(
+                request, str(request.url_for("orders:get", id=id)), 303
+            )
+        except Exception as e:
+            await add_toast(request, f"Failed to regenerate invoice: {e}", "error")
+
+    with modal("Regenerate invoice", open=True):
+        with tag.div(classes="flex flex-col gap-4"):
+            with tag.p():
+                text(
+                    "This re-renders the invoice PDF from the current billing "
+                    "details, tax data and template. The invoice number is kept; "
+                    "only the PDF file is replaced. Use this to pick up fixes that "
+                    "don't change the order itself (e.g. the seller tax number)."
+                )
+            with tag.div(classes="modal-action"):
+                with tag.form(method="dialog"):
+                    with button(ghost=True):
+                        text("Cancel")
+                with button(
+                    hx_post=str(request.url_for("orders:regenerate_invoice", id=id)),
+                    hx_target="#modal",
+                    variant="primary",
+                ):
+                    text("Regenerate Invoice")

--- a/server/polar/order/service.py
+++ b/server/polar/order/service.py
@@ -537,7 +537,7 @@ class OrderService:
         return order
 
     async def trigger_invoice_generation(
-        self, session: AsyncSession, order: Order
+        self, session: AsyncSession, order: Order, *, force: bool = False
     ) -> None:
         if order.status in (OrderStatus.draft, OrderStatus.void):
             raise OrderNotEligibleForInvoice(order)
@@ -546,7 +546,8 @@ class OrderService:
             raise MissingInvoiceBillingDetails(order)
 
         if (
-            order.invoice_path is not None
+            not force
+            and order.invoice_path is not None
             and order.invoice_checksum == invoice_service.compute_order_checksum(order)
         ):
             log.info(
@@ -557,12 +558,15 @@ class OrderService:
             )
             return
 
-        log.info("order.invoice_generation.scheduled", order_id=order.id)
-        enqueue_job("order.invoice", order_id=order.id)
+        log.info("order.invoice_generation.scheduled", order_id=order.id, force=force)
+        enqueue_job("order.invoice", order_id=order.id, force=force)
 
-    async def generate_invoice(self, session: AsyncSession, order: Order) -> Order:
+    async def generate_invoice(
+        self, session: AsyncSession, order: Order, *, force: bool = False
+    ) -> Order:
         if (
-            order.invoice_path is not None
+            not force
+            and order.invoice_path is not None
             and order.invoice_checksum == invoice_service.compute_order_checksum(order)
         ):
             log.info(

--- a/server/polar/order/tasks.py
+++ b/server/polar/order/tasks.py
@@ -247,7 +247,7 @@ async def order_subscription_renewal_notification(order_id: uuid.UUID) -> None:
         await order_service.send_subscription_renewal_notification(session, order)
 
 
-async def _run_order_invoice(order_id: uuid.UUID) -> None:
+async def _run_order_invoice(order_id: uuid.UUID, force: bool = False) -> None:
     async with AsyncSessionMaker() as session:
         repository = OrderRepository.from_session(session)
         order = await repository.get_by_id(
@@ -256,7 +256,7 @@ async def _run_order_invoice(order_id: uuid.UUID) -> None:
         if order is None:
             raise OrderDoesNotExist(order_id)
 
-        await order_service.generate_invoice(session, order)
+        await order_service.generate_invoice(session, order, force=force)
 
 
 @actor(
@@ -264,8 +264,8 @@ async def _run_order_invoice(order_id: uuid.UUID) -> None:
     priority=TaskPriority.LOW,
     queue_name=TaskQueue.INVOICES_AND_RECEIPTS,
 )
-async def order_invoice(order_id: uuid.UUID) -> None:
-    await _run_order_invoice(order_id)
+async def order_invoice(order_id: uuid.UUID, force: bool = False) -> None:
+    await _run_order_invoice(order_id, force=force)
 
 
 @actor(

--- a/server/tests/order/test_service.py
+++ b/server/tests/order/test_service.py
@@ -2900,7 +2900,9 @@ class TestTriggerInvoiceGeneration:
 
         await order_service.trigger_invoice_generation(session, order)
 
-        enqueue_job_mock.assert_called_once_with("order.invoice", order_id=order.id)
+        enqueue_job_mock.assert_called_once_with(
+            "order.invoice", order_id=order.id, force=False
+        )
 
     async def test_draft_order_raises(
         self,
@@ -2979,7 +2981,9 @@ class TestTriggerInvoiceGeneration:
 
         await order_service.trigger_invoice_generation(session, order)
 
-        enqueue_job_mock.assert_called_once_with("order.invoice", order_id=order.id)
+        enqueue_job_mock.assert_called_once_with(
+            "order.invoice", order_id=order.id, force=False
+        )
 
     async def test_existing_invoice_no_checksum(
         self,
@@ -3000,7 +3004,9 @@ class TestTriggerInvoiceGeneration:
 
         await order_service.trigger_invoice_generation(session, order)
 
-        enqueue_job_mock.assert_called_once_with("order.invoice", order_id=order.id)
+        enqueue_job_mock.assert_called_once_with(
+            "order.invoice", order_id=order.id, force=False
+        )
 
     async def test_checksum_mismatch(
         self,
@@ -3022,7 +3028,9 @@ class TestTriggerInvoiceGeneration:
 
         await order_service.trigger_invoice_generation(session, order)
 
-        enqueue_job_mock.assert_called_once_with("order.invoice", order_id=order.id)
+        enqueue_job_mock.assert_called_once_with(
+            "order.invoice", order_id=order.id, force=False
+        )
 
     async def test_checksum_match_skips(
         self,
@@ -3045,6 +3053,30 @@ class TestTriggerInvoiceGeneration:
         await order_service.trigger_invoice_generation(session, order)
 
         enqueue_job_mock.assert_not_called()
+
+    async def test_force_bypasses_checksum_match(
+        self,
+        enqueue_job_mock: MagicMock,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            billing_name="John Doe",
+            billing_address=Address(country=CountryAlpha2("US")),
+        )
+        order.invoice_path = "invoices/current.pdf"
+        order.invoice_checksum = invoice_service.compute_order_checksum(order)
+
+        await order_service.trigger_invoice_generation(session, order, force=True)
+
+        enqueue_job_mock.assert_called_once_with(
+            "order.invoice", order_id=order.id, force=True
+        )
 
 
 @pytest.mark.asyncio
@@ -3103,6 +3135,34 @@ class TestGenerateInvoice:
 
         assert result is order
         create_order_invoice_mock.assert_not_called()
+
+    async def test_force_regenerates_when_checksum_matches(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        create_order_invoice_mock = mocker.patch(
+            "polar.order.service.invoice_service.create_order_invoice",
+            new_callable=AsyncMock,
+            return_value="invoices/regenerated.pdf",
+        )
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            billing_name="John Doe",
+            billing_address=Address(country=CountryAlpha2("US")),
+        )
+        order.invoice_path = "invoices/current.pdf"
+        order.invoice_checksum = invoice_service.compute_order_checksum(order)
+
+        updated = await order_service.generate_invoice(session, order, force=True)
+
+        create_order_invoice_mock.assert_called_once()
+        assert updated.invoice_path == "invoices/regenerated.pdf"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a backoffice action to regenerate an order’s invoice PDF. It schedules a forced invoice job that re-renders the PDF while keeping the same invoice number.

- **New Features**
  - Added “Regenerate Invoice” action for orders with an existing invoice; opens a modal, schedules regeneration, shows success/error toasts, and redirects back to the order. Only the PDF is replaced.
  - Added a `force` option across invoice generation (`trigger_invoice_generation`, `generate_invoice`, and the `order.invoice` task) to bypass checksum gating while still enforcing eligibility (not draft/void; billing details required).

<sup>Written for commit a6e60e02f7c7b6af116493f5d7ecd0801afecb3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

