### PR TITLE
slack-benefit: Ensure that channel was unarchived successfully before continuing

### DIFF
--- a/server/polar/benefit/strategies/slack_shared_channel/service.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/service.py
@@ -126,14 +126,24 @@ class BenefitSlackSharedChannelService(
         context = self._build_context(customer)
 
         existing_channel_id = grant_properties.get("channel_id")
-        if existing_channel_id and await self._unarchive_channel(
-            bot_token=bot_token,
-            channel=existing_channel_id,
-            bound_logger=bound_logger,
-        ):
+        unarchive_error: str | None = None
+        if existing_channel_id:
+            unarchive_error = await self._unarchive_channel(
+                bot_token=bot_token,
+                channel=existing_channel_id,
+                bound_logger=bound_logger,
+            )
+            if unarchive_error is not None and unarchive_error != "channel_not_found":
+                raise BenefitActionRequiredError(
+                    f"Slack channel unarchive error: {unarchive_error}"
+                )
+
+        if existing_channel_id and unarchive_error is None:
             channel_id = existing_channel_id
             channel_name = grant_properties.get("channel_name", "")
-        elif sibling_channel := await self._find_sibling_channel(benefit, customer):
+        elif sibling_channel := await self._find_sibling_channel(
+            benefit, customer, exclude_channel_id=existing_channel_id
+        ):
             channel_id, channel_name = sibling_channel
         else:
             channel_id, channel_name, created = await self._create_channel(
@@ -359,7 +369,11 @@ class BenefitSlackSharedChannelService(
         return integration
 
     async def _find_sibling_channel(
-        self, benefit: Benefit, customer: Customer
+        self,
+        benefit: Benefit,
+        customer: Customer,
+        *,
+        exclude_channel_id: str | None = None,
     ) -> tuple[str, str] | None:
         repository = BenefitGrantRepository.from_session(self.session)
         grants = await repository.list_granted_by_benefit_and_customer(
@@ -367,7 +381,11 @@ class BenefitSlackSharedChannelService(
         )
         for grant in grants:
             channel_id = grant.properties.get("channel_id")
-            if isinstance(channel_id, str) and channel_id:
+            if (
+                isinstance(channel_id, str)
+                and channel_id
+                and channel_id != exclude_channel_id
+            ):
                 channel_name = grant.properties.get("channel_name")
                 return channel_id, channel_name if isinstance(channel_name, str) else ""
         return None
@@ -429,12 +447,12 @@ class BenefitSlackSharedChannelService(
                     continue
 
                 if channel.get("is_archived"):
-                    unarchived = await self._unarchive_channel(
+                    unarchive_error = await self._unarchive_channel(
                         bot_token=bot_token,
                         channel=channel_id,
                         bound_logger=bound_logger,
                     )
-                    if not unarchived:
+                    if unarchive_error is not None:
                         return None
 
                 if channel.get("is_private"):
@@ -491,7 +509,7 @@ class BenefitSlackSharedChannelService(
         bot_token: str,
         channel: str,
         bound_logger: Any,
-    ) -> bool:
+    ) -> str | None:
         try:
             result = await self._client.conversations_unarchive(
                 bot_token=bot_token, channel=channel
@@ -501,7 +519,7 @@ class BenefitSlackSharedChannelService(
 
         error = result.get("error", "")
         if result.get("ok") or error == "not_archived":
-            return True
+            return None
 
         if error in _ARCHIVE_TRANSIENT_ERRORS:
             raise BenefitRetriableError()
@@ -511,7 +529,7 @@ class BenefitSlackSharedChannelService(
             channel_id=channel,
             error=error,
         )
-        return False
+        return error
 
     async def _create_channel(
         self,

--- a/server/polar/benefit/strategies/slack_shared_channel/service.py
+++ b/server/polar/benefit/strategies/slack_shared_channel/service.py
@@ -126,14 +126,13 @@ class BenefitSlackSharedChannelService(
         context = self._build_context(customer)
 
         existing_channel_id = grant_properties.get("channel_id")
-        if existing_channel_id:
+        if existing_channel_id and await self._unarchive_channel(
+            bot_token=bot_token,
+            channel=existing_channel_id,
+            bound_logger=bound_logger,
+        ):
             channel_id = existing_channel_id
             channel_name = grant_properties.get("channel_name", "")
-            await self._unarchive_channel(
-                bot_token=bot_token,
-                channel=channel_id,
-                bound_logger=bound_logger,
-            )
         elif sibling_channel := await self._find_sibling_channel(benefit, customer):
             channel_id, channel_name = sibling_channel
         else:

--- a/server/tests/benefit/strategies/test_slack_shared_channel.py
+++ b/server/tests/benefit/strategies/test_slack_shared_channel.py
@@ -1101,6 +1101,101 @@ class TestSlackSharedChannelGrant:
             email="admin@customer.example",
         )
 
+    async def test_grant_ignores_sibling_with_deleted_channel(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        customer.name = "Acme"
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        await create_benefit_grant(
+            save_fixture,
+            customer,
+            benefit,
+            granted=True,
+            properties={
+                "invited_email": "first@customer.example",
+                "channel_id": "CDELETED",
+                "channel_name": "support-acme",
+                "invite_id": "I001",
+            },
+        )
+        client = _mock_client(
+            mocker,
+            conversations_unarchive=AsyncMock(
+                return_value={"ok": False, "error": "channel_not_found"}
+            ),
+            conversations_create=AsyncMock(
+                return_value={
+                    "ok": True,
+                    "channel": {"id": "CNEW", "name": "support-acme"},
+                }
+            ),
+        )
+        strategy = _strategy(session, redis, client)
+
+        existing: BenefitGrantSlackSharedChannelProperties = {
+            "invited_email": "admin@customer.example",
+            "channel_id": "CDELETED",
+            "channel_name": "support-acme",
+        }
+        result = await strategy.grant(benefit, customer, existing)
+
+        assert result["channel_id"] == "CNEW"
+        client.conversations_create.assert_awaited_once()
+        client.conversations_invite_shared.assert_awaited_once_with(
+            bot_token="xoxb-test-token",
+            channel="CNEW",
+            email="admin@customer.example",
+        )
+
+    async def test_grant_existing_channel_unarchive_error_raises(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        customer.name = "Acme"
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_unarchive=AsyncMock(
+                return_value={"ok": False, "error": "restricted_action"}
+            ),
+        )
+        strategy = _strategy(session, redis, client)
+
+        existing: BenefitGrantSlackSharedChannelProperties = {
+            "invited_email": "admin@customer.example",
+            "channel_id": "CARCHIVED",
+            "channel_name": "support-acme",
+        }
+
+        with pytest.raises(BenefitActionRequiredError):
+            await strategy.grant(benefit, customer, existing)
+
+        client.conversations_create.assert_not_awaited()
+        client.conversations_invite_shared.assert_not_awaited()
+
     @pytest.mark.parametrize(
         "error",
         ["ratelimited", "internal_error", "fatal_error", "service_unavailable"],

--- a/server/tests/benefit/strategies/test_slack_shared_channel.py
+++ b/server/tests/benefit/strategies/test_slack_shared_channel.py
@@ -1051,6 +1051,56 @@ class TestSlackSharedChannelGrant:
             email="admin@customer.example",
         )
 
+    async def test_grant_falls_back_when_stored_channel_is_deleted(
+        self,
+        session: AsyncSession,
+        redis: Redis,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        customer.name = "Acme"
+        benefit = await create_benefit(
+            save_fixture,
+            organization=organization,
+            type=BenefitType.slack_shared_channel,
+            properties=_BASE_PROPERTIES,
+        )
+        await _create_integration(save_fixture, benefit)
+        client = _mock_client(
+            mocker,
+            conversations_unarchive=AsyncMock(
+                return_value={"ok": False, "error": "channel_not_found"}
+            ),
+            conversations_create=AsyncMock(
+                return_value={
+                    "ok": True,
+                    "channel": {"id": "CNEW", "name": "support-acme"},
+                }
+            ),
+        )
+        strategy = _strategy(session, redis, client)
+
+        existing: BenefitGrantSlackSharedChannelProperties = {
+            "invited_email": "admin@customer.example",
+            "channel_id": "CDELETED",
+            "channel_name": "support-acme-deleted",
+        }
+        result = await strategy.grant(benefit, customer, existing)
+
+        assert result["channel_id"] == "CNEW"
+        assert result["channel_name"] == "support-acme"
+        client.conversations_unarchive.assert_awaited_once_with(
+            bot_token="xoxb-test-token", channel="CDELETED"
+        )
+        client.conversations_create.assert_awaited_once()
+        client.conversations_invite_shared.assert_awaited_once_with(
+            bot_token="xoxb-test-token",
+            channel="CNEW",
+            email="admin@customer.example",
+        )
+
     @pytest.mark.parametrize(
         "error",
         ["ratelimited", "internal_error", "fatal_error", "service_unavailable"],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure Slack shared channel provisioning only reuses a stored channel after a successful unarchive and ignores sibling grants that reference a deleted channel. If unarchive returns `channel_not_found` we find/create a channel; otherwise we surface an action-required error.

- **Bug Fixes**
  - Reuse `existing_channel_id` only when `_unarchive_channel` returns no error; raise `BenefitActionRequiredError` for non-`channel_not_found` errors.
  - Add tests for fallback creation, ignoring deleted sibling channels, and error propagation.

<sup>Written for commit 6b1de1f0787464af4e16d1690bf5ce8b3b846f56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

