### PR TITLE
Do not fail formatting on generated CHANGELOG

### DIFF
--- a/clients/.oxfmtrc.json
+++ b/clients/.oxfmtrc.json
@@ -7,5 +7,11 @@
   "useTabs": false,
   "sortTailwindcss": {},
   "sortPackageJson": false,
-  "ignorePatterns": ["node_modules", "dist", "coverage", ".changeset"]
+  "ignorePatterns": [
+    "node_modules",
+    "dist",
+    "coverage",
+    ".changeset",
+    "**/CHANGELOG.md"
+  ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ignore generated changelogs in the client formatter to prevent CI formatting failures. Added `**/CHANGELOG.md` to `ignorePatterns` in `clients/.oxfmtrc.json`.

<sup>Written for commit ce57adc3c4db094b7b7209b11f0d85f896ce25fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

