### PR TITLE
polar: Sync member role to Polar customer

### DIFF
--- a/server/polar/integrations/polar/client.py
+++ b/server/polar/integrations/polar/client.py
@@ -24,9 +24,11 @@ from polar.v2026_04.inputs import (
     EventCreateExternalCustomer,
     EventMetadataInput,
     LLMMetadata,
+    MemberUpdate,
 )
 from polar.v2026_04.literals import (
     DiscountDuration,
+    MemberRole,
     SubscriptionProrationBehavior,
 )
 from polar.v2026_04.literals import (
@@ -452,18 +454,27 @@ class PolarSelfClient:
                 _raise_network_error(span, e, "add_member")
 
     async def update_member(
-        self, *, external_customer_id: str, external_id: str, name: str
+        self,
+        *,
+        external_customer_id: str,
+        external_id: str,
+        name: str,
+        role: str | None = None,
     ) -> None:
         with logfire.span(
             "polar.update_member",
             external_customer_id=external_customer_id,
             external_id=external_id,
+            role=role,
         ) as span:
+            member_update: MemberUpdate = {"name": name}
+            if role is not None:
+                member_update["role"] = cast(MemberRole, role)
             try:
                 await self._sdk.customers.members.update_external(
                     external_customer_id,
                     external_id,
-                    name=name,
+                    **member_update,
                 )
             except (PolarClientError, PolarServerError) as e:
                 if e.status_code == 404:

--- a/server/polar/integrations/polar/service.py
+++ b/server/polar/integrations/polar/service.py
@@ -156,7 +156,12 @@ class PolarSelfService:
         )
 
     def enqueue_update_member(
-        self, *, external_customer_id: str, external_id: str, name: str
+        self,
+        *,
+        external_customer_id: str,
+        external_id: str,
+        name: str,
+        role: MemberRole | None = None,
     ) -> None:
         if not self.is_configured:
             return
@@ -165,6 +170,7 @@ class PolarSelfService:
             external_customer_id=external_customer_id,
             external_id=external_id,
             name=name,
+            role=role.value if role is not None else None,
         )
 
     def enqueue_update_customer_slug(

--- a/server/polar/integrations/polar/tasks.py
+++ b/server/polar/integrations/polar/tasks.py
@@ -104,11 +104,27 @@ async def add_member(
 
 
 @actor(actor_name="polar_self.update_member", priority=TaskPriority.LOW)
-async def update_member(external_customer_id: str, external_id: str, name: str) -> None:
-    await get_client().update_member(
+async def update_member(
+    external_customer_id: str, external_id: str, name: str, role: str | None = None
+) -> None:
+    client = get_client()
+    try:
+        await client.get_member_by_external_id(
+            external_customer_id=external_customer_id,
+            external_id=external_id,
+        )
+    except PolarClientError as e:
+        if e.status_code == 404 and can_retry():
+            raise Retry(delay=1000) from e
+        if e.status_code == 404:
+            return
+        raise
+
+    await client.update_member(
         external_customer_id=external_customer_id,
         external_id=external_id,
         name=name,
+        role=role,
     )
 
 

--- a/server/polar/user_organization/service.py
+++ b/server/polar/user_organization/service.py
@@ -7,6 +7,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload
 
 from polar.exceptions import PolarError
+from polar.integrations.polar.service import billing_member_role
 from polar.integrations.polar.service import polar_self as polar_self_service
 from polar.kit.utils import utc_now
 from polar.models import User, UserOrganization
@@ -214,6 +215,13 @@ class UserOrganizationService:
             .values(role=role)
         )
         user_org.role = role
+        user = user_org.user
+        polar_self_service.enqueue_update_member(
+            external_customer_id=str(organization_id),
+            external_id=str(user_id),
+            name=user.full_name or user.email.split("@", 1)[0],
+            role=billing_member_role(role),
+        )
         log.info(
             "organization.member.role_changed",
             organization_id=organization_id,
@@ -267,6 +275,12 @@ class UserOrganizationService:
             # different user as owner. Surface as `AlreadyOwner` so the
             # caller can refresh state and retry.
             raise AlreadyOwner(new_owner_user_id, organization_id) from e
+        polar_self_service.enqueue_update_member(
+            external_customer_id=str(organization_id),
+            external_id=str(new_owner_user_id),
+            name=new_owner_user.full_name or new_owner_user.email.split("@", 1)[0],
+            role=billing_member_role(OrganizationRole.owner),
+        )
         log.info(
             "organization.ownership.transferred",
             organization_id=organization_id,

--- a/server/tests/integrations/polar/test_service.py
+++ b/server/tests/integrations/polar/test_service.py
@@ -38,6 +38,7 @@ from polar.integrations.polar.exceptions import (
     TransactionFeeBenefitError,
 )
 from polar.integrations.polar.service import polar_self
+from polar.models.member import MemberRole
 from polar.models.organization import Organization, SupportTier
 from polar.postgres import AsyncReadSession, AsyncSession
 
@@ -309,6 +310,47 @@ def list_grants_mock(mocker: MockerFixture) -> AsyncMock:
     client.list_customer_benefit_grants = AsyncMock(return_value=[])
     mocker.patch("polar.integrations.polar.service.get_client", return_value=client)
     return client.list_customer_benefit_grants
+
+
+class TestEnqueueUpdateMember:
+    def test_enqueues_with_role_value(
+        self, configured: None, mocker: MockerFixture
+    ) -> None:
+        enqueue = mocker.patch("polar.integrations.polar.service.enqueue_job")
+
+        polar_self.enqueue_update_member(
+            external_customer_id="org-123",
+            external_id="user-123",
+            name="Jane",
+            role=MemberRole.billing_manager,
+        )
+
+        enqueue.assert_called_once_with(
+            "polar_self.update_member",
+            external_customer_id="org-123",
+            external_id="user-123",
+            name="Jane",
+            role="billing_manager",
+        )
+
+    def test_enqueues_without_role(
+        self, configured: None, mocker: MockerFixture
+    ) -> None:
+        enqueue = mocker.patch("polar.integrations.polar.service.enqueue_job")
+
+        polar_self.enqueue_update_member(
+            external_customer_id="org-123",
+            external_id="user-123",
+            name="Jane",
+        )
+
+        enqueue.assert_called_once_with(
+            "polar_self.update_member",
+            external_customer_id="org-123",
+            external_id="user-123",
+            name="Jane",
+            role=None,
+        )
 
 
 class TestEnqueueTrackOrganizationReviewUsage:

--- a/server/tests/integrations/polar/test_tasks.py
+++ b/server/tests/integrations/polar/test_tasks.py
@@ -245,6 +245,7 @@ class TestUpdateMember:
         mocker: MockerFixture,
     ) -> None:
         client = AsyncMock(spec=PolarSelfClient)
+        client.get_member_by_external_id.return_value = MagicMock(id="member-123")
         mocker.patch("polar.integrations.polar.tasks.get_client", return_value=client)
 
         await update_member(
@@ -257,7 +258,73 @@ class TestUpdateMember:
             external_customer_id="org-123",
             external_id="user-123",
             name="Updated Name",
+            role=None,
         )
+
+    async def test_forwards_role(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        client = AsyncMock(spec=PolarSelfClient)
+        client.get_member_by_external_id.return_value = MagicMock(id="member-123")
+        mocker.patch("polar.integrations.polar.tasks.get_client", return_value=client)
+
+        await update_member(
+            external_customer_id="org-123",
+            external_id="user-123",
+            name="Updated Name",
+            role="billing_manager",
+        )
+
+        client.update_member.assert_called_once_with(
+            external_customer_id="org-123",
+            external_id="user-123",
+            name="Updated Name",
+            role="billing_manager",
+        )
+
+    async def test_retries_when_member_is_not_ready(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        client = AsyncMock(spec=PolarSelfClient)
+        client.get_member_by_external_id.side_effect = ResourceNotFound(
+            404,
+            ResourceNotFoundData(error="ResourceNotFound", detail="Not found"),
+        )
+        mocker.patch("polar.integrations.polar.tasks.get_client", return_value=client)
+        mocker.patch("polar.integrations.polar.tasks.can_retry", return_value=True)
+
+        with pytest.raises(Retry):
+            await update_member(
+                external_customer_id="org-123",
+                external_id="user-123",
+                name="Updated Name",
+                role="billing_manager",
+            )
+
+        client.update_member.assert_not_called()
+
+    async def test_noops_when_member_never_appears(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        client = AsyncMock(spec=PolarSelfClient)
+        client.get_member_by_external_id.side_effect = ResourceNotFound(
+            404,
+            ResourceNotFoundData(error="ResourceNotFound", detail="Not found"),
+        )
+        mocker.patch("polar.integrations.polar.tasks.get_client", return_value=client)
+        mocker.patch("polar.integrations.polar.tasks.can_retry", return_value=False)
+
+        await update_member(
+            external_customer_id="org-123",
+            external_id="user-123",
+            name="Updated Name",
+            role="billing_manager",
+        )
+
+        client.update_member.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/server/tests/user_organization/test_service.py
+++ b/server/tests/user_organization/test_service.py
@@ -5,6 +5,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from polar.models import Account, Organization, User, UserOrganization
+from polar.models.member import MemberRole
 from polar.models.user import IdentityVerificationStatus
 from polar.models.user_organization import OrganizationRole
 from polar.user_organization.service import (
@@ -324,6 +325,95 @@ class TestSetRole:
 
         assert result.role == OrganizationRole.admin
 
+    async def test_promotion_syncs_billing_member_role(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: Any,
+        organization: Organization,
+        user_second: User,
+    ) -> None:
+        enqueue_update_member_mock = mocker.patch(
+            "polar.user_organization.service.polar_self_service.enqueue_update_member"
+        )
+        relation = UserOrganization(
+            user_id=user_second.id, organization_id=organization.id
+        )
+        await save_fixture(relation)
+
+        await user_organization_service.set_role(
+            session,
+            user_id=user_second.id,
+            organization_id=organization.id,
+            role=OrganizationRole.admin,
+        )
+
+        enqueue_update_member_mock.assert_called_once_with(
+            external_customer_id=str(organization.id),
+            external_id=str(user_second.id),
+            name=user_second.email.split("@", 1)[0],
+            role=MemberRole.billing_manager,
+        )
+
+    async def test_demotion_syncs_billing_member_role(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: Any,
+        organization: Organization,
+        user_second: User,
+    ) -> None:
+        enqueue_update_member_mock = mocker.patch(
+            "polar.user_organization.service.polar_self_service.enqueue_update_member"
+        )
+        relation = UserOrganization(
+            user_id=user_second.id,
+            organization_id=organization.id,
+            role=OrganizationRole.admin,
+        )
+        await save_fixture(relation)
+
+        await user_organization_service.set_role(
+            session,
+            user_id=user_second.id,
+            organization_id=organization.id,
+            role=OrganizationRole.member,
+        )
+
+        enqueue_update_member_mock.assert_called_once_with(
+            external_customer_id=str(organization.id),
+            external_id=str(user_second.id),
+            name=user_second.email.split("@", 1)[0],
+            role=MemberRole.member,
+        )
+
+    async def test_unchanged_role_does_not_sync(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: Any,
+        organization: Organization,
+        user_second: User,
+    ) -> None:
+        enqueue_update_member_mock = mocker.patch(
+            "polar.user_organization.service.polar_self_service.enqueue_update_member"
+        )
+        relation = UserOrganization(
+            user_id=user_second.id,
+            organization_id=organization.id,
+            role=OrganizationRole.admin,
+        )
+        await save_fixture(relation)
+
+        await user_organization_service.set_role(
+            session,
+            user_id=user_second.id,
+            organization_id=organization.id,
+            role=OrganizationRole.admin,
+        )
+
+        enqueue_update_member_mock.assert_not_called()
+
     async def test_owner_role_rejected(
         self,
         save_fixture: SaveFixture,
@@ -427,6 +517,48 @@ class TestTransferOwnership:
         assert previous.role == OrganizationRole.admin
         assert new is not None
         assert new.role == OrganizationRole.owner
+
+    async def test_syncs_billing_member_role_for_new_owner(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        session: Any,
+        organization: Organization,
+        user: User,
+        user_second: User,
+    ) -> None:
+        enqueue_update_member_mock = mocker.patch(
+            "polar.user_organization.service.polar_self_service.enqueue_update_member"
+        )
+        await save_fixture(
+            UserOrganization(
+                user_id=user.id,
+                organization_id=organization.id,
+                role=OrganizationRole.owner,
+            )
+        )
+        await save_fixture(
+            UserOrganization(
+                user_id=user_second.id,
+                organization_id=organization.id,
+                role=OrganizationRole.member,
+            )
+        )
+        user_second.identity_verification_status = IdentityVerificationStatus.verified
+        await save_fixture(user_second)
+
+        await user_organization_service.transfer_ownership(
+            session,
+            new_owner_user_id=user_second.id,
+            organization_id=organization.id,
+        )
+
+        enqueue_update_member_mock.assert_called_once_with(
+            external_customer_id=str(organization.id),
+            external_id=str(user_second.id),
+            name=user_second.email.split("@", 1)[0],
+            role=MemberRole.billing_manager,
+        )
 
     async def test_rejects_unverified_user(
         self,


### PR DESCRIPTION
Fixes https://github.com/polarsource/feedback/issues/216

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync organization member role changes to the Polar customer so billing permissions stay accurate. Extends the Polar Self client and background job to update member role alongside name, with safe retries if the member isn’t ready yet.

- **Bug Fixes**
  - Added optional role to client `update_member` and forwarded it to the SDK (`MemberUpdate.role`).
  - Task now checks member existence and retries on 404 when allowed; no-ops otherwise. Still forwards role (or `None`).
  - `enqueue_update_member` accepts `MemberRole | None` and passes `role.value`.
  - On `set_role` and `transfer_ownership`, enqueue a role sync using `billing_member_role`; skip when unchanged.
  - Added tests for enqueueing, task retry/no-op, and syncing on promotion/demotion/ownership transfer.

<sup>Written for commit 05f16ce46208f4d6b7c0b8510af583c695fd78f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

