### PR TITLE
fix(customer): top customers avatar falls back to owner email

### DIFF
--- a/server/polar/compass/assistant/entity_tools.py
+++ b/server/polar/compass/assistant/entity_tools.py
@@ -904,12 +904,12 @@ async def top_customers_by_revenue(
         return f"No paid orders were found for {window}."
     rows: list[Row] = [
         {
-            "avatar": _avatar_url_for_email(email) if email else None,
-            "customer": email or name,
+            "avatar": customer.avatar_url,
+            "customer": customer.email or customer.name,
             "revenue": net_revenue,
             "orders": order_count,
         }
-        for _, email, name, order_count, net_revenue in ranked
+        for customer, order_count, net_revenue in ranked
     ]
     columns = [
         DataTableColumn(key="avatar", label="", format=ColumnFormat.avatar),

--- a/server/polar/customer/endpoints.py
+++ b/server/polar/customer/endpoints.py
@@ -17,7 +17,6 @@ from polar.kit.pagination import ListResource, PaginationParamsQuery
 from polar.kit.schemas import MultipleQueryFilter
 from polar.kit.time_queries import TimeInterval
 from polar.models import Customer, PaymentMethod
-from polar.models.customer import _avatar_url_for_email
 from polar.openapi import APITag
 from polar.organization.schemas import OrganizationID
 from polar.payment_method.schemas import PaymentMethodTypeAdapter
@@ -246,14 +245,14 @@ async def top(
     )
     return [
         TopCustomer(
-            id=customer_id,
-            email=email,
-            name=name,
-            avatar_url=_avatar_url_for_email(email) if email else None,
+            id=customer.id,
+            email=customer.email,
+            name=customer.name,
+            avatar_url=customer.avatar_url,
             order_count=order_count,
             net_revenue=net_revenue,
         )
-        for customer_id, email, name, order_count, net_revenue in ranked
+        for customer, order_count, net_revenue in ranked
     ]
 
 

--- a/server/polar/customer/service.py
+++ b/server/polar/customer/service.py
@@ -181,7 +181,7 @@ class CustomerService:
         start: datetime | None = None,
         end: datetime | None = None,
         limit: int = 10,
-    ) -> Sequence[tuple[uuid.UUID, str | None, str | None, int, int]]:
+    ) -> Sequence[tuple[Customer, int, int]]:
         await assert_organization_permission(
             session,
             auth_subject,

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -65,10 +65,6 @@ class OrderRepository(
         """Customers ranked by paid net revenue: (customer, order count, net
         revenue in cents), descending.
 
-        Returns the `Customer` entities so callers can derive display fields
-        (e.g. `avatar_url`, which falls back to the owner member's email for
-        team customers) from a single source of truth.
-
         Partially refunded orders count with the refunded portion subtracted,
         so the ranking reflects money actually kept.
 

--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -61,9 +61,13 @@ class OrderRepository(
         start: datetime | None = None,
         end: datetime | None = None,
         limit: int = 10,
-    ) -> Sequence[tuple[UUID, str | None, str | None, int, int]]:
-        """Customers ranked by paid net revenue: (customer_id, email, name,
-        order count, net revenue in cents), descending.
+    ) -> Sequence[tuple[Customer, int, int]]:
+        """Customers ranked by paid net revenue: (customer, order count, net
+        revenue in cents), descending.
+
+        Returns the `Customer` entities so callers can derive display fields
+        (e.g. `avatar_url`, which falls back to the owner member's email for
+        team customers) from a single source of truth.
 
         Partially refunded orders count with the refunded portion subtracted,
         so the ranking reflects money actually kept.
@@ -77,19 +81,18 @@ class OrderRepository(
         )
         statement = (
             select(
-                Customer.id,
-                Customer.email,
-                Customer.name,
+                Customer,
                 func.count(Order.id),
                 net_revenue,
             )
+            .select_from(Order)
             .join(Customer, Customer.id == Order.customer_id)
             .where(
                 Order.organization_id == organization_id,
                 Order.status.in_(OrderStatus.paid_statuses()),
                 Order.is_deleted.is_(False),
             )
-            .group_by(Customer.id, Customer.email, Customer.name)
+            .group_by(Customer.id)
             .order_by(net_revenue.desc())
             .limit(limit)
         )
@@ -98,9 +101,7 @@ class OrderRepository(
         if end is not None:
             statement = statement.where(Order.created_at < end)
         result = await self.session.execute(statement)
-        return [
-            (row[0], row[1], row[2], int(row[3]), int(row[4])) for row in result.all()
-        ]
+        return [(row[0], int(row[1]), int(row[2])) for row in result.all()]
 
     async def get_paid_revenue_by_country(
         self,

--- a/server/tests/customer/test_endpoints.py
+++ b/server/tests/customer/test_endpoints.py
@@ -9,12 +9,14 @@ from polar.member.repository import MemberRepository
 from polar.models import (
     Benefit,
     Customer,
+    Member,
+    MemberRole,
     Organization,
     Product,
     User,
     UserOrganization,
 )
-from polar.models.customer import _avatar_url_for_email
+from polar.models.customer import CustomerType, _avatar_url_for_email
 from polar.models.subscription import SubscriptionStatus
 from polar.models.user_organization import OrganizationRole
 from polar.postgres import AsyncSession
@@ -469,6 +471,44 @@ class TestTopCustomers:
         assert json[0]["avatar_url"] == _avatar_url_for_email("best@example.com")
         assert json[1]["net_revenue"] == 4_000
         assert json[1]["order_count"] == 1
+
+    @pytest.mark.auth
+    async def test_team_customer_without_email_uses_owner_avatar(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        organization: Organization,
+        user_organization: UserOrganization,
+        product: Product,
+    ) -> None:
+        customer = Customer(
+            email=None,
+            name="Acme Inc.",
+            type=CustomerType.team,
+            organization=organization,
+        )
+        await save_fixture(customer)
+        owner = Member(
+            customer_id=customer.id,
+            organization_id=organization.id,
+            email="owner@polar.sh",
+            role=MemberRole.owner,
+        )
+        await save_fixture(owner)
+        await create_order(
+            save_fixture, customer=customer, product=product, subtotal_amount=10_000
+        )
+
+        response = await client.get(
+            "/v1/customers/top", params={"organization_id": str(organization.id)}
+        )
+
+        assert response.status_code == 200
+        json = response.json()
+        assert len(json) == 1
+        assert json[0]["id"] == str(customer.id)
+        assert json[0]["email"] is None
+        assert json[0]["avatar_url"] == _avatar_url_for_email("owner@polar.sh")
 
     @pytest.mark.auth
     async def test_start_filter(


### PR DESCRIPTION
## Summary

**Related Issue**: Closes polarsource/feedback#354

Team customers created without a direct email got `avatar_url: null` from `GET /v1/customers/top`, while the customer **detail** and **create** endpoints correctly return an avatar derived from the owner member's email. This fixes that inconsistency so the same customer no longer shows an avatar everywhere except the top-customers widget.

## What

- `OrderRepository.get_revenue_by_customer` now ranks on and returns the `Customer` entity — `(Customer, order_count, net_revenue)` — instead of scalar `(id, email, name, …)` columns.
- The `/v1/customers/top` endpoint builds `TopCustomer` from the `Customer` object, so `avatar_url` comes straight from the `Customer.avatar_url` property.
- The compass assistant's `top_customers_by_revenue` tool consumes the same repository method and now also derives its avatar from `Customer.avatar_url` (same latent bug, fixed consistently).
- Added a regression test: a team customer with `email=None` plus an owner member returns the owner-email avatar from `/top`.

## Why

`Customer.avatar_url` already implements the fallback:

```python
email = self.email or (self.owner.email if self.owner else None)
return _avatar_url_for_email(email) if email else None
```

The `/top` endpoint replicated only the `email`-based half (`_avatar_url_for_email(email) if email else None`), so team customers without an email showed no avatar despite having one on their detail page and at creation. Deriving from the model property gives a single source of truth.

## How

Selecting the full `Customer` entity (grouped by its primary key) lets the `owner` relationship — already `lazy="selectin"` — load automatically, so `Customer.avatar_url`'s owner fallback resolves with no extra query wiring. Both callers of the shared repository method were updated to the new tuple shape.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [ ] Linting and type checking pass — `ruff check` passes; `uv run task lint_types` (mypy) and the pytest suite could **not** be run in this ephemeral environment (the pinned Python 3.14.6 toolchain and Postgres aren't provisioned here). The SQLAlchemy query change was validated in an isolated SQLAlchemy repro (entity select + `select_from`/`join` + group-by-on-PK + `selectin` owner load).
- [x] No unrelated changes or drive-by fixes are included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gv3a3vnBRbyBdiayBV5oL

---
_Generated by [Claude Code](https://claude.ai/code/session_011gv3a3vnBRbyBdiayBV5oL)_

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

