### PR TITLE
fix(payment-method): only hold a card when a charge is coming

### DIFF
--- a/clients/apps/web/src/components/CustomerPortal/CustomerSubscriptionDetails.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerSubscriptionDetails.tsx
@@ -5,7 +5,6 @@ import { SubscriptionStatusLabel } from '@/components/Subscriptions/utils'
 import {
   useCustomerClearPendingSubscriptionUpdate,
   useCustomerCancelSubscription,
-  useCustomerUncancelSubscription,
 } from '@/hooks/queries/customerPortal'
 import { Client, schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
@@ -22,6 +21,7 @@ import { useModal } from '../Modal/useModal'
 import { DetailRow } from '../Shared/DetailRow'
 import CustomerChangePlanModal from './CustomerChangePlanModal'
 import { CustomerSubscriptionHeader } from './CustomerSubscriptionHeader'
+import UncancelSubscriptionButton from './UncancelSubscriptionButton'
 
 const CustomerSubscriptionDetails = ({
   subscription,
@@ -61,7 +61,6 @@ const CustomerSubscriptionDetails = ({
   const showSubscriptionUpdates =
     organization.customer_portal_settings.subscription.update_plan === true
 
-  const uncancelSubscription = useCustomerUncancelSubscription(api)
   const clearPendingUpdate = useCustomerClearPendingSubscriptionUpdate(api)
   const router = useRouter()
 
@@ -225,16 +224,15 @@ const CustomerSubscriptionDetails = ({
           subscription.cancel_at_period_end &&
           subscription.current_period_end &&
           new Date(subscription.current_period_end) > new Date() && (
-            <Button
-              onClick={async () => {
-                await uncancelSubscription.mutateAsync({ id: subscription.id })
+            <UncancelSubscriptionButton
+              api={api}
+              subscription={subscription}
+              customerSessionToken={customerSessionToken}
+              onUncancelled={async () => {
                 await revalidate(`customer_portal`)
                 router.refresh()
               }}
-              loading={uncancelSubscription.isPending}
-            >
-              Uncancel
-            </Button>
+            />
           )}
 
         <Button className="hidden md:flex" onClick={showBenefitGrantsModal}>

--- a/clients/apps/web/src/components/CustomerPortal/UncancelSubscriptionButton.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/UncancelSubscriptionButton.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { toast } from '@/components/Toast/use-toast'
+import {
+  useCustomerPaymentMethods,
+  useCustomerUncancelSubscription,
+} from '@/hooks/queries/customerPortal'
+import { PolarEmbedPaymentMethod } from '@polar-sh/checkout/payment-method'
+import type { Client, schemas } from '@polar-sh/client'
+import { Button } from '@polar-sh/orbit'
+import { useQueryClient } from '@tanstack/react-query'
+import { useTheme } from 'next-themes'
+
+const UncancelSubscriptionButton = ({
+  api,
+  subscription,
+  customerSessionToken,
+  onUncancelled,
+}: {
+  api: Client
+  subscription: schemas['CustomerSubscription']
+  customerSessionToken: string
+  onUncancelled: () => Promise<void>
+}) => {
+  const theme = useTheme()
+  const queryClient = useQueryClient()
+  const uncancelSubscription = useCustomerUncancelSubscription(api)
+  const { data: paymentMethods } = useCustomerPaymentMethods(api)
+
+  const uncancel = async () => {
+    const { error } = await uncancelSubscription.mutateAsync({
+      id: subscription.id,
+    })
+    if (error) {
+      toast({
+        title: 'Failed to uncancel subscription',
+        description:
+          typeof error.detail === 'string'
+            ? error.detail
+            : 'An error occurred while uncancelling the subscription.',
+        variant: 'error',
+      })
+      return
+    }
+    await onUncancelled()
+  }
+
+  const onClick = async () => {
+    if (paymentMethods && paymentMethods.items.length > 0) {
+      await uncancel()
+      return
+    }
+
+    const embed = await PolarEmbedPaymentMethod.create({
+      sessionToken: customerSessionToken,
+      theme: theme.resolvedTheme === 'dark' ? 'dark' : 'light',
+    })
+    embed.addEventListener('success', async () => {
+      await queryClient.invalidateQueries({
+        queryKey: ['customer_payment_methods'],
+      })
+      await uncancel()
+    })
+  }
+
+  return (
+    <Button
+      onClick={onClick}
+      loading={uncancelSubscription.isPending}
+      disabled={uncancelSubscription.isPending}
+    >
+      Uncancel
+    </Button>
+  )
+}
+
+export default UncancelSubscriptionButton

--- a/clients/apps/web/src/components/CustomerPortal/UncancelSubscriptionButton.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/UncancelSubscriptionButton.tsx
@@ -25,11 +25,8 @@ const UncancelSubscriptionButton = ({
   const theme = useTheme()
   const queryClient = useQueryClient()
   const uncancelSubscription = useCustomerUncancelSubscription(api)
-  const {
-    data: paymentMethods,
-    isPending: paymentMethodsPending,
-    isError: paymentMethodsError,
-  } = useCustomerPaymentMethods(api)
+  const { data: paymentMethods, isPending: paymentMethodsPending } =
+    useCustomerPaymentMethods(api)
 
   const uncancel = async () => {
     const { error } = await uncancelSubscription.mutateAsync({
@@ -50,10 +47,7 @@ const UncancelSubscriptionButton = ({
   }
 
   const onClick = async () => {
-    if (
-      paymentMethodsError ||
-      (paymentMethods && paymentMethods.items.length > 0)
-    ) {
+    if (paymentMethods && paymentMethods.items.length > 0) {
       await uncancel()
       return
     }

--- a/clients/apps/web/src/components/CustomerPortal/UncancelSubscriptionButton.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/UncancelSubscriptionButton.tsx
@@ -25,7 +25,11 @@ const UncancelSubscriptionButton = ({
   const theme = useTheme()
   const queryClient = useQueryClient()
   const uncancelSubscription = useCustomerUncancelSubscription(api)
-  const { data: paymentMethods } = useCustomerPaymentMethods(api)
+  const {
+    data: paymentMethods,
+    isPending: paymentMethodsPending,
+    isError: paymentMethodsError,
+  } = useCustomerPaymentMethods(api)
 
   const uncancel = async () => {
     const { error } = await uncancelSubscription.mutateAsync({
@@ -46,7 +50,10 @@ const UncancelSubscriptionButton = ({
   }
 
   const onClick = async () => {
-    if (paymentMethods && paymentMethods.items.length > 0) {
+    if (
+      paymentMethodsError ||
+      (paymentMethods && paymentMethods.items.length > 0)
+    ) {
       await uncancel()
       return
     }
@@ -66,8 +73,8 @@ const UncancelSubscriptionButton = ({
   return (
     <Button
       onClick={onClick}
-      loading={uncancelSubscription.isPending}
-      disabled={uncancelSubscription.isPending}
+      loading={uncancelSubscription.isPending || paymentMethodsPending}
+      disabled={uncancelSubscription.isPending || paymentMethodsPending}
     >
       Uncancel
     </Button>

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -50012,7 +50012,7 @@ export interface operations {
         }
         content?: never
       }
-      /** @description Payment method is used by active subscription(s). */
+      /** @description Payment method is still needed to bill a subscription. */
       400: {
         headers: {
           [name: string]: unknown

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -35918,6 +35918,17 @@ export interface components {
       /** Detail */
       detail: string
     }
+    /** UncancelWithoutPaymentMethod */
+    UncancelWithoutPaymentMethod: {
+      /**
+       * Error
+       * @example UncancelWithoutPaymentMethod
+       * @constant
+       */
+      error: 'UncancelWithoutPaymentMethod'
+      /** Detail */
+      detail: string
+    }
     /** UniqueAggregation */
     UniqueAggregation: {
       /**
@@ -51825,6 +51836,15 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['ResourceNotFound']
+        }
+      }
+      /** @description The subscription has no payment method to renew with. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['UncancelWithoutPaymentMethod']
         }
       }
       /** @description Validation Error */

--- a/server/polar/customer_portal/endpoints/customer.py
+++ b/server/polar/customer_portal/endpoints/customer.py
@@ -200,7 +200,7 @@ async def confirm_payment_method(
     responses={
         204: {"description": "Payment method deleted."},
         400: {
-            "description": "Payment method is used by active subscription(s).",
+            "description": "Payment method is still needed to bill a subscription.",
             "model": PaymentMethodInUseByActiveSubscription.schema(),
         },
         404: {

--- a/server/polar/customer_portal/endpoints/subscription.py
+++ b/server/polar/customer_portal/endpoints/subscription.py
@@ -36,6 +36,7 @@ from ..service.subscription import (
     CustomerSubscriptionSortProperty,
     PauseResumeNotAllowed,
     RevokeNotAllowed,
+    UncancelWithoutPaymentMethod,
     UpdateSubscriptionPlanNotAllowed,
     UpdateSubscriptionSeatsNotAllowed,
 )
@@ -234,6 +235,10 @@ async def preview_change(
             | PauseResumeNotAllowed.schema(),
         },
         404: SubscriptionNotFound,
+        409: {
+            "description": "The subscription has no payment method to renew with.",
+            "model": UncancelWithoutPaymentMethod.schema(),
+        },
     },
 )
 async def update(

--- a/server/polar/customer_portal/service/subscription.py
+++ b/server/polar/customer_portal/service/subscription.py
@@ -20,6 +20,7 @@ from polar.models import (
     SubscriptionMeter,
 )
 from polar.models.subscription import CustomerCancellationReason
+from polar.payment_method.service import payment_method as payment_method_service
 from polar.subscription.schemas import SubscriptionChargePreview
 from polar.subscription.service import (
     AlreadyCanceledSubscription,
@@ -63,6 +64,14 @@ class RevokeNotAllowed(CustomerSubscriptionError):
         super().__init__(
             "This subscription can only be revoked while it is past-due "
             "with no benefit grace period.",
+            409,
+        )
+
+
+class UncancelWithoutPaymentMethod(CustomerSubscriptionError):
+    def __init__(self) -> None:
+        super().__init__(
+            "Add a payment method before uncancelling this subscription.",
             409,
         )
 
@@ -293,6 +302,13 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
         session: AsyncSession,
         subscription: Subscription,
     ) -> Subscription:
+        if subscription.can_uncancel():
+            payment_method = await payment_method_service.get_customer_payment_method(
+                session, subscription.customer
+            )
+            if payment_method is None:
+                raise UncancelWithoutPaymentMethod()
+
         async with SubscriptionUpdateContext(
             session, subscription, subscription_service
         ) as ctx:

--- a/server/polar/models/subscription.py
+++ b/server/polar/models/subscription.py
@@ -21,6 +21,7 @@ from sqlalchemy import (
     Uuid,
     cast,
     event,
+    select,
     type_coerce,
 )
 from sqlalchemy.ext.associationproxy import AssociationProxy, association_proxy
@@ -37,7 +38,9 @@ from polar.kit.metadata import MetadataMixin
 from polar.kit.utils import utc_now
 from polar.product.guard import is_metered_price
 
+from .product_price import ProductPrice
 from .subscription_meter import SubscriptionMeter
+from .subscription_product_price import SubscriptionProductPrice
 
 if TYPE_CHECKING:
     from . import (
@@ -51,8 +54,6 @@ if TYPE_CHECKING:
         Organization,
         PaymentMethod,
         Product,
-        ProductPrice,
-        SubscriptionProductPrice,
         SubscriptionUpdate,
     )
 
@@ -460,6 +461,40 @@ class Subscription(CustomFieldDataMixin, MetadataMixin, RecordModel):
     def _billable_expression(cls) -> ColumnElement[bool]:
         return type_coerce(
             cls.status.in_(SubscriptionStatus.billable_statuses()),
+            Boolean,
+        )
+
+    @hybrid_property
+    def requires_payment_method(self) -> bool:
+        """Whether a payment method is still needed to bill this subscription."""
+        if not self.billable:
+            return False
+        if SubscriptionStatus.is_active(self.status) and self.cancel_at_period_end:
+            return any(is_metered_price(price) for price in self.prices)
+        return True
+
+    @requires_payment_method.inplace.expression
+    @classmethod
+    def _requires_payment_method_expression(cls) -> ColumnElement[bool]:
+        has_metered_price = (
+            select(SubscriptionProductPrice.subscription_id)
+            .join(
+                ProductPrice,
+                ProductPrice.id == SubscriptionProductPrice.product_price_id,
+            )
+            .where(
+                SubscriptionProductPrice.subscription_id == cls.id,
+                ProductPrice.is_metered,
+            )
+            .exists()
+        )
+        return type_coerce(
+            cls.status.in_(SubscriptionStatus.billable_statuses())
+            & (
+                ~cls.status.in_(SubscriptionStatus.active_statuses())
+                | cls.cancel_at_period_end.is_(False)
+                | has_metered_price
+            ),
             Boolean,
         )
 

--- a/server/polar/models/subscription.py
+++ b/server/polar/models/subscription.py
@@ -467,6 +467,8 @@ class Subscription(CustomFieldDataMixin, MetadataMixin, RecordModel):
     @hybrid_property
     def requires_payment_method(self) -> bool:
         """Whether a payment method is still needed to bill this subscription."""
+        if self.status == SubscriptionStatus.paused:
+            return self.resumes_at is not None
         if not self.billable:
             return False
         if SubscriptionStatus.is_active(self.status) and self.cancel_at_period_end:
@@ -488,12 +490,18 @@ class Subscription(CustomFieldDataMixin, MetadataMixin, RecordModel):
             )
             .exists()
         )
+        scheduled_resume = (cls.status == SubscriptionStatus.paused) & (
+            cls.resumes_at.is_not(None)
+        )
         return type_coerce(
-            cls.status.in_(SubscriptionStatus.billable_statuses())
-            & (
-                ~cls.status.in_(SubscriptionStatus.active_statuses())
-                | cls.cancel_at_period_end.is_(False)
-                | has_metered_price
+            scheduled_resume
+            | (
+                cls.status.in_(SubscriptionStatus.billable_statuses())
+                & (
+                    ~cls.status.in_(SubscriptionStatus.active_statuses())
+                    | cls.cancel_at_period_end.is_(False)
+                    | has_metered_price
+                )
             ),
             Boolean,
         )

--- a/server/polar/payment_method/repository.py
+++ b/server/polar/payment_method/repository.py
@@ -121,9 +121,9 @@ class PaymentMethodRepository(
         options: Options = (),
     ) -> Sequence[PaymentMethod]:
         """
-        Find card payment methods expiring within the window that back a billable
-        subscription and have no sent `payment_method_expiration_reminder` email logged for
-        that expiration.
+        Find card payment methods expiring within the window that back a subscription
+        still needing one, and have no sent `payment_method_expiration_reminder` email
+        logged for that expiration.
         """
         periods = expiring_periods(now, window_end)
         if not periods:
@@ -135,11 +135,11 @@ class PaymentMethodRepository(
             *(and_(exp_year == year, exp_month == month) for year, month in periods)
         )
 
-        billable_subscription_subquery = (
+        requiring_subscription_subquery = (
             select(Subscription.id)
             .where(
                 Subscription.payment_method_id == PaymentMethod.id,
-                Subscription.billable.is_(True),
+                Subscription.requires_payment_method.is_(True),
                 Subscription.deleted_at.is_(None),
             )
             .correlate(PaymentMethod)
@@ -168,7 +168,7 @@ class PaymentMethodRepository(
             .where(
                 PaymentMethod.type == "card",
                 expiring_condition,
-                billable_subscription_subquery,
+                requiring_subscription_subquery,
                 ~already_sent_subquery,
             )
             .options(*options)

--- a/server/polar/payment_method/service.py
+++ b/server/polar/payment_method/service.py
@@ -165,11 +165,11 @@ class PaymentMethodService:
         )
 
         subscription_repository = SubscriptionRepository.from_session(session)
-        subscriptions = await subscription_repository.list_billable_by_payment_method(
+        subscriptions = await subscription_repository.list_requiring_payment_method(
             payment_method.id, options=(joinedload(Subscription.product),)
         )
         product_names = sorted({s.product.name for s in subscriptions})
-        # The card doesn't back anything billable, bail out
+        # The card doesn't back anything that will be charged, bail out
         if not product_names:
             return
 

--- a/server/polar/payment_method/service.py
+++ b/server/polar/payment_method/service.py
@@ -48,7 +48,7 @@ class PaymentMethodInUseByActiveSubscription(PaymentMethodError):
     def __init__(self, subscription_ids: list[uuid.UUID]) -> None:
         self.subscription_ids = subscription_ids
         message = (
-            "This payment method is used by an active subscription. "
+            "This payment method is still needed to bill a subscription. "
             "Add another one or cancel the subscription first."
         )
         super().__init__(message, 400)

--- a/server/polar/payment_method/service.py
+++ b/server/polar/payment_method/service.py
@@ -48,8 +48,8 @@ class PaymentMethodInUseByActiveSubscription(PaymentMethodError):
     def __init__(self, subscription_ids: list[uuid.UUID]) -> None:
         self.subscription_ids = subscription_ids
         message = (
-            "Cannot delete payment method. It is currently used by active "
-            "subscription and no alternative payment methods "
+            "This payment method is used by an active subscription. "
+            "Add another one or cancel the subscription first."
         )
         super().__init__(message, 400)
 
@@ -230,16 +230,6 @@ class PaymentMethodService:
                 deduplication_key=deduplication_key,
             )
 
-    async def _get_billable_subscription_ids(
-        self, session: AsyncSession, payment_method: PaymentMethod
-    ) -> list[uuid.UUID]:
-        stmt = select(Subscription.id).where(
-            Subscription.payment_method_id == payment_method.id,
-            Subscription.billable.is_(True),
-        )
-        result = await session.execute(stmt)
-        return [row[0] for row in result.fetchall()]
-
     async def _get_alternative_payment_method(
         self,
         session: AsyncSession,
@@ -291,11 +281,14 @@ class PaymentMethodService:
         payment_method: PaymentMethod,
         force: bool = False,
     ) -> None:
-        billable_subscription_ids = await self._get_billable_subscription_ids(
-            session, payment_method
+        subscription_repository = SubscriptionRepository.from_session(session)
+        requiring_subscription_ids = list(
+            await subscription_repository.list_ids_requiring_payment_method(
+                payment_method.id
+            )
         )
 
-        if billable_subscription_ids:
+        if requiring_subscription_ids:
             alternative_payment_method = await self._get_alternative_payment_method(
                 session, payment_method
             )
@@ -305,11 +298,11 @@ class PaymentMethodService:
                     session,
                     from_payment_method=payment_method,
                     to_payment_method=alternative_payment_method,
-                    subscription_ids=billable_subscription_ids,
+                    subscription_ids=requiring_subscription_ids,
                 )
             elif not force:
                 # No alternative payment method available, raise exception
-                raise PaymentMethodInUseByActiveSubscription(billable_subscription_ids)
+                raise PaymentMethodInUseByActiveSubscription(requiring_subscription_ids)
 
         if payment_method.processor == PaymentProcessor.stripe:
             try:

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -130,6 +130,7 @@ class SubscriptionRepository(
             .where(
                 Subscription.payment_method_id == payment_method_id,
                 Subscription.requires_payment_method.is_(True),
+                Subscription.ended_at.is_(None),
             )
         )
         result = await self.session.execute(statement)

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -121,6 +121,20 @@ class SubscriptionRepository(
         )
         return await self.get_all(statement)
 
+    async def list_ids_requiring_payment_method(
+        self, payment_method_id: UUID
+    ) -> Sequence[UUID]:
+        statement = (
+            self.get_base_statement()
+            .with_only_columns(Subscription.id)
+            .where(
+                Subscription.payment_method_id == payment_method_id,
+                Subscription.requires_payment_method.is_(True),
+            )
+        )
+        result = await self.session.execute(statement)
+        return result.scalars().all()
+
     def get_billable_by_organization_statement(
         self, organization_id: UUID, *, options: Options = ()
     ) -> Select[tuple[Subscription]]:

--- a/server/polar/subscription/repository.py
+++ b/server/polar/subscription/repository.py
@@ -107,14 +107,14 @@ class SubscriptionRepository(
         )
         return await self.get_all(statement)
 
-    async def list_billable_by_payment_method(
+    async def list_requiring_payment_method(
         self, payment_method_id: UUID, *, options: Options = ()
     ) -> Sequence[Subscription]:
         statement = (
             self.get_base_statement()
             .where(
                 Subscription.payment_method_id == payment_method_id,
-                Subscription.status.in_(SubscriptionStatus.billable_statuses()),
+                Subscription.requires_payment_method.is_(True),
                 Subscription.ended_at.is_(None),
             )
             .options(*options)

--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -1973,10 +1973,7 @@ class SubscriptionService:
         if subscription.ended_at:
             raise ResourceUnavailable()
 
-        if not (
-            subscription.status in SubscriptionStatus.billable_statuses()
-            and subscription.cancel_at_period_end
-        ):
+        if not subscription.can_uncancel():
             raise BadRequest()
 
         subscription.cancel_at_period_end = False

--- a/server/tests/customer_portal/endpoints/test_customer.py
+++ b/server/tests/customer_portal/endpoints/test_customer.py
@@ -159,11 +159,6 @@ class TestDeletePaymentMethod:
         )
         assert response.status_code == 400
 
-        # Check error message
-        error_data = response.json()
-        assert "Cannot delete payment method" in error_data["detail"]
-        assert "no alternative payment methods" in error_data["detail"]
-
         # Verify payment method is NOT deleted
         await session.refresh(payment_method)
         assert payment_method.deleted_at is None

--- a/server/tests/customer_portal/endpoints/test_customer.py
+++ b/server/tests/customer_portal/endpoints/test_customer.py
@@ -195,6 +195,39 @@ class TestDeletePaymentMethod:
         await session.refresh(payment_method)
         assert payment_method.deleted_at is not None
 
+    @pytest.mark.auth(CUSTOMER_AUTH_SUBJECT)
+    @pytest.mark.keep_session_state
+    async def test_delete_payment_method_with_subscription_ending_at_period_end_succeeds(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        # Create a payment method
+        payment_method = await create_payment_method(save_fixture, customer)
+
+        # Create a subscription set to cancel at period end using this payment method
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.active,
+            cancel_at_period_end=True,
+        )
+        subscription.payment_method = payment_method
+        await save_fixture(subscription)
+
+        response = await client.delete(
+            f"/v1/customer-portal/customers/me/payment-methods/{payment_method.id}"
+        )
+        assert response.status_code == 204
+
+        # Verify payment method is soft deleted
+        await session.refresh(payment_method)
+        assert payment_method.deleted_at is not None
+
 
 @pytest.mark.asyncio
 class TestUpdateDefaultPaymentMethod:

--- a/server/tests/customer_portal/endpoints/test_subscription.py
+++ b/server/tests/customer_portal/endpoints/test_subscription.py
@@ -22,6 +22,7 @@ from tests.fixtures.random_objects import (
     create_benefit,
     create_canceled_subscription,
     create_order,
+    create_payment_method,
     create_product,
     set_product_benefits,
 )
@@ -368,6 +369,29 @@ class TestSubscriptionUpdateUncancel:
         assert response.status_code == 410
 
     @pytest.mark.auth(CUSTOMER_AUTH_SUBJECT)
+    async def test_uncancel_without_payment_method(
+        self,
+        save_fixture: SaveFixture,
+        client: AsyncClient,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_canceled_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+        )
+
+        response = await client.patch(
+            f"/v1/customer-portal/subscriptions/{subscription.id}",
+            json=dict(
+                cancel_at_period_end=False,
+            ),
+        )
+
+        assert response.status_code == 409
+
+    @pytest.mark.auth(CUSTOMER_AUTH_SUBJECT)
     async def test_valid(
         self,
         save_fixture: SaveFixture,
@@ -375,6 +399,7 @@ class TestSubscriptionUpdateUncancel:
         product: Product,
         customer: Customer,
     ) -> None:
+        await create_payment_method(save_fixture, customer)
         subscription = await create_canceled_subscription(
             save_fixture,
             product=product,

--- a/server/tests/models/test_subscription.py
+++ b/server/tests/models/test_subscription.py
@@ -1,7 +1,10 @@
+from datetime import timedelta
+
 import pytest
 from sqlalchemy import select
 
 from polar.enums import TaxBehavior
+from polar.kit.utils import utc_now
 from polar.models import Customer, Order, Product, Subscription
 from polar.models.subscription import SubscriptionStatus
 from polar.models.subscription_product_price import SubscriptionProductPrice
@@ -151,6 +154,30 @@ class TestRequiresPaymentMethod:
 
         assert subscription.requires_payment_method is True
         assert await _matches_expression(session, subscription) is True
+
+    @pytest.mark.parametrize("scheduled_resume", [True, False])
+    async def test_paused_subscription_follows_the_scheduled_resume(
+        self,
+        scheduled_resume: bool,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+        subscription.paused_at = utc_now()
+        subscription.resumes_at = (
+            utc_now() + timedelta(days=30) if scheduled_resume else None
+        )
+        await save_fixture(subscription)
+
+        assert subscription.requires_payment_method is scheduled_resume
+        assert await _matches_expression(session, subscription) is scheduled_resume
 
     async def test_metered_subscription_revoked(
         self,

--- a/server/tests/models/test_subscription.py
+++ b/server/tests/models/test_subscription.py
@@ -1,8 +1,13 @@
 import pytest
+from sqlalchemy import select
 
 from polar.enums import TaxBehavior
-from polar.models import Order, Subscription
+from polar.models import Customer, Order, Product, Subscription
+from polar.models.subscription import SubscriptionStatus
 from polar.models.subscription_product_price import SubscriptionProductPrice
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+from tests.fixtures.random_objects import create_subscription
 
 
 def _prices(*amounts: int) -> list[SubscriptionProductPrice]:
@@ -74,3 +79,92 @@ class TestUpdateAmountAndCurrency:
         subscription.update_amount_and_currency(_prices(3000), None)
         assert subscription.amount == 3000
         assert subscription.net_amount == 3000
+
+
+async def _matches_expression(
+    session: AsyncSession, subscription: Subscription
+) -> bool:
+    result = await session.execute(
+        select(Subscription.id).where(
+            Subscription.id == subscription.id,
+            Subscription.requires_payment_method.is_(True),
+        )
+    )
+    return result.scalar_one_or_none() is not None
+
+
+@pytest.mark.asyncio
+class TestRequiresPaymentMethod:
+    @pytest.mark.parametrize(
+        ("status", "cancel_at_period_end", "expected"),
+        [
+            (SubscriptionStatus.active, False, True),
+            (SubscriptionStatus.trialing, False, True),
+            (SubscriptionStatus.past_due, False, True),
+            (SubscriptionStatus.active, True, False),
+            (SubscriptionStatus.trialing, True, False),
+            # Its unpaid order is still being retried against the card.
+            (SubscriptionStatus.past_due, True, True),
+            (SubscriptionStatus.incomplete, False, False),
+            (SubscriptionStatus.canceled, False, False),
+            (SubscriptionStatus.unpaid, False, False),
+            (SubscriptionStatus.paused, False, False),
+        ],
+    )
+    async def test_status_and_scheduled_cancellation(
+        self,
+        status: SubscriptionStatus,
+        cancel_at_period_end: bool,
+        expected: bool,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=status,
+            cancel_at_period_end=cancel_at_period_end,
+        )
+
+        assert subscription.requires_payment_method is expected
+        assert await _matches_expression(session, subscription) is expected
+
+    @pytest.mark.parametrize("cancel_at_period_end", [True, False])
+    async def test_metered_subscription_always_requires_one(
+        self,
+        cancel_at_period_end: bool,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product_recurring_metered: Product,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product_recurring_metered,
+            customer=customer,
+            status=SubscriptionStatus.active,
+            cancel_at_period_end=cancel_at_period_end,
+        )
+
+        assert subscription.requires_payment_method is True
+        assert await _matches_expression(session, subscription) is True
+
+    async def test_metered_subscription_revoked(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product_recurring_metered: Product,
+    ) -> None:
+        subscription = await create_subscription(
+            save_fixture,
+            product=product_recurring_metered,
+            customer=customer,
+            status=SubscriptionStatus.canceled,
+        )
+
+        assert subscription.requires_payment_method is False
+        assert await _matches_expression(session, subscription) is False

--- a/server/tests/payment_method/test_repository.py
+++ b/server/tests/payment_method/test_repository.py
@@ -70,6 +70,7 @@ async def create_expiring_card(
     exp_year: int = 2026,
     type: str = "card",
     status: SubscriptionStatus = SubscriptionStatus.active,
+    cancel_at_period_end: bool = False,
 ) -> PaymentMethod:
     payment_method = await create_payment_method(
         save_fixture,
@@ -88,6 +89,7 @@ async def create_expiring_card(
             product=product,
             customer=customer,
             payment_method=payment_method,
+            cancel_at_period_end=cancel_at_period_end,
         )
     else:
         await create_subscription(
@@ -96,6 +98,7 @@ async def create_expiring_card(
             customer=customer,
             payment_method=payment_method,
             status=status,
+            cancel_at_period_end=cancel_at_period_end,
         )
     return payment_method
 
@@ -191,6 +194,41 @@ class TestGetCardsExpiring:
         result = await repository.get_cards_needing_expiration_reminder(NOW, WINDOW_END)
 
         assert result == []
+
+    async def test_excludes_card_whose_subscription_ends_at_period_end(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        await create_expiring_card(
+            save_fixture, customer, product, cancel_at_period_end=True
+        )
+
+        repository = PaymentMethodRepository.from_session(session)
+        result = await repository.get_cards_needing_expiration_reminder(NOW, WINDOW_END)
+
+        assert result == []
+
+    async def test_includes_card_whose_ending_subscription_is_metered(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product_recurring_metered: Product,
+    ) -> None:
+        payment_method = await create_expiring_card(
+            save_fixture,
+            customer,
+            product_recurring_metered,
+            cancel_at_period_end=True,
+        )
+
+        repository = PaymentMethodRepository.from_session(session)
+        result = await repository.get_cards_needing_expiration_reminder(NOW, WINDOW_END)
+
+        assert [pm.id for pm in result] == [payment_method.id]
 
     async def test_excludes_card_whose_subscription_is_soft_deleted(
         self,

--- a/server/tests/payment_method/test_service.py
+++ b/server/tests/payment_method/test_service.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from typing import cast
 from unittest.mock import MagicMock
 
@@ -6,6 +7,7 @@ from pytest_mock import MockerFixture
 
 from polar.enums import PaymentProcessor, SubscriptionRecurringInterval
 from polar.integrations.stripe.service import StripeService
+from polar.kit.utils import utc_now
 from polar.models import Customer, Organization, PaymentMethod, Product
 from polar.models.organization import OrganizationCustomerEmailSettings
 from polar.models.subscription import SubscriptionStatus
@@ -250,6 +252,39 @@ class TestDelete:
             cancel_at_period_end=True,
         )
         subscription.payment_method = payment_method
+        await save_fixture(subscription)
+
+        with pytest.raises(PaymentMethodInUseByActiveSubscription):
+            await payment_method_service.delete(session, payment_method)
+
+        await session.refresh(payment_method)
+        assert payment_method.deleted_at is None
+
+    async def test_delete_payment_method_with_scheduled_resume_raises_exception(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        payment_method = PaymentMethod(
+            processor=PaymentProcessor.stripe,
+            processor_id="pm_test_paused",
+            type="card",
+            method_metadata={"brand": "visa", "last4": "4242"},
+            customer=customer,
+        )
+        await save_fixture(payment_method)
+
+        subscription = await create_subscription(
+            save_fixture,
+            status=SubscriptionStatus.paused,
+            product=product,
+            customer=customer,
+        )
+        subscription.payment_method = payment_method
+        subscription.paused_at = utc_now()
+        subscription.resumes_at = utc_now() + timedelta(days=30)
         await save_fixture(subscription)
 
         with pytest.raises(PaymentMethodInUseByActiveSubscription):

--- a/server/tests/payment_method/test_service.py
+++ b/server/tests/payment_method/test_service.py
@@ -552,6 +552,54 @@ class TestSendExpiringReminderEmail:
 
         enqueue_email_template_mock.assert_not_called()
 
+    async def test_skips_when_the_subscription_ends_at_period_end(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+        enqueue_email_template_mock: MagicMock,
+    ) -> None:
+        payment_method = await create_expiring_card(save_fixture, customer)
+        await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            payment_method=payment_method,
+            cancel_at_period_end=True,
+        )
+
+        await payment_method_service.send_expiration_reminder_email(
+            session, payment_method
+        )
+
+        enqueue_email_template_mock.assert_not_called()
+
+    async def test_sends_when_the_ending_subscription_is_metered(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product_recurring_metered: Product,
+        enqueue_email_template_mock: MagicMock,
+    ) -> None:
+        payment_method = await create_expiring_card(save_fixture, customer)
+        await create_active_subscription(
+            save_fixture,
+            product=product_recurring_metered,
+            customer=customer,
+            payment_method=payment_method,
+            cancel_at_period_end=True,
+        )
+
+        await payment_method_service.send_expiration_reminder_email(
+            session, payment_method
+        )
+
+        enqueue_email_template_mock.assert_called_once()
+        email = enqueue_email_template_mock.call_args.args[0]
+        assert email.props.product_names == [product_recurring_metered.name]
+
     async def test_skips_non_card_payment_method(
         self,
         session: AsyncSession,

--- a/server/tests/payment_method/test_service.py
+++ b/server/tests/payment_method/test_service.py
@@ -123,7 +123,7 @@ class TestDelete:
             SubscriptionStatus.past_due,
         ],
     )
-    async def test_delete_payment_method_with_billable_subscription_raises_exception(
+    async def test_delete_payment_method_with_renewing_subscription_raises_exception(
         self,
         status: SubscriptionStatus,
         session: AsyncSession,
@@ -153,7 +153,107 @@ class TestDelete:
             await payment_method_service.delete(session, payment_method)
 
         assert subscription.id in exc_info.value.subscription_ids
-        assert "Cannot delete payment method" in str(exc_info.value)
+
+        await session.refresh(payment_method)
+        assert payment_method.deleted_at is None
+
+    @pytest.mark.parametrize(
+        "status",
+        [SubscriptionStatus.trialing, SubscriptionStatus.active],
+    )
+    async def test_delete_payment_method_with_subscription_ending_at_period_end_succeeds(
+        self,
+        status: SubscriptionStatus,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        payment_method = PaymentMethod(
+            processor=PaymentProcessor.stripe,
+            processor_id="pm_test_ending",
+            type="card",
+            method_metadata={"brand": "visa", "last4": "4242"},
+            customer=customer,
+        )
+        await save_fixture(payment_method)
+
+        subscription = await create_subscription(
+            save_fixture,
+            status=status,
+            product=product,
+            customer=customer,
+            cancel_at_period_end=True,
+        )
+        subscription.payment_method = payment_method
+        await save_fixture(subscription)
+
+        await payment_method_service.delete(session, payment_method)
+
+        await session.flush()
+        await session.refresh(payment_method)
+        assert payment_method.deleted_at is not None
+
+    async def test_delete_payment_method_with_past_due_subscription_ending_raises_exception(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product: Product,
+    ) -> None:
+        payment_method = PaymentMethod(
+            processor=PaymentProcessor.stripe,
+            processor_id="pm_test_past_due",
+            type="card",
+            method_metadata={"brand": "visa", "last4": "4242"},
+            customer=customer,
+        )
+        await save_fixture(payment_method)
+
+        subscription = await create_subscription(
+            save_fixture,
+            status=SubscriptionStatus.past_due,
+            product=product,
+            customer=customer,
+            cancel_at_period_end=True,
+        )
+        subscription.payment_method = payment_method
+        await save_fixture(subscription)
+
+        with pytest.raises(PaymentMethodInUseByActiveSubscription):
+            await payment_method_service.delete(session, payment_method)
+
+        await session.refresh(payment_method)
+        assert payment_method.deleted_at is None
+
+    async def test_delete_payment_method_with_metered_subscription_ending_raises_exception(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        customer: Customer,
+        product_recurring_metered: Product,
+    ) -> None:
+        payment_method = PaymentMethod(
+            processor=PaymentProcessor.stripe,
+            processor_id="pm_test_metered",
+            type="card",
+            method_metadata={"brand": "visa", "last4": "4242"},
+            customer=customer,
+        )
+        await save_fixture(payment_method)
+
+        subscription = await create_subscription(
+            save_fixture,
+            status=SubscriptionStatus.active,
+            product=product_recurring_metered,
+            customer=customer,
+            cancel_at_period_end=True,
+        )
+        subscription.payment_method = payment_method
+        await save_fixture(subscription)
+
+        with pytest.raises(PaymentMethodInUseByActiveSubscription):
+            await payment_method_service.delete(session, payment_method)
 
         await session.refresh(payment_method)
         assert payment_method.deleted_at is None


### PR DESCRIPTION
**Related Issue**: polarsource/feedback#235

A customer whose subscription is set to cancel at period end can now remove their card.

## What

`Subscription.requires_payment_method` replaces `billable` as the test for holding a card on file. A subscription set to cancel at period end no longer needs one — with two carve-outs: `past_due`, whose unpaid order is still being retried, and metered pricing, whose final cycle still bills usage.

Deletion is blocked while the subscription renews:

https://github.com/user-attachments/assets/8ded4601-83dc-4071-83a9-21f5b024052b

Set to cancel at period end, it goes through:

https://github.com/user-attachments/assets/f2c3b91e-39a6-403c-a900-08bcdd48bbe0

`past_due` stays blocked:

https://github.com/user-attachments/assets/bbb3eb25-36a7-4dff-acb8-5e03efea082e

Two call sites follow the same rule. The expiring-card reminder no longer nags about a card that will not be charged again. Un-cancelling now requires a card, and the portal asks for one:

https://github.com/user-attachments/assets/c9381a22-619e-4fc2-9c2b-3e5d0c5f0c11

## Why

`billable` is defined by status alone, and a subscription set to cancel at period end keeps `status = active` until the period ends. So the card was held for a renewal that will never happen, and the error read as a hard failure — truncated mid-sentence, with no way out.

Removing the card opens a second gap: un-cancel had no payment-method check, so the next renewal would fail. Hence the guard.

## How

`requires_payment_method` is a hybrid property, so the same rule holds in Python and in SQL. The deletion gate, the reminder scan and the reminder itself all read it.

The portal's un-cancel returns 409 when the customer has no card. Merchants un-cancelling from the dashboard or the API are unaffected.

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

