### PR TITLE
Clear customer_tax_id when disabling business purchase on checkout

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -2221,7 +2221,17 @@ class CheckoutService:
         if checkout_update.customer_billing_address:
             checkout.customer_billing_address = checkout_update.customer_billing_address
 
-        if (
+        # Turning off business purchase must clear the business billing fields.
+        # Otherwise a stale tax ID keeps reverse-charge (0% VAT) treatment on the
+        # order and invoice even though the checkout is no longer a business purchase.
+        disabling_business_customer = (
+            checkout_update.is_business_customer is False
+            and "is_business_customer" in checkout_update.model_fields_set
+        )
+        if disabling_business_customer:
+            checkout.customer_billing_name = None
+
+        if disabling_business_customer or (
             checkout_update.customer_tax_id is None
             and "customer_tax_id" in checkout_update.model_fields_set
         ):

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -3511,6 +3511,31 @@ class TestUpdate:
         assert checkout.customer_billing_address is not None
         assert checkout.customer_billing_address.country == "US"
 
+    async def test_disabling_business_customer_clears_tax_id(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        checkout_one_time_custom: Checkout,
+    ) -> None:
+        checkout_one_time_custom.is_business_customer = True
+        checkout_one_time_custom.customer_billing_name = "ACME Inc."
+        checkout_one_time_custom.customer_tax_id = (
+            "FR61954506077",
+            TaxIDFormat.eu_vat,
+        )
+        await save_fixture(checkout_one_time_custom)
+
+        checkout = await checkout_service.update(
+            session,
+            checkout_one_time_custom,
+            CheckoutUpdate(is_business_customer=False),
+        )
+
+        assert checkout.is_business_customer is False
+        assert checkout.customer_tax_id is None
+        assert checkout.customer_tax_id_number is None
+        assert checkout.customer_billing_name is None
+
     async def test_silent_calculate_tax_error(
         self,
         session: AsyncSession,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clears business tax details when a user turns off “Purchase as a business” in checkout, so VAT is calculated correctly. Prevents stale VAT IDs from causing reverse-charge (0% VAT) on orders and invoices. Fixes #13649.

- **Bug Fixes**
  - When `is_business_customer` is set to false, clear `customer_tax_id`, `customer_tax_id_number`, and `customer_billing_name`.
  - Added a test to confirm these fields are cleared when disabling business purchase.

<sup>Written for commit 4ad65ec20691ee7e03ca1dd06bdb616f5c2921eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

