### PR TITLE
refactor: use inlinemodalheaders on modals to allow mobile to close

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/[spanId]/EditEventTypeModal.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/[spanId]/EditEventTypeModal.tsx
@@ -80,15 +80,17 @@ export const EditEventTypeModal = ({
   return (
     <SyntaxHighlighterProvider>
       <div className="flex flex-col overflow-y-auto">
-        <InlineModalHeader className="pb-2" hide={hide}>
-          <h2 className="text-lg">Edit Event Type</h2>
+        <InlineModalHeader hide={hide}>
+          <div className="flex flex-col gap-1">
+            <h2 className="text-lg">Edit Event Type</h2>
+            <p className="dark:text-polar-500 text-sm font-normal text-gray-500">
+              {/* eslint-disable-next-line react/no-unescaped-entities */}
+              Update the display label for event type "{eventName}"
+            </p>
+          </div>
         </InlineModalHeader>
 
         <div className="flex flex-col gap-y-6 px-8 pb-10">
-          <p className="dark:text-polar-500 text-sm text-gray-500">
-            {/* eslint-disable-next-line react/no-unescaped-entities */}
-            Update the display label for event type "{eventName}"
-          </p>
           <Form {...form}>
             <form
               onSubmit={form.handleSubmit(onSubmit)}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/[spanId]/EditEventTypeModal.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/[spanId]/EditEventTypeModal.tsx
@@ -8,7 +8,7 @@ import {
 import { useToast } from '@/components/Toast/use-toast'
 import { useUpdateEventType } from '@/hooks/queries/event_types'
 import { apiErrorToast, setValidationErrors } from '@/utils/api/errors'
-import { Button } from '@polar-sh/orbit'
+import { Button, InlineModalHeader } from '@polar-sh/orbit'
 import { Input } from '@polar-sh/orbit'
 import {
   Form,
@@ -79,16 +79,16 @@ export const EditEventTypeModal = ({
 
   return (
     <SyntaxHighlighterProvider>
-      <div className="flex flex-col gap-y-6 overflow-y-auto px-8 py-10">
-        <div>
-          <h2 className="text-xl">Edit Event Type</h2>
-          <p className="dark:text-polar-500 mt-2 text-sm text-gray-500">
+      <div className="flex flex-col overflow-y-auto">
+        <InlineModalHeader className="pb-2" hide={hide}>
+          <h2 className="text-lg">Edit Event Type</h2>
+        </InlineModalHeader>
+
+        <div className="flex flex-col gap-y-6 px-8 pb-10">
+          <p className="dark:text-polar-500 text-sm text-gray-500">
             {/* eslint-disable-next-line react/no-unescaped-entities */}
             Update the display label for event type "{eventName}"
           </p>
-        </div>
-
-        <div className="flex flex-col gap-y-6">
           <Form {...form}>
             <form
               onSubmit={form.handleSubmit(onSubmit)}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/[spanId]/EditEventTypeModal.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/[spanId]/EditEventTypeModal.tsx
@@ -162,7 +162,7 @@ export const EditEventTypeModal = ({
           </Form>
         </div>
 
-        <div className="dark:border-polar-700 border-t border-gray-200 pt-6">
+        <div className="dark:border-polar-700 border-t border-gray-200 px-8 pt-6 pb-10">
           <div className="flex flex-col gap-y-2">
             <h3>Ingesting Events</h3>
             <p className="dark:text-polar-500 text-sm text-gray-500">

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/[spanId]/EditEventTypeModal.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/analytics/costs/[spanId]/EditEventTypeModal.tsx
@@ -8,8 +8,7 @@ import {
 import { useToast } from '@/components/Toast/use-toast'
 import { useUpdateEventType } from '@/hooks/queries/event_types'
 import { apiErrorToast, setValidationErrors } from '@/utils/api/errors'
-import { Button, InlineModalHeader } from '@polar-sh/orbit'
-import { Input } from '@polar-sh/orbit'
+import { Button, InlineModalHeader, Input, Text } from '@polar-sh/orbit'
 import {
   Form,
   FormControl,
@@ -82,7 +81,9 @@ export const EditEventTypeModal = ({
       <div className="flex flex-col overflow-y-auto">
         <InlineModalHeader hide={hide}>
           <div className="flex flex-col gap-1">
-            <h2 className="text-lg">Edit Event Type</h2>
+            <Text variant="heading-xxs" as="h2">
+              Edit Event Type
+            </Text>
             <p className="dark:text-polar-500 text-sm font-normal text-gray-500">
               {/* eslint-disable-next-line react/no-unescaped-entities */}
               Update the display label for event type "{eventName}"

--- a/clients/apps/web/src/components/CustomFields/UpdateCustomFieldModalContent.tsx
+++ b/clients/apps/web/src/components/CustomFields/UpdateCustomFieldModalContent.tsx
@@ -2,7 +2,7 @@ import { useUpdateCustomField } from '@/hooks/queries'
 import { setValidationErrors } from '@/utils/api/errors'
 import { stripEmptyProperties } from '@/utils/object'
 import { isValidationError, schemas } from '@polar-sh/client'
-import { Button } from '@polar-sh/orbit'
+import { Button, InlineModalHeader } from '@polar-sh/orbit'
 import { Form } from '@polar-sh/ui/components/ui/form'
 import { useCallback } from 'react'
 import { useForm } from 'react-hook-form'
@@ -63,14 +63,14 @@ const UpdateCustomFieldModalContent = ({
   )
 
   return (
-    <div className="flex flex-col gap-y-6 overflow-y-auto px-8 py-10">
-      <div>
+    <div className="flex flex-col overflow-y-auto">
+      <InlineModalHeader className="pb-2" hide={hideModal}>
         <h2 className="text-lg">Update Custom Field</h2>
-        <p className="dark:text-polar-500 mt-2 text-sm text-gray-500">
+      </InlineModalHeader>
+      <div className="flex flex-col gap-y-6 px-8 pb-10">
+        <p className="dark:text-polar-500 text-sm text-gray-500">
           Type cannot be changed.
         </p>
-      </div>
-      <div className="flex flex-col gap-y-6">
         <Form {...form}>
           <form
             className="flex flex-col gap-y-6"

--- a/clients/apps/web/src/components/CustomFields/UpdateCustomFieldModalContent.tsx
+++ b/clients/apps/web/src/components/CustomFields/UpdateCustomFieldModalContent.tsx
@@ -64,13 +64,15 @@ const UpdateCustomFieldModalContent = ({
 
   return (
     <div className="flex flex-col overflow-y-auto">
-      <InlineModalHeader className="pb-2" hide={hideModal}>
-        <h2 className="text-lg">Update Custom Field</h2>
+      <InlineModalHeader hide={hideModal}>
+        <div className="flex flex-col gap-1">
+          <h2 className="text-lg">Update Custom Field</h2>
+          <p className="dark:text-polar-500 text-sm font-normal text-gray-500">
+            Type cannot be changed.
+          </p>
+        </div>
       </InlineModalHeader>
       <div className="flex flex-col gap-y-6 px-8 pb-10">
-        <p className="dark:text-polar-500 text-sm text-gray-500">
-          Type cannot be changed.
-        </p>
         <Form {...form}>
           <form
             className="flex flex-col gap-y-6"

--- a/clients/apps/web/src/components/CustomFields/UpdateCustomFieldModalContent.tsx
+++ b/clients/apps/web/src/components/CustomFields/UpdateCustomFieldModalContent.tsx
@@ -2,7 +2,7 @@ import { useUpdateCustomField } from '@/hooks/queries'
 import { setValidationErrors } from '@/utils/api/errors'
 import { stripEmptyProperties } from '@/utils/object'
 import { isValidationError, schemas } from '@polar-sh/client'
-import { Button, InlineModalHeader } from '@polar-sh/orbit'
+import { Button, InlineModalHeader, Text } from '@polar-sh/orbit'
 import { Form } from '@polar-sh/ui/components/ui/form'
 import { useCallback } from 'react'
 import { useForm } from 'react-hook-form'
@@ -66,7 +66,9 @@ const UpdateCustomFieldModalContent = ({
     <div className="flex flex-col overflow-y-auto">
       <InlineModalHeader hide={hideModal}>
         <div className="flex flex-col gap-1">
-          <h2 className="text-lg">Update Custom Field</h2>
+          <Text variant="heading-xxs" as="h2">
+            Update Custom Field
+          </Text>
           <p className="dark:text-polar-500 text-sm font-normal text-gray-500">
             Type cannot be changed.
           </p>

--- a/clients/apps/web/src/components/Discounts/CreateDiscountModalContent.tsx
+++ b/clients/apps/web/src/components/Discounts/CreateDiscountModalContent.tsx
@@ -70,7 +70,7 @@ const CreateDiscountModalContent = ({
 
   return (
     <div className="flex flex-col overflow-y-auto">
-      <InlineModalHeader className="pb-2" hide={hideModal}>
+      <InlineModalHeader hide={hideModal}>
         <h2 className="text-lg">Create Discount</h2>
       </InlineModalHeader>
       <div className="flex flex-col gap-y-6 px-8 pb-10">

--- a/clients/apps/web/src/components/Discounts/CreateDiscountModalContent.tsx
+++ b/clients/apps/web/src/components/Discounts/CreateDiscountModalContent.tsx
@@ -1,7 +1,7 @@
 import { useCreateDiscount } from '@/hooks/queries'
 import { setValidationErrors } from '@/utils/api/errors'
 import { schemas } from '@polar-sh/client'
-import { Button } from '@polar-sh/orbit'
+import { Button, InlineModalHeader } from '@polar-sh/orbit'
 import { Form } from '@polar-sh/ui/components/ui/form'
 import { useCallback } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
@@ -69,11 +69,11 @@ const CreateDiscountModalContent = ({
   )
 
   return (
-    <div className="flex flex-col gap-y-6 overflow-y-auto px-8 py-10">
-      <div>
+    <div className="flex flex-col overflow-y-auto">
+      <InlineModalHeader className="pb-2" hide={hideModal}>
         <h2 className="text-lg">Create Discount</h2>
-      </div>
-      <div className="flex flex-col gap-y-6">
+      </InlineModalHeader>
+      <div className="flex flex-col gap-y-6 px-8 pb-10">
         <Form {...form}>
           <form
             className="flex flex-col gap-y-6"

--- a/clients/apps/web/src/components/Discounts/CreateDiscountModalContent.tsx
+++ b/clients/apps/web/src/components/Discounts/CreateDiscountModalContent.tsx
@@ -1,7 +1,7 @@
 import { useCreateDiscount } from '@/hooks/queries'
 import { setValidationErrors } from '@/utils/api/errors'
 import { schemas } from '@polar-sh/client'
-import { Button, InlineModalHeader } from '@polar-sh/orbit'
+import { Button, InlineModalHeader, Text } from '@polar-sh/orbit'
 import { Form } from '@polar-sh/ui/components/ui/form'
 import { useCallback } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
@@ -71,7 +71,9 @@ const CreateDiscountModalContent = ({
   return (
     <div className="flex flex-col overflow-y-auto">
       <InlineModalHeader hide={hideModal}>
-        <h2 className="text-lg">Create Discount</h2>
+        <Text variant="heading-xxs" as="h2">
+          Create Discount
+        </Text>
       </InlineModalHeader>
       <div className="flex flex-col gap-y-6 px-8 pb-10">
         <Form {...form}>

--- a/clients/apps/web/src/components/Discounts/UpdateDiscountModalContent.tsx
+++ b/clients/apps/web/src/components/Discounts/UpdateDiscountModalContent.tsx
@@ -2,7 +2,7 @@ import { useUpdateDiscount } from '@/hooks/queries'
 import { setValidationErrors } from '@/utils/api/errors'
 import { isDiscountFixed } from '@/utils/discount'
 import { isValidationError, schemas } from '@polar-sh/client'
-import { Button } from '@polar-sh/orbit'
+import { Button, InlineModalHeader } from '@polar-sh/orbit'
 import { Form } from '@polar-sh/ui/components/ui/form'
 import { useCallback } from 'react'
 import { useForm } from 'react-hook-form'
@@ -105,14 +105,14 @@ const UpdateDiscountModalContent = ({
   )
 
   return (
-    <div className="flex flex-col gap-y-6 overflow-y-auto px-8 py-10">
-      <div>
+    <div className="flex flex-col overflow-y-auto">
+      <InlineModalHeader className="pb-2" hide={hideModal}>
         <h2 className="text-lg">Update Discount</h2>
-        <p className="dark:text-polar-500 mt-2 text-sm text-gray-500">
+      </InlineModalHeader>
+      <div className="flex flex-col gap-y-6 px-8 pb-10">
+        <p className="dark:text-polar-500 text-sm text-gray-500">
           Amount and options cannot be changed.
         </p>
-      </div>
-      <div className="flex flex-col gap-y-6">
         <Form {...form}>
           <form
             className="flex flex-col gap-y-6"

--- a/clients/apps/web/src/components/Discounts/UpdateDiscountModalContent.tsx
+++ b/clients/apps/web/src/components/Discounts/UpdateDiscountModalContent.tsx
@@ -2,7 +2,7 @@ import { useUpdateDiscount } from '@/hooks/queries'
 import { setValidationErrors } from '@/utils/api/errors'
 import { isDiscountFixed } from '@/utils/discount'
 import { isValidationError, schemas } from '@polar-sh/client'
-import { Button, InlineModalHeader } from '@polar-sh/orbit'
+import { Button, InlineModalHeader, Text } from '@polar-sh/orbit'
 import { Form } from '@polar-sh/ui/components/ui/form'
 import { useCallback } from 'react'
 import { useForm } from 'react-hook-form'
@@ -108,7 +108,9 @@ const UpdateDiscountModalContent = ({
     <div className="flex flex-col overflow-y-auto">
       <InlineModalHeader hide={hideModal}>
         <div className="flex flex-col gap-1">
-          <h2 className="text-lg">Update Discount</h2>
+          <Text variant="heading-xxs" as="h2">
+            Update Discount
+          </Text>
           <p className="dark:text-polar-500 text-sm font-normal text-gray-500">
             Amount and options cannot be changed.
           </p>

--- a/clients/apps/web/src/components/Discounts/UpdateDiscountModalContent.tsx
+++ b/clients/apps/web/src/components/Discounts/UpdateDiscountModalContent.tsx
@@ -106,13 +106,15 @@ const UpdateDiscountModalContent = ({
 
   return (
     <div className="flex flex-col overflow-y-auto">
-      <InlineModalHeader className="pb-2" hide={hideModal}>
-        <h2 className="text-lg">Update Discount</h2>
+      <InlineModalHeader hide={hideModal}>
+        <div className="flex flex-col gap-1">
+          <h2 className="text-lg">Update Discount</h2>
+          <p className="dark:text-polar-500 text-sm font-normal text-gray-500">
+            Amount and options cannot be changed.
+          </p>
+        </div>
       </InlineModalHeader>
       <div className="flex flex-col gap-y-6 px-8 pb-10">
-        <p className="dark:text-polar-500 text-sm text-gray-500">
-          Amount and options cannot be changed.
-        </p>
         <Form {...form}>
           <form
             className="flex flex-col gap-y-6"

--- a/clients/apps/web/src/components/Meter/CreateMeterModalContent.tsx
+++ b/clients/apps/web/src/components/Meter/CreateMeterModalContent.tsx
@@ -1,7 +1,7 @@
 import { useCreateMeter } from '@/hooks/queries/meters'
 import { setValidationErrors } from '@/utils/api/errors'
 import { isValidationError, schemas } from '@polar-sh/client'
-import { Button, InlineModalHeader } from '@polar-sh/orbit'
+import { Button, InlineModalHeader, Text } from '@polar-sh/orbit'
 import { Form } from '@polar-sh/ui/components/ui/form'
 import { useCallback } from 'react'
 import { useForm } from 'react-hook-form'
@@ -79,7 +79,9 @@ const CreateMeterModalContent = ({
   return (
     <div className="flex flex-col overflow-y-auto">
       <InlineModalHeader hide={hideModal}>
-        <h2 className="text-lg">Create Meter</h2>
+        <Text variant="heading-xxs" as="h2">
+          Create Meter
+        </Text>
       </InlineModalHeader>
       <div className="flex flex-col gap-y-6 px-8 pb-10">
         <div className="dark:text-polar-500 space-y-2 text-sm text-gray-500">

--- a/clients/apps/web/src/components/Meter/CreateMeterModalContent.tsx
+++ b/clients/apps/web/src/components/Meter/CreateMeterModalContent.tsx
@@ -78,7 +78,7 @@ const CreateMeterModalContent = ({
 
   return (
     <div className="flex flex-col overflow-y-auto">
-      <InlineModalHeader className="pb-2" hide={hideModal}>
+      <InlineModalHeader hide={hideModal}>
         <h2 className="text-lg">Create Meter</h2>
       </InlineModalHeader>
       <div className="flex flex-col gap-y-6 px-8 pb-10">

--- a/clients/apps/web/src/components/Meter/CreateMeterModalContent.tsx
+++ b/clients/apps/web/src/components/Meter/CreateMeterModalContent.tsx
@@ -1,7 +1,7 @@
 import { useCreateMeter } from '@/hooks/queries/meters'
 import { setValidationErrors } from '@/utils/api/errors'
 import { isValidationError, schemas } from '@polar-sh/client'
-import { Button } from '@polar-sh/orbit'
+import { Button, InlineModalHeader } from '@polar-sh/orbit'
 import { Form } from '@polar-sh/ui/components/ui/form'
 import { useCallback } from 'react'
 import { useForm } from 'react-hook-form'
@@ -77,10 +77,12 @@ const CreateMeterModalContent = ({
   )
 
   return (
-    <div className="flex flex-col gap-y-6 overflow-y-auto px-8 py-10">
-      <div>
+    <div className="flex flex-col overflow-y-auto">
+      <InlineModalHeader className="pb-2" hide={hideModal}>
         <h2 className="text-lg">Create Meter</h2>
-        <div className="dark:text-polar-500 mt-2 space-y-2 text-sm text-gray-500">
+      </InlineModalHeader>
+      <div className="flex flex-col gap-y-6 px-8 pb-10">
+        <div className="dark:text-polar-500 space-y-2 text-sm text-gray-500">
           <p>
             Meters are aggregated filters on ingested events. They are used to
             calculate your customer&apos;s usage of whatever you choose to
@@ -92,8 +94,6 @@ const CreateMeterModalContent = ({
             events with an arbitrary name like <code>api_call</code>.
           </p>
         </div>
-      </div>
-      <div className="flex flex-col gap-y-6">
         <Form {...form}>
           <form className="flex flex-col gap-y-6">
             <MeterForm organizationId={organization.id} />

--- a/clients/apps/web/src/components/Meter/MeterUpdateModal.tsx
+++ b/clients/apps/web/src/components/Meter/MeterUpdateModal.tsx
@@ -1,7 +1,7 @@
 import { useMeter, useUpdateMeter } from '@/hooks/queries/meters'
 import { setValidationErrors } from '@/utils/api/errors'
 import { isValidationError, schemas } from '@polar-sh/client'
-import { Button, InlineModalHeader } from '@polar-sh/orbit'
+import { Button, InlineModalHeader, Text } from '@polar-sh/orbit'
 import { Form } from '@polar-sh/ui/components/ui/form'
 import { useRouter } from 'next/navigation'
 import { useCallback } from 'react'
@@ -70,7 +70,9 @@ export const MeterUpdateModal = ({
   return (
     <div className="flex flex-col overflow-y-auto">
       <InlineModalHeader hide={hide}>
-        <h2 className="text-lg">Edit Meter</h2>
+        <Text variant="heading-xxs" as="h2">
+          Edit Meter
+        </Text>
       </InlineModalHeader>
       <div className="flex flex-col gap-8 px-8 pb-12">
         <p className="dark:text-polar-500 text-gray-500">

--- a/clients/apps/web/src/components/Meter/MeterUpdateModal.tsx
+++ b/clients/apps/web/src/components/Meter/MeterUpdateModal.tsx
@@ -69,7 +69,7 @@ export const MeterUpdateModal = ({
 
   return (
     <div className="flex flex-col overflow-y-auto">
-      <InlineModalHeader className="pb-2" hide={hide}>
+      <InlineModalHeader hide={hide}>
         <h2 className="text-lg">Edit Meter</h2>
       </InlineModalHeader>
       <div className="flex flex-col gap-8 px-8 pb-12">

--- a/clients/apps/web/src/components/Meter/MeterUpdateModal.tsx
+++ b/clients/apps/web/src/components/Meter/MeterUpdateModal.tsx
@@ -1,7 +1,7 @@
 import { useMeter, useUpdateMeter } from '@/hooks/queries/meters'
 import { setValidationErrors } from '@/utils/api/errors'
 import { isValidationError, schemas } from '@polar-sh/client'
-import { Button } from '@polar-sh/orbit'
+import { Button, InlineModalHeader } from '@polar-sh/orbit'
 import { Form } from '@polar-sh/ui/components/ui/form'
 import { useRouter } from 'next/navigation'
 import { useCallback } from 'react'
@@ -68,13 +68,15 @@ export const MeterUpdateModal = ({
   if (!meter) return null
 
   return (
-    <div className="flex flex-col gap-8 overflow-y-auto px-8 py-12">
-      <h2 className="text-xl">Edit Meter</h2>
-      <p className="dark:text-polar-500 text-gray-500">
-        Meters are aggregations of events. You can create a meter to track
-        events that match a filter.
-      </p>
-      <div className="flex flex-col gap-y-6">
+    <div className="flex flex-col overflow-y-auto">
+      <InlineModalHeader className="pb-2" hide={hide}>
+        <h2 className="text-lg">Edit Meter</h2>
+      </InlineModalHeader>
+      <div className="flex flex-col gap-8 px-8 pb-12">
+        <p className="dark:text-polar-500 text-gray-500">
+          Meters are aggregations of events. You can create a meter to track
+          events that match a filter.
+        </p>
         <Form {...form}>
           <form
             onSubmit={handleSubmit(onSubmit)}

--- a/clients/apps/web/src/components/Refunds/RefundModal.tsx
+++ b/clients/apps/web/src/components/Refunds/RefundModal.tsx
@@ -87,7 +87,7 @@ export const RefundModal = ({ order, hide }: RefundModalProps) => {
 
   return (
     <div className="flex flex-col overflow-y-auto">
-      <InlineModalHeader className="pb-2" hide={hide}>
+      <InlineModalHeader hide={hide}>
         <h2 className="text-lg">Refund Order</h2>
       </InlineModalHeader>
       <div className="flex flex-col gap-8 px-8 pb-12">

--- a/clients/apps/web/src/components/Refunds/RefundModal.tsx
+++ b/clients/apps/web/src/components/Refunds/RefundModal.tsx
@@ -2,7 +2,7 @@ import { useCreateRefund } from '@/hooks/queries'
 import { extractApiErrorMessage } from '@/utils/api/errors'
 import { enums, schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
-import { Button, InlineModalHeader } from '@polar-sh/orbit'
+import { Button, InlineModalHeader, Text } from '@polar-sh/orbit'
 import MoneyInput from '@polar-sh/ui/components/atoms/MoneyInput'
 import {
   Select,
@@ -88,7 +88,9 @@ export const RefundModal = ({ order, hide }: RefundModalProps) => {
   return (
     <div className="flex flex-col overflow-y-auto">
       <InlineModalHeader hide={hide}>
-        <h2 className="text-lg">Refund Order</h2>
+        <Text variant="heading-xxs" as="h2">
+          Refund Order
+        </Text>
       </InlineModalHeader>
       <div className="flex flex-col gap-8 px-8 pb-12">
         <p className="dark:text-polar-500 text-gray-500">

--- a/clients/apps/web/src/components/Refunds/RefundModal.tsx
+++ b/clients/apps/web/src/components/Refunds/RefundModal.tsx
@@ -2,7 +2,7 @@ import { useCreateRefund } from '@/hooks/queries'
 import { extractApiErrorMessage } from '@/utils/api/errors'
 import { enums, schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
-import { Button } from '@polar-sh/orbit'
+import { Button, InlineModalHeader } from '@polar-sh/orbit'
 import MoneyInput from '@polar-sh/ui/components/atoms/MoneyInput'
 import {
   Select,
@@ -86,166 +86,170 @@ export const RefundModal = ({ order, hide }: RefundModalProps) => {
   }
 
   return (
-    <div className="flex flex-col gap-8 overflow-y-auto px-8 py-12">
-      <h2 className="text-xl">Refund Order</h2>
-      <p className="dark:text-polar-500 text-gray-500">
-        You can refund in part or full. Your customer will see it on their bank
-        statement in 5-10 days.
-      </p>
+    <div className="flex flex-col overflow-y-auto">
+      <InlineModalHeader className="pb-2" hide={hide}>
+        <h2 className="text-lg">Refund Order</h2>
+      </InlineModalHeader>
+      <div className="flex flex-col gap-8 px-8 pb-12">
+        <p className="dark:text-polar-500 text-gray-500">
+          You can refund in part or full. Your customer will see it on their
+          bank statement in 5-10 days.
+        </p>
 
-      <Form {...form}>
-        <form
-          onSubmit={form.handleSubmit(handleRefundOrder)}
-          className="flex flex-col gap-4"
-        >
-          <div className="flex flex-col gap-4">
-            <FormField
-              control={form.control}
-              name="amount"
-              rules={{
-                required: 'Amount is required',
-                min: {
-                  value: 0.01,
-                  message: 'Amount must be greater than 0',
-                },
-                max: {
-                  value: maximumRefundAmount,
-                  message: `Amount must be less or equal to ${formatCurrency(
-                    'compact',
-                  )(maximumRefundAmount, order.currency)}`,
-                },
-              }}
-              render={({ field }) => (
-                <FormItem>
-                  <div className="flex h-4 flex-row items-center justify-between">
-                    <FormLabel>Amount (excl. tax)</FormLabel>
-                    {canRefund && !isMaximumRefund && (
-                      <button
-                        type="button"
-                        onClick={() =>
-                          form.setValue('amount', maximumRefundAmount, {
-                            shouldValidate: true,
-                            shouldDirty: true,
-                          })
-                        }
-                        className="dark:text-polar-400 dark:hover:text-polar-200 text-xs text-gray-500 underline hover:text-gray-900"
-                      >
-                        Refund fully
-                      </button>
-                    )}
-                  </div>
-                  <FormControl>
-                    <MoneyInput
-                      placeholder={0}
-                      currency={order.currency}
-                      {...field}
-                    />
-                  </FormControl>
-                  {amount > 0 && amount <= maximumRefundAmount && (
-                    <p className="dark:text-polar-400 text-xs text-gray-500">
-                      Customer will be refunded{' '}
-                      <span className="dark:text-polar-200 font-medium text-gray-900">
-                        {formatCurrency('compact')(
-                          previewTotal,
-                          order.currency,
-                        )}
-                      </span>{' '}
-                      ({formatCurrency('compact')(amount, order.currency)} +{' '}
-                      {formatCurrency('compact')(previewTax, order.currency)}{' '}
-                      tax)
-                    </p>
-                  )}
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name="reason"
-              rules={{
-                required: 'Reason is required',
-              }}
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Reason</FormLabel>
-                  <FormControl>
-                    <Select
-                      {...field}
-                      value={field.value || ''}
-                      onValueChange={field.onChange}
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select Reason" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {Object.values(enums.refundReasonValues).map(
-                          (reason) => (
-                            <SelectItem key={reason} value={reason}>
-                              {RefundReasonDisplay[reason]}
-                            </SelectItem>
-                          ),
-                        )}
-                      </SelectContent>
-                    </Select>
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            {!order.subscription_id && (
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(handleRefundOrder)}
+            className="flex flex-col gap-4"
+          >
+            <div className="flex flex-col gap-4">
               <FormField
                 control={form.control}
-                name="revoke_benefits"
+                name="amount"
+                rules={{
+                  required: 'Amount is required',
+                  min: {
+                    value: 0.01,
+                    message: 'Amount must be greater than 0',
+                  },
+                  max: {
+                    value: maximumRefundAmount,
+                    message: `Amount must be less or equal to ${formatCurrency(
+                      'compact',
+                    )(maximumRefundAmount, order.currency)}`,
+                  },
+                }}
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Revoke Benefits</FormLabel>
+                    <div className="flex h-4 flex-row items-center justify-between">
+                      <FormLabel>Amount (excl. tax)</FormLabel>
+                      {canRefund && !isMaximumRefund && (
+                        <button
+                          type="button"
+                          onClick={() =>
+                            form.setValue('amount', maximumRefundAmount, {
+                              shouldValidate: true,
+                              shouldDirty: true,
+                            })
+                          }
+                          className="dark:text-polar-400 dark:hover:text-polar-200 text-xs text-gray-500 underline hover:text-gray-900"
+                        >
+                          Refund fully
+                        </button>
+                      )}
+                    </div>
                     <FormControl>
-                      <div className="flex flex-row items-center gap-x-2">
-                        <Checkbox
-                          defaultChecked={field.value}
-                          onCheckedChange={field.onChange}
-                        />
-                        <p className="text-sm">
-                          Revoke the associated customer benefits
-                        </p>
-                      </div>
+                      <MoneyInput
+                        placeholder={0}
+                        currency={order.currency}
+                        {...field}
+                      />
+                    </FormControl>
+                    {amount > 0 && amount <= maximumRefundAmount && (
+                      <p className="dark:text-polar-400 text-xs text-gray-500">
+                        Customer will be refunded{' '}
+                        <span className="dark:text-polar-200 font-medium text-gray-900">
+                          {formatCurrency('compact')(
+                            previewTotal,
+                            order.currency,
+                          )}
+                        </span>{' '}
+                        ({formatCurrency('compact')(amount, order.currency)} +{' '}
+                        {formatCurrency('compact')(previewTax, order.currency)}{' '}
+                        tax)
+                      </p>
+                    )}
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="reason"
+                rules={{
+                  required: 'Reason is required',
+                }}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Reason</FormLabel>
+                    <FormControl>
+                      <Select
+                        {...field}
+                        value={field.value || ''}
+                        onValueChange={field.onChange}
+                      >
+                        <SelectTrigger>
+                          <SelectValue placeholder="Select Reason" />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {Object.values(enums.refundReasonValues).map(
+                            (reason) => (
+                              <SelectItem key={reason} value={reason}>
+                                {RefundReasonDisplay[reason]}
+                              </SelectItem>
+                            ),
+                          )}
+                        </SelectContent>
+                      </Select>
                     </FormControl>
                     <FormMessage />
                   </FormItem>
                 )}
               />
-            )}
-          </div>
-          <div className="dark:text-polar-500 dark:bg-polar-800 space-y-1.5 rounded-xl bg-gray-50 p-3 text-sm text-gray-500">
-            <p>
-              The original payment processing fees stay deducted from your
-              balance. No additional fees are charged for the refund itself.
-            </p>
-            <p>
-              <a
-                href="https://polar.sh/docs/features/refunds"
-                className="underline hover:no-underline"
-                target="_blank"
-                rel="noreferrer noopener"
+              {!order.subscription_id && (
+                <FormField
+                  control={form.control}
+                  name="revoke_benefits"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Revoke Benefits</FormLabel>
+                      <FormControl>
+                        <div className="flex flex-row items-center gap-x-2">
+                          <Checkbox
+                            defaultChecked={field.value}
+                            onCheckedChange={field.onChange}
+                          />
+                          <p className="text-sm">
+                            Revoke the associated customer benefits
+                          </p>
+                        </div>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              )}
+            </div>
+            <div className="dark:text-polar-500 dark:bg-polar-800 space-y-1.5 rounded-xl bg-gray-50 p-3 text-sm text-gray-500">
+              <p>
+                The original payment processing fees stay deducted from your
+                balance. No additional fees are charged for the refund itself.
+              </p>
+              <p>
+                <a
+                  href="https://polar.sh/docs/features/refunds"
+                  className="underline hover:no-underline"
+                  target="_blank"
+                  rel="noreferrer noopener"
+                >
+                  Learn more about refunds
+                </a>
+              </p>
+            </div>
+            <div className="flex flex-col gap-4 md:flex-row-reverse md:items-center md:justify-start">
+              <Button
+                type="submit"
+                disabled={!canRefund}
+                loading={createRefund.isPending}
               >
-                Learn more about refunds
-              </a>
-            </p>
-          </div>
-          <div className="flex flex-col gap-4 md:flex-row-reverse md:items-center md:justify-start">
-            <Button
-              type="submit"
-              disabled={!canRefund}
-              loading={createRefund.isPending}
-            >
-              Refund Order
-            </Button>
-            <Button variant="ghost" onClick={hide}>
-              Cancel
-            </Button>
-          </div>
-        </form>
-      </Form>
+                Refund Order
+              </Button>
+              <Button variant="ghost" onClick={hide}>
+                Cancel
+              </Button>
+            </div>
+          </form>
+        </Form>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Updated some modals to use `InlineModalHeader` to allow mobile being closed on mobile devices where it takes up all of the screen.

| Screenshot example |
|---|
| <img width="601" height="464" alt="Screenshot 2026-08-12 at 08 36 45" src="https://github.com/user-attachments/assets/3ff3adf7-ee9f-47bf-92fe-ffad995ce760" /> |



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

