### PR TITLE
Backfill balance consumed by orders voided before #13475

### DIFF
--- a/server/scripts/backfill_void_order_consumed_balance.py
+++ b/server/scripts/backfill_void_order_consumed_balance.py
@@ -1,0 +1,101 @@
+import structlog
+import typer
+from sqlalchemy import exists, select
+from sqlalchemy.orm import joinedload
+
+from polar.kit.db.postgres import AsyncSession, create_async_sessionmaker
+from polar.models import Order, WalletTransaction
+from polar.models.order import OrderStatus
+from polar.postgres import create_async_engine
+from polar.wallet.service import wallet as wallet_service
+from scripts.helper import typer_async
+
+log = structlog.get_logger()
+cli = typer.Typer()
+
+
+async def run_backfill(session: AsyncSession, *, dry_run: bool = True) -> int:
+    """Restore wallet balance consumed by orders voided before the fix.
+
+    An order that consumed customer wallet balance records it as a negative
+    ``applied_balance_amount`` and debits the billing wallet at creation. Before
+    polarsource/polar#13475, voiding such an order left that debit in place, so
+    the customer permanently lost credit against an invoice that will never be
+    collected.
+
+    For every void order still missing its restoration, this creates the
+    positive balance transaction the fixed ``void()`` now emits
+    (``-applied_balance_amount``, tied to the order). It is idempotent: an order
+    that already has a matching restoration transaction is skipped, so it is
+    safe to re-run and won't double-credit orders voided after the fix.
+
+    Returns the number of orders restored (or that would be restored on a dry
+    run).
+    """
+    restoration_exists = (
+        select(WalletTransaction.id)
+        .where(
+            WalletTransaction.order_id == Order.id,
+            WalletTransaction.amount == -Order.applied_balance_amount,
+        )
+        .correlate(Order)
+    )
+
+    statement = (
+        select(Order)
+        .where(
+            Order.status == OrderStatus.void,
+            Order.applied_balance_amount < 0,
+            ~exists(restoration_exists),
+        )
+        .options(joinedload(Order.customer))
+        .order_by(Order.created_at)
+    )
+
+    orders = (await session.scalars(statement)).all()
+    typer.echo(f"Found {len(orders)} void order(s) missing balance restoration.\n")
+
+    total_amount = 0
+    for order in orders:
+        restore_amount = -order.applied_balance_amount
+        typer.echo(
+            f"  {order.id} customer={order.customer_id} "
+            f"restore={restore_amount} {order.currency}"
+        )
+        total_amount += restore_amount
+
+        if not dry_run:
+            await wallet_service.create_balance_transaction(
+                session,
+                order.customer,
+                restore_amount,
+                order.currency,
+                order=order,
+            )
+
+    if dry_run:
+        typer.echo(
+            f"\nDry run — would restore {total_amount} across {len(orders)} order(s). "
+            f"Pass --no-dry-run to apply."
+        )
+    else:
+        await session.commit()
+        typer.echo(f"\nRestored {total_amount} across {len(orders)} order(s).")
+
+    return len(orders)
+
+
+@cli.command()
+@typer_async
+async def backfill(dry_run: bool = True) -> None:
+    engine = create_async_engine("script")
+    sessionmaker = create_async_sessionmaker(engine)
+    try:
+        async with sessionmaker() as session:
+            await run_backfill(session, dry_run=dry_run)
+    finally:
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    cli()

--- a/server/tests/scripts/test_backfill_void_order_consumed_balance.py
+++ b/server/tests/scripts/test_backfill_void_order_consumed_balance.py
@@ -1,0 +1,135 @@
+import pytest
+
+from polar.kit.db.postgres import AsyncSession
+from polar.models import Customer, Product, WalletTransaction
+from polar.models.order import OrderStatus
+from polar.wallet.service import wallet as wallet_service
+from scripts.backfill_void_order_consumed_balance import run_backfill
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import (
+    create_order,
+    create_wallet_billing,
+    create_wallet_transaction,
+)
+
+
+@pytest.mark.asyncio
+class TestBackfillVoidOrderConsumedBalance:
+    async def test_restores_consumed_balance(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.void,
+            subtotal_amount=3000,
+            applied_balance_amount=-1000,
+        )
+        # Customer had 1000, consumed by the order at creation. The old void()
+        # never gave it back, so the wallet sits at 0.
+        wallet = await create_wallet_billing(
+            save_fixture, customer=customer, initial_balance=1000
+        )
+        await create_wallet_transaction(save_fixture, wallet=wallet, amount=-1000)
+
+        restored = await run_backfill(session, dry_run=False)
+
+        assert restored == 1
+        balance = await wallet_service.get_billing_wallet_balance(
+            session, customer, order.currency
+        )
+        assert balance == 1000
+
+    async def test_dry_run_makes_no_changes(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.void,
+            subtotal_amount=3000,
+            applied_balance_amount=-1000,
+        )
+        wallet = await create_wallet_billing(
+            save_fixture, customer=customer, initial_balance=1000
+        )
+        await create_wallet_transaction(save_fixture, wallet=wallet, amount=-1000)
+
+        restored = await run_backfill(session, dry_run=True)
+
+        assert restored == 1
+        balance = await wallet_service.get_billing_wallet_balance(
+            session, customer, order.currency
+        )
+        assert balance == 0
+
+    async def test_idempotent_when_restoration_exists(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        order = await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.void,
+            subtotal_amount=3000,
+            applied_balance_amount=-1000,
+        )
+        wallet = await create_wallet_billing(
+            save_fixture, customer=customer, initial_balance=1000
+        )
+        await create_wallet_transaction(save_fixture, wallet=wallet, amount=-1000)
+        # The fixed void() already restored the consumed balance for this order.
+        restoration = WalletTransaction(
+            wallet=wallet, amount=1000, currency=wallet.currency, order=order
+        )
+        await save_fixture(restoration)
+
+        restored = await run_backfill(session, dry_run=False)
+
+        assert restored == 0
+        balance = await wallet_service.get_billing_wallet_balance(
+            session, customer, order.currency
+        )
+        assert balance == 1000
+
+    async def test_ignores_pending_and_non_negative_balance(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.pending,
+            subtotal_amount=3000,
+            applied_balance_amount=-1000,
+        )
+        await create_order(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=OrderStatus.void,
+            subtotal_amount=3000,
+            applied_balance_amount=0,
+        )
+
+        restored = await run_backfill(session, dry_run=False)
+
+        assert restored == 0


### PR DESCRIPTION
## Summary

Backfill for #13475.

That PR fixed `order_service.void()` to restore wallet balance an order consumed (negative `applied_balance_amount`, debited at creation). Before it, voiding such an order left the debit in place, permanently depleting the customer's wallet against an invoice that will never be collected. This backfills the customers voided under the old behaviour.

## What

- `scripts/backfill_void_order_consumed_balance.py` — dry-run-by-default script that, for every order in `void` status with `applied_balance_amount < 0` still missing its restoration, creates the exact transaction the fixed `void()` now emits: `+(-applied_balance_amount)`, tied to the order, via `wallet_service.create_balance_transaction`.
- Idempotent: an order that already has a matching restoration transaction is skipped, so re-runs and orders voided *after* the fix are never double-credited.
- Tests in `tests/scripts/test_backfill_void_order_consumed_balance.py` (restore, dry-run no-op, idempotency, ignores pending / non-negative balance).

## Impact

Current production scope: **14 orders across 14 customers, $94.76 total (all USD)** — measured with the script's exact idempotency predicate.

## How to run

```bash
cd server
uv run python -m scripts.backfill_void_order_consumed_balance            # dry run — lists affected orders
uv run python -m scripts.backfill_void_order_consumed_balance --no-dry-run
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

