### PR TITLE
Prevent changing redeemed discount duration

### DIFF
--- a/server/polar/discount/service.py
+++ b/server/polar/discount/service.py
@@ -266,9 +266,9 @@ class DiscountService(ResourceServiceReader[Discount]):
 
         if discount.redemptions_count > 0:
             forbidden_fields = (
-                {"amount", "currency", "amounts"}
+                {"amount", "currency", "amounts", "duration_in_months"}
                 if isinstance(discount, DiscountFixed)
-                else {"basis_points"}
+                else {"basis_points", "duration_in_months"}
             )
             for field in forbidden_fields:
                 if field in discount_update.model_fields_set:

--- a/server/tests/discount/test_service.py
+++ b/server/tests/discount/test_service.py
@@ -306,6 +306,56 @@ class TestUpdate:
                 auth_subject=auth_subject,
             )
 
+    @pytest.mark.parametrize("type", [DiscountType.fixed, DiscountType.percentage])
+    @pytest.mark.auth
+    async def test_update_duration_in_months_with_redemptions(
+        self,
+        auth_subject: AuthSubject[User],
+        user_organization: UserOrganization,
+        type: DiscountType,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        discount: Discount
+        if type == DiscountType.fixed:
+            discount = await create_discount(
+                save_fixture,
+                type=DiscountType.fixed,
+                amounts={"usd": 5000},
+                duration=DiscountDuration.repeating,
+                duration_in_months=3,
+                organization=organization,
+            )
+        else:
+            discount = await create_discount(
+                save_fixture,
+                type=DiscountType.percentage,
+                basis_points=5000,
+                duration=DiscountDuration.repeating,
+                duration_in_months=3,
+                organization=organization,
+            )
+        checkout = await create_checkout(save_fixture, products=[product])
+        await create_discount_redemption(
+            save_fixture, discount=discount, checkout=checkout
+        )
+        await session.refresh(discount, ["organization", "redemptions_count"])
+
+        with pytest.raises(PolarRequestValidationError) as exc_info:
+            await discount_service.update(
+                session,
+                discount,
+                discount_update=DiscountUpdate(duration_in_months=1),
+                auth_subject=auth_subject,
+            )
+
+        assert exc_info.value.errors()[0]["loc"] == (
+            "body",
+            "duration_in_months",
+        )
+
     @pytest.mark.parametrize(
         "field",
         [


### PR DESCRIPTION
## Summary

- prevent `duration_in_months` from changing after a discount has been redeemed
- apply the guard to both fixed and percentage repeating discounts
- add regression coverage for both discount types

## Root cause

The post-redemption immutability check covered monetary fields and `duration`, but omitted `duration_in_months`. As a result, changing the number of discounted billing cycles remained possible after customers had redeemed a repeating discount.

## Impact

Redeemed repeating discounts now preserve the billing duration originally promised to customers. Updates that keep the existing value remain allowed.

## Validation

- `uv run pytest tests/discount -q` (88 passed)
- `uv run task lint_types` (1,672 source files checked)
- Ruff lint and format checks on touched files
- ADR compliance check: no violations

Fixes polarsource/feedback#295

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

