### PR TITLE
feat(email): add index on email_logs deduplication_key

### DIFF
--- a/server/migrations/versions/2026-08-11-1505_add_index_on_email_logs_deduplication_key.py
+++ b/server/migrations/versions/2026-08-11-1505_add_index_on_email_logs_deduplication_key.py
@@ -1,0 +1,47 @@
+"""add index on email_logs deduplication_key
+
+Revision ID: 89e805c471b0
+Revises: 9a1c47f0b3d2
+Create Date: 2026-08-11 15:05:09.141659
+
+"""
+
+from alembic import op
+
+# Polar Custom Imports
+
+# revision identifiers, used by Alembic.
+revision = "89e805c471b0"
+down_revision = "9a1c47f0b3d2"
+branch_labels: tuple[str] | None = None
+depends_on: tuple[str] | None = None
+
+INDEX = "ix_email_logs_deduplication_key"
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        # Drop any INVALID leftover from an interrupted concurrent build first.
+        op.drop_index(
+            INDEX,
+            table_name="email_logs",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            INDEX,
+            "email_logs",
+            ["deduplication_key"],
+            postgresql_where="deduplication_key IS NOT NULL",
+            postgresql_concurrently=True,
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            INDEX,
+            table_name="email_logs",
+            if_exists=True,
+            postgresql_concurrently=True,
+        )

--- a/server/polar/models/email_log.py
+++ b/server/polar/models/email_log.py
@@ -2,7 +2,7 @@ from enum import StrEnum
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import String, Uuid
+from sqlalchemy import Index, String, Uuid
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -17,6 +17,13 @@ class EmailLogStatus(StrEnum):
 
 class EmailLog(RecordModel):
     __tablename__ = "email_logs"
+    __table_args__ = (
+        Index(
+            "ix_email_logs_deduplication_key",
+            "deduplication_key",
+            postgresql_where="deduplication_key IS NOT NULL",
+        ),
+    )
 
     organization_id: Mapped[UUID | None] = mapped_column(
         Uuid, nullable=True, index=True


### PR DESCRIPTION
Preparing for #13613


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a concurrent, partial (WHERE deduplication_key IS NOT NULL) non-unique index on email_logs(deduplication_key) to speed up the reminder scanner’s dedup lookup. The migration drops any invalid leftover before creating it, and the same partial index is defined in the model; dedup stays in application logic via NOT EXISTS.

<sup>Written for commit 44be3f7e16bd77ebd092db6f9d7f2b84a8e546aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



