### PR TITLE
redis: Add TCP keepalive and health check intervals

### DIFF
--- a/server/polar/redis.py
+++ b/server/polar/redis.py
@@ -1,3 +1,4 @@
+import socket
 from typing import TYPE_CHECKING, Literal
 
 import redis.asyncio as _async_redis
@@ -19,6 +20,18 @@ else:
 REDIS_RETRY_ON_ERRROR: list[type[RedisError]] = [ConnectionError, TimeoutError]
 REDIS_RETRY = Retry(default_backoff(), retries=50)
 
+# TCP_KEEPIDLE is Linux, TCP_KEEPALIVE its macOS equivalent
+REDIS_KEEPALIVE_OPTIONS: dict[int, int] = {
+    getattr(socket, name): value
+    for name, value in (
+        ("TCP_KEEPIDLE", 60),
+        ("TCP_KEEPALIVE", 60),
+        ("TCP_KEEPINTVL", 30),
+        ("TCP_KEEPCNT", 3),
+    )
+    if hasattr(socket, name)
+}
+
 type ProcessName = Literal["app", "rate-limit", "worker", "script"]
 
 
@@ -29,6 +42,9 @@ def create_redis(process_name: ProcessName) -> Redis:
         retry_on_error=REDIS_RETRY_ON_ERRROR,
         retry=REDIS_RETRY,
         client_name=f"{settings.ENV.value}.{process_name}",
+        socket_keepalive=True,
+        socket_keepalive_options=REDIS_KEEPALIVE_OPTIONS,
+        health_check_interval=30,
     )
 
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add TCP keepalive and a 30s health check to `redis` connections to prevent idle disconnects and improve connection stability between Render and AWS Redis.

- **Bug Fixes**
  - Enable `socket_keepalive` with OS-specific options: idle 60s, interval 30s, count 3 (supports Linux/macOS constants).
  - Set `health_check_interval=30` to proactively detect dead connections.

<sup>Written for commit f66e1215406dfade48b793709d11acdfb10a1a3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

