### PR TITLE
Fix Sentry reporting from Lambda workers

### DIFF
--- a/server/polar/sentry.py
+++ b/server/polar/sentry.py
@@ -6,6 +6,7 @@ import sentry_sdk
 from dramatiq import get_broker
 from sentry_sdk.integrations.argv import ArgvIntegration
 from sentry_sdk.integrations.atexit import AtexitIntegration
+from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
 from sentry_sdk.integrations.dedupe import DedupeIntegration
 from sentry_sdk.integrations.dramatiq import DramatiqIntegration as _DramatiqIntegration
 from sentry_sdk.integrations.dramatiq import SentryMiddleware
@@ -47,7 +48,7 @@ def before_send(event: Event, hint: Hint) -> Event | None:
     return event
 
 
-def configure_sentry() -> None:
+def configure_sentry(*, aws_lambda: bool = False) -> None:
     sentry_sdk.init(
         dsn=settings.SENTRY_DSN,
         traces_sample_rate=None,  # `0` still opts in to trace continuation
@@ -74,6 +75,7 @@ def configure_sentry() -> None:
             StarletteIntegration(transaction_style="endpoint"),
             FastApiIntegration(transaction_style="endpoint"),
             DramatiqIntegration(),
+            *([AwsLambdaIntegration()] if aws_lambda else []),
         ],
     )
 

--- a/server/polar/worker/aws_lambda.py
+++ b/server/polar/worker/aws_lambda.py
@@ -2,6 +2,7 @@ import asyncio
 from typing import Any
 
 import logfire
+import sentry_sdk
 import structlog
 
 from polar.config import settings
@@ -22,7 +23,7 @@ from ._sqs import (
     set_message_visibility,
 )
 
-configure_sentry()
+configure_sentry(aws_lambda=True)
 configure_logfire("worker")
 configure_logging(logfire=True)
 
@@ -58,6 +59,7 @@ def handler(event: dict[str, Any], context: Any) -> dict[str, Any]:
                     )
                 )
             except Exception as exc:
+                sentry_sdk.capture_exception(exc)
                 log.error(
                     "polar.worker.sqs_task_failed",
                     message_id=message_id,
@@ -135,6 +137,7 @@ def _apply_retry_backoff(record: dict[str, Any], exception: BaseException) -> bo
             backoff_seconds=delay_seconds,
         )
         return True
-    except Exception:
+    except Exception as exc:
+        sentry_sdk.capture_exception(exc)
         log.error("polar.worker.sqs_backoff_failed", exc_info=True)
         return True


### PR DESCRIPTION
## Summary

- enable Sentry's AWS Lambda integration for the Lambda worker entrypoint
- explicitly capture task and retry-backoff exceptions that are intentionally handled by the SQS partial-batch flow

## Root cause

The worker caught task exceptions so it could apply retry backoff and return an SQS partial-batch response. Sentry's logging integration is configured for breadcrumbs only, so those handled exceptions never became Sentry events. Default Sentry integrations are disabled globally, which also meant the AWS Lambda integration was absent and the Lambda lifecycle did not drain the Sentry transport.

Fixes #13366

## Validation

- `uv run task lint`
- `uv run task lint_types`
- ADR compliance check — no violations