### PR TITLE
tf/redis: Configure Render principal and set up in prod

### DIFF
--- a/terraform/production/aws.tf
+++ b/terraform/production/aws.tf
@@ -35,6 +35,27 @@ resource "aws_vpc_security_group_ingress_rule" "redis_lambda" {
   ip_protocol                  = "tcp"
 }
 
+module "redis_private_link" {
+  source = "../modules/redis_private_link"
+
+  name                     = "polar-production-worker-redis"
+  vpc_id                   = module.vpc.vpc_id
+  subnet_ids               = module.vpc.private_subnet_ids
+  redis_host               = module.redis.host
+  redis_port               = module.redis.port
+  redis_arn                = module.redis.arn
+  allowed_principals       = ["arn:aws:iam::557508356783:root"]
+  permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
+}
+
+resource "aws_vpc_security_group_ingress_rule" "redis_nlb" {
+  security_group_id            = module.redis.security_group_id
+  referenced_security_group_id = module.redis_private_link.nlb_security_group_id
+  from_port                    = module.redis.port
+  to_port                      = module.redis.port
+  ip_protocol                  = "tcp"
+}
+
 locals {
   files_bucket_name        = "polar-production-files"
   files_public_bucket_name = "polar-public-files"

--- a/terraform/production/outputs.tf
+++ b/terraform/production/outputs.tf
@@ -22,3 +22,8 @@ output "redis_id" {
   description = "The Redis ID. Used for the render_redis data source."
   value       = render_redis.redis.id
 }
+
+output "redis_endpoint_service_name" {
+  description = "VPC endpoint service name for the worker Redis. Provide to Render when creating the private link."
+  value       = module.redis_private_link.service_name
+}

--- a/terraform/sandbox/aws.tf
+++ b/terraform/sandbox/aws.tf
@@ -44,6 +44,7 @@ module "redis_private_link" {
   redis_host               = module.redis.host
   redis_port               = module.redis.port
   redis_arn                = module.redis.arn
+  allowed_principals       = ["arn:aws:iam::557508356783:root"]
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
 }
 

--- a/terraform/test/aws.tf
+++ b/terraform/test/aws.tf
@@ -47,6 +47,7 @@ module "redis_private_link" {
   redis_host               = module.redis[0].host
   redis_port               = module.redis[0].port
   redis_arn                = module.redis[0].arn
+  allowed_principals       = ["arn:aws:iam::557508356783:root"]
   permissions_boundary_arn = data.aws_iam_policy.permission_boundary.arn
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set up AWS PrivateLink for the production worker Redis and allow Render’s AWS account to connect. Also renamed the Redis module input from num_cache_clusters to node_count for clarity.

- New Features
  - Provisioned PrivateLink for Redis in prod with allowed_principals = ["arn:aws:iam::557508356783:root"].
  - Added SG ingress to allow NLB traffic to Redis.
  - Exposed redis_endpoint_service_name output for Render.
  - Applied the same allowed_principals in sandbox and test.

- Refactors
  - Renamed num_cache_clusters -> node_count in the Redis module and all envs.
  - Multi-AZ and automatic failover now derive from node_count > 1.

<sup>Written for commit 8c52d97639bfe863fea9263056714fe24c1c463e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

