### PR TITLE
Clear stale tax data on all business-customer transitions in checkout

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -2224,12 +2224,12 @@ class CheckoutService:
         # Turning off business purchase must clear the business billing fields.
         # Otherwise a stale tax ID keeps reverse-charge (0% VAT) treatment on the
         # order and invoice even though the checkout is no longer a business purchase.
+        # `customer_billing_name` is cleared after the field-copy loop below, since
+        # that loop would otherwise re-apply it from the same request.
         disabling_business_customer = (
             checkout_update.is_business_customer is False
             and "is_business_customer" in checkout_update.model_fields_set
         )
-        if disabling_business_customer:
-            checkout.customer_billing_name = None
 
         if disabling_business_customer or (
             checkout_update.customer_tax_id is None
@@ -2312,6 +2312,9 @@ class CheckoutService:
         ).items():
             setattr(checkout, attr, value)
 
+        if disabling_business_customer:
+            checkout.customer_billing_name = None
+
         # `None` locale would opt in to browser-based language detection.
         # If people haven't opted in to this yet, we hardcode the default locale
         # to `en-US` to keep the current behavior
@@ -2349,6 +2352,8 @@ class CheckoutService:
             checkout.payment_method_type = None
             if not checkout.require_billing_address:
                 checkout.is_business_customer = False
+                checkout.customer_tax_id = None
+                checkout.customer_billing_name = None
 
     async def _update_price(
         self,

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -3536,6 +3536,28 @@ class TestUpdate:
         assert checkout.customer_tax_id_number is None
         assert checkout.customer_billing_name is None
 
+    async def test_disabling_business_customer_clears_billing_name_sent_in_request(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        checkout_one_time_custom: Checkout,
+    ) -> None:
+        checkout_one_time_custom.is_business_customer = True
+        checkout_one_time_custom.customer_billing_name = "ACME Inc."
+        await save_fixture(checkout_one_time_custom)
+
+        checkout = await checkout_service.update(
+            session,
+            checkout_one_time_custom,
+            CheckoutUpdate(
+                is_business_customer=False,
+                customer_billing_name="ACME Inc.",
+            ),
+        )
+
+        assert checkout.is_business_customer is False
+        assert checkout.customer_billing_name is None
+
     async def test_silent_calculate_tax_error(
         self,
         session: AsyncSession,
@@ -3960,6 +3982,34 @@ class TestUpdate:
         assert checkout.discount == discount_percentage_100
         assert checkout.is_payment_form_required is False
         assert checkout.is_business_customer is False
+
+    async def test_full_discount_clears_business_tax_fields(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        checkout_one_time_fixed: Checkout,
+        discount_percentage_100: Discount,
+    ) -> None:
+        checkout_one_time_fixed.is_business_customer = True
+        checkout_one_time_fixed.customer_billing_name = "ACME Inc."
+        checkout_one_time_fixed.customer_billing_address = AddressInput.model_validate(
+            {"country": "FR"}
+        )
+        checkout_one_time_fixed.customer_tax_id = (
+            "FR61954506077",
+            TaxIDFormat.eu_vat,
+        )
+        await save_fixture(checkout_one_time_fixed)
+
+        checkout = await checkout_service.update(
+            session,
+            checkout_one_time_fixed,
+            CheckoutUpdatePublic(discount_code=discount_percentage_100.code),
+        )
+
+        assert checkout.is_business_customer is False
+        assert checkout.customer_tax_id is None
+        assert checkout.customer_billing_name is None
 
     async def test_full_discount_resets_payment_method(
         self,


### PR DESCRIPTION
Follow-up to https://github.com/polarsource/polar/pull/13650 to close some gaps

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clear stale business tax data on all transitions away from business checkout to prevent reverse-charge (0% VAT) being applied to non-business orders.

- **Bug Fixes**
  - When `is_business_customer=false`, clear `customer_billing_name` after the field-copy loop so it isn’t re-applied from the request.
  - When the payment form resets (e.g., 100% discount), also clear `customer_tax_id` and `customer_billing_name` alongside flipping `is_business_customer` to false.
  - Added tests for both cases.

<sup>Written for commit 22301ffa1e7f7bbd7749ac8ee1dc14d3b1fbca09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

