### PR TITLE
docs: background jobs for merchant migration precheck & catalog import

### DIFF
--- a/handbook/engineering/design-documents/merchant-migrations.mdx
+++ b/handbook/engineering/design-documents/merchant-migrations.mdx
@@ -140,7 +140,7 @@ We want to start with the following sources, and extend them to more if needed.
 
 |                   | How we read it     | How cards move | Notes                           |
 | ----------------- | ------------------ | -------------- | ------------------------------- |
-| **Stripe**        | Stripe App (OAuth) | PAN copy       | Read scopes + `subscription_write` for the cutover pause |
+| **Stripe**        | Restricted API key (`rk_…`) | PAN copy       | Read scopes + `subscription_write` for the cutover pause |
 | **Lemon Squeezy** | API key            | (pending)      |                                 |
 | **Paddle**        | API key            | PAN import     | They use Ixopay as a card vault |
 
@@ -151,11 +151,11 @@ We want to start with the following sources, and extend them to more if needed.
 The idea is to create a new `migration` module (I'm up for new name suggestions) with similar structure as we have now, with an `adapters` submodule.
 
 ### Main classes
-- **`MigrationJob`** one row per migration run for an org. The root: source platform and current step.
-- **`MigrationRecord`** one row per imported thing (customer, product, subscription, order, …), mapping `source_id → target_id` with a status. It's our idempotency layer, scoped per org, so we can trigger multiple migrations safely.
+- **`MerchantMigration`** one row per migration run for an org. The root: source platform and current step.
+- **`MerchantMigrationRecord`** one row per imported thing (customer, product, subscription, order, …), mapping `source_id → target_id` with a status. It's our idempotency layer, scoped per org, so we can trigger multiple migrations safely.
 - **`SourceAdapter`** we will have one for every billing provider (e.g. `StripeAdapter`). Its main responsibility is to read the current billing provider API and provide a generic representation the migration service can work with. `extract()` must be incremental as customer data can be huge. It also stops billing on the source at cutover via `stop_source_subscription()`, the adapter's only write.
-- **`PanTransferStep`** the checklist for moving cards (step, owner, status, kind, inputs - see Appendix B). Stored as a JSONB column on `MigrationJob`: a list of step objects.
-- **`MigrationService`** the main orchestrator.
+- **`PanTransferStep`** the checklist for moving cards (step, owner, status, kind, inputs - see Appendix B). Stored as a JSONB column on `MerchantMigration`: a list of step objects.
+- **`MerchantMigrationService`** the main orchestrator.
 - **`CanonicalRecord`** to have everything normalized in memory first (variants: `CanonicalProduct` / `Customer` / `Subscription`). The precheck engine reads these and returns a `PrecheckReport` (Appendix A); Appendix C shows the flow end to end.
 
 ## Background jobs: precheck & catalog import
@@ -260,16 +260,16 @@ The merchant walks the checklist as a guided, one-step-at-a-time wizard and can 
 This shows how the classes communicate. Precheck/import run as background batches in production (see *Background jobs*); the snippet is the logical flow.
 
 ```python
-# 1. read + normalize from the source
-#    Stripe: mint a short-lived access token from the stored OAuth refresh token
-token = await stripe_oauth.refresh(job.source_refresh_token)  # rotates; persist token.refresh_token
-records = [r async for r in StripeAdapter(api_key=token.access_token).extract()]
+# 1. read + normalize from the source (Stripe: merchant-pasted restricted key)
+records = [r async for r in StripeAdapter(api_key=job.source_credentials["api_key"]).extract()]
 # records = [CanonicalProduct(...), CanonicalCustomer(...), CanonicalSubscription(...)]
 
 # 2. precheck (no writes), then stage each record in the ledger
 report = precheck.run(records, org)        # PrecheckReport(can_start=True, blockers=0, ...)
 for r in records:
-    repo.upsert(MigrationRecord(job_id=job.id, source_id=r.source_id, canonical=r))
+    repo.upsert(MerchantMigrationRecord(
+        merchant_migration_id=job.id, source_id=r.source_id, canonical=r
+    ))
 
 # 3. import through the existing services (subscriptions created paused)
 await product_service.import_from_canonical(canonical_product)

--- a/handbook/engineering/design-documents/merchant-migrations.mdx
+++ b/handbook/engineering/design-documents/merchant-migrations.mdx
@@ -174,6 +174,7 @@ No separate Job table. `MerchantMigration` holds a single JSONB **operation** (n
 | `error` | Set when `failed` |
 | `cursor` | Opaque resume point for the current chain (Stripe page cursor, or last processed record id / type phase). Persisted on the migration so a reenqueue only needs `migration_id`. Cleared or ignored once `done`. |
 | `last_progress_at` | Bumped each successful batch; used to detect stalled ops |
+| `selection` | Import only: snapshot of `record_ids` **or** `exclude_record_ids` from the start request (whichever mode the client used). Small by design — see selection below. |
 
 **`step` names the phase; `operation.status` says where we are in that phase.** Starting an operation advances `step` to that phase immediately — they stay aligned. There is no separate `kind` on the operation (it would always duplicate `step`). Do **not** clear `operation` on success — set `status=done` so idle vs finished is explicit.
 
@@ -196,7 +197,11 @@ No separate Job table. `MerchantMigration` holds a single JSONB **operation** (n
 | Import finished | `create_catalog` | `{status: done}` |
 | Partial re-import | `create_catalog` | `{status: pending\|running}` again, then `done` |
 
-Import selection (`record_ids` / `exclude_record_ids`) is applied when the import starts (mark or filter pending rows once). Workers then only process `pending` selected rows — no need to keep the full selection list on the operation.
+Import selection stays compact on the operation (same shape as today’s API): either `record_ids` (opt-in) or `exclude_record_ids` (opt-out). Workers never expand that into a million row updates.
+
+Example: 1M customers, merchant unchecks one → request is `exclude_record_ids: [that_id]`. Stored on the operation as ~one UUID. Each import batch queries `pending` rows of the current type **except** those ids (or **only** `record_ids` in opt-in mode), ordered by id, limited to the batch size, after the cursor. The excluded row stays `pending` so a later partial import can still pick it up. Opt-in of a handful of rows is the same idea with a small include list.
+
+Do **not** “select” by writing a flag on every included row — that turns an exclude-1 catalog into a million writes at start.
 
 ### Two linear job chains
 
@@ -215,7 +220,7 @@ flowchart TB
 
 **Precheck** — start endpoint locks the migration (`FOR UPDATE`), sets `step=pre_check` and `operation` (`status=pending`, empty cursor), enqueues the first batch. The first worker flips `status=running`, pages `adapter.extract()`, upserts ledger rows, writes the next `cursor` + `last_progress_at`, reenqueues. When extract is exhausted, classify with `PrecheckEngine`, set `operation.status=done` (step stays `pre_check` for review).
 
-**Import** — same blockers as today; apply selection; set `step=create_catalog` and `operation` (`status=pending`); enqueue. Batches flip to `running` and import up to N pending selected records for the current type (products, then customers, then subscriptions — cursor carries which type and where). When nothing remains, set `operation.status=done` (step stays `create_catalog`). A later partial re-import sets `operation` back to `pending`/`running`, then `done` again, without changing `step`.
+**Import** — same blockers as today; snapshot selection onto the operation; set `step=create_catalog` and `operation` (`status=pending`); enqueue. Batches flip to `running` and import up to N selected `pending` records for the current type (products, then customers, then subscriptions — cursor carries which type and where; selection filters the query). When nothing remains, set `operation.status=done` (step stays `create_catalog`). A later partial re-import sets a new `selection` and `operation` back to `pending`/`running`, then `done` again, without changing `step`.
 
 Actors live in `polar/merchant_migration/tasks.py`. Batch size ~25–50; tune later.
 
@@ -225,7 +230,7 @@ Actors live in `polar/merchant_migration/tasks.py`. Batch size ~25–50; tune la
 | --- | --- |
 | **Record** | Mark ledger row `failed` + `error`; the batch continues. Does not fail the operation. |
 | **Task** | On catchable errors: if `can_retry()`, re-raise; if not, set `operation.status=failed` + `error` in the same session, then re-raise/return. |
-| **Stall** | On `GET` of the migration (while the client polls): if `operation.status` is `pending` or `running` and `last_progress_at` is older than a stall threshold (15–30 min; for `pending`, also use `started_at` / enqueue time if we store one), mark `failed`. Stale tasks that wake later no-op when they see `failed` or `done`. |
+| **Stall** | On `GET` of the migration (while the client polls): if `operation.status` is `pending` or `running` and `last_progress_at` is older than a stall threshold (15–30 min), mark `failed`. Set `last_progress_at` when enqueueing (`pending`) as well as on each batch. Stale tasks that wake later no-op when they see `failed` or `done`. |
 
 Unrecoverable start errors (blockers, wrong step, concurrent op) fail immediately with **409** / the existing status-coded errors — no enqueue.
 

--- a/handbook/engineering/design-documents/merchant-migrations.mdx
+++ b/handbook/engineering/design-documents/merchant-migrations.mdx
@@ -33,14 +33,14 @@ A migration is divided into two things:
 
 ## Migration process
 
-The migration is split into 3 phases. The **setup** phase, where the merchant creates a new migration, checks that everything is OK, and creates the catalog on the Polar side (precheck and catalog import run as background jobs — see *Background jobs: precheck & catalog import*). The **migration** phase, where we copy the PAN information from the current billing provider to Polar's account, and Polar moves each subscription one by one. The **cleanup** phase: once enough subscriptions are moved, the merchant stops billing on the old provider and removes the old integration (code, keys).
+The migration is split into 3 phases. The **setup** phase, where the merchant creates a new migration, checks that everything is OK, and creates the catalog on the Polar side (precheck and catalog import are background jobs — see below). The **migration** phase, where we copy the PAN information from the current billing provider to Polar's account, and Polar moves each subscription one by one. The **cleanup** phase: once enough subscriptions are moved, the merchant stops billing on the old provider and removes the old integration (code, keys).
 
 ```mermaid
 flowchart TB
   subgraph S["Setup phase"]
     A["Source setup<br/>Connect Stripe via restricted key; LS/Paddle via API key"]
-    B["Pre-check<br/>Background: extract + stage + classify"]
-    C["Create catalog & subscriptions<br/>Background: sequential product → customer → subscription batches (paused)"]
+    B["Pre-check<br/>Background job"]
+    C["Create catalog & subscriptions<br/>Background job; subscriptions paused"]
     A --> B --> C
   end
   subgraph M["Migration phase"]
@@ -80,7 +80,7 @@ Imported subscriptions are created `paused` (we considered a separate `migration
 
 Only step 4 is irreversible, and every check is read-only, so a subscription that fails one is left billing on the source and paused on Polar, with a reason on its ledger row. A trial carries over as `trialing` until its end date.
 
-**Retries.** One subscription per job, each in its own transaction (same one-task-one-transaction rule as import batches; see *Background jobs* and [ADR-0003](/engineering/decisions/0003-request-scoped-unit-of-work)). The cancellation is stamped with a marker (Stripe: `cancellation_details.comment`) so a run that dies between cancelling on the source and committing finishes the move on retry instead of reading its own cancellation as the customer having churned. `MerchantMigrationRecord.cutover_status` (`moved`/`skipped`/`failed`, null = not reached) is the ledger; retrying re-opens everything that isn't `moved`. When cutover workers are wired, reuse the import operation's `can_retry()` final-attempt write and stall-on-GET check for orchestration-level failure.
+**Retries.** One subscription per job, each in its own transaction ([ADR-0003](/engineering/decisions/0003-request-scoped-unit-of-work)). The cancellation is stamped with a marker (Stripe: `cancellation_details.comment`) so a run that dies between cancelling on the source and committing finishes the move on retry instead of reading its own cancellation as the customer having churned. `MerchantMigrationRecord.cutover_status` (`moved`/`skipped`/`failed`, null = not reached) is the ledger; retrying re-opens everything that isn't `moved`.
 
 Polar will bill the next billing cycle. If for some reason the payment fails on the next billing cycle, the subscription will enter the normal dunning state where we send an email to the customer.
 
@@ -192,8 +192,8 @@ No separate Job table. `MerchantMigration` holds a single JSONB **operation** (n
 | Precheck in flight | `pre_check` | `{status: running, cursor: …}` |
 | Precheck finished — review records | `pre_check` | `{status: done}` |
 | Precheck failed | `pre_check` | `{status: failed, error: …, cursor: …}` |
-| Import just enqueued | `create_catalog` | `{status: pending, …}` |
-| Import in flight | `create_catalog` | `{status: running, cursor: …}` |
+| Import just enqueued | `create_catalog` | `{status: pending, selection: {exclude_record_ids: […]}, …}` |
+| Import in flight | `create_catalog` | `{status: running, cursor: …, selection: …}` |
 | Import finished | `create_catalog` | `{status: done}` |
 | Partial re-import | `create_catalog` | `{status: pending\|running}` again, then `done` |
 
@@ -341,27 +341,26 @@ The merchant walks the checklist as a guided, one-step-at-a-time wizard and can 
 
 ## Appendix C: An implementation example
 
-This shows how the classes communicate. Extraction and import are **batched in background workers** in production (see *Background jobs: precheck & catalog import*); the snippet below is the logical flow, not the HTTP request body.
+This shows how the classes communicate. Precheck/import run as background batches in production (see *Background jobs*); the snippet is the logical flow.
 
 ```python
-# 1. read + normalize from the source (incremental; each extract_batch pages + stages)
+# 1. read + normalize from the source
 #    Stripe: mint a short-lived access token from the stored OAuth refresh token
 token = await stripe_oauth.refresh(job.source_refresh_token)  # rotates; persist token.refresh_token
 records = [r async for r in StripeAdapter(api_key=token.access_token).extract()]
 # records = [CanonicalProduct(...), CanonicalCustomer(...), CanonicalSubscription(...)]
 
-# 2. precheck against the staged ledger, then classify (precheck.classify task)
+# 2. precheck (no writes), then stage each record in the ledger
 report = precheck.run(records, org)        # PrecheckReport(can_start=True, blockers=0, ...)
 for r in records:
     repo.upsert(MigrationRecord(job_id=job.id, source_id=r.source_id, canonical=r))
 
-# 3. import through the existing services in sequential type batches
-#    (products → customers → subscriptions; cursor on the migration operation)
+# 3. import through the existing services (subscriptions created paused)
 await product_service.import_from_canonical(canonical_product)
 await subscription_service.import_from_canonical(canonical_subscription)
 ```
 
-Card move (PAN copy) and the subscription migration are described under *Moving cards* and *Switching subscriptions*. Cutover workers follow the same one-entity-per-job and ledger patterns as the import batches.
+Card move (PAN copy) and the subscription migration are described under *Moving cards* and *Switching subscriptions*.
 
 ## Appendix D: Stripe → Polar
 

--- a/handbook/engineering/design-documents/merchant-migrations.mdx
+++ b/handbook/engineering/design-documents/merchant-migrations.mdx
@@ -166,26 +166,35 @@ Cutover stays as specified under *Switching subscriptions* (one subscription per
 
 ### Operation status JSON
 
-No separate Job table. `MerchantMigration` holds a single JSONB **operation** (null when idle). `MerchantMigrationRecord` remains the per-entity ledger and source of progress counts.
+No separate Job table. `MerchantMigration` holds a single JSONB **operation** (null only before any background work has started — typically while still on `source_setup`). `MerchantMigrationRecord` remains the per-entity ledger and source of progress counts.
 
 | Field | Purpose |
 | --- | --- |
-| `status` | `running` \| `failed` |
+| `status` | `pending` \| `running` \| `done` \| `failed` |
 | `error` | Set when `failed` |
-| `cursor` | Opaque resume point for the current chain (Stripe page cursor, or last processed record id / type phase). Persisted on the migration so a reenqueue only needs `migration_id`. |
+| `cursor` | Opaque resume point for the current chain (Stripe page cursor, or last processed record id / type phase). Persisted on the migration so a reenqueue only needs `migration_id`. Cleared or ignored once `done`. |
 | `last_progress_at` | Bumped each successful batch; used to detect stalled ops |
 
-**`step` names the phase; `operation` says whether that phase is still working.** Starting an operation advances `step` to that phase immediately — they stay aligned. There is no separate `kind` on the operation (it would always duplicate `step`). Clearing `operation` means the phase finished (or never started background work); `step` stays put until the merchant moves on.
+**`step` names the phase; `operation.status` says where we are in that phase.** Starting an operation advances `step` to that phase immediately — they stay aligned. There is no separate `kind` on the operation (it would always duplicate `step`). Do **not** clear `operation` on success — set `status=done` so idle vs finished is explicit.
+
+| `operation.status` | Meaning |
+| --- | --- |
+| `pending` | Enqueued; worker has not started (or not yet claimed) the first batch |
+| `running` | A batch is in progress / chain is active |
+| `done` | This step’s background work finished successfully |
+| `failed` | Task exhausted retries or stall detected; merchant can retry |
 
 | Moment | `step` | `operation` |
 | --- | --- | --- |
 | Connected, not started | `source_setup` | `null` |
+| Precheck just enqueued | `pre_check` | `{status: pending, cursor: null}` |
 | Precheck in flight | `pre_check` | `{status: running, cursor: …}` |
-| Precheck done — review records | `pre_check` | `null` |
+| Precheck finished — review records | `pre_check` | `{status: done}` |
 | Precheck failed | `pre_check` | `{status: failed, error: …, cursor: …}` |
+| Import just enqueued | `create_catalog` | `{status: pending, …}` |
 | Import in flight | `create_catalog` | `{status: running, cursor: …}` |
-| Import done | `create_catalog` | `null` |
-| Partial re-import | `create_catalog` | `{status: running, …}` again |
+| Import finished | `create_catalog` | `{status: done}` |
+| Partial re-import | `create_catalog` | `{status: pending\|running}` again, then `done` |
 
 Import selection (`record_ids` / `exclude_record_ids`) is applied when the import starts (mark or filter pending rows once). Workers then only process `pending` selected rows — no need to keep the full selection list on the operation.
 
@@ -195,18 +204,18 @@ One Dramatiq task = one DB transaction. Prefer one self-reenqueuing actor per ch
 
 ```mermaid
 flowchart TB
-  StartPrecheck["POST /precheck → 202\nstep=pre_check, operation=running"] --> Precheck["precheck batch\nextract + stage; cursor on operation"]
+  StartPrecheck["POST /precheck → 202\nstep=pre_check, operation=pending"] --> Precheck["precheck batch\nstatus=running; cursor on operation"]
   Precheck -->|"more pages"| Precheck
-  Precheck -->|"done"| Classify["classify\nclear operation"]
+  Precheck -->|"done"| Classify["classify\noperation.status=done"]
 
-  StartImport["POST /import → 202\nstep=create_catalog, operation=running"] --> Import["import batch\nproducts → customers → subscriptions\ncursor encodes type + position"]
+  StartImport["POST /import → 202\nstep=create_catalog, operation=pending"] --> Import["import batch\nproducts → customers → subscriptions\ncursor encodes type + position"]
   Import -->|"more"| Import
-  Import -->|"done"| Finalize["clear operation\nstep stays create_catalog"]
+  Import -->|"done"| Finalize["operation.status=done\nstep stays create_catalog"]
 ```
 
-**Precheck** — start endpoint locks the migration (`FOR UPDATE`), sets `step=pre_check` and `operation` (`status=running`, empty cursor), enqueues the first batch. Each batch pages `adapter.extract()`, upserts ledger rows, writes the next `cursor` + `last_progress_at`, reenqueues. When extract is exhausted, classify with `PrecheckEngine`, clear `operation` (step stays `pre_check` for review).
+**Precheck** — start endpoint locks the migration (`FOR UPDATE`), sets `step=pre_check` and `operation` (`status=pending`, empty cursor), enqueues the first batch. The first worker flips `status=running`, pages `adapter.extract()`, upserts ledger rows, writes the next `cursor` + `last_progress_at`, reenqueues. When extract is exhausted, classify with `PrecheckEngine`, set `operation.status=done` (step stays `pre_check` for review).
 
-**Import** — same blockers as today; apply selection; set `step=create_catalog` and `operation` (`status=running`); enqueue. Each batch imports up to N pending selected records for the current type (products, then customers, then subscriptions — cursor carries which type and where). When nothing remains, clear `operation` (step stays `create_catalog`). A later partial re-import sets `operation` again without changing `step`.
+**Import** — same blockers as today; apply selection; set `step=create_catalog` and `operation` (`status=pending`); enqueue. Batches flip to `running` and import up to N pending selected records for the current type (products, then customers, then subscriptions — cursor carries which type and where). When nothing remains, set `operation.status=done` (step stays `create_catalog`). A later partial re-import sets `operation` back to `pending`/`running`, then `done` again, without changing `step`.
 
 Actors live in `polar/merchant_migration/tasks.py`. Batch size ~25–50; tune later.
 
@@ -216,7 +225,7 @@ Actors live in `polar/merchant_migration/tasks.py`. Batch size ~25–50; tune la
 | --- | --- |
 | **Record** | Mark ledger row `failed` + `error`; the batch continues. Does not fail the operation. |
 | **Task** | On catchable errors: if `can_retry()`, re-raise; if not, set `operation.status=failed` + `error` in the same session, then re-raise/return. |
-| **Stall** | On `GET` of the migration (while the client polls): if `operation` is `running` and `last_progress_at` is older than a stall threshold (15–30 min), mark `failed`. Stale tasks that wake later no-op when they see `failed` or a cleared operation. |
+| **Stall** | On `GET` of the migration (while the client polls): if `operation.status` is `pending` or `running` and `last_progress_at` is older than a stall threshold (15–30 min; for `pending`, also use `started_at` / enqueue time if we store one), mark `failed`. Stale tasks that wake later no-op when they see `failed` or `done`. |
 
 Unrecoverable start errors (blockers, wrong step, concurrent op) fail immediately with **409** / the existing status-coded errors — no enqueue.
 
@@ -224,7 +233,7 @@ Unrecoverable start errors (blockers, wrong step, concurrent op) fail immediatel
 
 | Endpoint | Behavior |
 | --- | --- |
-| `POST /{id}/precheck` | Enqueue; **202** + migration (with `operation`). **409** if an operation is already running. |
+| `POST /{id}/precheck` | Enqueue; **202** + migration (with `operation`). **409** if `operation.status` is already `pending` or `running`. |
 | `POST /{id}/import` | Same; body still takes selection. |
 | `GET /{id}` | Includes `operation`; may apply the stall check above. |
 | `/records` + `/records/summary` | Unchanged; clients poll these for counts. |
@@ -233,7 +242,7 @@ Drop the sync import report as the mutation response body. Progress is the ledge
 
 ### UI (high level)
 
-The dashboard should reflect that precheck/import are background work: the merchant can leave and come back. Poll the migration (and record summary) while `operation` is running; within the current `step`, show in-progress vs idle vs failed + retry. Detailed UI is out of scope for this design.
+The dashboard should reflect that precheck/import are background work: the merchant can leave and come back. Poll the migration (and record summary) while `operation.status` is `pending` or `running`; within the current `step`, branch on `pending`/`running`/`done`/`failed` (+ retry). Detailed UI is out of scope for this design.
 
 ### Implementation follow-up
 

--- a/handbook/engineering/design-documents/merchant-migrations.mdx
+++ b/handbook/engineering/design-documents/merchant-migrations.mdx
@@ -3,7 +3,7 @@
 
 **Created**: 2026-06-15
 
-**Last Updated**: 2026-07-01
+**Last Updated**: 2026-08-12
 </Info>
 
 # Merchant Migrations to Polar
@@ -33,14 +33,14 @@ A migration is divided into two things:
 
 ## Migration process
 
-The migration is split into 3 phases. The **setup** phase, where the merchant creates a new migration, checks that everything is OK, and creates the catalog on the Polar side. The **migration** phase, where we copy the PAN information from the current billing provider to Polar's account, and Polar moves each subscription one by one. The **cleanup** phase: once enough subscriptions are moved, the merchant stops billing on the old provider and removes the old integration (code, keys).
+The migration is split into 3 phases. The **setup** phase, where the merchant creates a new migration, checks that everything is OK, and creates the catalog on the Polar side (precheck and catalog import run as background jobs — see *Background jobs: precheck & catalog import*). The **migration** phase, where we copy the PAN information from the current billing provider to Polar's account, and Polar moves each subscription one by one. The **cleanup** phase: once enough subscriptions are moved, the merchant stops billing on the old provider and removes the old integration (code, keys).
 
 ```mermaid
 flowchart TB
   subgraph S["Setup phase"]
-    A["Source setup<br/>Connect Stripe via the Polar Stripe App (OAuth); LS/Paddle via API key"]
-    B["Pre-check<br/>Check products, prices, discounts can be imported into Polar"]
-    C["Create catalog & subscriptions<br/>Products, discounts, customers, and subscriptions in a paused state"]
+    A["Source setup<br/>Connect Stripe via restricted key; LS/Paddle via API key"]
+    B["Pre-check<br/>Background: extract + stage + classify"]
+    C["Create catalog & subscriptions<br/>Background: batched products ∥ customers, then subscriptions (paused)"]
     A --> B --> C
   end
   subgraph M["Migration phase"]
@@ -158,6 +158,139 @@ The idea is to create a new `migration` module (I'm up for new name suggestions)
 - **`MigrationService`** the main orchestrator.
 - **`CanonicalRecord`** to have everything normalized in memory first (variants: `CanonicalProduct` / `Customer` / `Subscription`). The precheck engine reads these and returns a `PrecheckReport` (Appendix A); Appendix C shows the flow end to end.
 
+## Background jobs: precheck & catalog import
+
+Precheck and catalog import must not run inside the HTTP request. Large Stripe catalogs time out at the gateway and violate [ADR-0003](/engineering/decisions/0003-request-scoped-unit-of-work) if a single task tries to import everything in one transaction. Both pipelines run as Dramatiq background jobs, batched and re-enqueued the same way as `meter.backfill_events` (cursor + self-reenqueue under the default ~60s worker time limit).
+
+Cutover stays as specified under *Switching subscriptions*: one subscription per job, each in its own transaction, with `MerchantMigrationRecord.cutover_status` as the ledger. The operation state and failure/watchdog patterns below are what cutover orchestration should reuse when those workers are wired.
+
+### Operation state (no parallel Job table)
+
+`MerchantMigration` carries a single active **operation** (JSONB or typed columns). We do not invent a separate job table: the migration row is the job, and `MerchantMigrationRecord` remains the per-entity ledger.
+
+| Field | Purpose |
+| --- | --- |
+| `kind` | `precheck` \| `import` \| null when idle |
+| `status` | `queued` \| `running` \| `succeeded` \| `failed` |
+| `phase` | Import only: `products` \| `customers` \| `subscriptions` \| `finalize`. Null for precheck. |
+| `error` | Last fatal message when `failed` |
+| `started_at` / `finished_at` | Operation lifetime |
+| `last_progress_at` | Bumped when a batch stages/imports work or advances phase; used by the stall watchdog |
+| `selection` | Snapshot of `record_ids` / `exclude_record_ids` for an import run |
+| `cursor` | Opaque cursor for the current batching task (Stripe page / record id) |
+| `staged_count` | Optional; exposed during precheck extract so the UI can show “Reading from Stripe…” |
+
+`step` stays the merchant-facing phase (`source_setup` → `pre_check` → `create_catalog` → …) and **only advances when an operation succeeds**. While precheck runs, `step` remains `source_setup`; the UI keys off `operation`, not a new step enum value. Do not invent step values for “in progress”.
+
+Progress for the UI comes from existing record statuses and `/records/summary` — not a separate percent counter — except during Stripe extract, where `staged_count` on the operation is enough.
+
+### Task graph
+
+One Dramatiq task = one DB transaction ([ADR-0003](/engineering/decisions/0003-request-scoped-unit-of-work)). Prefer batched self-reenqueue over raising the actor time limit. Actors live in `polar/merchant_migration/tasks.py`.
+
+```mermaid
+flowchart TB
+  subgraph api [API]
+    StartPrecheck["POST /precheck → 202"]
+    StartImport["POST /import → 202"]
+  end
+
+  subgraph precheckPipe [Precheck pipeline]
+    PExtract["precheck.extract_batch\nStripe page + stage records"]
+    PClassify["precheck.classify\nPrecheckEngine; step=pre_check"]
+    PExtract -->|"more pages"| PExtract
+    PExtract -->|"done"| PClassify
+  end
+
+  subgraph importPipe [Import pipeline]
+    IStart["import.start\nvalidate blockers; set selection"]
+    IProd["import.products_batch"]
+    ICust["import.customers_batch"]
+    IWait["import.after_catalog\nbarrier when products+customers done"]
+    ISub["import.subscriptions_batch"]
+    IDone["import.finalize\nstep=create_catalog"]
+    IStart --> IProd
+    IStart --> ICust
+    IProd --> IWait
+    ICust --> IWait
+    IWait --> ISub
+    ISub -->|"more"| ISub
+    ISub -->|"done"| IDone
+  end
+
+  StartPrecheck --> PExtract
+  StartImport --> IStart
+```
+
+**Precheck**
+
+- `merchant_migration.precheck.start` — lock migration (`FOR UPDATE`), set operation, enqueue the first extract batch.
+- `merchant_migration.precheck.extract_batch` — page the source via incremental `adapter.extract()`, upsert ledger rows, bump `last_progress_at` / `staged_count`, reenqueue with cursor until exhausted.
+- `merchant_migration.precheck.classify` — run `PrecheckEngine` against the staged ledger, advance `step` → `pre_check`, mark operation `succeeded`.
+
+**Import** (products ∥ customers, then subscriptions)
+
+Products and customers are independent; subscriptions depend on both (see `CatalogImporter`).
+
+- `import.start` — same import blockers as today; snapshot selection onto the operation; mark `running`; enqueue product and customer batch roots in parallel.
+- `import.{products,customers,subscriptions}_batch` — process N pending selected records of that type (batch size ~25–50; tune later), update ledger statuses, bump `last_progress_at`, reenqueue until none left.
+- Barrier: when a products/customers batch finishes with no remaining work, enqueue `import.after_catalog`, which starts subscriptions only once **both** types have zero pending selected rows (check the DB, not in-memory counters — safe under retries).
+- `import.finalize` — set `step=create_catalog`, operation `succeeded`.
+
+Partial re-import after `create_catalog` (merchant selects remaining pending rows) starts a new import operation without regressing `step`.
+
+### Failure layers
+
+Do not conflate per-record failures with task/orchestration failures.
+
+| Layer | What happens | Aborts operation? |
+| --- | --- | --- |
+| **Record** | Mark that ledger row `failed` + `error`; the batch continues | No — finalize still runs; UI shows failed counts |
+| **Task / orchestration** | Exception in a worker (Stripe outage mid-batch, bug, killed worker) | Yes — operation → `failed` so the merchant can retry |
+
+**Discovering task-level failure** (not guessing from silence):
+
+1. **Final Dramatiq retry** — reuse `can_retry()` / `get_retries()` from `polar.worker`. On catchable failures: if `can_retry()`, re-raise so Dramatiq retries; if not, write `operation.status=failed` + `error` in the same task session, then re-raise (or return). That is the explicit “crashed repeatedly” signal — we only mark failed once retries are exhausted.
+2. **Stall watchdog** — covers the case Dramatiq never delivers a final failure (message lost, worker OOM without retry). Each successful batch bumps `operation.last_progress_at`. A low-priority `merchant_migration.watchdog` actor (or a check on `GET` of the migration) marks the operation `failed` if `status in (queued, running)` and `now - last_progress_at > stall_threshold` (15–30 minutes). Stale in-flight tasks that later wake up must no-op when they see `operation.status=failed`.
+
+Operation also fails immediately (no retries) for unrecoverable errors at start: blockers, wrong step, lost lock, concurrent operation.
+
+Idempotency: only touch `pending` selected rows. The ledger is durable progress, so retries are safe.
+
+### API contract
+
+| Endpoint | Behavior |
+| --- | --- |
+| `POST /{id}/precheck` | Enqueue; return **202** + migration (with `operation`). Reject **409** if another operation is active. |
+| `POST /{id}/import` | Same; body still takes selection (`record_ids` / `exclude_record_ids`). |
+| `GET /{id}` | Include `operation` (and derived progress fields such as `staged_count` when useful). |
+| Existing `/records` + `/records/summary` | Unchanged; the UI polls these during import. |
+
+The sync `MerchantMigrationImportReport` is no longer the import response body. The client builds the receipt from summary counts (as `ImportedHandoff` already does). Start endpoints take the migration `FOR UPDATE`; only one operation at a time. Workers re-check operation kind/status before writing; stale tasks no-op.
+
+### Frontend UX
+
+The migration detail page and stepper remain the status surface. While an operation is `queued` or `running`, replace the assessment/import CTA with a **dedicated progress panel** (same bordered `background-card` chrome as `ImportedHandoff`) — not a transient loading Alert.
+
+- Heading and body make background work obvious, e.g. “Importing your catalog” / “This runs in the background. You can leave and come back — we’ll keep going.”
+- Show phase + live counts inside the panel (products / customers / subscriptions imported vs remaining pending from summary; during precheck extract, `staged_count` + “Reading from Stripe…”).
+- Spinner or subtle motion on the panel header so it reads as active work, not a stuck empty state.
+- Poll `useMerchantMigration` and `useMerchantMigrationRecordSummary` with `refetchInterval` while the operation is in flight (same pattern as benefit-grant provisioning).
+
+On success: precheck → existing review / `PrecheckPanel`; import → existing `ImportedHandoff`. Optionally toast if the merchant left and returns after success. On failure: the same panel slot switches to danger copy + `operation.error` + **Retry** (re-POST; selection from the last operation snapshot or re-chosen). Leaving and returning resumes polling from `operation` on the migration.
+
+No SSE/WebSockets for this flow; polling matches the rest of the dashboard.
+
+### Implementation follow-up
+
+After this design is accepted, ship in roughly this order (separate PR from the doc):
+
+1. Model + schema for `operation`; Alembic migration.
+2. `tasks.py` + thin service methods to start ops; endpoints return 202.
+3. Refactor `CatalogImporter` / staging into batch APIs used by tasks.
+4. Frontend polling + dedicated progress panel; regenerate the API client.
+5. Tests: task batching, barrier, concurrent start 409, stall watchdog, UI polling states.
+
 ## Testing and rollout
 
 We can't test this on sandbox: PAN Copy and PAN Import only run on Stripe live, so we validate against live production. (love the YOLO mode with money)
@@ -240,26 +373,27 @@ The merchant walks the checklist as a guided, one-step-at-a-time wizard and can 
 
 ## Appendix C: An implementation example
 
-This shows how the classes communicate.
+This shows how the classes communicate. Extraction and import are **batched in background workers** in production (see *Background jobs: precheck & catalog import*); the snippet below is the logical flow, not the HTTP request body.
 
 ```python
-# 1. read + normalize from the source
+# 1. read + normalize from the source (incremental; each extract_batch pages + stages)
 #    Stripe: mint a short-lived access token from the stored OAuth refresh token
 token = await stripe_oauth.refresh(job.source_refresh_token)  # rotates; persist token.refresh_token
 records = [r async for r in StripeAdapter(api_key=token.access_token).extract()]
 # records = [CanonicalProduct(...), CanonicalCustomer(...), CanonicalSubscription(...)]
 
-# 2. precheck (no writes), then stage each record in the ledger
+# 2. precheck against the staged ledger, then classify (precheck.classify task)
 report = precheck.run(records, org)        # PrecheckReport(can_start=True, blockers=0, ...)
 for r in records:
     repo.upsert(MigrationRecord(job_id=job.id, source_id=r.source_id, canonical=r))
 
-# 3. import through the existing services (subscriptions created paused via the flag)
+# 3. import through the existing services in type-ordered batches
+#    (products ∥ customers, then subscriptions; each batch is its own Dramatiq task)
 await product_service.import_from_canonical(canonical_product)
 await subscription_service.import_from_canonical(canonical_subscription)
 ```
 
-Card move (PAN copy) and the subscription migration are described under *Moving cards* and *Switching subscriptions*.
+Card move (PAN copy) and the subscription migration are described under *Moving cards* and *Switching subscriptions*. Cutover workers follow the same one-entity-per-job and ledger patterns as the import batches.
 
 ## Appendix D: Stripe → Polar
 

--- a/handbook/engineering/design-documents/merchant-migrations.mdx
+++ b/handbook/engineering/design-documents/merchant-migrations.mdx
@@ -170,13 +170,22 @@ No separate Job table. `MerchantMigration` holds a single JSONB **operation** (n
 
 | Field | Purpose |
 | --- | --- |
-| `kind` | `precheck` \| `import` |
 | `status` | `running` \| `failed` |
 | `error` | Set when `failed` |
 | `cursor` | Opaque resume point for the current chain (Stripe page cursor, or last processed record id / type phase). Persisted on the migration so a reenqueue only needs `migration_id`. |
 | `last_progress_at` | Bumped each successful batch; used to detect stalled ops |
 
-`step` stays the merchant-facing phase and **only advances when an operation succeeds**. While precheck runs, `step` remains `source_setup`; in-flight work is read from `operation`, not from new step enum values.
+**`step` names the phase; `operation` says whether that phase is still working.** Starting an operation advances `step` to that phase immediately — they stay aligned. There is no separate `kind` on the operation (it would always duplicate `step`). Clearing `operation` means the phase finished (or never started background work); `step` stays put until the merchant moves on.
+
+| Moment | `step` | `operation` |
+| --- | --- | --- |
+| Connected, not started | `source_setup` | `null` |
+| Precheck in flight | `pre_check` | `{status: running, cursor: …}` |
+| Precheck done — review records | `pre_check` | `null` |
+| Precheck failed | `pre_check` | `{status: failed, error: …, cursor: …}` |
+| Import in flight | `create_catalog` | `{status: running, cursor: …}` |
+| Import done | `create_catalog` | `null` |
+| Partial re-import | `create_catalog` | `{status: running, …}` again |
 
 Import selection (`record_ids` / `exclude_record_ids`) is applied when the import starts (mark or filter pending rows once). Workers then only process `pending` selected rows — no need to keep the full selection list on the operation.
 
@@ -186,18 +195,18 @@ One Dramatiq task = one DB transaction. Prefer one self-reenqueuing actor per ch
 
 ```mermaid
 flowchart TB
-  StartPrecheck["POST /precheck → 202"] --> Precheck["precheck batch\nextract + stage; cursor on operation"]
+  StartPrecheck["POST /precheck → 202\nstep=pre_check, operation=running"] --> Precheck["precheck batch\nextract + stage; cursor on operation"]
   Precheck -->|"more pages"| Precheck
-  Precheck -->|"done"| Classify["classify → step=pre_check\nclear operation"]
+  Precheck -->|"done"| Classify["classify\nclear operation"]
 
-  StartImport["POST /import → 202"] --> Import["import batch\nproducts → customers → subscriptions\ncursor encodes type + position"]
+  StartImport["POST /import → 202\nstep=create_catalog, operation=running"] --> Import["import batch\nproducts → customers → subscriptions\ncursor encodes type + position"]
   Import -->|"more"| Import
-  Import -->|"done"| Finalize["step=create_catalog\nclear operation"]
+  Import -->|"done"| Finalize["clear operation\nstep stays create_catalog"]
 ```
 
-**Precheck** — start endpoint locks the migration (`FOR UPDATE`), sets `operation` (`kind=precheck`, `status=running`, empty cursor), enqueues the first batch. Each batch pages `adapter.extract()`, upserts ledger rows, writes the next `cursor` + `last_progress_at`, reenqueues. When extract is exhausted, classify with `PrecheckEngine`, set `step=pre_check`, clear `operation`.
+**Precheck** — start endpoint locks the migration (`FOR UPDATE`), sets `step=pre_check` and `operation` (`status=running`, empty cursor), enqueues the first batch. Each batch pages `adapter.extract()`, upserts ledger rows, writes the next `cursor` + `last_progress_at`, reenqueues. When extract is exhausted, classify with `PrecheckEngine`, clear `operation` (step stays `pre_check` for review).
 
-**Import** — same blockers as today; apply selection; set `operation` (`kind=import`); enqueue. Each batch imports up to N pending selected records for the current type (products, then customers, then subscriptions — cursor carries which type and where). When nothing remains, set `step=create_catalog` (or leave it if already there on a partial re-import), clear `operation`.
+**Import** — same blockers as today; apply selection; set `step=create_catalog` and `operation` (`status=running`); enqueue. Each batch imports up to N pending selected records for the current type (products, then customers, then subscriptions — cursor carries which type and where). When nothing remains, clear `operation` (step stays `create_catalog`). A later partial re-import sets `operation` again without changing `step`.
 
 Actors live in `polar/merchant_migration/tasks.py`. Batch size ~25–50; tune later.
 
@@ -224,7 +233,7 @@ Drop the sync import report as the mutation response body. Progress is the ledge
 
 ### UI (high level)
 
-The dashboard should reflect that precheck/import are background work: the merchant can leave and come back. Poll the migration (and record summary) while `operation` is running; show a clear in-progress state and a retry path when `failed`. Detailed UI is out of scope for this design.
+The dashboard should reflect that precheck/import are background work: the merchant can leave and come back. Poll the migration (and record summary) while `operation` is running; within the current `step`, show in-progress vs idle vs failed + retry. Detailed UI is out of scope for this design.
 
 ### Implementation follow-up
 

--- a/handbook/engineering/design-documents/merchant-migrations.mdx
+++ b/handbook/engineering/design-documents/merchant-migrations.mdx
@@ -40,7 +40,7 @@ flowchart TB
   subgraph S["Setup phase"]
     A["Source setup<br/>Connect Stripe via restricted key; LS/Paddle via API key"]
     B["Pre-check<br/>Background: extract + stage + classify"]
-    C["Create catalog & subscriptions<br/>Background: batched products ∥ customers, then subscriptions (paused)"]
+    C["Create catalog & subscriptions<br/>Background: sequential product → customer → subscription batches (paused)"]
     A --> B --> C
   end
   subgraph M["Migration phase"]
@@ -80,7 +80,7 @@ Imported subscriptions are created `paused` (we considered a separate `migration
 
 Only step 4 is irreversible, and every check is read-only, so a subscription that fails one is left billing on the source and paused on Polar, with a reason on its ledger row. A trial carries over as `trialing` until its end date.
 
-**Retries.** One subscription per job, each in its own transaction. The cancellation is stamped with a marker (Stripe: `cancellation_details.comment`) so a run that dies between cancelling on the source and committing finishes the move on retry instead of reading its own cancellation as the customer having churned. `MerchantMigrationRecord.cutover_status` (`moved`/`skipped`/`failed`, null = not reached) is the ledger; retrying re-opens everything that isn't `moved`.
+**Retries.** One subscription per job, each in its own transaction (same one-task-one-transaction rule as import batches; see *Background jobs* and [ADR-0003](/engineering/decisions/0003-request-scoped-unit-of-work)). The cancellation is stamped with a marker (Stripe: `cancellation_details.comment`) so a run that dies between cancelling on the source and committing finishes the move on retry instead of reading its own cancellation as the customer having churned. `MerchantMigrationRecord.cutover_status` (`moved`/`skipped`/`failed`, null = not reached) is the ledger; retrying re-opens everything that isn't `moved`. When cutover workers are wired, reuse the import operation's `can_retry()` final-attempt write and stall-on-GET check for orchestration-level failure.
 
 Polar will bill the next billing cycle. If for some reason the payment fails on the next billing cycle, the subscription will enter the normal dunning state where we send an email to the customer.
 
@@ -160,136 +160,81 @@ The idea is to create a new `migration` module (I'm up for new name suggestions)
 
 ## Background jobs: precheck & catalog import
 
-Precheck and catalog import must not run inside the HTTP request. Large Stripe catalogs time out at the gateway and violate [ADR-0003](/engineering/decisions/0003-request-scoped-unit-of-work) if a single task tries to import everything in one transaction. Both pipelines run as Dramatiq background jobs, batched and re-enqueued the same way as `meter.backfill_events` (cursor + self-reenqueue under the default ~60s worker time limit).
+Precheck and catalog import must not run inside the HTTP request. Large Stripe catalogs time out at the gateway and violate [ADR-0003](/engineering/decisions/0003-request-scoped-unit-of-work) if a single task tries to import everything in one transaction. Both pipelines run as Dramatiq background jobs: batched self-reenqueue under the default ~60s worker time limit, same pattern as `meter.backfill_events`.
 
-Cutover stays as specified under *Switching subscriptions*: one subscription per job, each in its own transaction, with `MerchantMigrationRecord.cutover_status` as the ledger. The operation state and failure/watchdog patterns below are what cutover orchestration should reuse when those workers are wired.
+Cutover stays as specified under *Switching subscriptions* (one subscription per job). Reuse the thin operation status and `can_retry()` failure handling below when those workers are wired.
 
-### Operation state (no parallel Job table)
+### Operation status JSON
 
-`MerchantMigration` carries a single active **operation** (JSONB or typed columns). We do not invent a separate job table: the migration row is the job, and `MerchantMigrationRecord` remains the per-entity ledger.
+No separate Job table. `MerchantMigration` holds a single JSONB **operation** (null when idle). `MerchantMigrationRecord` remains the per-entity ledger and source of progress counts.
 
 | Field | Purpose |
 | --- | --- |
-| `kind` | `precheck` \| `import` \| null when idle |
-| `status` | `queued` \| `running` \| `succeeded` \| `failed` |
-| `phase` | Import only: `products` \| `customers` \| `subscriptions` \| `finalize`. Null for precheck. |
-| `error` | Last fatal message when `failed` |
-| `started_at` / `finished_at` | Operation lifetime |
-| `last_progress_at` | Bumped when a batch stages/imports work or advances phase; used by the stall watchdog |
-| `selection` | Snapshot of `record_ids` / `exclude_record_ids` for an import run |
-| `cursor` | Opaque cursor for the current batching task (Stripe page / record id) |
-| `staged_count` | Optional; exposed during precheck extract so the UI can show “Reading from Stripe…” |
+| `kind` | `precheck` \| `import` |
+| `status` | `running` \| `failed` |
+| `error` | Set when `failed` |
+| `cursor` | Opaque resume point for the current chain (Stripe page cursor, or last processed record id / type phase). Persisted on the migration so a reenqueue only needs `migration_id`. |
+| `last_progress_at` | Bumped each successful batch; used to detect stalled ops |
 
-`step` stays the merchant-facing phase (`source_setup` → `pre_check` → `create_catalog` → …) and **only advances when an operation succeeds**. While precheck runs, `step` remains `source_setup`; the UI keys off `operation`, not a new step enum value. Do not invent step values for “in progress”.
+`step` stays the merchant-facing phase and **only advances when an operation succeeds**. While precheck runs, `step` remains `source_setup`; in-flight work is read from `operation`, not from new step enum values.
 
-Progress for the UI comes from existing record statuses and `/records/summary` — not a separate percent counter — except during Stripe extract, where `staged_count` on the operation is enough.
+Import selection (`record_ids` / `exclude_record_ids`) is applied when the import starts (mark or filter pending rows once). Workers then only process `pending` selected rows — no need to keep the full selection list on the operation.
 
-### Task graph
+### Two linear job chains
 
-One Dramatiq task = one DB transaction ([ADR-0003](/engineering/decisions/0003-request-scoped-unit-of-work)). Prefer batched self-reenqueue over raising the actor time limit. Actors live in `polar/merchant_migration/tasks.py`.
+One Dramatiq task = one DB transaction. Prefer one self-reenqueuing actor per chain over a fan-out of named phase actors. Products then customers then subscriptions is sequential on purpose: products are few, and a barrier between parallel waves is more complexity than the wall-clock win.
 
 ```mermaid
 flowchart TB
-  subgraph api [API]
-    StartPrecheck["POST /precheck → 202"]
-    StartImport["POST /import → 202"]
-  end
+  StartPrecheck["POST /precheck → 202"] --> Precheck["precheck batch\nextract + stage; cursor on operation"]
+  Precheck -->|"more pages"| Precheck
+  Precheck -->|"done"| Classify["classify → step=pre_check\nclear operation"]
 
-  subgraph precheckPipe [Precheck pipeline]
-    PExtract["precheck.extract_batch\nStripe page + stage records"]
-    PClassify["precheck.classify\nPrecheckEngine; step=pre_check"]
-    PExtract -->|"more pages"| PExtract
-    PExtract -->|"done"| PClassify
-  end
-
-  subgraph importPipe [Import pipeline]
-    IStart["import.start\nvalidate blockers; set selection"]
-    IProd["import.products_batch"]
-    ICust["import.customers_batch"]
-    IWait["import.after_catalog\nbarrier when products+customers done"]
-    ISub["import.subscriptions_batch"]
-    IDone["import.finalize\nstep=create_catalog"]
-    IStart --> IProd
-    IStart --> ICust
-    IProd --> IWait
-    ICust --> IWait
-    IWait --> ISub
-    ISub -->|"more"| ISub
-    ISub -->|"done"| IDone
-  end
-
-  StartPrecheck --> PExtract
-  StartImport --> IStart
+  StartImport["POST /import → 202"] --> Import["import batch\nproducts → customers → subscriptions\ncursor encodes type + position"]
+  Import -->|"more"| Import
+  Import -->|"done"| Finalize["step=create_catalog\nclear operation"]
 ```
 
-**Precheck**
+**Precheck** — start endpoint locks the migration (`FOR UPDATE`), sets `operation` (`kind=precheck`, `status=running`, empty cursor), enqueues the first batch. Each batch pages `adapter.extract()`, upserts ledger rows, writes the next `cursor` + `last_progress_at`, reenqueues. When extract is exhausted, classify with `PrecheckEngine`, set `step=pre_check`, clear `operation`.
 
-- `merchant_migration.precheck.start` — lock migration (`FOR UPDATE`), set operation, enqueue the first extract batch.
-- `merchant_migration.precheck.extract_batch` — page the source via incremental `adapter.extract()`, upsert ledger rows, bump `last_progress_at` / `staged_count`, reenqueue with cursor until exhausted.
-- `merchant_migration.precheck.classify` — run `PrecheckEngine` against the staged ledger, advance `step` → `pre_check`, mark operation `succeeded`.
+**Import** — same blockers as today; apply selection; set `operation` (`kind=import`); enqueue. Each batch imports up to N pending selected records for the current type (products, then customers, then subscriptions — cursor carries which type and where). When nothing remains, set `step=create_catalog` (or leave it if already there on a partial re-import), clear `operation`.
 
-**Import** (products ∥ customers, then subscriptions)
+Actors live in `polar/merchant_migration/tasks.py`. Batch size ~25–50; tune later.
 
-Products and customers are independent; subscriptions depend on both (see `CatalogImporter`).
+### Failures
 
-- `import.start` — same import blockers as today; snapshot selection onto the operation; mark `running`; enqueue product and customer batch roots in parallel.
-- `import.{products,customers,subscriptions}_batch` — process N pending selected records of that type (batch size ~25–50; tune later), update ledger statuses, bump `last_progress_at`, reenqueue until none left.
-- Barrier: when a products/customers batch finishes with no remaining work, enqueue `import.after_catalog`, which starts subscriptions only once **both** types have zero pending selected rows (check the DB, not in-memory counters — safe under retries).
-- `import.finalize` — set `step=create_catalog`, operation `succeeded`.
+| Layer | Behavior |
+| --- | --- |
+| **Record** | Mark ledger row `failed` + `error`; the batch continues. Does not fail the operation. |
+| **Task** | On catchable errors: if `can_retry()`, re-raise; if not, set `operation.status=failed` + `error` in the same session, then re-raise/return. |
+| **Stall** | On `GET` of the migration (while the client polls): if `operation` is `running` and `last_progress_at` is older than a stall threshold (15–30 min), mark `failed`. Stale tasks that wake later no-op when they see `failed` or a cleared operation. |
 
-Partial re-import after `create_catalog` (merchant selects remaining pending rows) starts a new import operation without regressing `step`.
+Unrecoverable start errors (blockers, wrong step, concurrent op) fail immediately with **409** / the existing status-coded errors — no enqueue.
 
-### Failure layers
-
-Do not conflate per-record failures with task/orchestration failures.
-
-| Layer | What happens | Aborts operation? |
-| --- | --- | --- |
-| **Record** | Mark that ledger row `failed` + `error`; the batch continues | No — finalize still runs; UI shows failed counts |
-| **Task / orchestration** | Exception in a worker (Stripe outage mid-batch, bug, killed worker) | Yes — operation → `failed` so the merchant can retry |
-
-**Discovering task-level failure** (not guessing from silence):
-
-1. **Final Dramatiq retry** — reuse `can_retry()` / `get_retries()` from `polar.worker`. On catchable failures: if `can_retry()`, re-raise so Dramatiq retries; if not, write `operation.status=failed` + `error` in the same task session, then re-raise (or return). That is the explicit “crashed repeatedly” signal — we only mark failed once retries are exhausted.
-2. **Stall watchdog** — covers the case Dramatiq never delivers a final failure (message lost, worker OOM without retry). Each successful batch bumps `operation.last_progress_at`. A low-priority `merchant_migration.watchdog` actor (or a check on `GET` of the migration) marks the operation `failed` if `status in (queued, running)` and `now - last_progress_at > stall_threshold` (15–30 minutes). Stale in-flight tasks that later wake up must no-op when they see `operation.status=failed`.
-
-Operation also fails immediately (no retries) for unrecoverable errors at start: blockers, wrong step, lost lock, concurrent operation.
-
-Idempotency: only touch `pending` selected rows. The ledger is durable progress, so retries are safe.
-
-### API contract
+### API
 
 | Endpoint | Behavior |
 | --- | --- |
-| `POST /{id}/precheck` | Enqueue; return **202** + migration (with `operation`). Reject **409** if another operation is active. |
-| `POST /{id}/import` | Same; body still takes selection (`record_ids` / `exclude_record_ids`). |
-| `GET /{id}` | Include `operation` (and derived progress fields such as `staged_count` when useful). |
-| Existing `/records` + `/records/summary` | Unchanged; the UI polls these during import. |
+| `POST /{id}/precheck` | Enqueue; **202** + migration (with `operation`). **409** if an operation is already running. |
+| `POST /{id}/import` | Same; body still takes selection. |
+| `GET /{id}` | Includes `operation`; may apply the stall check above. |
+| `/records` + `/records/summary` | Unchanged; clients poll these for counts. |
 
-The sync `MerchantMigrationImportReport` is no longer the import response body. The client builds the receipt from summary counts (as `ImportedHandoff` already does). Start endpoints take the migration `FOR UPDATE`; only one operation at a time. Workers re-check operation kind/status before writing; stale tasks no-op.
+Drop the sync import report as the mutation response body. Progress is the ledger + `operation`.
 
-### Frontend UX
+### UI (high level)
 
-The migration detail page and stepper remain the status surface. While an operation is `queued` or `running`, replace the assessment/import CTA with a **dedicated progress panel** (same bordered `background-card` chrome as `ImportedHandoff`) — not a transient loading Alert.
-
-- Heading and body make background work obvious, e.g. “Importing your catalog” / “This runs in the background. You can leave and come back — we’ll keep going.”
-- Show phase + live counts inside the panel (products / customers / subscriptions imported vs remaining pending from summary; during precheck extract, `staged_count` + “Reading from Stripe…”).
-- Spinner or subtle motion on the panel header so it reads as active work, not a stuck empty state.
-- Poll `useMerchantMigration` and `useMerchantMigrationRecordSummary` with `refetchInterval` while the operation is in flight (same pattern as benefit-grant provisioning).
-
-On success: precheck → existing review / `PrecheckPanel`; import → existing `ImportedHandoff`. Optionally toast if the merchant left and returns after success. On failure: the same panel slot switches to danger copy + `operation.error` + **Retry** (re-POST; selection from the last operation snapshot or re-chosen). Leaving and returning resumes polling from `operation` on the migration.
-
-No SSE/WebSockets for this flow; polling matches the rest of the dashboard.
+The dashboard should reflect that precheck/import are background work: the merchant can leave and come back. Poll the migration (and record summary) while `operation` is running; show a clear in-progress state and a retry path when `failed`. Detailed UI is out of scope for this design.
 
 ### Implementation follow-up
 
-After this design is accepted, ship in roughly this order (separate PR from the doc):
+After acceptance, separate PR(s):
 
-1. Model + schema for `operation`; Alembic migration.
-2. `tasks.py` + thin service methods to start ops; endpoints return 202.
-3. Refactor `CatalogImporter` / staging into batch APIs used by tasks.
-4. Frontend polling + dedicated progress panel; regenerate the API client.
-5. Tests: task batching, barrier, concurrent start 409, stall watchdog, UI polling states.
+1. `operation` JSONB on `MerchantMigration` + Alembic.
+2. `tasks.py` + start methods; endpoints return 202.
+3. Batch APIs for extract/import (refactor today’s sync paths).
+4. Thin dashboard wiring to poll and surface running/failed (not part of this design PR).
+5. Tests: batching, cursor resume, concurrent start 409, final-retry failure, stall-on-GET.
 
 ## Testing and rollout
 
@@ -387,8 +332,8 @@ report = precheck.run(records, org)        # PrecheckReport(can_start=True, bloc
 for r in records:
     repo.upsert(MigrationRecord(job_id=job.id, source_id=r.source_id, canonical=r))
 
-# 3. import through the existing services in type-ordered batches
-#    (products ∥ customers, then subscriptions; each batch is its own Dramatiq task)
+# 3. import through the existing services in sequential type batches
+#    (products → customers → subscriptions; cursor on the migration operation)
 await product_service.import_from_canonical(canonical_product)
 await subscription_service.import_from_canonical(canonical_subscription)
 ```

--- a/handbook/engineering/design-documents/merchant-migrations.mdx
+++ b/handbook/engineering/design-documents/merchant-migrations.mdx
@@ -160,104 +160,20 @@ The idea is to create a new `migration` module (I'm up for new name suggestions)
 
 ## Background jobs: precheck & catalog import
 
-Precheck and catalog import must not run inside the HTTP request. Large Stripe catalogs time out at the gateway and violate [ADR-0003](/engineering/decisions/0003-request-scoped-unit-of-work) if a single task tries to import everything in one transaction. Both pipelines run as Dramatiq background jobs: batched self-reenqueue under the default ~60s worker time limit, same pattern as `meter.backfill_events`.
+Precheck and catalog import run as **Dramatiq background jobs** (batched self-reenqueue; one task = one transaction, see [ADR-0003](/engineering/decisions/0003-request-scoped-unit-of-work)). Start endpoints return **202**; the client polls the migration.
 
-Cutover stays as specified under *Switching subscriptions* (one subscription per job). Reuse the thin operation status and `can_retry()` failure handling below when those workers are wired.
+`MerchantMigration` carries a JSONB **operation** (null until the first background run). Starting work advances `step` to that phase; `operation` tracks progress within it:
 
-### Operation status JSON
-
-No separate Job table. `MerchantMigration` holds a single JSONB **operation** (null only before any background work has started — typically while still on `source_setup`). `MerchantMigrationRecord` remains the per-entity ledger and source of progress counts.
-
-| Field | Purpose |
+| Field | Notes |
 | --- | --- |
-| `status` | `pending` \| `running` \| `done` \| `failed` |
-| `error` | Set when `failed` |
-| `cursor` | Opaque resume point for the current chain (Stripe page cursor, or last processed record id / type phase). Persisted on the migration so a reenqueue only needs `migration_id`. Cleared or ignored once `done`. |
-| `last_progress_at` | Bumped each successful batch; used to detect stalled ops |
-| `selection` | Import only: snapshot of `record_ids` **or** `exclude_record_ids` from the start request (whichever mode the client used). Small by design — see selection below. |
+| `status` | `pending` → `running` → `done`, or `failed` |
+| `cursor` | Resume point for the batch chain |
+| `selection` | Import only: compact `record_ids` or `exclude_record_ids` (filter queries; don’t mark every row) |
+| `error` / `last_progress_at` | Failure message; stall detection on read |
 
-**`step` names the phase; `operation.status` says where we are in that phase.** Starting an operation advances `step` to that phase immediately — they stay aligned. There is no separate `kind` on the operation (it would always duplicate `step`). Do **not** clear `operation` on success — set `status=done` so idle vs finished is explicit.
+**Precheck:** `step=pre_check`, extract→stage→classify until `done`. **Import:** `step=create_catalog`, products→customers→subscriptions until `done`. Record-level failures stay on the ledger; task-level failure sets `operation.status=failed` (final `can_retry()`, or stall on `GET`). Cutover stays one subscription per job (*Switching subscriptions*).
 
-| `operation.status` | Meaning |
-| --- | --- |
-| `pending` | Enqueued; worker has not started (or not yet claimed) the first batch |
-| `running` | A batch is in progress / chain is active |
-| `done` | This step’s background work finished successfully |
-| `failed` | Task exhausted retries or stall detected; merchant can retry |
-
-| Moment | `step` | `operation` |
-| --- | --- | --- |
-| Connected, not started | `source_setup` | `null` |
-| Precheck just enqueued | `pre_check` | `{status: pending, cursor: null}` |
-| Precheck in flight | `pre_check` | `{status: running, cursor: …}` |
-| Precheck finished — review records | `pre_check` | `{status: done}` |
-| Precheck failed | `pre_check` | `{status: failed, error: …, cursor: …}` |
-| Import just enqueued | `create_catalog` | `{status: pending, selection: {exclude_record_ids: […]}, …}` |
-| Import in flight | `create_catalog` | `{status: running, cursor: …, selection: …}` |
-| Import finished | `create_catalog` | `{status: done}` |
-| Partial re-import | `create_catalog` | `{status: pending\|running}` again, then `done` |
-
-Import selection stays compact on the operation (same shape as today’s API): either `record_ids` (opt-in) or `exclude_record_ids` (opt-out). Workers never expand that into a million row updates.
-
-Example: 1M customers, merchant unchecks one → request is `exclude_record_ids: [that_id]`. Stored on the operation as ~one UUID. Each import batch queries `pending` rows of the current type **except** those ids (or **only** `record_ids` in opt-in mode), ordered by id, limited to the batch size, after the cursor. The excluded row stays `pending` so a later partial import can still pick it up. Opt-in of a handful of rows is the same idea with a small include list.
-
-Do **not** “select” by writing a flag on every included row — that turns an exclude-1 catalog into a million writes at start.
-
-### Two linear job chains
-
-One Dramatiq task = one DB transaction. Prefer one self-reenqueuing actor per chain over a fan-out of named phase actors. Products then customers then subscriptions is sequential on purpose: products are few, and a barrier between parallel waves is more complexity than the wall-clock win.
-
-```mermaid
-flowchart TB
-  StartPrecheck["POST /precheck → 202\nstep=pre_check, operation=pending"] --> Precheck["precheck batch\nstatus=running; cursor on operation"]
-  Precheck -->|"more pages"| Precheck
-  Precheck -->|"done"| Classify["classify\noperation.status=done"]
-
-  StartImport["POST /import → 202\nstep=create_catalog, operation=pending"] --> Import["import batch\nproducts → customers → subscriptions\ncursor encodes type + position"]
-  Import -->|"more"| Import
-  Import -->|"done"| Finalize["operation.status=done\nstep stays create_catalog"]
-```
-
-**Precheck** — start endpoint locks the migration (`FOR UPDATE`), sets `step=pre_check` and `operation` (`status=pending`, empty cursor), enqueues the first batch. The first worker flips `status=running`, pages `adapter.extract()`, upserts ledger rows, writes the next `cursor` + `last_progress_at`, reenqueues. When extract is exhausted, classify with `PrecheckEngine`, set `operation.status=done` (step stays `pre_check` for review).
-
-**Import** — same blockers as today; snapshot selection onto the operation; set `step=create_catalog` and `operation` (`status=pending`); enqueue. Batches flip to `running` and import up to N selected `pending` records for the current type (products, then customers, then subscriptions — cursor carries which type and where; selection filters the query). When nothing remains, set `operation.status=done` (step stays `create_catalog`). A later partial re-import sets a new `selection` and `operation` back to `pending`/`running`, then `done` again, without changing `step`.
-
-Actors live in `polar/merchant_migration/tasks.py`. Batch size ~25–50; tune later.
-
-### Failures
-
-| Layer | Behavior |
-| --- | --- |
-| **Record** | Mark ledger row `failed` + `error`; the batch continues. Does not fail the operation. |
-| **Task** | On catchable errors: if `can_retry()`, re-raise; if not, set `operation.status=failed` + `error` in the same session, then re-raise/return. |
-| **Stall** | On `GET` of the migration (while the client polls): if `operation.status` is `pending` or `running` and `last_progress_at` is older than a stall threshold (15–30 min), mark `failed`. Set `last_progress_at` when enqueueing (`pending`) as well as on each batch. Stale tasks that wake later no-op when they see `failed` or `done`. |
-
-Unrecoverable start errors (blockers, wrong step, concurrent op) fail immediately with **409** / the existing status-coded errors — no enqueue.
-
-### API
-
-| Endpoint | Behavior |
-| --- | --- |
-| `POST /{id}/precheck` | Enqueue; **202** + migration (with `operation`). **409** if `operation.status` is already `pending` or `running`. |
-| `POST /{id}/import` | Same; body still takes selection. |
-| `GET /{id}` | Includes `operation`; may apply the stall check above. |
-| `/records` + `/records/summary` | Unchanged; clients poll these for counts. |
-
-Drop the sync import report as the mutation response body. Progress is the ledger + `operation`.
-
-### UI (high level)
-
-The dashboard should reflect that precheck/import are background work: the merchant can leave and come back. Poll the migration (and record summary) while `operation.status` is `pending` or `running`; within the current `step`, branch on `pending`/`running`/`done`/`failed` (+ retry). Detailed UI is out of scope for this design.
-
-### Implementation follow-up
-
-After acceptance, separate PR(s):
-
-1. `operation` JSONB on `MerchantMigration` + Alembic.
-2. `tasks.py` + start methods; endpoints return 202.
-3. Batch APIs for extract/import (refactor today’s sync paths).
-4. Thin dashboard wiring to poll and surface running/failed (not part of this design PR).
-5. Tests: batching, cursor resume, concurrent start 409, final-retry failure, stall-on-GET.
+The UI should treat this as leave-and-return background work (poll while `pending`/`running`; retry on `failed`). Details are out of scope here.
 
 ## Testing and rollout
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the merchant migrations design doc with a short, high-level note that precheck and catalog import run as background jobs, plus the `operation` states (`pending` / `running` / `done` / `failed`).

## Test plan

- [ ] Skim the *Background jobs* section — should stay high-level
- [ ] Confirm it still fits with the existing setup/cutover narrative

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6b89d95-8c84-4626-83b4-ec26ffb49f0a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6b89d95-8c84-4626-83b4-ec26ffb49f0a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

