### PR TITLE
slack-benefit: Handle transient errors with a retry

### DIFF
--- a/server/polar/benefit/strategies/slack_shared_channel/service.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/service.py
@@ -42,7 +42,7 @@ log: Logger = structlog.get_logger()
 _PROVISIONING_LOCK_TTL_SECONDS = 60
 
 _ARCHIVE_NOOP_ERRORS = {"already_archived", "channel_not_found"}
-_ARCHIVE_TRANSIENT_ERRORS = {
+_TRANSIENT_ERRORS = {
     "ratelimited",
     "internal_error",
     "fatal_error",
@@ -263,7 +263,7 @@ class BenefitSlackSharedChannelService(
                     grant_properties, keep_channel=error != "channel_not_found"
                 )
             bound_logger.warning("Slack archive returned error", error=error)
-            if error in _ARCHIVE_TRANSIENT_ERRORS:
+            if error in _TRANSIENT_ERRORS:
                 raise BenefitRetriableError()
             raise BenefitActionRequiredError(f"Slack archive error: {error}")
 
@@ -504,7 +504,7 @@ class BenefitSlackSharedChannelService(
         if result.get("ok") or error == "not_archived":
             return True
 
-        if error in _ARCHIVE_TRANSIENT_ERRORS:
+        if error in _TRANSIENT_ERRORS:
             raise BenefitRetriableError()
 
         bound_logger.info(
@@ -618,6 +618,8 @@ class BenefitSlackSharedChannelService(
 
         if not result.get("ok"):
             error = result.get("error", "")
+            if error in _TRANSIENT_ERRORS:
+                raise BenefitRetriableError()
             raise BenefitActionRequiredError(f"Slack invite error: {error}")
 
         return result

--- a/server/polar/benefit/strategies/slack_shared_channel/service.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/service.py
@@ -1,4 +1,3 @@
-import secrets
 from typing import Any, Unpack, cast
 from uuid import UUID
 
@@ -142,6 +141,7 @@ class BenefitSlackSharedChannelService(
                 template=properties["channel_name_template"],
                 context=context,
                 is_private=properties["private"],
+                suffix=customer.id.hex[:4],
                 bound_logger=bound_logger,
             )
 
@@ -393,12 +393,10 @@ class BenefitSlackSharedChannelService(
         self,
         *,
         bot_token: str,
-        template: str,
-        context: TemplateContext,
+        name: str,
         is_private: bool,
         bound_logger: Any,
     ) -> tuple[str, str] | None:
-        name = self._render_channel_name(template, context)
         types = ["private_channel"] if is_private else ["public_channel"]
         cursor: str | None = None
 
@@ -521,6 +519,7 @@ class BenefitSlackSharedChannelService(
         template: str,
         context: TemplateContext,
         is_private: bool,
+        suffix: str,
         bound_logger: Any,
     ) -> tuple[str, str, bool]:
         name = self._render_channel_name(template, context)
@@ -537,8 +536,7 @@ class BenefitSlackSharedChannelService(
 
         existing = await self._find_channel_by_name(
             bot_token=bot_token,
-            template=template,
-            context=context,
+            name=name,
             is_private=is_private,
             bound_logger=bound_logger,
         )
@@ -546,15 +544,26 @@ class BenefitSlackSharedChannelService(
             channel_id, channel_name = existing
             return channel_id, channel_name, False
 
-        name = self._render_channel_name(template, context, suffix=secrets.token_hex(2))
+        suffixed_name = self._render_channel_name(template, context, suffix=suffix)
         result = await self._create_channel_once(
-            bot_token=bot_token, name=name, is_private=is_private
+            bot_token=bot_token, name=suffixed_name, is_private=is_private
         )
         if result.get("ok"):
             channel = result.get("channel") or {}
-            return channel["id"], channel.get("name", name), True
+            return channel["id"], channel.get("name", suffixed_name), True
 
         error = result.get("error", "")
+        if error == "name_taken":
+            existing = await self._find_channel_by_name(
+                bot_token=bot_token,
+                name=suffixed_name,
+                is_private=is_private,
+                bound_logger=bound_logger,
+            )
+            if existing:
+                channel_id, channel_name = existing
+                return channel_id, channel_name, False
+
         raise BenefitActionRequiredError(f"Slack error: {error}")
 
     async def _create_channel_once(

--- a/server/tests/benefit/strategies/test_slack_shared_channel.py
+++ b/server/tests/benefit/strategies/test_slack_shared_channel.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock
 from uuid import uuid4
 
@@ -1089,6 +1089,85 @@ class TestSlackSharedChannelGrant:
 
         with pytest.raises(BenefitRetriableError):
             await strategy.grant(benefit, customer, existing)
+
+    @pytest.mark.parametrize(
+        "error",
+        ["ratelimited", "internal_error", "fatal_error", "service_unavailable"],
+    )
+    async def test_grant_invite_transient_error_is_retriable(
+        self,
+        error: str,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        customer.name = "Acme"
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_invite_shared=AsyncMock(
+                return_value={"ok": False, "error": error}
+            ),
+        )
+        strategy = _strategy(session, redis, client)
+
+        with pytest.raises(BenefitRetriableError):
+            await strategy.grant(
+                benefit,
+                customer,
+                {"invited_email": "admin@customer.example"},
+            )
+
+    async def test_grant_invite_permanent_error_raises_action_required(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        customer.name = "Acme"
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_invite_shared=AsyncMock(
+                return_value={"ok": False, "error": "invalid_email"}
+            ),
+        )
+        strategy = _strategy(session, redis, client)
+
+        with pytest.raises(
+            BenefitActionRequiredError, match="invalid_email"
+        ) as exc_info:
+            await strategy.grant(
+                benefit,
+                customer,
+                {"invited_email": "admin@customer.example"},
+            )
+
+        grant_properties = cast(
+            BenefitGrantSlackSharedChannelProperties | None,
+            exc_info.value.grant_properties,
+        )
+        assert grant_properties is not None
+        assert grant_properties["channel_id"] == "C123"
+        assert grant_properties["channel_name"] == "support-acme"
 
     async def test_grant_retries_on_name_taken(
         self,

--- a/server/tests/benefit/strategies/test_slack_shared_channel.py
+++ b/server/tests/benefit/strategies/test_slack_shared_channel.py
@@ -1208,6 +1208,134 @@ class TestSlackSharedChannelGrant:
         assert result["channel_id"] == "C456"
         assert client.conversations_create.await_count == 2
 
+    async def test_grant_retry_after_transient_invite_error_reuses_channel(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        customer.name = "Acme"
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_create=AsyncMock(
+                side_effect=[
+                    {"ok": True, "channel": {"id": "C123", "name": "support-acme"}},
+                    {"ok": False, "error": "name_taken"},
+                ]
+            ),
+            conversations_list=AsyncMock(
+                return_value={
+                    "ok": True,
+                    "channels": [
+                        {
+                            "id": "C123",
+                            "name": "support-acme",
+                            "is_private": True,
+                            "is_member": True,
+                            "is_archived": False,
+                        }
+                    ],
+                }
+            ),
+            conversations_invite_shared=AsyncMock(
+                side_effect=[
+                    {"ok": False, "error": "internal_error"},
+                    {
+                        "ok": True,
+                        "invite_id": "I123",
+                        "url": "https://slack.com/share/I123",
+                    },
+                ]
+            ),
+        )
+        strategy = _strategy(session, redis, client)
+
+        with pytest.raises(BenefitRetriableError):
+            await strategy.grant(
+                benefit,
+                customer,
+                {"invited_email": "admin@customer.example"},
+            )
+
+        result = await strategy.grant(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example"},
+        )
+
+        assert result["channel_id"] == "C123"
+        assert result["invite_id"] == "I123"
+        assert client.conversations_create.await_count == 2
+
+    async def test_grant_retry_adopts_suffixed_channel(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        customer.name = "Acme"
+        suffixed_name = f"support-acme-{customer.id.hex[:4]}"
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_create=AsyncMock(
+                return_value={"ok": False, "error": "name_taken"}
+            ),
+            conversations_list=AsyncMock(
+                return_value={
+                    "ok": True,
+                    "channels": [
+                        {
+                            "id": "CTAKEN",
+                            "name": "support-acme",
+                            "is_private": True,
+                            "is_member": False,
+                            "is_archived": False,
+                        },
+                        {
+                            "id": "CSUFFIXED",
+                            "name": suffixed_name,
+                            "is_private": True,
+                            "is_member": True,
+                            "is_archived": False,
+                        },
+                    ],
+                }
+            ),
+        )
+        strategy = _strategy(session, redis, client)
+
+        result = await strategy.grant(
+            benefit,
+            customer,
+            {"invited_email": "admin@customer.example"},
+        )
+
+        assert result["channel_id"] == "CSUFFIXED"
+        assert result["channel_name"] == suffixed_name
+        client.conversations_create.assert_awaited_with(
+            bot_token="xoxb-test-token", name=suffixed_name, is_private=True
+        )
+
     async def test_grant_name_taken_twice_raises(
         self,
         session: AsyncSession,


### PR DESCRIPTION
Solves https://github.com/polarsource/feedback/issues/176

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add retries for transient Slack API errors in the shared channel benefit and make fallback channel names deterministic to avoid duplicates after retries. This reduces failed grants and prevents duplicate channels while keeping permanent failures clear.

- **Bug Fixes**
  - Retry on `_TRANSIENT_ERRORS` (`ratelimited`, `internal_error`, `fatal_error`, `service_unavailable`) during archive, unarchive, and invite; permanent invite errors still raise `BenefitActionRequiredError` with grant context.
  - Use a deterministic fallback channel name by suffixing with the short hex of `customer.id`, and adopt the existing suffixed channel on `name_taken` to avoid creating duplicates across retries.

<sup>Written for commit fae1a625d564f66ddef0dca0262958d070c27c6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

