### PR TITLE
dx: use Tinybird ARM image and remove skip-tinybird flags

### DIFF
--- a/.agents/skills/local-environment/rules/start-environment.md
+++ b/.agents/skills/local-environment/rules/start-environment.md
@@ -13,27 +13,33 @@ plain `dev docker up` returns once containers are created.
 ## Basic commands
 
 **Start in background (the default):**
+
 ```bash
 dev docker up -d
 ```
 
 **Start and block until app services are healthy:**
+
 ```bash
 dev docker up -d --wait
 ```
+
 `--wait` returns only once api answers `/healthz` and web responds. Prefer it in
 scripts and tooling so "up finished" means "actually serving" rather than "the
 container was created" — on first boot the app keeps compiling and migrating for
 a while after the container starts.
 
 **Start in the foreground and stream logs:**
+
 ```bash
 dev docker up --no-detach
 ```
+
 Shared infra still starts detached; only the app stack is attached, so Ctrl+C
 stops the app stack.
 
 **Start specific services:**
+
 ```bash
 dev docker up -d api            # api (+ shared infra)
 dev docker up -d web            # web (+ shared infra)
@@ -42,16 +48,15 @@ dev docker up -d api worker     # api and worker
 
 ## Options
 
-| Flag | Description |
-|------|-------------|
-| `-d` / `--detach` | Detached / background (default) |
-| `--no-detach` | Foreground; stream app logs until you stop it |
-| `--wait` | Block until app services are healthy (detached only) |
-| `-b` / `--build` | Rebuild images before starting |
-| `--pull` | Refresh base images before building (see below) |
-| `--monitoring` | Include Prometheus and Grafana in shared infra |
-| `--skip-tinybird` | Don't start Tinybird |
-| `-i N` | Target instance N explicitly (usually auto-detected) |
+| Flag              | Description                                          |
+| ----------------- | ---------------------------------------------------- |
+| `-d` / `--detach` | Detached / background (default)                      |
+| `--no-detach`     | Foreground; stream app logs until you stop it        |
+| `--wait`          | Block until app services are healthy (detached only) |
+| `-b` / `--build`  | Rebuild images before starting                       |
+| `--pull`          | Refresh base images before building (see below)      |
+| `--monitoring`    | Include Prometheus and Grafana in shared infra       |
+| `-i N`            | Target instance N explicitly (usually auto-detected) |
 
 ## Rebuilding with fresh bases
 

--- a/dev/cli/README.md
+++ b/dev/cli/README.md
@@ -16,11 +16,13 @@ Now you can use `dev` from anywhere in the repo.
 ## Privacy & Analytics
 
 The CLI collects anonymous usage analytics to help improve the tool. This includes:
+
 - Command name and flags used (secrets/tokens are automatically redacted)
 - Operating system
 - Git user name and email (for identification)
 
 To disable analytics, set either environment variable:
+
 - `DEV_CLI_NO_ANALYTICS=1` — Polar-specific opt-out
 - `DO_NOT_TRACK=1` — Standard privacy flag
 
@@ -107,7 +109,6 @@ def run(ctx: Context) -> bool:
     """Execute the step. Return True on success."""
     # ctx.clean - if --clean flag was passed
     # ctx.skip_integrations - if --skip-integrations was passed
-    # ctx.skip_tinybird - if --skip-tinybird was passed
     # ctx.database_name - if --database-name was passed
     step_status(True, "Did something", "details")
     return True

--- a/dev/cli/cli.py
+++ b/dev/cli/cli.py
@@ -151,10 +151,6 @@ def up(
         bool,
         typer.Option("--skip-integrations", help="Skip GitHub/Stripe setup prompts"),
     ] = False,
-    skip_tinybird: Annotated[
-        bool,
-        typer.Option("--skip-tinybird", help="Skip starting and waiting for Tinybird"),
-    ] = False,
     database_name: Annotated[
         str | None,
         typer.Option(
@@ -185,7 +181,6 @@ def up(
     ctx = Context(
         clean=clean,
         skip_integrations=skip_integrations,
-        skip_tinybird=skip_tinybird,
         database_name=database_name,
     )
     steps = discover_steps()

--- a/dev/cli/commands/docker.py
+++ b/dev/cli/commands/docker.py
@@ -724,7 +724,7 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
                 raise typer.Exit(1)
         elif monitoring:
             console.print(
-                "[yellow]Shared infra is already running; --monitoring and only take effect on first start. Run `dev docker down --all` first to apply.[/yellow]"
+                "[yellow]Shared infra is already running; --monitoring only takes effect on first start. Run `dev docker down --all` first to apply.[/yellow]"
             )
 
         env = _build_compose_env(instance)

--- a/dev/cli/commands/docker.py
+++ b/dev/cli/commands/docker.py
@@ -414,7 +414,7 @@ def _ensure_network() -> None:
     console.print(f"[dim]Created docker network: {SHARED_NETWORK_NAME}[/dim]")
 
 
-def _shared_compose_cmd(monitoring: bool = False, tinybird: bool = False) -> list[str]:
+def _shared_compose_cmd(monitoring: bool = False) -> list[str]:
     cmd = [
         "docker",
         "compose",
@@ -426,8 +426,6 @@ def _shared_compose_cmd(monitoring: bool = False, tinybird: bool = False) -> lis
     profiles = []
     if monitoring:
         profiles.append("monitoring")
-    if tinybird:
-        profiles.append("tinybird")
     for profile in profiles:
         cmd.extend(["--profile", profile])
     return cmd
@@ -669,7 +667,7 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
           `polar-app-N` project
         """
         if service in SHARED_SERVICES:
-            return _shared_compose_cmd(monitoring=True, tinybird=True), {}
+            return _shared_compose_cmd(monitoring=True), {}
         return _build_compose_cmd(instance), _build_compose_env(instance)
 
     @docker_app.command("up")
@@ -705,12 +703,6 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
                 "--monitoring", help="Include Prometheus and Grafana in shared infra"
             ),
         ] = False,
-        skip_tinybird: Annotated[
-            bool,
-            typer.Option(
-                "--skip-tinybird", help="Skip starting Tinybird service"
-            ),
-        ] = False,
         services: Annotated[
             list[str] | None,
             typer.Argument(help="Services to start (default: all app services)"),
@@ -724,15 +716,15 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
         # Bring shared infra up first if it isn't already running.
         _ensure_network()
         if not _shared_is_running():
-            shared_cmd = _shared_compose_cmd(monitoring=monitoring, tinybird=not skip_tinybird) + ["up", "-d"]
+            shared_cmd = _shared_compose_cmd(monitoring=monitoring) + ["up", "-d"]
             console.print("[bold blue]Starting Polar shared infra[/bold blue]")
             result = run_command(shared_cmd)
             if not result or result.returncode != 0:
                 console.print("[red]Failed to start shared infra[/red]")
                 raise typer.Exit(1)
-        elif monitoring or skip_tinybird:
+        elif monitoring:
             console.print(
-                "[yellow]Shared infra is already running; --monitoring and --skip-tinybird only take effect on first start. Run `dev docker down --all` first to apply.[/yellow]"
+                "[yellow]Shared infra is already running; --monitoring and only take effect on first start. Run `dev docker down --all` first to apply.[/yellow]"
             )
 
         env = _build_compose_env(instance)
@@ -800,7 +792,7 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
 
         if all_:
             console.print("[dim]Stopping shared infra...[/dim]")
-            shared = _shared_compose_cmd(monitoring=True, tinybird=True) + ["down"]
+            shared = _shared_compose_cmd(monitoring=True) + ["down"]
             result = run_command(shared)
             if not result or result.returncode != 0:
                 console.print("[red]Failed to stop shared infra[/red]")
@@ -843,7 +835,7 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
         """List running containers — both shared infra and this instance's app stack."""
         instance = _get_instance(ctx)
         console.print(f"[bold]Shared ({SHARED_PROJECT_NAME})[/bold]")
-        run_command(_shared_compose_cmd(monitoring=True, tinybird=True) + ["ps"])
+        run_command(_shared_compose_cmd(monitoring=True) + ["ps"])
         console.print(f"\n[bold]App ({app_project(instance)})[/bold]")
         run_command(
             _build_compose_cmd(instance) + ["ps"], env=_build_compose_env(instance)
@@ -996,7 +988,7 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
 
         if all_:
             console.print("[dim]Wiping shared infra volumes...[/dim]")
-            shared = _shared_compose_cmd(monitoring=True, tinybird=True) + [
+            shared = _shared_compose_cmd(monitoring=True) + [
                 "down",
                 "-v",
                 "--remove-orphans",

--- a/dev/cli/commands/seed.py
+++ b/dev/cli/commands/seed.py
@@ -101,11 +101,6 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
             "--reset",
             help="Recreate the database before loading fresh seed data.",
         ),
-        skip_tinybird: bool = typer.Option(
-            False,
-            "--skip-tinybird",
-            help="Skip seeding events to Tinybird.",
-        ),
     ) -> None:
         """Load sample data (users, organizations, products) into the database."""
         console.print()
@@ -140,8 +135,6 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
 
             _print_info("Loading fresh seed data. This usually takes a few minutes.")
             seed_cmd = ["uv", "run", "task", "seeds_load"]
-            if skip_tinybird:
-                seed_cmd.append("--skip-tinybird")
             with step_spinner("Seeding database..."):
                 result = run_command(seed_cmd, cwd=SERVER_DIR, capture=True)
             if not result or result.returncode != 0:
@@ -170,9 +163,6 @@ def register(app: typer.Typer, prompt_setup: callable) -> None:
             console.print()
 
             cmd = ["uv", "run", "task", "seeds_load"]
-
-        if skip_tinybird:
-            cmd.append("--skip-tinybird")
 
         _print_info("This usually takes a few minutes.")
         with step_spinner("Seeding database..."):

--- a/dev/cli/shared.py
+++ b/dev/cli/shared.py
@@ -35,7 +35,6 @@ class Context:
 
     clean: bool = False
     skip_integrations: bool = False
-    skip_tinybird: bool = False
     database_name: str | None = None
     state: dict = field(default_factory=dict)
 

--- a/dev/cli/up_steps/04_start_infrastructure.py
+++ b/dev/cli/up_steps/04_start_infrastructure.py
@@ -41,14 +41,9 @@ def run(ctx: Context) -> bool:
         return True
 
     compose_cmd = ["docker", "compose"]
-    # Include tinybird profile by default; exclude it when skip_tinybird is set
-    if not ctx.skip_tinybird:
-        compose_cmd.extend(["--profile", "tinybird"])
     compose_cmd.extend(["up", "-d"])
 
-    service_name = "PostgreSQL, Redis, Minio"
-    if not ctx.skip_tinybird:
-        service_name += ", Tinybird"
+    service_name = "PostgreSQL, Redis, Minio, Tinybird"
 
     with step_spinner(f"Starting {service_name}..."):
         result = run_command(

--- a/dev/cli/up_steps/05_wait_for_services.py
+++ b/dev/cli/up_steps/05_wait_for_services.py
@@ -94,24 +94,20 @@ def run(ctx: Context) -> bool:
             step_status(False, "Redis", "timeout after 60s")
             return False
 
-    # Only wait for Tinybird if not skipped
-    if ctx.skip_tinybird:
-        step_status(True, "Tinybird", "skipped")
-    else:
-        with step_spinner("Waiting for Tinybird..."):
-            token = wait_for_tinybird_and_get_token(timeout=90)
-            if token:
-                update_secrets(
-                    {
-                        "POLAR_TINYBIRD_API_TOKEN": token,
-                        "POLAR_TINYBIRD_READ_TOKEN": token,
-                        "POLAR_TINYBIRD_CLICKHOUSE_TOKEN": token,
-                    }
-                )
-                run_command([str(ROOT_DIR / "dev" / "setup-environment")], capture=True)
-                step_status(True, "Tinybird", "ready (token configured)")
-            else:
-                step_status(False, "Tinybird", "timeout - continuing without it")
-                # Don't fail the whole setup for tinybird
+    with step_spinner("Waiting for Tinybird..."):
+        token = wait_for_tinybird_and_get_token(timeout=90)
+        if token:
+            update_secrets(
+                {
+                    "POLAR_TINYBIRD_API_TOKEN": token,
+                    "POLAR_TINYBIRD_READ_TOKEN": token,
+                    "POLAR_TINYBIRD_CLICKHOUSE_TOKEN": token,
+                }
+            )
+            run_command([str(ROOT_DIR / "dev" / "setup-environment")], capture=True)
+            step_status(True, "Tinybird", "ready (token configured)")
+        else:
+            step_status(False, "Tinybird", "timeout - continuing without it")
+            # Don't fail the whole setup for tinybird
 
     return True

--- a/dev/create-worktree
+++ b/dev/create-worktree
@@ -40,6 +40,6 @@ fi
 
 # Set up environment in the worktree
 echo "Setting up environment in $worktree_dir"
-cd "$worktree_dir" && ./dev/cli/dev up --skip-integrations --skip-tinybird --database-name "$db_name"
+cd "$worktree_dir" && ./dev/cli/dev up --skip-integrations --database-name "$db_name"
 
 echo "Worktree setup complete for $name"

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -110,7 +110,6 @@ services:
 
   tinybird:
     image: tinybirdco/tinybird-local:latest
-    platform: linux/amd64
     ports:
       - "${TINYBIRD_PORT:-7181}:7181"
       - "${TINYBIRD_ADMIN_PORT:-7182}:7182"
@@ -123,8 +122,6 @@ services:
       interval: 5s
       timeout: 10s
       retries: 30
-    profiles:
-      - tinybird
 
   localstack:
     # Pinned: newer tags may require a LOCALSTACK_AUTH_TOKEN.

--- a/server/scripts/seeds_load.py
+++ b/server/scripts/seeds_load.py
@@ -1233,9 +1233,7 @@ async def create_support_cases_seed(session: AsyncSession) -> None:
         print(f"Seeded dispute case on org '{dispute_org.slug}'")
 
 
-async def create_seed_data(
-    session: AsyncSession, redis: Redis, *, skip_tinybird: bool = False
-) -> None:
+async def create_seed_data(session: AsyncSession, redis: Redis) -> None:
     """Create sample data for development and testing."""
 
     # Check if seed data already exists
@@ -2119,10 +2117,9 @@ async def create_seed_data(
                     pending_tinybird_events.extend(inserted)
                     pending_tinybird_ancestors.update(ancestors_by_event)
 
-        if not skip_tinybird:
-            await _flush_tinybird_events(
-                pending_tinybird_events, pending_tinybird_ancestors
-            )
+        await _flush_tinybird_events(
+            pending_tinybird_events, pending_tinybird_ancestors
+        )
 
         # Create real Subscription rows for acme-corp customers so that PG-based
         # metrics (MRR, Trial MRR, Active Subscriptions) have data to display.
@@ -2561,7 +2558,7 @@ def _write_webhook_secret_to_env(secret: str) -> None:
 
 
 async def create_single_org_seed(
-    session: AsyncSession, redis: Redis, slug: str, *, skip_tinybird: bool = False
+    session: AsyncSession, redis: Redis, slug: str
 ) -> None:
     """Create a single organization with products, customers, and timeline events."""
     name = slug.replace("-", " ").title()
@@ -2710,10 +2707,7 @@ async def create_single_org_seed(
                 pending_tinybird_events.extend(inserted)
                 pending_tinybird_ancestors.update(ancestors_by_event)
 
-    if not skip_tinybird:
-        await _flush_tinybird_events(
-            pending_tinybird_events, pending_tinybird_ancestors
-        )
+    await _flush_tinybird_events(pending_tinybird_events, pending_tinybird_ancestors)
 
     await session.commit()
     print(f"✅ Created organization '{name}' ({slug})")
@@ -2730,11 +2724,6 @@ def seeds_load(
         "--new-org",
         help="Create a single new organization with this slug, with products, customers, and timeline events.",
     ),
-    skip_tinybird: bool = typer.Option(
-        False,
-        "--skip-tinybird",
-        help="Skip seeding events to Tinybird.",
-    ),
 ) -> None:
     """Load sample/test data into the database."""
     if ctx.invoked_subcommand is not None:
@@ -2747,11 +2736,9 @@ def seeds_load(
             sessionmaker = create_async_sessionmaker(engine)
             async with sessionmaker() as session:
                 if new_org:
-                    await create_single_org_seed(
-                        session, redis, new_org, skip_tinybird=skip_tinybird
-                    )
+                    await create_single_org_seed(session, redis, new_org)
                 else:
-                    await create_seed_data(session, redis, skip_tinybird=skip_tinybird)
+                    await create_seed_data(session, redis)
 
     asyncio.run(run())
 


### PR DESCRIPTION

Tinybird now ships a Docker image for ARM architecture. Confirmed it now runs super smoothly with Apple Silicon Mac.

- Removes the AMD64 tag in docker-compose.yml
- Removes the now useless `--skip-tinybird` flags in the dev CLI


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

