### PR TITLE
Fix repeating discounts in interval-change charge previews

### DIFF
--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -2388,6 +2388,8 @@ class SubscriptionService:
     async def _compute_charge_preview(
         self, session: AsyncSession, subscription: Subscription
     ) -> SubscriptionChargePreview:
+        next_period_start = subscription.current_period_end
+
         # Apply any pending subscription update (product change, seats change)
         pending_update = subscription.pending_update
         if pending_update is not None:
@@ -2455,16 +2457,13 @@ class SubscriptionService:
         items.extend(proration_items)
 
         applicable_discount = None
-        # Ensure the discount has not expired yet for the next charge (so at current_period_end)
+        # Ensure the discount has not expired yet for the next charge
         if subscription.discount is not None:
             # If discount hasn't been applied yet, it will be applied at the next cycle
-            # (current_period_end will become the new current_period_start)
-            discount_applied_at = (
-                subscription.discount_applied_at or subscription.current_period_end
-            )
+            discount_applied_at = subscription.discount_applied_at or next_period_start
             if not subscription.discount.is_repetition_expired(
                 discount_applied_at,
-                subscription.current_period_end,
+                next_period_start,
             ):
                 applicable_discount = subscription.discount
 

--- a/server/tests/subscription/test_service_charge_preview.py
+++ b/server/tests/subscription/test_service_charge_preview.py
@@ -360,6 +360,56 @@ class TestCalculateChargePreview:
 
         assert preview.base_amount == 1000
 
+    async def test_pending_interval_update_keeps_repeating_discount(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.percentage,
+            basis_points=2500,
+            duration=DiscountDuration.repeating,
+            duration_in_months=2,
+            organization=organization,
+        )
+        annual_product = await create_product(
+            save_fixture,
+            organization=organization,
+            recurring_interval=SubscriptionRecurringInterval.year,
+            prices=[(10000, "usd")],
+        )
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            discount=discount,
+            current_period_start=datetime(2024, 1, 1, tzinfo=UTC),
+            current_period_end=datetime(2024, 2, 1, tzinfo=UTC),
+        )
+
+        from polar.subscription.update import generate_subscription_update
+
+        subscription_update, _ = generate_subscription_update(
+            subscription,
+            SubscriptionProrationBehavior.next_period,
+            product=annual_product,
+        )
+        await save_fixture(subscription_update)
+        subscription.pending_update = subscription_update
+        await save_fixture(subscription)
+
+        preview = await subscription_service.calculate_charge_preview(
+            session, subscription
+        )
+
+        assert preview.base_amount == 10000
+        assert preview.discount_amount == 2500
+        assert preview.net_amount == 7500
+
 
 @pytest.mark.asyncio
 class TestCalculateChargePreviewTaxMatchesOrder:

--- a/server/tests/subscription/test_service_charge_preview.py
+++ b/server/tests/subscription/test_service_charge_preview.py
@@ -29,6 +29,7 @@ from polar.models.subscription_meter import SubscriptionMeter
 from polar.postgres import AsyncSession
 from polar.subscription.service import SubscriptionUpdateContext
 from polar.subscription.service import subscription as subscription_service
+from polar.subscription.update import generate_subscription_update
 from polar.tax.calculation import get_tax_behavior_from_option
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
@@ -338,8 +339,6 @@ class TestCalculateChargePreview:
             save_fixture, product=product, customer=customer
         )
 
-        from polar.subscription.update import generate_subscription_update
-
         subscription_update, _ = generate_subscription_update(
             subscription,
             SubscriptionProrationBehavior.prorate,
@@ -390,8 +389,6 @@ class TestCalculateChargePreview:
             current_period_start=datetime(2024, 1, 1, tzinfo=UTC),
             current_period_end=datetime(2024, 2, 1, tzinfo=UTC),
         )
-
-        from polar.subscription.update import generate_subscription_update
 
         subscription_update, _ = generate_subscription_update(
             subscription,


### PR DESCRIPTION
## Summary

- preserve the next renewal timestamp before applying a pending subscription update in charge previews
- evaluate repeating discount expiration at the start of the upcoming billing period
- cover monthly-to-yearly pending updates with a regression test

## Root cause

Applying an interval-changing pending update mutates `current_period_end` to the end of the new interval before the preview checks discount repetition. The preview therefore evaluated expiration as much as a year too late instead of at the renewal boundary.

## Impact

Charge previews now match the actual subscription cycle behavior, so customers see repeating discounts that will still apply to their next charge.

## Testing

- `uv run pytest tests/subscription/test_service_charge_preview.py -q` (14 passed)
- `uv run task lint_check`
- `uv run task lint_types`

Fixes polarsource/feedback#303

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

