### PR TITLE
Implement subpages for Customer toplist/at risk/cost drivers

### DIFF
--- a/clients/apps/orbit/src/app/components/subnav/page.tsx
+++ b/clients/apps/orbit/src/app/components/subnav/page.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import { useState } from 'react'
+import { Subnav, SubnavItem } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import {
+  Example,
+  PageHeader,
+  PropsTable,
+  Section,
+  type PropRow,
+} from '@/components/docs'
+
+const sections = ['Overview', 'Top Customers', 'At Risk', 'Cost Drivers']
+
+function BasicDemo() {
+  const [active, setActive] = useState('Overview')
+  return (
+    <Subnav label="Customer sections">
+      {sections.map((section) => (
+        <SubnavItem key={section} active={active === section}>
+          <a
+            href="#"
+            onClick={(event) => {
+              event.preventDefault()
+              setActive(section)
+            }}
+          >
+            {section}
+          </a>
+        </SubnavItem>
+      ))}
+    </Subnav>
+  )
+}
+
+function PagePlacementDemo() {
+  const [active, setActive] = useState('Top Customers')
+  return (
+    <Box flexDirection="column" rowGap="xl" flex={1}>
+      <Subnav label="Customer sections">
+        {sections.map((section) => (
+          <SubnavItem key={section} active={active === section}>
+            <a
+              href="#"
+              onClick={(event) => {
+                event.preventDefault()
+                setActive(section)
+              }}
+            >
+              {section}
+            </a>
+          </SubnavItem>
+        ))}
+      </Subnav>
+      <Box
+        height={96}
+        borderRadius="m"
+        backgroundColor="background-card"
+        alignItems="center"
+        justifyContent="center"
+      />
+    </Box>
+  )
+}
+
+const basicCode = `import Link from 'next/link'
+import { Subnav, SubnavItem } from '@polar-sh/orbit'
+
+<Subnav label="Customer sections">
+  <SubnavItem active={pathname === overviewHref}>
+    <Link href={overviewHref}>Overview</Link>
+  </SubnavItem>
+  <SubnavItem active={pathname === topHref}>
+    <Link href={topHref}>Top Customers</Link>
+  </SubnavItem>
+</Subnav>`
+
+const placementCode = `<Box flexDirection="column" rowGap="xl">
+  <Subnav label="Customer sections">…</Subnav>
+  {content}
+</Box>`
+
+const subnavProps: PropRow[] = [
+  {
+    name: 'label',
+    type: 'string',
+    default: "'Secondary'",
+    description:
+      'Accessible name for the navigation landmark, distinguishing it from the primary navigation.',
+  },
+  {
+    name: 'children',
+    type: 'ReactNode',
+    required: true,
+    description: 'One or more SubnavItem elements.',
+  },
+]
+
+const subnavItemProps: PropRow[] = [
+  {
+    name: 'active',
+    type: 'boolean',
+    default: 'false',
+    description:
+      'Marks the item as the section currently shown. Emphasised and exposed via aria-current="page".',
+  },
+  {
+    name: 'children',
+    type: 'ReactNode',
+    required: true,
+    description:
+      "The link for the section. Pass your router's link element so client-side navigation is preserved; color and typography are inherited from the item.",
+  },
+]
+
+export default function SubnavPage() {
+  return (
+    <>
+      <PageHeader
+        title="Subnav"
+        description="A horizontal row of links for switching between the sections of a page."
+      />
+
+      <Section
+        title="Basic"
+        description="Items wrap the consumer's link element. The active item reads in the primary text color and carries a round indicator dot centered beneath it; the rest are muted until hovered."
+      >
+        <Example code={basicCode}>
+          <BasicDemo />
+        </Example>
+      </Section>
+
+      <Section
+        title="Page placement"
+        description="Typically placed between the page header and the content it switches."
+      >
+        <Example code={placementCode} align="stretch">
+          <PagePlacementDemo />
+        </Example>
+      </Section>
+
+      <Section title="Subnav props">
+        <PropsTable rows={subnavProps} slug="subnav" />
+      </Section>
+
+      <Section title="SubnavItem props">
+        <PropsTable rows={subnavItemProps} slug="subnav" />
+      </Section>
+    </>
+  )
+}

--- a/clients/apps/orbit/src/lib/registry.ts
+++ b/clients/apps/orbit/src/lib/registry.ts
@@ -147,6 +147,12 @@ const components: NavItem[] = [
     description: 'Tabbed navigation between related views.',
   },
   {
+    title: 'Subnav',
+    slug: 'subnav',
+    href: '/components/subnav',
+    description: 'Horizontal link navigation between the sections of a page.',
+  },
+  {
     title: 'SegmentedControl',
     slug: 'segmented-control',
     href: '/components/segmented-control',

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/at-risk/AtRiskPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/at-risk/AtRiskPage.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import { CustomerCell } from '@/components/Customer/CustomerCell'
+import { CustomersPageShell } from '@/components/Customer/CustomersPageShell'
+import {
+  AtRiskItem,
+  cancelDate,
+  useAtRisk,
+} from '@/components/Customer/useAtRisk'
+import { EmptyState } from '@/components/Shared/EmptyState'
+import { useClientSidePagination } from '@/hooks/useClientSidePagination'
+import { schemas } from '@polar-sh/client'
+import { formatCurrency } from '@polar-sh/currency'
+import { Alert, DataTable, DataTableColumnDef, Text } from '@polar-sh/orbit'
+import { ShieldCheck } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+
+// Maximum accepted per status query (API_PAGINATION_MAX_LIMIT).
+const LIMIT = 100
+
+const columns: DataTableColumnDef<AtRiskItem>[] = [
+  {
+    id: 'customer',
+    enableSorting: false,
+    header: 'Customer',
+    cell: ({ row: { original } }) => (
+      <CustomerCell
+        name={original.subscription.customer.name}
+        email={original.subscription.customer.email}
+        avatarUrl={original.subscription.customer.avatar_url}
+      />
+    ),
+  },
+  {
+    id: 'product',
+    enableSorting: false,
+    header: 'Product',
+    cell: ({ row: { original } }) => original.subscription.product.name,
+  },
+  {
+    id: 'amount',
+    enableSorting: false,
+    header: 'Amount',
+    cell: ({ row: { original } }) =>
+      formatCurrency('statistics')(
+        original.subscription.amount,
+        original.subscription.currency,
+      ),
+  },
+  {
+    id: 'status',
+    enableSorting: false,
+    header: 'Status',
+    cell: ({ row: { original } }) => (
+      <Text color={original.reason === 'past_due' ? 'danger' : 'warning'}>
+        {original.reason === 'past_due'
+          ? 'Past due'
+          : `Cancels ${cancelDate(original.subscription)}`}
+      </Text>
+    ),
+  },
+]
+
+interface AtRiskPageProps {
+  organization: schemas['Organization']
+}
+
+export const AtRiskPage = ({ organization }: AtRiskPageProps) => {
+  const router = useRouter()
+  const { items, isLoading, isError, refetch } = useAtRisk(organization, LIMIT)
+  const { pageItems, pagination, setPagination, rowCount, pageCount } =
+    useClientSidePagination(items)
+
+  return (
+    <CustomersPageShell organization={organization}>
+      {isError ? (
+        <Alert
+          variant="danger"
+          title="Could not load at-risk subscriptions"
+          actions={[{ text: 'Retry', onClick: () => refetch() }]}
+        />
+      ) : !isLoading && items.length === 0 ? (
+        <EmptyState
+          icon={<ShieldCheck />}
+          title="Nothing at risk"
+          description="No payment issues or scheduled cancellations."
+        />
+      ) : (
+        <DataTable
+          columns={columns}
+          data={pageItems}
+          isLoading={isLoading}
+          rowCount={rowCount}
+          pageCount={pageCount}
+          pagination={pagination}
+          onPaginationChange={setPagination}
+          getRowId={(item) => item.subscription.id}
+          onRowClick={(row) =>
+            router.push(
+              `/dashboard/${organization.slug}/customers/${row.original.subscription.customer_id}`,
+            )
+          }
+        />
+      )}
+    </CustomersPageShell>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/at-risk/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/at-risk/page.tsx
@@ -1,0 +1,23 @@
+import { getServerSideAPI } from '@/utils/client/serverside'
+import { getOrganizationBySlugOrNotFound } from '@/utils/organization'
+import { Metadata } from 'next'
+import { AtRiskPage } from './AtRiskPage'
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'At Risk Customers', // " | Polar is added by the template"
+  }
+}
+
+export default async function Page(props: {
+  params: Promise<{ organization: string }>
+}) {
+  const params = await props.params
+  const api = await getServerSideAPI()
+  const organization = await getOrganizationBySlugOrNotFound(
+    api,
+    params.organization,
+  )
+
+  return <AtRiskPage organization={organization} />
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/cost-drivers/CostDriversPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/cost-drivers/CostDriversPage.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import { CustomerCell } from '@/components/Customer/CustomerCell'
+import { CustomersPageShell } from '@/components/Customer/CustomersPageShell'
+import { EmptyState } from '@/components/Shared/EmptyState'
+import { CustomerStatItem, useEventCustomerStats } from '@/hooks/queries/events'
+import { useClientSidePagination } from '@/hooks/useClientSidePagination'
+import { ChartRange, getChartRangeParams, toISODate } from '@/utils/metrics'
+import { schemas } from '@polar-sh/client'
+import { formatCurrency } from '@polar-sh/currency'
+import { Alert, DataTable, DataTableColumnDef } from '@polar-sh/orbit'
+import { Coins } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useMemo, useState } from 'react'
+
+const LIMIT = 200
+
+const cost = (stat: CustomerStatItem) =>
+  parseFloat(String(stat.totals?.['_cost_amount'] ?? '0'))
+
+const columns: DataTableColumnDef<CustomerStatItem>[] = [
+  {
+    id: 'customer',
+    enableSorting: false,
+    header: 'Customer',
+    cell: ({ row: { original: stat } }) => (
+      <CustomerCell
+        name={stat.name ?? stat.external_customer_id}
+        email={stat.email}
+      />
+    ),
+  },
+  {
+    accessorKey: 'occurrences',
+    enableSorting: false,
+    header: 'Events',
+    cell: ({ getValue }) => (getValue() as number).toLocaleString(),
+  },
+  {
+    accessorKey: 'share',
+    enableSorting: false,
+    header: 'Share of Costs',
+    cell: ({ getValue }) => `${Math.round((getValue() as number) * 100)}%`,
+  },
+  {
+    id: 'cost',
+    enableSorting: false,
+    header: 'Cost',
+    cell: ({ row: { original: stat } }) =>
+      formatCurrency('subcent')(cost(stat), 'usd'),
+  },
+]
+
+interface CostDriversPageProps {
+  organization: schemas['Organization']
+}
+
+export const CostDriversPage = ({ organization }: CostDriversPageProps) => {
+  const router = useRouter()
+  const [range, setRange] = useState<ChartRange>('30d')
+  const [startDate, endDate] = useMemo(
+    () => getChartRangeParams(range, organization.created_at),
+    [range, organization.created_at],
+  )
+
+  const { data, isLoading, isError, refetch } = useEventCustomerStats(
+    organization.id,
+    {
+      start_date: toISODate(startDate),
+      end_date: toISODate(endDate),
+      aggregate_fields: ['_cost.amount'],
+      limit: LIMIT,
+    },
+  )
+
+  const stats = useMemo(
+    () => (data?.items ?? []).filter((stat) => cost(stat) > 0),
+    [data],
+  )
+
+  const {
+    pageItems,
+    pagination,
+    setPagination,
+    resetPage,
+    rowCount,
+    pageCount,
+  } = useClientSidePagination(stats)
+
+  return (
+    <CustomersPageShell
+      organization={organization}
+      range={range}
+      onRangeChange={(value) => {
+        setRange(value)
+        resetPage()
+      }}
+    >
+      {isError ? (
+        <Alert
+          variant="danger"
+          title="Could not load cost statistics"
+          actions={[{ text: 'Retry', onClick: () => refetch() }]}
+        />
+      ) : !isLoading && stats.length === 0 ? (
+        <EmptyState
+          icon={<Coins />}
+          title="No cost data"
+          description="Costs come from _cost metadata on ingested events."
+        />
+      ) : (
+        <DataTable
+          columns={columns}
+          data={pageItems}
+          isLoading={isLoading}
+          rowCount={rowCount}
+          pageCount={pageCount}
+          pagination={pagination}
+          onPaginationChange={setPagination}
+          getRowId={(stat, index) =>
+            stat.customer_id ?? stat.external_customer_id ?? String(index)
+          }
+          onRowClick={(row) => {
+            if (row.original.customer_id) {
+              router.push(
+                `/dashboard/${organization.slug}/customers/${row.original.customer_id}`,
+              )
+            }
+          }}
+        />
+      )}
+    </CustomersPageShell>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/cost-drivers/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/cost-drivers/page.tsx
@@ -1,0 +1,31 @@
+import OrganizationPermissionGuard from '@/components/Auth/OrganizationPermissionGuard'
+import { getServerSideAPI } from '@/utils/client/serverside'
+import { getOrganizationBySlugOrNotFound } from '@/utils/organization'
+import { Metadata } from 'next'
+import { CostDriversPage } from './CostDriversPage'
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Cost Drivers', // " | Polar is added by the template"
+  }
+}
+
+export default async function Page(props: {
+  params: Promise<{ organization: string }>
+}) {
+  const params = await props.params
+  const api = await getServerSideAPI()
+  const organization = await getOrganizationBySlugOrNotFound(
+    api,
+    params.organization,
+  )
+
+  return (
+    <OrganizationPermissionGuard
+      organizationSlug={params.organization}
+      permission="analytics:read"
+    >
+      <CostDriversPage organization={organization} />
+    </OrganizationPermissionGuard>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/top/TopCustomersPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/top/TopCustomersPage.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { CustomerCell } from '@/components/Customer/CustomerCell'
+import { CustomersPageShell } from '@/components/Customer/CustomersPageShell'
+import { EmptyState } from '@/components/Shared/EmptyState'
+import { useTopCustomers } from '@/hooks/queries'
+import { useClientSidePagination } from '@/hooks/useClientSidePagination'
+import { ChartRange, getChartRangeParams } from '@/utils/metrics'
+import { schemas } from '@polar-sh/client'
+import { formatCurrency } from '@polar-sh/currency'
+import { Alert, DataTable, DataTableColumnDef } from '@polar-sh/orbit'
+import { TrendingUp } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useMemo, useState } from 'react'
+
+// Maximum accepted by the `/v1/customers/top` endpoint.
+const LIMIT = 50
+
+const columns: DataTableColumnDef<schemas['TopCustomer']>[] = [
+  {
+    accessorKey: 'name',
+    enableSorting: false,
+    header: 'Customer',
+    cell: ({ row: { original: customer } }) => (
+      <CustomerCell
+        name={customer.name}
+        email={customer.email}
+        avatarUrl={customer.avatar_url}
+      />
+    ),
+  },
+  {
+    accessorKey: 'order_count',
+    enableSorting: false,
+    header: 'Orders',
+    cell: ({ getValue }) => (getValue() as number).toLocaleString(),
+  },
+  {
+    accessorKey: 'net_revenue',
+    enableSorting: false,
+    header: 'Net Revenue',
+    cell: ({ getValue }) =>
+      formatCurrency('statistics')(getValue() as number, 'usd'),
+  },
+]
+
+interface TopCustomersPageProps {
+  organization: schemas['Organization']
+}
+
+export const TopCustomersPage = ({ organization }: TopCustomersPageProps) => {
+  const router = useRouter()
+  const [range, setRange] = useState<ChartRange>('30d')
+  const [startDate, endDate] = useMemo(
+    () => getChartRangeParams(range, organization.created_at),
+    [range, organization.created_at],
+  )
+
+  const {
+    data: topCustomers,
+    isLoading,
+    isError,
+    refetch,
+  } = useTopCustomers(organization.id, {
+    start: startDate,
+    end: endDate,
+    limit: LIMIT,
+  })
+
+  const {
+    pageItems,
+    pagination,
+    setPagination,
+    resetPage,
+    rowCount,
+    pageCount,
+  } = useClientSidePagination(topCustomers ?? [])
+
+  return (
+    <CustomersPageShell
+      organization={organization}
+      range={range}
+      onRangeChange={(value) => {
+        setRange(value)
+        resetPage()
+      }}
+    >
+      {isError ? (
+        <Alert
+          variant="danger"
+          title="Could not load top customers"
+          actions={[{ text: 'Retry', onClick: () => refetch() }]}
+        />
+      ) : !isLoading && (topCustomers ?? []).length === 0 ? (
+        <EmptyState
+          icon={<TrendingUp />}
+          title="No revenue yet"
+          description="No paid orders were recorded in this period."
+        />
+      ) : (
+        <DataTable
+          columns={columns}
+          data={pageItems}
+          isLoading={isLoading}
+          rowCount={rowCount}
+          pageCount={pageCount}
+          pagination={pagination}
+          onPaginationChange={setPagination}
+          getRowId={(customer) => customer.id}
+          onRowClick={(row) =>
+            router.push(
+              `/dashboard/${organization.slug}/customers/${row.original.id}`,
+            )
+          }
+        />
+      )}
+    </CustomersPageShell>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/top/page.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/top/page.tsx
@@ -1,0 +1,23 @@
+import { getServerSideAPI } from '@/utils/client/serverside'
+import { getOrganizationBySlugOrNotFound } from '@/utils/organization'
+import { Metadata } from 'next'
+import { TopCustomersPage } from './TopCustomersPage'
+
+export async function generateMetadata(): Promise<Metadata> {
+  return {
+    title: 'Top Customers', // " | Polar is added by the template"
+  }
+}
+
+export default async function Page(props: {
+  params: Promise<{ organization: string }>
+}) {
+  const params = await props.params
+  const api = await getServerSideAPI()
+  const organization = await getOrganizationBySlugOrNotFound(
+    api,
+    params.organization,
+  )
+
+  return <TopCustomersPage organization={organization} />
+}

--- a/clients/apps/web/src/components/Customer/AtRiskList.tsx
+++ b/clients/apps/web/src/components/Customer/AtRiskList.tsx
@@ -8,24 +8,11 @@ import {
   ToplistText,
   ToplistValue,
 } from '@/components/Shared/Toplist'
-import { useSubscriptions } from '@/hooks/queries'
 import { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
 import { Alert, Avatar } from '@polar-sh/orbit'
 import { ShieldCheck } from 'lucide-react'
-import { useMemo } from 'react'
-
-type RiskReason = 'past_due' | 'canceling'
-
-interface AtRiskItem {
-  subscription: schemas['Subscription']
-  reason: RiskReason
-}
-
-const cancelDate = (subscription: schemas['Subscription']) =>
-  new Date(
-    subscription.ends_at ?? subscription.current_period_end,
-  ).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+import { cancelDate, useAtRisk } from './useAtRisk'
 
 interface AtRiskListProps {
   organization: schemas['Organization']
@@ -33,60 +20,22 @@ interface AtRiskListProps {
 
 export const AtRiskList = ({ organization }: AtRiskListProps) => {
   const {
-    data: pastDue,
-    isLoading: pastDueLoading,
-    isError: pastDueError,
-    refetch: refetchPastDue,
-  } = useSubscriptions(organization.id, {
-    status: ['past_due'],
-    limit: 10,
-    sorting: ['-amount'],
-  })
-  const {
-    data: canceling,
-    isLoading: cancelingLoading,
-    isError: cancelingError,
-    refetch: refetchCanceling,
-  } = useSubscriptions(organization.id, {
-    status: ['active', 'trialing'],
-    cancel_at_period_end: true,
-    limit: 10,
-    sorting: ['current_period_end'],
-  })
+    items: atRisk,
+    isLoading,
+    isError,
+    refetch,
+  } = useAtRisk(organization, 5)
 
-  const atRisk = useMemo<AtRiskItem[]>(() => {
-    const pastDueItems = (pastDue?.items ?? []).map((subscription) => ({
-      subscription,
-      reason: 'past_due' as const,
-    }))
-    const pastDueIds = new Set(pastDueItems.map((item) => item.subscription.id))
-    const cancelingItems = (canceling?.items ?? [])
-      .filter((subscription) => !pastDueIds.has(subscription.id))
-      .map((subscription) => ({
-        subscription,
-        reason: 'canceling' as const,
-      }))
-    return [...pastDueItems, ...cancelingItems].slice(0, 5)
-  }, [pastDue, canceling])
-
-  if (pastDueLoading || cancelingLoading) {
+  if (isLoading) {
     return <ToplistSkeleton rows={3} />
   }
 
-  if (pastDueError || cancelingError) {
+  if (isError) {
     return (
       <Alert
         variant="danger"
         title="Could not load at-risk subscriptions"
-        actions={[
-          {
-            text: 'Retry',
-            onClick: () => {
-              refetchPastDue()
-              refetchCanceling()
-            },
-          },
-        ]}
+        actions={[{ text: 'Retry', onClick: refetch }]}
       />
     )
   }

--- a/clients/apps/web/src/components/Customer/CustomerCell.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerCell.tsx
@@ -1,0 +1,29 @@
+import { Avatar, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+
+interface CustomerCellProps {
+  name?: string | null
+  email?: string | null
+  avatarUrl?: string | null
+}
+
+export const CustomerCell = ({ name, email, avatarUrl }: CustomerCellProps) => {
+  const display = name ?? email ?? '-'
+  return (
+    <Box alignItems="center" columnGap="m" minWidth={0}>
+      <Avatar
+        className="h-8 w-8"
+        avatar_url={avatarUrl ?? null}
+        name={display}
+      />
+      <Box flexDirection="column" minWidth={0}>
+        <Text truncate>{display}</Text>
+        {name && email ? (
+          <Text truncate color="muted" variant="caption">
+            {email}
+          </Text>
+        ) : null}
+      </Box>
+    </Box>
+  )
+}

--- a/clients/apps/web/src/components/Customer/CustomersOverview.tsx
+++ b/clients/apps/web/src/components/Customer/CustomersOverview.tsx
@@ -1,15 +1,15 @@
 'use client'
 
-import { MasterDetailLayoutContent } from '@/components/Layout/MasterDetailLayout'
 import { ToplistHeader } from '@/components/Shared/Toplist'
 import { useHasPermission } from '@/hooks/permissions'
-import { CHART_RANGES, ChartRange, getChartRangeParams } from '@/utils/metrics'
+import { ChartRange, getChartRangeParams } from '@/utils/metrics'
 import { schemas } from '@polar-sh/client'
-import { Grid, SegmentedControl, Text } from '@polar-sh/orbit'
+import { Grid } from '@polar-sh/orbit'
 import { Box } from '@polar-sh/orbit/Box'
 import { useMemo, useState } from 'react'
 import { AtRiskList } from './AtRiskList'
 import { CustomerGrowthChart } from './CustomerGrowthChart'
+import { CustomersPageShell } from './CustomersPageShell'
 import { TopCostCustomersList } from './TopCostCustomersList'
 import { TopCustomersList } from './TopCustomersList'
 
@@ -26,21 +26,10 @@ export const CustomersOverview = ({ organization }: CustomersOverviewProps) => {
   const canReadAnalytics = useHasPermission(organization.id, 'analytics:read')
 
   return (
-    <MasterDetailLayoutContent
-      header={
-        <>
-          <Text variant="heading-xxs" as="h1">
-            Customers
-          </Text>
-          <SegmentedControl
-            options={(
-              Object.entries(CHART_RANGES) as [ChartRange, string][]
-            ).map(([value, label]) => ({ value, label }))}
-            value={range}
-            onChange={setRange}
-          />
-        </>
-      }
+    <CustomersPageShell
+      organization={organization}
+      range={range}
+      onRangeChange={setRange}
     >
       <Box flexDirection="column" rowGap="4xl">
         <CustomerGrowthChart
@@ -84,6 +73,6 @@ export const CustomersOverview = ({ organization }: CustomersOverviewProps) => {
           )}
         </Grid>
       </Box>
-    </MasterDetailLayoutContent>
+    </CustomersPageShell>
   )
 }

--- a/clients/apps/web/src/components/Customer/CustomersPageShell.tsx
+++ b/clients/apps/web/src/components/Customer/CustomersPageShell.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { MasterDetailLayoutContent } from '@/components/Layout/MasterDetailLayout'
+import { CHART_RANGES, ChartRange } from '@/utils/metrics'
+import { schemas } from '@polar-sh/client'
+import { SegmentedControl, Text } from '@polar-sh/orbit'
+import { Box } from '@polar-sh/orbit/Box'
+import { PropsWithChildren } from 'react'
+import { CustomersSubnav } from './CustomersSubnav'
+
+interface CustomersPageShellProps extends PropsWithChildren {
+  organization: schemas['Organization']
+  range?: ChartRange
+  onRangeChange?: (range: ChartRange) => void
+}
+
+export const CustomersPageShell = ({
+  organization,
+  range,
+  onRangeChange,
+  children,
+}: CustomersPageShellProps) => (
+  <MasterDetailLayoutContent
+    header={
+      <Box
+        height="2rem"
+        display="flex"
+        flexDirection="row"
+        alignItems="center"
+        justifyContent="between"
+        rowGap="xl"
+        width="100%"
+      >
+        <Text variant="heading-xs" as="h1">
+          Customers
+        </Text>
+        {range && onRangeChange ? (
+          <SegmentedControl
+            options={(
+              Object.entries(CHART_RANGES) as [ChartRange, string][]
+            ).map(([value, label]) => ({ value, label }))}
+            value={range}
+            onChange={onRangeChange}
+          />
+        ) : null}
+      </Box>
+    }
+  >
+    <Box flexDirection="column" rowGap="2xl">
+      <CustomersSubnav organization={organization} />
+      {children}
+    </Box>
+  </MasterDetailLayoutContent>
+)

--- a/clients/apps/web/src/components/Customer/CustomersSubnav.tsx
+++ b/clients/apps/web/src/components/Customer/CustomersSubnav.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useHasPermission } from '@/hooks/permissions'
+import { schemas } from '@polar-sh/client'
+import { Subnav, SubnavItem } from '@polar-sh/orbit'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+interface CustomersSubnavProps {
+  organization: schemas['Organization']
+}
+
+export const CustomersSubnav = ({ organization }: CustomersSubnavProps) => {
+  const pathname = usePathname()
+  const canReadAnalytics = useHasPermission(organization.id, 'analytics:read')
+  const base = `/dashboard/${organization.slug}/customers`
+
+  const items = [
+    { label: 'Overview', href: base },
+    { label: 'Top Customers', href: `${base}/top` },
+    { label: 'At Risk', href: `${base}/at-risk` },
+    ...(canReadAnalytics
+      ? [{ label: 'Cost Drivers', href: `${base}/cost-drivers` }]
+      : []),
+  ]
+
+  return (
+    <Subnav label="Customer sections">
+      {items.map(({ label, href }) => (
+        <SubnavItem key={href} active={pathname === href}>
+          <Link href={href}>{label}</Link>
+        </SubnavItem>
+      ))}
+    </Subnav>
+  )
+}

--- a/clients/apps/web/src/components/Customer/useAtRisk.ts
+++ b/clients/apps/web/src/components/Customer/useAtRisk.ts
@@ -59,9 +59,6 @@ export const useAtRisk = (
     items,
     isLoading: pastDueLoading || cancelingLoading,
     isError: pastDueError || cancelingError,
-    refetch: () => {
-      refetchPastDue()
-      refetchCanceling()
-    },
+    refetch: () => Promise.all([refetchPastDue(), refetchCanceling()]),
   }
 }

--- a/clients/apps/web/src/components/Customer/useAtRisk.ts
+++ b/clients/apps/web/src/components/Customer/useAtRisk.ts
@@ -1,0 +1,67 @@
+import { useSubscriptions } from '@/hooks/queries'
+import { schemas } from '@polar-sh/client'
+import { useMemo } from 'react'
+
+export type RiskReason = 'past_due' | 'canceling'
+
+export interface AtRiskItem {
+  subscription: schemas['Subscription']
+  reason: RiskReason
+}
+
+export const cancelDate = (subscription: schemas['Subscription']) =>
+  new Date(
+    subscription.ends_at ?? subscription.current_period_end,
+  ).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+
+export const useAtRisk = (
+  organization: schemas['Organization'],
+  limit: number,
+) => {
+  const {
+    data: pastDue,
+    isLoading: pastDueLoading,
+    isError: pastDueError,
+    refetch: refetchPastDue,
+  } = useSubscriptions(organization.id, {
+    status: ['past_due'],
+    limit,
+    sorting: ['-amount'],
+  })
+  const {
+    data: canceling,
+    isLoading: cancelingLoading,
+    isError: cancelingError,
+    refetch: refetchCanceling,
+  } = useSubscriptions(organization.id, {
+    status: ['active', 'trialing'],
+    cancel_at_period_end: true,
+    limit,
+    sorting: ['current_period_end'],
+  })
+
+  const items = useMemo<AtRiskItem[]>(() => {
+    const pastDueItems = (pastDue?.items ?? []).map((subscription) => ({
+      subscription,
+      reason: 'past_due' as const,
+    }))
+    const pastDueIds = new Set(pastDueItems.map((item) => item.subscription.id))
+    const cancelingItems = (canceling?.items ?? [])
+      .filter((subscription) => !pastDueIds.has(subscription.id))
+      .map((subscription) => ({
+        subscription,
+        reason: 'canceling' as const,
+      }))
+    return [...pastDueItems, ...cancelingItems].slice(0, limit)
+  }, [pastDue, canceling, limit])
+
+  return {
+    items,
+    isLoading: pastDueLoading || cancelingLoading,
+    isError: pastDueError || cancelingError,
+    refetch: () => {
+      refetchPastDue()
+      refetchCanceling()
+    },
+  }
+}

--- a/clients/apps/web/src/hooks/useClientSidePagination.ts
+++ b/clients/apps/web/src/hooks/useClientSidePagination.ts
@@ -1,29 +1,47 @@
 'use client'
 
-import { useMemo } from 'react'
+import { DataTablePaginationState } from '@/utils/datatable'
+import { functionalUpdate, OnChangeFn } from '@tanstack/react-table'
+import { useCallback, useMemo } from 'react'
 import { useDataTableQueryState } from './useDataTableQueryState'
 
 /**
  * Client-side pagination over a fully fetched list, for endpoints that return
  * a bounded ranking rather than paginated results. Pagination state is bound
- * to the URL query string via useDataTableQueryState; call `resetPage` when a
- * filter owned by the page (e.g. the chart range) changes.
+ * to the URL query string via useDataTableQueryState; malformed or
+ * out-of-range URL values are clamped to the valid range. Call `resetPage`
+ * when a filter owned by the page (e.g. the chart range) changes.
  */
 export const useClientSidePagination = <T>(
   items: T[],
   defaultPageSize = 20,
 ) => {
-  const { pagination, setPagination, resetPage } = useDataTableQueryState({
-    defaultPageSize,
-  })
+  const {
+    pagination: rawPagination,
+    setPagination: setRawPagination,
+    resetPage,
+  } = useDataTableQueryState({ defaultPageSize })
+
+  const pageSize = Math.max(1, rawPagination.pageSize)
+  const pageCount = Math.max(1, Math.ceil(items.length / pageSize))
+  const pageIndex = Math.min(
+    Math.max(0, rawPagination.pageIndex),
+    pageCount - 1,
+  )
+
+  const pagination = useMemo(
+    () => ({ pageIndex, pageSize }),
+    [pageIndex, pageSize],
+  )
+
+  const setPagination = useCallback<OnChangeFn<DataTablePaginationState>>(
+    (updater) => setRawPagination(functionalUpdate(updater, pagination)),
+    [pagination, setRawPagination],
+  )
 
   const pageItems = useMemo(
-    () =>
-      items.slice(
-        pagination.pageIndex * pagination.pageSize,
-        (pagination.pageIndex + 1) * pagination.pageSize,
-      ),
-    [items, pagination],
+    () => items.slice(pageIndex * pageSize, (pageIndex + 1) * pageSize),
+    [items, pageIndex, pageSize],
   )
 
   return {
@@ -32,6 +50,6 @@ export const useClientSidePagination = <T>(
     setPagination,
     resetPage,
     rowCount: items.length,
-    pageCount: Math.max(1, Math.ceil(items.length / pagination.pageSize)),
+    pageCount,
   }
 }

--- a/clients/apps/web/src/hooks/useClientSidePagination.ts
+++ b/clients/apps/web/src/hooks/useClientSidePagination.ts
@@ -1,0 +1,37 @@
+'use client'
+
+import { useMemo } from 'react'
+import { useDataTableQueryState } from './useDataTableQueryState'
+
+/**
+ * Client-side pagination over a fully fetched list, for endpoints that return
+ * a bounded ranking rather than paginated results. Pagination state is bound
+ * to the URL query string via useDataTableQueryState; call `resetPage` when a
+ * filter owned by the page (e.g. the chart range) changes.
+ */
+export const useClientSidePagination = <T>(
+  items: T[],
+  defaultPageSize = 20,
+) => {
+  const { pagination, setPagination, resetPage } = useDataTableQueryState({
+    defaultPageSize,
+  })
+
+  const pageItems = useMemo(
+    () =>
+      items.slice(
+        pagination.pageIndex * pagination.pageSize,
+        (pagination.pageIndex + 1) * pagination.pageSize,
+      ),
+    [items, pagination],
+  )
+
+  return {
+    pageItems,
+    pagination,
+    setPagination,
+    resetPage,
+    rowCount: items.length,
+    pageCount: Math.max(1, Math.ceil(items.length / pagination.pageSize)),
+  }
+}

--- a/clients/packages/orbit/src/components/Subnav.tsx
+++ b/clients/packages/orbit/src/components/Subnav.tsx
@@ -3,17 +3,13 @@ import { Box } from './Box'
 import { Text } from './Text'
 
 export interface SubnavProps extends PropsWithChildren {
-  /**
-   * Accessible name for the navigation landmark, distinguishing it from the
-   * page's primary navigation for assistive technology.
-   */
+  /** Accessible name for the navigation landmark. */
   label?: string
 }
 
 /**
  * A horizontal row of links for switching between the sections of a page.
- * Compose it with `SubnavItem`, passing your router's link element as the
- * item's child so client-side navigation is preserved.
+ * Compose with `SubnavItem`, passing your router's link element as the child.
  */
 export const Subnav = ({ label = 'Secondary', children }: SubnavProps) => (
   <Box as="nav" aria-label={label}>
@@ -24,25 +20,12 @@ export const Subnav = ({ label = 'Secondary', children }: SubnavProps) => (
 )
 
 export interface SubnavItemProps {
-  /**
-   * Marks the item as the section currently shown. The active item is
-   * emphasised, underlined, and exposed to assistive technology via
-   * `aria-current`.
-   */
+  /** Marks the item as the section currently shown (sets `aria-current`). */
   active?: boolean
-  /**
-   * The link (or button) for the section. Styling is inherited, so any
-   * anchor-like element works — a framework `<Link>`, a plain `<a>`, or a
-   * `<button>` with its chrome reset.
-   */
+  /** The link element for the section; color and typography are inherited. */
   children: ReactNode
 }
 
-// The item styles the list element and lets the link inherit color and
-// typography, so it stays agnostic of which link component the consumer's
-// router provides. The round indicator dot, centered under the label, is
-// always rendered — transparent unless active — so activating an item never
-// shifts layout.
 export const SubnavItem = ({ active, children }: SubnavItemProps) => (
   <Box
     as="li"

--- a/clients/packages/orbit/src/components/Subnav.tsx
+++ b/clients/packages/orbit/src/components/Subnav.tsx
@@ -1,0 +1,66 @@
+import type { PropsWithChildren, ReactNode } from 'react'
+import { Box } from './Box'
+import { Text } from './Text'
+
+export interface SubnavProps extends PropsWithChildren {
+  /**
+   * Accessible name for the navigation landmark, distinguishing it from the
+   * page's primary navigation for assistive technology.
+   */
+  label?: string
+}
+
+/**
+ * A horizontal row of links for switching between the sections of a page.
+ * Compose it with `SubnavItem`, passing your router's link element as the
+ * item's child so client-side navigation is preserved.
+ */
+export const Subnav = ({ label = 'Secondary', children }: SubnavProps) => (
+  <Box as="nav" aria-label={label}>
+    <Box as="ul" alignItems="end" columnGap="xl" flexWrap="wrap" rowGap="s">
+      {children}
+    </Box>
+  </Box>
+)
+
+export interface SubnavItemProps {
+  /**
+   * Marks the item as the section currently shown. The active item is
+   * emphasised, underlined, and exposed to assistive technology via
+   * `aria-current`.
+   */
+  active?: boolean
+  /**
+   * The link (or button) for the section. Styling is inherited, so any
+   * anchor-like element works — a framework `<Link>`, a plain `<a>`, or a
+   * `<button>` with its chrome reset.
+   */
+  children: ReactNode
+}
+
+// The item styles the list element and lets the link inherit color and
+// typography, so it stays agnostic of which link component the consumer's
+// router provides. The round indicator dot, centered under the label, is
+// always rendered — transparent unless active — so activating an item never
+// shifts layout.
+export const SubnavItem = ({ active, children }: SubnavItemProps) => (
+  <Box
+    as="li"
+    aria-current={active ? 'page' : undefined}
+    flexDirection="column"
+    alignItems="center"
+    rowGap="s"
+    display="flex"
+    color={
+      active
+        ? 'text-primary'
+        : { base: 'text-secondary', hover: 'text-primary' }
+    }
+    transitionProperty="colors"
+    transitionDuration="fast"
+  >
+    <Text as="span" variant="heading-xxs" color="inherit">
+      {children}
+    </Text>
+  </Box>
+)

--- a/clients/packages/orbit/src/index.ts
+++ b/clients/packages/orbit/src/index.ts
@@ -52,6 +52,8 @@ export {
 export { Spinner, SpinnerNoMargin } from './components/Spinner'
 export { Status } from './components/Status'
 export type { StatusColor, StatusProps } from './components/Status'
+export { Subnav, SubnavItem } from './components/Subnav'
+export type { SubnavItemProps, SubnavProps } from './components/Subnav'
 export { Switch } from './components/Switch'
 export { Tabs, TabsContent, TabsList, TabsTrigger } from './components/Tabs'
 export { Text } from './components/Text'


### PR DESCRIPTION

<img width="1800" height="1009" alt="image" src="https://github.com/user-attachments/assets/11992c16-c1c8-4db8-8257-5d37556373bd" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds dedicated Customers subpages (Top, At Risk, Cost Drivers) with a shared subnav and page shell for clearer navigation. Also adds a `Subnav` component in `@polar-sh/orbit` with docs, and improves data fetching states across these views.

- New Features
  - Customers subnav: Overview, Top Customers, At Risk, Cost Drivers (gated by analytics:read).
  - New pages with data tables, client-side pagination (URL-bound), empty/error states, and row-click to customer detail.
  - Range picker on Top and Cost Drivers; pagination resets on range change.
  - New `CustomerCell` for avatar/name/email.
  - New hooks: `useClientSidePagination`, `useAtRisk`.
  - `@polar-sh/orbit`: added `Subnav` and `SubnavItem`, exported and documented with examples.

- Refactors
  - Extracted `CustomersPageShell` and `CustomersSubnav`; `CustomersOverview` now uses the shell.
  - `AtRiskList` now uses `useAtRisk` with simplified loading/error handling.
  - Stabilized data fetching and pagination guardrails (clamped params, consistent range handling, improved error states).

<sup>Written for commit 258fd8e9fc390a68fb41bbde021e96695e1a378f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



