### PR TITLE
Revert "server/order: stop retries on old order.trigger_payment jobs (#13355)"

### DIFF
--- a/server/polar/order/tasks.py
+++ b/server/polar/order/tasks.py
@@ -21,7 +21,6 @@ from polar.worker import (
     actor,
     can_retry,
     enqueue_job,
-    get_retries,
 )
 
 from .repository import OrderRepository
@@ -113,18 +112,6 @@ async def trigger_payment(
     payment_method_id: uuid.UUID,
     payment_trigger: str | None = None,
 ) -> None:
-    if get_retries() > 0:
-        # We have a lot of piled up trigger payment jobs that we shouldn't retry
-        # Exhaust them for now so we don't trigger more dunning processes than necessary
-        log.info(
-            "Dead-lettering payment trigger",
-            order_id=order_id,
-            payment_method_id=payment_method_id,
-            payment_trigger=payment_trigger,
-            retries=get_retries(),
-        )
-        return
-
     async with AsyncSessionMaker() as session:
         repository = OrderRepository.from_session(session)
         order = await repository.get_by_id(


### PR DESCRIPTION

Those old jobs should have been exhausted by now, so let's reintroduce standard retry behavior for this task.

Fix https://github.com/polarsource/feedback/issues/315


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

