### PR TITLE
server: Use AnyIO for subprocesses

### DIFF
--- a/server/emails/README.md
+++ b/server/emails/README.md
@@ -71,12 +71,12 @@ enqueue_email_template(
 )
 ```
 
-If you need to render synchronously (e.g. in scripts or workers that already run outside the event loop), you can use `render_email_template` directly:
+If you need to render a template directly, use `render_email_template` from an async context:
 
 ```python
 from polar.email.react import render_email_template
 
-body = render_email_template(email)
+body = await render_email_template(email)
 ```
 
 ## How does it work?

--- a/server/polar/backoffice/email_logs/endpoints.py
+++ b/server/polar/backoffice/email_logs/endpoints.py
@@ -162,7 +162,7 @@ async def get_email_log(
     rendered_html: str | None = None
     if email_log.email_template is not None:
         try:
-            rendered_html = render_from_json(
+            rendered_html = await render_from_json(
                 email_log.email_template,
                 json.dumps(email_log.email_props, default=str),
             )

--- a/server/polar/email/react.py
+++ b/server/polar/email/react.py
@@ -1,6 +1,7 @@
 import re
-import subprocess
 from typing import TYPE_CHECKING
+
+import anyio
 
 from polar.config import settings
 
@@ -17,20 +18,22 @@ def _transform_avatar_urls_for_email(props_json: str) -> str:
     )
 
 
-def render_from_json(template: str, props_json: str) -> str:
-    process = subprocess.Popen(
+async def render_from_json(template: str, props_json: str) -> str:
+    process = await anyio.run_process(
         [
             settings.EMAIL_RENDERER_BINARY_PATH,
             template,
             props_json,
         ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        check=False,
     )
-    stdout, stderr = process.communicate()
     if process.returncode != 0:
-        raise Exception(f"Error in react-email process: {stderr.decode('utf-8')}")
-    return stdout.decode("utf-8")
+        assert process.stderr is not None
+        raise Exception(
+            f"Error in react-email process: {process.stderr.decode('utf-8')}"
+        )
+    assert process.stdout is not None
+    return process.stdout.decode("utf-8")
 
 
 def serialize_email_props(email: "Email") -> str:
@@ -38,8 +41,8 @@ def serialize_email_props(email: "Email") -> str:
     return _transform_avatar_urls_for_email(props_json)
 
 
-def render_email_template(email: "Email") -> str:
-    return render_from_json(email.template, serialize_email_props(email))
+async def render_email_template(email: "Email") -> str:
+    return await render_from_json(email.template, serialize_email_props(email))
 
 
 __all__ = ["render_email_template", "render_from_json", "serialize_email_props"]

--- a/server/polar/email/tasks.py
+++ b/server/polar/email/tasks.py
@@ -32,7 +32,7 @@ async def email_send(
     if html_content is None:
         assert template is not None
         assert props_json is not None
-        html_content = render_from_json(template, props_json)
+        html_content = await render_from_json(template, props_json)
 
     processor_id: str | None = None
     status = EmailLogStatus.sent

--- a/server/polar/invoice/render.py
+++ b/server/polar/invoice/render.py
@@ -1,10 +1,9 @@
-import asyncio
 import os
 import sys
 import traceback
-from asyncio.subprocess import PIPE
 from pathlib import Path
 
+import anyio
 from pydantic import BaseModel
 
 from .generator import Invoice, InvoiceGenerator
@@ -51,21 +50,21 @@ async def render_invoice_pdf(
     payload = InvoiceRenderRequest(
         invoice=invoice, heading_title=heading_title
     ).model_dump_json()
-    process = await asyncio.create_subprocess_exec(
-        sys.executable,
-        "-m",
-        "polar.invoice.render",
-        stdin=PIPE,
-        stdout=PIPE,
-        stderr=PIPE,
+    process = await anyio.run_process(
+        [sys.executable, "-m", "polar.invoice.render"],
+        input=payload.encode("utf-8"),
+        check=False,
         cwd=SERVER_DIRECTORY,
         env=build_invoice_renderer_env(),
     )
-    stdout, stderr = await process.communicate(payload.encode("utf-8"))
     if process.returncode != 0:
-        error = stderr.decode("utf-8").strip() or "unknown invoice renderer error"
+        assert process.stderr is not None
+        error = (
+            process.stderr.decode("utf-8").strip() or "unknown invoice renderer error"
+        )
         raise InvoiceRenderError(f"Invoice renderer failed: {error}")
-    return stdout
+    assert process.stdout is not None
+    return process.stdout
 
 
 def main() -> int:

--- a/server/polar/receipt/render.py
+++ b/server/polar/receipt/render.py
@@ -1,9 +1,8 @@
-import asyncio
 import sys
 import traceback
-from asyncio.subprocess import PIPE
 from pathlib import Path
 
+import anyio
 from pydantic import BaseModel
 
 from polar.invoice.render import build_invoice_renderer_env
@@ -13,7 +12,6 @@ from .generator import Receipt, ReceiptGenerator
 SERVER_DIRECTORY = Path(__file__).resolve().parents[2]
 
 RENDER_TIMEOUT_SECONDS = 60.0
-KILL_WAIT_SECONDS = 5.0
 
 
 class ReceiptRenderRequest(BaseModel):
@@ -25,35 +23,28 @@ class ReceiptRenderError(Exception): ...
 
 async def render_receipt_pdf(receipt: Receipt) -> bytes:
     payload = ReceiptRenderRequest(receipt=receipt).model_dump_json()
-    process = await asyncio.create_subprocess_exec(
-        sys.executable,
-        "-m",
-        "polar.receipt.render",
-        stdin=PIPE,
-        stdout=PIPE,
-        stderr=PIPE,
-        cwd=SERVER_DIRECTORY,
-        env=build_invoice_renderer_env(),
-    )
     try:
-        stdout, stderr = await asyncio.wait_for(
-            process.communicate(payload.encode("utf-8")),
-            timeout=RENDER_TIMEOUT_SECONDS,
-        )
+        with anyio.fail_after(RENDER_TIMEOUT_SECONDS):
+            process = await anyio.run_process(
+                [sys.executable, "-m", "polar.receipt.render"],
+                input=payload.encode("utf-8"),
+                check=False,
+                cwd=SERVER_DIRECTORY,
+                env=build_invoice_renderer_env(),
+            )
     except TimeoutError:
-        process.kill()
-        try:
-            await asyncio.wait_for(process.wait(), timeout=KILL_WAIT_SECONDS)
-        except TimeoutError:
-            pass
         raise ReceiptRenderError(
             f"Receipt renderer timed out after {RENDER_TIMEOUT_SECONDS}s"
         )
 
     if process.returncode != 0:
-        error = stderr.decode("utf-8").strip() or "unknown receipt renderer error"
+        assert process.stderr is not None
+        error = (
+            process.stderr.decode("utf-8").strip() or "unknown receipt renderer error"
+        )
         raise ReceiptRenderError(f"Receipt renderer failed: {error}")
-    return stdout
+    assert process.stdout is not None
+    return process.stdout
 
 
 def main() -> int:

--- a/server/tests/invoice/test_render.py
+++ b/server/tests/invoice/test_render.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import subprocess
 import sys
 from collections.abc import Mapping
 
@@ -76,40 +77,29 @@ def test_build_invoice_renderer_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "UNRELATED_RUNTIME_VAR" not in env
 
 
-class StubProcess:
-    def __init__(self, stdout: bytes, stderr: bytes, returncode: int) -> None:
-        self.stdout = stdout
-        self.stderr = stderr
-        self.returncode = returncode
-
-    async def communicate(self, input: bytes) -> tuple[bytes, bytes]:
-        self.input = input
-        return self.stdout, self.stderr
-
-
 @pytest.mark.asyncio
 async def test_render_invoice_pdf_raises_on_subprocess_failure(
     invoice: Invoice, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    process = StubProcess(b"", b"boom", 1)
     monkeypatch.setenv("POLAR_ENV", "testing")
     monkeypatch.setenv("POLAR_CUSTOM_OVERRIDE", "1")
     monkeypatch.setenv("PROMETHEUS_MULTIPROC_DIR", "/tmp/does-not-exist")
 
-    async def create_subprocess_exec(*args: object, **kwargs: object) -> StubProcess:
-        kwargs_dict = kwargs if isinstance(kwargs, Mapping) else {}
-        assert args == (sys.executable, "-m", "polar.invoice.render")
-        assert kwargs_dict["cwd"] == SERVER_DIRECTORY
-        env = kwargs_dict["env"]
+    async def run_process(
+        command: list[str], **kwargs: object
+    ) -> subprocess.CompletedProcess[bytes]:
+        assert command == [sys.executable, "-m", "polar.invoice.render"]
+        assert kwargs["input"]
+        assert kwargs["check"] is False
+        assert kwargs["cwd"] == SERVER_DIRECTORY
+        env = kwargs["env"]
         assert isinstance(env, Mapping)
         assert env["POLAR_ENV"] == "testing"
         assert env["POLAR_CUSTOM_OVERRIDE"] == "1"
         assert "PROMETHEUS_MULTIPROC_DIR" not in env
-        return process
+        return subprocess.CompletedProcess(command, 1, stdout=b"", stderr=b"boom")
 
-    monkeypatch.setattr(
-        "polar.invoice.render.asyncio.create_subprocess_exec", create_subprocess_exec
-    )
+    monkeypatch.setattr("polar.invoice.render.anyio.run_process", run_process)
 
     with pytest.raises(InvoiceRenderError, match="Invoice renderer failed: boom"):
         await render_invoice_pdf(invoice)

--- a/server/tests/notifications/test_email.py
+++ b/server/tests/notifications/test_email.py
@@ -16,7 +16,7 @@ from polar.notifications.notification import (
 
 async def check_diff(notification: NotificationPayloadBase) -> None:
     subject = notification.subject()
-    body = render_email_template(notification.to_email())
+    body = await render_email_template(notification.to_email())
     expected = f"{subject}\n<hr>\n{body}"
 
     # Run with `POLAR_TEST_RECORD=1 pytest` to produce new golden files :-)
@@ -145,7 +145,7 @@ async def test_MaintainerFileFlaggedMaliciousNotification() -> None:
 )
 async def test_injection_payloads(payload: NotificationPayloadBase) -> None:
     subject = payload.subject()
-    body = render_email_template(payload.to_email())
+    body = await render_email_template(payload.to_email())
     assert str(123456 * 9) not in subject
     assert str(123456 * 9) not in body
 
@@ -173,6 +173,6 @@ async def test_MaintainerNewProductSaleNotification_backwards_compatibility() ->
     assert n.billing_reason is None
 
     subject = n.subject()
-    body = render_email_template(n.to_email())
+    body = await render_email_template(n.to_email())
     assert "Old Product" in body
     assert "$10.00" in subject

--- a/server/tests/receipt/test_render.py
+++ b/server/tests/receipt/test_render.py
@@ -1,7 +1,8 @@
 import datetime
+import subprocess
 import sys
-from collections.abc import Mapping
 
+import anyio
 import pytest
 
 from polar.invoice.generator import InvoiceItem
@@ -67,75 +68,45 @@ async def test_render_receipt_pdf(receipt: Receipt) -> None:
     assert pdf.startswith(b"%PDF")
 
 
-class StubProcess:
-    def __init__(self, stdout: bytes, stderr: bytes, returncode: int) -> None:
-        self.stdout = stdout
-        self.stderr = stderr
-        self.returncode = returncode
-
-    async def communicate(self, input: bytes) -> tuple[bytes, bytes]:
-        self.input = input
-        return self.stdout, self.stderr
-
-
 @pytest.mark.asyncio
 async def test_render_receipt_pdf_raises_on_subprocess_failure(
     receipt: Receipt, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    process = StubProcess(b"", b"boom", 1)
+    async def run_process(
+        command: list[str], **kwargs: object
+    ) -> subprocess.CompletedProcess[bytes]:
+        assert command == [sys.executable, "-m", "polar.receipt.render"]
+        assert kwargs["input"]
+        assert kwargs["check"] is False
+        assert kwargs["cwd"] == SERVER_DIRECTORY
+        return subprocess.CompletedProcess(command, 1, stdout=b"", stderr=b"boom")
 
-    async def create_subprocess_exec(*args: object, **kwargs: object) -> StubProcess:
-        kwargs_dict = kwargs if isinstance(kwargs, Mapping) else {}
-        assert args == (sys.executable, "-m", "polar.receipt.render")
-        assert kwargs_dict["cwd"] == SERVER_DIRECTORY
-        return process
-
-    monkeypatch.setattr(
-        "polar.receipt.render.asyncio.create_subprocess_exec", create_subprocess_exec
-    )
+    monkeypatch.setattr("polar.receipt.render.anyio.run_process", run_process)
 
     with pytest.raises(ReceiptRenderError, match="Receipt renderer failed: boom"):
         await render_receipt_pdf(receipt)
-
-
-class HangingProcess:
-    """Simulates a subprocess that hangs forever on communicate."""
-
-    def __init__(self) -> None:
-        self.killed = False
-        self.returncode: int | None = None
-
-    async def communicate(self, input: bytes) -> tuple[bytes, bytes]:
-        # Hang forever.
-        import asyncio
-
-        await asyncio.sleep(3600)
-        return b"", b""
-
-    def kill(self) -> None:
-        self.killed = True
-        self.returncode = -9
-
-    async def wait(self) -> int:
-        return self.returncode or 0
 
 
 @pytest.mark.asyncio
 async def test_render_receipt_pdf_timeout(
     receipt: Receipt, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    process = HangingProcess()
+    cancelled = False
 
-    async def create_subprocess_exec(*args: object, **kwargs: object) -> HangingProcess:
-        return process
+    async def run_process(
+        command: list[str], **kwargs: object
+    ) -> subprocess.CompletedProcess[bytes]:
+        nonlocal cancelled
+        try:
+            await anyio.sleep_forever()
+            raise AssertionError("unreachable")
+        finally:
+            cancelled = True
 
-    monkeypatch.setattr(
-        "polar.receipt.render.asyncio.create_subprocess_exec", create_subprocess_exec
-    )
+    monkeypatch.setattr("polar.receipt.render.anyio.run_process", run_process)
     monkeypatch.setattr("polar.receipt.render.RENDER_TIMEOUT_SECONDS", 0.1)
-    monkeypatch.setattr("polar.receipt.render.KILL_WAIT_SECONDS", 0.1)
 
     with pytest.raises(ReceiptRenderError, match="timed out"):
         await render_receipt_pdf(receipt)
 
-    assert process.killed
+    assert cancelled


### PR DESCRIPTION
## Summary

- make React email rendering asynchronous with `anyio.run_process`
- move invoice and receipt subprocess execution from `asyncio` to AnyIO
- preserve renderer error handling and receipt timeout cancellation
- update email rendering call sites, tests, and documentation for the async API

## Why

The email renderer used `subprocess.Popen().communicate()` inside async worker and backoffice code, blocking the event loop until the renderer completed. AnyIO runs and supervises these subprocesses asynchronously, including cancellation cleanup.

Closes #10021.

## Validation

- `POLAR_ENV=testing uv run python -m pytest tests/email/test_tasks.py tests/notifications/test_email.py tests/invoice/test_render.py tests/receipt/test_render.py` — 22 passed
- `uv run task lint`
- `uv run task lint_types`
- ADR check — no violations