### PR TITLE
config: Don't mask the DB password in DB config

### DIFF
--- a/server/polar/config.py
+++ b/server/polar/config.py
@@ -612,20 +612,18 @@ class Settings(BaseSettings):
                     path=database,
                 )
             )
-        return str(
-            URL.create(
-                f"postgresql+{driver}",
-                username=username,
-                password=password,
-                database=database,
-                query={
-                    "host": [
-                        f"{host}:{port}",
-                        f"{fallback_host}:{fallback_port or port}",
-                    ]
-                },
-            )
-        )
+        return URL.create(
+            f"postgresql+{driver}",
+            username=username,
+            password=password,
+            database=database,
+            query={
+                "host": [
+                    f"{host}:{port}",
+                    f"{fallback_host}:{fallback_port or port}",
+                ]
+            },
+        ).render_as_string(hide_password=False)
 
     def get_postgres_dsn(self, driver: Literal["asyncpg", "psycopg2"]) -> str:
         return self._build_postgres_dsn(

--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -1,0 +1,62 @@
+from typing import Any, Literal
+
+from sqlalchemy.dialects.postgresql.asyncpg import PGDialect_asyncpg
+from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
+from sqlalchemy.engine import make_url
+
+from polar.config import settings
+
+
+def build_dsn(
+    driver: Literal["asyncpg", "psycopg2"],
+    *,
+    fallback_host: str | None = "fallback.example.com",
+    fallback_port: int | None = 5432,
+) -> str:
+    return settings._build_postgres_dsn(
+        driver,
+        username="polar",
+        password="s3cret",
+        host="primary.example.com",
+        port=6432,
+        database="polar",
+        fallback_host=fallback_host,
+        fallback_port=fallback_port,
+    )
+
+
+def get_connect_args(dsn: str) -> dict[str, Any]:
+    url = make_url(dsn)
+    dialect = (
+        PGDialect_asyncpg()
+        if url.drivername.endswith("asyncpg")
+        else PGDialect_psycopg2()
+    )
+    _, connect_args = dialect.create_connect_args(url)
+    return connect_args
+
+
+class TestBuildPostgresDsn:
+    def test_no_fallback(self) -> None:
+        dsn = build_dsn("asyncpg", fallback_host=None, fallback_port=None)
+
+        assert dsn == "postgresql+asyncpg://polar:s3cret@primary.example.com:6432/polar"
+
+    def test_fallback_asyncpg(self) -> None:
+        connect_args = get_connect_args(build_dsn("asyncpg"))
+
+        assert connect_args["host"] == ["primary.example.com", "fallback.example.com"]
+        assert connect_args["port"] == [6432, 5432]
+        assert connect_args["password"] == "s3cret"
+
+    def test_fallback_psycopg2(self) -> None:
+        connect_args = get_connect_args(build_dsn("psycopg2"))
+
+        assert connect_args["host"] == "primary.example.com,fallback.example.com"
+        assert connect_args["port"] == "6432,5432"
+        assert connect_args["password"] == "s3cret"
+
+    def test_fallback_port_defaults_to_primary_port(self) -> None:
+        connect_args = get_connect_args(build_dsn("asyncpg", fallback_port=None))
+
+        assert connect_args["port"] == [6432, 6432]


### PR DESCRIPTION
Without this we connect with a masked password which fails connection. This is likely the root cause why we couldn't connect to pgbouncer when we rolled it out initially.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DB connections by emitting an unmasked Postgres DSN from config, ensuring the real password is used (including with pgbouncer). Fallback host/port behavior remains intact for both drivers.

- **Bug Fixes**
  - Build DSN with URL.render_as_string(hide_password=False) so the password isn’t masked.
  - Added tests for `asyncpg` and `psycopg2` covering no-fallback and fallback cases, password passthrough, and defaulting fallback port to the primary port.

<sup>Written for commit 0bf299855aa56c9bc8d3c8e7cf3ee072defba665. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

