### PR TITLE
sdk: fix error class names collisions

### DIFF
--- a/sdk/generator/generator/casing.py
+++ b/sdk/generator/generator/casing.py
@@ -18,7 +18,18 @@ def to_snake_case(name: str) -> str:
 
 def to_pascal_case(name: str) -> str:
     """Convert a string to PascalCase."""
-    return "".join(word[:1].upper() + word[1:] for word in name.split("_") if word)
+    result = []
+    capitalize_next = True
+    for c in name:
+        if c in "_-":
+            capitalize_next = True
+            continue
+        if capitalize_next:
+            result.append(c.upper())
+            capitalize_next = False
+        else:
+            result.append(c.lower())
+    return "".join(result)
 
 
 def to_camel_case(name: str) -> str:

--- a/sdk/generator/generator/ir.py
+++ b/sdk/generator/generator/ir.py
@@ -1181,7 +1181,9 @@ def _generate_ir_version(
                     description,
                 ) in error_responses_raw:
                     type = None
-                    name = to_pascal_case(f"{method_name}_{status_code}_error")
+                    name = to_pascal_case(
+                        f"{service.name}_{method_name}_{status_code}_error"
+                    )
                     if schema_raw is not None:
                         type = _convert_typeref(
                             schema_raw,

--- a/sdk/generator/generator/ir.py
+++ b/sdk/generator/generator/ir.py
@@ -1182,7 +1182,7 @@ def _generate_ir_version(
                 ) in error_responses_raw:
                     type = None
                     name = to_pascal_case(
-                        f"{service.name}_{method_name}_{status_code}_error"
+                        f"{'_'.join(service_key)}_{method_name}_{status_code}_error"
                     )
                     if schema_raw is not None:
                         type = _convert_typeref(

--- a/sdk/generator/python/template/polar/version/webhooks.py
+++ b/sdk/generator/python/template/polar/version/webhooks.py
@@ -5,9 +5,9 @@ import typing
 
 from polar.base import deserialize
 from polar.webhooks import (
-    PolarWebhookError as PolarWebhookError,
-    PolarWebhookUnknownTypeError as PolarWebhookUnknownTypeError,
-    PolarWebhookVerificationError as PolarWebhookVerificationError,
+    PolarWebhookError,
+    PolarWebhookUnknownTypeError,
+    PolarWebhookVerificationError,
     validate_event as _validate_event,
 )
 {% if enum_imports %}

--- a/sdk/generator/python/template/polar/version/webhooks.py
+++ b/sdk/generator/python/template/polar/version/webhooks.py
@@ -74,3 +74,14 @@ def validate_event(
 
 def _load_payload(data: dict[str, typing.Any]) -> WebhookPayload:
     return deserialize(data, WebhookPayload)
+
+__all__ = [
+    "PolarWebhookError",
+    "PolarWebhookUnknownTypeError",
+    "PolarWebhookVerificationError",
+    "validate_event",
+    "WebhookPayload",
+    {% for model in api.webhooks %}
+    "{{ model.name }}",
+    {% endfor %}
+]

--- a/sdk/generator/python/template/pyproject.toml
+++ b/sdk/generator/python/template/pyproject.toml
@@ -43,6 +43,7 @@ target-version = "py311"
 
 [tool.ruff.lint]
 extend-select = ["I", "UP"]
+ignore = ["B006"]
 
 [tool.uv]
 default-groups = ["dev"]

--- a/sdk/generator/tests/test_casing.py
+++ b/sdk/generator/tests/test_casing.py
@@ -58,6 +58,7 @@ class TestToPascalCase:
             ("_leading", "Leading"),
             ("trailing_", "Trailing"),
             ("__double__", "Double"),
+            ("dash-separated", "DashSeparated"),
         ],
     )
     def test_to_pascal_case(self, input_str, expected):

--- a/sdk/generator/tests/test_ir.py
+++ b/sdk/generator/tests/test_ir.py
@@ -1695,7 +1695,7 @@ _STRING = {"kind": "primitive", "type": "string"}
                                                 "description": "Validation error",
                                             },
                                             {
-                                                "name": "Get503Error",
+                                                "name": "ProductsGet503Error",
                                                 "status_code": 503,
                                                 "response_type": "none",
                                                 "description": "Service unavailable — no body",

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -44,9 +44,7 @@ from polar.v2026_04 import PolarAsync
 
 async def main() -> None:
     polar = PolarAsync("polar_oat_xxx")
-    customer_state = await polar.customers.get_state_external(
-        "customer_external_id"
-    )
+    customer_state = await polar.customers.get_state_external("customer_external_id")
     print(customer_state)
 
 
@@ -135,7 +133,9 @@ async def polar_webhook(request: Request) -> dict[str, bool]:
             webhook_secret,
         )
     except PolarWebhookVerificationError as exc:
-        raise HTTPException(status_code=403, detail="Invalid webhook signature") from exc
+        raise HTTPException(
+            status_code=403, detail="Invalid webhook signature"
+        ) from exc
     except PolarWebhookError as exc:
         raise HTTPException(status_code=400, detail="Invalid webhook payload") from exc
 

--- a/sdk/python/polar/.agents/skills/polar-python-sdk/SKILL.md
+++ b/sdk/python/polar/.agents/skills/polar-python-sdk/SKILL.md
@@ -112,8 +112,7 @@ from polar.v2026_04.outputs import CustomerState
 
 def has_feature_access(customer_state: CustomerState, benefit_id: str) -> bool:
     return any(
-        grant.benefit_id == benefit_id
-        for grant in customer_state.granted_benefits
+        grant.benefit_id == benefit_id for grant in customer_state.granted_benefits
     )
 
 

--- a/sdk/python/polar/__init__.py
+++ b/sdk/python/polar/__init__.py
@@ -6,11 +6,11 @@ from polar.base import (
     deserialize,
 )
 
-__version__ = "1.0.0a16"
+__version__ = "0.0.0"
 __all__ = [
+    "PolarClientError",
     "PolarError",
     "PolarNetworkError",
     "PolarServerError",
-    "PolarClientError",
     "deserialize",
 ]

--- a/sdk/python/polar/base.py
+++ b/sdk/python/polar/base.py
@@ -233,4 +233,3 @@ def parse_response_none(
     errors: dict[int, type[E]] | None = None,
 ) -> None:
     _handle_errors(response, errors)
-    return None

--- a/sdk/python/polar/v2026_04/errors.py
+++ b/sdk/python/polar/v2026_04/errors.py
@@ -332,7 +332,7 @@ class PaymentMethodInUseByActiveSubscription(PolarClientError):
         super().__init__(status_code, error)
 
 
-class CustomersCheckEmailUpdate401Error(PolarClientError):
+class CustomerPortalCustomersCheckEmailUpdate401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -341,7 +341,7 @@ class CustomersCheckEmailUpdate401Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class CustomersVerifyEmailUpdate401Error(PolarClientError):
+class CustomerPortalCustomersVerifyEmailUpdate401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -350,7 +350,7 @@ class CustomersVerifyEmailUpdate401Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class CustomersVerifyEmailUpdate422Error(PolarClientError):
+class CustomerPortalCustomersVerifyEmailUpdate422Error(PolarClientError):
     error_type = None
     error: None
 
@@ -359,7 +359,7 @@ class CustomersVerifyEmailUpdate422Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class SeatsListSeats401Error(PolarClientError):
+class CustomerPortalSeatsListSeats401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -368,7 +368,7 @@ class SeatsListSeats401Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class SeatsListSeats403Error(PolarClientError):
+class CustomerPortalSeatsListSeats403Error(PolarClientError):
     error_type = None
     error: None
 
@@ -377,7 +377,7 @@ class SeatsListSeats403Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class SeatsListSeats404Error(PolarClientError):
+class CustomerPortalSeatsListSeats404Error(PolarClientError):
     error_type = None
     error: None
 
@@ -386,7 +386,7 @@ class SeatsListSeats404Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class SeatsAssignSeat400Error(PolarClientError):
+class CustomerPortalSeatsAssignSeat400Error(PolarClientError):
     error_type = None
     error: None
 
@@ -395,7 +395,7 @@ class SeatsAssignSeat400Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class SeatsAssignSeat401Error(PolarClientError):
+class CustomerPortalSeatsAssignSeat401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -404,7 +404,7 @@ class SeatsAssignSeat401Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class SeatsAssignSeat403Error(PolarClientError):
+class CustomerPortalSeatsAssignSeat403Error(PolarClientError):
     error_type = None
     error: None
 
@@ -413,7 +413,7 @@ class SeatsAssignSeat403Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class SeatsAssignSeat404Error(PolarClientError):
+class CustomerPortalSeatsAssignSeat404Error(PolarClientError):
     error_type = None
     error: None
 
@@ -422,7 +422,7 @@ class SeatsAssignSeat404Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class SeatsRevokeSeat401Error(PolarClientError):
+class CustomerPortalSeatsRevokeSeat401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -431,7 +431,7 @@ class SeatsRevokeSeat401Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class SeatsRevokeSeat403Error(PolarClientError):
+class CustomerPortalSeatsRevokeSeat403Error(PolarClientError):
     error_type = None
     error: None
 
@@ -440,7 +440,7 @@ class SeatsRevokeSeat403Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class SeatsRevokeSeat404Error(PolarClientError):
+class CustomerPortalSeatsRevokeSeat404Error(PolarClientError):
     error_type = None
     error: None
 
@@ -449,7 +449,7 @@ class SeatsRevokeSeat404Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class SeatsResendInvitation400Error(PolarClientError):
+class CustomerPortalSeatsResendInvitation400Error(PolarClientError):
     error_type = None
     error: None
 
@@ -458,7 +458,7 @@ class SeatsResendInvitation400Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class SeatsResendInvitation401Error(PolarClientError):
+class CustomerPortalSeatsResendInvitation401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -467,7 +467,7 @@ class SeatsResendInvitation401Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class SeatsResendInvitation403Error(PolarClientError):
+class CustomerPortalSeatsResendInvitation403Error(PolarClientError):
     error_type = None
     error: None
 
@@ -476,7 +476,7 @@ class SeatsResendInvitation403Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class SeatsResendInvitation404Error(PolarClientError):
+class CustomerPortalSeatsResendInvitation404Error(PolarClientError):
     error_type = None
     error: None
 
@@ -485,7 +485,7 @@ class SeatsResendInvitation404Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class SeatsListClaimedSubscriptions401Error(PolarClientError):
+class CustomerPortalSeatsListClaimedSubscriptions401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -494,7 +494,7 @@ class SeatsListClaimedSubscriptions401Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class MembersListMembers401Error(PolarClientError):
+class CustomerPortalMembersListMembers401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -503,7 +503,7 @@ class MembersListMembers401Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class MembersListMembers403Error(PolarClientError):
+class CustomerPortalMembersListMembers403Error(PolarClientError):
     error_type = None
     error: None
 
@@ -512,7 +512,7 @@ class MembersListMembers403Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class MembersAddMember400Error(PolarClientError):
+class CustomerPortalMembersAddMember400Error(PolarClientError):
     error_type = None
     error: None
 
@@ -521,7 +521,7 @@ class MembersAddMember400Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class MembersAddMember401Error(PolarClientError):
+class CustomerPortalMembersAddMember401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -530,7 +530,7 @@ class MembersAddMember401Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class MembersAddMember403Error(PolarClientError):
+class CustomerPortalMembersAddMember403Error(PolarClientError):
     error_type = None
     error: None
 
@@ -539,7 +539,7 @@ class MembersAddMember403Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class MembersRemoveMember400Error(PolarClientError):
+class CustomerPortalMembersRemoveMember400Error(PolarClientError):
     error_type = None
     error: None
 
@@ -548,7 +548,7 @@ class MembersRemoveMember400Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class MembersRemoveMember401Error(PolarClientError):
+class CustomerPortalMembersRemoveMember401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -557,7 +557,7 @@ class MembersRemoveMember401Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class MembersRemoveMember403Error(PolarClientError):
+class CustomerPortalMembersRemoveMember403Error(PolarClientError):
     error_type = None
     error: None
 
@@ -566,7 +566,7 @@ class MembersRemoveMember403Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class MembersRemoveMember404Error(PolarClientError):
+class CustomerPortalMembersRemoveMember404Error(PolarClientError):
     error_type = None
     error: None
 
@@ -575,7 +575,7 @@ class MembersRemoveMember404Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class MembersUpdateMember400Error(PolarClientError):
+class CustomerPortalMembersUpdateMember400Error(PolarClientError):
     error_type = None
     error: None
 
@@ -584,7 +584,7 @@ class MembersUpdateMember400Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class MembersUpdateMember401Error(PolarClientError):
+class CustomerPortalMembersUpdateMember401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -593,7 +593,7 @@ class MembersUpdateMember401Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class MembersUpdateMember403Error(PolarClientError):
+class CustomerPortalMembersUpdateMember403Error(PolarClientError):
     error_type = None
     error: None
 
@@ -602,7 +602,7 @@ class MembersUpdateMember403Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class MembersUpdateMember404Error(PolarClientError):
+class CustomerPortalMembersUpdateMember404Error(PolarClientError):
     error_type = None
     error: None
 
@@ -638,7 +638,7 @@ class ManualRetryLimitExceeded(PolarClientError):
         super().__init__(status_code, error)
 
 
-class SubscriptionsUpdate403Error(PolarClientError):
+class CustomerPortalSubscriptionsUpdate403Error(PolarClientError):
     error_type = AlreadyCanceledSubscriptionModel | PauseResumeNotAllowedModel
     error: AlreadyCanceledSubscriptionModel | PauseResumeNotAllowedModel
 

--- a/sdk/python/polar/v2026_04/errors.py
+++ b/sdk/python/polar/v2026_04/errors.py
@@ -26,9 +26,6 @@ from polar.v2026_04.outputs import (
     HTTPValidationError as HTTPValidationErrorModel,
 )
 from polar.v2026_04.outputs import (
-    InactiveSubscription as InactiveSubscriptionModel,
-)
-from polar.v2026_04.outputs import (
     ManualRetryLimitExceeded as ManualRetryLimitExceededModel,
 )
 from polar.v2026_04.outputs import (
@@ -51,6 +48,9 @@ from polar.v2026_04.outputs import (
 )
 from polar.v2026_04.outputs import (
     OrganizationNotReadyForPayments as OrganizationNotReadyForPaymentsModel,
+)
+from polar.v2026_04.outputs import (
+    PauseResumeNotAllowed as PauseResumeNotAllowedModel,
 )
 from polar.v2026_04.outputs import (
     PaymentActionRequired as PaymentActionRequiredModel,
@@ -165,20 +165,7 @@ class PaymentFailed(PolarClientError):
         super().__init__(status_code, error)
 
 
-class SubscriptionsUpdate403Error(PolarClientError):
-    error_type = AlreadyCanceledSubscriptionModel | InactiveSubscriptionModel
-    error: AlreadyCanceledSubscriptionModel | InactiveSubscriptionModel
-
-    def __init__(
-        self,
-        status_code: int,
-        error: AlreadyCanceledSubscriptionModel | InactiveSubscriptionModel,
-    ) -> None:
-        self.error = error
-        super().__init__(status_code, error)
-
-
-class Finalize402Error(PolarClientError):
+class OrdersFinalize402Error(PolarClientError):
     error_type = PaymentFailedModel | PaymentActionRequiredModel
     error: PaymentFailedModel | PaymentActionRequiredModel
 
@@ -189,7 +176,7 @@ class Finalize402Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class Finalize403Error(PolarClientError):
+class OrdersFinalize403Error(PolarClientError):
     error_type = OffSessionChargesNotEnabledModel | OrganizationNotReadyForPaymentsModel
     error: OffSessionChargesNotEnabledModel | OrganizationNotReadyForPaymentsModel
 
@@ -251,7 +238,7 @@ class DisputeNotOpenError(PolarClientError):
         super().__init__(status_code, error)
 
 
-class Update403Error(PolarClientError):
+class CheckoutsUpdate403Error(PolarClientError):
     error_type = CheckoutForbiddenErrorModel
     error: CheckoutForbiddenErrorModel
 
@@ -269,7 +256,7 @@ class ExpiredCheckoutError(PolarClientError):
         super().__init__(status_code, error)
 
 
-class ClientUpdate403Error(PolarClientError):
+class CheckoutsClientUpdate403Error(PolarClientError):
     error_type = CheckoutForbiddenErrorModel
     error: CheckoutForbiddenErrorModel
 
@@ -287,7 +274,7 @@ class PaymentError(PolarClientError):
         super().__init__(status_code, error)
 
 
-class ClientConfirm403Error(PolarClientError):
+class CheckoutsClientConfirm403Error(PolarClientError):
     error_type = CheckoutForbiddenErrorModel
     error: CheckoutForbiddenErrorModel
 
@@ -345,7 +332,7 @@ class PaymentMethodInUseByActiveSubscription(PolarClientError):
         super().__init__(status_code, error)
 
 
-class CheckEmailUpdate401Error(PolarClientError):
+class CustomersCheckEmailUpdate401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -354,7 +341,7 @@ class CheckEmailUpdate401Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class VerifyEmailUpdate401Error(PolarClientError):
+class CustomersVerifyEmailUpdate401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -363,7 +350,7 @@ class VerifyEmailUpdate401Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class VerifyEmailUpdate422Error(PolarClientError):
+class CustomersVerifyEmailUpdate422Error(PolarClientError):
     error_type = None
     error: None
 
@@ -372,7 +359,7 @@ class VerifyEmailUpdate422Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class ListSeats401Error(PolarClientError):
+class SeatsListSeats401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -381,7 +368,7 @@ class ListSeats401Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class ListSeats403Error(PolarClientError):
+class SeatsListSeats403Error(PolarClientError):
     error_type = None
     error: None
 
@@ -390,7 +377,7 @@ class ListSeats403Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class ListSeats404Error(PolarClientError):
+class SeatsListSeats404Error(PolarClientError):
     error_type = None
     error: None
 
@@ -399,7 +386,7 @@ class ListSeats404Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class AssignSeat400Error(PolarClientError):
+class SeatsAssignSeat400Error(PolarClientError):
     error_type = None
     error: None
 
@@ -408,7 +395,7 @@ class AssignSeat400Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class AssignSeat401Error(PolarClientError):
+class SeatsAssignSeat401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -417,7 +404,7 @@ class AssignSeat401Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class AssignSeat403Error(PolarClientError):
+class SeatsAssignSeat403Error(PolarClientError):
     error_type = None
     error: None
 
@@ -426,7 +413,7 @@ class AssignSeat403Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class AssignSeat404Error(PolarClientError):
+class SeatsAssignSeat404Error(PolarClientError):
     error_type = None
     error: None
 
@@ -435,7 +422,7 @@ class AssignSeat404Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class RevokeSeat401Error(PolarClientError):
+class SeatsRevokeSeat401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -444,7 +431,7 @@ class RevokeSeat401Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class RevokeSeat403Error(PolarClientError):
+class SeatsRevokeSeat403Error(PolarClientError):
     error_type = None
     error: None
 
@@ -453,7 +440,7 @@ class RevokeSeat403Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class RevokeSeat404Error(PolarClientError):
+class SeatsRevokeSeat404Error(PolarClientError):
     error_type = None
     error: None
 
@@ -462,7 +449,7 @@ class RevokeSeat404Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class ResendInvitation400Error(PolarClientError):
+class SeatsResendInvitation400Error(PolarClientError):
     error_type = None
     error: None
 
@@ -471,7 +458,7 @@ class ResendInvitation400Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class ResendInvitation401Error(PolarClientError):
+class SeatsResendInvitation401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -480,7 +467,7 @@ class ResendInvitation401Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class ResendInvitation403Error(PolarClientError):
+class SeatsResendInvitation403Error(PolarClientError):
     error_type = None
     error: None
 
@@ -489,7 +476,7 @@ class ResendInvitation403Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class ResendInvitation404Error(PolarClientError):
+class SeatsResendInvitation404Error(PolarClientError):
     error_type = None
     error: None
 
@@ -498,7 +485,7 @@ class ResendInvitation404Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class ListClaimedSubscriptions401Error(PolarClientError):
+class SeatsListClaimedSubscriptions401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -507,7 +494,7 @@ class ListClaimedSubscriptions401Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class ListMembers401Error(PolarClientError):
+class MembersListMembers401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -516,7 +503,7 @@ class ListMembers401Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class ListMembers403Error(PolarClientError):
+class MembersListMembers403Error(PolarClientError):
     error_type = None
     error: None
 
@@ -525,7 +512,7 @@ class ListMembers403Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class AddMember400Error(PolarClientError):
+class MembersAddMember400Error(PolarClientError):
     error_type = None
     error: None
 
@@ -534,7 +521,7 @@ class AddMember400Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class AddMember401Error(PolarClientError):
+class MembersAddMember401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -543,7 +530,7 @@ class AddMember401Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class AddMember403Error(PolarClientError):
+class MembersAddMember403Error(PolarClientError):
     error_type = None
     error: None
 
@@ -552,7 +539,7 @@ class AddMember403Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class RemoveMember400Error(PolarClientError):
+class MembersRemoveMember400Error(PolarClientError):
     error_type = None
     error: None
 
@@ -561,7 +548,7 @@ class RemoveMember400Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class RemoveMember401Error(PolarClientError):
+class MembersRemoveMember401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -570,7 +557,7 @@ class RemoveMember401Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class RemoveMember403Error(PolarClientError):
+class MembersRemoveMember403Error(PolarClientError):
     error_type = None
     error: None
 
@@ -579,7 +566,7 @@ class RemoveMember403Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class RemoveMember404Error(PolarClientError):
+class MembersRemoveMember404Error(PolarClientError):
     error_type = None
     error: None
 
@@ -588,7 +575,7 @@ class RemoveMember404Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class UpdateMember400Error(PolarClientError):
+class MembersUpdateMember400Error(PolarClientError):
     error_type = None
     error: None
 
@@ -597,7 +584,7 @@ class UpdateMember400Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class UpdateMember401Error(PolarClientError):
+class MembersUpdateMember401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -606,7 +593,7 @@ class UpdateMember401Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class UpdateMember403Error(PolarClientError):
+class MembersUpdateMember403Error(PolarClientError):
     error_type = None
     error: None
 
@@ -615,7 +602,7 @@ class UpdateMember403Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class UpdateMember404Error(PolarClientError):
+class MembersUpdateMember404Error(PolarClientError):
     error_type = None
     error: None
 
@@ -651,7 +638,20 @@ class ManualRetryLimitExceeded(PolarClientError):
         super().__init__(status_code, error)
 
 
-class GetClaimInfo400Error(PolarClientError):
+class SubscriptionsUpdate403Error(PolarClientError):
+    error_type = AlreadyCanceledSubscriptionModel | PauseResumeNotAllowedModel
+    error: AlreadyCanceledSubscriptionModel | PauseResumeNotAllowedModel
+
+    def __init__(
+        self,
+        status_code: int,
+        error: AlreadyCanceledSubscriptionModel | PauseResumeNotAllowedModel,
+    ) -> None:
+        self.error = error
+        super().__init__(status_code, error)
+
+
+class CustomerSeatsListSeats401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -660,7 +660,7 @@ class GetClaimInfo400Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class GetClaimInfo403Error(PolarClientError):
+class CustomerSeatsListSeats403Error(PolarClientError):
     error_type = None
     error: None
 
@@ -669,7 +669,7 @@ class GetClaimInfo403Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class GetClaimInfo404Error(PolarClientError):
+class CustomerSeatsListSeats404Error(PolarClientError):
     error_type = None
     error: None
 
@@ -678,7 +678,7 @@ class GetClaimInfo404Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class ClaimSeat400Error(PolarClientError):
+class CustomerSeatsAssignSeat400Error(PolarClientError):
     error_type = None
     error: None
 
@@ -687,7 +687,7 @@ class ClaimSeat400Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class ClaimSeat403Error(PolarClientError):
+class CustomerSeatsAssignSeat401Error(PolarClientError):
     error_type = None
     error: None
 
@@ -696,7 +696,133 @@ class ClaimSeat403Error(PolarClientError):
         super().__init__(status_code, error)
 
 
-class Update404Error(PolarClientError):
+class CustomerSeatsAssignSeat403Error(PolarClientError):
+    error_type = None
+    error: None
+
+    def __init__(self, status_code: int, error: None) -> None:
+        self.error = error
+        super().__init__(status_code, error)
+
+
+class CustomerSeatsAssignSeat404Error(PolarClientError):
+    error_type = None
+    error: None
+
+    def __init__(self, status_code: int, error: None) -> None:
+        self.error = error
+        super().__init__(status_code, error)
+
+
+class CustomerSeatsRevokeSeat401Error(PolarClientError):
+    error_type = None
+    error: None
+
+    def __init__(self, status_code: int, error: None) -> None:
+        self.error = error
+        super().__init__(status_code, error)
+
+
+class CustomerSeatsRevokeSeat403Error(PolarClientError):
+    error_type = None
+    error: None
+
+    def __init__(self, status_code: int, error: None) -> None:
+        self.error = error
+        super().__init__(status_code, error)
+
+
+class CustomerSeatsRevokeSeat404Error(PolarClientError):
+    error_type = None
+    error: None
+
+    def __init__(self, status_code: int, error: None) -> None:
+        self.error = error
+        super().__init__(status_code, error)
+
+
+class CustomerSeatsResendInvitation400Error(PolarClientError):
+    error_type = None
+    error: None
+
+    def __init__(self, status_code: int, error: None) -> None:
+        self.error = error
+        super().__init__(status_code, error)
+
+
+class CustomerSeatsResendInvitation401Error(PolarClientError):
+    error_type = None
+    error: None
+
+    def __init__(self, status_code: int, error: None) -> None:
+        self.error = error
+        super().__init__(status_code, error)
+
+
+class CustomerSeatsResendInvitation403Error(PolarClientError):
+    error_type = None
+    error: None
+
+    def __init__(self, status_code: int, error: None) -> None:
+        self.error = error
+        super().__init__(status_code, error)
+
+
+class CustomerSeatsResendInvitation404Error(PolarClientError):
+    error_type = None
+    error: None
+
+    def __init__(self, status_code: int, error: None) -> None:
+        self.error = error
+        super().__init__(status_code, error)
+
+
+class CustomerSeatsGetClaimInfo400Error(PolarClientError):
+    error_type = None
+    error: None
+
+    def __init__(self, status_code: int, error: None) -> None:
+        self.error = error
+        super().__init__(status_code, error)
+
+
+class CustomerSeatsGetClaimInfo403Error(PolarClientError):
+    error_type = None
+    error: None
+
+    def __init__(self, status_code: int, error: None) -> None:
+        self.error = error
+        super().__init__(status_code, error)
+
+
+class CustomerSeatsGetClaimInfo404Error(PolarClientError):
+    error_type = None
+    error: None
+
+    def __init__(self, status_code: int, error: None) -> None:
+        self.error = error
+        super().__init__(status_code, error)
+
+
+class CustomerSeatsClaimSeat400Error(PolarClientError):
+    error_type = None
+    error: None
+
+    def __init__(self, status_code: int, error: None) -> None:
+        self.error = error
+        super().__init__(status_code, error)
+
+
+class CustomerSeatsClaimSeat403Error(PolarClientError):
+    error_type = None
+    error: None
+
+    def __init__(self, status_code: int, error: None) -> None:
+        self.error = error
+        super().__init__(status_code, error)
+
+
+class EventTypesUpdate404Error(PolarClientError):
     error_type = None
     error: None
 

--- a/sdk/python/polar/v2026_04/inputs.py
+++ b/sdk/python/polar/v2026_04/inputs.py
@@ -93,13 +93,13 @@ You can store up to **50 key-value pairs**."""
 class BenefitCustomCreateProperties(typing.TypedDict):
     """Properties for creating a benefit of type `custom`."""
 
-    note: typing.NotRequired[str | None | None]
+    note: typing.NotRequired[str | None]
 
 
 class BenefitCustomProperties(typing.TypedDict):
     """Properties for a benefit of type `custom`."""
 
-    note: str | None | None
+    note: str | None
 
 
 class BenefitCustomUpdate(typing.TypedDict):
@@ -278,13 +278,11 @@ You can store up to **50 key-value pairs**."""
 class BenefitFeatureFlagCreateProperties(typing.TypedDict):
     """Properties for creating a benefit of type `feature_flag`."""
 
-    ...
 
 
 class BenefitFeatureFlagProperties(typing.TypedDict):
     """Properties for a benefit of type `feature_flag`."""
 
-    ...
 
 
 class BenefitFeatureFlagUpdate(typing.TypedDict):
@@ -583,7 +581,7 @@ You can store up to **50 key-value pairs**."""
 class CheckoutConfirmStripe(typing.TypedDict):
     """Confirm a checkout session using a Stripe confirmation token."""
 
-    custom_field_data: typing.NotRequired[dict[str, str | int | bool | str | None]]
+    custom_field_data: typing.NotRequired[dict[str, str | int | bool | None]]
     """Key-value object storing custom field values."""
 
     product_id: typing.NotRequired[str | None]
@@ -650,7 +648,7 @@ The value must be either:
 
 You can store up to **50 key-value pairs**."""
 
-    custom_field_data: typing.NotRequired[dict[str, str | int | bool | str | None]]
+    custom_field_data: typing.NotRequired[dict[str, str | int | bool | None]]
     """Key-value object storing custom field values."""
 
     discount_id: typing.NotRequired[str | None]
@@ -945,7 +943,7 @@ You can store up to **50 key-value pairs**."""
 class CheckoutUpdate(typing.TypedDict):
     """Update an existing checkout session using an access token."""
 
-    custom_field_data: typing.NotRequired[dict[str, str | int | bool | str | None]]
+    custom_field_data: typing.NotRequired[dict[str, str | int | bool | None]]
     """Key-value object storing custom field values."""
 
     product_id: typing.NotRequired[str | None]
@@ -1034,7 +1032,7 @@ You can store up to **50 key-value pairs**."""
 class CheckoutUpdatePublic(typing.TypedDict):
     """Update an existing checkout session using the client secret."""
 
-    custom_field_data: typing.NotRequired[dict[str, str | int | bool | str | None]]
+    custom_field_data: typing.NotRequired[dict[str, str | int | bool | None]]
     """Key-value object storing custom field values."""
 
     product_id: typing.NotRequired[str | None]
@@ -2343,7 +2341,7 @@ class OAuth2ClientConfiguration(typing.TypedDict):
 
     grant_types: typing.NotRequired[
         list[
-            typing.Literal["authorization_code"] | typing.Literal["refresh_token"]
+            typing.Literal["authorization_code", "refresh_token"]
         ]
     ]
 
@@ -2371,7 +2369,7 @@ class OAuth2ClientConfigurationUpdate(typing.TypedDict):
 
     grant_types: typing.NotRequired[
         list[
-            typing.Literal["authorization_code"] | typing.Literal["refresh_token"]
+            typing.Literal["authorization_code", "refresh_token"]
         ]
     ]
 
@@ -2397,7 +2395,7 @@ class OAuth2ClientConfigurationUpdate(typing.TypedDict):
 class OrderCreate(typing.TypedDict):
     """Schema to create a draft order for an off-session charge."""
 
-    custom_field_data: typing.NotRequired[dict[str, str | int | bool | str | None]]
+    custom_field_data: typing.NotRequired[dict[str, str | int | bool | None]]
     """Key-value object storing custom field values."""
 
     metadata: typing.NotRequired[dict[str, str | int | float | bool]]
@@ -2584,12 +2582,7 @@ class OrganizationDetails(typing.TypedDict):
     """Switching from another platform?"""
 
     switching_from: typing.NotRequired[
-        typing.Literal["paddle"]
-        | typing.Literal["lemon_squeezy"]
-        | typing.Literal["gumroad"]
-        | typing.Literal["stripe"]
-        | typing.Literal["other"]
-        | None
+        typing.Literal["paddle", "lemon_squeezy", "gumroad", "stripe", "other"] | None
     ]
     """Which platform the organization is migrating from."""
 

--- a/sdk/python/polar/v2026_04/literals.py
+++ b/sdk/python/polar/v2026_04/literals.py
@@ -786,7 +786,6 @@ PaymentTrigger: typing.TypeAlias = typing.Literal[
 Permission: typing.TypeAlias = typing.Literal[
     "pull", "triage", "push", "maintain", "admin"
 ]
-"""The permission level to grant. Read more about roles and their permissions on [GitHub documentation](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role)."""
 PresentmentCurrency: typing.TypeAlias = typing.Literal[
     "aed",
     "all",

--- a/sdk/python/polar/v2026_04/outputs.py
+++ b/sdk/python/polar/v2026_04/outputs.py
@@ -748,7 +748,7 @@ class BenefitCustom:
 class BenefitCustomProperties:
     """Properties for a benefit of type `custom`."""
 
-    note: str | None | None
+    note: str | None
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
@@ -788,7 +788,7 @@ class BenefitCustomSubscriber:
 class BenefitCustomSubscriberProperties:
     """Properties available to subscribers for a benefit of type `custom`."""
 
-    note: str | None | None
+    note: str | None
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
@@ -1063,7 +1063,6 @@ class BenefitFeatureFlag:
 class BenefitFeatureFlagProperties:
     """Properties for a benefit of type `feature_flag`."""
 
-    ...
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
@@ -1103,7 +1102,6 @@ class BenefitFeatureFlagSubscriber:
 class BenefitFeatureFlagSubscriberProperties:
     """Properties available to subscribers for a benefit of type `feature_flag`."""
 
-    ...
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
@@ -2340,7 +2338,7 @@ class Checkout:
     modified_at: str | None
     """Last modification timestamp of the object."""
 
-    custom_field_data: dict[str, str | int | bool | str | None] | None = None
+    custom_field_data: dict[str, str | int | bool | None] | None = None
     """Key-value object storing custom field values."""
 
     payment_processor: PaymentProcessor
@@ -2886,7 +2884,7 @@ class CheckoutPublic:
     modified_at: str | None
     """Last modification timestamp of the object."""
 
-    custom_field_data: dict[str, str | int | bool | str | None] | None = None
+    custom_field_data: dict[str, str | int | bool | None] | None = None
     """Key-value object storing custom field values."""
 
     payment_processor: PaymentProcessor
@@ -3055,7 +3053,7 @@ class CheckoutPublicConfirmed:
     modified_at: str | None
     """Last modification timestamp of the object."""
 
-    custom_field_data: dict[str, str | int | bool | str | None] | None = None
+    custom_field_data: dict[str, str | int | bool | None] | None = None
     """Key-value object storing custom field values."""
 
     payment_processor: PaymentProcessor
@@ -4758,7 +4756,7 @@ class CustomerStateSubscription:
     modified_at: str | None
     """Last modification timestamp of the object."""
 
-    custom_field_data: dict[str, str | int | bool | str | None] | None = None
+    custom_field_data: dict[str, str | int | bool | None] | None = None
     """Key-value object storing custom field values."""
 
     metadata: MetadataOutputType
@@ -6073,13 +6071,6 @@ class HTTPValidationError:
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
-class InactiveSubscription:
-    error: typing.Literal["InactiveSubscription"]
-
-    detail: str
-
-
-@dataclasses.dataclass(kw_only=True, slots=True)
 class IntrospectTokenResponse:
     active: bool
 
@@ -6857,115 +6848,115 @@ class MetricPeriod:
     timestamp: str
     """Timestamp of this period data."""
 
-    active_subscriptions: int | float | None | None = None
+    active_subscriptions: int | float | None = None
 
-    committed_subscriptions: int | float | None | None = None
+    committed_subscriptions: int | float | None = None
 
-    monthly_recurring_revenue: int | float | None | None = None
+    monthly_recurring_revenue: int | float | None = None
 
-    trial_monthly_recurring_revenue: int | float | None | None = None
+    trial_monthly_recurring_revenue: int | float | None = None
 
-    committed_monthly_recurring_revenue: int | float | None | None = None
+    committed_monthly_recurring_revenue: int | float | None = None
 
-    trial_committed_monthly_recurring_revenue: int | float | None | None = None
+    trial_committed_monthly_recurring_revenue: int | float | None = None
 
-    average_revenue_per_user: int | float | None | None = None
+    average_revenue_per_user: int | float | None = None
 
-    checkouts: int | float | None | None = None
+    checkouts: int | float | None = None
 
-    succeeded_checkouts: int | float | None | None = None
+    succeeded_checkouts: int | float | None = None
 
-    churned_subscriptions: int | float | None | None = None
+    churned_subscriptions: int | float | None = None
 
-    churn_rate: int | float | None | None = None
+    churn_rate: int | float | None = None
 
-    seats_total: int | float | None | None = None
+    seats_total: int | float | None = None
 
-    seats_claimed: int | float | None | None = None
+    seats_claimed: int | float | None = None
 
-    seats_pending: int | float | None | None = None
+    seats_pending: int | float | None = None
 
-    seat_customers: int | float | None | None = None
+    seat_customers: int | float | None = None
 
-    new_seat_customers: int | float | None | None = None
+    new_seat_customers: int | float | None = None
 
-    churned_seat_customers: int | float | None | None = None
+    churned_seat_customers: int | float | None = None
 
-    orders: int | float | None | None = None
+    orders: int | float | None = None
 
-    revenue: int | float | None | None = None
+    revenue: int | float | None = None
 
-    net_revenue: int | float | None | None = None
+    net_revenue: int | float | None = None
 
-    cumulative_revenue: int | float | None | None = None
+    cumulative_revenue: int | float | None = None
 
-    net_cumulative_revenue: int | float | None | None = None
+    net_cumulative_revenue: int | float | None = None
 
-    costs: int | float | None | None = None
+    costs: int | float | None = None
 
-    cumulative_costs: int | float | None | None = None
+    cumulative_costs: int | float | None = None
 
-    average_order_value: int | float | None | None = None
+    average_order_value: int | float | None = None
 
-    net_average_order_value: int | float | None | None = None
+    net_average_order_value: int | float | None = None
 
-    cost_per_user: int | float | None | None = None
+    cost_per_user: int | float | None = None
 
-    active_user_by_event: int | float | None | None = None
+    active_user_by_event: int | float | None = None
 
-    one_time_products: int | float | None | None = None
+    one_time_products: int | float | None = None
 
-    one_time_products_revenue: int | float | None | None = None
+    one_time_products_revenue: int | float | None = None
 
-    one_time_products_net_revenue: int | float | None | None = None
+    one_time_products_net_revenue: int | float | None = None
 
-    new_subscriptions: int | float | None | None = None
+    new_subscriptions: int | float | None = None
 
-    new_subscriptions_revenue: int | float | None | None = None
+    new_subscriptions_revenue: int | float | None = None
 
-    new_subscriptions_net_revenue: int | float | None | None = None
+    new_subscriptions_net_revenue: int | float | None = None
 
-    renewed_subscriptions: int | float | None | None = None
+    renewed_subscriptions: int | float | None = None
 
-    renewed_subscriptions_revenue: int | float | None | None = None
+    renewed_subscriptions_revenue: int | float | None = None
 
-    renewed_subscriptions_net_revenue: int | float | None | None = None
+    renewed_subscriptions_net_revenue: int | float | None = None
 
-    canceled_subscriptions: int | float | None | None = None
+    canceled_subscriptions: int | float | None = None
 
-    canceled_subscriptions_customer_service: int | float | None | None = None
+    canceled_subscriptions_customer_service: int | float | None = None
 
-    canceled_subscriptions_low_quality: int | float | None | None = None
+    canceled_subscriptions_low_quality: int | float | None = None
 
-    canceled_subscriptions_missing_features: int | float | None | None = None
+    canceled_subscriptions_missing_features: int | float | None = None
 
-    canceled_subscriptions_switched_service: int | float | None | None = None
+    canceled_subscriptions_switched_service: int | float | None = None
 
-    canceled_subscriptions_too_complex: int | float | None | None = None
+    canceled_subscriptions_too_complex: int | float | None = None
 
-    canceled_subscriptions_too_expensive: int | float | None | None = None
+    canceled_subscriptions_too_expensive: int | float | None = None
 
-    canceled_subscriptions_unused: int | float | None | None = None
+    canceled_subscriptions_unused: int | float | None = None
 
-    canceled_subscriptions_other: int | float | None | None = None
+    canceled_subscriptions_other: int | float | None = None
 
-    annual_recurring_revenue: int | float | None | None = None
+    annual_recurring_revenue: int | float | None = None
 
-    committed_annual_recurring_revenue: int | float | None | None = None
+    committed_annual_recurring_revenue: int | float | None = None
 
-    checkouts_conversion: int | float | None | None = None
+    checkouts_conversion: int | float | None = None
 
-    ltv: int | float | None | None = None
+    ltv: int | float | None = None
 
-    gross_margin: int | float | None | None = None
+    gross_margin: int | float | None = None
 
-    gross_margin_percentage: int | float | None | None = None
+    gross_margin_percentage: int | float | None = None
 
-    cashflow: int | float | None | None = None
+    cashflow: int | float | None = None
 
-    average_seats_per_customer: int | float | None | None = None
+    average_seats_per_customer: int | float | None = None
 
-    seat_utilization_rate: int | float | None | None = None
+    seat_utilization_rate: int | float | None = None
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
@@ -7131,115 +7122,115 @@ class MetricsResponse:
 
 @dataclasses.dataclass(kw_only=True, slots=True)
 class MetricsTotals:
-    active_subscriptions: int | float | None | None = None
+    active_subscriptions: int | float | None = None
 
-    committed_subscriptions: int | float | None | None = None
+    committed_subscriptions: int | float | None = None
 
-    monthly_recurring_revenue: int | float | None | None = None
+    monthly_recurring_revenue: int | float | None = None
 
-    trial_monthly_recurring_revenue: int | float | None | None = None
+    trial_monthly_recurring_revenue: int | float | None = None
 
-    committed_monthly_recurring_revenue: int | float | None | None = None
+    committed_monthly_recurring_revenue: int | float | None = None
 
-    trial_committed_monthly_recurring_revenue: int | float | None | None = None
+    trial_committed_monthly_recurring_revenue: int | float | None = None
 
-    average_revenue_per_user: int | float | None | None = None
+    average_revenue_per_user: int | float | None = None
 
-    checkouts: int | float | None | None = None
+    checkouts: int | float | None = None
 
-    succeeded_checkouts: int | float | None | None = None
+    succeeded_checkouts: int | float | None = None
 
-    churned_subscriptions: int | float | None | None = None
+    churned_subscriptions: int | float | None = None
 
-    churn_rate: int | float | None | None = None
+    churn_rate: int | float | None = None
 
-    seats_total: int | float | None | None = None
+    seats_total: int | float | None = None
 
-    seats_claimed: int | float | None | None = None
+    seats_claimed: int | float | None = None
 
-    seats_pending: int | float | None | None = None
+    seats_pending: int | float | None = None
 
-    seat_customers: int | float | None | None = None
+    seat_customers: int | float | None = None
 
-    new_seat_customers: int | float | None | None = None
+    new_seat_customers: int | float | None = None
 
-    churned_seat_customers: int | float | None | None = None
+    churned_seat_customers: int | float | None = None
 
-    orders: int | float | None | None = None
+    orders: int | float | None = None
 
-    revenue: int | float | None | None = None
+    revenue: int | float | None = None
 
-    net_revenue: int | float | None | None = None
+    net_revenue: int | float | None = None
 
-    cumulative_revenue: int | float | None | None = None
+    cumulative_revenue: int | float | None = None
 
-    net_cumulative_revenue: int | float | None | None = None
+    net_cumulative_revenue: int | float | None = None
 
-    costs: int | float | None | None = None
+    costs: int | float | None = None
 
-    cumulative_costs: int | float | None | None = None
+    cumulative_costs: int | float | None = None
 
-    average_order_value: int | float | None | None = None
+    average_order_value: int | float | None = None
 
-    net_average_order_value: int | float | None | None = None
+    net_average_order_value: int | float | None = None
 
-    cost_per_user: int | float | None | None = None
+    cost_per_user: int | float | None = None
 
-    active_user_by_event: int | float | None | None = None
+    active_user_by_event: int | float | None = None
 
-    one_time_products: int | float | None | None = None
+    one_time_products: int | float | None = None
 
-    one_time_products_revenue: int | float | None | None = None
+    one_time_products_revenue: int | float | None = None
 
-    one_time_products_net_revenue: int | float | None | None = None
+    one_time_products_net_revenue: int | float | None = None
 
-    new_subscriptions: int | float | None | None = None
+    new_subscriptions: int | float | None = None
 
-    new_subscriptions_revenue: int | float | None | None = None
+    new_subscriptions_revenue: int | float | None = None
 
-    new_subscriptions_net_revenue: int | float | None | None = None
+    new_subscriptions_net_revenue: int | float | None = None
 
-    renewed_subscriptions: int | float | None | None = None
+    renewed_subscriptions: int | float | None = None
 
-    renewed_subscriptions_revenue: int | float | None | None = None
+    renewed_subscriptions_revenue: int | float | None = None
 
-    renewed_subscriptions_net_revenue: int | float | None | None = None
+    renewed_subscriptions_net_revenue: int | float | None = None
 
-    canceled_subscriptions: int | float | None | None = None
+    canceled_subscriptions: int | float | None = None
 
-    canceled_subscriptions_customer_service: int | float | None | None = None
+    canceled_subscriptions_customer_service: int | float | None = None
 
-    canceled_subscriptions_low_quality: int | float | None | None = None
+    canceled_subscriptions_low_quality: int | float | None = None
 
-    canceled_subscriptions_missing_features: int | float | None | None = None
+    canceled_subscriptions_missing_features: int | float | None = None
 
-    canceled_subscriptions_switched_service: int | float | None | None = None
+    canceled_subscriptions_switched_service: int | float | None = None
 
-    canceled_subscriptions_too_complex: int | float | None | None = None
+    canceled_subscriptions_too_complex: int | float | None = None
 
-    canceled_subscriptions_too_expensive: int | float | None | None = None
+    canceled_subscriptions_too_expensive: int | float | None = None
 
-    canceled_subscriptions_unused: int | float | None | None = None
+    canceled_subscriptions_unused: int | float | None = None
 
-    canceled_subscriptions_other: int | float | None | None = None
+    canceled_subscriptions_other: int | float | None = None
 
-    annual_recurring_revenue: int | float | None | None = None
+    annual_recurring_revenue: int | float | None = None
 
-    committed_annual_recurring_revenue: int | float | None | None = None
+    committed_annual_recurring_revenue: int | float | None = None
 
-    checkouts_conversion: int | float | None | None = None
+    checkouts_conversion: int | float | None = None
 
-    ltv: int | float | None | None = None
+    ltv: int | float | None = None
 
-    gross_margin: int | float | None | None = None
+    gross_margin: int | float | None = None
 
-    gross_margin_percentage: int | float | None | None = None
+    gross_margin_percentage: int | float | None = None
 
-    cashflow: int | float | None | None = None
+    cashflow: int | float | None = None
 
-    average_seats_per_customer: int | float | None | None = None
+    average_seats_per_customer: int | float | None = None
 
-    seat_utilization_rate: int | float | None | None = None
+    seat_utilization_rate: int | float | None = None
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
@@ -7370,7 +7361,7 @@ class Order:
 
     metadata: MetadataOutputType
 
-    custom_field_data: dict[str, str | int | bool | str | None] | None = None
+    custom_field_data: dict[str, str | int | bool | None] | None = None
     """Key-value object storing custom field values."""
 
     platform_fee_amount: int
@@ -8877,7 +8868,7 @@ class Subscription:
 
     metadata: MetadataOutputType
 
-    custom_field_data: dict[str, str | int | bool | str | None] | None = None
+    custom_field_data: dict[str, str | int | bool | None] | None = None
     """Key-value object storing custom field values."""
 
     customer: SubscriptionCustomer

--- a/sdk/python/polar/v2026_04/services/checkouts.py
+++ b/sdk/python/polar/v2026_04/services/checkouts.py
@@ -5,13 +5,13 @@ import typing
 
 from polar.base import AsyncServiceBase, SyncServiceBase, parse_response_json
 from polar.v2026_04.errors import (
-    ClientConfirm403Error,
-    ClientUpdate403Error,
+    CheckoutsClientConfirm403Error,
+    CheckoutsClientUpdate403Error,
+    CheckoutsUpdate403Error,
     ExpiredCheckoutError,
     HTTPValidationError,
     PaymentError,
     ResourceNotFound,
-    Update403Error,
 )
 from polar.v2026_04.inputs import (
     CheckoutConfirmStripe,
@@ -224,7 +224,7 @@ class CheckoutsSync(SyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            Update403Error: The checkout is expired, the customer already has an active subscription, or the organization is not ready to accept payments.
+            CheckoutsUpdate403Error: The checkout is expired, the customer already has an active subscription, or the organization is not ready to accept payments.
             ResourceNotFound: Checkout session not found.
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
@@ -242,7 +242,7 @@ class CheckoutsSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            403: Update403Error,
+            403: CheckoutsUpdate403Error,
             404: ResourceNotFound,
             422: HTTPValidationError,
         }
@@ -295,7 +295,7 @@ class CheckoutsSync(SyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            ClientUpdate403Error: The checkout is expired, the customer already has an active subscription, or the organization is not ready to accept payments.
+            CheckoutsClientUpdate403Error: The checkout is expired, the customer already has an active subscription, or the organization is not ready to accept payments.
             ResourceNotFound: Checkout session not found.
             ExpiredCheckoutError: The checkout session is expired.
             HTTPValidationError: Validation Error
@@ -314,7 +314,7 @@ class CheckoutsSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            403: ClientUpdate403Error,
+            403: CheckoutsClientUpdate403Error,
             404: ResourceNotFound,
             410: ExpiredCheckoutError,
             422: HTTPValidationError,
@@ -337,7 +337,7 @@ class CheckoutsSync(SyncServiceBase):
 
         Raises:
             PaymentError: The payment failed.
-            ClientConfirm403Error: The checkout is expired, the customer already has an active subscription, or the organization is not ready to accept payments.
+            CheckoutsClientConfirm403Error: The checkout is expired, the customer already has an active subscription, or the organization is not ready to accept payments.
             ResourceNotFound: Checkout session not found.
             ExpiredCheckoutError: The checkout session is expired.
             HTTPValidationError: Validation Error
@@ -357,7 +357,7 @@ class CheckoutsSync(SyncServiceBase):
         response = self.client.send_request(request)
         method_errors = {
             400: PaymentError,
-            403: ClientConfirm403Error,
+            403: CheckoutsClientConfirm403Error,
             404: ResourceNotFound,
             410: ExpiredCheckoutError,
             422: HTTPValidationError,
@@ -559,7 +559,7 @@ class CheckoutsAsync(AsyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            Update403Error: The checkout is expired, the customer already has an active subscription, or the organization is not ready to accept payments.
+            CheckoutsUpdate403Error: The checkout is expired, the customer already has an active subscription, or the organization is not ready to accept payments.
             ResourceNotFound: Checkout session not found.
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
@@ -577,7 +577,7 @@ class CheckoutsAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            403: Update403Error,
+            403: CheckoutsUpdate403Error,
             404: ResourceNotFound,
             422: HTTPValidationError,
         }
@@ -630,7 +630,7 @@ class CheckoutsAsync(AsyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            ClientUpdate403Error: The checkout is expired, the customer already has an active subscription, or the organization is not ready to accept payments.
+            CheckoutsClientUpdate403Error: The checkout is expired, the customer already has an active subscription, or the organization is not ready to accept payments.
             ResourceNotFound: Checkout session not found.
             ExpiredCheckoutError: The checkout session is expired.
             HTTPValidationError: Validation Error
@@ -649,7 +649,7 @@ class CheckoutsAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            403: ClientUpdate403Error,
+            403: CheckoutsClientUpdate403Error,
             404: ResourceNotFound,
             410: ExpiredCheckoutError,
             422: HTTPValidationError,
@@ -672,7 +672,7 @@ class CheckoutsAsync(AsyncServiceBase):
 
         Raises:
             PaymentError: The payment failed.
-            ClientConfirm403Error: The checkout is expired, the customer already has an active subscription, or the organization is not ready to accept payments.
+            CheckoutsClientConfirm403Error: The checkout is expired, the customer already has an active subscription, or the organization is not ready to accept payments.
             ResourceNotFound: Checkout session not found.
             ExpiredCheckoutError: The checkout session is expired.
             HTTPValidationError: Validation Error
@@ -692,7 +692,7 @@ class CheckoutsAsync(AsyncServiceBase):
         response = await self.client.send_request(request)
         method_errors = {
             400: PaymentError,
-            403: ClientConfirm403Error,
+            403: CheckoutsClientConfirm403Error,
             404: ResourceNotFound,
             410: ExpiredCheckoutError,
             422: HTTPValidationError,

--- a/sdk/python/polar/v2026_04/services/customer_portal/customers.py
+++ b/sdk/python/polar/v2026_04/services/customer_portal/customers.py
@@ -9,14 +9,14 @@ from polar.base import (
     parse_response_none,
 )
 from polar.v2026_04.errors import (
-    CheckEmailUpdate401Error,
     CustomerNotReady,
+    CustomersCheckEmailUpdate401Error,
+    CustomersVerifyEmailUpdate401Error,
+    CustomersVerifyEmailUpdate422Error,
     HTTPValidationError,
     PaymentMethodInUseByActiveSubscription,
     PaymentMethodSetupFailed,
     ResourceNotFound,
-    VerifyEmailUpdate401Error,
-    VerifyEmailUpdate422Error,
 )
 from polar.v2026_04.inputs import (
     CustomerEmailUpdateRequest,
@@ -297,7 +297,7 @@ class CustomersSync(SyncServiceBase):
             token:
 
         Raises:
-            CheckEmailUpdate401Error: Invalid or expired verification token.
+            CustomersCheckEmailUpdate401Error: Invalid or expired verification token.
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -313,7 +313,7 @@ class CustomersSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            401: CheckEmailUpdate401Error,
+            401: CustomersCheckEmailUpdate401Error,
             422: HTTPValidationError,
         }
         return parse_response_none(response, method_errors)
@@ -329,8 +329,8 @@ class CustomersSync(SyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            VerifyEmailUpdate401Error: Invalid or expired verification token.
-            VerifyEmailUpdate422Error: Email address is already in use.
+            CustomersVerifyEmailUpdate401Error: Invalid or expired verification token.
+            CustomersVerifyEmailUpdate422Error: Email address is already in use.
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
             PolarServerError: Raised when the server returns a 5xx error response.
@@ -344,8 +344,8 @@ class CustomersSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            401: VerifyEmailUpdate401Error,
-            422: VerifyEmailUpdate422Error,
+            401: CustomersVerifyEmailUpdate401Error,
+            422: CustomersVerifyEmailUpdate422Error,
         }
         return parse_response_json(
             response, CustomerEmailUpdateVerifyResponse, method_errors
@@ -616,7 +616,7 @@ class CustomersAsync(AsyncServiceBase):
             token:
 
         Raises:
-            CheckEmailUpdate401Error: Invalid or expired verification token.
+            CustomersCheckEmailUpdate401Error: Invalid or expired verification token.
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -632,7 +632,7 @@ class CustomersAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            401: CheckEmailUpdate401Error,
+            401: CustomersCheckEmailUpdate401Error,
             422: HTTPValidationError,
         }
         return parse_response_none(response, method_errors)
@@ -648,8 +648,8 @@ class CustomersAsync(AsyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            VerifyEmailUpdate401Error: Invalid or expired verification token.
-            VerifyEmailUpdate422Error: Email address is already in use.
+            CustomersVerifyEmailUpdate401Error: Invalid or expired verification token.
+            CustomersVerifyEmailUpdate422Error: Email address is already in use.
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
             PolarServerError: Raised when the server returns a 5xx error response.
@@ -663,8 +663,8 @@ class CustomersAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            401: VerifyEmailUpdate401Error,
-            422: VerifyEmailUpdate422Error,
+            401: CustomersVerifyEmailUpdate401Error,
+            422: CustomersVerifyEmailUpdate422Error,
         }
         return parse_response_json(
             response, CustomerEmailUpdateVerifyResponse, method_errors

--- a/sdk/python/polar/v2026_04/services/customer_portal/customers.py
+++ b/sdk/python/polar/v2026_04/services/customer_portal/customers.py
@@ -10,9 +10,9 @@ from polar.base import (
 )
 from polar.v2026_04.errors import (
     CustomerNotReady,
-    CustomersCheckEmailUpdate401Error,
-    CustomersVerifyEmailUpdate401Error,
-    CustomersVerifyEmailUpdate422Error,
+    CustomerPortalCustomersCheckEmailUpdate401Error,
+    CustomerPortalCustomersVerifyEmailUpdate401Error,
+    CustomerPortalCustomersVerifyEmailUpdate422Error,
     HTTPValidationError,
     PaymentMethodInUseByActiveSubscription,
     PaymentMethodSetupFailed,
@@ -297,7 +297,7 @@ class CustomersSync(SyncServiceBase):
             token:
 
         Raises:
-            CustomersCheckEmailUpdate401Error: Invalid or expired verification token.
+            CustomerPortalCustomersCheckEmailUpdate401Error: Invalid or expired verification token.
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -313,7 +313,7 @@ class CustomersSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            401: CustomersCheckEmailUpdate401Error,
+            401: CustomerPortalCustomersCheckEmailUpdate401Error,
             422: HTTPValidationError,
         }
         return parse_response_none(response, method_errors)
@@ -329,8 +329,8 @@ class CustomersSync(SyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            CustomersVerifyEmailUpdate401Error: Invalid or expired verification token.
-            CustomersVerifyEmailUpdate422Error: Email address is already in use.
+            CustomerPortalCustomersVerifyEmailUpdate401Error: Invalid or expired verification token.
+            CustomerPortalCustomersVerifyEmailUpdate422Error: Email address is already in use.
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
             PolarServerError: Raised when the server returns a 5xx error response.
@@ -344,8 +344,8 @@ class CustomersSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            401: CustomersVerifyEmailUpdate401Error,
-            422: CustomersVerifyEmailUpdate422Error,
+            401: CustomerPortalCustomersVerifyEmailUpdate401Error,
+            422: CustomerPortalCustomersVerifyEmailUpdate422Error,
         }
         return parse_response_json(
             response, CustomerEmailUpdateVerifyResponse, method_errors
@@ -616,7 +616,7 @@ class CustomersAsync(AsyncServiceBase):
             token:
 
         Raises:
-            CustomersCheckEmailUpdate401Error: Invalid or expired verification token.
+            CustomerPortalCustomersCheckEmailUpdate401Error: Invalid or expired verification token.
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -632,7 +632,7 @@ class CustomersAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            401: CustomersCheckEmailUpdate401Error,
+            401: CustomerPortalCustomersCheckEmailUpdate401Error,
             422: HTTPValidationError,
         }
         return parse_response_none(response, method_errors)
@@ -648,8 +648,8 @@ class CustomersAsync(AsyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            CustomersVerifyEmailUpdate401Error: Invalid or expired verification token.
-            CustomersVerifyEmailUpdate422Error: Email address is already in use.
+            CustomerPortalCustomersVerifyEmailUpdate401Error: Invalid or expired verification token.
+            CustomerPortalCustomersVerifyEmailUpdate422Error: Email address is already in use.
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
             PolarServerError: Raised when the server returns a 5xx error response.
@@ -663,8 +663,8 @@ class CustomersAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            401: CustomersVerifyEmailUpdate401Error,
-            422: CustomersVerifyEmailUpdate422Error,
+            401: CustomerPortalCustomersVerifyEmailUpdate401Error,
+            422: CustomerPortalCustomersVerifyEmailUpdate422Error,
         }
         return parse_response_json(
             response, CustomerEmailUpdateVerifyResponse, method_errors

--- a/sdk/python/polar/v2026_04/services/customer_portal/members.py
+++ b/sdk/python/polar/v2026_04/services/customer_portal/members.py
@@ -9,20 +9,20 @@ from polar.base import (
     parse_response_none,
 )
 from polar.v2026_04.errors import (
-    AddMember400Error,
-    AddMember401Error,
-    AddMember403Error,
     HTTPValidationError,
-    ListMembers401Error,
-    ListMembers403Error,
-    RemoveMember400Error,
-    RemoveMember401Error,
-    RemoveMember403Error,
-    RemoveMember404Error,
-    UpdateMember400Error,
-    UpdateMember401Error,
-    UpdateMember403Error,
-    UpdateMember404Error,
+    MembersAddMember400Error,
+    MembersAddMember401Error,
+    MembersAddMember403Error,
+    MembersListMembers401Error,
+    MembersListMembers403Error,
+    MembersRemoveMember400Error,
+    MembersRemoveMember401Error,
+    MembersRemoveMember403Error,
+    MembersRemoveMember404Error,
+    MembersUpdateMember400Error,
+    MembersUpdateMember401Error,
+    MembersUpdateMember403Error,
+    MembersUpdateMember404Error,
 )
 from polar.v2026_04.inputs import (
     CustomerPortalMemberCreate,
@@ -51,8 +51,8 @@ class MembersSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
 
         Raises:
-            ListMembers401Error: Authentication required
-            ListMembers403Error: Not permitted - requires owner or billing manager role
+            MembersListMembers401Error: Authentication required
+            MembersListMembers403Error: Not permitted - requires owner or billing manager role
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -69,8 +69,8 @@ class MembersSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            401: ListMembers401Error,
-            403: ListMembers403Error,
+            401: MembersListMembers401Error,
+            403: MembersListMembers403Error,
             422: HTTPValidationError,
         }
         return parse_response_json(
@@ -96,8 +96,8 @@ class MembersSync(SyncServiceBase):
             A generator that yields items of type CustomerPortalMember.
 
         Raises:
-            ListMembers401Error: Authentication required
-            ListMembers403Error: Not permitted - requires owner or billing manager role
+            MembersListMembers401Error: Authentication required
+            MembersListMembers403Error: Not permitted - requires owner or billing manager role
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -130,9 +130,9 @@ class MembersSync(SyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            AddMember400Error: Invalid request or member already exists.
-            AddMember401Error: Authentication required
-            AddMember403Error: Not permitted - requires owner or billing manager role
+            MembersAddMember400Error: Invalid request or member already exists.
+            MembersAddMember401Error: Authentication required
+            MembersAddMember403Error: Not permitted - requires owner or billing manager role
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -147,9 +147,9 @@ class MembersSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            400: AddMember400Error,
-            401: AddMember401Error,
-            403: AddMember403Error,
+            400: MembersAddMember400Error,
+            401: MembersAddMember401Error,
+            403: MembersAddMember403Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerPortalMember, method_errors)
@@ -171,10 +171,10 @@ class MembersSync(SyncServiceBase):
             id:
 
         Raises:
-            RemoveMember400Error: Cannot remove the only owner.
-            RemoveMember401Error: Authentication required
-            RemoveMember403Error: Not permitted - requires owner or billing manager role
-            RemoveMember404Error: Member not found.
+            MembersRemoveMember400Error: Cannot remove the only owner.
+            MembersRemoveMember401Error: Authentication required
+            MembersRemoveMember403Error: Not permitted - requires owner or billing manager role
+            MembersRemoveMember404Error: Member not found.
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -190,10 +190,10 @@ class MembersSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            400: RemoveMember400Error,
-            401: RemoveMember401Error,
-            403: RemoveMember403Error,
-            404: RemoveMember404Error,
+            400: MembersRemoveMember400Error,
+            401: MembersRemoveMember401Error,
+            403: MembersRemoveMember403Error,
+            404: MembersRemoveMember404Error,
             422: HTTPValidationError,
         }
         return parse_response_none(response, method_errors)
@@ -217,10 +217,10 @@ class MembersSync(SyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            UpdateMember400Error: Invalid role change.
-            UpdateMember401Error: Authentication required
-            UpdateMember403Error: Not permitted - requires owner or billing manager role
-            UpdateMember404Error: Member not found.
+            MembersUpdateMember400Error: Invalid role change.
+            MembersUpdateMember401Error: Authentication required
+            MembersUpdateMember403Error: Not permitted - requires owner or billing manager role
+            MembersUpdateMember404Error: Member not found.
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -237,10 +237,10 @@ class MembersSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            400: UpdateMember400Error,
-            401: UpdateMember401Error,
-            403: UpdateMember403Error,
-            404: UpdateMember404Error,
+            400: MembersUpdateMember400Error,
+            401: MembersUpdateMember401Error,
+            403: MembersUpdateMember403Error,
+            404: MembersUpdateMember404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerPortalMember, method_errors)
@@ -263,8 +263,8 @@ class MembersAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
 
         Raises:
-            ListMembers401Error: Authentication required
-            ListMembers403Error: Not permitted - requires owner or billing manager role
+            MembersListMembers401Error: Authentication required
+            MembersListMembers403Error: Not permitted - requires owner or billing manager role
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -281,8 +281,8 @@ class MembersAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            401: ListMembers401Error,
-            403: ListMembers403Error,
+            401: MembersListMembers401Error,
+            403: MembersListMembers403Error,
             422: HTTPValidationError,
         }
         return parse_response_json(
@@ -308,8 +308,8 @@ class MembersAsync(AsyncServiceBase):
             An async generator that yields items of type CustomerPortalMember.
 
         Raises:
-            ListMembers401Error: Authentication required
-            ListMembers403Error: Not permitted - requires owner or billing manager role
+            MembersListMembers401Error: Authentication required
+            MembersListMembers403Error: Not permitted - requires owner or billing manager role
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -343,9 +343,9 @@ class MembersAsync(AsyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            AddMember400Error: Invalid request or member already exists.
-            AddMember401Error: Authentication required
-            AddMember403Error: Not permitted - requires owner or billing manager role
+            MembersAddMember400Error: Invalid request or member already exists.
+            MembersAddMember401Error: Authentication required
+            MembersAddMember403Error: Not permitted - requires owner or billing manager role
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -360,9 +360,9 @@ class MembersAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            400: AddMember400Error,
-            401: AddMember401Error,
-            403: AddMember403Error,
+            400: MembersAddMember400Error,
+            401: MembersAddMember401Error,
+            403: MembersAddMember403Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerPortalMember, method_errors)
@@ -384,10 +384,10 @@ class MembersAsync(AsyncServiceBase):
             id:
 
         Raises:
-            RemoveMember400Error: Cannot remove the only owner.
-            RemoveMember401Error: Authentication required
-            RemoveMember403Error: Not permitted - requires owner or billing manager role
-            RemoveMember404Error: Member not found.
+            MembersRemoveMember400Error: Cannot remove the only owner.
+            MembersRemoveMember401Error: Authentication required
+            MembersRemoveMember403Error: Not permitted - requires owner or billing manager role
+            MembersRemoveMember404Error: Member not found.
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -403,10 +403,10 @@ class MembersAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            400: RemoveMember400Error,
-            401: RemoveMember401Error,
-            403: RemoveMember403Error,
-            404: RemoveMember404Error,
+            400: MembersRemoveMember400Error,
+            401: MembersRemoveMember401Error,
+            403: MembersRemoveMember403Error,
+            404: MembersRemoveMember404Error,
             422: HTTPValidationError,
         }
         return parse_response_none(response, method_errors)
@@ -430,10 +430,10 @@ class MembersAsync(AsyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            UpdateMember400Error: Invalid role change.
-            UpdateMember401Error: Authentication required
-            UpdateMember403Error: Not permitted - requires owner or billing manager role
-            UpdateMember404Error: Member not found.
+            MembersUpdateMember400Error: Invalid role change.
+            MembersUpdateMember401Error: Authentication required
+            MembersUpdateMember403Error: Not permitted - requires owner or billing manager role
+            MembersUpdateMember404Error: Member not found.
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -450,10 +450,10 @@ class MembersAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            400: UpdateMember400Error,
-            401: UpdateMember401Error,
-            403: UpdateMember403Error,
-            404: UpdateMember404Error,
+            400: MembersUpdateMember400Error,
+            401: MembersUpdateMember401Error,
+            403: MembersUpdateMember403Error,
+            404: MembersUpdateMember404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerPortalMember, method_errors)

--- a/sdk/python/polar/v2026_04/services/customer_portal/members.py
+++ b/sdk/python/polar/v2026_04/services/customer_portal/members.py
@@ -9,20 +9,20 @@ from polar.base import (
     parse_response_none,
 )
 from polar.v2026_04.errors import (
+    CustomerPortalMembersAddMember400Error,
+    CustomerPortalMembersAddMember401Error,
+    CustomerPortalMembersAddMember403Error,
+    CustomerPortalMembersListMembers401Error,
+    CustomerPortalMembersListMembers403Error,
+    CustomerPortalMembersRemoveMember400Error,
+    CustomerPortalMembersRemoveMember401Error,
+    CustomerPortalMembersRemoveMember403Error,
+    CustomerPortalMembersRemoveMember404Error,
+    CustomerPortalMembersUpdateMember400Error,
+    CustomerPortalMembersUpdateMember401Error,
+    CustomerPortalMembersUpdateMember403Error,
+    CustomerPortalMembersUpdateMember404Error,
     HTTPValidationError,
-    MembersAddMember400Error,
-    MembersAddMember401Error,
-    MembersAddMember403Error,
-    MembersListMembers401Error,
-    MembersListMembers403Error,
-    MembersRemoveMember400Error,
-    MembersRemoveMember401Error,
-    MembersRemoveMember403Error,
-    MembersRemoveMember404Error,
-    MembersUpdateMember400Error,
-    MembersUpdateMember401Error,
-    MembersUpdateMember403Error,
-    MembersUpdateMember404Error,
 )
 from polar.v2026_04.inputs import (
     CustomerPortalMemberCreate,
@@ -51,8 +51,8 @@ class MembersSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
 
         Raises:
-            MembersListMembers401Error: Authentication required
-            MembersListMembers403Error: Not permitted - requires owner or billing manager role
+            CustomerPortalMembersListMembers401Error: Authentication required
+            CustomerPortalMembersListMembers403Error: Not permitted - requires owner or billing manager role
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -69,8 +69,8 @@ class MembersSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            401: MembersListMembers401Error,
-            403: MembersListMembers403Error,
+            401: CustomerPortalMembersListMembers401Error,
+            403: CustomerPortalMembersListMembers403Error,
             422: HTTPValidationError,
         }
         return parse_response_json(
@@ -96,8 +96,8 @@ class MembersSync(SyncServiceBase):
             A generator that yields items of type CustomerPortalMember.
 
         Raises:
-            MembersListMembers401Error: Authentication required
-            MembersListMembers403Error: Not permitted - requires owner or billing manager role
+            CustomerPortalMembersListMembers401Error: Authentication required
+            CustomerPortalMembersListMembers403Error: Not permitted - requires owner or billing manager role
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -130,9 +130,9 @@ class MembersSync(SyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            MembersAddMember400Error: Invalid request or member already exists.
-            MembersAddMember401Error: Authentication required
-            MembersAddMember403Error: Not permitted - requires owner or billing manager role
+            CustomerPortalMembersAddMember400Error: Invalid request or member already exists.
+            CustomerPortalMembersAddMember401Error: Authentication required
+            CustomerPortalMembersAddMember403Error: Not permitted - requires owner or billing manager role
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -147,9 +147,9 @@ class MembersSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            400: MembersAddMember400Error,
-            401: MembersAddMember401Error,
-            403: MembersAddMember403Error,
+            400: CustomerPortalMembersAddMember400Error,
+            401: CustomerPortalMembersAddMember401Error,
+            403: CustomerPortalMembersAddMember403Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerPortalMember, method_errors)
@@ -171,10 +171,10 @@ class MembersSync(SyncServiceBase):
             id:
 
         Raises:
-            MembersRemoveMember400Error: Cannot remove the only owner.
-            MembersRemoveMember401Error: Authentication required
-            MembersRemoveMember403Error: Not permitted - requires owner or billing manager role
-            MembersRemoveMember404Error: Member not found.
+            CustomerPortalMembersRemoveMember400Error: Cannot remove the only owner.
+            CustomerPortalMembersRemoveMember401Error: Authentication required
+            CustomerPortalMembersRemoveMember403Error: Not permitted - requires owner or billing manager role
+            CustomerPortalMembersRemoveMember404Error: Member not found.
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -190,10 +190,10 @@ class MembersSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            400: MembersRemoveMember400Error,
-            401: MembersRemoveMember401Error,
-            403: MembersRemoveMember403Error,
-            404: MembersRemoveMember404Error,
+            400: CustomerPortalMembersRemoveMember400Error,
+            401: CustomerPortalMembersRemoveMember401Error,
+            403: CustomerPortalMembersRemoveMember403Error,
+            404: CustomerPortalMembersRemoveMember404Error,
             422: HTTPValidationError,
         }
         return parse_response_none(response, method_errors)
@@ -217,10 +217,10 @@ class MembersSync(SyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            MembersUpdateMember400Error: Invalid role change.
-            MembersUpdateMember401Error: Authentication required
-            MembersUpdateMember403Error: Not permitted - requires owner or billing manager role
-            MembersUpdateMember404Error: Member not found.
+            CustomerPortalMembersUpdateMember400Error: Invalid role change.
+            CustomerPortalMembersUpdateMember401Error: Authentication required
+            CustomerPortalMembersUpdateMember403Error: Not permitted - requires owner or billing manager role
+            CustomerPortalMembersUpdateMember404Error: Member not found.
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -237,10 +237,10 @@ class MembersSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            400: MembersUpdateMember400Error,
-            401: MembersUpdateMember401Error,
-            403: MembersUpdateMember403Error,
-            404: MembersUpdateMember404Error,
+            400: CustomerPortalMembersUpdateMember400Error,
+            401: CustomerPortalMembersUpdateMember401Error,
+            403: CustomerPortalMembersUpdateMember403Error,
+            404: CustomerPortalMembersUpdateMember404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerPortalMember, method_errors)
@@ -263,8 +263,8 @@ class MembersAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
 
         Raises:
-            MembersListMembers401Error: Authentication required
-            MembersListMembers403Error: Not permitted - requires owner or billing manager role
+            CustomerPortalMembersListMembers401Error: Authentication required
+            CustomerPortalMembersListMembers403Error: Not permitted - requires owner or billing manager role
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -281,8 +281,8 @@ class MembersAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            401: MembersListMembers401Error,
-            403: MembersListMembers403Error,
+            401: CustomerPortalMembersListMembers401Error,
+            403: CustomerPortalMembersListMembers403Error,
             422: HTTPValidationError,
         }
         return parse_response_json(
@@ -308,8 +308,8 @@ class MembersAsync(AsyncServiceBase):
             An async generator that yields items of type CustomerPortalMember.
 
         Raises:
-            MembersListMembers401Error: Authentication required
-            MembersListMembers403Error: Not permitted - requires owner or billing manager role
+            CustomerPortalMembersListMembers401Error: Authentication required
+            CustomerPortalMembersListMembers403Error: Not permitted - requires owner or billing manager role
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -343,9 +343,9 @@ class MembersAsync(AsyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            MembersAddMember400Error: Invalid request or member already exists.
-            MembersAddMember401Error: Authentication required
-            MembersAddMember403Error: Not permitted - requires owner or billing manager role
+            CustomerPortalMembersAddMember400Error: Invalid request or member already exists.
+            CustomerPortalMembersAddMember401Error: Authentication required
+            CustomerPortalMembersAddMember403Error: Not permitted - requires owner or billing manager role
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -360,9 +360,9 @@ class MembersAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            400: MembersAddMember400Error,
-            401: MembersAddMember401Error,
-            403: MembersAddMember403Error,
+            400: CustomerPortalMembersAddMember400Error,
+            401: CustomerPortalMembersAddMember401Error,
+            403: CustomerPortalMembersAddMember403Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerPortalMember, method_errors)
@@ -384,10 +384,10 @@ class MembersAsync(AsyncServiceBase):
             id:
 
         Raises:
-            MembersRemoveMember400Error: Cannot remove the only owner.
-            MembersRemoveMember401Error: Authentication required
-            MembersRemoveMember403Error: Not permitted - requires owner or billing manager role
-            MembersRemoveMember404Error: Member not found.
+            CustomerPortalMembersRemoveMember400Error: Cannot remove the only owner.
+            CustomerPortalMembersRemoveMember401Error: Authentication required
+            CustomerPortalMembersRemoveMember403Error: Not permitted - requires owner or billing manager role
+            CustomerPortalMembersRemoveMember404Error: Member not found.
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -403,10 +403,10 @@ class MembersAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            400: MembersRemoveMember400Error,
-            401: MembersRemoveMember401Error,
-            403: MembersRemoveMember403Error,
-            404: MembersRemoveMember404Error,
+            400: CustomerPortalMembersRemoveMember400Error,
+            401: CustomerPortalMembersRemoveMember401Error,
+            403: CustomerPortalMembersRemoveMember403Error,
+            404: CustomerPortalMembersRemoveMember404Error,
             422: HTTPValidationError,
         }
         return parse_response_none(response, method_errors)
@@ -430,10 +430,10 @@ class MembersAsync(AsyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            MembersUpdateMember400Error: Invalid role change.
-            MembersUpdateMember401Error: Authentication required
-            MembersUpdateMember403Error: Not permitted - requires owner or billing manager role
-            MembersUpdateMember404Error: Member not found.
+            CustomerPortalMembersUpdateMember400Error: Invalid role change.
+            CustomerPortalMembersUpdateMember401Error: Authentication required
+            CustomerPortalMembersUpdateMember403Error: Not permitted - requires owner or billing manager role
+            CustomerPortalMembersUpdateMember404Error: Member not found.
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -450,10 +450,10 @@ class MembersAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            400: MembersUpdateMember400Error,
-            401: MembersUpdateMember401Error,
-            403: MembersUpdateMember403Error,
-            404: MembersUpdateMember404Error,
+            400: CustomerPortalMembersUpdateMember400Error,
+            401: CustomerPortalMembersUpdateMember401Error,
+            403: CustomerPortalMembersUpdateMember403Error,
+            404: CustomerPortalMembersUpdateMember404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerPortalMember, method_errors)

--- a/sdk/python/polar/v2026_04/services/customer_portal/seats.py
+++ b/sdk/python/polar/v2026_04/services/customer_portal/seats.py
@@ -4,22 +4,22 @@ import typing
 
 from polar.base import AsyncServiceBase, SyncServiceBase, parse_response_json
 from polar.v2026_04.errors import (
+    CustomerPortalSeatsAssignSeat400Error,
+    CustomerPortalSeatsAssignSeat401Error,
+    CustomerPortalSeatsAssignSeat403Error,
+    CustomerPortalSeatsAssignSeat404Error,
+    CustomerPortalSeatsListClaimedSubscriptions401Error,
+    CustomerPortalSeatsListSeats401Error,
+    CustomerPortalSeatsListSeats403Error,
+    CustomerPortalSeatsListSeats404Error,
+    CustomerPortalSeatsResendInvitation400Error,
+    CustomerPortalSeatsResendInvitation401Error,
+    CustomerPortalSeatsResendInvitation403Error,
+    CustomerPortalSeatsResendInvitation404Error,
+    CustomerPortalSeatsRevokeSeat401Error,
+    CustomerPortalSeatsRevokeSeat403Error,
+    CustomerPortalSeatsRevokeSeat404Error,
     HTTPValidationError,
-    SeatsAssignSeat400Error,
-    SeatsAssignSeat401Error,
-    SeatsAssignSeat403Error,
-    SeatsAssignSeat404Error,
-    SeatsListClaimedSubscriptions401Error,
-    SeatsListSeats401Error,
-    SeatsListSeats403Error,
-    SeatsListSeats404Error,
-    SeatsResendInvitation400Error,
-    SeatsResendInvitation401Error,
-    SeatsResendInvitation403Error,
-    SeatsResendInvitation404Error,
-    SeatsRevokeSeat401Error,
-    SeatsRevokeSeat403Error,
-    SeatsRevokeSeat404Error,
 )
 from polar.v2026_04.inputs import (
     CustomerSeatAssign,
@@ -47,9 +47,9 @@ class SeatsSync(SyncServiceBase):
             order_id: Order ID
 
         Raises:
-            SeatsListSeats401Error: Authentication required
-            SeatsListSeats403Error: Not permitted or seat-based pricing not enabled
-            SeatsListSeats404Error: Subscription or order not found
+            CustomerPortalSeatsListSeats401Error: Authentication required
+            CustomerPortalSeatsListSeats403Error: Not permitted or seat-based pricing not enabled
+            CustomerPortalSeatsListSeats404Error: Subscription or order not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -66,9 +66,9 @@ class SeatsSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            401: SeatsListSeats401Error,
-            403: SeatsListSeats403Error,
-            404: SeatsListSeats404Error,
+            401: CustomerPortalSeatsListSeats401Error,
+            403: CustomerPortalSeatsListSeats403Error,
+            404: CustomerPortalSeatsListSeats404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, SeatsList, method_errors)
@@ -82,10 +82,10 @@ class SeatsSync(SyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            SeatsAssignSeat400Error: No available seats or customer already has a seat
-            SeatsAssignSeat401Error: Authentication required
-            SeatsAssignSeat403Error: Not permitted or seat-based pricing not enabled
-            SeatsAssignSeat404Error: Subscription, order, or customer not found
+            CustomerPortalSeatsAssignSeat400Error: No available seats or customer already has a seat
+            CustomerPortalSeatsAssignSeat401Error: Authentication required
+            CustomerPortalSeatsAssignSeat403Error: Not permitted or seat-based pricing not enabled
+            CustomerPortalSeatsAssignSeat404Error: Subscription, order, or customer not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -100,10 +100,10 @@ class SeatsSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            400: SeatsAssignSeat400Error,
-            401: SeatsAssignSeat401Error,
-            403: SeatsAssignSeat403Error,
-            404: SeatsAssignSeat404Error,
+            400: CustomerPortalSeatsAssignSeat400Error,
+            401: CustomerPortalSeatsAssignSeat401Error,
+            403: CustomerPortalSeatsAssignSeat403Error,
+            404: CustomerPortalSeatsAssignSeat404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerSeat, method_errors)
@@ -117,9 +117,9 @@ class SeatsSync(SyncServiceBase):
             seat_id:
 
         Raises:
-            SeatsRevokeSeat401Error: Authentication required
-            SeatsRevokeSeat403Error: Not permitted or seat-based pricing not enabled
-            SeatsRevokeSeat404Error: Seat not found
+            CustomerPortalSeatsRevokeSeat401Error: Authentication required
+            CustomerPortalSeatsRevokeSeat403Error: Not permitted or seat-based pricing not enabled
+            CustomerPortalSeatsRevokeSeat404Error: Seat not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -135,9 +135,9 @@ class SeatsSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            401: SeatsRevokeSeat401Error,
-            403: SeatsRevokeSeat403Error,
-            404: SeatsRevokeSeat404Error,
+            401: CustomerPortalSeatsRevokeSeat401Error,
+            403: CustomerPortalSeatsRevokeSeat403Error,
+            404: CustomerPortalSeatsRevokeSeat404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerSeat, method_errors)
@@ -151,10 +151,10 @@ class SeatsSync(SyncServiceBase):
             seat_id:
 
         Raises:
-            SeatsResendInvitation400Error: Seat is not pending or already claimed
-            SeatsResendInvitation401Error: Authentication required
-            SeatsResendInvitation403Error: Not permitted or seat-based pricing not enabled
-            SeatsResendInvitation404Error: Seat not found
+            CustomerPortalSeatsResendInvitation400Error: Seat is not pending or already claimed
+            CustomerPortalSeatsResendInvitation401Error: Authentication required
+            CustomerPortalSeatsResendInvitation403Error: Not permitted or seat-based pricing not enabled
+            CustomerPortalSeatsResendInvitation404Error: Seat not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -170,10 +170,10 @@ class SeatsSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            400: SeatsResendInvitation400Error,
-            401: SeatsResendInvitation401Error,
-            403: SeatsResendInvitation403Error,
-            404: SeatsResendInvitation404Error,
+            400: CustomerPortalSeatsResendInvitation400Error,
+            401: CustomerPortalSeatsResendInvitation401Error,
+            403: CustomerPortalSeatsResendInvitation403Error,
+            404: CustomerPortalSeatsResendInvitation404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerSeat, method_errors)
@@ -194,7 +194,7 @@ class SeatsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
 
         Raises:
-            SeatsListClaimedSubscriptions401Error: Authentication required
+            CustomerPortalSeatsListClaimedSubscriptions401Error: Authentication required
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -211,7 +211,7 @@ class SeatsSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            401: SeatsListClaimedSubscriptions401Error,
+            401: CustomerPortalSeatsListClaimedSubscriptions401Error,
             422: HTTPValidationError,
         }
         return parse_response_json(
@@ -237,7 +237,7 @@ class SeatsSync(SyncServiceBase):
             A generator that yields items of type CustomerSubscription.
 
         Raises:
-            SeatsListClaimedSubscriptions401Error: Authentication required
+            CustomerPortalSeatsListClaimedSubscriptions401Error: Authentication required
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -269,9 +269,9 @@ class SeatsAsync(AsyncServiceBase):
             order_id: Order ID
 
         Raises:
-            SeatsListSeats401Error: Authentication required
-            SeatsListSeats403Error: Not permitted or seat-based pricing not enabled
-            SeatsListSeats404Error: Subscription or order not found
+            CustomerPortalSeatsListSeats401Error: Authentication required
+            CustomerPortalSeatsListSeats403Error: Not permitted or seat-based pricing not enabled
+            CustomerPortalSeatsListSeats404Error: Subscription or order not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -288,9 +288,9 @@ class SeatsAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            401: SeatsListSeats401Error,
-            403: SeatsListSeats403Error,
-            404: SeatsListSeats404Error,
+            401: CustomerPortalSeatsListSeats401Error,
+            403: CustomerPortalSeatsListSeats403Error,
+            404: CustomerPortalSeatsListSeats404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, SeatsList, method_errors)
@@ -304,10 +304,10 @@ class SeatsAsync(AsyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            SeatsAssignSeat400Error: No available seats or customer already has a seat
-            SeatsAssignSeat401Error: Authentication required
-            SeatsAssignSeat403Error: Not permitted or seat-based pricing not enabled
-            SeatsAssignSeat404Error: Subscription, order, or customer not found
+            CustomerPortalSeatsAssignSeat400Error: No available seats or customer already has a seat
+            CustomerPortalSeatsAssignSeat401Error: Authentication required
+            CustomerPortalSeatsAssignSeat403Error: Not permitted or seat-based pricing not enabled
+            CustomerPortalSeatsAssignSeat404Error: Subscription, order, or customer not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -322,10 +322,10 @@ class SeatsAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            400: SeatsAssignSeat400Error,
-            401: SeatsAssignSeat401Error,
-            403: SeatsAssignSeat403Error,
-            404: SeatsAssignSeat404Error,
+            400: CustomerPortalSeatsAssignSeat400Error,
+            401: CustomerPortalSeatsAssignSeat401Error,
+            403: CustomerPortalSeatsAssignSeat403Error,
+            404: CustomerPortalSeatsAssignSeat404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerSeat, method_errors)
@@ -339,9 +339,9 @@ class SeatsAsync(AsyncServiceBase):
             seat_id:
 
         Raises:
-            SeatsRevokeSeat401Error: Authentication required
-            SeatsRevokeSeat403Error: Not permitted or seat-based pricing not enabled
-            SeatsRevokeSeat404Error: Seat not found
+            CustomerPortalSeatsRevokeSeat401Error: Authentication required
+            CustomerPortalSeatsRevokeSeat403Error: Not permitted or seat-based pricing not enabled
+            CustomerPortalSeatsRevokeSeat404Error: Seat not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -357,9 +357,9 @@ class SeatsAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            401: SeatsRevokeSeat401Error,
-            403: SeatsRevokeSeat403Error,
-            404: SeatsRevokeSeat404Error,
+            401: CustomerPortalSeatsRevokeSeat401Error,
+            403: CustomerPortalSeatsRevokeSeat403Error,
+            404: CustomerPortalSeatsRevokeSeat404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerSeat, method_errors)
@@ -373,10 +373,10 @@ class SeatsAsync(AsyncServiceBase):
             seat_id:
 
         Raises:
-            SeatsResendInvitation400Error: Seat is not pending or already claimed
-            SeatsResendInvitation401Error: Authentication required
-            SeatsResendInvitation403Error: Not permitted or seat-based pricing not enabled
-            SeatsResendInvitation404Error: Seat not found
+            CustomerPortalSeatsResendInvitation400Error: Seat is not pending or already claimed
+            CustomerPortalSeatsResendInvitation401Error: Authentication required
+            CustomerPortalSeatsResendInvitation403Error: Not permitted or seat-based pricing not enabled
+            CustomerPortalSeatsResendInvitation404Error: Seat not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -392,10 +392,10 @@ class SeatsAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            400: SeatsResendInvitation400Error,
-            401: SeatsResendInvitation401Error,
-            403: SeatsResendInvitation403Error,
-            404: SeatsResendInvitation404Error,
+            400: CustomerPortalSeatsResendInvitation400Error,
+            401: CustomerPortalSeatsResendInvitation401Error,
+            403: CustomerPortalSeatsResendInvitation403Error,
+            404: CustomerPortalSeatsResendInvitation404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerSeat, method_errors)
@@ -416,7 +416,7 @@ class SeatsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
 
         Raises:
-            SeatsListClaimedSubscriptions401Error: Authentication required
+            CustomerPortalSeatsListClaimedSubscriptions401Error: Authentication required
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -433,7 +433,7 @@ class SeatsAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            401: SeatsListClaimedSubscriptions401Error,
+            401: CustomerPortalSeatsListClaimedSubscriptions401Error,
             422: HTTPValidationError,
         }
         return parse_response_json(
@@ -459,7 +459,7 @@ class SeatsAsync(AsyncServiceBase):
             An async generator that yields items of type CustomerSubscription.
 
         Raises:
-            SeatsListClaimedSubscriptions401Error: Authentication required
+            CustomerPortalSeatsListClaimedSubscriptions401Error: Authentication required
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.

--- a/sdk/python/polar/v2026_04/services/customer_portal/seats.py
+++ b/sdk/python/polar/v2026_04/services/customer_portal/seats.py
@@ -4,22 +4,22 @@ import typing
 
 from polar.base import AsyncServiceBase, SyncServiceBase, parse_response_json
 from polar.v2026_04.errors import (
-    AssignSeat400Error,
-    AssignSeat401Error,
-    AssignSeat403Error,
-    AssignSeat404Error,
     HTTPValidationError,
-    ListClaimedSubscriptions401Error,
-    ListSeats401Error,
-    ListSeats403Error,
-    ListSeats404Error,
-    ResendInvitation400Error,
-    ResendInvitation401Error,
-    ResendInvitation403Error,
-    ResendInvitation404Error,
-    RevokeSeat401Error,
-    RevokeSeat403Error,
-    RevokeSeat404Error,
+    SeatsAssignSeat400Error,
+    SeatsAssignSeat401Error,
+    SeatsAssignSeat403Error,
+    SeatsAssignSeat404Error,
+    SeatsListClaimedSubscriptions401Error,
+    SeatsListSeats401Error,
+    SeatsListSeats403Error,
+    SeatsListSeats404Error,
+    SeatsResendInvitation400Error,
+    SeatsResendInvitation401Error,
+    SeatsResendInvitation403Error,
+    SeatsResendInvitation404Error,
+    SeatsRevokeSeat401Error,
+    SeatsRevokeSeat403Error,
+    SeatsRevokeSeat404Error,
 )
 from polar.v2026_04.inputs import (
     CustomerSeatAssign,
@@ -47,9 +47,9 @@ class SeatsSync(SyncServiceBase):
             order_id: Order ID
 
         Raises:
-            ListSeats401Error: Authentication required
-            ListSeats403Error: Not permitted or seat-based pricing not enabled
-            ListSeats404Error: Subscription or order not found
+            SeatsListSeats401Error: Authentication required
+            SeatsListSeats403Error: Not permitted or seat-based pricing not enabled
+            SeatsListSeats404Error: Subscription or order not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -66,9 +66,9 @@ class SeatsSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            401: ListSeats401Error,
-            403: ListSeats403Error,
-            404: ListSeats404Error,
+            401: SeatsListSeats401Error,
+            403: SeatsListSeats403Error,
+            404: SeatsListSeats404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, SeatsList, method_errors)
@@ -82,10 +82,10 @@ class SeatsSync(SyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            AssignSeat400Error: No available seats or customer already has a seat
-            AssignSeat401Error: Authentication required
-            AssignSeat403Error: Not permitted or seat-based pricing not enabled
-            AssignSeat404Error: Subscription, order, or customer not found
+            SeatsAssignSeat400Error: No available seats or customer already has a seat
+            SeatsAssignSeat401Error: Authentication required
+            SeatsAssignSeat403Error: Not permitted or seat-based pricing not enabled
+            SeatsAssignSeat404Error: Subscription, order, or customer not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -100,10 +100,10 @@ class SeatsSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            400: AssignSeat400Error,
-            401: AssignSeat401Error,
-            403: AssignSeat403Error,
-            404: AssignSeat404Error,
+            400: SeatsAssignSeat400Error,
+            401: SeatsAssignSeat401Error,
+            403: SeatsAssignSeat403Error,
+            404: SeatsAssignSeat404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerSeat, method_errors)
@@ -117,9 +117,9 @@ class SeatsSync(SyncServiceBase):
             seat_id:
 
         Raises:
-            RevokeSeat401Error: Authentication required
-            RevokeSeat403Error: Not permitted or seat-based pricing not enabled
-            RevokeSeat404Error: Seat not found
+            SeatsRevokeSeat401Error: Authentication required
+            SeatsRevokeSeat403Error: Not permitted or seat-based pricing not enabled
+            SeatsRevokeSeat404Error: Seat not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -135,9 +135,9 @@ class SeatsSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            401: RevokeSeat401Error,
-            403: RevokeSeat403Error,
-            404: RevokeSeat404Error,
+            401: SeatsRevokeSeat401Error,
+            403: SeatsRevokeSeat403Error,
+            404: SeatsRevokeSeat404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerSeat, method_errors)
@@ -151,10 +151,10 @@ class SeatsSync(SyncServiceBase):
             seat_id:
 
         Raises:
-            ResendInvitation400Error: Seat is not pending or already claimed
-            ResendInvitation401Error: Authentication required
-            ResendInvitation403Error: Not permitted or seat-based pricing not enabled
-            ResendInvitation404Error: Seat not found
+            SeatsResendInvitation400Error: Seat is not pending or already claimed
+            SeatsResendInvitation401Error: Authentication required
+            SeatsResendInvitation403Error: Not permitted or seat-based pricing not enabled
+            SeatsResendInvitation404Error: Seat not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -170,10 +170,10 @@ class SeatsSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            400: ResendInvitation400Error,
-            401: ResendInvitation401Error,
-            403: ResendInvitation403Error,
-            404: ResendInvitation404Error,
+            400: SeatsResendInvitation400Error,
+            401: SeatsResendInvitation401Error,
+            403: SeatsResendInvitation403Error,
+            404: SeatsResendInvitation404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerSeat, method_errors)
@@ -194,7 +194,7 @@ class SeatsSync(SyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
 
         Raises:
-            ListClaimedSubscriptions401Error: Authentication required
+            SeatsListClaimedSubscriptions401Error: Authentication required
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -211,7 +211,7 @@ class SeatsSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            401: ListClaimedSubscriptions401Error,
+            401: SeatsListClaimedSubscriptions401Error,
             422: HTTPValidationError,
         }
         return parse_response_json(
@@ -237,7 +237,7 @@ class SeatsSync(SyncServiceBase):
             A generator that yields items of type CustomerSubscription.
 
         Raises:
-            ListClaimedSubscriptions401Error: Authentication required
+            SeatsListClaimedSubscriptions401Error: Authentication required
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -269,9 +269,9 @@ class SeatsAsync(AsyncServiceBase):
             order_id: Order ID
 
         Raises:
-            ListSeats401Error: Authentication required
-            ListSeats403Error: Not permitted or seat-based pricing not enabled
-            ListSeats404Error: Subscription or order not found
+            SeatsListSeats401Error: Authentication required
+            SeatsListSeats403Error: Not permitted or seat-based pricing not enabled
+            SeatsListSeats404Error: Subscription or order not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -288,9 +288,9 @@ class SeatsAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            401: ListSeats401Error,
-            403: ListSeats403Error,
-            404: ListSeats404Error,
+            401: SeatsListSeats401Error,
+            403: SeatsListSeats403Error,
+            404: SeatsListSeats404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, SeatsList, method_errors)
@@ -304,10 +304,10 @@ class SeatsAsync(AsyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            AssignSeat400Error: No available seats or customer already has a seat
-            AssignSeat401Error: Authentication required
-            AssignSeat403Error: Not permitted or seat-based pricing not enabled
-            AssignSeat404Error: Subscription, order, or customer not found
+            SeatsAssignSeat400Error: No available seats or customer already has a seat
+            SeatsAssignSeat401Error: Authentication required
+            SeatsAssignSeat403Error: Not permitted or seat-based pricing not enabled
+            SeatsAssignSeat404Error: Subscription, order, or customer not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -322,10 +322,10 @@ class SeatsAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            400: AssignSeat400Error,
-            401: AssignSeat401Error,
-            403: AssignSeat403Error,
-            404: AssignSeat404Error,
+            400: SeatsAssignSeat400Error,
+            401: SeatsAssignSeat401Error,
+            403: SeatsAssignSeat403Error,
+            404: SeatsAssignSeat404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerSeat, method_errors)
@@ -339,9 +339,9 @@ class SeatsAsync(AsyncServiceBase):
             seat_id:
 
         Raises:
-            RevokeSeat401Error: Authentication required
-            RevokeSeat403Error: Not permitted or seat-based pricing not enabled
-            RevokeSeat404Error: Seat not found
+            SeatsRevokeSeat401Error: Authentication required
+            SeatsRevokeSeat403Error: Not permitted or seat-based pricing not enabled
+            SeatsRevokeSeat404Error: Seat not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -357,9 +357,9 @@ class SeatsAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            401: RevokeSeat401Error,
-            403: RevokeSeat403Error,
-            404: RevokeSeat404Error,
+            401: SeatsRevokeSeat401Error,
+            403: SeatsRevokeSeat403Error,
+            404: SeatsRevokeSeat404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerSeat, method_errors)
@@ -373,10 +373,10 @@ class SeatsAsync(AsyncServiceBase):
             seat_id:
 
         Raises:
-            ResendInvitation400Error: Seat is not pending or already claimed
-            ResendInvitation401Error: Authentication required
-            ResendInvitation403Error: Not permitted or seat-based pricing not enabled
-            ResendInvitation404Error: Seat not found
+            SeatsResendInvitation400Error: Seat is not pending or already claimed
+            SeatsResendInvitation401Error: Authentication required
+            SeatsResendInvitation403Error: Not permitted or seat-based pricing not enabled
+            SeatsResendInvitation404Error: Seat not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -392,10 +392,10 @@ class SeatsAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            400: ResendInvitation400Error,
-            401: ResendInvitation401Error,
-            403: ResendInvitation403Error,
-            404: ResendInvitation404Error,
+            400: SeatsResendInvitation400Error,
+            401: SeatsResendInvitation401Error,
+            403: SeatsResendInvitation403Error,
+            404: SeatsResendInvitation404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerSeat, method_errors)
@@ -416,7 +416,7 @@ class SeatsAsync(AsyncServiceBase):
             limit: Size of a page, defaults to 10. Maximum is 100.
 
         Raises:
-            ListClaimedSubscriptions401Error: Authentication required
+            SeatsListClaimedSubscriptions401Error: Authentication required
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -433,7 +433,7 @@ class SeatsAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            401: ListClaimedSubscriptions401Error,
+            401: SeatsListClaimedSubscriptions401Error,
             422: HTTPValidationError,
         }
         return parse_response_json(
@@ -459,7 +459,7 @@ class SeatsAsync(AsyncServiceBase):
             An async generator that yields items of type CustomerSubscription.
 
         Raises:
-            ListClaimedSubscriptions401Error: Authentication required
+            SeatsListClaimedSubscriptions401Error: Authentication required
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.

--- a/sdk/python/polar/v2026_04/services/customer_portal/subscriptions.py
+++ b/sdk/python/polar/v2026_04/services/customer_portal/subscriptions.py
@@ -9,7 +9,7 @@ from polar.v2026_04.errors import (
     HTTPValidationError,
     PaymentFailed,
     ResourceNotFound,
-    Update403Error,
+    SubscriptionsUpdate403Error,
 )
 from polar.v2026_04.inputs import (
     CustomerSubscriptionCancel,
@@ -249,7 +249,7 @@ class SubscriptionsSync(SyncServiceBase):
 
         Raises:
             PaymentFailed: Payment required to apply the subscription update.
-            Update403Error: Customer subscription is already canceled or will be at the end of the period, the user lacks billing permissions, or pausing/resuming is not enabled for the organization.
+            SubscriptionsUpdate403Error: Customer subscription is already canceled or will be at the end of the period, the user lacks billing permissions, or pausing/resuming is not enabled for the organization.
             ResourceNotFound: Customer subscription was not found.
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
@@ -268,7 +268,7 @@ class SubscriptionsSync(SyncServiceBase):
         response = self.client.send_request(request)
         method_errors = {
             402: PaymentFailed,
-            403: Update403Error,
+            403: SubscriptionsUpdate403Error,
             404: ResourceNotFound,
             422: HTTPValidationError,
         }
@@ -497,7 +497,7 @@ class SubscriptionsAsync(AsyncServiceBase):
 
         Raises:
             PaymentFailed: Payment required to apply the subscription update.
-            Update403Error: Customer subscription is already canceled or will be at the end of the period, the user lacks billing permissions, or pausing/resuming is not enabled for the organization.
+            SubscriptionsUpdate403Error: Customer subscription is already canceled or will be at the end of the period, the user lacks billing permissions, or pausing/resuming is not enabled for the organization.
             ResourceNotFound: Customer subscription was not found.
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
@@ -516,7 +516,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         response = await self.client.send_request(request)
         method_errors = {
             402: PaymentFailed,
-            403: Update403Error,
+            403: SubscriptionsUpdate403Error,
             404: ResourceNotFound,
             422: HTTPValidationError,
         }

--- a/sdk/python/polar/v2026_04/services/customer_portal/subscriptions.py
+++ b/sdk/python/polar/v2026_04/services/customer_portal/subscriptions.py
@@ -6,10 +6,10 @@ import typing
 from polar.base import AsyncServiceBase, SyncServiceBase, parse_response_json
 from polar.v2026_04.errors import (
     AlreadyCanceledSubscription,
+    CustomerPortalSubscriptionsUpdate403Error,
     HTTPValidationError,
     PaymentFailed,
     ResourceNotFound,
-    SubscriptionsUpdate403Error,
 )
 from polar.v2026_04.inputs import (
     CustomerSubscriptionCancel,
@@ -249,7 +249,7 @@ class SubscriptionsSync(SyncServiceBase):
 
         Raises:
             PaymentFailed: Payment required to apply the subscription update.
-            SubscriptionsUpdate403Error: Customer subscription is already canceled or will be at the end of the period, the user lacks billing permissions, or pausing/resuming is not enabled for the organization.
+            CustomerPortalSubscriptionsUpdate403Error: Customer subscription is already canceled or will be at the end of the period, the user lacks billing permissions, or pausing/resuming is not enabled for the organization.
             ResourceNotFound: Customer subscription was not found.
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
@@ -268,7 +268,7 @@ class SubscriptionsSync(SyncServiceBase):
         response = self.client.send_request(request)
         method_errors = {
             402: PaymentFailed,
-            403: SubscriptionsUpdate403Error,
+            403: CustomerPortalSubscriptionsUpdate403Error,
             404: ResourceNotFound,
             422: HTTPValidationError,
         }
@@ -497,7 +497,7 @@ class SubscriptionsAsync(AsyncServiceBase):
 
         Raises:
             PaymentFailed: Payment required to apply the subscription update.
-            SubscriptionsUpdate403Error: Customer subscription is already canceled or will be at the end of the period, the user lacks billing permissions, or pausing/resuming is not enabled for the organization.
+            CustomerPortalSubscriptionsUpdate403Error: Customer subscription is already canceled or will be at the end of the period, the user lacks billing permissions, or pausing/resuming is not enabled for the organization.
             ResourceNotFound: Customer subscription was not found.
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
@@ -516,7 +516,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         response = await self.client.send_request(request)
         method_errors = {
             402: PaymentFailed,
-            403: SubscriptionsUpdate403Error,
+            403: CustomerPortalSubscriptionsUpdate403Error,
             404: ResourceNotFound,
             422: HTTPValidationError,
         }

--- a/sdk/python/polar/v2026_04/services/customer_seats.py
+++ b/sdk/python/polar/v2026_04/services/customer_seats.py
@@ -4,26 +4,26 @@ import typing
 
 from polar.base import AsyncServiceBase, SyncServiceBase, parse_response_json
 from polar.v2026_04.errors import (
-    AssignSeat400Error,
-    AssignSeat401Error,
-    AssignSeat403Error,
-    AssignSeat404Error,
-    ClaimSeat400Error,
-    ClaimSeat403Error,
-    GetClaimInfo400Error,
-    GetClaimInfo403Error,
-    GetClaimInfo404Error,
+    CustomerSeatsAssignSeat400Error,
+    CustomerSeatsAssignSeat401Error,
+    CustomerSeatsAssignSeat403Error,
+    CustomerSeatsAssignSeat404Error,
+    CustomerSeatsClaimSeat400Error,
+    CustomerSeatsClaimSeat403Error,
+    CustomerSeatsGetClaimInfo400Error,
+    CustomerSeatsGetClaimInfo403Error,
+    CustomerSeatsGetClaimInfo404Error,
+    CustomerSeatsListSeats401Error,
+    CustomerSeatsListSeats403Error,
+    CustomerSeatsListSeats404Error,
+    CustomerSeatsResendInvitation400Error,
+    CustomerSeatsResendInvitation401Error,
+    CustomerSeatsResendInvitation403Error,
+    CustomerSeatsResendInvitation404Error,
+    CustomerSeatsRevokeSeat401Error,
+    CustomerSeatsRevokeSeat403Error,
+    CustomerSeatsRevokeSeat404Error,
     HTTPValidationError,
-    ListSeats401Error,
-    ListSeats403Error,
-    ListSeats404Error,
-    ResendInvitation400Error,
-    ResendInvitation401Error,
-    ResendInvitation403Error,
-    ResendInvitation404Error,
-    RevokeSeat401Error,
-    RevokeSeat403Error,
-    RevokeSeat404Error,
 )
 from polar.v2026_04.inputs import (
     SeatAssign,
@@ -52,9 +52,9 @@ class CustomerSeatsSync(SyncServiceBase):
             order_id:
 
         Raises:
-            ListSeats401Error: Authentication required
-            ListSeats403Error: Not permitted or seat-based pricing not enabled
-            ListSeats404Error: Subscription or order not found
+            CustomerSeatsListSeats401Error: Authentication required
+            CustomerSeatsListSeats403Error: Not permitted or seat-based pricing not enabled
+            CustomerSeatsListSeats404Error: Subscription or order not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -71,9 +71,9 @@ class CustomerSeatsSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            401: ListSeats401Error,
-            403: ListSeats403Error,
-            404: ListSeats404Error,
+            401: CustomerSeatsListSeats401Error,
+            403: CustomerSeatsListSeats403Error,
+            404: CustomerSeatsListSeats404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, SeatsList, method_errors)
@@ -89,10 +89,10 @@ class CustomerSeatsSync(SyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            AssignSeat400Error: No available seats or customer already has a seat
-            AssignSeat401Error: Authentication required
-            AssignSeat403Error: Not permitted or seat-based pricing not enabled
-            AssignSeat404Error: Subscription, order, or customer not found
+            CustomerSeatsAssignSeat400Error: No available seats or customer already has a seat
+            CustomerSeatsAssignSeat401Error: Authentication required
+            CustomerSeatsAssignSeat403Error: Not permitted or seat-based pricing not enabled
+            CustomerSeatsAssignSeat404Error: Subscription, order, or customer not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -107,10 +107,10 @@ class CustomerSeatsSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            400: AssignSeat400Error,
-            401: AssignSeat401Error,
-            403: AssignSeat403Error,
-            404: AssignSeat404Error,
+            400: CustomerSeatsAssignSeat400Error,
+            401: CustomerSeatsAssignSeat401Error,
+            403: CustomerSeatsAssignSeat403Error,
+            404: CustomerSeatsAssignSeat404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerSeat, method_errors)
@@ -126,9 +126,9 @@ class CustomerSeatsSync(SyncServiceBase):
             seat_id:
 
         Raises:
-            RevokeSeat401Error: Authentication required
-            RevokeSeat403Error: Not permitted or seat-based pricing not enabled
-            RevokeSeat404Error: Seat not found
+            CustomerSeatsRevokeSeat401Error: Authentication required
+            CustomerSeatsRevokeSeat403Error: Not permitted or seat-based pricing not enabled
+            CustomerSeatsRevokeSeat404Error: Seat not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -144,9 +144,9 @@ class CustomerSeatsSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            401: RevokeSeat401Error,
-            403: RevokeSeat403Error,
-            404: RevokeSeat404Error,
+            401: CustomerSeatsRevokeSeat401Error,
+            403: CustomerSeatsRevokeSeat403Error,
+            404: CustomerSeatsRevokeSeat404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerSeat, method_errors)
@@ -162,10 +162,10 @@ class CustomerSeatsSync(SyncServiceBase):
             seat_id:
 
         Raises:
-            ResendInvitation400Error: Seat is not pending or already claimed
-            ResendInvitation401Error: Authentication required
-            ResendInvitation403Error: Not permitted or seat-based pricing not enabled
-            ResendInvitation404Error: Seat not found
+            CustomerSeatsResendInvitation400Error: Seat is not pending or already claimed
+            CustomerSeatsResendInvitation401Error: Authentication required
+            CustomerSeatsResendInvitation403Error: Not permitted or seat-based pricing not enabled
+            CustomerSeatsResendInvitation404Error: Seat not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -181,10 +181,10 @@ class CustomerSeatsSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            400: ResendInvitation400Error,
-            401: ResendInvitation401Error,
-            403: ResendInvitation403Error,
-            404: ResendInvitation404Error,
+            400: CustomerSeatsResendInvitation400Error,
+            401: CustomerSeatsResendInvitation401Error,
+            403: CustomerSeatsResendInvitation403Error,
+            404: CustomerSeatsResendInvitation404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerSeat, method_errors)
@@ -198,9 +198,9 @@ class CustomerSeatsSync(SyncServiceBase):
             invitation_token:
 
         Raises:
-            GetClaimInfo400Error: Invalid or expired invitation token
-            GetClaimInfo403Error: Seat-based pricing not enabled for organization
-            GetClaimInfo404Error: Seat not found
+            CustomerSeatsGetClaimInfo400Error: Invalid or expired invitation token
+            CustomerSeatsGetClaimInfo403Error: Seat-based pricing not enabled for organization
+            CustomerSeatsGetClaimInfo404Error: Seat not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -216,9 +216,9 @@ class CustomerSeatsSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            400: GetClaimInfo400Error,
-            403: GetClaimInfo403Error,
-            404: GetClaimInfo404Error,
+            400: CustomerSeatsGetClaimInfo400Error,
+            403: CustomerSeatsGetClaimInfo403Error,
+            404: CustomerSeatsGetClaimInfo404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, SeatClaimInfo, method_errors)
@@ -232,8 +232,8 @@ class CustomerSeatsSync(SyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            ClaimSeat400Error: Invalid, expired, or already claimed token
-            ClaimSeat403Error: Seat-based pricing not enabled for organization
+            CustomerSeatsClaimSeat400Error: Invalid, expired, or already claimed token
+            CustomerSeatsClaimSeat403Error: Seat-based pricing not enabled for organization
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -248,8 +248,8 @@ class CustomerSeatsSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            400: ClaimSeat400Error,
-            403: ClaimSeat403Error,
+            400: CustomerSeatsClaimSeat400Error,
+            403: CustomerSeatsClaimSeat403Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerSeatClaimResponse, method_errors)
@@ -270,9 +270,9 @@ class CustomerSeatsAsync(AsyncServiceBase):
             order_id:
 
         Raises:
-            ListSeats401Error: Authentication required
-            ListSeats403Error: Not permitted or seat-based pricing not enabled
-            ListSeats404Error: Subscription or order not found
+            CustomerSeatsListSeats401Error: Authentication required
+            CustomerSeatsListSeats403Error: Not permitted or seat-based pricing not enabled
+            CustomerSeatsListSeats404Error: Subscription or order not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -289,9 +289,9 @@ class CustomerSeatsAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            401: ListSeats401Error,
-            403: ListSeats403Error,
-            404: ListSeats404Error,
+            401: CustomerSeatsListSeats401Error,
+            403: CustomerSeatsListSeats403Error,
+            404: CustomerSeatsListSeats404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, SeatsList, method_errors)
@@ -307,10 +307,10 @@ class CustomerSeatsAsync(AsyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            AssignSeat400Error: No available seats or customer already has a seat
-            AssignSeat401Error: Authentication required
-            AssignSeat403Error: Not permitted or seat-based pricing not enabled
-            AssignSeat404Error: Subscription, order, or customer not found
+            CustomerSeatsAssignSeat400Error: No available seats or customer already has a seat
+            CustomerSeatsAssignSeat401Error: Authentication required
+            CustomerSeatsAssignSeat403Error: Not permitted or seat-based pricing not enabled
+            CustomerSeatsAssignSeat404Error: Subscription, order, or customer not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -325,10 +325,10 @@ class CustomerSeatsAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            400: AssignSeat400Error,
-            401: AssignSeat401Error,
-            403: AssignSeat403Error,
-            404: AssignSeat404Error,
+            400: CustomerSeatsAssignSeat400Error,
+            401: CustomerSeatsAssignSeat401Error,
+            403: CustomerSeatsAssignSeat403Error,
+            404: CustomerSeatsAssignSeat404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerSeat, method_errors)
@@ -344,9 +344,9 @@ class CustomerSeatsAsync(AsyncServiceBase):
             seat_id:
 
         Raises:
-            RevokeSeat401Error: Authentication required
-            RevokeSeat403Error: Not permitted or seat-based pricing not enabled
-            RevokeSeat404Error: Seat not found
+            CustomerSeatsRevokeSeat401Error: Authentication required
+            CustomerSeatsRevokeSeat403Error: Not permitted or seat-based pricing not enabled
+            CustomerSeatsRevokeSeat404Error: Seat not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -362,9 +362,9 @@ class CustomerSeatsAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            401: RevokeSeat401Error,
-            403: RevokeSeat403Error,
-            404: RevokeSeat404Error,
+            401: CustomerSeatsRevokeSeat401Error,
+            403: CustomerSeatsRevokeSeat403Error,
+            404: CustomerSeatsRevokeSeat404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerSeat, method_errors)
@@ -380,10 +380,10 @@ class CustomerSeatsAsync(AsyncServiceBase):
             seat_id:
 
         Raises:
-            ResendInvitation400Error: Seat is not pending or already claimed
-            ResendInvitation401Error: Authentication required
-            ResendInvitation403Error: Not permitted or seat-based pricing not enabled
-            ResendInvitation404Error: Seat not found
+            CustomerSeatsResendInvitation400Error: Seat is not pending or already claimed
+            CustomerSeatsResendInvitation401Error: Authentication required
+            CustomerSeatsResendInvitation403Error: Not permitted or seat-based pricing not enabled
+            CustomerSeatsResendInvitation404Error: Seat not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -399,10 +399,10 @@ class CustomerSeatsAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            400: ResendInvitation400Error,
-            401: ResendInvitation401Error,
-            403: ResendInvitation403Error,
-            404: ResendInvitation404Error,
+            400: CustomerSeatsResendInvitation400Error,
+            401: CustomerSeatsResendInvitation401Error,
+            403: CustomerSeatsResendInvitation403Error,
+            404: CustomerSeatsResendInvitation404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerSeat, method_errors)
@@ -416,9 +416,9 @@ class CustomerSeatsAsync(AsyncServiceBase):
             invitation_token:
 
         Raises:
-            GetClaimInfo400Error: Invalid or expired invitation token
-            GetClaimInfo403Error: Seat-based pricing not enabled for organization
-            GetClaimInfo404Error: Seat not found
+            CustomerSeatsGetClaimInfo400Error: Invalid or expired invitation token
+            CustomerSeatsGetClaimInfo403Error: Seat-based pricing not enabled for organization
+            CustomerSeatsGetClaimInfo404Error: Seat not found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -434,9 +434,9 @@ class CustomerSeatsAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            400: GetClaimInfo400Error,
-            403: GetClaimInfo403Error,
-            404: GetClaimInfo404Error,
+            400: CustomerSeatsGetClaimInfo400Error,
+            403: CustomerSeatsGetClaimInfo403Error,
+            404: CustomerSeatsGetClaimInfo404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, SeatClaimInfo, method_errors)
@@ -450,8 +450,8 @@ class CustomerSeatsAsync(AsyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            ClaimSeat400Error: Invalid, expired, or already claimed token
-            ClaimSeat403Error: Seat-based pricing not enabled for organization
+            CustomerSeatsClaimSeat400Error: Invalid, expired, or already claimed token
+            CustomerSeatsClaimSeat403Error: Seat-based pricing not enabled for organization
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -466,8 +466,8 @@ class CustomerSeatsAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            400: ClaimSeat400Error,
-            403: ClaimSeat403Error,
+            400: CustomerSeatsClaimSeat400Error,
+            403: CustomerSeatsClaimSeat403Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, CustomerSeatClaimResponse, method_errors)

--- a/sdk/python/polar/v2026_04/services/event_types.py
+++ b/sdk/python/polar/v2026_04/services/event_types.py
@@ -5,8 +5,8 @@ import typing
 
 from polar.base import AsyncServiceBase, SyncServiceBase, parse_response_json
 from polar.v2026_04.errors import (
+    EventTypesUpdate404Error,
     HTTPValidationError,
-    Update404Error,
 )
 from polar.v2026_04.inputs import (
     EventTypeUpdate,
@@ -158,7 +158,7 @@ class EventTypesSync(SyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            Update404Error: Not Found
+            EventTypesUpdate404Error: Not Found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -175,7 +175,7 @@ class EventTypesSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            404: Update404Error,
+            404: EventTypesUpdate404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, EventType, method_errors)
@@ -318,7 +318,7 @@ class EventTypesAsync(AsyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            Update404Error: Not Found
+            EventTypesUpdate404Error: Not Found
             HTTPValidationError: Validation Error
             PolarNetworkError: Raised when a network error occurs while making the request.
             PolarRateLimitError: Raised when the rate limit is exceeded.
@@ -335,7 +335,7 @@ class EventTypesAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            404: Update404Error,
+            404: EventTypesUpdate404Error,
             422: HTTPValidationError,
         }
         return parse_response_json(response, EventType, method_errors)

--- a/sdk/python/polar/v2026_04/services/orders.py
+++ b/sdk/python/polar/v2026_04/services/orders.py
@@ -10,12 +10,12 @@ from polar.base import (
     parse_response_text,
 )
 from polar.v2026_04.errors import (
-    Finalize402Error,
-    Finalize403Error,
     HTTPValidationError,
     MissingInvoiceBillingDetails,
     OrderNotDraft,
     OrderNotEligibleForInvoice,
+    OrdersFinalize402Error,
+    OrdersFinalize403Error,
     ResourceNotFound,
 )
 from polar.v2026_04.inputs import (
@@ -334,8 +334,8 @@ class OrdersSync(SyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            Finalize402Error: The charge failed, or requires customer authentication (e.g. a 3DS challenge) that can't be completed off-session.
-            Finalize403Error: Off-session charges are not enabled for this organization, or its account can't currently accept payments.
+            OrdersFinalize402Error: The charge failed, or requires customer authentication (e.g. a 3DS challenge) that can't be completed off-session.
+            OrdersFinalize403Error: Off-session charges are not enabled for this organization, or its account can't currently accept payments.
             ResourceNotFound: Order not found.
             OrderNotDraft: The order is not in `draft` status.
             HTTPValidationError: Validation Error
@@ -354,8 +354,8 @@ class OrdersSync(SyncServiceBase):
         )
         response = self.client.send_request(request)
         method_errors = {
-            402: Finalize402Error,
-            403: Finalize403Error,
+            402: OrdersFinalize402Error,
+            403: OrdersFinalize403Error,
             404: ResourceNotFound,
             412: OrderNotDraft,
             422: HTTPValidationError,
@@ -766,8 +766,8 @@ class OrdersAsync(AsyncServiceBase):
             **kwargs: Request body parameters
 
         Raises:
-            Finalize402Error: The charge failed, or requires customer authentication (e.g. a 3DS challenge) that can't be completed off-session.
-            Finalize403Error: Off-session charges are not enabled for this organization, or its account can't currently accept payments.
+            OrdersFinalize402Error: The charge failed, or requires customer authentication (e.g. a 3DS challenge) that can't be completed off-session.
+            OrdersFinalize403Error: Off-session charges are not enabled for this organization, or its account can't currently accept payments.
             ResourceNotFound: Order not found.
             OrderNotDraft: The order is not in `draft` status.
             HTTPValidationError: Validation Error
@@ -786,8 +786,8 @@ class OrdersAsync(AsyncServiceBase):
         )
         response = await self.client.send_request(request)
         method_errors = {
-            402: Finalize402Error,
-            403: Finalize403Error,
+            402: OrdersFinalize402Error,
+            403: OrdersFinalize403Error,
             404: ResourceNotFound,
             412: OrderNotDraft,
             422: HTTPValidationError,

--- a/sdk/python/polar/v2026_04/services/subscriptions.py
+++ b/sdk/python/polar/v2026_04/services/subscriptions.py
@@ -15,7 +15,6 @@ from polar.v2026_04.errors import (
     PaymentFailed,
     ResourceNotFound,
     SubscriptionLocked,
-    SubscriptionsUpdate403Error,
 )
 from polar.v2026_04.inputs import (
     MetadataQuery,
@@ -419,7 +418,7 @@ class SubscriptionsSync(SyncServiceBase):
 
         Raises:
             PaymentFailed: Payment required to apply the subscription update.
-            SubscriptionsUpdate403Error: Subscription is already canceled or will be at the end of the period, or is not active.
+            AlreadyCanceledSubscription: Subscription is already canceled or will be at the end of the period.
             ResourceNotFound: Subscription not found.
             SubscriptionLocked: Subscription is pending an update.
             HTTPValidationError: Validation Error
@@ -439,7 +438,7 @@ class SubscriptionsSync(SyncServiceBase):
         response = self.client.send_request(request)
         method_errors = {
             402: PaymentFailed,
-            403: SubscriptionsUpdate403Error,
+            403: AlreadyCanceledSubscription,
             404: ResourceNotFound,
             409: SubscriptionLocked,
             422: HTTPValidationError,
@@ -826,7 +825,7 @@ class SubscriptionsAsync(AsyncServiceBase):
 
         Raises:
             PaymentFailed: Payment required to apply the subscription update.
-            SubscriptionsUpdate403Error: Subscription is already canceled or will be at the end of the period, or is not active.
+            AlreadyCanceledSubscription: Subscription is already canceled or will be at the end of the period.
             ResourceNotFound: Subscription not found.
             SubscriptionLocked: Subscription is pending an update.
             HTTPValidationError: Validation Error
@@ -846,7 +845,7 @@ class SubscriptionsAsync(AsyncServiceBase):
         response = await self.client.send_request(request)
         method_errors = {
             402: PaymentFailed,
-            403: SubscriptionsUpdate403Error,
+            403: AlreadyCanceledSubscription,
             404: ResourceNotFound,
             409: SubscriptionLocked,
             422: HTTPValidationError,

--- a/sdk/python/polar/v2026_04/services/webhooks.py
+++ b/sdk/python/polar/v2026_04/services/webhooks.py
@@ -282,11 +282,7 @@ class WebhooksSync(SyncServiceBase):
         end_timestamp: str | None = None,
         succeeded: bool | None = None,
         query: str | None = None,
-        http_code_class: typing.Literal["2xx"]
-        | typing.Literal["3xx"]
-        | typing.Literal["4xx"]
-        | typing.Literal["5xx"]
-        | None = None,
+        http_code_class: typing.Literal["2xx", "3xx", "4xx", "5xx"] | None = None,
         event_type: WebhookEventType | list[WebhookEventType] | None = None,
         page: int = 1,
         limit: int = 10,
@@ -345,11 +341,7 @@ class WebhooksSync(SyncServiceBase):
         end_timestamp: str | None = None,
         succeeded: bool | None = None,
         query: str | None = None,
-        http_code_class: typing.Literal["2xx"]
-        | typing.Literal["3xx"]
-        | typing.Literal["4xx"]
-        | typing.Literal["5xx"]
-        | None = None,
+        http_code_class: typing.Literal["2xx", "3xx", "4xx", "5xx"] | None = None,
         event_type: WebhookEventType | list[WebhookEventType] | None = None,
         page: int = 1,
         limit: int = 10,
@@ -689,11 +681,7 @@ class WebhooksAsync(AsyncServiceBase):
         end_timestamp: str | None = None,
         succeeded: bool | None = None,
         query: str | None = None,
-        http_code_class: typing.Literal["2xx"]
-        | typing.Literal["3xx"]
-        | typing.Literal["4xx"]
-        | typing.Literal["5xx"]
-        | None = None,
+        http_code_class: typing.Literal["2xx", "3xx", "4xx", "5xx"] | None = None,
         event_type: WebhookEventType | list[WebhookEventType] | None = None,
         page: int = 1,
         limit: int = 10,
@@ -752,11 +740,7 @@ class WebhooksAsync(AsyncServiceBase):
         end_timestamp: str | None = None,
         succeeded: bool | None = None,
         query: str | None = None,
-        http_code_class: typing.Literal["2xx"]
-        | typing.Literal["3xx"]
-        | typing.Literal["4xx"]
-        | typing.Literal["5xx"]
-        | None = None,
+        http_code_class: typing.Literal["2xx", "3xx", "4xx", "5xx"] | None = None,
         event_type: WebhookEventType | list[WebhookEventType] | None = None,
         page: int = 1,
         limit: int = 10,

--- a/sdk/python/polar/v2026_04/webhooks.py
+++ b/sdk/python/polar/v2026_04/webhooks.py
@@ -19,6 +19,11 @@ from polar.v2026_04.outputs import (
     Subscription,
 )
 from polar.webhooks import (
+    PolarWebhookError,
+    PolarWebhookUnknownTypeError,
+    PolarWebhookVerificationError,
+)
+from polar.webhooks import (
     validate_event as _validate_event,
 )
 
@@ -669,3 +674,49 @@ def validate_event(
 
 def _load_payload(data: dict[str, typing.Any]) -> WebhookPayload:
     return deserialize(data, WebhookPayload)
+
+
+__all__ = [
+    "PolarWebhookError",
+    "PolarWebhookUnknownTypeError",
+    "PolarWebhookVerificationError",
+    "WebhookBenefitCreatedPayload",
+    "WebhookBenefitGrantCreatedPayload",
+    "WebhookBenefitGrantCycledPayload",
+    "WebhookBenefitGrantRevokedPayload",
+    "WebhookBenefitGrantUpdatedPayload",
+    "WebhookBenefitUpdatedPayload",
+    "WebhookCheckoutCreatedPayload",
+    "WebhookCheckoutExpiredPayload",
+    "WebhookCheckoutUpdatedPayload",
+    "WebhookCustomerCreatedPayload",
+    "WebhookCustomerDeletedPayload",
+    "WebhookCustomerSeatAssignedPayload",
+    "WebhookCustomerSeatClaimedPayload",
+    "WebhookCustomerSeatRevokedPayload",
+    "WebhookCustomerStateChangedPayload",
+    "WebhookCustomerUpdatedPayload",
+    "WebhookMemberCreatedPayload",
+    "WebhookMemberDeletedPayload",
+    "WebhookMemberUpdatedPayload",
+    "WebhookOrderCreatedPayload",
+    "WebhookOrderPaidPayload",
+    "WebhookOrderRefundedPayload",
+    "WebhookOrderUpdatedPayload",
+    "WebhookOrganizationUpdatedPayload",
+    "WebhookPayload",
+    "WebhookProductCreatedPayload",
+    "WebhookProductUpdatedPayload",
+    "WebhookRefundCreatedPayload",
+    "WebhookRefundUpdatedPayload",
+    "WebhookSubscriptionActivePayload",
+    "WebhookSubscriptionCanceledPayload",
+    "WebhookSubscriptionCreatedPayload",
+    "WebhookSubscriptionPastDuePayload",
+    "WebhookSubscriptionPausedPayload",
+    "WebhookSubscriptionResumedPayload",
+    "WebhookSubscriptionRevokedPayload",
+    "WebhookSubscriptionUncanceledPayload",
+    "WebhookSubscriptionUpdatedPayload",
+    "validate_event",
+]

--- a/sdk/python/polar/v2026_04/webhooks.py
+++ b/sdk/python/polar/v2026_04/webhooks.py
@@ -19,15 +19,6 @@ from polar.v2026_04.outputs import (
     Subscription,
 )
 from polar.webhooks import (
-    PolarWebhookError as PolarWebhookError,
-)
-from polar.webhooks import (
-    PolarWebhookUnknownTypeError as PolarWebhookUnknownTypeError,
-)
-from polar.webhooks import (
-    PolarWebhookVerificationError as PolarWebhookVerificationError,
-)
-from polar.webhooks import (
     validate_event as _validate_event,
 )
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -43,6 +43,7 @@ target-version = "py311"
 
 [tool.ruff.lint]
 extend-select = ["I", "UP"]
+ignore = ["B006"]
 
 [tool.uv]
 default-groups = ["dev"]

--- a/sdk/python/uv.lock
+++ b/sdk/python/uv.lock
@@ -29,21 +29,12 @@ wheels = [
 ]
 
 [[package]]
-name = "attrs"
-version = "26.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
-]
-
-[[package]]
 name = "certifi"
-version = "2026.6.17"
+version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c9/c7/424b75da314c1045981bd9777432fad05a9e0c69daa4ed7e308bbaffe405/certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432", size = 134594, upload-time = "2026-06-17T10:31:07.894Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db", size = 133289, upload-time = "2026-06-17T10:31:06.348Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
 ]
 
 [[package]]
@@ -53,18 +44,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
-]
-
-[[package]]
-name = "deprecated"
-version = "1.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "wrapt" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
 ]
 
 [[package]]
@@ -124,11 +103,11 @@ wheels = [
 
 [[package]]
 name = "packaging"
-version = "26.2"
+version = "26.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
 ]
 
 [[package]]
@@ -198,106 +177,62 @@ wheels = [
 ]
 
 [[package]]
-name = "python-dateutil"
-version = "2.9.0.post0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
-]
-
-[[package]]
 name = "ruff"
-version = "0.15.22"
+version = "0.16.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3a/06/ae069393fc66e8ff33036d4b368003833bf6e88ccf182e17e7a2f1c754fd/ruff-0.15.22.tar.gz", hash = "sha256:3f15175b1fb580126f58285a5dae6b2ea89000136d980c64499211f116b54809", size = 4785063, upload-time = "2026-07-16T15:14:13.244Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/25/7113f6d5498888c5fb7db34081cba7d5971c4cb1bfb26819966eee68f003/ruff-0.16.1.tar.gz", hash = "sha256:fedad7c801dabd3fb9741d76aca39246e6ddd9ca446a015875207bf19f1e6bc7", size = 4877500, upload-time = "2026-07-30T19:37:01.379Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/18/ee54b7ae1e121be7a28ea6da4b67564ebb0530e183a54415ab7e3bcd2c4e/ruff-0.15.22-py3-none-linux_armv6l.whl", hash = "sha256:44423e73493737f5e7c5b41d475483898ff37afcdae38bc3da5085e29af1c2d8", size = 10781258, upload-time = "2026-07-16T15:13:19.452Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/d2/2520cb14761ddbeaf57642a76942fc36adcbdbe53b4532241995f6fc485c/ruff-0.15.22-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b82c6482946e9eda7ff2e091d25b8bad3f718684e1916d41bd56873cee05b697", size = 10999477, upload-time = "2026-07-16T15:13:23.318Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/10/74e53572aa758dfaa678c2a2646b5c5515d884b7ca56be4d2ce03ca4b560/ruff-0.15.22-py3-none-macosx_11_0_arm64.whl", hash = "sha256:11c1c715af53a09f714e011106bffc419751ec8232fcb5da42173284ea3fec6f", size = 10466716, upload-time = "2026-07-16T15:13:26.162Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/cc/44eaaf0844e028182f2d0a8f2190d0f359159aed0a9e5ab861d892f1ae2a/ruff-0.15.22-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:742a29cf29bddb7c8327895d6a10e0e6c5b38a96dd407af9b5d0857f809c0576", size = 10892644, upload-time = "2026-07-16T15:13:29.229Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/21/8edf559014d2b0f82beea19cfb713993ad802ccda16868769979c6090a84/ruff-0.15.22-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72af58b951b0ae395935ae79763dc349bc0eb706319d28f7a33ad2cfb3cfc178", size = 10576719, upload-time = "2026-07-16T15:13:32.35Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/1e/3a13abd392a3b50b62e5938a831f9ab6e588358cacad5c18545b716d2182/ruff-0.15.22-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62d425005c1835eb24e2ee4161cb90e8db263415f4a71c8c72c33abaa6c0c224", size = 11376494, upload-time = "2026-07-16T15:13:35.958Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/3e/422d3d95bcf04dd78e1aeac22184d4f9a8fb2c01865d39d44618484a0317/ruff-0.15.22-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8b9b3f8779a4f08c969defc3c8c35abffaa757e601ed5ae66d6d1db6519969a", size = 12208370, upload-time = "2026-07-16T15:13:39.185Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/91/5d065a0e0a02bf4813f5119ad278462eed081d2b832eb7c021ade0ec9e65/ruff-0.15.22-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1e0dd1b2e4d3d585f897a0d137cbf4eaf6223bef4e8ce34d6bb12556c5f9249e", size = 11581098, upload-time = "2026-07-16T15:13:42.132Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/f9/a0d4871d12fae702eb1f41b686caf05f1f8b124dc6db6f784f53d74918fa/ruff-0.15.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365523eb91d9224e1bcb03b022fbf0facb8f9e23792a2c53d9d4b3924bdbdebb", size = 11399422, upload-time = "2026-07-16T15:13:45.2Z" },
-    { url = "https://files.pythonhosted.org/packages/18/80/c843a5176cddbceb0b7e8dd41cf9993490796c1c469348d384f5a5c13c56/ruff-0.15.22-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:fabfd168afdf29fee5be98b831efa9683c94d7c5a3b58b9ce5a2e38444589a74", size = 11381683, upload-time = "2026-07-16T15:13:48.46Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/00/8485de0ae92239438a36cfc51350db9b9e85c9ebdfaea91b18e422706662/ruff-0.15.22-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:225dbf095a87f1d9f90f5fd7924d2613ee452a75a4308c63a8f50f761787aa7c", size = 10850295, upload-time = "2026-07-16T15:13:51.655Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/91/24977ec2ec72eaf15e4394ace2959fdff2dd1e14f03e005e838023407169/ruff-0.15.22-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1877d63b9d24ed278744f1523fd11b85540566d54641f97c566d7d9dc5ca5296", size = 10579640, upload-time = "2026-07-16T15:13:54.79Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/47/9b51216951974df1f263ac19da550d34252e0ed7218c25f10c5ef9ed7517/ruff-0.15.22-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a1606c510bd7215680d32efab38965f7cdec3ef69f5170a3f4791404ffdd5262", size = 11105077, upload-time = "2026-07-16T15:13:57.915Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/47/20e9d4a3b8016778acea5fc32bb50d35d207500a17ddb529ffa6996feef8/ruff-0.15.22-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:630479b18625f5ffc373f77603a22a9f8ac0acd7ff0501178b5db28ec71e9c64", size = 11490980, upload-time = "2026-07-16T15:14:01.032Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/76/3f72d8fc38c1cb77b38c56a70da9d0c17700cc1cc50f9649c9d3c8f5ba71/ruff-0.15.22-py3-none-win32.whl", hash = "sha256:e5ba0e4a13fd14abbed2a77b517a3911290c6c6c59ef67784328d1668fab76cf", size = 10789165, upload-time = "2026-07-16T15:14:04.16Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/46/4965251734c2b6fcdca1b1b187d20bcac3af0ee5b083b89c910bb961ce3a/ruff-0.15.22-py3-none-win_amd64.whl", hash = "sha256:9be63ba1eb936acd2d1342fb8337c356353706fce233b2a15a09a97037e6acde", size = 11938297, upload-time = "2026-07-16T15:14:07.316Z" },
-    { url = "https://files.pythonhosted.org/packages/57/c9/e69b1ff4c8b69093ef08b8919ab767af0569666865b39c30a8795d88d3c6/ruff-0.15.22-py3-none-win_arm64.whl", hash = "sha256:e1168075b72158510839f250027659cdd78476f40507dd517892304c41318661", size = 11298172, upload-time = "2026-07-16T15:14:10.51Z" },
-]
-
-[[package]]
-name = "six"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bd/694da69368e0973de65df2ddc73ab18d43c469d5963d9b150911de6bc513/ruff-0.16.1-py3-none-linux_armv6l.whl", hash = "sha256:58edb313b88f0c5460a26adf5f39a37a3be789494a15e3e411e35fa78b89f9a0", size = 10839126, upload-time = "2026-07-30T19:36:13.697Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/f0/b626e5d5bd0dd9576263658ef12885e2288afd1029a48e26ffed65ec1ac1/ruff-0.16.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:fde5a99e2f97479af66edd6622c6d5a2a7592c77cf4153d9e4428f5eeb55b60c", size = 11070253, upload-time = "2026-07-30T19:36:17.14Z" },
+    { url = "https://files.pythonhosted.org/packages/83/63/f40acfb6b35b88623e71684942b552c3edd96035f5d98f313815f7b277de/ruff-0.16.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e0d4c20532fca4f7fa609369161d968dd28f65d83dabbd61d8e9c7edbf7001f6", size = 10561425, upload-time = "2026-07-30T19:36:20.04Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/dd/14ec0e9c2b4d315547dd38765004b4863e354e1b52cb308272215d9f6f6d/ruff-0.16.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30affbcedf59ad5703d9c91f82266e02b47739f797e1a7b6e158e5526a6dae38", size = 10948879, upload-time = "2026-07-30T19:36:22.476Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e9/9d870cbae575030fdef595f04b4b97573c525b5497cce4f4498cf2f85446/ruff-0.16.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:24e9c631573cbca9d20f1283f8f479b2afa4a8503504822bd71a293889f16743", size = 10643691, upload-time = "2026-07-30T19:36:24.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/09/12743d544e2173f53ecd27217c65f90d2bc0f8424a66a60339e56bbc0457/ruff-0.16.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b41bdd48fb420987a9b5212e4957c26ad4abce401fa9ea9d4d85843727945f4f", size = 11435354, upload-time = "2026-07-30T19:36:28.447Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/89/a1652b2daee52083c9554a6333b678a8b01d0400f976827bb87857f9449a/ruff-0.16.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b0d1e1393b7648079e13669de1c1f4fde06d4583e84d8fd5c1551e0a77a2aa75", size = 12259033, upload-time = "2026-07-30T19:36:31.326Z" },
+    { url = "https://files.pythonhosted.org/packages/16/96/ecdcb8c54ee7b123b487f807eb014e6e019155a0b81dfb669acd52f28ce3/ruff-0.16.1-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:07bf434b1c95f4e093be4532068ef4fcf00924eb2ade8796075980902d6fd54a", size = 11667981, upload-time = "2026-07-30T19:36:34.394Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/90/c52e12e0d862e9572f2a33aa227409143520abe53111e9a6babbac7b4af8/ruff-0.16.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39897739f112253ee4fdd2e8aa9a4f9ded99fb2be367d5f31dfa4ded6025584c", size = 11468183, upload-time = "2026-07-30T19:36:37.339Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6b/4ffb7ad1d83eb16cf8cbb3c8815d3f11c88460fd162d4b372a2059be1c2a/ruff-0.16.1-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:82ae3c0c0d74daf17b968a10b7b3bb3ef297ab7de0c1f749646b25e690ccb150", size = 11470071, upload-time = "2026-07-30T19:36:39.91Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/72/32ae7db4c0b5e32ab611787caa19d1546800676d79f7483b7100a3561bf4/ruff-0.16.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4d5f2ed10f8242d83fc08d521301089364e3375375705356f20c0e31606ef3ef", size = 10919503, upload-time = "2026-07-30T19:36:42.65Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ca/3d901ba6ad6fc38da39c3448fc6c59ac945679293a17c3ceb6d6c1cba13e/ruff-0.16.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a4665b309891f83f3e3c25447935f1213e9abbd4b5640af7a1f2def9f8d413c1", size = 10649861, upload-time = "2026-07-30T19:36:45.18Z" },
+    { url = "https://files.pythonhosted.org/packages/92/79/894ef1ced26552d5f8c9cf6d85b0687840e1128c55aeab7b9c2d54a0d880/ruff-0.16.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:26e9ca5c9bc3971f20d3cf18a957f52ffd6a5f6564ff15c4912a144dcac22494", size = 11148137, upload-time = "2026-07-30T19:36:47.936Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/69/3609a09fa1cb46cc28b762363e440a354204e5dff01bd0c8d7437874d6b9/ruff-0.16.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:67e1e1e3fa4f0c82f0e36d4cd61e661f6e7a6196cb1aa92fe0828fa7b8f257cd", size = 11559211, upload-time = "2026-07-30T19:36:50.448Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/8a/fb22af2fd78a736e241fabf67e30ce1799a64244026377a49e133af90762/ruff-0.16.1-py3-none-win32.whl", hash = "sha256:d31765e131295b8445caf301e3e8a85b34d1b9b211b4109b7ba457888b051806", size = 10838258, upload-time = "2026-07-30T19:36:53.298Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/35/e57fd9fb5d423961df087a00b12d42c0a830288dc2f3b45ecca299158b4f/ruff-0.16.1-py3-none-win_amd64.whl", hash = "sha256:09b05e8b90c2cb06ad63464350e7a45e8e44a2dfe52072ebfba6666ca8d3f596", size = 11961111, upload-time = "2026-07-30T19:36:56.107Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/46/240ea004bf6dc4feb40e9832f2205a476a47dd5b8a3f8211a5fc5f95e20e/ruff-0.16.1-py3-none-win_arm64.whl", hash = "sha256:dbaadaac38c70239f056d306b7476f246b0bf000fa6b3876402acbf5b227eaf8", size = 11309414, upload-time = "2026-07-30T19:36:58.79Z" },
 ]
 
 [[package]]
 name = "standardwebhooks"
-version = "1.0.1"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-    { name = "deprecated" },
-    { name = "httpx" },
-    { name = "python-dateutil" },
-    { name = "types-deprecated" },
-    { name = "types-python-dateutil" },
+sdist = { url = "https://files.pythonhosted.org/packages/50/81/a26b812525dd9ad6cc0f6ba2f8eafd5bf595542e319d95123aa92b51bf22/standardwebhooks-1.1.0.tar.gz", hash = "sha256:e5cb66e21a6356ebb9375aeb57f1348583323015808d475a7c1baaa4b718068a", size = 3232, upload-time = "2026-07-21T15:49:51.45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/dc/0cd2bd9a536e61ad0ee9de3b724492a38faa88ce1828fbc15940824664c3/standardwebhooks-1.1.0-py3-none-any.whl", hash = "sha256:9a88d48a1f198be61517fc7ad328cf58ba02b73f0fbd8941d4213e9c0b6c2a61", size = 3538, upload-time = "2026-07-21T15:49:50.519Z" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/7d/04fc3aa177403472d3ddae90953d8f878dc5fd21ba29c02fc9e97e10703f/standardwebhooks-1.0.1.tar.gz", hash = "sha256:b557bb2e4b16ada179a517ec0fe6cbec5acf976c5619922bf29c457f89a451bd", size = 5103, upload-time = "2026-02-18T19:13:06.793Z" }
 
 [[package]]
 name = "ty"
-version = "0.0.60"
+version = "0.0.66"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0a/6e/1ab6f2727622d38ddfb2a7f994209b3087190b76885e2f754dbb6e58e0c9/ty-0.0.60.tar.gz", hash = "sha256:ebd7517d1aa8d8c3793cbf03c263679a42b939eca650df583234f92a5eb5837a", size = 6189323, upload-time = "2026-07-16T10:18:14.124Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/58/4f6ab2a86589e422a3cf840bcf6114c565e4c39ddf4d0b7cd328af5b52b4/ty-0.0.66.tar.gz", hash = "sha256:24bddd4479ce445b51ac015410dd2d34af1cadd62a77f5b3cb269149ed83f9b5", size = 6520402, upload-time = "2026-08-04T01:09:47.714Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/fc/c82d30b753dfb9d83ac34568478d9487bc42e1e79241a22b57f4b28fabee/ty-0.0.60-py3-none-linux_armv6l.whl", hash = "sha256:0842270c2e10d8416ca9f8aca1357c827efc5212300fbbc709e186e66fc7f9da", size = 11831443, upload-time = "2026-07-16T10:17:34.912Z" },
-    { url = "https://files.pythonhosted.org/packages/47/d4/09e386d816076d1d90c57baee7f607e1475b625bb9f9279b28302da22f18/ty-0.0.60-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f49d024571cd7e569081638ab0ccc9e6795d642c6b9208addecc5e487364f0a3", size = 11624536, upload-time = "2026-07-16T10:17:37.445Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/1e/e527e29fd9a3d41ddc419a43b37927c42a0d8ee4ca8a148ce4e022328f2f/ty-0.0.60-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5b006c9a793d735ff808999775bbc0f07f91de50e931799f17322440cd9d055f", size = 11032920, upload-time = "2026-07-16T10:17:39.695Z" },
-    { url = "https://files.pythonhosted.org/packages/79/e0/0f294bf2521f2836ba1a4682d4301c2038e4dfedee3a70df8f6005694978/ty-0.0.60-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:233033de40a0722420380d40f0eeebe8eb0d3afeeab3a6e7b1388e2caf1a017c", size = 11575334, upload-time = "2026-07-16T10:17:41.644Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/8c/682e46e29165d9c94829576687092a8ea4556dd5882b11edd32bc7f4b534/ty-0.0.60-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:61bcbd67f653ae2966d0e423879127907c6f8b567d64b6db93cb8f6cca7045ed", size = 11659354, upload-time = "2026-07-16T10:17:43.815Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/d3/6baf7eb3cf9459416032285a10ffe1309f7e255e3f1974372bc41d44cfd3/ty-0.0.60-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b72e44a0be08ad778693d49b00b03bb784c1465d8265b3b392b355b34257a437", size = 12293710, upload-time = "2026-07-16T10:17:46.032Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/f7/b287d78c93449fc5153891ad040be55e0718711ae7c0f2c54d3b88dd4d00/ty-0.0.60-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:13b89f03a76f149350617345ae33bd332d2c6023dc5d560dd10a4f0210fba13a", size = 12837636, upload-time = "2026-07-16T10:17:48.453Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/f2/3d8c77ca5f836fb6280231030df5a4504476a38d4554330d2be42125888e/ty-0.0.60-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:30db8ebf6715da30afac62311ac773bf436ed503ed989cc9d4be4d3bdc3cbd43", size = 12383469, upload-time = "2026-07-16T10:17:50.567Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/98/958047501d74f9d0df357df28fea1de2afa18f1e6b2dc4a3ea4975c83e14/ty-0.0.60-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9ecd6dc686f90c3bfe22c9b435e4a5325f5066f706bfe95c1616ef425b1f0654", size = 12132334, upload-time = "2026-07-16T10:17:52.718Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/8f/b2853634da28aac01ea0ba8ef7695dc3d6c9aaf9c63dfdcf7c7435bc6c25/ty-0.0.60-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a2292124558d839e31afd9829b11dda726ce65096b1feb80d14a1ddc7ccb0f28", size = 12359945, upload-time = "2026-07-16T10:17:55.143Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/ae/bfecc71fcf1b833117bfb0efb76e14f5772874775274115ac94f64c5ba7a/ty-0.0.60-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:78812ec03da2c3141030ee1717fb09f0845eb552a77e79680c1cca598861ddaf", size = 11534812, upload-time = "2026-07-16T10:17:57.165Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/23/1236c1ab9cd6b2daba9c558c9dcf04644f7b636f3bab3c15e74c7f80f5e1/ty-0.0.60-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a92c1dbc48f8b414ddcf199c1119054de00f8ee995528fa9d9c2e4ddd13cd0c1", size = 11677591, upload-time = "2026-07-16T10:17:59.747Z" },
-    { url = "https://files.pythonhosted.org/packages/49/49/86c9230d9a8bf1755ca4b0165e7cb6bdfa2e495f0a105b24c6a27b5a542c/ty-0.0.60-py3-none-musllinux_1_2_i686.whl", hash = "sha256:2c367d5ffe545004f0603e5599614062230678eeab980acd32850a7c19d60fc9", size = 11901279, upload-time = "2026-07-16T10:18:02.301Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/0a/0c2e9904362d9c63700116feb192a3e10122eef49a417cde84068b2562fd/ty-0.0.60-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a94b1f99aa8f8ca5879341a5351af708b85ce19c7494db320c719a1e129d08e8", size = 12230659, upload-time = "2026-07-16T10:18:04.384Z" },
-    { url = "https://files.pythonhosted.org/packages/84/4d/39c414f6b4bc944b2bac19c181438ee393c8eb34e9e21d97e5a148745f95/ty-0.0.60-py3-none-win32.whl", hash = "sha256:5ea2c85249581fb0060b9ff63b5313330f48930b2e50f6c85a5a322701626cc5", size = 11175286, upload-time = "2026-07-16T10:18:06.523Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/08/fdf4072d96c71b65fe98c9ca2ea5b3d2d0f6e20873bb2639e8c7827bd5f6/ty-0.0.60-py3-none-win_amd64.whl", hash = "sha256:15d83c3d793cb07840b8888c084cc2c49eb8acc29456a2fcdfbfd509c82526e5", size = 12249240, upload-time = "2026-07-16T10:18:08.701Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/a2/83a496d717f712f894cf26690bcd9465ca23cd1c9139cac669d9cca45d14/ty-0.0.60-py3-none-win_arm64.whl", hash = "sha256:32e63228c3d21ddb192385aaf54501f19478be7b764f7572014d5110e53a9085", size = 11620140, upload-time = "2026-07-16T10:18:11.316Z" },
-]
-
-[[package]]
-name = "types-deprecated"
-version = "1.3.1.20260520"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e9/86/8cc66b0a4d01826e64f86e0001b8755105d1b6052c654e2448a0e72750ee/types_deprecated-1.3.1.20260520.tar.gz", hash = "sha256:4d0d9e5521432d9ce88169fb8b793b45d70d8e8cc1a7ecd5a4465abbf83c9ab4", size = 8649, upload-time = "2026-05-20T05:55:57.211Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/27/e8fd41f0d41b964870d370e7fc78311193910fe9a15c7399ade4a4aeea58/types_deprecated-1.3.1.20260520-py3-none-any.whl", hash = "sha256:8af853b7ccd3b7685159f3ab2e3b6f7999b6cd7e425cda02749e32a42a96c7d6", size = 9105, upload-time = "2026-05-20T05:55:56.259Z" },
-]
-
-[[package]]
-name = "types-python-dateutil"
-version = "2.9.0.20260716"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/9a/aefb9f80ff79641d36149352afe66ca835c5e6894deb518418f786f4b8ad/types_python_dateutil-2.9.0.20260716.tar.gz", hash = "sha256:1d55d1c3024bdb4861bb6a6622c9ec800c433d87bdc5b16fb84cdd0eed4ef2cb", size = 17516, upload-time = "2026-07-16T04:48:06.604Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/16/85/cff97326a81e7e8877803e78e3ea56c840b85bb811934b9c936f7c40f185/types_python_dateutil-2.9.0.20260716-py3-none-any.whl", hash = "sha256:1ae41d51a5c5f6bbeeb7f1f34df7086d55ff1605cf88d2ed71a7a276e1a7794e", size = 18443, upload-time = "2026-07-16T04:48:05.793Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4d/bbc28310d6d887ef73e5800f062c4bf54caa35a1b47d70c7b03d0515ecf1/ty-0.0.66-py3-none-linux_armv6l.whl", hash = "sha256:8b46450438b54b732338e4d7a78a7d2f5e1a012a13d77d121aacaca20fb814e2", size = 12409743, upload-time = "2026-08-04T01:09:01.229Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4e/c3d2eb2242fa0a2ef445ca2c7009dc9118e5b3dcb8b8a8bec70d58c8e4bc/ty-0.0.66-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:8e4adbe662bc3c62b52b83d46b07f703fdc3c123bb72601606c58be5ea017ed3", size = 12078362, upload-time = "2026-08-04T01:09:04.233Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/7a4b5e45d701a8de6b714dacf6ffca91b0411baaceaa781d494037623a18/ty-0.0.66-py3-none-macosx_11_0_arm64.whl", hash = "sha256:776814351735847eb934f9a3cbea21d2278ba14aa0fc099f683da11bc2d5c90a", size = 11583289, upload-time = "2026-08-04T01:09:06.973Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/4a/fbb1f71ee2999f981f8c4b3b139231e4bcff4ede0c3b37e858fd1334ed26/ty-0.0.66-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cca1da877f613965b954bfd22d495386e260ec767c5536c8022cca98a260ea5d", size = 12137274, upload-time = "2026-08-04T01:09:09.592Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/07/9e0662f6603a5ac171ae6b314396e677ead4b45695fc948efb0a4837051f/ty-0.0.66-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:aa523e777bc36c0fbf8ded5844096f46cbfc3712fe5a003351a94259b7e86cf4", size = 12207047, upload-time = "2026-08-04T01:09:12.533Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/cc/12e01bc2ea47fa7bf20fc6cdd3249d6a340be9be4edc52b1d77256245dd0/ty-0.0.66-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3f7993c1f95f80a4e44056e6aaf8e46e608d778db131ae5ce59262ab59358f9a", size = 12919304, upload-time = "2026-08-04T01:09:15.175Z" },
+    { url = "https://files.pythonhosted.org/packages/75/88/c6c0d3a8e71c9cdb560cc5c627a4bba6c47b5eec460b2f8c449b57c6d03a/ty-0.0.66-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f9b29354bcbac9f53b6952d8f46789bd81eeb9bdd7a68df7d26e654ca7498c3c", size = 13470963, upload-time = "2026-08-04T01:09:17.849Z" },
+    { url = "https://files.pythonhosted.org/packages/27/c2/2f8c18063412ad80e1b3f87afce7bd50982b4a048166607b67f80660a9fb/ty-0.0.66-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fbf4e5325f7f584d9c346946e7c415b2e3cd3b8f1119d468082a90a6afd020ce", size = 13244773, upload-time = "2026-08-04T01:09:20.59Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/f6/fdae2b95831116dffc055ad53a99a8f21437263651047b3ad46def4950a3/ty-0.0.66-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bd304363764bd723c22fb20b17035c345420fdf66fee856934b158ebde08a91", size = 12751343, upload-time = "2026-08-04T01:09:23.225Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1e/7e75f0371d11463a256dc2bee98b0df401e0fa06021e200b8b601d21949d/ty-0.0.66-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:205d8589bd957ea9718d488b731b2fbdd0d1b1cefd37c79f52c0deb7cafddfef", size = 13068057, upload-time = "2026-08-04T01:09:26.052Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/84/f20f24518f6f0bea936e2e668ede250b9ce0774624559931599bd1f42772/ty-0.0.66-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7304a1df54741a2343801354f41d7ad87974acb541ee3e93c26cb6a1a0b863af", size = 12082318, upload-time = "2026-08-04T01:09:28.877Z" },
+    { url = "https://files.pythonhosted.org/packages/08/20/70ca0eac2427d4a58a81a3a9426b20e46fb4a5a13aefc9edc2e5172e1243/ty-0.0.66-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:cf2c062863e5da0f588b0b120fec0da2e81c0913ee4cd07b50d77aa60ffd8deb", size = 12228978, upload-time = "2026-08-04T01:09:31.905Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/01/5a461ab34456d788248780830aed673c9e0e796f6e9dd92d3dbf02e04d7f/ty-0.0.66-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a58d32c879d86428978332adf21e85009ec269314a23d330c3483c65b57aedc7", size = 12471917, upload-time = "2026-08-04T01:09:34.418Z" },
+    { url = "https://files.pythonhosted.org/packages/46/ed/f8eb5eff7c9ee644490c6d2626425935c097acc54871adf659ea70624a2c/ty-0.0.66-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b2f810fa3516c977630d78dbe9161592b3c27029fa9bb81074366624d9b5e4b6", size = 12858086, upload-time = "2026-08-04T01:09:37.602Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7f/8a78361f752274a550a7f6f07f127b246ece7d7fdde31121d22074e46eab/ty-0.0.66-py3-none-win32.whl", hash = "sha256:d28c3df565a387c1c5ea359aa452a46d19163616ef71be819058a424a62f1ae1", size = 11782494, upload-time = "2026-08-04T01:09:40.136Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/e2/deed22b823ce309b8410d50414fd15afe9e90aee8b8ca04789ba55c21231/ty-0.0.66-py3-none-win_amd64.whl", hash = "sha256:e3a457f3312c078f24c47d0da6e4f73de34d0a77ed2de22571c066c80b2fd5e7", size = 12893338, upload-time = "2026-08-04T01:09:42.825Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ce/6c828f42ef1ed39f53f57f9c0cdcdf03e23666fa7a29d799042a2c34bcb4/ty-0.0.66-py3-none-win_arm64.whl", hash = "sha256:2f62ae247b9c75674fcc060635f9f00210357da7681de59234d97b50fb9e9e94", size = 12227381, upload-time = "2026-08-04T01:09:45.365Z" },
 ]
 
 [[package]]
@@ -307,79 +242,4 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
-]
-
-[[package]]
-name = "wrapt"
-version = "2.2.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/15/0c2d55168707465abfc41f33c0b23d792a5fa9b65c26983606940900a120/wrapt-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f1a2ff355ece6a111ca7a20dc86df6659c9205d3fcee674ca34f2a2854fd4e73", size = 80782, upload-time = "2026-06-20T23:47:44.367Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/b5/5c0b093eb48f8a062ef6267d3cb36e9bb1b88440181f6545a383c60efdf8/wrapt-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55b9a899e6fff5444f229d30aa6e9ac92d2216d9d60f33c771b5d76a760d5f8e", size = 81678, upload-time = "2026-06-20T23:47:45.857Z" },
-    { url = "https://files.pythonhosted.org/packages/34/f3/de70937472dd3e8a4e6811192f9c6075efdffd4a2cd9b4596bf160f89668/wrapt-2.2.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a2d78c363f97d8bd718ee40432c66395685e9e98528ccaa423c3355d1715a26d", size = 159671, upload-time = "2026-06-20T23:47:47.345Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/ec/40aed2330e7f02ecf74386ffcfef9ccb7108c6a430f15b6a252b663b1bed/wrapt-2.2.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d619e1eed9bd4f6ed9f24cd61971aa086fa86505289628d464bcf8a2c2e3f328", size = 160785, upload-time = "2026-06-20T23:47:48.759Z" },
-    { url = "https://files.pythonhosted.org/packages/45/04/aa5309beed5344b00220ae6b3b24055852192656194c27947bee1736306a/wrapt-2.2.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:518b0c5e323511ec56a38894802ddd5e1222626484e68efe63f201854ad788e5", size = 153699, upload-time = "2026-06-20T23:47:50.177Z" },
-    { url = "https://files.pythonhosted.org/packages/01/df/2def7e99d1fe87eea413f95f671924cdddcb08823b1ffd212748dfa6d062/wrapt-2.2.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4bccea5cdecffa9dd70e343741f0e41e0a16619313d04b72f78bb525162ebcd0", size = 159695, upload-time = "2026-06-20T23:47:51.602Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/f6/a906d01a2ce12157bad2404957b3e2140da354b8a70b2fa48bbf282871c0/wrapt-2.2.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:209112cafd963710a05d199aae431d79a28bc76eb8e6d1bbbb8ad24340722cae", size = 152813, upload-time = "2026-06-20T23:47:53.03Z" },
-    { url = "https://files.pythonhosted.org/packages/02/49/bc0086292d239575b4c08f4cf8a4079fa58abbad58ec23abf84833a283ed/wrapt-2.2.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e5a5290e4bf2f332fc29ce72ffb9a2fff678aaac047e2e9f5f7165cd7792e099", size = 158809, upload-time = "2026-06-20T23:47:54.391Z" },
-    { url = "https://files.pythonhosted.org/packages/55/83/8fbd034de1f3e907edaa18786d5dd8f6932874edee0826c7cecb5cab03a1/wrapt-2.2.2-cp311-cp311-win32.whl", hash = "sha256:5499236ad1dc116012e2a5dd943f3f31af12fce452128e2bbcbd55a7d3d4d14c", size = 77414, upload-time = "2026-06-20T23:47:55.882Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/9c/23695baa331c6de4e874c3d78b8e0bed92e1d2a274e665b29858f6841672/wrapt-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:8636809939152be6ae20a6cef0fed9fe60f411b47847d0426a826884b469e971", size = 80368, upload-time = "2026-06-20T23:47:57.237Z" },
-    { url = "https://files.pythonhosted.org/packages/08/49/40cefc342bf89b234a4490d741290fce781774b831aefb39c25471da96c9/wrapt-2.2.2-cp311-cp311-win_arm64.whl", hash = "sha256:5d0a142f7af07caeb5e5da87493162a7b8efa19ba919e550a746f7446e13fb30", size = 79489, upload-time = "2026-06-20T23:47:58.56Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
-    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
-    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
-    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
-    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
-    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
-    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
-    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
-    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
-    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
-    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
-    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
-    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
-    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
-    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
-    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
-    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
-    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
-    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
-    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
-    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
-    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
-    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
-    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
-    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
-    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
-    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@polar-sh/sdk",
-  "version": "1.0.0-alpha.16",
+  "version": "0.0.0",
   "description": "Polar SDK — A billing platform for the intelligence era",
   "keywords": [
     "api",

--- a/sdk/typescript/pnpm-lock.yaml
+++ b/sdk/typescript/pnpm-lock.yaml
@@ -16,51 +16,27 @@ importers:
         version: 0.56.0
       oxlint:
         specifier: ^1.71.0
-        version: 1.74.0
+        version: 1.77.0
       standardwebhooks:
         specifier: ^1.0.0
         version: 1.0.0
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.9(typescript@6.0.3)
+        version: 0.22.14(typescript@6.0.3)
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@types/node@22.20.1)(vite@8.1.5(@types/node@22.20.1))
+        version: 4.1.10(@types/node@22.20.1)(vite@8.2.0(@types/node@22.20.1))
 
 packages:
-
-  '@emnapi/core@1.11.1':
-    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
-
-  '@emnapi/core@1.11.2':
-    resolution: {integrity: sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==}
-
-  '@emnapi/runtime@1.11.1':
-    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
-
-  '@emnapi/runtime@1.11.2':
-    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
-
-  '@emnapi/wasi-threads@1.2.2':
-    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
-  '@napi-rs/wasm-runtime@1.1.6':
-    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1
-      '@emnapi/runtime': ^1.7.1
-
-  '@oxc-project/types@0.139.0':
-    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
-
-  '@oxc-project/types@0.140.0':
-    resolution: {integrity: sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ==}
+  '@oxc-project/types@0.142.0':
+    resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
 
   '@oxfmt/binding-android-arm-eabi@0.56.0':
     resolution: {integrity: sha512-CSCxi7ovYojgfdPOdUb9T508HKeAdDIKeRGg7x8IZwVJrWz9gVgX7MbUnFqtQAE4QvoNo07mj2JlwnOzJw4qqA==}
@@ -184,124 +160,124 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@oxlint/binding-android-arm-eabi@1.74.0':
-    resolution: {integrity: sha512-+gHd12muVI9ZLBaWLPkHt3Fj7jihFjgQ1MGtBaRL8vWrWrI0P7dLUty/cHrHS0oqPYIRgQUJsPu2CExQuMcwNw==}
+  '@oxlint/binding-android-arm-eabi@1.77.0':
+    resolution: {integrity: sha512-E06sKWS6PiI6HRxS1wyQg22HvApt01hI7fV+T3wUk3OSbaaP4a3hYGY/MIQDmASqCiRjBdpRQYkgMkqH82cWmQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [android]
 
-  '@oxlint/binding-android-arm64@1.74.0':
-    resolution: {integrity: sha512-xjKdoMB+H+RCOByv/7l7nfIGW9mlOisqYdcyC75UqYuQecLpReAeEYUf2CNeDEI3KtmUgxpRw/+c63y4AeF/Bw==}
+  '@oxlint/binding-android-arm64@1.77.0':
+    resolution: {integrity: sha512-NvsKz0KZxTp9cYWPLf+FXaSZwB3oO3peAjtukpOMBgse2vhQSoIIVqeO1yR0lEo/UcdZIDL18uq+kL0LzQ0ytA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@oxlint/binding-darwin-arm64@1.74.0':
-    resolution: {integrity: sha512-iUK7wvc6sejMKsC+Pt67mntoF5weFcyEunhZfLJceU6gL419mexz5wBkSx/EnkFBExMLNtOi9fnDSc5xfK0IzQ==}
+  '@oxlint/binding-darwin-arm64@1.77.0':
+    resolution: {integrity: sha512-bgjTn6nW4bQCFBvSvuHCpDD+sONvmpo4lGI4PxzMt1quBA+xYxhczk6RiCn3GZ9gY8uhaBbwhj9MdKGfu6T9DA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@oxlint/binding-darwin-x64@1.74.0':
-    resolution: {integrity: sha512-ggKc/tn5SJ1u2yG2izC6VKODfYKV8MQ2AicJlNzOjuyrC29udvOef6/JzK2r32xqCnBDLFouR1VCkjzEI0/N9Q==}
+  '@oxlint/binding-darwin-x64@1.77.0':
+    resolution: {integrity: sha512-aotaIttH1R6j1Rwhx0M0htgeZyGtVQqYNTVEYMN/UcgHPquGA6kmk9OyuDc3a2GKUQBC+3C3GVQCcrRPMYqAFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@oxlint/binding-freebsd-x64@1.74.0':
-    resolution: {integrity: sha512-u++dH/43jy9hTLbneaWlS0gla/Bp1JdwJ2zgevCl8nDFUh6qRCGMxcL0f0lb7By3A9p/LfFr+7cG4HU1hG856g==}
+  '@oxlint/binding-freebsd-x64@1.77.0':
+    resolution: {integrity: sha512-nNx/wta7ksRAdYvq+l4AWjXkLxEXHALhENxjj2cYbQAIR4ybaA5L+hCbE63HOmft5czQ6ks+hb8vmEAnn7YGPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.74.0':
-    resolution: {integrity: sha512-Sj1zmtFDVTPeIbIz4ZfcXAbFHqCmKCXdCUlAJzvTF7I20NTH1RDpoF2PhkqNODutJzVhJYmm3oz0GwgY+tvE2g==}
+  '@oxlint/binding-linux-arm-gnueabihf@1.77.0':
+    resolution: {integrity: sha512-tMLLjM7xXtzXisVCzkOTXNCy9bZVId2wteNwjohlFDR/jY6WagpEDA1c1wu4xRc20Hojaxj+V6DSR7gbKxijWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm-musleabihf@1.74.0':
-    resolution: {integrity: sha512-//PKyQb/tQXcHArx2f7z+oVI/eMS2Jpv+edNuAtOrgIhWdGcpHxogveAxzmF2rpH1AIHp4Hq04RF/rgJdiICnQ==}
+  '@oxlint/binding-linux-arm-musleabihf@1.77.0':
+    resolution: {integrity: sha512-MiAFDFaqR0tmHTAyo0YDcZ5hyLREdYw/RQhc2R3cbT+8O3tB+zqPM2th9TTQ+Uo3jn/embS+DO+HyX9ztCPkOQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@oxlint/binding-linux-arm64-gnu@1.74.0':
-    resolution: {integrity: sha512-/k1Me+aX2tjuH10K62mLS0y8cLkJBHX6Ce0xPK+eWeel4bSdEGZ8dv4+hYMzg0GrSmjwy4yAYsDPeEeKBft/2w==}
+  '@oxlint/binding-linux-arm64-gnu@1.77.0':
+    resolution: {integrity: sha512-/xqQ3B16i1T4cyt/9Mn+4CpzhUXoBXp7kVpIwzOXNFLj5JmK1bIjsbSnX296Gg8A/o7oDtKWikFgBx0SLwztkw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-arm64-musl@1.74.0':
-    resolution: {integrity: sha512-3tFSjBxc5D8/zvjEuLvOqcA8ZXKD0+6NuaVO/edeamNc49MoAsbfaC9s1UiwODwgF6slGaF8yJA2TPkukd77tg==}
+  '@oxlint/binding-linux-arm64-musl@1.77.0':
+    resolution: {integrity: sha512-LSbwuRKiNCenPDcbARqAZ5RfBy7gmj7vOvfJRLeCDU3gFtSxWbhv/+VTlaUqzUhNj1gFLHB8h7ALnxa/Az6z6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-ppc64-gnu@1.74.0':
-    resolution: {integrity: sha512-9QggtPkSPXOCTu8Szis7auOK/sC7KdQaN+/TujP7YVVhzCAOhgdRfgv8uEz0r2tk5xdgus5rLYUrCDoZNtiRUw==}
+  '@oxlint/binding-linux-ppc64-gnu@1.77.0':
+    resolution: {integrity: sha512-QWdcH31mXEUe5Nq1s0CfCpceaKjIo9uZtwDjAuL681g1axf+5x8xrg/eXWaw//4NCxYZ4V4e5Hu5tvdR+pTBlg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-gnu@1.74.0':
-    resolution: {integrity: sha512-VM5VPUJ4DJIWiK+AZn8FScUqMr6OFrCAYybMYjEEi7W13ParI64MByiXTkKMqZpBmvQ9zxl9Ebq2VUOiZRJYUg==}
+  '@oxlint/binding-linux-riscv64-gnu@1.77.0':
+    resolution: {integrity: sha512-GnOfYgJxbcElOiPZaDFDl406ONddwvOWk2jvAAAEjwAl4GofNoHF+/HHUIBYa6bFCArlcGPi0XjC4cU1pkgF/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-riscv64-musl@1.74.0':
-    resolution: {integrity: sha512-SaDY1gh9rOA592J54g+gu5hkOFFQBZsMmIYHs+NRHG+Uq0OxtuuCXMWQ3vu1830Eugv5uMXyjG+bv2Z9y4IXjw==}
+  '@oxlint/binding-linux-riscv64-musl@1.77.0':
+    resolution: {integrity: sha512-AyEMTUCf0xY+hHF+IxqXFQIX0yQOIR8ykpY0lJNOw9xYqOzUX8dyZfRvlG0RfXwuQn2eonf/8NrMmDSZJjdqsA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-linux-s390x-gnu@1.74.0':
-    resolution: {integrity: sha512-ZATQeHZCyr6MbDveg0obD5sxLHFOghtOdC5jwVwYlvFWqtFOxctgFEG6Ef/64hYvZrWyhyCckB10AelqLopeDA==}
+  '@oxlint/binding-linux-s390x-gnu@1.77.0':
+    resolution: {integrity: sha512-sPLzEcNvxd/oyVQ5oZo92CiHkFkpBeRop13E/P3TPY+hZfXHKCOWKI70TE2RYwMKFJDc20EMjH16L7NZICtKTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-gnu@1.74.0':
-    resolution: {integrity: sha512-+aIvJyrdeD7LwCQ2WYLMUWNmnbeDRSPb40aBYtPjD9+PTqUwgJnk+HK5yLfSMeqXrMrDhE9uTmtt2y50tvjhHw==}
+  '@oxlint/binding-linux-x64-gnu@1.77.0':
+    resolution: {integrity: sha512-1Oh2ssH2L7lwyvkdSqaMUfsGfwU2Wfvew+obBUYjRVqhpBcUpwnsPSEr1IzVi9XqkuY10geiLsNKecqaZC34Dw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@oxlint/binding-linux-x64-musl@1.74.0':
-    resolution: {integrity: sha512-XyktaR8lhK2qWiCK0Tk8oYD+/cgn+oHA6ddRnxSSXUKkkojkV78CmShZUxQF+yrBFs0SuW+JBOPG6hecyc/iZg==}
+  '@oxlint/binding-linux-x64-musl@1.77.0':
+    resolution: {integrity: sha512-0j/2wRgNGO+Qj/M1uu/p57h/hFTTWWcfie0ufkbabeus2s5+/QqkCflnMOwLLN5m2GsNeWp4xdl4cPa4n7QCOQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@oxlint/binding-openharmony-arm64@1.74.0':
-    resolution: {integrity: sha512-mzbjrPl4neaVUiJ1fUiEUxTGaSZBoiKtaoB6jmIpz9S+VOA2vDYmJpihQ82w6178V5jxziclTg8Cgj5yF6tTDg==}
+  '@oxlint/binding-openharmony-arm64@1.77.0':
+    resolution: {integrity: sha512-BJ/j54qS0usEnyDkLYURMj2iiD9h5Cyy+ppzeMSXBGRXaGRNWnj1Mw14NqWMR5E/PzdgB30OOCCzLzbRoduafw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@oxlint/binding-win32-arm64-msvc@1.74.0':
-    resolution: {integrity: sha512-vUAe9okpS2Oa5+lX67lqHMuNUvfkleRKwrUDJ/WJBsgmddvZ1mrsh2HVmuFDRzqFELhaJhFaCNOuR6a7L3rtIA==}
+  '@oxlint/binding-win32-arm64-msvc@1.77.0':
+    resolution: {integrity: sha512-Yh8w+g2Lpx7StrvtYkoz9JJvXjB9wxgFChFNb85nrXm/wj/XTwGWS1hve9+900HL7llrntYB3YP+y32E3tRqzA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@oxlint/binding-win32-ia32-msvc@1.74.0':
-    resolution: {integrity: sha512-yyXXJyYYSXL4I8K8jAWjJs+J3fa9gH2JmEbo4f5adm+1tNC9itseicBNuwK7BDHvqQ5J534s+yDULu89vYL2ZQ==}
+  '@oxlint/binding-win32-ia32-msvc@1.77.0':
+    resolution: {integrity: sha512-zja5b7+6a7UsRFgAQSrnax5vrzliEyNPLCjfXONu/vTWswaIVZGFajJZptaeRvPE4LghtFdAzVFlexTm7MVTGA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ia32]
     os: [win32]
 
-  '@oxlint/binding-win32-x64-msvc@1.74.0':
-    resolution: {integrity: sha512-VTC9IYTIMrVUk/i6Ms1ohzzDKZFkWn0KU2OBbPBzgmVZ2V30165T/zK4LztTr0Xgp9fZ1qQZ1rsZAu/rEmySlA==}
+  '@oxlint/binding-win32-x64-msvc@1.77.0':
+    resolution: {integrity: sha512-+teyvPDZ2RjUvo+SuCqS/UhaJl1QtdW5fWT5NJTV61V5MIuIS90Db9LixmtEGvXixyttiK62P96MSu3UlpviBw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -309,192 +285,92 @@ packages:
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
 
-  '@rolldown/binding-android-arm64@1.1.5':
-    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+  '@rolldown/binding-android-arm64@1.2.2':
+    resolution: {integrity: sha512-l7x215OGvo1s52JWmR8U/DAVzEDWBCIbTm28aeJV/WDTSHgcKXaZTuBT0hJMs5NggilfJTW3clZVvd24yfKJxA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-android-arm64@1.2.0':
-    resolution: {integrity: sha512-9yB1l95IrJuNGDFdOYe79vdApdz6WWBCObE+rQ2LUliYUlcyFwSYIb2xb5/Ifw7dAtMy2ZqNyd8QTSOc7duAKw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
-  '@rolldown/binding-darwin-arm64@1.1.5':
-    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
+  '@rolldown/binding-darwin-arm64@1.2.2':
+    resolution: {integrity: sha512-9u9Xv6c1AJZT0FfwH5vrMG5Jjcwhc1MlyrPu0XfTqkzsmqfks2M6W/o5XwAJgVVN/jHpqqngC1WevHKKTIUtIA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-arm64@1.2.0':
-    resolution: {integrity: sha512-pexNaW9ACLUOaBITOpU6qVu4VrsOFIjTv6bzgu0YUATo4eUJx0V605PxwZfndpPOn0ilqGqvGQ0M8UW0IE24jg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rolldown/binding-darwin-x64@1.1.5':
-    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+  '@rolldown/binding-darwin-x64@1.2.2':
+    resolution: {integrity: sha512-9W1mbGZAfW3oqd85bhBkmpyHCCzL1TeG/zFFP3vg7b0rlly8cxOcre5nXwz+LHazCwac2MNWgPdPCHndABjpWQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.2.0':
-    resolution: {integrity: sha512-NqKYaq0355ZmNMG4QGpxtEDxsc7tGDhjhCm4PpE0cwnBW+5Il95LJyq414niEiaKLVjnVHBEjSo1wngKxJNiFw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rolldown/binding-freebsd-x64@1.1.5':
-    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
+  '@rolldown/binding-freebsd-x64@1.2.2':
+    resolution: {integrity: sha512-0p1lhiCSCyaerFwtrdZQUx7NqGk6LQnaRKWX7tFQqwQgvX0rjM15cIkm3pax1UpEakK14C4mOxx/jSqCBdBRqQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-freebsd-x64@1.2.0':
-    resolution: {integrity: sha512-3vPoHzh6eBTz9IbB0/qZdSr0Qeks2echn+I4cHu2joV74VriPDdldswksEDzrl1mBB+oPRi+67+3Ib59paxIPQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
-    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.2':
+    resolution: {integrity: sha512-e+cOJXrJ2L3zx6YzqPg+f6Wbk3V1cKB8bOhbaYdVYN3DdquzNdRAmrbETz1qnt5yp/c7JNlNjmITiA2cVneQ7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.2.0':
-    resolution: {integrity: sha512-E6NNefZ1bUVmKJq2tJkf45J4Zyczj7qm9rUT7NY+Xo2474Y13qWAwc2tvBt0BAVbmtXR1llkxXg0Ou1jbDf2SQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@rolldown/binding-linux-arm64-gnu@1.1.5':
-    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
+  '@rolldown/binding-linux-arm64-gnu@1.2.2':
+    resolution: {integrity: sha512-JsSMsj6sNat/MuhG5fnBD7QgbtpHKVe30x5/bAVirDHdhoQRXJkF6xc0Jqk8O4fiCUQAzMOoH9wZi3m60c8wtg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-gnu@1.2.0':
-    resolution: {integrity: sha512-D+TgkdgM1vu+7/Fpf8+v0ARW+RXEP9Ccazgm8zQ4JFFd9Q7SrYQ2TakU5S5ihazQDgpKyAgZDOcIFsvoHmTZ8w==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-arm64-musl@1.1.5':
-    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+  '@rolldown/binding-linux-arm64-musl@1.2.2':
+    resolution: {integrity: sha512-B5G/zJdHaoJn9vD50eGHWkiWfmq8Uhi3IiLPJTzmZTrAalk1bztUikSXo0qga18ibE0IXboyeMUnhPjhAJ45wQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-arm64-musl@1.2.0':
-    resolution: {integrity: sha512-wUqdwJBbAv0APN87GecstdMUtLjjNTs0hBALpxETD73mccFxdmt/XeizXDtN5RAlBwNKmI+Tg+blect2G+8IeQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
-    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
+  '@rolldown/binding-linux-ppc64-gnu@1.2.2':
+    resolution: {integrity: sha512-6mC/awzKka8W6EoekjegpfGkjz8jXWDX63pqu/HYVpyKtZfu65Jsh4QAH3Kej3CAv/c1oGX7psTmFEbr0mDxLA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.2.0':
-    resolution: {integrity: sha512-9DtF35qR9/NrfhM4oxLplCzVVjE+KKm8Pjemi0i/sdhAWkUasjmSo8WTTubNJClhSHCfyk2yeyoXDQEDPtDAAw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-s390x-gnu@1.1.5':
-    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+  '@rolldown/binding-linux-s390x-gnu@1.2.2':
+    resolution: {integrity: sha512-412MX9fJLdA1IK28EZnc8jYv2HRTleOZgfLQumJ5zy7OeJLZlg/CETwFaXjNmGVxG51cFHpKLqb5LKvBC+HsHA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.2.0':
-    resolution: {integrity: sha512-RzuHrBh8X8Hntd2N4VR02QGEciq/9JhcZoTpR/Cee6otRrlILGCf3cg2ygHuih+ZebUnWmMrDX6ITI85btO6rQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-x64-gnu@1.1.5':
-    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
+  '@rolldown/binding-linux-x64-gnu@1.2.2':
+    resolution: {integrity: sha512-Q/+HI/ToJafZ1iCqGgVQXUEkIjufHCTF0gBQ2a5o3cg7GJ2h0qyq3nvvSmU+bGda2/7ygXpTY4TM6gO9OhQ0ZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.2.0':
-    resolution: {integrity: sha512-MK7L0018jjh1jR3mh21G2j1zAVcpscJBlPo2z19pRjv2XOYGRhaV4LyiD8HO6nCDdZln9IFgCMIV5yt4E3klGQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-x64-musl@1.1.5':
-    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+  '@rolldown/binding-linux-x64-musl@1.2.2':
+    resolution: {integrity: sha512-ZKp/w41n6wCvxzxQHtQSbuphfX3Y4cCvbjkKHusrLx4lh+JWLTU7StSltO/DKARISzbj368d+qUaCjI8K2wzXw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-x64-musl@1.2.0':
-    resolution: {integrity: sha512-gyrxLQ9NfGb/9LoVnC4kb9miUghw1mghnkfYvNHSnVIXriabnfgGPUP4RLcJm87q3KgYz4FYUG8IDiWUT+CpSw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@rolldown/binding-openharmony-arm64@1.1.5':
-    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
+  '@rolldown/binding-openharmony-arm64@1.2.2':
+    resolution: {integrity: sha512-pxE6xD4KS3eAROkKK5yrhB9/3+vhlhVGMvlQLbdpzrBGDbKrnzx3RLwPaHvasLo6jgaiBLn7e04Df9C4tYhjmA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-openharmony-arm64@1.2.0':
-    resolution: {integrity: sha512-/6VFMQGRmrhP77KXDC+StIxGzcNp5JOIyYtw0CQ8gPlzhpiIRucYfoM5FaFamHd5BJYIdH86yfP46l1p3WdrFA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@rolldown/binding-wasm32-wasi@1.1.5':
-    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
-
-  '@rolldown/binding-wasm32-wasi@1.2.0':
-    resolution: {integrity: sha512-rwdbUL465kisF24WEJLvP3JrEG6E5GRuIHt5wpMwHGERtHe4Wm2CIvtf5gTBgr2tGOHKh5NdKEAFS2VkOPE91g==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [wasm32]
-
-  '@rolldown/binding-win32-arm64-msvc@1.1.5':
-    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+  '@rolldown/binding-win32-arm64-msvc@1.2.2':
+    resolution: {integrity: sha512-4MqEue5re+xIZzAWsB8sj0P1kqZySWqIuN4t6QaIO/YA6SFwySOLruvWQFzfmqk8LBK2P30KCSJwf6mJCZZ5/A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.2.0':
-    resolution: {integrity: sha512-+5suHwRiKGmhwyUaNT8a5QbrBvLFh2DbO910TEmGRH1aSxwrCezodvGQnulv4uiWEIv1Kq4ypRsJ5+O+ry1DiA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rolldown/binding-win32-x64-msvc@1.1.5':
-    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
-  '@rolldown/binding-win32-x64-msvc@1.2.0':
-    resolution: {integrity: sha512-WfFv6/qGufotqBSBzBYwgpCkJBk8Nj7697LL9vTz/XWc67e0r3oewu8iMRwQj3AUL45GVD7wVsPjCsAAtW66Wg==}
+  '@rolldown/binding-win32-x64-msvc@1.2.2':
+    resolution: {integrity: sha512-NweNxxD0Nf9t8v7kodun45Ijp3EIwYY+uydPP6qBEYvfBqhIjN6dZMzlQja3tqX/aLs3F3Uz+AxDpKgRhpOZQg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -507,9 +383,6 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
-
-  '@tybys/wasm-util@0.10.3':
-    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -552,130 +425,140 @@ packages:
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
-  '@yuku-codegen/binding-darwin-arm64@0.6.5':
-    resolution: {integrity: sha512-uR1OCnftxC89GP6ZLPbaAXU9wdycmXt5BUQAOaDUmU/b38WJefse4RcL793rsOw1rkb8UC3UqP9F8hQ0lDB5xg==}
+  '@yuku-codegen/binding-android-arm64@0.8.3':
+    resolution: {integrity: sha512-/EKnnqwvN7xYoVDhQEIEJTdPDwGW1wkFz/2Eku3ES/IJd4lcQh/OaIDFBmoJKvpe12enrb1TIoYh1fxasGXolA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@yuku-codegen/binding-darwin-arm64@0.8.3':
+    resolution: {integrity: sha512-DFAOliF5YIPv3ayNHGOJhIun6Af4kMaL/YXxf8ZtD1qrOIMFnX/AQBhwfvLalhwmmxuGA8AUteaKRHBvdKZFVA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@yuku-codegen/binding-darwin-x64@0.6.5':
-    resolution: {integrity: sha512-b5m/NymPwAV8OYmWPK0GwVeXw/D7EMIr1GkgL9fW/JCFDvkSkBTz8cbGl5Jkoxr+bamOZy4C1ySngpU///4CFQ==}
+  '@yuku-codegen/binding-darwin-x64@0.8.3':
+    resolution: {integrity: sha512-WlMh4/oEibaTzE9j5Zq8qnsrH4Ii4kWdcDv/Pj2Rb/MYSrKghtg+bxbWpPe/6zJD21p9zZBApQUxl8ECpZOJuQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@yuku-codegen/binding-freebsd-x64@0.6.5':
-    resolution: {integrity: sha512-wLTe/QeBF37qb4bR++t/jLP3LQ7oS76lsZigk7J10IR2GwD4w8GJqhIm1NsAwho6OjWDNnfxkkw/Oadf/jex4Q==}
+  '@yuku-codegen/binding-freebsd-x64@0.8.3':
+    resolution: {integrity: sha512-hoDOpPP0FTxPSD+6w0Gs4p8iL1yXe6jjIXcdzNxyT1KE6B3JI6O0gTIWQISJ+8QyNpNjIwBb7nHCdRavktJM6A==}
     cpu: [x64]
     os: [freebsd]
 
-  '@yuku-codegen/binding-linux-arm-gnu@0.6.5':
-    resolution: {integrity: sha512-Clah7LByDMBFkHKeRsUrqoftiyocoYaAmDc7aM14S9qghvKPnbTAtvrG8QOLMkWviWS+rQ94YWFGqzk1cRxAnA==}
+  '@yuku-codegen/binding-linux-arm-gnu@0.8.3':
+    resolution: {integrity: sha512-nNW0GGMJyF04pK4A7Kq7WAYtUWU9uI5ugDAoXl9yHpd3IIZ8UI+zFlM01e+ZGWnQcdxYYLumeRe/EjzZT9bVfQ==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-codegen/binding-linux-arm-musl@0.6.5':
-    resolution: {integrity: sha512-3ghZT7Dtp5tzIyfSFWcLFxtwnXjrrqLhO+MTuw3Am03K9Coo2NQICwwA9DN2HBrb8KXES1U43an1rNgzRw9xog==}
+  '@yuku-codegen/binding-linux-arm-musl@0.8.3':
+    resolution: {integrity: sha512-/jpxKhO8AV5TmXgT3R2Gv3YctKRUhyDzd5bQw8TiJ3O4z7qerHzoW2kE40fPAO3L434/IZtZbdhr8HuOqiwECA==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@yuku-codegen/binding-linux-arm64-gnu@0.6.5':
-    resolution: {integrity: sha512-9zT+uVEtVJkvm0Ba5BkUgBXNqw3kcolV9RAf0kSgIe44bi5Lp6MPqCRm9JrWnJTZOySzPII3oRNRl9dtBlOdLg==}
+  '@yuku-codegen/binding-linux-arm64-gnu@0.8.3':
+    resolution: {integrity: sha512-CYhLJfnCknabfLvUjsanxC5s3BBtZHUwfzdDL7GcqShIRQh2qqgG7pPfFrFJ6Jp56kkjKXkfluFGn9nnIv0nZg==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-codegen/binding-linux-arm64-musl@0.6.5':
-    resolution: {integrity: sha512-Uyi/vT++0gyVsyan3XvEii8AWbc+yFJ3M0GEloup7eBx1j4FtK7oq23F6mbQD1gNaozGKkN74fCJpIxF176hZA==}
+  '@yuku-codegen/binding-linux-arm64-musl@0.8.3':
+    resolution: {integrity: sha512-c6gEdnI0MgA7/rVw6CACMciSbAcxVwLyD/jSBbMLWUeqqbysCNGrGPAHdpSaadpz3W1bd+OdXt9XWjfm66708w==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-codegen/binding-linux-x64-gnu@0.6.5':
-    resolution: {integrity: sha512-JZzAbPDh5eQ2GRAAbo7cKcFabPQ9UEAQglk1BE0psoWUDt1wktp4ZX9ZJgDgF9EbSH3UUACo0lIkWUtSjRyRoQ==}
+  '@yuku-codegen/binding-linux-x64-gnu@0.8.3':
+    resolution: {integrity: sha512-CRVZ9Rw5lIah/PpWeShWv7XiUCMY15N6rZRA2sEZrQvc5Az7Dv9/wsDMa6oBMkfQLXuDkFo4G1QOYyWbebjejg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-codegen/binding-linux-x64-musl@0.6.5':
-    resolution: {integrity: sha512-Dmh6Qhoo1UNM10eDLs/DND8E3cLfQQboFfZgnnNNIJ2RQ/G0GXGh7Kzff1QmglUNuRami42NkTrsF9VrkCttZg==}
+  '@yuku-codegen/binding-linux-x64-musl@0.8.3':
+    resolution: {integrity: sha512-G12Nhecjmv7OlbCX6Y4HU4wYYePd111kTE+yTjbitnt+P3m8bNegtYG4ZGo4scGTq8cKsLF4xcda1XNzCUA6nQ==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-codegen/binding-win32-arm64@0.6.5':
-    resolution: {integrity: sha512-UAq2wLFT0mRN2rzJfZjmaqVMJD9kYywARc6Wk8Ggnm4p8yJYigNxMkJ0gt3bpd0MOnvre4LFEDyAMr4esRubuQ==}
+  '@yuku-codegen/binding-win32-arm64@0.8.3':
+    resolution: {integrity: sha512-i8bpXWaMlik9DvFl+89emEx3RZFtSd21Vlt0UrnPvUC7h8NGElP2SwQcdcG+pPmihFIYJAoIuJLw7YdQcFcDkA==}
     cpu: [arm64]
     os: [win32]
 
-  '@yuku-codegen/binding-win32-x64@0.6.5':
-    resolution: {integrity: sha512-hlEo+UIMHaEoLHe8woLr9eI6fz+8LRwdRrid/iegVU1N+53zkh4WMkI8N7e4vUNKKMVN2kJo6Z73J+JfskHO1g==}
+  '@yuku-codegen/binding-win32-x64@0.8.3':
+    resolution: {integrity: sha512-vlYymeTSsx+qxZoNvdl6KehgYDaQC4Sk/9KUnM3V2mriyCwSdhW7lqdpQGl+RLGsDTxyuRGjzGIjgRWk3lohmA==}
     cpu: [x64]
     os: [win32]
 
-  '@yuku-parser/binding-darwin-arm64@0.6.5':
-    resolution: {integrity: sha512-QVdaZzj9T3KdaprM8VYpiYIFJrcJB347P2U3bg683nPQaDNmX733CFtCqpkc1KHccFf199EXx4OazkJlnHvImA==}
+  '@yuku-parser/binding-android-arm64@0.8.3':
+    resolution: {integrity: sha512-vySYRsMeul9ssvxeHdxgS9ZUIcq7gqljWNqgokjJE0uQWvVvOprihJ6hOsiifVqWsla0BMc3vAFBvNS9QqCw7g==}
+    cpu: [arm64]
+    os: [android]
+
+  '@yuku-parser/binding-darwin-arm64@0.8.3':
+    resolution: {integrity: sha512-+wpB/wqhiZ685Y77I+lj6v9pHSAJ3Y+QMHJmvch0Q0ahIMbNwtKk3s54MhtjCMKO1qpjPbyN/PjuHDg2hbKaVQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@yuku-parser/binding-darwin-x64@0.6.5':
-    resolution: {integrity: sha512-9omiEXwzJo3hsJiaohFek44wKRmnNy8o8acf8PXJdVo19I9O5eY7c3Nhca1DRTozoLqIJEI68CH8OoR2/Dv7ww==}
+  '@yuku-parser/binding-darwin-x64@0.8.3':
+    resolution: {integrity: sha512-jKqiWejj4zVy7pPtEGu4/Ty+pG1h7ooQOXIkm7shKZTSwTU9X8X+eoH11uIeKHZi2SQWV0GhNz0J56eerseysQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@yuku-parser/binding-freebsd-x64@0.6.5':
-    resolution: {integrity: sha512-0BZ14CHc8H3EHmlAMhxTDVMYijsT1nNZUhl6JTm/xzl+Gaun/vahgdaJaFESuweLeZ1WnwVfPVPvjsdfnbTN8g==}
+  '@yuku-parser/binding-freebsd-x64@0.8.3':
+    resolution: {integrity: sha512-FC7zSwzFzd4z9bsId07CiHLR+Iw6yW/LzIQhL5AUtPUuVXLgEyx0rilgbRUYkl1CT3GJcLpkh63WuPZUSgCDzw==}
     cpu: [x64]
     os: [freebsd]
 
-  '@yuku-parser/binding-linux-arm-gnu@0.6.5':
-    resolution: {integrity: sha512-VidTdzelGosQDkVkU4X/9qrILPT5HunzL5shW9jrq860naAEjGS/41a4s3J5KBRsKRHscwOsbtSzUev1TMdgfg==}
+  '@yuku-parser/binding-linux-arm-gnu@0.8.3':
+    resolution: {integrity: sha512-So61j88b9/ygDnUPlWCm1EUPw4HSxAyDjrNHKgud5N3aRDQ3kw94nW7TriXbo7GBXID9oBHCMNm1r1Fof/Df5Q==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-arm-musl@0.6.5':
-    resolution: {integrity: sha512-Xes/SwXQiPFPqLMhnwjRv0s6mlm6V7+jpw/kmCMkal9Q0UfS4hVpFo2T5NNIKNLCj5qAZ+2EPtgDBz0S1lH4xg==}
+  '@yuku-parser/binding-linux-arm-musl@0.8.3':
+    resolution: {integrity: sha512-Nmnn20yJvSSKL8ZdtqReBRSGCDkSMqR5jEk/Sk/cdIdZmqVD49Z6M7w2GbMjdrxMI1MBPbsWFMMWxa93cd5t5g==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@yuku-parser/binding-linux-arm64-gnu@0.6.5':
-    resolution: {integrity: sha512-MaFn3Vh+kBETYXtPYBaCQUMsUk5SqSatM+mp9Vz7COuCKXim7cG8kGcUpqq93wegLEkkEnv8pyiDFFx/gmNOiQ==}
+  '@yuku-parser/binding-linux-arm64-gnu@0.8.3':
+    resolution: {integrity: sha512-Lfgw7AXJ0rxu6BMPGgfc8HLJWEIr8BHhCzcQp/75k+NM90uCLkHlBNqIg/K42KlSvBgAvu9euOvjdswib+4qJA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-arm64-musl@0.6.5':
-    resolution: {integrity: sha512-s7GAjJ7kzmnEBVAq5c5B+h/DCOSZG7WqTNpFRYUVGQU+D8wf1gMnfDQ5v8zFdByhpHiW+HNerxI8sml5dl47Rw==}
+  '@yuku-parser/binding-linux-arm64-musl@0.8.3':
+    resolution: {integrity: sha512-cfRyu87xsJ0tFkHNsnMC4Rq6+xsFJ6i2dc4VAH52d2qLvykEJU/Mdi3ul1O2PyOApX/LoLT3uQZ0fWs3D5XE4w==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-parser/binding-linux-x64-gnu@0.6.5':
-    resolution: {integrity: sha512-5/+mLrZdCtGoKOw/zNJC0+fSy4aKI97JvPm5rr8DXui/l3+BrvU5g7czp1DVHN67I7VzTLizu2n2y5cz2CjzEg==}
+  '@yuku-parser/binding-linux-x64-gnu@0.8.3':
+    resolution: {integrity: sha512-GcQQCUuYxbm6P1n+io/A50rvWKDeWHutIp6rW0ycDOZuEQjOb8hDVgS88+NDyOnd9FfS0/Z6GXopcRFDyKpzOg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@yuku-parser/binding-linux-x64-musl@0.6.5':
-    resolution: {integrity: sha512-Svj4h/WZQ1VdAxaFJrakVi85IzUJPYWcNw15gNPoeNg+/SGGTTkTeUzODiMRY/8ioJ/k3+/K7zQwASIEBF7L3Q==}
+  '@yuku-parser/binding-linux-x64-musl@0.8.3':
+    resolution: {integrity: sha512-rMkImBGZzg7GZlj8krYtdiezyjYI4igjKWMut5T65jHyNWFigMQrEpn9mDIBflloW9FKhGE3mN6yTZ/N+4HRwg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@yuku-parser/binding-win32-arm64@0.6.5':
-    resolution: {integrity: sha512-N96G8zoKihVwhMaH+kLp8MFIA1i3+dRaBO4KYK0otTPVdX+3uS2wpUY5vDLj4JbkKARuQA/DUmfgjleoXL6ugA==}
+  '@yuku-parser/binding-win32-arm64@0.8.3':
+    resolution: {integrity: sha512-/2Pl2cAzCXWxah8FqJapEj/ikpt9cEutEZFCa0hnbfrshkn5+C+aBM3ZDq62d1jsgQjBMmqr5HVhJUA4OAG/Tg==}
     cpu: [arm64]
     os: [win32]
 
-  '@yuku-parser/binding-win32-x64@0.6.5':
-    resolution: {integrity: sha512-RP7rz120SodZI/vUc1H4uzIMEZrxeG//d11qWUI5inMbU4YSnufJAScwjV+qQHxD3FAwoueNxsPjrVxagwAymg==}
+  '@yuku-parser/binding-win32-x64@0.8.3':
+    resolution: {integrity: sha512-Ntnvjoan9jnfLhn7Kn3h8j/bhsbVdQSVmKUqFULKtmwImLCJVHOJbLL4qbEJyrOQ7r/FBL1/c/dRvx/AQWzzXg==}
     cpu: [x64]
     os: [win32]
 
-  '@yuku-toolchain/types@0.5.43':
-    resolution: {integrity: sha512-kSpvPntnXw5+lYjO71ffBEnQ5ycQ74KGIYknh0TS4xeyCuBkOqxyJumxZkMhLBBUCLjDAbx2+Icnr3Zh4ftjpQ==}
+  '@yuku-toolchain/types@0.8.3':
+    resolution: {integrity: sha512-9LN3HYs3A9qSPVFunsxlbfwBcUgexti3TmhOzIxB/UH8zFuaHQJXTRDcN17DW6cp1GsyZtiZA7f18uIra36Jag==}
 
   ansis@4.3.1:
     resolution: {integrity: sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==}
@@ -754,85 +637,85 @@ packages:
     resolution: {integrity: sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ==}
     engines: {node: ^22.18.0 || >=24.0.0}
 
-  lightningcss-android-arm64@1.32.0:
-    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [android]
 
-  lightningcss-darwin-arm64@1.32.0:
-    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
 
-  lightningcss-darwin-x64@1.32.0:
-    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [darwin]
 
-  lightningcss-freebsd-x64@1.32.0:
-    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
 
-  lightningcss-linux-arm-gnueabihf@1.32.0:
-    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm]
     os: [linux]
 
-  lightningcss-linux-arm64-gnu@1.32.0:
-    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  lightningcss-linux-arm64-musl@1.32.0:
-    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  lightningcss-linux-x64-gnu@1.32.0:
-    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  lightningcss-linux-x64-musl@1.32.0:
-    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  lightningcss-win32-arm64-msvc@1.32.0:
-    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
 
-  lightningcss-win32-x64-msvc@1.32.0:
-    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [win32]
 
-  lightningcss@1.32.0:
-    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -853,12 +736,12 @@ packages:
       vite-plus:
         optional: true
 
-  oxlint@1.74.0:
-    resolution: {integrity: sha512-odGl2s2x5IOJoj3A0v1k0PGBXVFBZeZ2+AK/+K2MJur7Ghi3bkyX5NuLUWHKqa4js1wjep3hJeuTQJOlr+4+dA==}
+  oxlint@1.77.0:
+    resolution: {integrity: sha512-qnGh8XJHaQ0dprrDXNQZgS0FgjI6v+V3+X8DwmaV++5Aamy6jGKfDdQ1TUvhUxtmKFAbEf4/WeO5QZX+5WSngg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      oxlint-tsgolint: '>=0.24.0'
+      oxlint-tsgolint: '>=7.0.2001'
       vite-plus: '*'
     peerDependenciesMeta:
       oxlint-tsgolint:
@@ -876,8 +759,8 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.19:
-    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   quansync@1.0.0:
@@ -886,8 +769,8 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
-  rolldown-plugin-dts@0.27.11:
-    resolution: {integrity: sha512-DnBl4USSTV/h/sgy//QjCLHVo2JypE/52P5QugGeYaEqZmjBz/FYESOld0MhyIhul2U3Vsh41K63UWGHhJU/qQ==}
+  rolldown-plugin-dts@0.27.14:
+    resolution: {integrity: sha512-ZvuDDwoIpRK9RPxDXratCpklFO9QZZWndf/sd0VBFb4LEj0jj07UcHK9OCh7V4XiFz2Z89ziyBC2K6tJiDjrbw==}
     engines: {node: ^22.18.0 || >=24.11.0}
     peerDependencies:
       '@typescript/native-preview': '*'
@@ -905,19 +788,9 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown@1.1.5:
-    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
+  rolldown@1.2.2:
+    resolution: {integrity: sha512-opwpo1tQBAcpSUJDt94B7hhLNGOKjCdE//XXjeLrnx9b83bjnw45tXdg1b09yEw/VLFBJGZpwRULMmOZo7ol+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
-  rolldown@1.2.0:
-    resolution: {integrity: sha512-u7tgm5l4Yw1iTqUL4EcYOAt7fFvCgQMLeidrnD4GALlC6aOznCjezYajgxeyKw27u0Q5N7fwgCzjVyPIWzwuBA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
-  semver@7.8.5:
-    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
-    engines: {node: '>=10'}
     hasBin: true
 
   siginfo@2.0.0:
@@ -939,8 +812,8 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.2.4:
-    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.17:
@@ -951,22 +824,22 @@ packages:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
-  tinyrainbow@3.1.0:
-    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
     engines: {node: '>=14.0.0'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
-  tsdown@0.22.9:
-    resolution: {integrity: sha512-/0QEjQEhOU1t1YxOIAGzFN7bIssd8P0pBpkOmNLCQi3c5UtrcMF5bvq3f30xHJNW9QCA9aUNcNAorMr2CTd6Lg==}
+  tsdown@0.22.14:
+    resolution: {integrity: sha512-ule7Y+fsAN2iZbLDoo7C4KYljFJNJJ+fLshyn+9gozeTspVersWHxwdGB+Dm2hzA38s6muFnUTl0jK3vJm9ifQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
     peerDependencies:
       '@arethetypeswrong/core': ^0.18.1
-      '@tsdown/css': 0.22.9
-      '@tsdown/exe': 0.22.9
+      '@tsdown/css': 0.22.14
+      '@tsdown/exe': 0.22.14
       '@vitejs/devtools': '*'
       publint: ^0.3.8
       tsx: '*'
@@ -993,9 +866,6 @@ packages:
       unrun:
         optional: true
 
-  tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -1007,13 +877,17 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
-  vite@8.1.5:
-    resolution: {integrity: sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==}
+  verkit@0.3.2:
+    resolution: {integrity: sha512-zj/ob3UsvJGN0whEAKFp53REA5X66hvffVqoCtVQAakJKnKlH+/PcOfMoFwIG/o4rElqLv/ycAFlx8ZlXUorCg==}
+    engines: {node: '>=18.12.0'}
+
+  vite@8.2.0:
+    resolution: {integrity: sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
-      '@vitejs/devtools': ^0.3.0
+      '@vitejs/devtools': ^0.4.0
       esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
@@ -1096,63 +970,20 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  yuku-ast@0.1.7:
-    resolution: {integrity: sha512-2RiMEWv500TixY5rJy6OZd4fSy9WYZKWh6gGbIJ7y7vAGcuCugWOWwOLGaQcRZrXcPUfqtLtvpaJ3SdXtWlhKA==}
+  yuku-ast@0.8.3:
+    resolution: {integrity: sha512-8x34yU5uhHUnJXzy2Qvjvec/vE9BzS0/2khVT1MsLmSLO/P8Q1Wp8IxHv+IhD+HMYETk6kherOSvP4JPWw2joQ==}
 
-  yuku-codegen@0.6.5:
-    resolution: {integrity: sha512-g8gbp05j2NNSKe0Uu2ViBRvawzXaWggxS9YwcVJ2d3I99VxbeOeENSUseA8AXPCZj/gcLkQxl7uhTmtK36qh8Q==}
+  yuku-codegen@0.8.3:
+    resolution: {integrity: sha512-okdo5bb+TfebQa4JOjz9QxeT34D6CcBxu8dxaPUdFEKRdLkp+D2Fah2OanepK+XTyPXdmAJzAo9iXvYvZ/5rmg==}
 
-  yuku-parser@0.6.5:
-    resolution: {integrity: sha512-9A5zaOqE3X3wcPOTK97CYInpKwaUGYnwfHWasJaI2Je1OhI4pQmRA6YCSh7oKewEb2iJM4xlJdbwwj4Aydty7w==}
+  yuku-parser@0.8.3:
+    resolution: {integrity: sha512-KPQcpF9aj77ywlJBIkQWCQ9DObdxnCA8AJdUOmA5CZZx042Xt4+dvbQmPJfWxF3E+KG5dVAZ2fBKuDJ8VsKWgA==}
 
 snapshots:
 
-  '@emnapi/core@1.11.1':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.2
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/core@1.11.2':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.2
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@1.11.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@1.11.2':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.2.2':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@tybys/wasm-util': 0.10.3
-    optional: true
-
-  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
-    dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@tybys/wasm-util': 0.10.3
-    optional: true
-
-  '@oxc-project/types@0.139.0': {}
-
-  '@oxc-project/types@0.140.0': {}
+  '@oxc-project/types@0.142.0': {}
 
   '@oxfmt/binding-android-arm-eabi@0.56.0':
     optional: true
@@ -1211,163 +1042,107 @@ snapshots:
   '@oxfmt/binding-win32-x64-msvc@0.56.0':
     optional: true
 
-  '@oxlint/binding-android-arm-eabi@1.74.0':
+  '@oxlint/binding-android-arm-eabi@1.77.0':
     optional: true
 
-  '@oxlint/binding-android-arm64@1.74.0':
+  '@oxlint/binding-android-arm64@1.77.0':
     optional: true
 
-  '@oxlint/binding-darwin-arm64@1.74.0':
+  '@oxlint/binding-darwin-arm64@1.77.0':
     optional: true
 
-  '@oxlint/binding-darwin-x64@1.74.0':
+  '@oxlint/binding-darwin-x64@1.77.0':
     optional: true
 
-  '@oxlint/binding-freebsd-x64@1.74.0':
+  '@oxlint/binding-freebsd-x64@1.77.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-gnueabihf@1.74.0':
+  '@oxlint/binding-linux-arm-gnueabihf@1.77.0':
     optional: true
 
-  '@oxlint/binding-linux-arm-musleabihf@1.74.0':
+  '@oxlint/binding-linux-arm-musleabihf@1.77.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-gnu@1.74.0':
+  '@oxlint/binding-linux-arm64-gnu@1.77.0':
     optional: true
 
-  '@oxlint/binding-linux-arm64-musl@1.74.0':
+  '@oxlint/binding-linux-arm64-musl@1.77.0':
     optional: true
 
-  '@oxlint/binding-linux-ppc64-gnu@1.74.0':
+  '@oxlint/binding-linux-ppc64-gnu@1.77.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-gnu@1.74.0':
+  '@oxlint/binding-linux-riscv64-gnu@1.77.0':
     optional: true
 
-  '@oxlint/binding-linux-riscv64-musl@1.74.0':
+  '@oxlint/binding-linux-riscv64-musl@1.77.0':
     optional: true
 
-  '@oxlint/binding-linux-s390x-gnu@1.74.0':
+  '@oxlint/binding-linux-s390x-gnu@1.77.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-gnu@1.74.0':
+  '@oxlint/binding-linux-x64-gnu@1.77.0':
     optional: true
 
-  '@oxlint/binding-linux-x64-musl@1.74.0':
+  '@oxlint/binding-linux-x64-musl@1.77.0':
     optional: true
 
-  '@oxlint/binding-openharmony-arm64@1.74.0':
+  '@oxlint/binding-openharmony-arm64@1.77.0':
     optional: true
 
-  '@oxlint/binding-win32-arm64-msvc@1.74.0':
+  '@oxlint/binding-win32-arm64-msvc@1.77.0':
     optional: true
 
-  '@oxlint/binding-win32-ia32-msvc@1.74.0':
+  '@oxlint/binding-win32-ia32-msvc@1.77.0':
     optional: true
 
-  '@oxlint/binding-win32-x64-msvc@1.74.0':
+  '@oxlint/binding-win32-x64-msvc@1.77.0':
     optional: true
 
   '@quansync/fs@1.0.0':
     dependencies:
       quansync: 1.0.0
 
-  '@rolldown/binding-android-arm64@1.1.5':
+  '@rolldown/binding-android-arm64@1.2.2':
     optional: true
 
-  '@rolldown/binding-android-arm64@1.2.0':
+  '@rolldown/binding-darwin-arm64@1.2.2':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.1.5':
+  '@rolldown/binding-darwin-x64@1.2.2':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.2.0':
+  '@rolldown/binding-freebsd-x64@1.2.2':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.1.5':
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.2':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.2.0':
+  '@rolldown/binding-linux-arm64-gnu@1.2.2':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.1.5':
+  '@rolldown/binding-linux-arm64-musl@1.2.2':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.2.0':
+  '@rolldown/binding-linux-ppc64-gnu@1.2.2':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+  '@rolldown/binding-linux-s390x-gnu@1.2.2':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.2.0':
+  '@rolldown/binding-linux-x64-gnu@1.2.2':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+  '@rolldown/binding-linux-x64-musl@1.2.2':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.2.0':
+  '@rolldown/binding-openharmony-arm64@1.2.2':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.1.5':
+  '@rolldown/binding-win32-arm64-msvc@1.2.2':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.2.0':
-    optional: true
-
-  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
-    optional: true
-
-  '@rolldown/binding-linux-ppc64-gnu@1.2.0':
-    optional: true
-
-  '@rolldown/binding-linux-s390x-gnu@1.1.5':
-    optional: true
-
-  '@rolldown/binding-linux-s390x-gnu@1.2.0':
-    optional: true
-
-  '@rolldown/binding-linux-x64-gnu@1.1.5':
-    optional: true
-
-  '@rolldown/binding-linux-x64-gnu@1.2.0':
-    optional: true
-
-  '@rolldown/binding-linux-x64-musl@1.1.5':
-    optional: true
-
-  '@rolldown/binding-linux-x64-musl@1.2.0':
-    optional: true
-
-  '@rolldown/binding-openharmony-arm64@1.1.5':
-    optional: true
-
-  '@rolldown/binding-openharmony-arm64@1.2.0':
-    optional: true
-
-  '@rolldown/binding-wasm32-wasi@1.1.5':
-    dependencies:
-      '@emnapi/core': 1.11.1
-      '@emnapi/runtime': 1.11.1
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
-    optional: true
-
-  '@rolldown/binding-wasm32-wasi@1.2.0':
-    dependencies:
-      '@emnapi/core': 1.11.2
-      '@emnapi/runtime': 1.11.2
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)
-    optional: true
-
-  '@rolldown/binding-win32-arm64-msvc@1.1.5':
-    optional: true
-
-  '@rolldown/binding-win32-arm64-msvc@1.2.0':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.1.5':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.2.0':
+  '@rolldown/binding-win32-x64-msvc@1.2.2':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -1375,11 +1150,6 @@ snapshots:
   '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
-
-  '@tybys/wasm-util@0.10.3':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
 
   '@types/chai@5.2.3':
     dependencies:
@@ -1401,19 +1171,19 @@ snapshots:
       '@vitest/spy': 4.1.10
       '@vitest/utils': 4.1.10
       chai: 6.2.2
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.10(vite@8.1.5(@types/node@22.20.1))':
+  '@vitest/mocker@4.1.10(vite@8.2.0(@types/node@22.20.1))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.5(@types/node@22.20.1)
+      vite: 8.2.0(@types/node@22.20.1)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.1.1
 
   '@vitest/runner@4.1.10':
     dependencies:
@@ -1433,75 +1203,81 @@ snapshots:
     dependencies:
       '@vitest/pretty-format': 4.1.10
       convert-source-map: 2.0.0
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.1.1
 
-  '@yuku-codegen/binding-darwin-arm64@0.6.5':
+  '@yuku-codegen/binding-android-arm64@0.8.3':
     optional: true
 
-  '@yuku-codegen/binding-darwin-x64@0.6.5':
+  '@yuku-codegen/binding-darwin-arm64@0.8.3':
     optional: true
 
-  '@yuku-codegen/binding-freebsd-x64@0.6.5':
+  '@yuku-codegen/binding-darwin-x64@0.8.3':
     optional: true
 
-  '@yuku-codegen/binding-linux-arm-gnu@0.6.5':
+  '@yuku-codegen/binding-freebsd-x64@0.8.3':
     optional: true
 
-  '@yuku-codegen/binding-linux-arm-musl@0.6.5':
+  '@yuku-codegen/binding-linux-arm-gnu@0.8.3':
     optional: true
 
-  '@yuku-codegen/binding-linux-arm64-gnu@0.6.5':
+  '@yuku-codegen/binding-linux-arm-musl@0.8.3':
     optional: true
 
-  '@yuku-codegen/binding-linux-arm64-musl@0.6.5':
+  '@yuku-codegen/binding-linux-arm64-gnu@0.8.3':
     optional: true
 
-  '@yuku-codegen/binding-linux-x64-gnu@0.6.5':
+  '@yuku-codegen/binding-linux-arm64-musl@0.8.3':
     optional: true
 
-  '@yuku-codegen/binding-linux-x64-musl@0.6.5':
+  '@yuku-codegen/binding-linux-x64-gnu@0.8.3':
     optional: true
 
-  '@yuku-codegen/binding-win32-arm64@0.6.5':
+  '@yuku-codegen/binding-linux-x64-musl@0.8.3':
     optional: true
 
-  '@yuku-codegen/binding-win32-x64@0.6.5':
+  '@yuku-codegen/binding-win32-arm64@0.8.3':
     optional: true
 
-  '@yuku-parser/binding-darwin-arm64@0.6.5':
+  '@yuku-codegen/binding-win32-x64@0.8.3':
     optional: true
 
-  '@yuku-parser/binding-darwin-x64@0.6.5':
+  '@yuku-parser/binding-android-arm64@0.8.3':
     optional: true
 
-  '@yuku-parser/binding-freebsd-x64@0.6.5':
+  '@yuku-parser/binding-darwin-arm64@0.8.3':
     optional: true
 
-  '@yuku-parser/binding-linux-arm-gnu@0.6.5':
+  '@yuku-parser/binding-darwin-x64@0.8.3':
     optional: true
 
-  '@yuku-parser/binding-linux-arm-musl@0.6.5':
+  '@yuku-parser/binding-freebsd-x64@0.8.3':
     optional: true
 
-  '@yuku-parser/binding-linux-arm64-gnu@0.6.5':
+  '@yuku-parser/binding-linux-arm-gnu@0.8.3':
     optional: true
 
-  '@yuku-parser/binding-linux-arm64-musl@0.6.5':
+  '@yuku-parser/binding-linux-arm-musl@0.8.3':
     optional: true
 
-  '@yuku-parser/binding-linux-x64-gnu@0.6.5':
+  '@yuku-parser/binding-linux-arm64-gnu@0.8.3':
     optional: true
 
-  '@yuku-parser/binding-linux-x64-musl@0.6.5':
+  '@yuku-parser/binding-linux-arm64-musl@0.8.3':
     optional: true
 
-  '@yuku-parser/binding-win32-arm64@0.6.5':
+  '@yuku-parser/binding-linux-x64-gnu@0.8.3':
     optional: true
 
-  '@yuku-parser/binding-win32-x64@0.6.5':
+  '@yuku-parser/binding-linux-x64-musl@0.8.3':
     optional: true
 
-  '@yuku-toolchain/types@0.5.43': {}
+  '@yuku-parser/binding-win32-arm64@0.8.3':
+    optional: true
+
+  '@yuku-parser/binding-win32-x64@0.8.3':
+    optional: true
+
+  '@yuku-toolchain/types@0.8.3': {}
 
   ansis@4.3.1: {}
 
@@ -1546,60 +1322,60 @@ snapshots:
 
   import-without-cache@0.4.0: {}
 
-  lightningcss-android-arm64@1.32.0:
+  lightningcss-android-arm64@1.33.0:
     optional: true
 
-  lightningcss-darwin-arm64@1.32.0:
+  lightningcss-darwin-arm64@1.33.0:
     optional: true
 
-  lightningcss-darwin-x64@1.32.0:
+  lightningcss-darwin-x64@1.33.0:
     optional: true
 
-  lightningcss-freebsd-x64@1.32.0:
+  lightningcss-freebsd-x64@1.33.0:
     optional: true
 
-  lightningcss-linux-arm-gnueabihf@1.32.0:
+  lightningcss-linux-arm-gnueabihf@1.33.0:
     optional: true
 
-  lightningcss-linux-arm64-gnu@1.32.0:
+  lightningcss-linux-arm64-gnu@1.33.0:
     optional: true
 
-  lightningcss-linux-arm64-musl@1.32.0:
+  lightningcss-linux-arm64-musl@1.33.0:
     optional: true
 
-  lightningcss-linux-x64-gnu@1.32.0:
+  lightningcss-linux-x64-gnu@1.33.0:
     optional: true
 
-  lightningcss-linux-x64-musl@1.32.0:
+  lightningcss-linux-x64-musl@1.33.0:
     optional: true
 
-  lightningcss-win32-arm64-msvc@1.32.0:
+  lightningcss-win32-arm64-msvc@1.33.0:
     optional: true
 
-  lightningcss-win32-x64-msvc@1.32.0:
+  lightningcss-win32-x64-msvc@1.33.0:
     optional: true
 
-  lightningcss@1.32.0:
+  lightningcss@1.33.0:
     dependencies:
       detect-libc: 2.1.2
     optionalDependencies:
-      lightningcss-android-arm64: 1.32.0
-      lightningcss-darwin-arm64: 1.32.0
-      lightningcss-darwin-x64: 1.32.0
-      lightningcss-freebsd-x64: 1.32.0
-      lightningcss-linux-arm-gnueabihf: 1.32.0
-      lightningcss-linux-arm64-gnu: 1.32.0
-      lightningcss-linux-arm64-musl: 1.32.0
-      lightningcss-linux-x64-gnu: 1.32.0
-      lightningcss-linux-x64-musl: 1.32.0
-      lightningcss-win32-arm64-msvc: 1.32.0
-      lightningcss-win32-x64-msvc: 1.32.0
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.17: {}
 
   obug@2.1.4: {}
 
@@ -1627,27 +1403,27 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.56.0
       '@oxfmt/binding-win32-x64-msvc': 0.56.0
 
-  oxlint@1.74.0:
+  oxlint@1.77.0:
     optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.74.0
-      '@oxlint/binding-android-arm64': 1.74.0
-      '@oxlint/binding-darwin-arm64': 1.74.0
-      '@oxlint/binding-darwin-x64': 1.74.0
-      '@oxlint/binding-freebsd-x64': 1.74.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.74.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.74.0
-      '@oxlint/binding-linux-arm64-gnu': 1.74.0
-      '@oxlint/binding-linux-arm64-musl': 1.74.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.74.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.74.0
-      '@oxlint/binding-linux-riscv64-musl': 1.74.0
-      '@oxlint/binding-linux-s390x-gnu': 1.74.0
-      '@oxlint/binding-linux-x64-gnu': 1.74.0
-      '@oxlint/binding-linux-x64-musl': 1.74.0
-      '@oxlint/binding-openharmony-arm64': 1.74.0
-      '@oxlint/binding-win32-arm64-msvc': 1.74.0
-      '@oxlint/binding-win32-ia32-msvc': 1.74.0
-      '@oxlint/binding-win32-x64-msvc': 1.74.0
+      '@oxlint/binding-android-arm-eabi': 1.77.0
+      '@oxlint/binding-android-arm64': 1.77.0
+      '@oxlint/binding-darwin-arm64': 1.77.0
+      '@oxlint/binding-darwin-x64': 1.77.0
+      '@oxlint/binding-freebsd-x64': 1.77.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.77.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.77.0
+      '@oxlint/binding-linux-arm64-gnu': 1.77.0
+      '@oxlint/binding-linux-arm64-musl': 1.77.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.77.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.77.0
+      '@oxlint/binding-linux-riscv64-musl': 1.77.0
+      '@oxlint/binding-linux-s390x-gnu': 1.77.0
+      '@oxlint/binding-linux-x64-gnu': 1.77.0
+      '@oxlint/binding-linux-x64-musl': 1.77.0
+      '@oxlint/binding-openharmony-arm64': 1.77.0
+      '@oxlint/binding-win32-arm64-msvc': 1.77.0
+      '@oxlint/binding-win32-ia32-msvc': 1.77.0
+      '@oxlint/binding-win32-x64-msvc': 1.77.0
 
   pathe@2.0.3: {}
 
@@ -1655,9 +1431,9 @@ snapshots:
 
   picomatch@4.0.5: {}
 
-  postcss@8.5.19:
+  postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -1665,63 +1441,39 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
-  rolldown-plugin-dts@0.27.11(rolldown@1.2.0)(typescript@6.0.3):
+  rolldown-plugin-dts@0.27.14(rolldown@1.2.2)(typescript@6.0.3):
     dependencies:
       dts-resolver: 3.0.0
       get-tsconfig: 5.0.0-beta.5
       obug: 2.1.4
-      rolldown: 1.2.0
-      yuku-ast: 0.1.7
-      yuku-codegen: 0.6.5
-      yuku-parser: 0.6.5
+      rolldown: 1.2.2
+      yuku-ast: 0.8.3
+      yuku-codegen: 0.8.3
+      yuku-parser: 0.8.3
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown@1.1.5:
+  rolldown@1.2.2:
     dependencies:
-      '@oxc-project/types': 0.139.0
+      '@oxc-project/types': 0.142.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.1.5
-      '@rolldown/binding-darwin-arm64': 1.1.5
-      '@rolldown/binding-darwin-x64': 1.1.5
-      '@rolldown/binding-freebsd-x64': 1.1.5
-      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
-      '@rolldown/binding-linux-arm64-gnu': 1.1.5
-      '@rolldown/binding-linux-arm64-musl': 1.1.5
-      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
-      '@rolldown/binding-linux-s390x-gnu': 1.1.5
-      '@rolldown/binding-linux-x64-gnu': 1.1.5
-      '@rolldown/binding-linux-x64-musl': 1.1.5
-      '@rolldown/binding-openharmony-arm64': 1.1.5
-      '@rolldown/binding-wasm32-wasi': 1.1.5
-      '@rolldown/binding-win32-arm64-msvc': 1.1.5
-      '@rolldown/binding-win32-x64-msvc': 1.1.5
-
-  rolldown@1.2.0:
-    dependencies:
-      '@oxc-project/types': 0.140.0
-      '@rolldown/pluginutils': 1.0.1
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.2.0
-      '@rolldown/binding-darwin-arm64': 1.2.0
-      '@rolldown/binding-darwin-x64': 1.2.0
-      '@rolldown/binding-freebsd-x64': 1.2.0
-      '@rolldown/binding-linux-arm-gnueabihf': 1.2.0
-      '@rolldown/binding-linux-arm64-gnu': 1.2.0
-      '@rolldown/binding-linux-arm64-musl': 1.2.0
-      '@rolldown/binding-linux-ppc64-gnu': 1.2.0
-      '@rolldown/binding-linux-s390x-gnu': 1.2.0
-      '@rolldown/binding-linux-x64-gnu': 1.2.0
-      '@rolldown/binding-linux-x64-musl': 1.2.0
-      '@rolldown/binding-openharmony-arm64': 1.2.0
-      '@rolldown/binding-wasm32-wasi': 1.2.0
-      '@rolldown/binding-win32-arm64-msvc': 1.2.0
-      '@rolldown/binding-win32-x64-msvc': 1.2.0
-
-  semver@7.8.5: {}
+      '@rolldown/binding-android-arm64': 1.2.2
+      '@rolldown/binding-darwin-arm64': 1.2.2
+      '@rolldown/binding-darwin-x64': 1.2.2
+      '@rolldown/binding-freebsd-x64': 1.2.2
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.2
+      '@rolldown/binding-linux-arm64-gnu': 1.2.2
+      '@rolldown/binding-linux-arm64-musl': 1.2.2
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.2
+      '@rolldown/binding-linux-s390x-gnu': 1.2.2
+      '@rolldown/binding-linux-x64-gnu': 1.2.2
+      '@rolldown/binding-linux-x64-musl': 1.2.2
+      '@rolldown/binding-openharmony-arm64': 1.2.2
+      '@rolldown/binding-win32-arm64-msvc': 1.2.2
+      '@rolldown/binding-win32-x64-msvc': 1.2.2
 
   siginfo@2.0.0: {}
 
@@ -1738,7 +1490,7 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.2.4: {}
+  tinyexec@1.3.0: {}
 
   tinyglobby@0.2.17:
     dependencies:
@@ -1747,11 +1499,11 @@ snapshots:
 
   tinypool@2.1.0: {}
 
-  tinyrainbow@3.1.0: {}
+  tinyrainbow@3.1.1: {}
 
   tree-kill@1.2.2: {}
 
-  tsdown@0.22.9(typescript@6.0.3):
+  tsdown@0.22.14(typescript@6.0.3):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -1761,13 +1513,13 @@ snapshots:
       import-without-cache: 0.4.0
       obug: 2.1.4
       picomatch: 4.0.5
-      rolldown: 1.2.0
-      rolldown-plugin-dts: 0.27.11(rolldown@1.2.0)(typescript@6.0.3)
-      semver: 7.8.5
-      tinyexec: 1.2.4
+      rolldown: 1.2.2
+      rolldown-plugin-dts: 0.27.14(rolldown@1.2.2)(typescript@6.0.3)
+      tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
+      verkit: 0.3.2
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -1775,9 +1527,6 @@ snapshots:
       - '@volar/typescript'
       - oxc-resolver
       - vue-tsc
-
-  tslib@2.8.1:
-    optional: true
 
   typescript@6.0.3: {}
 
@@ -1788,21 +1537,23 @@ snapshots:
 
   undici-types@6.21.0: {}
 
-  vite@8.1.5(@types/node@22.20.1):
+  verkit@0.3.2: {}
+
+  vite@8.2.0(@types/node@22.20.1):
     dependencies:
-      lightningcss: 1.32.0
+      lightningcss: 1.33.0
       picomatch: 4.0.5
-      postcss: 8.5.19
-      rolldown: 1.1.5
+      postcss: 8.5.25
+      rolldown: 1.2.2
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.20.1
       fsevents: 2.3.3
 
-  vitest@4.1.10(@types/node@22.20.1)(vite@8.1.5(@types/node@22.20.1)):
+  vitest@4.1.10(@types/node@22.20.1)(vite@8.2.0(@types/node@22.20.1)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.5(@types/node@22.20.1))
+      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@22.20.1))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -1816,10 +1567,10 @@ snapshots:
       picomatch: 4.0.5
       std-env: 4.2.0
       tinybench: 2.9.0
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
       tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.1.5(@types/node@22.20.1)
+      tinyrainbow: 3.1.1
+      vite: 8.2.0(@types/node@22.20.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.20.1
@@ -1831,38 +1582,41 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  yuku-ast@0.1.7:
+  yuku-ast@0.8.3:
     dependencies:
-      '@yuku-toolchain/types': 0.5.43
+      '@yuku-toolchain/types': 0.8.3
 
-  yuku-codegen@0.6.5:
+  yuku-codegen@0.8.3:
     dependencies:
-      '@yuku-toolchain/types': 0.5.43
+      '@yuku-toolchain/types': 0.8.3
     optionalDependencies:
-      '@yuku-codegen/binding-darwin-arm64': 0.6.5
-      '@yuku-codegen/binding-darwin-x64': 0.6.5
-      '@yuku-codegen/binding-freebsd-x64': 0.6.5
-      '@yuku-codegen/binding-linux-arm-gnu': 0.6.5
-      '@yuku-codegen/binding-linux-arm-musl': 0.6.5
-      '@yuku-codegen/binding-linux-arm64-gnu': 0.6.5
-      '@yuku-codegen/binding-linux-arm64-musl': 0.6.5
-      '@yuku-codegen/binding-linux-x64-gnu': 0.6.5
-      '@yuku-codegen/binding-linux-x64-musl': 0.6.5
-      '@yuku-codegen/binding-win32-arm64': 0.6.5
-      '@yuku-codegen/binding-win32-x64': 0.6.5
+      '@yuku-codegen/binding-android-arm64': 0.8.3
+      '@yuku-codegen/binding-darwin-arm64': 0.8.3
+      '@yuku-codegen/binding-darwin-x64': 0.8.3
+      '@yuku-codegen/binding-freebsd-x64': 0.8.3
+      '@yuku-codegen/binding-linux-arm-gnu': 0.8.3
+      '@yuku-codegen/binding-linux-arm-musl': 0.8.3
+      '@yuku-codegen/binding-linux-arm64-gnu': 0.8.3
+      '@yuku-codegen/binding-linux-arm64-musl': 0.8.3
+      '@yuku-codegen/binding-linux-x64-gnu': 0.8.3
+      '@yuku-codegen/binding-linux-x64-musl': 0.8.3
+      '@yuku-codegen/binding-win32-arm64': 0.8.3
+      '@yuku-codegen/binding-win32-x64': 0.8.3
 
-  yuku-parser@0.6.5:
+  yuku-parser@0.8.3:
     dependencies:
-      '@yuku-toolchain/types': 0.5.43
+      '@yuku-toolchain/types': 0.8.3
+      yuku-ast: 0.8.3
     optionalDependencies:
-      '@yuku-parser/binding-darwin-arm64': 0.6.5
-      '@yuku-parser/binding-darwin-x64': 0.6.5
-      '@yuku-parser/binding-freebsd-x64': 0.6.5
-      '@yuku-parser/binding-linux-arm-gnu': 0.6.5
-      '@yuku-parser/binding-linux-arm-musl': 0.6.5
-      '@yuku-parser/binding-linux-arm64-gnu': 0.6.5
-      '@yuku-parser/binding-linux-arm64-musl': 0.6.5
-      '@yuku-parser/binding-linux-x64-gnu': 0.6.5
-      '@yuku-parser/binding-linux-x64-musl': 0.6.5
-      '@yuku-parser/binding-win32-arm64': 0.6.5
-      '@yuku-parser/binding-win32-x64': 0.6.5
+      '@yuku-parser/binding-android-arm64': 0.8.3
+      '@yuku-parser/binding-darwin-arm64': 0.8.3
+      '@yuku-parser/binding-darwin-x64': 0.8.3
+      '@yuku-parser/binding-freebsd-x64': 0.8.3
+      '@yuku-parser/binding-linux-arm-gnu': 0.8.3
+      '@yuku-parser/binding-linux-arm-musl': 0.8.3
+      '@yuku-parser/binding-linux-arm64-gnu': 0.8.3
+      '@yuku-parser/binding-linux-arm64-musl': 0.8.3
+      '@yuku-parser/binding-linux-x64-gnu': 0.8.3
+      '@yuku-parser/binding-linux-x64-musl': 0.8.3
+      '@yuku-parser/binding-win32-arm64': 0.8.3
+      '@yuku-parser/binding-win32-x64': 0.8.3

--- a/sdk/typescript/src/2026-04/errors.ts
+++ b/sdk/typescript/src/2026-04/errors.ts
@@ -7,7 +7,6 @@ import type {
   DisputeNotOpenError as DisputeNotOpenErrorModel,
   ExpiredCheckoutError as ExpiredCheckoutErrorModel,
   HTTPValidationError as HTTPValidationErrorModel,
-  InactiveSubscription as InactiveSubscriptionModel,
   ManualRetryLimitExceeded as ManualRetryLimitExceededModel,
   MissingInvoiceBillingDetails as MissingInvoiceBillingDetailsModel,
   NotPermitted as NotPermittedModel,
@@ -16,6 +15,7 @@ import type {
   OrderNotEligibleForInvoice as OrderNotEligibleForInvoiceModel,
   OrderNotEligibleForRetry as OrderNotEligibleForRetryModel,
   OrganizationNotReadyForPayments as OrganizationNotReadyForPaymentsModel,
+  PauseResumeNotAllowed as PauseResumeNotAllowedModel,
   PaymentActionRequired as PaymentActionRequiredModel,
   PaymentAlreadyInProgress as PaymentAlreadyInProgressModel,
   PaymentError as PaymentErrorModel,
@@ -127,23 +127,9 @@ export class PaymentFailed extends PolarClientError<PaymentFailedModel> {
   }
 }
 /**
- * Subscription is already canceled or will be at the end of the period, or is not active.
- */
-export class SubscriptionsUpdate403Error extends PolarClientError<
-  AlreadyCanceledSubscriptionModel | InactiveSubscriptionModel
-> {
-  constructor(
-    public readonly statusCode: 403,
-    public readonly error: AlreadyCanceledSubscriptionModel | InactiveSubscriptionModel,
-  ) {
-    super(statusCode, error);
-    this.name = "SubscriptionsUpdate403Error";
-  }
-}
-/**
  * The charge failed, or requires customer authentication (e.g. a 3DS challenge) that can't be completed off-session.
  */
-export class Finalize402Error extends PolarClientError<
+export class OrdersFinalize402Error extends PolarClientError<
   PaymentFailedModel | PaymentActionRequiredModel
 > {
   constructor(
@@ -151,13 +137,13 @@ export class Finalize402Error extends PolarClientError<
     public readonly error: PaymentFailedModel | PaymentActionRequiredModel,
   ) {
     super(statusCode, error);
-    this.name = "Finalize402Error";
+    this.name = "OrdersFinalize402Error";
   }
 }
 /**
  * Off-session charges are not enabled for this organization, or its account can't currently accept payments.
  */
-export class Finalize403Error extends PolarClientError<
+export class OrdersFinalize403Error extends PolarClientError<
   OffSessionChargesNotEnabledModel | OrganizationNotReadyForPaymentsModel
 > {
   constructor(
@@ -165,7 +151,7 @@ export class Finalize403Error extends PolarClientError<
     public readonly error: OffSessionChargesNotEnabledModel | OrganizationNotReadyForPaymentsModel,
   ) {
     super(statusCode, error);
-    this.name = "Finalize403Error";
+    this.name = "OrdersFinalize403Error";
   }
 }
 /**
@@ -231,13 +217,13 @@ export class DisputeNotOpenError extends PolarClientError<DisputeNotOpenErrorMod
 /**
  * The checkout is expired, the customer already has an active subscription, or the organization is not ready to accept payments.
  */
-export class Update403Error extends PolarClientError<CheckoutForbiddenErrorModel> {
+export class CheckoutsUpdate403Error extends PolarClientError<CheckoutForbiddenErrorModel> {
   constructor(
     public readonly statusCode: 403,
     public readonly error: CheckoutForbiddenErrorModel,
   ) {
     super(statusCode, error);
-    this.name = "Update403Error";
+    this.name = "CheckoutsUpdate403Error";
   }
 }
 /**
@@ -255,13 +241,13 @@ export class ExpiredCheckoutError extends PolarClientError<ExpiredCheckoutErrorM
 /**
  * The checkout is expired, the customer already has an active subscription, or the organization is not ready to accept payments.
  */
-export class ClientUpdate403Error extends PolarClientError<CheckoutForbiddenErrorModel> {
+export class CheckoutsClientUpdate403Error extends PolarClientError<CheckoutForbiddenErrorModel> {
   constructor(
     public readonly statusCode: 403,
     public readonly error: CheckoutForbiddenErrorModel,
   ) {
     super(statusCode, error);
-    this.name = "ClientUpdate403Error";
+    this.name = "CheckoutsClientUpdate403Error";
   }
 }
 /**
@@ -279,13 +265,13 @@ export class PaymentError extends PolarClientError<PaymentErrorModel> {
 /**
  * The checkout is expired, the customer already has an active subscription, or the organization is not ready to accept payments.
  */
-export class ClientConfirm403Error extends PolarClientError<CheckoutForbiddenErrorModel> {
+export class CheckoutsClientConfirm403Error extends PolarClientError<CheckoutForbiddenErrorModel> {
   constructor(
     public readonly statusCode: 403,
     public readonly error: CheckoutForbiddenErrorModel,
   ) {
     super(statusCode, error);
-    this.name = "ClientConfirm403Error";
+    this.name = "CheckoutsClientConfirm403Error";
   }
 }
 /**
@@ -351,373 +337,373 @@ export class PaymentMethodInUseByActiveSubscription extends PolarClientError<Pay
 /**
  * Invalid or expired verification token.
  */
-export class CheckEmailUpdate401Error extends PolarClientError<null> {
+export class CustomersCheckEmailUpdate401Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 401,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "CheckEmailUpdate401Error";
+    this.name = "CustomersCheckEmailUpdate401Error";
   }
 }
 /**
  * Invalid or expired verification token.
  */
-export class VerifyEmailUpdate401Error extends PolarClientError<null> {
+export class CustomersVerifyEmailUpdate401Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 401,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "VerifyEmailUpdate401Error";
+    this.name = "CustomersVerifyEmailUpdate401Error";
   }
 }
 /**
  * Email address is already in use.
  */
-export class VerifyEmailUpdate422Error extends PolarClientError<null> {
+export class CustomersVerifyEmailUpdate422Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 422,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "VerifyEmailUpdate422Error";
+    this.name = "CustomersVerifyEmailUpdate422Error";
   }
 }
 /**
  * Authentication required
  */
-export class ListSeats401Error extends PolarClientError<null> {
+export class SeatsListSeats401Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 401,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "ListSeats401Error";
+    this.name = "SeatsListSeats401Error";
   }
 }
 /**
  * Not permitted or seat-based pricing not enabled
  */
-export class ListSeats403Error extends PolarClientError<null> {
+export class SeatsListSeats403Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 403,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "ListSeats403Error";
+    this.name = "SeatsListSeats403Error";
   }
 }
 /**
  * Subscription or order not found
  */
-export class ListSeats404Error extends PolarClientError<null> {
+export class SeatsListSeats404Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 404,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "ListSeats404Error";
+    this.name = "SeatsListSeats404Error";
   }
 }
 /**
  * No available seats or customer already has a seat
  */
-export class AssignSeat400Error extends PolarClientError<null> {
+export class SeatsAssignSeat400Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 400,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "AssignSeat400Error";
+    this.name = "SeatsAssignSeat400Error";
   }
 }
 /**
  * Authentication required
  */
-export class AssignSeat401Error extends PolarClientError<null> {
+export class SeatsAssignSeat401Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 401,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "AssignSeat401Error";
+    this.name = "SeatsAssignSeat401Error";
   }
 }
 /**
  * Not permitted or seat-based pricing not enabled
  */
-export class AssignSeat403Error extends PolarClientError<null> {
+export class SeatsAssignSeat403Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 403,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "AssignSeat403Error";
+    this.name = "SeatsAssignSeat403Error";
   }
 }
 /**
  * Subscription, order, or customer not found
  */
-export class AssignSeat404Error extends PolarClientError<null> {
+export class SeatsAssignSeat404Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 404,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "AssignSeat404Error";
+    this.name = "SeatsAssignSeat404Error";
   }
 }
 /**
  * Authentication required
  */
-export class RevokeSeat401Error extends PolarClientError<null> {
+export class SeatsRevokeSeat401Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 401,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "RevokeSeat401Error";
+    this.name = "SeatsRevokeSeat401Error";
   }
 }
 /**
  * Not permitted or seat-based pricing not enabled
  */
-export class RevokeSeat403Error extends PolarClientError<null> {
+export class SeatsRevokeSeat403Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 403,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "RevokeSeat403Error";
+    this.name = "SeatsRevokeSeat403Error";
   }
 }
 /**
  * Seat not found
  */
-export class RevokeSeat404Error extends PolarClientError<null> {
+export class SeatsRevokeSeat404Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 404,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "RevokeSeat404Error";
+    this.name = "SeatsRevokeSeat404Error";
   }
 }
 /**
  * Seat is not pending or already claimed
  */
-export class ResendInvitation400Error extends PolarClientError<null> {
+export class SeatsResendInvitation400Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 400,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "ResendInvitation400Error";
+    this.name = "SeatsResendInvitation400Error";
   }
 }
 /**
  * Authentication required
  */
-export class ResendInvitation401Error extends PolarClientError<null> {
+export class SeatsResendInvitation401Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 401,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "ResendInvitation401Error";
+    this.name = "SeatsResendInvitation401Error";
   }
 }
 /**
  * Not permitted or seat-based pricing not enabled
  */
-export class ResendInvitation403Error extends PolarClientError<null> {
+export class SeatsResendInvitation403Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 403,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "ResendInvitation403Error";
+    this.name = "SeatsResendInvitation403Error";
   }
 }
 /**
  * Seat not found
  */
-export class ResendInvitation404Error extends PolarClientError<null> {
+export class SeatsResendInvitation404Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 404,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "ResendInvitation404Error";
+    this.name = "SeatsResendInvitation404Error";
   }
 }
 /**
  * Authentication required
  */
-export class ListClaimedSubscriptions401Error extends PolarClientError<null> {
+export class SeatsListClaimedSubscriptions401Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 401,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "ListClaimedSubscriptions401Error";
+    this.name = "SeatsListClaimedSubscriptions401Error";
   }
 }
 /**
  * Authentication required
  */
-export class ListMembers401Error extends PolarClientError<null> {
+export class MembersListMembers401Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 401,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "ListMembers401Error";
+    this.name = "MembersListMembers401Error";
   }
 }
 /**
  * Not permitted - requires owner or billing manager role
  */
-export class ListMembers403Error extends PolarClientError<null> {
+export class MembersListMembers403Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 403,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "ListMembers403Error";
+    this.name = "MembersListMembers403Error";
   }
 }
 /**
  * Invalid request or member already exists.
  */
-export class AddMember400Error extends PolarClientError<null> {
+export class MembersAddMember400Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 400,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "AddMember400Error";
+    this.name = "MembersAddMember400Error";
   }
 }
 /**
  * Authentication required
  */
-export class AddMember401Error extends PolarClientError<null> {
+export class MembersAddMember401Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 401,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "AddMember401Error";
+    this.name = "MembersAddMember401Error";
   }
 }
 /**
  * Not permitted - requires owner or billing manager role
  */
-export class AddMember403Error extends PolarClientError<null> {
+export class MembersAddMember403Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 403,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "AddMember403Error";
+    this.name = "MembersAddMember403Error";
   }
 }
 /**
  * Cannot remove the only owner.
  */
-export class RemoveMember400Error extends PolarClientError<null> {
+export class MembersRemoveMember400Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 400,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "RemoveMember400Error";
+    this.name = "MembersRemoveMember400Error";
   }
 }
 /**
  * Authentication required
  */
-export class RemoveMember401Error extends PolarClientError<null> {
+export class MembersRemoveMember401Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 401,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "RemoveMember401Error";
+    this.name = "MembersRemoveMember401Error";
   }
 }
 /**
  * Not permitted - requires owner or billing manager role
  */
-export class RemoveMember403Error extends PolarClientError<null> {
+export class MembersRemoveMember403Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 403,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "RemoveMember403Error";
+    this.name = "MembersRemoveMember403Error";
   }
 }
 /**
  * Member not found.
  */
-export class RemoveMember404Error extends PolarClientError<null> {
+export class MembersRemoveMember404Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 404,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "RemoveMember404Error";
+    this.name = "MembersRemoveMember404Error";
   }
 }
 /**
  * Invalid role change.
  */
-export class UpdateMember400Error extends PolarClientError<null> {
+export class MembersUpdateMember400Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 400,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "UpdateMember400Error";
+    this.name = "MembersUpdateMember400Error";
   }
 }
 /**
  * Authentication required
  */
-export class UpdateMember401Error extends PolarClientError<null> {
+export class MembersUpdateMember401Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 401,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "UpdateMember401Error";
+    this.name = "MembersUpdateMember401Error";
   }
 }
 /**
  * Not permitted - requires owner or billing manager role
  */
-export class UpdateMember403Error extends PolarClientError<null> {
+export class MembersUpdateMember403Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 403,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "UpdateMember403Error";
+    this.name = "MembersUpdateMember403Error";
   }
 }
 /**
  * Member not found.
  */
-export class UpdateMember404Error extends PolarClientError<null> {
+export class MembersUpdateMember404Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 404,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "UpdateMember404Error";
+    this.name = "MembersUpdateMember404Error";
   }
 }
 /**
@@ -757,74 +743,256 @@ export class ManualRetryLimitExceeded extends PolarClientError<ManualRetryLimitE
   }
 }
 /**
- * Invalid or expired invitation token
+ * Customer subscription is already canceled or will be at the end of the period, the user lacks billing permissions, or pausing/resuming is not enabled for the organization.
  */
-export class GetClaimInfo400Error extends PolarClientError<null> {
+export class SubscriptionsUpdate403Error extends PolarClientError<
+  AlreadyCanceledSubscriptionModel | PauseResumeNotAllowedModel
+> {
   constructor(
-    public readonly statusCode: 400,
-    public readonly error: null,
+    public readonly statusCode: 403,
+    public readonly error: AlreadyCanceledSubscriptionModel | PauseResumeNotAllowedModel,
   ) {
     super(statusCode, error);
-    this.name = "GetClaimInfo400Error";
+    this.name = "SubscriptionsUpdate403Error";
   }
 }
 /**
- * Seat-based pricing not enabled for organization
+ * Authentication required
  */
-export class GetClaimInfo403Error extends PolarClientError<null> {
+export class CustomerSeatsListSeats401Error extends PolarClientError<null> {
+  constructor(
+    public readonly statusCode: 401,
+    public readonly error: null,
+  ) {
+    super(statusCode, error);
+    this.name = "CustomerSeatsListSeats401Error";
+  }
+}
+/**
+ * Not permitted or seat-based pricing not enabled
+ */
+export class CustomerSeatsListSeats403Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 403,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "GetClaimInfo403Error";
+    this.name = "CustomerSeatsListSeats403Error";
+  }
+}
+/**
+ * Subscription or order not found
+ */
+export class CustomerSeatsListSeats404Error extends PolarClientError<null> {
+  constructor(
+    public readonly statusCode: 404,
+    public readonly error: null,
+  ) {
+    super(statusCode, error);
+    this.name = "CustomerSeatsListSeats404Error";
+  }
+}
+/**
+ * No available seats or customer already has a seat
+ */
+export class CustomerSeatsAssignSeat400Error extends PolarClientError<null> {
+  constructor(
+    public readonly statusCode: 400,
+    public readonly error: null,
+  ) {
+    super(statusCode, error);
+    this.name = "CustomerSeatsAssignSeat400Error";
+  }
+}
+/**
+ * Authentication required
+ */
+export class CustomerSeatsAssignSeat401Error extends PolarClientError<null> {
+  constructor(
+    public readonly statusCode: 401,
+    public readonly error: null,
+  ) {
+    super(statusCode, error);
+    this.name = "CustomerSeatsAssignSeat401Error";
+  }
+}
+/**
+ * Not permitted or seat-based pricing not enabled
+ */
+export class CustomerSeatsAssignSeat403Error extends PolarClientError<null> {
+  constructor(
+    public readonly statusCode: 403,
+    public readonly error: null,
+  ) {
+    super(statusCode, error);
+    this.name = "CustomerSeatsAssignSeat403Error";
+  }
+}
+/**
+ * Subscription, order, or customer not found
+ */
+export class CustomerSeatsAssignSeat404Error extends PolarClientError<null> {
+  constructor(
+    public readonly statusCode: 404,
+    public readonly error: null,
+  ) {
+    super(statusCode, error);
+    this.name = "CustomerSeatsAssignSeat404Error";
+  }
+}
+/**
+ * Authentication required
+ */
+export class CustomerSeatsRevokeSeat401Error extends PolarClientError<null> {
+  constructor(
+    public readonly statusCode: 401,
+    public readonly error: null,
+  ) {
+    super(statusCode, error);
+    this.name = "CustomerSeatsRevokeSeat401Error";
+  }
+}
+/**
+ * Not permitted or seat-based pricing not enabled
+ */
+export class CustomerSeatsRevokeSeat403Error extends PolarClientError<null> {
+  constructor(
+    public readonly statusCode: 403,
+    public readonly error: null,
+  ) {
+    super(statusCode, error);
+    this.name = "CustomerSeatsRevokeSeat403Error";
   }
 }
 /**
  * Seat not found
  */
-export class GetClaimInfo404Error extends PolarClientError<null> {
+export class CustomerSeatsRevokeSeat404Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 404,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "GetClaimInfo404Error";
+    this.name = "CustomerSeatsRevokeSeat404Error";
   }
 }
 /**
- * Invalid, expired, or already claimed token
+ * Seat is not pending or already claimed
  */
-export class ClaimSeat400Error extends PolarClientError<null> {
+export class CustomerSeatsResendInvitation400Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 400,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "ClaimSeat400Error";
+    this.name = "CustomerSeatsResendInvitation400Error";
   }
 }
 /**
- * Seat-based pricing not enabled for organization
+ * Authentication required
  */
-export class ClaimSeat403Error extends PolarClientError<null> {
+export class CustomerSeatsResendInvitation401Error extends PolarClientError<null> {
+  constructor(
+    public readonly statusCode: 401,
+    public readonly error: null,
+  ) {
+    super(statusCode, error);
+    this.name = "CustomerSeatsResendInvitation401Error";
+  }
+}
+/**
+ * Not permitted or seat-based pricing not enabled
+ */
+export class CustomerSeatsResendInvitation403Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 403,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "ClaimSeat403Error";
+    this.name = "CustomerSeatsResendInvitation403Error";
   }
 }
 /**
- * Not Found
+ * Seat not found
  */
-export class Update404Error extends PolarClientError<null> {
+export class CustomerSeatsResendInvitation404Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 404,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "Update404Error";
+    this.name = "CustomerSeatsResendInvitation404Error";
+  }
+}
+/**
+ * Invalid or expired invitation token
+ */
+export class CustomerSeatsGetClaimInfo400Error extends PolarClientError<null> {
+  constructor(
+    public readonly statusCode: 400,
+    public readonly error: null,
+  ) {
+    super(statusCode, error);
+    this.name = "CustomerSeatsGetClaimInfo400Error";
+  }
+}
+/**
+ * Seat-based pricing not enabled for organization
+ */
+export class CustomerSeatsGetClaimInfo403Error extends PolarClientError<null> {
+  constructor(
+    public readonly statusCode: 403,
+    public readonly error: null,
+  ) {
+    super(statusCode, error);
+    this.name = "CustomerSeatsGetClaimInfo403Error";
+  }
+}
+/**
+ * Seat not found
+ */
+export class CustomerSeatsGetClaimInfo404Error extends PolarClientError<null> {
+  constructor(
+    public readonly statusCode: 404,
+    public readonly error: null,
+  ) {
+    super(statusCode, error);
+    this.name = "CustomerSeatsGetClaimInfo404Error";
+  }
+}
+/**
+ * Invalid, expired, or already claimed token
+ */
+export class CustomerSeatsClaimSeat400Error extends PolarClientError<null> {
+  constructor(
+    public readonly statusCode: 400,
+    public readonly error: null,
+  ) {
+    super(statusCode, error);
+    this.name = "CustomerSeatsClaimSeat400Error";
+  }
+}
+/**
+ * Seat-based pricing not enabled for organization
+ */
+export class CustomerSeatsClaimSeat403Error extends PolarClientError<null> {
+  constructor(
+    public readonly statusCode: 403,
+    public readonly error: null,
+  ) {
+    super(statusCode, error);
+    this.name = "CustomerSeatsClaimSeat403Error";
+  }
+}
+/**
+ * Not Found
+ */
+export class EventTypesUpdate404Error extends PolarClientError<null> {
+  constructor(
+    public readonly statusCode: 404,
+    public readonly error: null,
+  ) {
+    super(statusCode, error);
+    this.name = "EventTypesUpdate404Error";
   }
 }

--- a/sdk/typescript/src/2026-04/errors.ts
+++ b/sdk/typescript/src/2026-04/errors.ts
@@ -337,373 +337,373 @@ export class PaymentMethodInUseByActiveSubscription extends PolarClientError<Pay
 /**
  * Invalid or expired verification token.
  */
-export class CustomersCheckEmailUpdate401Error extends PolarClientError<null> {
+export class CustomerPortalCustomersCheckEmailUpdate401Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 401,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "CustomersCheckEmailUpdate401Error";
+    this.name = "CustomerPortalCustomersCheckEmailUpdate401Error";
   }
 }
 /**
  * Invalid or expired verification token.
  */
-export class CustomersVerifyEmailUpdate401Error extends PolarClientError<null> {
+export class CustomerPortalCustomersVerifyEmailUpdate401Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 401,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "CustomersVerifyEmailUpdate401Error";
+    this.name = "CustomerPortalCustomersVerifyEmailUpdate401Error";
   }
 }
 /**
  * Email address is already in use.
  */
-export class CustomersVerifyEmailUpdate422Error extends PolarClientError<null> {
+export class CustomerPortalCustomersVerifyEmailUpdate422Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 422,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "CustomersVerifyEmailUpdate422Error";
+    this.name = "CustomerPortalCustomersVerifyEmailUpdate422Error";
   }
 }
 /**
  * Authentication required
  */
-export class SeatsListSeats401Error extends PolarClientError<null> {
+export class CustomerPortalSeatsListSeats401Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 401,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "SeatsListSeats401Error";
+    this.name = "CustomerPortalSeatsListSeats401Error";
   }
 }
 /**
  * Not permitted or seat-based pricing not enabled
  */
-export class SeatsListSeats403Error extends PolarClientError<null> {
+export class CustomerPortalSeatsListSeats403Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 403,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "SeatsListSeats403Error";
+    this.name = "CustomerPortalSeatsListSeats403Error";
   }
 }
 /**
  * Subscription or order not found
  */
-export class SeatsListSeats404Error extends PolarClientError<null> {
+export class CustomerPortalSeatsListSeats404Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 404,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "SeatsListSeats404Error";
+    this.name = "CustomerPortalSeatsListSeats404Error";
   }
 }
 /**
  * No available seats or customer already has a seat
  */
-export class SeatsAssignSeat400Error extends PolarClientError<null> {
+export class CustomerPortalSeatsAssignSeat400Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 400,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "SeatsAssignSeat400Error";
+    this.name = "CustomerPortalSeatsAssignSeat400Error";
   }
 }
 /**
  * Authentication required
  */
-export class SeatsAssignSeat401Error extends PolarClientError<null> {
+export class CustomerPortalSeatsAssignSeat401Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 401,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "SeatsAssignSeat401Error";
+    this.name = "CustomerPortalSeatsAssignSeat401Error";
   }
 }
 /**
  * Not permitted or seat-based pricing not enabled
  */
-export class SeatsAssignSeat403Error extends PolarClientError<null> {
+export class CustomerPortalSeatsAssignSeat403Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 403,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "SeatsAssignSeat403Error";
+    this.name = "CustomerPortalSeatsAssignSeat403Error";
   }
 }
 /**
  * Subscription, order, or customer not found
  */
-export class SeatsAssignSeat404Error extends PolarClientError<null> {
+export class CustomerPortalSeatsAssignSeat404Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 404,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "SeatsAssignSeat404Error";
+    this.name = "CustomerPortalSeatsAssignSeat404Error";
   }
 }
 /**
  * Authentication required
  */
-export class SeatsRevokeSeat401Error extends PolarClientError<null> {
+export class CustomerPortalSeatsRevokeSeat401Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 401,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "SeatsRevokeSeat401Error";
+    this.name = "CustomerPortalSeatsRevokeSeat401Error";
   }
 }
 /**
  * Not permitted or seat-based pricing not enabled
  */
-export class SeatsRevokeSeat403Error extends PolarClientError<null> {
+export class CustomerPortalSeatsRevokeSeat403Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 403,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "SeatsRevokeSeat403Error";
+    this.name = "CustomerPortalSeatsRevokeSeat403Error";
   }
 }
 /**
  * Seat not found
  */
-export class SeatsRevokeSeat404Error extends PolarClientError<null> {
+export class CustomerPortalSeatsRevokeSeat404Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 404,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "SeatsRevokeSeat404Error";
+    this.name = "CustomerPortalSeatsRevokeSeat404Error";
   }
 }
 /**
  * Seat is not pending or already claimed
  */
-export class SeatsResendInvitation400Error extends PolarClientError<null> {
+export class CustomerPortalSeatsResendInvitation400Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 400,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "SeatsResendInvitation400Error";
+    this.name = "CustomerPortalSeatsResendInvitation400Error";
   }
 }
 /**
  * Authentication required
  */
-export class SeatsResendInvitation401Error extends PolarClientError<null> {
+export class CustomerPortalSeatsResendInvitation401Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 401,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "SeatsResendInvitation401Error";
+    this.name = "CustomerPortalSeatsResendInvitation401Error";
   }
 }
 /**
  * Not permitted or seat-based pricing not enabled
  */
-export class SeatsResendInvitation403Error extends PolarClientError<null> {
+export class CustomerPortalSeatsResendInvitation403Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 403,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "SeatsResendInvitation403Error";
+    this.name = "CustomerPortalSeatsResendInvitation403Error";
   }
 }
 /**
  * Seat not found
  */
-export class SeatsResendInvitation404Error extends PolarClientError<null> {
+export class CustomerPortalSeatsResendInvitation404Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 404,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "SeatsResendInvitation404Error";
+    this.name = "CustomerPortalSeatsResendInvitation404Error";
   }
 }
 /**
  * Authentication required
  */
-export class SeatsListClaimedSubscriptions401Error extends PolarClientError<null> {
+export class CustomerPortalSeatsListClaimedSubscriptions401Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 401,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "SeatsListClaimedSubscriptions401Error";
+    this.name = "CustomerPortalSeatsListClaimedSubscriptions401Error";
   }
 }
 /**
  * Authentication required
  */
-export class MembersListMembers401Error extends PolarClientError<null> {
+export class CustomerPortalMembersListMembers401Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 401,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "MembersListMembers401Error";
+    this.name = "CustomerPortalMembersListMembers401Error";
   }
 }
 /**
  * Not permitted - requires owner or billing manager role
  */
-export class MembersListMembers403Error extends PolarClientError<null> {
+export class CustomerPortalMembersListMembers403Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 403,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "MembersListMembers403Error";
+    this.name = "CustomerPortalMembersListMembers403Error";
   }
 }
 /**
  * Invalid request or member already exists.
  */
-export class MembersAddMember400Error extends PolarClientError<null> {
+export class CustomerPortalMembersAddMember400Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 400,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "MembersAddMember400Error";
+    this.name = "CustomerPortalMembersAddMember400Error";
   }
 }
 /**
  * Authentication required
  */
-export class MembersAddMember401Error extends PolarClientError<null> {
+export class CustomerPortalMembersAddMember401Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 401,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "MembersAddMember401Error";
+    this.name = "CustomerPortalMembersAddMember401Error";
   }
 }
 /**
  * Not permitted - requires owner or billing manager role
  */
-export class MembersAddMember403Error extends PolarClientError<null> {
+export class CustomerPortalMembersAddMember403Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 403,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "MembersAddMember403Error";
+    this.name = "CustomerPortalMembersAddMember403Error";
   }
 }
 /**
  * Cannot remove the only owner.
  */
-export class MembersRemoveMember400Error extends PolarClientError<null> {
+export class CustomerPortalMembersRemoveMember400Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 400,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "MembersRemoveMember400Error";
+    this.name = "CustomerPortalMembersRemoveMember400Error";
   }
 }
 /**
  * Authentication required
  */
-export class MembersRemoveMember401Error extends PolarClientError<null> {
+export class CustomerPortalMembersRemoveMember401Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 401,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "MembersRemoveMember401Error";
+    this.name = "CustomerPortalMembersRemoveMember401Error";
   }
 }
 /**
  * Not permitted - requires owner or billing manager role
  */
-export class MembersRemoveMember403Error extends PolarClientError<null> {
+export class CustomerPortalMembersRemoveMember403Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 403,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "MembersRemoveMember403Error";
+    this.name = "CustomerPortalMembersRemoveMember403Error";
   }
 }
 /**
  * Member not found.
  */
-export class MembersRemoveMember404Error extends PolarClientError<null> {
+export class CustomerPortalMembersRemoveMember404Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 404,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "MembersRemoveMember404Error";
+    this.name = "CustomerPortalMembersRemoveMember404Error";
   }
 }
 /**
  * Invalid role change.
  */
-export class MembersUpdateMember400Error extends PolarClientError<null> {
+export class CustomerPortalMembersUpdateMember400Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 400,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "MembersUpdateMember400Error";
+    this.name = "CustomerPortalMembersUpdateMember400Error";
   }
 }
 /**
  * Authentication required
  */
-export class MembersUpdateMember401Error extends PolarClientError<null> {
+export class CustomerPortalMembersUpdateMember401Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 401,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "MembersUpdateMember401Error";
+    this.name = "CustomerPortalMembersUpdateMember401Error";
   }
 }
 /**
  * Not permitted - requires owner or billing manager role
  */
-export class MembersUpdateMember403Error extends PolarClientError<null> {
+export class CustomerPortalMembersUpdateMember403Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 403,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "MembersUpdateMember403Error";
+    this.name = "CustomerPortalMembersUpdateMember403Error";
   }
 }
 /**
  * Member not found.
  */
-export class MembersUpdateMember404Error extends PolarClientError<null> {
+export class CustomerPortalMembersUpdateMember404Error extends PolarClientError<null> {
   constructor(
     public readonly statusCode: 404,
     public readonly error: null,
   ) {
     super(statusCode, error);
-    this.name = "MembersUpdateMember404Error";
+    this.name = "CustomerPortalMembersUpdateMember404Error";
   }
 }
 /**
@@ -745,7 +745,7 @@ export class ManualRetryLimitExceeded extends PolarClientError<ManualRetryLimitE
 /**
  * Customer subscription is already canceled or will be at the end of the period, the user lacks billing permissions, or pausing/resuming is not enabled for the organization.
  */
-export class SubscriptionsUpdate403Error extends PolarClientError<
+export class CustomerPortalSubscriptionsUpdate403Error extends PolarClientError<
   AlreadyCanceledSubscriptionModel | PauseResumeNotAllowedModel
 > {
   constructor(
@@ -753,7 +753,7 @@ export class SubscriptionsUpdate403Error extends PolarClientError<
     public readonly error: AlreadyCanceledSubscriptionModel | PauseResumeNotAllowedModel,
   ) {
     super(statusCode, error);
-    this.name = "SubscriptionsUpdate403Error";
+    this.name = "CustomerPortalSubscriptionsUpdate403Error";
   }
 }
 /**

--- a/sdk/typescript/src/2026-04/models.ts
+++ b/sdk/typescript/src/2026-04/models.ts
@@ -916,7 +916,7 @@ export type PaymentTrigger =
   | "retry_payment_method_update"
   | "retry_admin";
 /**
- * Permission
+ * The permission level to grant. Read more about roles and their permissions on [GitHub documentation](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role).
  */
 export type Permission = "pull" | "triage" | "push" | "maintain" | "admin";
 /**

--- a/sdk/typescript/src/2026-04/models.ts
+++ b/sdk/typescript/src/2026-04/models.ts
@@ -916,7 +916,7 @@ export type PaymentTrigger =
   | "retry_payment_method_update"
   | "retry_admin";
 /**
- * The permission level to grant. Read more about roles and their permissions on [GitHub documentation](https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role).
+ * Permission
  */
 export type Permission = "pull" | "triage" | "push" | "maintain" | "admin";
 /**
@@ -13520,19 +13520,6 @@ export interface HTTPValidationError {
    * detail
    */
   detail?: ValidationError[];
-}
-/**
- * InactiveSubscription
- */
-export interface InactiveSubscription {
-  /**
-   * error
-   */
-  error: "InactiveSubscription";
-  /**
-   * detail
-   */
-  detail: string;
 }
 /**
  * IntrospectTokenResponse

--- a/sdk/typescript/src/2026-04/services/checkouts.ts
+++ b/sdk/typescript/src/2026-04/services/checkouts.ts
@@ -13,13 +13,13 @@ import type {
 } from "../models";
 
 import {
-  ClientConfirm403Error,
-  ClientUpdate403Error,
+  CheckoutsClientConfirm403Error,
+  CheckoutsClientUpdate403Error,
+  CheckoutsUpdate403Error,
   ExpiredCheckoutError,
   HTTPValidationError,
   PaymentError,
   ResourceNotFound,
-  Update403Error,
 } from "../errors";
 
 export const listCheckouts = (client: ClientBase) => {
@@ -180,7 +180,7 @@ export const updateCheckouts = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {Update403Error} The checkout is expired, the customer already has an active subscription, or the organization is not ready to accept payments.
+   * @throws {CheckoutsUpdate403Error} The checkout is expired, the customer already has an active subscription, or the organization is not ready to accept payments.
    * @throws {ResourceNotFound} Checkout session not found.
    * @throws {HTTPValidationError} Validation Error
    */
@@ -198,7 +198,7 @@ export const updateCheckouts = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<Checkout>(response, "json", {
-      403: Update403Error,
+      403: CheckoutsUpdate403Error,
       404: ResourceNotFound,
       422: HTTPValidationError,
     });
@@ -247,7 +247,7 @@ export const clientUpdateCheckouts = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {ClientUpdate403Error} The checkout is expired, the customer already has an active subscription, or the organization is not ready to accept payments.
+   * @throws {CheckoutsClientUpdate403Error} The checkout is expired, the customer already has an active subscription, or the organization is not ready to accept payments.
    * @throws {ResourceNotFound} Checkout session not found.
    * @throws {ExpiredCheckoutError} The checkout session is expired.
    * @throws {HTTPValidationError} Validation Error
@@ -266,7 +266,7 @@ export const clientUpdateCheckouts = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<CheckoutPublic>(response, "json", {
-      403: ClientUpdate403Error,
+      403: CheckoutsClientUpdate403Error,
       404: ResourceNotFound,
       410: ExpiredCheckoutError,
       422: HTTPValidationError,
@@ -286,7 +286,7 @@ export const clientConfirmCheckouts = (client: ClientBase) => {
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
    * @throws {PaymentError} The payment failed.
-   * @throws {ClientConfirm403Error} The checkout is expired, the customer already has an active subscription, or the organization is not ready to accept payments.
+   * @throws {CheckoutsClientConfirm403Error} The checkout is expired, the customer already has an active subscription, or the organization is not ready to accept payments.
    * @throws {ResourceNotFound} Checkout session not found.
    * @throws {ExpiredCheckoutError} The checkout session is expired.
    * @throws {HTTPValidationError} Validation Error
@@ -309,7 +309,7 @@ export const clientConfirmCheckouts = (client: ClientBase) => {
     const response = await client.sendRequest(request);
     return client.parseResponse<CheckoutPublicConfirmed>(response, "json", {
       400: PaymentError,
-      403: ClientConfirm403Error,
+      403: CheckoutsClientConfirm403Error,
       404: ResourceNotFound,
       410: ExpiredCheckoutError,
       422: HTTPValidationError,

--- a/sdk/typescript/src/2026-04/services/customer_portal/customers.ts
+++ b/sdk/typescript/src/2026-04/services/customer_portal/customers.ts
@@ -14,9 +14,9 @@ import type {
 
 import {
   CustomerNotReady,
-  CustomersCheckEmailUpdate401Error,
-  CustomersVerifyEmailUpdate401Error,
-  CustomersVerifyEmailUpdate422Error,
+  CustomerPortalCustomersCheckEmailUpdate401Error,
+  CustomerPortalCustomersVerifyEmailUpdate401Error,
+  CustomerPortalCustomersVerifyEmailUpdate422Error,
   HTTPValidationError,
   PaymentMethodInUseByActiveSubscription,
   PaymentMethodSetupFailed,
@@ -271,7 +271,7 @@ export const checkEmailUpdateCustomers = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {CustomersCheckEmailUpdate401Error} Invalid or expired verification token.
+   * @throws {CustomerPortalCustomersCheckEmailUpdate401Error} Invalid or expired verification token.
    * @throws {HTTPValidationError} Validation Error
    */
   return async (query: { token: string }): Promise<void> => {
@@ -288,7 +288,7 @@ export const checkEmailUpdateCustomers = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<void>(response, "none", {
-      401: CustomersCheckEmailUpdate401Error,
+      401: CustomerPortalCustomersCheckEmailUpdate401Error,
       422: HTTPValidationError,
     });
   };
@@ -302,8 +302,8 @@ export const verifyEmailUpdateCustomers = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {CustomersVerifyEmailUpdate401Error} Invalid or expired verification token.
-   * @throws {CustomersVerifyEmailUpdate422Error} Email address is already in use.
+   * @throws {CustomerPortalCustomersVerifyEmailUpdate401Error} Invalid or expired verification token.
+   * @throws {CustomerPortalCustomersVerifyEmailUpdate422Error} Email address is already in use.
    */
   return async (
     body: CustomerEmailUpdateVerifyRequest,
@@ -319,8 +319,8 @@ export const verifyEmailUpdateCustomers = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<CustomerEmailUpdateVerifyResponse>(response, "json", {
-      401: CustomersVerifyEmailUpdate401Error,
-      422: CustomersVerifyEmailUpdate422Error,
+      401: CustomerPortalCustomersVerifyEmailUpdate401Error,
+      422: CustomerPortalCustomersVerifyEmailUpdate422Error,
     });
   };
 };

--- a/sdk/typescript/src/2026-04/services/customer_portal/customers.ts
+++ b/sdk/typescript/src/2026-04/services/customer_portal/customers.ts
@@ -13,14 +13,14 @@ import type {
 } from "../../models";
 
 import {
-  CheckEmailUpdate401Error,
   CustomerNotReady,
+  CustomersCheckEmailUpdate401Error,
+  CustomersVerifyEmailUpdate401Error,
+  CustomersVerifyEmailUpdate422Error,
   HTTPValidationError,
   PaymentMethodInUseByActiveSubscription,
   PaymentMethodSetupFailed,
   ResourceNotFound,
-  VerifyEmailUpdate401Error,
-  VerifyEmailUpdate422Error,
 } from "../../errors";
 
 export const getCustomers = (client: ClientBase) => {
@@ -271,7 +271,7 @@ export const checkEmailUpdateCustomers = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {CheckEmailUpdate401Error} Invalid or expired verification token.
+   * @throws {CustomersCheckEmailUpdate401Error} Invalid or expired verification token.
    * @throws {HTTPValidationError} Validation Error
    */
   return async (query: { token: string }): Promise<void> => {
@@ -288,7 +288,7 @@ export const checkEmailUpdateCustomers = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<void>(response, "none", {
-      401: CheckEmailUpdate401Error,
+      401: CustomersCheckEmailUpdate401Error,
       422: HTTPValidationError,
     });
   };
@@ -302,8 +302,8 @@ export const verifyEmailUpdateCustomers = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {VerifyEmailUpdate401Error} Invalid or expired verification token.
-   * @throws {VerifyEmailUpdate422Error} Email address is already in use.
+   * @throws {CustomersVerifyEmailUpdate401Error} Invalid or expired verification token.
+   * @throws {CustomersVerifyEmailUpdate422Error} Email address is already in use.
    */
   return async (
     body: CustomerEmailUpdateVerifyRequest,
@@ -319,8 +319,8 @@ export const verifyEmailUpdateCustomers = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<CustomerEmailUpdateVerifyResponse>(response, "json", {
-      401: VerifyEmailUpdate401Error,
-      422: VerifyEmailUpdate422Error,
+      401: CustomersVerifyEmailUpdate401Error,
+      422: CustomersVerifyEmailUpdate422Error,
     });
   };
 };

--- a/sdk/typescript/src/2026-04/services/customer_portal/members.ts
+++ b/sdk/typescript/src/2026-04/services/customer_portal/members.ts
@@ -7,20 +7,20 @@ import type {
 } from "../../models";
 
 import {
+  CustomerPortalMembersAddMember400Error,
+  CustomerPortalMembersAddMember401Error,
+  CustomerPortalMembersAddMember403Error,
+  CustomerPortalMembersListMembers401Error,
+  CustomerPortalMembersListMembers403Error,
+  CustomerPortalMembersRemoveMember400Error,
+  CustomerPortalMembersRemoveMember401Error,
+  CustomerPortalMembersRemoveMember403Error,
+  CustomerPortalMembersRemoveMember404Error,
+  CustomerPortalMembersUpdateMember400Error,
+  CustomerPortalMembersUpdateMember401Error,
+  CustomerPortalMembersUpdateMember403Error,
+  CustomerPortalMembersUpdateMember404Error,
   HTTPValidationError,
-  MembersAddMember400Error,
-  MembersAddMember401Error,
-  MembersAddMember403Error,
-  MembersListMembers401Error,
-  MembersListMembers403Error,
-  MembersRemoveMember400Error,
-  MembersRemoveMember401Error,
-  MembersRemoveMember403Error,
-  MembersRemoveMember404Error,
-  MembersUpdateMember400Error,
-  MembersUpdateMember401Error,
-  MembersUpdateMember403Error,
-  MembersUpdateMember404Error,
 } from "../../errors";
 
 export const listMembersMembers = (client: ClientBase) => {
@@ -34,8 +34,8 @@ export const listMembersMembers = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {MembersListMembers401Error} Authentication required
-   * @throws {MembersListMembers403Error} Not permitted - requires owner or billing manager role
+   * @throws {CustomerPortalMembersListMembers401Error} Authentication required
+   * @throws {CustomerPortalMembersListMembers403Error} Not permitted - requires owner or billing manager role
    * @throws {HTTPValidationError} Validation Error
    */
   return async (query?: {
@@ -56,8 +56,8 @@ export const listMembersMembers = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<ListResourceCustomerPortalMember>(response, "json", {
-      401: MembersListMembers401Error,
-      403: MembersListMembers403Error,
+      401: CustomerPortalMembersListMembers401Error,
+      403: CustomerPortalMembersListMembers403Error,
       422: HTTPValidationError,
     });
   };
@@ -72,8 +72,8 @@ export const listMembersMembers = (client: ClientBase) => {
  * @throws {PolarNetworkError} When a network error occurs
  * @throws {PolarRateLimitError} When the rate limit is exceeded
  * @throws {PolarServerError} When the server returns a 5xx error
- * @throws {MembersListMembers401Error} Authentication required
- * @throws {MembersListMembers403Error} Not permitted - requires owner or billing manager role
+ * @throws {CustomerPortalMembersListMembers401Error} Authentication required
+ * @throws {CustomerPortalMembersListMembers403Error} Not permitted - requires owner or billing manager role
  * @throws {HTTPValidationError} Validation Error
  */
 export const iterListMembersMembers = (client: ClientBase) => {
@@ -113,9 +113,9 @@ export const addMemberMembers = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {MembersAddMember400Error} Invalid request or member already exists.
-   * @throws {MembersAddMember401Error} Authentication required
-   * @throws {MembersAddMember403Error} Not permitted - requires owner or billing manager role
+   * @throws {CustomerPortalMembersAddMember400Error} Invalid request or member already exists.
+   * @throws {CustomerPortalMembersAddMember401Error} Authentication required
+   * @throws {CustomerPortalMembersAddMember403Error} Not permitted - requires owner or billing manager role
    * @throws {HTTPValidationError} Validation Error
    */
   return async (body: CustomerPortalMemberCreate): Promise<CustomerPortalMember> => {
@@ -130,9 +130,9 @@ export const addMemberMembers = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<CustomerPortalMember>(response, "json", {
-      400: MembersAddMember400Error,
-      401: MembersAddMember401Error,
-      403: MembersAddMember403Error,
+      400: CustomerPortalMembersAddMember400Error,
+      401: CustomerPortalMembersAddMember401Error,
+      403: CustomerPortalMembersAddMember403Error,
       422: HTTPValidationError,
     });
   };
@@ -152,10 +152,10 @@ export const removeMemberMembers = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {MembersRemoveMember400Error} Cannot remove the only owner.
-   * @throws {MembersRemoveMember401Error} Authentication required
-   * @throws {MembersRemoveMember403Error} Not permitted - requires owner or billing manager role
-   * @throws {MembersRemoveMember404Error} Member not found.
+   * @throws {CustomerPortalMembersRemoveMember400Error} Cannot remove the only owner.
+   * @throws {CustomerPortalMembersRemoveMember401Error} Authentication required
+   * @throws {CustomerPortalMembersRemoveMember403Error} Not permitted - requires owner or billing manager role
+   * @throws {CustomerPortalMembersRemoveMember404Error} Member not found.
    * @throws {HTTPValidationError} Validation Error
    */
   return async (id: string): Promise<void> => {
@@ -172,10 +172,10 @@ export const removeMemberMembers = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<void>(response, "none", {
-      400: MembersRemoveMember400Error,
-      401: MembersRemoveMember401Error,
-      403: MembersRemoveMember403Error,
-      404: MembersRemoveMember404Error,
+      400: CustomerPortalMembersRemoveMember400Error,
+      401: CustomerPortalMembersRemoveMember401Error,
+      403: CustomerPortalMembersRemoveMember403Error,
+      404: CustomerPortalMembersRemoveMember404Error,
       422: HTTPValidationError,
     });
   };
@@ -196,10 +196,10 @@ export const updateMemberMembers = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {MembersUpdateMember400Error} Invalid role change.
-   * @throws {MembersUpdateMember401Error} Authentication required
-   * @throws {MembersUpdateMember403Error} Not permitted - requires owner or billing manager role
-   * @throws {MembersUpdateMember404Error} Member not found.
+   * @throws {CustomerPortalMembersUpdateMember400Error} Invalid role change.
+   * @throws {CustomerPortalMembersUpdateMember401Error} Authentication required
+   * @throws {CustomerPortalMembersUpdateMember403Error} Not permitted - requires owner or billing manager role
+   * @throws {CustomerPortalMembersUpdateMember404Error} Member not found.
    * @throws {HTTPValidationError} Validation Error
    */
   return async (id: string, body: CustomerPortalMemberUpdate): Promise<CustomerPortalMember> => {
@@ -216,10 +216,10 @@ export const updateMemberMembers = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<CustomerPortalMember>(response, "json", {
-      400: MembersUpdateMember400Error,
-      401: MembersUpdateMember401Error,
-      403: MembersUpdateMember403Error,
-      404: MembersUpdateMember404Error,
+      400: CustomerPortalMembersUpdateMember400Error,
+      401: CustomerPortalMembersUpdateMember401Error,
+      403: CustomerPortalMembersUpdateMember403Error,
+      404: CustomerPortalMembersUpdateMember404Error,
       422: HTTPValidationError,
     });
   };

--- a/sdk/typescript/src/2026-04/services/customer_portal/members.ts
+++ b/sdk/typescript/src/2026-04/services/customer_portal/members.ts
@@ -7,20 +7,20 @@ import type {
 } from "../../models";
 
 import {
-  AddMember400Error,
-  AddMember401Error,
-  AddMember403Error,
   HTTPValidationError,
-  ListMembers401Error,
-  ListMembers403Error,
-  RemoveMember400Error,
-  RemoveMember401Error,
-  RemoveMember403Error,
-  RemoveMember404Error,
-  UpdateMember400Error,
-  UpdateMember401Error,
-  UpdateMember403Error,
-  UpdateMember404Error,
+  MembersAddMember400Error,
+  MembersAddMember401Error,
+  MembersAddMember403Error,
+  MembersListMembers401Error,
+  MembersListMembers403Error,
+  MembersRemoveMember400Error,
+  MembersRemoveMember401Error,
+  MembersRemoveMember403Error,
+  MembersRemoveMember404Error,
+  MembersUpdateMember400Error,
+  MembersUpdateMember401Error,
+  MembersUpdateMember403Error,
+  MembersUpdateMember404Error,
 } from "../../errors";
 
 export const listMembersMembers = (client: ClientBase) => {
@@ -34,8 +34,8 @@ export const listMembersMembers = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {ListMembers401Error} Authentication required
-   * @throws {ListMembers403Error} Not permitted - requires owner or billing manager role
+   * @throws {MembersListMembers401Error} Authentication required
+   * @throws {MembersListMembers403Error} Not permitted - requires owner or billing manager role
    * @throws {HTTPValidationError} Validation Error
    */
   return async (query?: {
@@ -56,8 +56,8 @@ export const listMembersMembers = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<ListResourceCustomerPortalMember>(response, "json", {
-      401: ListMembers401Error,
-      403: ListMembers403Error,
+      401: MembersListMembers401Error,
+      403: MembersListMembers403Error,
       422: HTTPValidationError,
     });
   };
@@ -72,8 +72,8 @@ export const listMembersMembers = (client: ClientBase) => {
  * @throws {PolarNetworkError} When a network error occurs
  * @throws {PolarRateLimitError} When the rate limit is exceeded
  * @throws {PolarServerError} When the server returns a 5xx error
- * @throws {ListMembers401Error} Authentication required
- * @throws {ListMembers403Error} Not permitted - requires owner or billing manager role
+ * @throws {MembersListMembers401Error} Authentication required
+ * @throws {MembersListMembers403Error} Not permitted - requires owner or billing manager role
  * @throws {HTTPValidationError} Validation Error
  */
 export const iterListMembersMembers = (client: ClientBase) => {
@@ -113,9 +113,9 @@ export const addMemberMembers = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {AddMember400Error} Invalid request or member already exists.
-   * @throws {AddMember401Error} Authentication required
-   * @throws {AddMember403Error} Not permitted - requires owner or billing manager role
+   * @throws {MembersAddMember400Error} Invalid request or member already exists.
+   * @throws {MembersAddMember401Error} Authentication required
+   * @throws {MembersAddMember403Error} Not permitted - requires owner or billing manager role
    * @throws {HTTPValidationError} Validation Error
    */
   return async (body: CustomerPortalMemberCreate): Promise<CustomerPortalMember> => {
@@ -130,9 +130,9 @@ export const addMemberMembers = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<CustomerPortalMember>(response, "json", {
-      400: AddMember400Error,
-      401: AddMember401Error,
-      403: AddMember403Error,
+      400: MembersAddMember400Error,
+      401: MembersAddMember401Error,
+      403: MembersAddMember403Error,
       422: HTTPValidationError,
     });
   };
@@ -152,10 +152,10 @@ export const removeMemberMembers = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {RemoveMember400Error} Cannot remove the only owner.
-   * @throws {RemoveMember401Error} Authentication required
-   * @throws {RemoveMember403Error} Not permitted - requires owner or billing manager role
-   * @throws {RemoveMember404Error} Member not found.
+   * @throws {MembersRemoveMember400Error} Cannot remove the only owner.
+   * @throws {MembersRemoveMember401Error} Authentication required
+   * @throws {MembersRemoveMember403Error} Not permitted - requires owner or billing manager role
+   * @throws {MembersRemoveMember404Error} Member not found.
    * @throws {HTTPValidationError} Validation Error
    */
   return async (id: string): Promise<void> => {
@@ -172,10 +172,10 @@ export const removeMemberMembers = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<void>(response, "none", {
-      400: RemoveMember400Error,
-      401: RemoveMember401Error,
-      403: RemoveMember403Error,
-      404: RemoveMember404Error,
+      400: MembersRemoveMember400Error,
+      401: MembersRemoveMember401Error,
+      403: MembersRemoveMember403Error,
+      404: MembersRemoveMember404Error,
       422: HTTPValidationError,
     });
   };
@@ -196,10 +196,10 @@ export const updateMemberMembers = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {UpdateMember400Error} Invalid role change.
-   * @throws {UpdateMember401Error} Authentication required
-   * @throws {UpdateMember403Error} Not permitted - requires owner or billing manager role
-   * @throws {UpdateMember404Error} Member not found.
+   * @throws {MembersUpdateMember400Error} Invalid role change.
+   * @throws {MembersUpdateMember401Error} Authentication required
+   * @throws {MembersUpdateMember403Error} Not permitted - requires owner or billing manager role
+   * @throws {MembersUpdateMember404Error} Member not found.
    * @throws {HTTPValidationError} Validation Error
    */
   return async (id: string, body: CustomerPortalMemberUpdate): Promise<CustomerPortalMember> => {
@@ -216,10 +216,10 @@ export const updateMemberMembers = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<CustomerPortalMember>(response, "json", {
-      400: UpdateMember400Error,
-      401: UpdateMember401Error,
-      403: UpdateMember403Error,
-      404: UpdateMember404Error,
+      400: MembersUpdateMember400Error,
+      401: MembersUpdateMember401Error,
+      403: MembersUpdateMember403Error,
+      404: MembersUpdateMember404Error,
       422: HTTPValidationError,
     });
   };

--- a/sdk/typescript/src/2026-04/services/customer_portal/seats.ts
+++ b/sdk/typescript/src/2026-04/services/customer_portal/seats.ts
@@ -8,22 +8,22 @@ import type {
 } from "../../models";
 
 import {
-  AssignSeat400Error,
-  AssignSeat401Error,
-  AssignSeat403Error,
-  AssignSeat404Error,
   HTTPValidationError,
-  ListClaimedSubscriptions401Error,
-  ListSeats401Error,
-  ListSeats403Error,
-  ListSeats404Error,
-  ResendInvitation400Error,
-  ResendInvitation401Error,
-  ResendInvitation403Error,
-  ResendInvitation404Error,
-  RevokeSeat401Error,
-  RevokeSeat403Error,
-  RevokeSeat404Error,
+  SeatsAssignSeat400Error,
+  SeatsAssignSeat401Error,
+  SeatsAssignSeat403Error,
+  SeatsAssignSeat404Error,
+  SeatsListClaimedSubscriptions401Error,
+  SeatsListSeats401Error,
+  SeatsListSeats403Error,
+  SeatsListSeats404Error,
+  SeatsResendInvitation400Error,
+  SeatsResendInvitation401Error,
+  SeatsResendInvitation403Error,
+  SeatsResendInvitation404Error,
+  SeatsRevokeSeat401Error,
+  SeatsRevokeSeat403Error,
+  SeatsRevokeSeat404Error,
 } from "../../errors";
 
 export const listSeatsSeats = (client: ClientBase) => {
@@ -35,9 +35,9 @@ export const listSeatsSeats = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {ListSeats401Error} Authentication required
-   * @throws {ListSeats403Error} Not permitted or seat-based pricing not enabled
-   * @throws {ListSeats404Error} Subscription or order not found
+   * @throws {SeatsListSeats401Error} Authentication required
+   * @throws {SeatsListSeats403Error} Not permitted or seat-based pricing not enabled
+   * @throws {SeatsListSeats404Error} Subscription or order not found
    * @throws {HTTPValidationError} Validation Error
    */
   return async (query?: {
@@ -58,9 +58,9 @@ export const listSeatsSeats = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<SeatsList>(response, "json", {
-      401: ListSeats401Error,
-      403: ListSeats403Error,
-      404: ListSeats404Error,
+      401: SeatsListSeats401Error,
+      403: SeatsListSeats403Error,
+      404: SeatsListSeats404Error,
       422: HTTPValidationError,
     });
   };
@@ -73,10 +73,10 @@ export const assignSeatSeats = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {AssignSeat400Error} No available seats or customer already has a seat
-   * @throws {AssignSeat401Error} Authentication required
-   * @throws {AssignSeat403Error} Not permitted or seat-based pricing not enabled
-   * @throws {AssignSeat404Error} Subscription, order, or customer not found
+   * @throws {SeatsAssignSeat400Error} No available seats or customer already has a seat
+   * @throws {SeatsAssignSeat401Error} Authentication required
+   * @throws {SeatsAssignSeat403Error} Not permitted or seat-based pricing not enabled
+   * @throws {SeatsAssignSeat404Error} Subscription, order, or customer not found
    * @throws {HTTPValidationError} Validation Error
    */
   return async (body: CustomerSeatAssign): Promise<CustomerSeat> => {
@@ -91,10 +91,10 @@ export const assignSeatSeats = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<CustomerSeat>(response, "json", {
-      400: AssignSeat400Error,
-      401: AssignSeat401Error,
-      403: AssignSeat403Error,
-      404: AssignSeat404Error,
+      400: SeatsAssignSeat400Error,
+      401: SeatsAssignSeat401Error,
+      403: SeatsAssignSeat403Error,
+      404: SeatsAssignSeat404Error,
       422: HTTPValidationError,
     });
   };
@@ -107,9 +107,9 @@ export const revokeSeatSeats = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {RevokeSeat401Error} Authentication required
-   * @throws {RevokeSeat403Error} Not permitted or seat-based pricing not enabled
-   * @throws {RevokeSeat404Error} Seat not found
+   * @throws {SeatsRevokeSeat401Error} Authentication required
+   * @throws {SeatsRevokeSeat403Error} Not permitted or seat-based pricing not enabled
+   * @throws {SeatsRevokeSeat404Error} Seat not found
    * @throws {HTTPValidationError} Validation Error
    */
   return async (seat_id: string): Promise<CustomerSeat> => {
@@ -126,9 +126,9 @@ export const revokeSeatSeats = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<CustomerSeat>(response, "json", {
-      401: RevokeSeat401Error,
-      403: RevokeSeat403Error,
-      404: RevokeSeat404Error,
+      401: SeatsRevokeSeat401Error,
+      403: SeatsRevokeSeat403Error,
+      404: SeatsRevokeSeat404Error,
       422: HTTPValidationError,
     });
   };
@@ -141,10 +141,10 @@ export const resendInvitationSeats = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {ResendInvitation400Error} Seat is not pending or already claimed
-   * @throws {ResendInvitation401Error} Authentication required
-   * @throws {ResendInvitation403Error} Not permitted or seat-based pricing not enabled
-   * @throws {ResendInvitation404Error} Seat not found
+   * @throws {SeatsResendInvitation400Error} Seat is not pending or already claimed
+   * @throws {SeatsResendInvitation401Error} Authentication required
+   * @throws {SeatsResendInvitation403Error} Not permitted or seat-based pricing not enabled
+   * @throws {SeatsResendInvitation404Error} Seat not found
    * @throws {HTTPValidationError} Validation Error
    */
   return async (seat_id: string): Promise<CustomerSeat> => {
@@ -161,10 +161,10 @@ export const resendInvitationSeats = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<CustomerSeat>(response, "json", {
-      400: ResendInvitation400Error,
-      401: ResendInvitation401Error,
-      403: ResendInvitation403Error,
-      404: ResendInvitation404Error,
+      400: SeatsResendInvitation400Error,
+      401: SeatsResendInvitation401Error,
+      403: SeatsResendInvitation403Error,
+      404: SeatsResendInvitation404Error,
       422: HTTPValidationError,
     });
   };
@@ -180,7 +180,7 @@ export const listClaimedSubscriptionsSeats = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {ListClaimedSubscriptions401Error} Authentication required
+   * @throws {SeatsListClaimedSubscriptions401Error} Authentication required
    * @throws {HTTPValidationError} Validation Error
    */
   return async (query?: {
@@ -201,7 +201,7 @@ export const listClaimedSubscriptionsSeats = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<ListResourceCustomerSubscription>(response, "json", {
-      401: ListClaimedSubscriptions401Error,
+      401: SeatsListClaimedSubscriptions401Error,
       422: HTTPValidationError,
     });
   };
@@ -216,7 +216,7 @@ export const listClaimedSubscriptionsSeats = (client: ClientBase) => {
  * @throws {PolarNetworkError} When a network error occurs
  * @throws {PolarRateLimitError} When the rate limit is exceeded
  * @throws {PolarServerError} When the server returns a 5xx error
- * @throws {ListClaimedSubscriptions401Error} Authentication required
+ * @throws {SeatsListClaimedSubscriptions401Error} Authentication required
  * @throws {HTTPValidationError} Validation Error
  */
 export const iterListClaimedSubscriptionsSeats = (client: ClientBase) => {

--- a/sdk/typescript/src/2026-04/services/customer_portal/seats.ts
+++ b/sdk/typescript/src/2026-04/services/customer_portal/seats.ts
@@ -8,22 +8,22 @@ import type {
 } from "../../models";
 
 import {
+  CustomerPortalSeatsAssignSeat400Error,
+  CustomerPortalSeatsAssignSeat401Error,
+  CustomerPortalSeatsAssignSeat403Error,
+  CustomerPortalSeatsAssignSeat404Error,
+  CustomerPortalSeatsListClaimedSubscriptions401Error,
+  CustomerPortalSeatsListSeats401Error,
+  CustomerPortalSeatsListSeats403Error,
+  CustomerPortalSeatsListSeats404Error,
+  CustomerPortalSeatsResendInvitation400Error,
+  CustomerPortalSeatsResendInvitation401Error,
+  CustomerPortalSeatsResendInvitation403Error,
+  CustomerPortalSeatsResendInvitation404Error,
+  CustomerPortalSeatsRevokeSeat401Error,
+  CustomerPortalSeatsRevokeSeat403Error,
+  CustomerPortalSeatsRevokeSeat404Error,
   HTTPValidationError,
-  SeatsAssignSeat400Error,
-  SeatsAssignSeat401Error,
-  SeatsAssignSeat403Error,
-  SeatsAssignSeat404Error,
-  SeatsListClaimedSubscriptions401Error,
-  SeatsListSeats401Error,
-  SeatsListSeats403Error,
-  SeatsListSeats404Error,
-  SeatsResendInvitation400Error,
-  SeatsResendInvitation401Error,
-  SeatsResendInvitation403Error,
-  SeatsResendInvitation404Error,
-  SeatsRevokeSeat401Error,
-  SeatsRevokeSeat403Error,
-  SeatsRevokeSeat404Error,
 } from "../../errors";
 
 export const listSeatsSeats = (client: ClientBase) => {
@@ -35,9 +35,9 @@ export const listSeatsSeats = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {SeatsListSeats401Error} Authentication required
-   * @throws {SeatsListSeats403Error} Not permitted or seat-based pricing not enabled
-   * @throws {SeatsListSeats404Error} Subscription or order not found
+   * @throws {CustomerPortalSeatsListSeats401Error} Authentication required
+   * @throws {CustomerPortalSeatsListSeats403Error} Not permitted or seat-based pricing not enabled
+   * @throws {CustomerPortalSeatsListSeats404Error} Subscription or order not found
    * @throws {HTTPValidationError} Validation Error
    */
   return async (query?: {
@@ -58,9 +58,9 @@ export const listSeatsSeats = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<SeatsList>(response, "json", {
-      401: SeatsListSeats401Error,
-      403: SeatsListSeats403Error,
-      404: SeatsListSeats404Error,
+      401: CustomerPortalSeatsListSeats401Error,
+      403: CustomerPortalSeatsListSeats403Error,
+      404: CustomerPortalSeatsListSeats404Error,
       422: HTTPValidationError,
     });
   };
@@ -73,10 +73,10 @@ export const assignSeatSeats = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {SeatsAssignSeat400Error} No available seats or customer already has a seat
-   * @throws {SeatsAssignSeat401Error} Authentication required
-   * @throws {SeatsAssignSeat403Error} Not permitted or seat-based pricing not enabled
-   * @throws {SeatsAssignSeat404Error} Subscription, order, or customer not found
+   * @throws {CustomerPortalSeatsAssignSeat400Error} No available seats or customer already has a seat
+   * @throws {CustomerPortalSeatsAssignSeat401Error} Authentication required
+   * @throws {CustomerPortalSeatsAssignSeat403Error} Not permitted or seat-based pricing not enabled
+   * @throws {CustomerPortalSeatsAssignSeat404Error} Subscription, order, or customer not found
    * @throws {HTTPValidationError} Validation Error
    */
   return async (body: CustomerSeatAssign): Promise<CustomerSeat> => {
@@ -91,10 +91,10 @@ export const assignSeatSeats = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<CustomerSeat>(response, "json", {
-      400: SeatsAssignSeat400Error,
-      401: SeatsAssignSeat401Error,
-      403: SeatsAssignSeat403Error,
-      404: SeatsAssignSeat404Error,
+      400: CustomerPortalSeatsAssignSeat400Error,
+      401: CustomerPortalSeatsAssignSeat401Error,
+      403: CustomerPortalSeatsAssignSeat403Error,
+      404: CustomerPortalSeatsAssignSeat404Error,
       422: HTTPValidationError,
     });
   };
@@ -107,9 +107,9 @@ export const revokeSeatSeats = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {SeatsRevokeSeat401Error} Authentication required
-   * @throws {SeatsRevokeSeat403Error} Not permitted or seat-based pricing not enabled
-   * @throws {SeatsRevokeSeat404Error} Seat not found
+   * @throws {CustomerPortalSeatsRevokeSeat401Error} Authentication required
+   * @throws {CustomerPortalSeatsRevokeSeat403Error} Not permitted or seat-based pricing not enabled
+   * @throws {CustomerPortalSeatsRevokeSeat404Error} Seat not found
    * @throws {HTTPValidationError} Validation Error
    */
   return async (seat_id: string): Promise<CustomerSeat> => {
@@ -126,9 +126,9 @@ export const revokeSeatSeats = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<CustomerSeat>(response, "json", {
-      401: SeatsRevokeSeat401Error,
-      403: SeatsRevokeSeat403Error,
-      404: SeatsRevokeSeat404Error,
+      401: CustomerPortalSeatsRevokeSeat401Error,
+      403: CustomerPortalSeatsRevokeSeat403Error,
+      404: CustomerPortalSeatsRevokeSeat404Error,
       422: HTTPValidationError,
     });
   };
@@ -141,10 +141,10 @@ export const resendInvitationSeats = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {SeatsResendInvitation400Error} Seat is not pending or already claimed
-   * @throws {SeatsResendInvitation401Error} Authentication required
-   * @throws {SeatsResendInvitation403Error} Not permitted or seat-based pricing not enabled
-   * @throws {SeatsResendInvitation404Error} Seat not found
+   * @throws {CustomerPortalSeatsResendInvitation400Error} Seat is not pending or already claimed
+   * @throws {CustomerPortalSeatsResendInvitation401Error} Authentication required
+   * @throws {CustomerPortalSeatsResendInvitation403Error} Not permitted or seat-based pricing not enabled
+   * @throws {CustomerPortalSeatsResendInvitation404Error} Seat not found
    * @throws {HTTPValidationError} Validation Error
    */
   return async (seat_id: string): Promise<CustomerSeat> => {
@@ -161,10 +161,10 @@ export const resendInvitationSeats = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<CustomerSeat>(response, "json", {
-      400: SeatsResendInvitation400Error,
-      401: SeatsResendInvitation401Error,
-      403: SeatsResendInvitation403Error,
-      404: SeatsResendInvitation404Error,
+      400: CustomerPortalSeatsResendInvitation400Error,
+      401: CustomerPortalSeatsResendInvitation401Error,
+      403: CustomerPortalSeatsResendInvitation403Error,
+      404: CustomerPortalSeatsResendInvitation404Error,
       422: HTTPValidationError,
     });
   };
@@ -180,7 +180,7 @@ export const listClaimedSubscriptionsSeats = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {SeatsListClaimedSubscriptions401Error} Authentication required
+   * @throws {CustomerPortalSeatsListClaimedSubscriptions401Error} Authentication required
    * @throws {HTTPValidationError} Validation Error
    */
   return async (query?: {
@@ -201,7 +201,7 @@ export const listClaimedSubscriptionsSeats = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<ListResourceCustomerSubscription>(response, "json", {
-      401: SeatsListClaimedSubscriptions401Error,
+      401: CustomerPortalSeatsListClaimedSubscriptions401Error,
       422: HTTPValidationError,
     });
   };
@@ -216,7 +216,7 @@ export const listClaimedSubscriptionsSeats = (client: ClientBase) => {
  * @throws {PolarNetworkError} When a network error occurs
  * @throws {PolarRateLimitError} When the rate limit is exceeded
  * @throws {PolarServerError} When the server returns a 5xx error
- * @throws {SeatsListClaimedSubscriptions401Error} Authentication required
+ * @throws {CustomerPortalSeatsListClaimedSubscriptions401Error} Authentication required
  * @throws {HTTPValidationError} Validation Error
  */
 export const iterListClaimedSubscriptionsSeats = (client: ClientBase) => {

--- a/sdk/typescript/src/2026-04/services/customer_portal/subscriptions.ts
+++ b/sdk/typescript/src/2026-04/services/customer_portal/subscriptions.ts
@@ -8,10 +8,10 @@ import type {
 
 import {
   AlreadyCanceledSubscription,
+  CustomerPortalSubscriptionsUpdate403Error,
   HTTPValidationError,
   PaymentFailed,
   ResourceNotFound,
-  SubscriptionsUpdate403Error,
 } from "../../errors";
 
 export const listSubscriptions = (client: ClientBase) => {
@@ -172,7 +172,7 @@ export const updateSubscriptions = (client: ClientBase) => {
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
    * @throws {PaymentFailed} Payment required to apply the subscription update.
-   * @throws {SubscriptionsUpdate403Error} Customer subscription is already canceled or will be at the end of the period, the user lacks billing permissions, or pausing/resuming is not enabled for the organization.
+   * @throws {CustomerPortalSubscriptionsUpdate403Error} Customer subscription is already canceled or will be at the end of the period, the user lacks billing permissions, or pausing/resuming is not enabled for the organization.
    * @throws {ResourceNotFound} Customer subscription was not found.
    * @throws {HTTPValidationError} Validation Error
    */
@@ -191,7 +191,7 @@ export const updateSubscriptions = (client: ClientBase) => {
     const response = await client.sendRequest(request);
     return client.parseResponse<CustomerSubscription>(response, "json", {
       402: PaymentFailed,
-      403: SubscriptionsUpdate403Error,
+      403: CustomerPortalSubscriptionsUpdate403Error,
       404: ResourceNotFound,
       422: HTTPValidationError,
     });

--- a/sdk/typescript/src/2026-04/services/customer_portal/subscriptions.ts
+++ b/sdk/typescript/src/2026-04/services/customer_portal/subscriptions.ts
@@ -11,7 +11,7 @@ import {
   HTTPValidationError,
   PaymentFailed,
   ResourceNotFound,
-  Update403Error,
+  SubscriptionsUpdate403Error,
 } from "../../errors";
 
 export const listSubscriptions = (client: ClientBase) => {
@@ -172,7 +172,7 @@ export const updateSubscriptions = (client: ClientBase) => {
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
    * @throws {PaymentFailed} Payment required to apply the subscription update.
-   * @throws {Update403Error} Customer subscription is already canceled or will be at the end of the period, the user lacks billing permissions, or pausing/resuming is not enabled for the organization.
+   * @throws {SubscriptionsUpdate403Error} Customer subscription is already canceled or will be at the end of the period, the user lacks billing permissions, or pausing/resuming is not enabled for the organization.
    * @throws {ResourceNotFound} Customer subscription was not found.
    * @throws {HTTPValidationError} Validation Error
    */
@@ -191,7 +191,7 @@ export const updateSubscriptions = (client: ClientBase) => {
     const response = await client.sendRequest(request);
     return client.parseResponse<CustomerSubscription>(response, "json", {
       402: PaymentFailed,
-      403: Update403Error,
+      403: SubscriptionsUpdate403Error,
       404: ResourceNotFound,
       422: HTTPValidationError,
     });

--- a/sdk/typescript/src/2026-04/services/customer_seats.ts
+++ b/sdk/typescript/src/2026-04/services/customer_seats.ts
@@ -9,26 +9,26 @@ import type {
 } from "../models";
 
 import {
-  AssignSeat400Error,
-  AssignSeat401Error,
-  AssignSeat403Error,
-  AssignSeat404Error,
-  ClaimSeat400Error,
-  ClaimSeat403Error,
-  GetClaimInfo400Error,
-  GetClaimInfo403Error,
-  GetClaimInfo404Error,
+  CustomerSeatsAssignSeat400Error,
+  CustomerSeatsAssignSeat401Error,
+  CustomerSeatsAssignSeat403Error,
+  CustomerSeatsAssignSeat404Error,
+  CustomerSeatsClaimSeat400Error,
+  CustomerSeatsClaimSeat403Error,
+  CustomerSeatsGetClaimInfo400Error,
+  CustomerSeatsGetClaimInfo403Error,
+  CustomerSeatsGetClaimInfo404Error,
+  CustomerSeatsListSeats401Error,
+  CustomerSeatsListSeats403Error,
+  CustomerSeatsListSeats404Error,
+  CustomerSeatsResendInvitation400Error,
+  CustomerSeatsResendInvitation401Error,
+  CustomerSeatsResendInvitation403Error,
+  CustomerSeatsResendInvitation404Error,
+  CustomerSeatsRevokeSeat401Error,
+  CustomerSeatsRevokeSeat403Error,
+  CustomerSeatsRevokeSeat404Error,
   HTTPValidationError,
-  ListSeats401Error,
-  ListSeats403Error,
-  ListSeats404Error,
-  ResendInvitation400Error,
-  ResendInvitation401Error,
-  ResendInvitation403Error,
-  ResendInvitation404Error,
-  RevokeSeat401Error,
-  RevokeSeat403Error,
-  RevokeSeat404Error,
 } from "../errors";
 
 export const listSeatsCustomerSeats = (client: ClientBase) => {
@@ -40,9 +40,9 @@ export const listSeatsCustomerSeats = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {ListSeats401Error} Authentication required
-   * @throws {ListSeats403Error} Not permitted or seat-based pricing not enabled
-   * @throws {ListSeats404Error} Subscription or order not found
+   * @throws {CustomerSeatsListSeats401Error} Authentication required
+   * @throws {CustomerSeatsListSeats403Error} Not permitted or seat-based pricing not enabled
+   * @throws {CustomerSeatsListSeats404Error} Subscription or order not found
    * @throws {HTTPValidationError} Validation Error
    */
   return async (query?: {
@@ -63,9 +63,9 @@ export const listSeatsCustomerSeats = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<SeatsList>(response, "json", {
-      401: ListSeats401Error,
-      403: ListSeats403Error,
-      404: ListSeats404Error,
+      401: CustomerSeatsListSeats401Error,
+      403: CustomerSeatsListSeats403Error,
+      404: CustomerSeatsListSeats404Error,
       422: HTTPValidationError,
     });
   };
@@ -79,10 +79,10 @@ export const assignSeatCustomerSeats = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {AssignSeat400Error} No available seats or customer already has a seat
-   * @throws {AssignSeat401Error} Authentication required
-   * @throws {AssignSeat403Error} Not permitted or seat-based pricing not enabled
-   * @throws {AssignSeat404Error} Subscription, order, or customer not found
+   * @throws {CustomerSeatsAssignSeat400Error} No available seats or customer already has a seat
+   * @throws {CustomerSeatsAssignSeat401Error} Authentication required
+   * @throws {CustomerSeatsAssignSeat403Error} Not permitted or seat-based pricing not enabled
+   * @throws {CustomerSeatsAssignSeat404Error} Subscription, order, or customer not found
    * @throws {HTTPValidationError} Validation Error
    */
   return async (body: SeatAssign): Promise<CustomerSeat> => {
@@ -97,10 +97,10 @@ export const assignSeatCustomerSeats = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<CustomerSeat>(response, "json", {
-      400: AssignSeat400Error,
-      401: AssignSeat401Error,
-      403: AssignSeat403Error,
-      404: AssignSeat404Error,
+      400: CustomerSeatsAssignSeat400Error,
+      401: CustomerSeatsAssignSeat401Error,
+      403: CustomerSeatsAssignSeat403Error,
+      404: CustomerSeatsAssignSeat404Error,
       422: HTTPValidationError,
     });
   };
@@ -114,9 +114,9 @@ export const revokeSeatCustomerSeats = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {RevokeSeat401Error} Authentication required
-   * @throws {RevokeSeat403Error} Not permitted or seat-based pricing not enabled
-   * @throws {RevokeSeat404Error} Seat not found
+   * @throws {CustomerSeatsRevokeSeat401Error} Authentication required
+   * @throws {CustomerSeatsRevokeSeat403Error} Not permitted or seat-based pricing not enabled
+   * @throws {CustomerSeatsRevokeSeat404Error} Seat not found
    * @throws {HTTPValidationError} Validation Error
    */
   return async (seat_id: string): Promise<CustomerSeat> => {
@@ -133,9 +133,9 @@ export const revokeSeatCustomerSeats = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<CustomerSeat>(response, "json", {
-      401: RevokeSeat401Error,
-      403: RevokeSeat403Error,
-      404: RevokeSeat404Error,
+      401: CustomerSeatsRevokeSeat401Error,
+      403: CustomerSeatsRevokeSeat403Error,
+      404: CustomerSeatsRevokeSeat404Error,
       422: HTTPValidationError,
     });
   };
@@ -149,10 +149,10 @@ export const resendInvitationCustomerSeats = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {ResendInvitation400Error} Seat is not pending or already claimed
-   * @throws {ResendInvitation401Error} Authentication required
-   * @throws {ResendInvitation403Error} Not permitted or seat-based pricing not enabled
-   * @throws {ResendInvitation404Error} Seat not found
+   * @throws {CustomerSeatsResendInvitation400Error} Seat is not pending or already claimed
+   * @throws {CustomerSeatsResendInvitation401Error} Authentication required
+   * @throws {CustomerSeatsResendInvitation403Error} Not permitted or seat-based pricing not enabled
+   * @throws {CustomerSeatsResendInvitation404Error} Seat not found
    * @throws {HTTPValidationError} Validation Error
    */
   return async (seat_id: string): Promise<CustomerSeat> => {
@@ -169,10 +169,10 @@ export const resendInvitationCustomerSeats = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<CustomerSeat>(response, "json", {
-      400: ResendInvitation400Error,
-      401: ResendInvitation401Error,
-      403: ResendInvitation403Error,
-      404: ResendInvitation404Error,
+      400: CustomerSeatsResendInvitation400Error,
+      401: CustomerSeatsResendInvitation401Error,
+      403: CustomerSeatsResendInvitation403Error,
+      404: CustomerSeatsResendInvitation404Error,
       422: HTTPValidationError,
     });
   };
@@ -185,9 +185,9 @@ export const getClaimInfoCustomerSeats = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {GetClaimInfo400Error} Invalid or expired invitation token
-   * @throws {GetClaimInfo403Error} Seat-based pricing not enabled for organization
-   * @throws {GetClaimInfo404Error} Seat not found
+   * @throws {CustomerSeatsGetClaimInfo400Error} Invalid or expired invitation token
+   * @throws {CustomerSeatsGetClaimInfo403Error} Seat-based pricing not enabled for organization
+   * @throws {CustomerSeatsGetClaimInfo404Error} Seat not found
    * @throws {HTTPValidationError} Validation Error
    */
   return async (invitation_token: string): Promise<SeatClaimInfo> => {
@@ -204,9 +204,9 @@ export const getClaimInfoCustomerSeats = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<SeatClaimInfo>(response, "json", {
-      400: GetClaimInfo400Error,
-      403: GetClaimInfo403Error,
-      404: GetClaimInfo404Error,
+      400: CustomerSeatsGetClaimInfo400Error,
+      403: CustomerSeatsGetClaimInfo403Error,
+      404: CustomerSeatsGetClaimInfo404Error,
       422: HTTPValidationError,
     });
   };
@@ -219,8 +219,8 @@ export const claimSeatCustomerSeats = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {ClaimSeat400Error} Invalid, expired, or already claimed token
-   * @throws {ClaimSeat403Error} Seat-based pricing not enabled for organization
+   * @throws {CustomerSeatsClaimSeat400Error} Invalid, expired, or already claimed token
+   * @throws {CustomerSeatsClaimSeat403Error} Seat-based pricing not enabled for organization
    * @throws {HTTPValidationError} Validation Error
    */
   return async (body: SeatClaim): Promise<CustomerSeatClaimResponse> => {
@@ -235,8 +235,8 @@ export const claimSeatCustomerSeats = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<CustomerSeatClaimResponse>(response, "json", {
-      400: ClaimSeat400Error,
-      403: ClaimSeat403Error,
+      400: CustomerSeatsClaimSeat400Error,
+      403: CustomerSeatsClaimSeat403Error,
       422: HTTPValidationError,
     });
   };

--- a/sdk/typescript/src/2026-04/services/event_types.ts
+++ b/sdk/typescript/src/2026-04/services/event_types.ts
@@ -8,7 +8,7 @@ import type {
   ListResourceEventTypeWithStats,
 } from "../models";
 
-import { HTTPValidationError, Update404Error } from "../errors";
+import { EventTypesUpdate404Error, HTTPValidationError } from "../errors";
 
 export const listEventTypes = (client: ClientBase) => {
   /**
@@ -115,7 +115,7 @@ export const updateEventTypes = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {Update404Error} Not Found
+   * @throws {EventTypesUpdate404Error} Not Found
    * @throws {HTTPValidationError} Validation Error
    */
   return async (id: string, body: EventTypeUpdate): Promise<EventType> => {
@@ -132,7 +132,7 @@ export const updateEventTypes = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<EventType>(response, "json", {
-      404: Update404Error,
+      404: EventTypesUpdate404Error,
       422: HTTPValidationError,
     });
   };

--- a/sdk/typescript/src/2026-04/services/orders.ts
+++ b/sdk/typescript/src/2026-04/services/orders.ts
@@ -13,12 +13,12 @@ import type {
 } from "../models";
 
 import {
-  Finalize402Error,
-  Finalize403Error,
   HTTPValidationError,
   MissingInvoiceBillingDetails,
   OrderNotDraft,
   OrderNotEligibleForInvoice,
+  OrdersFinalize402Error,
+  OrdersFinalize403Error,
   ResourceNotFound,
 } from "../errors";
 
@@ -256,8 +256,8 @@ export const finalizeOrders = (client: ClientBase) => {
    * @throws {PolarNetworkError} When a network error occurs
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
-   * @throws {Finalize402Error} The charge failed, or requires customer authentication (e.g. a 3DS challenge) that can't be completed off-session.
-   * @throws {Finalize403Error} Off-session charges are not enabled for this organization, or its account can't currently accept payments.
+   * @throws {OrdersFinalize402Error} The charge failed, or requires customer authentication (e.g. a 3DS challenge) that can't be completed off-session.
+   * @throws {OrdersFinalize403Error} Off-session charges are not enabled for this organization, or its account can't currently accept payments.
    * @throws {ResourceNotFound} Order not found.
    * @throws {OrderNotDraft} The order is not in `draft` status.
    * @throws {HTTPValidationError} Validation Error
@@ -276,8 +276,8 @@ export const finalizeOrders = (client: ClientBase) => {
     );
     const response = await client.sendRequest(request);
     return client.parseResponse<Order>(response, "json", {
-      402: Finalize402Error,
-      403: Finalize403Error,
+      402: OrdersFinalize402Error,
+      403: OrdersFinalize403Error,
       404: ResourceNotFound,
       412: OrderNotDraft,
       422: HTTPValidationError,

--- a/sdk/typescript/src/2026-04/services/subscriptions.ts
+++ b/sdk/typescript/src/2026-04/services/subscriptions.ts
@@ -17,7 +17,6 @@ import {
   PaymentFailed,
   ResourceNotFound,
   SubscriptionLocked,
-  SubscriptionsUpdate403Error,
 } from "../errors";
 
 export const listSubscriptions = (client: ClientBase) => {
@@ -278,7 +277,7 @@ export const updateSubscriptions = (client: ClientBase) => {
    * @throws {PolarRateLimitError} When the rate limit is exceeded
    * @throws {PolarServerError} When the server returns a 5xx error
    * @throws {PaymentFailed} Payment required to apply the subscription update.
-   * @throws {SubscriptionsUpdate403Error} Subscription is already canceled or will be at the end of the period, or is not active.
+   * @throws {AlreadyCanceledSubscription} Subscription is already canceled or will be at the end of the period.
    * @throws {ResourceNotFound} Subscription not found.
    * @throws {SubscriptionLocked} Subscription is pending an update.
    * @throws {HTTPValidationError} Validation Error
@@ -298,7 +297,7 @@ export const updateSubscriptions = (client: ClientBase) => {
     const response = await client.sendRequest(request);
     return client.parseResponse<Subscription>(response, "json", {
       402: PaymentFailed,
-      403: SubscriptionsUpdate403Error,
+      403: AlreadyCanceledSubscription,
       404: ResourceNotFound,
       409: SubscriptionLocked,
       422: HTTPValidationError,


### PR DESCRIPTION

Fix for https://github.com/polarsource/feedback/issues/309

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Namespace SDK error classes by service and sub-service to prevent name collisions across endpoints in Python and TypeScript. Also fixes webhook exports and improves casing to handle dash-separated names.

- **Bug Fixes**
  - Prefix error classes with service scope (e.g., `OrdersFinalize402Error`, `EventTypesUpdate404Error`, `CustomerPortalCustomersVerifyEmailUpdate401Error`, `CustomerPortalSeatsAssignSeat404Error`, `CustomerSeatsGetClaimInfo404Error`, `CheckoutsUpdate403Error`).
  - Update generator IR to include service in error names; fix `to_pascal_case` to support dashes; adjust tests.
  - Add missing `PauseResumeNotAllowed` to subscription update errors; remove `InactiveSubscription`; map top-level `subscriptions.update` 403 to `AlreadyCanceledSubscription`.
  - Webhooks: export errors and payload models via `__all__`; remove redundant import aliases; simplify `http_code_class` literal.

- **Migration**
  - Rename error classes in imports, catches, and typings to the new namespaced forms. Examples: `Finalize402Error` -> `OrdersFinalize402Error`, `Update403Error` -> `CheckoutsUpdate403Error` or `CustomerPortalSubscriptionsUpdate403Error` (endpoint-specific), top-level `subscriptions.update` now throws `AlreadyCanceledSubscription` on 403, `AddMember401Error` -> `CustomerPortalMembersAddMember401Error`, `AssignSeat404Error` -> `CustomerPortalSeatsAssignSeat404Error` or `CustomerSeatsAssignSeat404Error`, `VerifyEmailUpdate401Error` -> `CustomerPortalCustomersVerifyEmailUpdate401Error`. No runtime behavior changes.

<sup>Written for commit c219b0ded178fe060f4a10b425f3735531871271. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

