### PR TITLE
Always show denied when organization is denied

### DIFF
--- a/clients/apps/web/src/components/Organization/AIValidationResult.tsx
+++ b/clients/apps/web/src/components/Organization/AIValidationResult.tsx
@@ -76,6 +76,17 @@ const AIValidationResult = ({
       return null
     }
 
+    if (organization.status === 'denied' || result.verdict === 'FAIL') {
+      return {
+        type: 'review_required',
+        title: 'Payment access denied',
+        message: 'Your organization does not meet our acceptable use policy.',
+        icon: (
+          <CircleAlertIcon className="dark:text-polar-400 -mt-0.5 h-4 w-4 text-gray-500" />
+        ),
+      }
+    }
+
     switch (result.verdict) {
       case 'PASS':
         return {
@@ -85,15 +96,6 @@ const AIValidationResult = ({
             'Your organization details have been automatically validated. You can accept payments immediately. A manual review will still take place, and any payout you request in the meantime will be paid out automatically once the review is complete.',
           icon: (
             <CheckCircleIcon className="dark:text-polar-400 -mt-0.5 h-4 w-4 text-gray-500" />
-          ),
-        }
-      case 'FAIL':
-        return {
-          type: 'review_required',
-          title: 'Payment access denied',
-          message: 'Your organization does not meet our acceptable use policy.',
-          icon: (
-            <CircleAlertIcon className="dark:text-polar-400 -mt-0.5 h-4 w-4 text-gray-500" />
           ),
         }
       case 'UNCERTAIN':
@@ -116,7 +118,8 @@ const AIValidationResult = ({
 
   const showAppeal =
     ((reviewStatus.data && reviewStatus.data.verdict) || timedOut) &&
-    status.type === 'review_required'
+    status.type === 'review_required' &&
+    !(organization.status === 'denied' && reviewStatus.data?.verdict === 'PASS')
 
   return (
     <div className="dark:bg-polar-800 rounded-2xl border bg-white">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure denied status always overrides AI validation. If an organization is denied, the UI now consistently shows “Payment access denied,” and the appeal option is hidden when appropriate.

- **Bug Fixes**
  - In `AIValidationResult`, short-circuit to denied when `organization.status === 'denied'` or the verdict is `FAIL`.
  - Hide appeal when the org is denied, even if the AI verdict is `PASS`.

<sup>Written for commit 254e29fec4db2ae7b2cfdca2c5d166700c04903d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

