### PR TITLE
tf/redis: Use AWS Redis in test and sandbox

### DIFF
--- a/terraform/sandbox/render.tf
+++ b/terraform/sandbox/render.tf
@@ -62,7 +62,7 @@ locals {
   read_replica = [for r in data.render_postgres.db.read_replicas : r if r.name == "polar-read"][0]
 
   # Redis connection info
-  redis_host = render_redis.redis_sandbox.id
+  redis_host = var.redis_private_link_host
   redis_port = "6379"
 
   # Forwarded allow IPs: Cloudflare ranges + Render proxy

--- a/terraform/sandbox/variables.tf
+++ b/terraform/sandbox/variables.tf
@@ -456,3 +456,8 @@ variable "turnstile_secret" {
   type        = string
   sensitive   = true
 }
+
+variable "redis_private_link_host" {
+  description = "DNS name of the Render private link to the sandbox worker Redis"
+  type        = string
+}

--- a/terraform/test/aws.tf
+++ b/terraform/test/aws.tf
@@ -37,6 +37,28 @@ resource "aws_vpc_security_group_ingress_rule" "redis_lambda" {
   ip_protocol                  = "tcp"
 }
 
+module "redis_private_link" {
+  count  = local.test_enabled ? 1 : 0
+  source = "../modules/redis_private_link"
+
+  name                     = "polar-test-worker-redis"
+  vpc_id                   = module.vpc[0].vpc_id
+  subnet_ids               = module.vpc[0].private_subnet_ids
+  redis_host               = module.redis[0].host
+  redis_port               = module.redis[0].port
+  redis_arn                = module.redis[0].arn
+  permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
+}
+
+resource "aws_vpc_security_group_ingress_rule" "redis_nlb" {
+  count                        = local.test_enabled ? 1 : 0
+  security_group_id            = module.redis[0].security_group_id
+  referenced_security_group_id = module.redis_private_link[0].nlb_security_group_id
+  from_port                    = module.redis[0].port
+  to_port                      = module.redis[0].port
+  ip_protocol                  = "tcp"
+}
+
 locals {
   files_bucket_name        = "polar-test-files"
   files_public_bucket_name = "polar-test-public-files"

--- a/terraform/test/outputs.tf
+++ b/terraform/test/outputs.tf
@@ -2,3 +2,8 @@ output "lambda_worker_ecr_repository_url" {
   description = "ECR repository URL for the test Lambda worker image."
   value       = try(module.lambda_worker_ecr[0].repository_url, null)
 }
+
+output "redis_endpoint_service_name" {
+  description = "VPC endpoint service name for the worker Redis. Provide to Render when creating the private link."
+  value       = try(module.redis_private_link[0].service_name, null)
+}

--- a/terraform/test/render.tf
+++ b/terraform/test/render.tf
@@ -102,7 +102,7 @@ locals {
   read_replica = [for r in render_postgres.db.read_replicas : r if r.name == "polar-read-test"][0]
 
   # Redis connection info
-  redis_host = local.test_enabled ? render_redis.redis[0].id : ""
+  redis_host = local.test_enabled ? var.redis_private_link_host : ""
   redis_port = "6379"
 
   # Forwarded allow IPs: Cloudflare ranges + Render proxy
@@ -149,7 +149,7 @@ module "test" {
     database_pool_size     = "10"
     postgres_database      = local.db_name
     postgres_read_database = local.db_name
-    redis_db               = "0"
+    redis_db               = "1"
     plan                   = "pro"
   }
 

--- a/terraform/test/variables.tf
+++ b/terraform/test/variables.tf
@@ -440,3 +440,8 @@ variable "turnstile_secret" {
   type        = string
   sensitive   = true
 }
+
+variable "redis_private_link_host" {
+  description = "DNS name of the Render private link to the test worker Redis"
+  type        = string
+}


### PR DESCRIPTION
This sets up the AWS privatelink in test and moves to use the AWS Redis instances in both test and sandbox.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

