### PR TITLE
fix(payment_method): skip expiration reminder for deleted payment methods

### DIFF
--- a/server/polar/payment_method/tasks.py
+++ b/server/polar/payment_method/tasks.py
@@ -8,7 +8,6 @@ from polar.worker import (
     TaskPriority,
     actor,
     enqueue_job,
-    get_message_timestamp,
 )
 
 from .repository import PaymentMethodRepository
@@ -53,13 +52,8 @@ async def send_expiration_reminder(payment_method_id: uuid.UUID) -> None:
             raise PaymentMethodDoesNotExist(payment_method_id)
 
         if payment_method.deleted_at is not None:
-            # If the message was enqueued after the payment method was deleted,
-            # it's a bug.
-            if get_message_timestamp() > payment_method.deleted_at:
-                raise PaymentMethodDoesNotExist(payment_method_id)
-            # Otherwise, just discard. It can happen under normal circumstances
-            # with race conditions or retries: the payment method was deleted
-            # between the scan enqueuing this task and its execution.
+            # The payment method was deleted between the scan enqueuing this
+            # task and its execution. It's a normal race, so just discard.
             return
 
         await payment_method_service.send_expiration_reminder_email(

--- a/server/polar/payment_method/tasks.py
+++ b/server/polar/payment_method/tasks.py
@@ -8,6 +8,7 @@ from polar.worker import (
     TaskPriority,
     actor,
     enqueue_job,
+    get_message_timestamp,
 )
 
 from .repository import PaymentMethodRepository
@@ -44,10 +45,22 @@ async def send_expiration_reminder(payment_method_id: uuid.UUID) -> None:
     async with AsyncSessionMaker() as session:
         repository = PaymentMethodRepository.from_session(session)
         payment_method = await repository.get_by_id(
-            payment_method_id, options=repository.get_eager_options()
+            payment_method_id,
+            options=repository.get_eager_options(),
+            include_deleted=True,
         )
         if payment_method is None:
             raise PaymentMethodDoesNotExist(payment_method_id)
+
+        if payment_method.deleted_at is not None:
+            # If the message was enqueued after the payment method was deleted,
+            # it's a bug.
+            if get_message_timestamp() > payment_method.deleted_at:
+                raise PaymentMethodDoesNotExist(payment_method_id)
+            # Otherwise, just discard. It can happen under normal circumstances
+            # with race conditions or retries: the payment method was deleted
+            # between the scan enqueuing this task and its execution.
+            return
 
         await payment_method_service.send_expiration_reminder_email(
             session, payment_method


### PR DESCRIPTION
Addresses https://github.com/polarsource/feedback/issues/349


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip sending expiration reminder emails for deleted payment methods to avoid unwanted emails. We now include deleted records and discard jobs when the method was deleted before execution.

- **Bug Fixes**
  - Load payment methods with `include_deleted=True` to detect deletions.
  - If `deleted_at` is set, return early without sending the reminder (handles races/retries).

<sup>Written for commit bfa6eb2cd4bf4a92938bf9dae30738fb0079c126. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



