### PR TITLE
dx: set up Cloud Agent dev environment + AGENTS.md notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,20 +167,38 @@ Standard lint/test commands live in `server/AGENTS.md` and `clients/AGENTS.md`.
 # Once per VM boot (Docker isn't managed by systemd here):
 sudo dockerd > /tmp/dockerd.log 2>&1 &
 
-dev up --skip-integrations --skip-tinybird   # deps, infra, migrations, builds
-dev start                                    # api + worker + web (+ stripe) in tmux session `polar`
+dev up --skip-integrations   # deps, infra (incl. Tinybird), migrations, builds
+dev seed                     # sample orgs/products + admin@polar.sh (NOT part of `dev up`)
+dev start                    # api + worker + web (+ stripe) in tmux session `polar`
 # Stop with:  dev stop
 # Status:     dev status
 ```
 
-`--skip-integrations` avoids interactive GitHub/Stripe prompts. `--skip-tinybird` skips the
-optional analytics stack (without it, dashboard Analytics/Overview widgets show a network error —
-expected and harmless). `dev start` ends by *attaching* to the `polar` tmux session; in a
-non-interactive agent shell, create/attach then immediately `tmux detach-client -s polar`, or
-run `dev api` / `dev worker` / `dev web` as individual detached processes. The stripe pane of
-`dev start` will prompt to install the Stripe CLI via Homebrew — decline on Linux (no Homebrew);
-checkout/payment testing needs a real Stripe sandbox later (`dev stripe`, see the
-`local-environment` skill's `payment-testing` rule).
+`--skip-integrations` avoids interactive GitHub/Stripe prompts. **Do not pass `--skip-tinybird`**
+if you need the dashboard Overview/homepage metrics — without Tinybird those widgets show a
+network error. `dev up` does **not** load sample data; run `dev seed` afterward. That creates
+`admin@polar.sh` with access to seeded orgs (notably `admin-org` with a `Pro` product, plus
+`acme-corp`, `polar`, etc.). Login OTP codes print in the API pane. If seed says "Already
+seeded" (exit 2), the DB already has `acme-corp` — use `dev seed --reset` only when you
+intentionally want a wipe.
+
+**Tinybird already-running gotcha.** Step `04_start_infrastructure` early-returns when
+Postgres/Redis/Minio are already up, and will **not** start a missing Tinybird container in
+that case. If `dev status` shows Tinybird down after `dev up`, start it explicitly:
+
+```bash
+cd server && docker compose --profile tinybird up -d
+# then wait for http://localhost:7181/tokens, write the admin_token into
+# ~/.config/polar/secrets.env as POLAR_TINYBIRD_{API,READ,CLICKHOUSE}_TOKEN,
+# run ./dev/setup-environment, and restart api/worker so they pick up the tokens.
+```
+
+`dev start` ends by *attaching* to the `polar` tmux session; in a non-interactive agent shell,
+create/attach then immediately `tmux detach-client -s polar`, or run `dev api` / `dev worker` /
+`dev web` as individual detached processes. The stripe pane of `dev start` will prompt to
+install the Stripe CLI via Homebrew — decline on Linux (no Homebrew); checkout/payment testing
+needs a real Stripe sandbox later (`dev stripe`, see the `local-environment` skill's
+`payment-testing` rule).
 
 **One-time shell wiring** (already done in this VM snapshot): `./dev/cli/install` adds the
 `dev` alias; Node 24 is installed via nvm (`clients/` requires it — `.nvmrc` is `24`); `uv` is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,43 +156,55 @@ Treat **Accepted** ADRs as binding:
 
 ## Cursor Cloud specific instructions
 
-The Cloud VM is set up to run the app **natively** (the `## Setup` path above:
-`docker compose` for infra only + `uv run task api`/`worker` + `pnpm dev`), **not** the
-`dev docker` full-stack CLI from the `local-environment` skill (that builds api/worker/web
-images and is heavier). Standard lint/test/build/run commands are already documented in
-`server/AGENTS.md` and `clients/AGENTS.md` — use those. Notes below are the non-obvious bits.
+Prefer the Polar Development CLI (`dev/cli/`, alias `dev`) — the same path local developers use.
+See `dev/cli/README.md` for the full command list. Do **not** use `dev docker` (the heavier
+image-based stack from the `local-environment` skill) unless you specifically need it.
+Standard lint/test commands live in `server/AGENTS.md` and `clients/AGENTS.md`.
 
-**Docker is not managed by systemd here.** On a fresh VM the daemon must be started
-manually once before using any container/infra: `sudo dockerd > /tmp/dockerd.log 2>&1 &`.
-The `ubuntu` user is in the `docker` group, so `docker`/`docker compose` work without `sudo`
-once the daemon is up. `/etc/docker/daemon.json` is pinned to `fuse-overlayfs` with
+**Day-to-day start sequence**
+
+```bash
+# Once per VM boot (Docker isn't managed by systemd here):
+sudo dockerd > /tmp/dockerd.log 2>&1 &
+
+dev up --skip-integrations --skip-tinybird   # deps, infra, migrations, builds
+dev start                                    # api + worker + web (+ stripe) in tmux session `polar`
+# Stop with:  dev stop
+# Status:     dev status
+```
+
+`--skip-integrations` avoids interactive GitHub/Stripe prompts. `--skip-tinybird` skips the
+optional analytics stack (without it, dashboard Analytics/Overview widgets show a network error —
+expected and harmless). `dev start` ends by *attaching* to the `polar` tmux session; in a
+non-interactive agent shell, create/attach then immediately `tmux detach-client -s polar`, or
+run `dev api` / `dev worker` / `dev web` as individual detached processes. The stripe pane of
+`dev start` will prompt to install the Stripe CLI via Homebrew — decline on Linux (no Homebrew);
+checkout/payment testing needs a real Stripe sandbox later (`dev stripe`, see the
+`local-environment` skill's `payment-testing` rule).
+
+**One-time shell wiring** (already done in this VM snapshot): `./dev/cli/install` adds the
+`dev` alias; Node 24 is installed via nvm (`clients/` requires it — `.nvmrc` is `24`); `uv` is
+at `~/.local/bin/uv`. Source `~/.bashrc` (or start a login shell) so `nvm use 24` and the
+`dev` alias are active.
+
+**Docker caveats.** `/etc/docker/daemon.json` is pinned to `fuse-overlayfs` with
 `features.containerd-snapshotter: false` — required for Docker 29 in this VM; don't remove it.
+The `ubuntu` user is in the `docker` group.
 
-**Infra + migrations.** Start Postgres/Redis/Minio with `cd server && docker compose up -d`
-(this compose file only starts infra; `prometheus`/`grafana`/`tinybird`/`localstack` are behind
-profiles). Then apply migrations with `uv run task db_migrate`. `uv` lives at `~/.local/bin/uv`
-(on PATH via `~/.bashrc`).
-
-**Backend won't even import its config without two build/gen artifacts** (both persist in the
-snapshot; regenerate only if missing): the email renderer binary `server/emails/bin/react-email-pkg`
-via `uv run task emails`, and `server/.jwks.json` + `server/.env` via `./dev/setup-environment`
-(also `uv run task generate_dev_jwks`). Missing → pydantic `EMAIL_RENDERER_BINARY_PATH` / `JWKS` errors.
+**Backend config artifacts.** Config import fails without the email renderer binary
+(`server/emails/bin/react-email-pkg`, built by `dev up` / `uv run task emails`) and
+`server/.jwks.json` + `server/.env` (from `./dev/setup-environment` / `dev up`). Missing →
+pydantic `EMAIL_RENDERER_BINARY_PATH` / `JWKS` errors. `dev status` reports "Worker unknown
+(check manually)" by design — confirm with `pgrep -af dramatiq` or the `polar` tmux pane.
 
 **Tests need no manual DB setup** — the `polar_test` database is auto-created/dropped by a
 `sqlalchemy_utils` fixture. Run `uv run task test` or a subset with
 `POLAR_ENV=testing uv run python -m pytest <path>`.
 
-**Login has no external dependency.** Email OTP login codes are printed in the API log; when the
-API runs natively grab it with `grep -a "LOGIN CODE" /tmp/polar-api.log | tail -1`. `admin@polar.sh`
+**Login.** Email OTP codes are printed in the API pane / log (`LOGIN CODE: …`). Grab with
+`tmux capture-pane -t polar:services.0 -p | grep -a "LOGIN CODE" | tail -1`. `admin@polar.sh`
 is the conventional test account.
 
-**Expected-but-harmless in local dev:** dashboard Analytics/Overview widgets show
-"A network error occurred" because the Tinybird/ClickHouse analytics service isn't running
-(optional, `tinybird` compose profile). The worker logs `prometheus_remote_write` connection
-errors (optional `monitoring` profile). Stripe keys in `server/.env` are placeholders — checkout/
-payment flows need a real Stripe sandbox (`dev stripe`, see the `local-environment` skill's
-`payment-testing` rule).
-
-**Onboarding gotcha:** the org-creation wizard's "Launch Dashboard" button only submits once the
+**Onboarding gotcha.** The org-creation wizard's "Launch Dashboard" button only submits once the
 Product step's required fields are filled (description ≥30 chars, ≥1 selling category, ≥1 pricing
 model). The AUP AI check auto-APPROVEs when `PYDANTIC_AI_GATEWAY_API_KEY` is unset.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,3 +153,46 @@ Treat **Accepted** ADRs as binding:
 - **S3 / Minio**: file storage.
 - **Redis**: cache and job queue.
 - **PostgreSQL**: primary database.
+
+## Cursor Cloud specific instructions
+
+The Cloud VM is set up to run the app **natively** (the `## Setup` path above:
+`docker compose` for infra only + `uv run task api`/`worker` + `pnpm dev`), **not** the
+`dev docker` full-stack CLI from the `local-environment` skill (that builds api/worker/web
+images and is heavier). Standard lint/test/build/run commands are already documented in
+`server/AGENTS.md` and `clients/AGENTS.md` — use those. Notes below are the non-obvious bits.
+
+**Docker is not managed by systemd here.** On a fresh VM the daemon must be started
+manually once before using any container/infra: `sudo dockerd > /tmp/dockerd.log 2>&1 &`.
+The `ubuntu` user is in the `docker` group, so `docker`/`docker compose` work without `sudo`
+once the daemon is up. `/etc/docker/daemon.json` is pinned to `fuse-overlayfs` with
+`features.containerd-snapshotter: false` — required for Docker 29 in this VM; don't remove it.
+
+**Infra + migrations.** Start Postgres/Redis/Minio with `cd server && docker compose up -d`
+(this compose file only starts infra; `prometheus`/`grafana`/`tinybird`/`localstack` are behind
+profiles). Then apply migrations with `uv run task db_migrate`. `uv` lives at `~/.local/bin/uv`
+(on PATH via `~/.bashrc`).
+
+**Backend won't even import its config without two build/gen artifacts** (both persist in the
+snapshot; regenerate only if missing): the email renderer binary `server/emails/bin/react-email-pkg`
+via `uv run task emails`, and `server/.jwks.json` + `server/.env` via `./dev/setup-environment`
+(also `uv run task generate_dev_jwks`). Missing → pydantic `EMAIL_RENDERER_BINARY_PATH` / `JWKS` errors.
+
+**Tests need no manual DB setup** — the `polar_test` database is auto-created/dropped by a
+`sqlalchemy_utils` fixture. Run `uv run task test` or a subset with
+`POLAR_ENV=testing uv run python -m pytest <path>`.
+
+**Login has no external dependency.** Email OTP login codes are printed in the API log; when the
+API runs natively grab it with `grep -a "LOGIN CODE" /tmp/polar-api.log | tail -1`. `admin@polar.sh`
+is the conventional test account.
+
+**Expected-but-harmless in local dev:** dashboard Analytics/Overview widgets show
+"A network error occurred" because the Tinybird/ClickHouse analytics service isn't running
+(optional, `tinybird` compose profile). The worker logs `prometheus_remote_write` connection
+errors (optional `monitoring` profile). Stripe keys in `server/.env` are placeholders — checkout/
+payment flows need a real Stripe sandbox (`dev stripe`, see the `local-environment` skill's
+`payment-testing` rule).
+
+**Onboarding gotcha:** the org-creation wizard's "Launch Dashboard" button only submits once the
+Product step's required fields are filled (description ≥30 chars, ≥1 selling category, ≥1 pricing
+model). The AUP AI check auto-APPROVEs when `PYDANTIC_AI_GATEWAY_API_KEY` is unset.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up the Polar development environment on the Cloud Agent VM using the same **`dev up` / `dev seed` / `dev start`** path local developers use, and documents non-obvious startup/run caveats for future agents.

The only code change is documentation in `AGENTS.md`. Environment setup lives in the VM snapshot + the startup update script.

## How to run (preferred)

```bash
# Once per VM boot (Docker isn't managed by systemd here)
sudo dockerd > /tmp/dockerd.log 2>&1 &

dev up --skip-integrations   # includes Tinybird (needed for Overview metrics)
dev seed                     # NOT part of `dev up` — creates admin@polar.sh + admin-org
dev start                    # api + worker + web in tmux session `polar`
```

### Seeding note

`dev up` does **not** seed. `dev seed` creates `admin@polar.sh` with access to seeded orgs including `admin-org` (product `Pro`), `acme-corp`, `polar`, etc. Login OTP codes print in the API pane.

### Tinybird gotcha

If Postgres/Redis/Minio are already running, `dev up`'s infra step early-returns and will not start a missing Tinybird container. Start it with `cd server && docker compose --profile tinybird up -d`, configure tokens, then restart api/worker.

## Validation

| Check | Result |
|---|---|
| `dev up --skip-integrations` | ✅ |
| Tinybird on :7181 | ✅ (`dev status`) |
| `dev seed` → `admin@polar.sh` / `admin-org` | ✅ |
| API `/healthz` + web | ✅ |
| `/dashboard/admin-org` Overview metrics | ✅ Orders: 6, charts render, no network-error toast |

[polar_admin_org_homepage_with_tinybird.mp4](https://cursor.com/agents/bc-f4545411-3748-4c48-afca-ae2ff0799148/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpolar_admin_org_homepage_with_tinybird.mp4)

[Admin Org homepage with Tinybird metrics](https://cursor.com/agents/bc-f4545411-3748-4c48-afca-ae2ff0799148/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fadmin_org_homepage.webp)

Earlier hello-world (create org + product) is also covered in prior commits / artifacts.

## Update script

```
export PATH="$HOME/.nvm/versions/node/v24.19.0/bin:$HOME/.local/bin:$PATH"
cd /workspace/server
uv sync
cd /workspace/clients
pnpm install
```

Service startup (`dockerd`, `dev up`, `dev seed`, `dev start`) stays out of the update script and is documented in `AGENTS.md`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f4545411-3748-4c48-afca-ae2ff0799148?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f4545411-3748-4c48-afca-ae2ff0799148&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

