### PR TITLE
Add a permission-aware Finance organization role

### DIFF
--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/[customerId]/CustomersPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/customers/[customerId]/CustomersPage.tsx
@@ -12,6 +12,7 @@ import { InlineModal } from '@polar-sh/orbit'
 import { useModal } from '@/components/Modal/useModal'
 import { toast } from '@/components/Toast/use-toast'
 import { useSafeCopy } from '@/hooks/clipboard'
+import { useHasPermission } from '@/hooks/permissions'
 import { useDeleteCustomer } from '@/hooks/queries'
 import { extractApiErrorMessage } from '@/utils/api/errors'
 import { api } from '@/utils/client'
@@ -52,6 +53,10 @@ const CustomerHeader = ({
   }
 }) => {
   const pushRouteWithoutCache = usePushRouteWithoutCache()
+  const canManageCustomers = useHasPermission(
+    organization.id,
+    'customers:manage',
+  )
 
   const {
     show: showEditCustomerModal,
@@ -188,19 +193,25 @@ const CustomerHeader = ({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem onClick={createCustomerSession}>
-            Copy Customer Portal
-          </DropdownMenuItem>
+          {canManageCustomers ? (
+            <DropdownMenuItem onClick={createCustomerSession}>
+              Copy Customer Portal
+            </DropdownMenuItem>
+          ) : null}
           <DropdownMenuItem>
             <a href={`mailto:${customer.email ?? ''}`}>Contact Customer</a>
           </DropdownMenuItem>
-          <DropdownMenuItem onClick={showEditCustomerModal}>
-            Edit Customer
-          </DropdownMenuItem>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem destructive onClick={showDeleteCustomerModal}>
-            Delete Customer
-          </DropdownMenuItem>
+          {canManageCustomers ? (
+            <>
+              <DropdownMenuItem onClick={showEditCustomerModal}>
+                Edit Customer
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem destructive onClick={showDeleteCustomerModal}>
+                Delete Customer
+              </DropdownMenuItem>
+            </>
+          ) : null}
         </DropdownMenuContent>
       </DropdownMenu>
       <InlineModal

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/ProductsPage.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/ProductsPage.tsx
@@ -4,6 +4,7 @@ import { DashboardBody } from '@/components/Layout/DashboardLayout'
 import Pagination from '@/components/Pagination/Pagination'
 import { ProductListItem } from '@/components/Products/ProductListItem'
 import { useProducts } from '@/hooks/queries/products'
+import { useHasPermission } from '@/hooks/permissions'
 import { useDebouncedCallback } from '@/hooks/utils'
 import {
   DataTablePaginationState,
@@ -50,6 +51,7 @@ export default function ClientPage({
 
   const router = useRouter()
   const pathname = usePathname()
+  const canManageProducts = useHasPermission(org.id, 'products:manage')
 
   const onPageChange = useCallback(
     (page: number) => {
@@ -184,19 +186,21 @@ export default function ClientPage({
               </Select>
             )}
           </div>
-          <Link
-            href={`/dashboard/${org.slug}/products/new`}
-            className="w-full md:w-fit"
-          >
-            <Button
-              role="link"
-              wrapperClassNames="gap-x-2 md:w-fit"
-              className="w-full"
+          {canManageProducts ? (
+            <Link
+              href={`/dashboard/${org.slug}/products/new`}
+              className="w-full md:w-fit"
             >
-              <AddOutlined className="h-4 w-4" />
-              <span>New Product</span>
-            </Button>
-          </Link>
+              <Button
+                role="link"
+                wrapperClassNames="gap-x-2 md:w-fit"
+                className="w-full"
+              >
+                <AddOutlined className="h-4 w-4" />
+                <span>New Product</span>
+              </Button>
+            </Link>
+          ) : null}
         </div>
         {products.data && products.data.items.length > 0 ? (
           <Pagination
@@ -208,7 +212,7 @@ export default function ClientPage({
           >
             <List size="small">
               {products.data.items
-                .sort((a, b) => {
+                .toSorted((a, b) => {
                   if (a.is_archived === b.is_archived) return 0
                   return a.is_archived ? 1 : -1
                 })
@@ -235,11 +239,13 @@ export default function ClientPage({
                   Start selling digital products today
                 </p>
               </div>
-              <Link href={`/dashboard/${org.slug}/products/new`}>
-                <Button role="link" variant="secondary">
-                  <span>Create Product</span>
-                </Button>
-              </Link>
+              {canManageProducts ? (
+                <Link href={`/dashboard/${org.slug}/products/new`}>
+                  <Button role="link" variant="secondary">
+                    <span>Create Product</span>
+                  </Button>
+                </Link>
+              ) : null}
             </div>
           </ShadowBoxOnMd>
         )}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/[id]/edit/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/[id]/edit/layout.tsx
@@ -1,0 +1,21 @@
+import OrganizationPermissionGuard from '@/components/Auth/OrganizationPermissionGuard'
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ organization: string }>
+}) {
+  const { organization } = await params
+
+  return (
+    <OrganizationPermissionGuard
+      organizationSlug={organization}
+      permission="products:manage"
+      standalone
+    >
+      {children}
+    </OrganizationPermissionGuard>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/benefits/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/benefits/layout.tsx
@@ -1,3 +1,4 @@
+import OrganizationPermissionGuard from '@/components/Auth/OrganizationPermissionGuard'
 import { BenefitListSidebar } from '@/components/Benefit/BenefitListSidebar'
 import { MasterDetailLayout } from '@/components/Layout/MasterDetailLayout'
 import { getServerSideAPI } from '@/utils/client/serverside'
@@ -17,10 +18,16 @@ export default async function Layout(
   )
 
   return (
-    <MasterDetailLayout
-      listView={<BenefitListSidebar organization={organization} />}
+    <OrganizationPermissionGuard
+      organizationSlug={params.organization}
+      permission="products:manage"
+      standalone
     >
-      {props.children}
-    </MasterDetailLayout>
+      <MasterDetailLayout
+        listView={<BenefitListSidebar organization={organization} />}
+      >
+        {props.children}
+      </MasterDetailLayout>
+    </OrganizationPermissionGuard>
   )
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/checkout-links/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/checkout-links/layout.tsx
@@ -1,3 +1,4 @@
+import OrganizationPermissionGuard from '@/components/Auth/OrganizationPermissionGuard'
 import { CheckoutLinkListSidebar } from '@/components/CheckoutLinks/CheckoutLinkListSidebar'
 import { MasterDetailLayout } from '@/components/Layout/MasterDetailLayout'
 import { getServerSideAPI } from '@/utils/client/serverside'
@@ -17,11 +18,17 @@ export default async function Layout(
   )
 
   return (
-    <MasterDetailLayout
-      listView={<CheckoutLinkListSidebar organization={organization} />}
-      wrapperClassName="max-w-(--breakpoint-sm)!"
+    <OrganizationPermissionGuard
+      organizationSlug={params.organization}
+      permission="products:manage"
+      standalone
     >
-      {props.children}
-    </MasterDetailLayout>
+      <MasterDetailLayout
+        listView={<CheckoutLinkListSidebar organization={organization} />}
+        wrapperClassName="max-w-(--breakpoint-sm)!"
+      >
+        {props.children}
+      </MasterDetailLayout>
+    </OrganizationPermissionGuard>
   )
 }

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/discounts/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/discounts/layout.tsx
@@ -1,0 +1,21 @@
+import OrganizationPermissionGuard from '@/components/Auth/OrganizationPermissionGuard'
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ organization: string }>
+}) {
+  const { organization } = await params
+
+  return (
+    <OrganizationPermissionGuard
+      organizationSlug={organization}
+      permission="products:manage"
+      standalone
+    >
+      {children}
+    </OrganizationPermissionGuard>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/meters/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/meters/layout.tsx
@@ -1,0 +1,21 @@
+import OrganizationPermissionGuard from '@/components/Auth/OrganizationPermissionGuard'
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ organization: string }>
+}) {
+  const { organization } = await params
+
+  return (
+    <OrganizationPermissionGuard
+      organizationSlug={organization}
+      permission="products:manage"
+      standalone
+    >
+      {children}
+    </OrganizationPermissionGuard>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/new/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/products/new/layout.tsx
@@ -1,0 +1,21 @@
+import OrganizationPermissionGuard from '@/components/Auth/OrganizationPermissionGuard'
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ organization: string }>
+}) {
+  const { organization } = await params
+
+  return (
+    <OrganizationPermissionGuard
+      organizationSlug={organization}
+      permission="products:manage"
+      standalone
+    >
+      {children}
+    </OrganizationPermissionGuard>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/disputes/layout.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/sales/disputes/layout.tsx
@@ -1,0 +1,21 @@
+import OrganizationPermissionGuard from '@/components/Auth/OrganizationPermissionGuard'
+
+export default async function Layout({
+  children,
+  params,
+}: {
+  children: React.ReactNode
+  params: Promise<{ organization: string }>
+}) {
+  const { organization } = await params
+
+  return (
+    <OrganizationPermissionGuard
+      organizationSlug={organization}
+      permission="organization:manage"
+      standalone
+    >
+      {children}
+    </OrganizationPermissionGuard>
+  )
+}

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/members/ChangeRoleModal.tsx
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/members/ChangeRoleModal.tsx
@@ -18,7 +18,7 @@ import { useMemo, useState } from 'react'
 
 import { ROLE_LABELS, ROLE_ORDER } from './constants'
 
-type AssignableRole = 'admin' | 'member'
+type AssignableRole = schemas['OrganizationMemberRoleUpdate']['role']
 
 export function ChangeRoleModal({
   organizationId,
@@ -106,6 +106,7 @@ export function ChangeRoleModal({
         </SelectTrigger>
         <SelectContent>
           <SelectItem value="admin">Admin</SelectItem>
+          <SelectItem value="finance">Finance</SelectItem>
           <SelectItem value="member">Member</SelectItem>
         </SelectContent>
       </Select>

--- a/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/members/constants.ts
+++ b/clients/apps/web/src/app/(main)/dashboard/[organization]/(header)/settings/members/constants.ts
@@ -5,7 +5,13 @@ type OrganizationRole = schemas['OrganizationRole']
 export const ROLE_LABELS: Record<OrganizationRole, string> = {
   owner: 'Owner',
   admin: 'Admin',
+  finance: 'Finance',
   member: 'Member',
 }
 
-export const ROLE_ORDER: OrganizationRole[] = ['owner', 'admin', 'member']
+export const ROLE_ORDER: OrganizationRole[] = [
+  'owner',
+  'admin',
+  'finance',
+  'member',
+]

--- a/clients/apps/web/src/components/Customer/CustomerListSidebar.tsx
+++ b/clients/apps/web/src/components/Customer/CustomerListSidebar.tsx
@@ -5,6 +5,7 @@ import { InlineModal } from '@polar-sh/orbit'
 import { useModal } from '@/components/Modal/useModal'
 import { Spinner } from '@polar-sh/orbit'
 import { useCustomers } from '@/hooks/queries'
+import { useHasPermission } from '@/hooks/permissions'
 import { useInViewport } from '@/hooks/utils'
 import { getServerURL } from '@/utils/api'
 
@@ -40,6 +41,10 @@ export const CustomerListSidebar: React.FC<CustomerListSidebarProps> = ({
 }) => {
   const pathname = usePathname()
   const searchParams = useSearchParams()
+  const canManageCustomers = useHasPermission(
+    organization.id,
+    'customers:manage',
+  )
 
   const [sorting, setSorting] = useQueryState(
     'sorting',
@@ -201,13 +206,15 @@ export const CustomerListSidebar: React.FC<CustomerListSidebarProps> = ({
               </DropdownMenuContent>
             </DropdownMenu>
 
-            <Button
-              size="icon"
-              className="h-6 w-6"
-              onClick={showCreateCustomerModal}
-            >
-              <AddOutlined fontSize="small" />
-            </Button>
+            {canManageCustomers ? (
+              <Button
+                size="icon"
+                className="h-6 w-6"
+                onClick={showCreateCustomerModal}
+              >
+                <AddOutlined fontSize="small" />
+              </Button>
+            ) : null}
           </div>
         </div>
         <div className="flex flex-row items-center gap-3 px-4 py-2">

--- a/clients/apps/web/src/components/Customer/MembersSection.tsx
+++ b/clients/apps/web/src/components/Customer/MembersSection.tsx
@@ -2,6 +2,7 @@
 
 import { useModal } from '@/components/Modal/useModal'
 import { useCopyMemberLoginLink } from '@/hooks/useCopyMemberLoginLink'
+import { useHasPermission } from '@/hooks/permissions'
 import { useMembers } from '@/hooks/queries/members'
 import { useMultipleCustomerSeats } from '@/hooks/queries/seats'
 import MoreVertOutlined from '@mui/icons-material/MoreVertOutlined'
@@ -56,6 +57,10 @@ export const MembersSection = ({
   subscriptions,
   orders,
 }: MembersSectionProps) => {
+  const canManageCustomers = useHasPermission(
+    organization.id,
+    'customers:manage',
+  )
   const { data: membersData, isLoading } = useMembers(customer.id)
   const copyMemberLoginLink = useCopyMemberLoginLink(organization.slug)
 
@@ -192,32 +197,33 @@ export const MembersSection = ({
             id: 'actions',
             header: () => null,
             size: 60,
-            cell: ({ row: { original } }) => (
-              <Box justifyContent="end" onClick={(e) => e.stopPropagation()}>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button className="h-8 w-8" variant="ghost" size="icon">
-                      <MoreVertOutlined fontSize="inherit" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end">
-                    <DropdownMenuItem
-                      onClick={() => {
-                        setSelectedMember(original)
-                        showEditMemberModal()
-                      }}
-                    >
-                      Edit member
-                    </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={() => copyMemberLoginLink(original.email)}
-                    >
-                      Copy login link
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </Box>
-            ),
+            cell: ({ row: { original } }) =>
+              canManageCustomers ? (
+                <Box justifyContent="end" onClick={(e) => e.stopPropagation()}>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button className="h-8 w-8" variant="ghost" size="icon">
+                        <MoreVertOutlined fontSize="inherit" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        onClick={() => {
+                          setSelectedMember(original)
+                          showEditMemberModal()
+                        }}
+                      >
+                        Edit member
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() => copyMemberLoginLink(original.email)}
+                      >
+                        Copy login link
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </Box>
+              ) : null,
           },
         ]}
         isLoading={isLoading}

--- a/clients/apps/web/src/components/Dashboard/navigation.test.ts
+++ b/clients/apps/web/src/components/Dashboard/navigation.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+import { filterRoutesByPermissions, Route } from './navigation'
+
+const routes: Route[] = [
+  {
+    id: 'home',
+    title: 'Home',
+    link: '/home',
+    if: true,
+  },
+  {
+    id: 'products',
+    title: 'Products',
+    link: '/products',
+    if: true,
+    permission: 'products:read',
+    subs: [
+      { title: 'Catalogue', link: '/products' },
+      {
+        title: 'Checkout Links',
+        link: '/products/checkout-links',
+        permission: 'products:manage',
+      },
+    ],
+  },
+  {
+    id: 'finance',
+    title: 'Finance',
+    link: '/finance',
+    if: true,
+    permission: 'finance:read',
+    subs: [
+      { title: 'Income', link: '/finance/income' },
+      {
+        title: 'Account',
+        link: '/finance/account',
+        permission: 'organization:manage',
+      },
+    ],
+  },
+  {
+    id: 'members',
+    title: 'Members',
+    link: '/members',
+    if: true,
+    permission: 'members:read',
+  },
+]
+
+describe('filterRoutesByPermissions', () => {
+  it('keeps readable routes and removes inaccessible actions', () => {
+    const visibleRoutes = filterRoutesByPermissions(routes, [
+      'products:read',
+      'finance:read',
+    ])
+
+    expect(visibleRoutes.map((route) => route.id)).toEqual([
+      'home',
+      'products',
+      'finance',
+    ])
+    expect(visibleRoutes[1].subs?.map((route) => route.title)).toEqual([
+      'Catalogue',
+    ])
+    expect(visibleRoutes[2].subs?.map((route) => route.title)).toEqual([
+      'Income',
+    ])
+  })
+
+  it('also applies feature conditions to subroutes', () => {
+    const conditionalRoutes: Route[] = [
+      {
+        id: 'sales',
+        title: 'Sales',
+        link: '/sales',
+        if: true,
+        subs: [
+          { title: 'Orders', link: '/sales' },
+          { title: 'Disputes', link: '/sales/disputes', if: () => false },
+        ],
+      },
+    ]
+
+    const visibleRoutes = filterRoutesByPermissions(conditionalRoutes, [])
+
+    expect(visibleRoutes[0].subs?.map((route) => route.title)).toEqual([
+      'Orders',
+    ])
+  })
+})

--- a/clients/apps/web/src/components/Dashboard/navigation.tsx
+++ b/clients/apps/web/src/components/Dashboard/navigation.tsx
@@ -1,5 +1,5 @@
 import { AppealCaseUnreadBadge } from '@/components/Organization/HumanReviewCase/AppealCaseUnreadBadge'
-import { useHasPermission } from '@/hooks/permissions'
+import { useOrganizationPermissions } from '@/hooks/permissions'
 import { PolarHog, usePostHog } from '@/hooks/posthog'
 import AllInclusiveOutlined from '@mui/icons-material/AllInclusiveOutlined'
 import AttachMoneyOutlined from '@mui/icons-material/AttachMoneyOutlined'
@@ -26,8 +26,11 @@ export type SubRoute = {
   readonly link: string
   readonly icon?: React.ReactNode
   readonly if?: boolean | (() => boolean)
+  readonly permission?: OrganizationPermission
   readonly extra?: React.ReactNode
 }
+
+type OrganizationPermission = schemas['OrganizationPermission']
 
 export type Route = {
   readonly id: string
@@ -35,6 +38,7 @@ export type Route = {
   readonly icon?: React.ReactElement
   readonly link: string
   readonly if: boolean | undefined
+  readonly permission?: OrganizationPermission
   readonly subs?: SubRoute[]
   readonly selectedExactMatchOnly?: boolean
   readonly selectedMatchFallback?: boolean
@@ -96,6 +100,29 @@ const applyIsActive = (path: string): ((r: Route) => RouteWithActive) => {
   }
 }
 
+export const filterRoutesByPermissions = (
+  routes: Route[],
+  permissions: readonly OrganizationPermission[],
+  allowAll = false,
+): Route[] =>
+  routes
+    .filter(
+      (route) =>
+        allowAll ||
+        (route.if &&
+          (!route.permission || permissions.includes(route.permission))),
+    )
+    .map((route) => ({
+      ...route,
+      subs: route.subs?.filter(
+        (child) =>
+          allowAll ||
+          ((typeof child.if === 'undefined' ||
+            (typeof child.if === 'function' ? child.if() : child.if)) &&
+            (!child.permission || permissions.includes(child.permission))),
+      ),
+    }))
+
 export const useResolveRoutes = (
   routesResolver: (
     org?: schemas['Organization'],
@@ -106,50 +133,22 @@ export const useResolveRoutes = (
 ): RouteWithActive[] => {
   const path = usePathname()
   const posthog = usePostHog()
+  const permissions = useOrganizationPermissions(org?.id)
 
   return useMemo(() => {
-    return (
-      routesResolver(org, posthog)
-        .filter((o) => allowAll || o.if)
-        // Filter out child routes if they have an if-function and it evaluates to false
-        .map((route) => {
-          if (route.subs && Array.isArray(route.subs)) {
-            return {
-              ...route,
-              subs: route.subs.filter(
-                (child) =>
-                  typeof child.if === 'undefined' ||
-                  (typeof child.if === 'function' ? child.if() : child.if),
-              ),
-            }
-          }
-          return route
-        })
-        .map(applyIsActive(path))
-    )
-  }, [org, path, allowAll, routesResolver, posthog])
-}
-
-type RouteOptions = {
-  canManageBilling: boolean
-}
-
-const useRouteOptions = (org?: schemas['Organization']): RouteOptions => {
-  const canManageBilling =
-    useHasPermission(org?.id, 'organization:manage') === true
-  return { canManageBilling }
+    return filterRoutesByPermissions(
+      routesResolver(org, posthog),
+      permissions,
+      allowAll,
+    ).map(applyIsActive(path))
+  }, [org, path, allowAll, routesResolver, posthog, permissions])
 }
 
 export const useDashboardRoutes = (
   org?: schemas['Organization'],
   allowAll?: boolean,
 ): RouteWithActive[] => {
-  const options = useRouteOptions(org)
-  return useResolveRoutes(
-    (org) => dashboardRoutesList(org, options),
-    org,
-    allowAll,
-  )
+  return useResolveRoutes((org) => dashboardRoutesList(org), org, allowAll)
 }
 
 export const useGeneralRoutes = (
@@ -163,12 +162,7 @@ export const useOrganizationRoutes = (
   org?: schemas['Organization'],
   allowAll?: boolean,
 ): RouteWithActive[] => {
-  const options = useRouteOptions(org)
-  return useResolveRoutes(
-    (org) => organizationRoutesList(org, options),
-    org,
-    allowAll,
-  )
+  return useResolveRoutes((org) => organizationRoutesList(org), org, allowAll)
 }
 
 export const useAccountRoutes = (): RouteWithActive[] => {
@@ -199,6 +193,7 @@ const generalRoutesList = (org?: schemas['Organization']): Route[] => [
       return currentRoute.startsWith(`/dashboard/${org?.slug}/compass`)
     },
     if: !!org?.feature_settings?.compass_enabled,
+    permission: 'analytics:read',
   },
   {
     id: 'new-products',
@@ -209,6 +204,7 @@ const generalRoutesList = (org?: schemas['Organization']): Route[] => [
       return currentRoute.startsWith(`/dashboard/${org?.slug}/products`)
     },
     if: true,
+    permission: 'products:read',
     subs: [
       {
         title: 'Catalogue',
@@ -219,21 +215,25 @@ const generalRoutesList = (org?: schemas['Organization']): Route[] => [
         title: 'Checkout Links',
         link: `/dashboard/${org?.slug}/products/checkout-links`,
         icon: <LinkOutlined fontSize="inherit" />,
+        permission: 'products:manage',
       },
       {
         title: 'Discounts',
         link: `/dashboard/${org?.slug}/products/discounts`,
         icon: <DiscountOutlined fontSize="inherit" />,
+        permission: 'products:manage',
       },
       {
         title: 'Benefits',
         link: `/dashboard/${org?.slug}/products/benefits`,
         icon: <DiamondOutlined fontSize="inherit" />,
+        permission: 'products:manage',
       },
       {
         title: 'Meters',
         link: `/dashboard/${org?.slug}/products/meters`,
         icon: <DonutLargeOutlined fontSize="inherit" />,
+        permission: 'products:manage',
       },
     ],
   },
@@ -246,6 +246,7 @@ const generalRoutesList = (org?: schemas['Organization']): Route[] => [
       return currentRoute.startsWith(`/dashboard/${org?.slug}/customers`)
     },
     if: true,
+    permission: 'customers:read',
   },
   {
     id: 'analytics',
@@ -253,6 +254,7 @@ const generalRoutesList = (org?: schemas['Organization']): Route[] => [
     icon: <TrendingUp fontSize="inherit" />,
     link: `/dashboard/${org?.slug}/analytics`,
     if: true,
+    permission: 'analytics:read',
     subs: [
       {
         title: 'Metrics',
@@ -277,6 +279,7 @@ const generalRoutesList = (org?: schemas['Organization']): Route[] => [
       return currentRoute.startsWith(`/dashboard/${org?.slug}/sales`)
     },
     if: true,
+    permission: 'sales:read',
     subs: [
       {
         title: 'Orders',
@@ -298,6 +301,7 @@ const generalRoutesList = (org?: schemas['Organization']): Route[] => [
         link: `/dashboard/${org?.slug}/sales/disputes`,
         icon: <GavelOutlined fontSize="inherit" />,
         if: !!org?.feature_settings?.disputes_enabled,
+        permission: 'organization:manage',
       },
     ],
   },
@@ -305,11 +309,10 @@ const generalRoutesList = (org?: schemas['Organization']): Route[] => [
 
 const dashboardRoutesList = (
   org: schemas['Organization'] | undefined,
-  options: RouteOptions,
 ): Route[] => [
   ...accountRoutesList(),
   ...generalRoutesList(org),
-  ...organizationRoutesList(org, options),
+  ...organizationRoutesList(org),
 ]
 
 const accountRoutesList = (): Route[] => [
@@ -346,13 +349,13 @@ const orgFinanceSubRoutesList = (org?: schemas['Organization']): SubRoute[] => [
   {
     title: 'Account',
     link: `/dashboard/${org?.slug}/finance/account`,
+    permission: 'organization:manage',
     extra: org ? <AppealCaseUnreadBadge organization={org} /> : undefined,
   },
 ]
 
 const organizationRoutesList = (
   org: schemas['Organization'] | undefined,
-  options: RouteOptions,
 ): Route[] => [
   {
     id: 'finance',
@@ -360,6 +363,7 @@ const organizationRoutesList = (
     link: `/dashboard/${org?.slug}/finance`,
     icon: <AttachMoneyOutlined fontSize="inherit" />,
     if: true,
+    permission: 'finance:read',
     subs: orgFinanceSubRoutesList(org),
     extra: org ? <AppealCaseUnreadBadge organization={org} /> : undefined,
   },
@@ -377,29 +381,34 @@ const organizationRoutesList = (
       {
         title: 'Billing',
         link: `/dashboard/${org?.slug}/settings/billing`,
-        if: options.canManageBilling,
+        permission: 'organization:manage',
       },
       {
         title: 'Members',
         link: `/dashboard/${org?.slug}/settings/members`,
+        permission: 'members:read',
       },
       {
         title: 'Webhooks',
         link: `/dashboard/${org?.slug}/settings/webhooks`,
+        permission: 'organization:manage',
       },
       {
         title: 'Custom Fields',
         link: `/dashboard/${org?.slug}/settings/custom-fields`,
+        permission: 'custom_fields:manage',
       },
       {
         title: 'Single Sign-On',
         link: `/dashboard/${org?.slug}/settings/sso`,
         if: !!org?.feature_settings?.sso_enabled,
+        permission: 'organization:manage',
       },
       {
         title: 'Migrations',
         link: `/dashboard/${org?.slug}/settings/migrations`,
         if: !!org?.feature_settings?.merchant_migration_enabled,
+        permission: 'organization:manage',
       },
     ],
   },

--- a/clients/apps/web/src/components/Dashboard/navigationProducts.tsx
+++ b/clients/apps/web/src/components/Dashboard/navigationProducts.tsx
@@ -27,6 +27,7 @@ const billingRoutesList = (org?: schemas['Organization']): Route[] => [
     checkIsActive: (path) =>
       path.startsWith(`/dashboard/${org?.slug}/products`),
     if: true,
+    permission: 'products:read',
     subs: [
       {
         title: 'Catalogue',
@@ -37,21 +38,25 @@ const billingRoutesList = (org?: schemas['Organization']): Route[] => [
         title: 'Meters',
         link: `/dashboard/${org?.slug}/products/meters`,
         icon: <DonutLargeOutlined fontSize="inherit" />,
+        permission: 'products:manage',
       },
       {
         title: 'Checkout Links',
         link: `/dashboard/${org?.slug}/products/checkout-links`,
         icon: <LinkOutlined fontSize="inherit" />,
+        permission: 'products:manage',
       },
       {
         title: 'Discounts',
         link: `/dashboard/${org?.slug}/products/discounts`,
         icon: <DiscountOutlined fontSize="inherit" />,
+        permission: 'products:manage',
       },
       {
         title: 'Benefits',
         link: `/dashboard/${org?.slug}/products/benefits`,
         icon: <DiamondOutlined fontSize="inherit" />,
+        permission: 'products:manage',
       },
     ],
   },
@@ -62,6 +67,7 @@ const billingRoutesList = (org?: schemas['Organization']): Route[] => [
     link: `/dashboard/${org?.slug}/sales`,
     checkIsActive: (path) => path.startsWith(`/dashboard/${org?.slug}/sales`),
     if: true,
+    permission: 'sales:read',
     subs: [
       {
         title: 'Orders',
@@ -83,6 +89,7 @@ const billingRoutesList = (org?: schemas['Organization']): Route[] => [
         link: `/dashboard/${org?.slug}/sales/disputes`,
         icon: <GavelOutlined fontSize="inherit" />,
         if: !!org?.feature_settings?.disputes_enabled,
+        permission: 'organization:manage',
       },
     ],
   },
@@ -92,6 +99,7 @@ const billingRoutesList = (org?: schemas['Organization']): Route[] => [
     icon: <AttachMoneyOutlined fontSize="inherit" />,
     link: `/dashboard/${org?.slug}/finance`,
     if: true,
+    permission: 'finance:read',
     extra: org ? <AppealCaseUnreadBadge organization={org} /> : undefined,
     subs: [
       { title: 'Income', link: `/dashboard/${org?.slug}/finance/income` },
@@ -100,6 +108,7 @@ const billingRoutesList = (org?: schemas['Organization']): Route[] => [
       {
         title: 'Account',
         link: `/dashboard/${org?.slug}/finance/account`,
+        permission: 'organization:manage',
         extra: org ? <AppealCaseUnreadBadge organization={org} /> : undefined,
       },
     ],
@@ -122,6 +131,7 @@ const insightsRoutesList = (org?: schemas['Organization']): Route[] => [
     link: `/dashboard/${org?.slug}/compass`,
     checkIsActive: (path) => path.startsWith(`/dashboard/${org?.slug}/compass`),
     if: !!org?.feature_settings?.compass_enabled,
+    permission: 'analytics:read',
   },
   {
     id: 'metrics',
@@ -129,6 +139,7 @@ const insightsRoutesList = (org?: schemas['Organization']): Route[] => [
     icon: <SignalCellularAltOutlined fontSize="inherit" />,
     link: `/dashboard/${org?.slug}/analytics/metrics`,
     if: true,
+    permission: 'analytics:read',
   },
   {
     id: 'costs',
@@ -136,6 +147,7 @@ const insightsRoutesList = (org?: schemas['Organization']): Route[] => [
     icon: <TrendingDown fontSize="inherit" />,
     link: `/dashboard/${org?.slug}/analytics/costs`,
     if: true,
+    permission: 'analytics:read',
   },
   {
     id: 'events',
@@ -143,6 +155,7 @@ const insightsRoutesList = (org?: schemas['Organization']): Route[] => [
     icon: <BoltOutlined fontSize="inherit" />,
     link: `/dashboard/${org?.slug}/analytics/events`,
     if: true,
+    permission: 'analytics:read',
   },
   {
     id: 'customers',
@@ -152,6 +165,7 @@ const insightsRoutesList = (org?: schemas['Organization']): Route[] => [
     checkIsActive: (path) =>
       path.startsWith(`/dashboard/${org?.slug}/customers`),
     if: true,
+    permission: 'customers:read',
   },
 ]
 

--- a/clients/apps/web/src/components/DashboardOverview/OverviewSection.tsx
+++ b/clients/apps/web/src/components/DashboardOverview/OverviewSection.tsx
@@ -48,6 +48,10 @@ export function OverviewSection({ organization }: OverviewSectionProps) {
   )
 
   const canReadAnalytics = useHasPermission(organization.id, 'analytics:read')
+  const canManageOrganization = useHasPermission(
+    organization.id,
+    'organization:manage',
+  )
 
   const { data, isLoading } = useMetrics(
     {
@@ -75,17 +79,19 @@ export function OverviewSection({ organization }: OverviewSectionProps) {
               value={range}
               onChange={setRange}
             />
-            <Button
-              type="button"
-              onClick={show}
-              variant="secondary"
-              size="sm"
-              wrapperClassNames="gap-x-2"
-              aria-label="Customize"
-            >
-              <Settings2 className="h-3.5 w-3.5" />
-              <span className="hidden md:inline">Customize</span>
-            </Button>
+            {canManageOrganization ? (
+              <Button
+                type="button"
+                onClick={show}
+                variant="secondary"
+                size="sm"
+                wrapperClassNames="gap-x-2"
+                aria-label="Customize"
+              >
+                <Settings2 className="h-3.5 w-3.5" />
+                <span className="hidden md:inline">Customize</span>
+              </Button>
+            ) : null}
           </div>
         ) : null}
       </div>

--- a/clients/apps/web/src/components/Payouts/AccountBalance.tsx
+++ b/clients/apps/web/src/components/Payouts/AccountBalance.tsx
@@ -1,4 +1,5 @@
 import { useTransactionsSummary } from '@/hooks/queries'
+import { useHasPermission } from '@/hooks/permissions'
 import { usePayoutAccountSetup } from '@/hooks/usePayoutAccountSetup'
 import { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
@@ -24,6 +25,11 @@ const AccountBalance: React.FC<AccountBalanceProps> = ({
   organization,
   onWithdrawSuccess: _onWithdrawSuccess,
 }) => {
+  const canManageFinance = useHasPermission(organization.id, 'finance:manage')
+  const canManageOrganization = useHasPermission(
+    organization.id,
+    'organization:manage',
+  )
   const {
     data: summary,
     refetch: refetchBalance,
@@ -39,6 +45,7 @@ const AccountBalance: React.FC<AccountBalanceProps> = ({
   } = usePayoutAccountSetup(
     organization,
     `/dashboard/${organization.slug}/finance/payouts`,
+    canManageOrganization,
   )
 
   const {
@@ -77,9 +84,11 @@ const AccountBalance: React.FC<AccountBalanceProps> = ({
           <Text variant="heading-xxs" as="h2">
             Available Balance
           </Text>
-          <Button className="self-start" onClick={showPayoutConfirmModal}>
-            Withdraw
-          </Button>
+          {canManageFinance ? (
+            <Button className="self-start" onClick={showPayoutConfirmModal}>
+              Withdraw
+            </Button>
+          ) : null}
         </WellHeader>
         <WellContent>
           <Text variant="heading-s" loading={isLoading}>
@@ -115,76 +124,82 @@ const AccountBalance: React.FC<AccountBalanceProps> = ({
           </Text>
         </WellFooter>
       </Well>
-      <Well className="flex-1 justify-start rounded-2xl bg-gray-50 p-6">
-        <WellHeader className="flex flex-row items-center justify-between gap-x-6">
-          <Text variant="heading-xxs" as="h2">
-            Payout Account
-          </Text>
-          {payoutAccount || hasReusableAccounts ? (
-            <Button
-              className="self-start"
-              variant="secondary"
-              onClick={openManage}
+      {canManageOrganization ? (
+        <Well className="flex-1 justify-start rounded-2xl bg-gray-50 p-6">
+          <WellHeader className="flex flex-row items-center justify-between gap-x-6">
+            <Text variant="heading-xxs" as="h2">
+              Payout Account
+            </Text>
+            {payoutAccount || hasReusableAccounts ? (
+              <Button
+                className="self-start"
+                variant="secondary"
+                onClick={openManage}
+              >
+                Manage
+              </Button>
+            ) : (
+              <Button className="self-start" onClick={openCreate}>
+                Create
+              </Button>
+            )}
+          </WellHeader>
+          <WellContent>
+            <Text
+              variant="heading-s"
+              color={payoutAccount ? 'default' : 'disabled'}
+              loading={!payoutAccount && organization.payout_account_id != null}
             >
-              Manage
-            </Button>
-          ) : (
-            <Button className="self-start" onClick={openCreate}>
-              Create
-            </Button>
-          )}
-        </WellHeader>
-        <WellContent>
-          <Text
-            variant="heading-s"
-            color={payoutAccount ? 'default' : 'disabled'}
-            loading={!payoutAccount && organization.payout_account_id != null}
-          >
-            {payoutAccount
-              ? payoutAccount.type[0].toUpperCase() +
-                payoutAccount.type.slice(1)
-              : '—'}
-          </Text>
-        </WellContent>
-        <WellFooter className="mt-auto">
-          {payoutAccount ? (
-            <Box alignItems="center" columnGap="m">
-              <Text color="muted">
-                {payoutAccount.country.toUpperCase()} ·{' '}
-                {payoutAccount.currency.toUpperCase()}
-              </Text>
-              <Box display="inline-flex" alignItems="center" columnGap="xs">
-                <Box
-                  display="block"
-                  width={6}
-                  height={6}
-                  borderRadius="full"
-                  backgroundColor={
-                    payoutAccount.is_payout_ready
-                      ? 'background-success'
-                      : 'background-warning'
-                  }
-                />
-                <Text
-                  variant="caption"
-                  color={payoutAccount.is_payout_ready ? 'success' : 'warning'}
-                >
-                  {payoutAccount.is_payout_ready ? 'Ready' : 'Setup required'}
+              {payoutAccount
+                ? payoutAccount.type[0].toUpperCase() +
+                  payoutAccount.type.slice(1)
+                : '—'}
+            </Text>
+          </WellContent>
+          <WellFooter className="mt-auto">
+            {payoutAccount ? (
+              <Box alignItems="center" columnGap="m">
+                <Text color="muted">
+                  {payoutAccount.country.toUpperCase()} ·{' '}
+                  {payoutAccount.currency.toUpperCase()}
                 </Text>
+                <Box display="inline-flex" alignItems="center" columnGap="xs">
+                  <Box
+                    display="block"
+                    width={6}
+                    height={6}
+                    borderRadius="full"
+                    backgroundColor={
+                      payoutAccount.is_payout_ready
+                        ? 'background-success'
+                        : 'background-warning'
+                    }
+                  />
+                  <Text
+                    variant="caption"
+                    color={
+                      payoutAccount.is_payout_ready ? 'success' : 'warning'
+                    }
+                  >
+                    {payoutAccount.is_payout_ready ? 'Ready' : 'Setup required'}
+                  </Text>
+                </Box>
               </Box>
-            </Box>
-          ) : (
-            <Text color="muted">No payout account configured.</Text>
-          )}
-        </WellFooter>
-      </Well>
-      <WithdrawModal
-        organization={organization}
-        account={account}
-        isShown={isPayoutConfirmModalShown}
-        hide={hidePayoutConfirmModal}
-        onSuccess={onWithdrawSuccess}
-      />
+            ) : (
+              <Text color="muted">No payout account configured.</Text>
+            )}
+          </WellFooter>
+        </Well>
+      ) : null}
+      {canManageFinance ? (
+        <WithdrawModal
+          organization={organization}
+          account={account}
+          isShown={isPayoutConfirmModalShown}
+          hide={hidePayoutConfirmModal}
+          onSuccess={onWithdrawSuccess}
+        />
+      ) : null}
       <FeeCreditGrantsModal
         isShown={isCreditGrantsModalShown}
         hide={hideCreditGrantsModal}

--- a/clients/apps/web/src/components/Products/ProductListItem.tsx
+++ b/clients/apps/web/src/components/Products/ProductListItem.tsx
@@ -3,6 +3,7 @@ import { useModal } from '@/components/Modal/useModal'
 import LegacyRecurringProductPrices from '@/components/Products/LegacyRecurringProductPrices'
 import ProductPriceLabel from '@/components/Products/ProductPriceLabel'
 import { toast } from '@/components/Toast/use-toast'
+import { useHasPermission } from '@/hooks/permissions'
 import { useUpdateProduct } from '@/hooks/queries/products'
 import {
   hasLegacyRecurringPrices,
@@ -39,6 +40,7 @@ export const ProductListItem = ({
   currency,
 }: ProductListItemProps) => {
   const router = useRouter()
+  const canManageProducts = useHasPermission(organization.id, 'products:manage')
   const {
     show: showModal,
     hide: hideModal,
@@ -134,19 +136,21 @@ export const ProductListItem = ({
                     <ProductPriceLabel product={product} currency={currency} />
                   )}
                 </span>
-                <Button
-                  size="sm"
-                  variant="secondary"
-                  className="hidden md:inline-flex"
-                  onClick={(e) => {
-                    e.preventDefault()
-                    router.push(
-                      `/dashboard/${organization.slug}/products/checkout-links?productId=${product.id}`,
-                    )
-                  }}
-                >
-                  Share
-                </Button>
+                {canManageProducts ? (
+                  <Button
+                    size="sm"
+                    variant="secondary"
+                    className="hidden md:inline-flex"
+                    onClick={(e) => {
+                      e.preventDefault()
+                      router.push(
+                        `/dashboard/${organization.slug}/products/checkout-links?productId=${product.id}`,
+                      )
+                    }}
+                  >
+                    Share
+                  </Button>
+                ) : null}
                 <DropdownMenu>
                   <DropdownMenuTrigger className="focus:outline-none" asChild>
                     <Button
@@ -172,44 +176,47 @@ export const ProductListItem = ({
                     >
                       Copy Product ID
                     </DropdownMenuItem>
-                    <DropdownMenuItem
-                      onClick={handleContextMenuCallback(() => {
-                        router.push(
-                          `/dashboard/${organization.slug}/onboarding/integrate?productId=${product.id}`,
-                        )
-                      })}
-                    >
-                      Integrate Checkout
-                    </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                    {product.is_archived ? null : (
-                      <DropdownMenuItem
-                        onClick={handleContextMenuCallback(() => {
-                          router.push(
-                            `/dashboard/${organization.slug}/products/${product.id}/edit`,
-                          )
-                        })}
-                      >
-                        Edit Product
-                      </DropdownMenuItem>
-                    )}
-
-                    <DropdownMenuItem
-                      onClick={handleContextMenuCallback(() => {
-                        router.push(
-                          `/dashboard/${organization.slug}/products/new?fromProductId=${product.id}`,
-                        )
-                      })}
-                    >
-                      Duplicate Product
-                    </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      destructive
-                      onClick={handleContextMenuCallback(showModal)}
-                    >
-                      Archive Product
-                    </DropdownMenuItem>
+                    {canManageProducts ? (
+                      <>
+                        <DropdownMenuItem
+                          onClick={handleContextMenuCallback(() => {
+                            router.push(
+                              `/dashboard/${organization.slug}/onboarding/integrate?productId=${product.id}`,
+                            )
+                          })}
+                        >
+                          Integrate Checkout
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        {product.is_archived ? null : (
+                          <DropdownMenuItem
+                            onClick={handleContextMenuCallback(() => {
+                              router.push(
+                                `/dashboard/${organization.slug}/products/${product.id}/edit`,
+                              )
+                            })}
+                          >
+                            Edit Product
+                          </DropdownMenuItem>
+                        )}
+                        <DropdownMenuItem
+                          onClick={handleContextMenuCallback(() => {
+                            router.push(
+                              `/dashboard/${organization.slug}/products/new?fromProductId=${product.id}`,
+                            )
+                          })}
+                        >
+                          Duplicate Product
+                        </DropdownMenuItem>
+                        <DropdownMenuSeparator />
+                        <DropdownMenuItem
+                          destructive
+                          onClick={handleContextMenuCallback(showModal)}
+                        >
+                          Archive Product
+                        </DropdownMenuItem>
+                      </>
+                    ) : null}
                   </DropdownMenuContent>
                 </DropdownMenu>
               </>

--- a/clients/apps/web/src/components/Products/ProductPage/ProductPage.tsx
+++ b/clients/apps/web/src/components/Products/ProductPage/ProductPage.tsx
@@ -3,6 +3,7 @@ import { useModal } from '@/components/Modal/useModal'
 import LegacyRecurringProductPrices from '@/components/Products/LegacyRecurringProductPrices'
 import ProductPriceLabel from '@/components/Products/ProductPriceLabel'
 import { toast } from '@/components/Toast/use-toast'
+import { useHasPermission } from '@/hooks/permissions'
 import { useMetrics, useUpdateProduct } from '@/hooks/queries'
 import { apiErrorToast } from '@/utils/api/errors'
 import { getChartRangeParams } from '@/utils/metrics'
@@ -36,6 +37,7 @@ export interface ProductPageProps {
 }
 
 export const ProductPage = ({ organization, product }: ProductPageProps) => {
+  const canManageProducts = useHasPermission(organization.id, 'products:manage')
   const [allTimeStart, allTimeEnd, allTimeInterval] = getChartRangeParams(
     'all_time',
     product.created_at,
@@ -170,7 +172,7 @@ export const ProductPage = ({ organization, product }: ProductPageProps) => {
         }
         header={
           <div className="flex flex-row items-center justify-between gap-2">
-            {product.is_archived ? null : (
+            {!product.is_archived && canManageProducts ? (
               <div>
                 <Button
                   variant="secondary"
@@ -183,7 +185,7 @@ export const ProductPage = ({ organization, product }: ProductPageProps) => {
                   Edit Product
                 </Button>
               </div>
-            )}
+            ) : null}
             <div>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -209,7 +211,7 @@ export const ProductPage = ({ organization, product }: ProductPageProps) => {
                   >
                     Copy Product ID
                   </DropdownMenuItem>
-                  {!product.is_archived && (
+                  {!product.is_archived && canManageProducts ? (
                     <>
                       <DropdownMenuItem
                         onClick={() => {
@@ -235,15 +237,15 @@ export const ProductPage = ({ organization, product }: ProductPageProps) => {
                         Archive Product
                       </DropdownMenuItem>
                     </>
-                  )}
-                  {product.is_archived && (
+                  ) : null}
+                  {product.is_archived && canManageProducts ? (
                     <>
                       <DropdownMenuSeparator />
                       <DropdownMenuItem onClick={showUnarchiveModal}>
                         Unarchive Product
                       </DropdownMenuItem>
                     </>
-                  )}
+                  ) : null}
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>

--- a/clients/apps/web/src/components/Search/OmniSearch.tsx
+++ b/clients/apps/web/src/components/Search/OmniSearch.tsx
@@ -4,6 +4,7 @@ import {
   useGeneralRoutes,
   useOrganizationRoutes,
 } from '@/components/Dashboard/navigation'
+import { useHasPermission } from '@/hooks/permissions'
 import { getServerURL } from '@/utils/api'
 import { schemas } from '@polar-sh/client'
 import { formatCurrency } from '@polar-sh/currency'
@@ -35,6 +36,7 @@ export const OmniSearch = ({
   organization,
 }: OmniSearchProps) => {
   const router = useRouter()
+  const canManageProducts = useHasPermission(organization.id, 'products:manage')
   const [query, setQuery] = useState('')
   const [results, setResults] = useState<SearchResult[]>([])
   const [loading, setLoading] = useState(false)
@@ -48,8 +50,8 @@ export const OmniSearch = ({
   )
 
   const quickActions = useMemo(
-    () => getQuickActions(organization.slug),
-    [organization.slug],
+    () => (canManageProducts ? getQuickActions(organization.slug) : []),
+    [canManageProducts, organization.slug],
   )
 
   const actionResults = useMemo(() => {

--- a/clients/apps/web/src/hooks/permissions.test.ts
+++ b/clients/apps/web/src/hooks/permissions.test.ts
@@ -1,0 +1,64 @@
+import { renderHook } from '@testing-library/react'
+import { schemas } from '@polar-sh/client'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const authState = vi.hoisted(() => ({
+  organizations: [] as schemas['OrganizationWithRole'][],
+}))
+
+vi.mock('@/hooks/auth', () => ({
+  useAuth: () => ({ userOrganizations: authState.organizations }),
+}))
+
+import { useHasPermission, useOrganizationPermissions } from './permissions'
+
+const financeOrganization = {
+  id: 'finance-organization',
+  permissions: [
+    'sales:read',
+    'sales:manage',
+    'finance:read',
+    'customers:read',
+    'products:read',
+    'custom_fields:read',
+    'analytics:read',
+  ],
+} as schemas['OrganizationWithRole']
+
+describe('organization permissions', () => {
+  beforeEach(() => {
+    authState.organizations = [financeOrganization]
+  })
+
+  it('returns the permissions embedded for the organization', () => {
+    const { result } = renderHook(() =>
+      useOrganizationPermissions(financeOrganization.id),
+    )
+
+    expect(result.current).toEqual(financeOrganization.permissions)
+  })
+
+  it('grants finance permissions and denies admin permissions', () => {
+    const { result: canReadFinance } = renderHook(() =>
+      useHasPermission(financeOrganization.id, 'finance:read'),
+    )
+    const { result: canManageFinance } = renderHook(() =>
+      useHasPermission(financeOrganization.id, 'finance:manage'),
+    )
+    const { result: canManageMembers } = renderHook(() =>
+      useHasPermission(financeOrganization.id, 'members:manage'),
+    )
+
+    expect(canReadFinance.current).toBe(true)
+    expect(canManageFinance.current).toBe(false)
+    expect(canManageMembers.current).toBe(false)
+  })
+
+  it('denies permissions when the organization is unavailable', () => {
+    const { result } = renderHook(() =>
+      useHasPermission('unknown-organization', 'finance:read'),
+    )
+
+    expect(result.current).toBe(false)
+  })
+})

--- a/clients/apps/web/src/hooks/permissions.ts
+++ b/clients/apps/web/src/hooks/permissions.ts
@@ -1,15 +1,21 @@
 import { useAuth } from '@/hooks/auth'
 import { OrganizationPermission } from '@/hooks/queries/roles'
 
-// Permissions are embedded on the user's organizations in the authenticated
-// payload (`x-polar-user`), so the check is synchronous — no query, no loading
-// state, and no flash before a definitive grant/denial.
+export const useOrganizationPermissions = (
+  organizationId: string | undefined,
+): readonly OrganizationPermission[] => {
+  const { userOrganizations } = useAuth()
+  if (!organizationId) return []
+  return (
+    userOrganizations.find((organization) => organization.id === organizationId)
+      ?.permissions ?? []
+  )
+}
+
 export const useHasPermission = (
   organizationId: string | undefined,
   permission: OrganizationPermission,
 ): boolean => {
-  const { userOrganizations } = useAuth()
-  if (!organizationId) return false
-  const organization = userOrganizations.find((o) => o.id === organizationId)
-  return organization?.permissions.includes(permission) ?? false
+  const permissions = useOrganizationPermissions(organizationId)
+  return permissions.includes(permission)
 }

--- a/clients/apps/web/src/hooks/queries/payout_accounts.ts
+++ b/clients/apps/web/src/hooks/queries/payout_accounts.ts
@@ -3,7 +3,10 @@ import { unwrap } from '@polar-sh/client'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { defaultRetry } from './retry'
 
-export const usePayoutAccount = (payoutAccountId: string | undefined) =>
+export const usePayoutAccount = (
+  payoutAccountId: string | undefined,
+  enabled = true,
+) =>
   useQuery({
     queryKey: ['payoutAccount', payoutAccountId],
     queryFn: () =>
@@ -13,14 +16,15 @@ export const usePayoutAccount = (payoutAccountId: string | undefined) =>
         }),
       ),
     retry: defaultRetry,
-    enabled: !!payoutAccountId,
+    enabled: enabled && !!payoutAccountId,
   })
 
-export const usePayoutAccounts = () =>
+export const usePayoutAccounts = (enabled = true) =>
   useQuery({
     queryKey: ['payoutAccounts'],
     queryFn: () => unwrap(api.GET('/v1/payout-accounts/')),
     retry: defaultRetry,
+    enabled,
   })
 
 export const useSyncPayoutAccount = (payoutAccountId: string) => {

--- a/clients/apps/web/src/hooks/usePayoutAccountSetup.tsx
+++ b/clients/apps/web/src/hooks/usePayoutAccountSetup.tsx
@@ -21,11 +21,13 @@ interface UsePayoutAccountSetupResult {
 export const usePayoutAccountSetup = (
   organization: schemas['Organization'],
   returnPath: string,
+  enabled = true,
 ): UsePayoutAccountSetupResult => {
   const { data: payoutAccount } = usePayoutAccount(
     organization.payout_account_id ?? undefined,
+    enabled,
   )
-  const { data: payoutAccountsList } = usePayoutAccounts()
+  const { data: payoutAccountsList } = usePayoutAccounts(enabled)
   const hasReusableAccounts = (payoutAccountsList?.items?.length ?? 0) > 0
 
   const {
@@ -52,7 +54,7 @@ export const usePayoutAccountSetup = (
     }
   }, [hasReusableAccounts, openManage, openCreate])
 
-  const modals = (
+  const modals = enabled ? (
     <>
       <Modal
         title="Create Payout Account"
@@ -80,7 +82,7 @@ export const usePayoutAccountSetup = (
         }
       />
     </>
-  )
+  ) : null
 
   return {
     payoutAccount,

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -968,9 +968,9 @@ export interface paths {
      * Set Member Role
      * @description Change a member's role on an organization.
      *
-     *     Only `admin` and `member` are accepted; ownership transfers go through
-     *     a separate flow (today the backoffice `change_owner` endpoint, which
-     *     calls `user_organization_service.transfer_ownership`).
+     *     `admin`, `finance`, and `member` are accepted; ownership transfers go
+     *     through a separate flow (today the backoffice `change_owner` endpoint,
+     *     which calls `user_organization_service.transfer_ownership`).
      *
      *     **Scopes**: `members:write`
      */
@@ -28045,7 +28045,7 @@ export interface components {
        * @description The role to assign. `owner` is rejected — ownership transfers go through a separate flow.
        * @enum {string}
        */
-      role: 'admin' | 'member'
+      role: 'admin' | 'finance' | 'member'
     }
     /** OrganizationNotReadyForPayments */
     OrganizationNotReadyForPayments: {
@@ -28396,7 +28396,7 @@ export interface components {
      * OrganizationRole
      * @enum {string}
      */
-    OrganizationRole: 'owner' | 'admin' | 'member'
+    OrganizationRole: 'owner' | 'admin' | 'finance' | 'member'
     /**
      * OrganizationRoleDefinition
      * @description A role available in an organization and the permissions it grants.
@@ -66619,7 +66619,7 @@ export const organizationKYCCountryAnyOf0Values: ReadonlyArray<
 ]
 export const organizationMemberRoleUpdateRoleValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['OrganizationMemberRoleUpdate']['role']
-> = ['admin', 'member']
+> = ['admin', 'finance', 'member']
 export const organizationPermissionValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['OrganizationPermission']
 > = [
@@ -66686,7 +66686,7 @@ export const organizationReviewSubCheckKeyValues: ReadonlyArray<
 ]
 export const organizationRoleValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['OrganizationRole']
-> = ['owner', 'admin', 'member']
+> = ['owner', 'admin', 'finance', 'member']
 export const organizationSSOConnectionTypeValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['OrganizationSSOConnectionType']
 > = ['oidc']

--- a/handbook/engineering/design-documents/rbac.mdx
+++ b/handbook/engineering/design-documents/rbac.mdx
@@ -1,27 +1,27 @@
 <Info>
 **Status**: Active
 **Created**: April 2026
-**Last Updated**: May 5, 2026
+**Last Updated**: August 12, 2026
 </Info>
 
 ## Summary
 
-Introduce role-based access control for users on a Polar organization. Three roles ship in this iteration — `owner`, `admin`, and `member` — replacing today's implicit binary where org-level admin capability (member management, organization deletion, payout-account selection, Finance and payouts) is gated by `Account.admin_id`: the single user who is recorded as the admin on the org's Polar-side billing `Account`, today set at org creation.
+Introduce role-based access control for users on a Polar organization. Four roles are available — `owner`, `admin`, `finance`, and `member` — replacing today's implicit binary where org-level admin capability (member management, organization deletion, payout-account selection, Finance and payouts) is gated by `Account.admin_id`: the single user who is recorded as the admin on the org's Polar-side billing `Account`, today set at org creation.
 
-All three roles are stored on the user–organization membership. `admin` and `member` are freely assignable; there is exactly one `owner` per organization. During rollout, `owner` is anchored to today's `Account.admin_id` via dual-write so the two never disagree. The end state of this work drops `Account.admin_id` and makes the role table itself the sole source of truth for ownership (a partial unique index enforces the singularity invariant; the KYC/identity-verification gate moves onto role transitions into `owner`). What `owner` adds on top of `admin` is a small set of ownership-tied responsibilities retained for KYC/KYB / UBO reasons: the legal/billing primary contact for the org, the recipient of identity-verification notifications, the sole authority to transfer ownership of the org, and a member-removal exemption (the `owner` cannot be removed from the org without first transferring ownership).
+All four roles are stored on the user–organization membership. `admin`, `finance`, and `member` are freely assignable; there is exactly one `owner` per organization. `finance` can manage sales and read the related finance, customer, product, custom-field, and analytics data, but cannot manage payouts, organization settings, members, products, or customers. During rollout, `owner` is anchored to today's `Account.admin_id` via dual-write so the two never disagree. The end state of this work drops `Account.admin_id` and makes the role table itself the sole source of truth for ownership (a partial unique index enforces the singularity invariant; the KYC/identity-verification gate moves onto role transitions into `owner`). What `owner` adds on top of `admin` is a small set of ownership-tied responsibilities retained for KYC/KYB / UBO reasons: the legal/billing primary contact for the org, the recipient of identity-verification notifications, the sole authority to transfer ownership of the org, and a member-removal exemption (the `owner` cannot be removed from the org without first transferring ownership).
 
 The change is mostly additive on top of the existing two-layer authorization architecture. Role lives on the user–organization membership and drives a fine-grained permission set that policies consult. Token scopes remain a per-token capability filter; policies AND a token-scope check with a role-permission check at runtime. The Stripe-side `PayoutAccount.admin_id` is a separate concept and is unaffected by this design.
 
 ## Goals
 
-- Introduce an `OrganizationRole` enum (`owner`, `admin`, `member`) attached to organization membership.
+- Introduce an `OrganizationRole` enum (`owner`, `admin`, `finance`, `member`) attached to organization membership.
 - Move org-level admin authorization off direct `Account.admin_id` checks and onto **role permissions** evaluated at policy time.
 - **Decommission `Account.admin_id`.** Once the role-based ownership has been validated in production, drop the column; the role table becomes the sole source of truth for ownership, the KYC/identity-verification gate moves onto role transitions into `owner`, and reads that previously joined `Account.admin_id` query the role instead.
 - Allow multiple admins per organization (alongside the singular `owner`).
 - Enforce that an organization always has at least one user with admin capability — i.e. `role ∈ {owner, admin}`. The singular `owner` always satisfies this.
 - Forbid removing the `owner` from the organization; ownership transfer remains a support/backoffice task in this iteration.
 - Provide back-end and front-end utilities to answer "does this user have permission X in this org?" cleanly, plus a small `is_owner(user, org)` predicate for the few owner-keyed invariants (member-removal exemption, role-validity) that are enforced outside the permission system.
-- Lay foundations for additional roles (Finance, Support, Developer, …) without re-shaping the architecture.
+- Lay foundations for additional roles (Support, Developer, …) without re-shaping the architecture.
 
 ## Non-Goals
 
@@ -33,7 +33,7 @@ The change is mostly additive on top of the existing two-layer authorization arc
 
 ## Key Concepts
 
-- **`OrganizationRole`** — new enum (`owner`, `admin`, `member`) attached to a membership. `admin` and `member` are freely assignable; `owner` is constrained to exactly one user per organization. During rollout that user is identified by `Account.admin_id`; in the end state, by a partial unique index on the role table itself.
+- **`OrganizationRole`** — enum (`owner`, `admin`, `finance`, `member`) attached to a membership. `admin`, `finance`, and `member` are freely assignable; `owner` is constrained to exactly one user per organization. During rollout that user is identified by `Account.admin_id`; in the end state, by a partial unique index on the role table itself.
 - **`owner`** — the singular role per organization. Carries every `admin` capability plus a small set of ownership-tied responsibilities (legal/billing primary contact, identity-verification notification recipient, sole authority for ownership transfer, exemption from member removal). The user holding it must be identity-verified (Stripe KYC); the gate sits on role transitions into `owner` once `Account.admin_id` is gone.
 - **Membership** — the link between a user and an organization. Today it carries no role; this design adds one.
 - **`Account`** — Polar's internal financial container for an organization. Holds the credit balance, fee structure, billing identity (name, address) for invoices and receipts, and a single `admin_id`. One per org. Distinct from the Stripe-side payout account.
@@ -94,10 +94,11 @@ Initial role → permissions assignments:
 | Role | Permissions |
 |---|---|
 | `member` | Read and write across operational resources (products, customers, subscriptions, benefits, discounts, checkout links/sessions, orders, refunds, files, events, meters, custom fields, license keys, webhooks, metrics, notifications, customer seats) and read of the member list. **Excludes** Finance (`transactions:*`, `payouts:*`, `wallets:*`, `disputes:read`), member management (`members:invite`, `members:remove`, `members:set_role`), and org management (`organizations:edit_settings`, `organizations:delete`, `organizations:manage_payout_account`). OAT management endpoints are web-only and gated by `organization:manage`, therefore admin-only. Billing-info edits on the org's `Account` (legal name, address, etc.) fall under `organizations:edit_settings` and are therefore admin-only by way of the org-management exclusion. |
+| `finance` | Read and write sales, plus read-only access to finance, customers, products, custom fields, and analytics. **Excludes** payout and payout-account management, organization and member management, writes outside sales, and event ingestion. |
 | `admin` | Every `member` permission **plus** the excluded set above. |
 | `owner` | Identical to `admin` in this iteration. Distinguished from admin by invariants (member-removal exemption, singularity per org), not by additional permissions. The `organizations:transfer_ownership` permission, if/when self-serve transfer ships, will be owner-only. |
 
-This keeps the day-1 footprint small: one bundle to split (`organizations:write`), one near-identity scope-to-permission map elsewhere, and three role permission sets. New permissions are added at the seam where role granularity needs to diverge from scope granularity, not preemptively.
+This keeps the footprint small: one bundle to split (`organizations:write`), one near-identity scope-to-permission map elsewhere, and four role permission sets. New permissions are added at the seam where role granularity needs to diverge from scope granularity, not preemptively.
 
 ### Where the permission check lives
 
@@ -134,7 +135,7 @@ Because a `PayoutAccount` can be linked to multiple organizations, its admin is 
 
 ## Data Model
 
-A new `OrganizationRole` enum with three members: `owner`, `admin`, `member`. The enum is attached to the user–organization membership row.
+A new `OrganizationRole` enum with four members: `owner`, `admin`, `finance`, `member`. The enum is attached to the user–organization membership row.
 
 The new role attribute is required (non-null) and defaults to `member` for new memberships. Backfill maps each existing `Account.admin_id` user into the `owner` role on their membership of the owning org; everyone else is `member`. The `admin` role starts unused on existing data — it is opt-in promotion above `member`.
 
@@ -264,5 +265,4 @@ A defense-in-depth design where personal-access tokens and organization-access t
 
 - **Phase 5 strategy.** Time-based wait, bundle-mismatch prompt, or accept the brief break for stale tabs?
 - **Phase 6 bake time.** How long does the role system run as the live authorization signal (with `Account.admin_id` still dual-written) before we trust it enough to drop the column? Concrete signals to wait on (zero policy-denial reports tied to role lookups, audit log showing no remaining `Account.admin_id` reads in production for N days) help anchor the decision.
-- **First-class "Finance" role.** RBAC.md anticipates Finance/Support/Developer roles. Should the enum reserve those values now (forward-compat) or add them when needed?
 - **Permission-table source of truth.** The `role → permissions` and `scope → implied_permissions` tables live in code in this design, generated into a frontend artefact for the permission hook. Is that sufficient long-term, or do we need a richer config layer (YAML, DB) once customer-facing role customisation is on the roadmap?

--- a/server/polar/auth/permission.py
+++ b/server/polar/auth/permission.py
@@ -80,10 +80,21 @@ _MEMBER_PERMISSIONS: set[OrganizationPermission] = {
     OrganizationPermission.events_ingest,
 }
 
+_FINANCE_PERMISSIONS: set[OrganizationPermission] = {
+    OrganizationPermission.sales_read,
+    OrganizationPermission.sales_manage,
+    OrganizationPermission.finance_read,
+    OrganizationPermission.customers_read,
+    OrganizationPermission.products_read,
+    OrganizationPermission.custom_fields_read,
+    OrganizationPermission.analytics_read,
+}
+
 ROLE_PERMISSIONS: dict[OrganizationRole, set[OrganizationPermission]] = {
     OrganizationRole.member: _MEMBER_PERMISSIONS,
     OrganizationRole.admin: _MEMBER_PERMISSIONS | _ADMIN_ONLY,
     OrganizationRole.owner: _MEMBER_PERMISSIONS | _ADMIN_ONLY,
+    OrganizationRole.finance: _FINANCE_PERMISSIONS,
 }
 
 

--- a/server/polar/models/user_organization.py
+++ b/server/polar/models/user_organization.py
@@ -15,6 +15,7 @@ from polar.models.user import User
 class OrganizationRole(StrEnum):
     owner = "owner"
     admin = "admin"
+    finance = "finance"
     member = "member"
 
 

--- a/server/polar/organization/endpoints.py
+++ b/server/polar/organization/endpoints.py
@@ -711,9 +711,9 @@ async def set_member_role(
 ) -> UserOrganization:
     """Change a member's role on an organization.
 
-    Only `admin` and `member` are accepted; ownership transfers go through
-    a separate flow (today the backoffice `change_owner` endpoint, which
-    calls `user_organization_service.transfer_ownership`).
+    `admin`, `finance`, and `member` are accepted; ownership transfers go
+    through a separate flow (today the backoffice `change_owner` endpoint,
+    which calls `user_organization_service.transfer_ownership`).
     """
     try:
         return await user_organization_service.set_role(

--- a/server/polar/user_organization/schemas.py
+++ b/server/polar/user_organization/schemas.py
@@ -32,7 +32,11 @@ class OrganizationMemberInvite(Schema):
 
 
 class OrganizationMemberRoleUpdate(Schema):
-    role: Literal[OrganizationRole.admin, OrganizationRole.member] = Field(
+    role: Literal[
+        OrganizationRole.admin,
+        OrganizationRole.finance,
+        OrganizationRole.member,
+    ] = Field(
         description=(
             "The role to assign. `owner` is rejected — ownership transfers "
             "go through a separate flow."

--- a/server/tests/auth/test_permission.py
+++ b/server/tests/auth/test_permission.py
@@ -1,0 +1,14 @@
+from polar.auth.permission import ROLE_PERMISSIONS, OrganizationPermission
+from polar.models.user_organization import OrganizationRole
+
+
+def test_finance_role_permissions() -> None:
+    assert ROLE_PERMISSIONS[OrganizationRole.finance] == {
+        OrganizationPermission.sales_read,
+        OrganizationPermission.sales_manage,
+        OrganizationPermission.finance_read,
+        OrganizationPermission.customers_read,
+        OrganizationPermission.products_read,
+        OrganizationPermission.custom_fields_read,
+        OrganizationPermission.analytics_read,
+    }

--- a/server/tests/authz/test_endpoints.py
+++ b/server/tests/authz/test_endpoints.py
@@ -66,6 +66,23 @@ class TestPolicyGuardGetAccount:
         assert response.status_code == 200
 
     @pytest.mark.auth
+    async def test_finance_returns_200(
+        self,
+        client: AsyncClient,
+        save_fixture: SaveFixture,
+        user: User,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        user_organization.role = OrganizationRole.finance
+        organization.account = await create_account(save_fixture, user=user)
+        await save_fixture(user_organization)
+        await save_fixture(organization)
+
+        response = await client.get(f"/v1/organizations/{organization.id}/account")
+        assert response.status_code == 200
+
+    @pytest.mark.auth
     async def test_blocked_org_returns_404(
         self,
         client: AsyncClient,

--- a/server/tests/authz/test_policies.py
+++ b/server/tests/authz/test_policies.py
@@ -65,6 +65,34 @@ class TestFinanceCanRead:
         assert isinstance(result, str)
         assert "permission" in result.lower()
 
+    @pytest.mark.auth
+    async def test_finance_allowed(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await _set_role(save_fixture, user_organization, OrganizationRole.finance)
+
+        result = await finance_policy.can_read(session, auth_subject, organization)
+        assert result is True
+
+    @pytest.mark.auth
+    async def test_finance_cannot_manage(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await _set_role(save_fixture, user_organization, OrganizationRole.finance)
+
+        result = await finance_policy.can_manage(session, auth_subject, organization)
+        assert result == "You don't have permission to manage financial data"
+
     @pytest.mark.auth(AuthSubjectFixture(subject="organization"))
     async def test_organization_subject_allowed(
         self,
@@ -107,6 +135,20 @@ class TestOrgCanManage:
         result = await org_policy.can_manage(session, auth_subject, organization)
         assert result == "You don't have permission to manage the organization"
 
+    @pytest.mark.auth
+    async def test_finance_denied(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await _set_role(save_fixture, user_organization, OrganizationRole.finance)
+
+        result = await org_policy.can_manage(session, auth_subject, organization)
+        assert result == "You don't have permission to manage the organization"
+
 
 @pytest.mark.asyncio
 class TestMembersCanManage:
@@ -134,6 +176,20 @@ class TestMembersCanManage:
         user_organization: UserOrganization,
     ) -> None:
         await _set_role(save_fixture, user_organization, OrganizationRole.member)
+
+        result = await members.can_manage(session, auth_subject, organization)
+        assert result == "You don't have permission to manage members"
+
+    @pytest.mark.auth
+    async def test_finance_denied(
+        self,
+        session: AsyncSession,
+        auth_subject: AuthSubject[User],
+        save_fixture: SaveFixture,
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        await _set_role(save_fixture, user_organization, OrganizationRole.finance)
 
         result = await members.can_manage(session, auth_subject, organization)
         assert result == "You don't have permission to manage members"

--- a/server/tests/organization/test_endpoints.py
+++ b/server/tests/organization/test_endpoints.py
@@ -116,6 +116,7 @@ class TestListRoles:
             OrganizationRole.member.value,
             OrganizationRole.admin.value,
             OrganizationRole.owner.value,
+            OrganizationRole.finance.value,
         }
         # Every role's permissions list is non-empty.
         for entry in roles:
@@ -878,6 +879,24 @@ class TestSetMemberRole:
         json = response.json()
         assert json["user_id"] == str(user_second.id)
         assert json["role"] == "admin"
+
+    @pytest.mark.auth
+    @pytest.mark.keep_session_state
+    async def test_assign_finance_role(
+        self,
+        client: AsyncClient,
+        organization: Organization,
+        user_second: User,
+        user_organization: UserOrganization,
+        user_organization_second: UserOrganization,
+    ) -> None:
+        response = await client.patch(
+            f"/v1/organizations/{organization.id}/members/{user_second.id}",
+            json={"role": "finance"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["role"] == "finance"
 
     @pytest.mark.auth
     @pytest.mark.keep_session_state

--- a/server/tests/user/test_endpoints.py
+++ b/server/tests/user/test_endpoints.py
@@ -70,6 +70,32 @@ async def test_get_users_me_embeds_member_permissions_without_admin_scopes(
 
 @pytest.mark.asyncio
 @pytest.mark.auth
+async def test_get_users_me_embeds_finance_permissions(
+    client: AsyncClient,
+    save_fixture: SaveFixture,
+    user_organization: UserOrganization,
+) -> None:
+    user_organization.role = OrganizationRole.finance
+    await save_fixture(user_organization)
+
+    response = await client.get("/v1/users/me")
+
+    assert response.status_code == 200
+    organization = response.json()["organizations"][0]
+    assert organization["role"] == OrganizationRole.finance
+    assert set(organization["permissions"]) == {
+        OrganizationPermission.sales_read,
+        OrganizationPermission.sales_manage,
+        OrganizationPermission.finance_read,
+        OrganizationPermission.customers_read,
+        OrganizationPermission.products_read,
+        OrganizationPermission.custom_fields_read,
+        OrganizationPermission.analytics_read,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.auth
 async def test_get_users_me_excludes_blocked_organizations(
     client: AsyncClient,
     save_fixture: SaveFixture,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Related PR**: https://github.com/polarsource/polar/pull/12805

Reworks the earlier Finance role prototype as an end-to-end RBAC change, including predictable dashboard navigation, route guards, and permission-aware write controls.

## What

- Adds the assignable `finance` organization role and generated API client types.
- Grants sales read/write plus read-only finance, customer, product, custom-field, and analytics access.
- Filters dashboard routes and search actions from embedded organization permissions.
- Adds direct guards for product-management and dispute routes.
- Hides product, customer, payout, and dashboard customization actions when their manage permission is absent.
- Documents and tests the Finance permission contract.

## Why

The original prototype only added backend role plumbing. Without frontend integration, Finance users would see inaccessible routes and controls that fail after interaction. This version makes the UI reflect the same permission set enforced by the API while retaining explicit direct-URL guards.

## How

Dashboard routes declare their required permission and are filtered against the permission array embedded in the authenticated organization payload. `useHasPermission` and the route resolver share that payload as the source of truth. Server layouts remain the authoritative direct-navigation guard.

## Verification

- 32 focused backend permission, policy, API embedding, role catalog, and role-assignment tests pass.
- 5 dashboard permission-hook and route-filter tests pass.
- Frontend lint and typecheck pass.
- Backend lint and typecheck pass.
- Real OTP flow: admin assigned the Finance role, then the Finance user verified filtered navigation, read-only controls, and direct-route denial.

[finance_role_dashboard_permissions.mp4](https://cursor.com/agents/bc-1fa4fa1b-f655-4d64-96f5-06e1ab31c7c0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffinance_role_dashboard_permissions.mp4)

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1fa4fa1b-f655-4d64-96f5-06e1ab31c7c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1fa4fa1b-f655-4d64-96f5-06e1ab31c7c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

