### PR TITLE
fix: fix dropping field changes when autosave is in-flight

### DIFF
--- a/clients/apps/web/src/components/Settings/FeatureSettings.tsx
+++ b/clients/apps/web/src/components/Settings/FeatureSettings.tsx
@@ -22,7 +22,7 @@ export default function FeatureSettings({
   const form = useForm<schemas['OrganizationFeatureSettings']>({
     defaultValues: organization.feature_settings || {},
   })
-  const { control, setError, reset } = form
+  const { control, setError } = form
 
   const updateOrganization = useUpdateOrganization()
   const onSave = async (
@@ -48,11 +48,9 @@ export default function FeatureSettings({
       })
 
       return
-    } else {
-      if (data?.feature_settings) {
-        reset(data.feature_settings)
-      }
     }
+
+    return data.feature_settings ?? undefined
   }
 
   useAutoSave({

--- a/clients/apps/web/src/components/Settings/OrganizationCustomerPortalSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationCustomerPortalSettings.tsx
@@ -36,7 +36,7 @@ const OrganizationCustomerPortalSettings: React.FC<
       },
     },
   })
-  const { control, setError, reset } = form
+  const { control, setError } = form
 
   const updateOrganization = useUpdateOrganization()
   const onSave = async (
@@ -64,7 +64,7 @@ const OrganizationCustomerPortalSettings: React.FC<
       return
     }
 
-    reset(data.customer_portal_settings)
+    return data.customer_portal_settings
   }
 
   useAutoSave({

--- a/clients/apps/web/src/components/Settings/OrganizationDisputeSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationDisputeSettings.tsx
@@ -33,7 +33,7 @@ const OrganizationDisputeSettings: React.FC<
   const form = useForm<schemas['OrganizationDisputeSettings']>({
     defaultValues: organization.dispute_settings,
   })
-  const { control, setError, setValue, clearErrors, reset } = form
+  const { control, setError, setValue, clearErrors } = form
   const [enabled, setEnabled] = React.useState(
     organization.dispute_settings.auto_accept_below_amount !== null,
   )
@@ -70,7 +70,7 @@ const OrganizationDisputeSettings: React.FC<
       return
     }
 
-    reset(data.dispute_settings)
+    return data.dispute_settings
   }
 
   useAutoSave({

--- a/clients/apps/web/src/components/Settings/OrganizationPaymentSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationPaymentSettings.tsx
@@ -54,7 +54,7 @@ const OrganizationPaymentSettings: React.FC<
       default_tax_behavior: organization.default_tax_behavior,
     },
   })
-  const { control, setError, reset } = form
+  const { control, setError } = form
 
   const updateOrganization = useUpdateOrganization()
   const onSave = async (body: FormSchema) => {
@@ -72,11 +72,11 @@ const OrganizationPaymentSettings: React.FC<
       return
     }
 
-    reset({
+    return {
       ...data,
       default_presentment_currency:
         data.default_presentment_currency as schemas['PresentmentCurrency'],
-    })
+    }
   }
 
   useAutoSave({

--- a/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationProfileSettings.tsx
@@ -458,7 +458,7 @@ const OrganizationProfileSettings: React.FC<
       ...organization,
     },
   })
-  const { setError, reset } = form
+  const { setError } = form
 
   const { currentUser } = useAuth()
 
@@ -511,16 +511,16 @@ const OrganizationProfileSettings: React.FC<
       return
     }
 
-    reset({
+    // Refresh the router to get the updated organization data from the server
+    router.refresh()
+
+    return {
       ...data,
       default_presentment_currency:
         data.default_presentment_currency as schemas['PresentmentCurrency'],
       country: data.country as schemas['CountryAlpha2Input'] | undefined,
       socials: [...(data.socials || []), ...emptySocials],
-    })
-
-    // Refresh the router to get the updated organization data from the server
-    router.refresh()
+    }
   }
 
   useAutoSave({

--- a/clients/apps/web/src/components/Settings/OrganizationSubscriptionSettings.tsx
+++ b/clients/apps/web/src/components/Settings/OrganizationSubscriptionSettings.tsx
@@ -28,7 +28,7 @@ const OrganizationSubscriptionSettings: React.FC<
   const form = useForm<schemas['OrganizationSubscriptionSettings']>({
     defaultValues: organization.subscription_settings,
   })
-  const { control, setError, reset } = form
+  const { control, setError } = form
 
   const updateOrganization = useUpdateOrganization()
   const onSave = async (
@@ -56,7 +56,7 @@ const OrganizationSubscriptionSettings: React.FC<
       return
     }
 
-    reset(data.subscription_settings)
+    return data.subscription_settings
   }
 
   useAutoSave({

--- a/clients/apps/web/src/hooks/useAutoSave.test.ts
+++ b/clients/apps/web/src/hooks/useAutoSave.test.ts
@@ -1,0 +1,201 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useForm } from 'react-hook-form'
+import { useAutoSave } from './useAutoSave'
+
+type FormValues = {
+  primary: string
+  secondary: string
+}
+
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T) => void
+}
+
+function defer<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+async function tick(work?: () => void) {
+  await act(async () => {
+    work?.()
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+function setup(initial: FormValues) {
+  const calls: {
+    values: FormValues
+    deferred: Deferred<FormValues | undefined>
+  }[] = []
+  const onSave = vi.fn((values: FormValues) => {
+    const deferred = defer<FormValues | undefined>()
+    calls.push({ values: { ...values }, deferred })
+    return deferred.promise
+  })
+  const hook = renderHook(() => {
+    const form = useForm<FormValues>({ defaultValues: initial })
+    useAutoSave({ form, onSave, delay: 200 })
+    return form
+  })
+
+  return { ...hook, calls, onSave }
+}
+
+describe('useAutoSave', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('debounces changes and resets to the saved values without another save', async () => {
+    const { calls, result } = setup({ primary: 'initial', secondary: '' })
+
+    act(() => result.current.setValue('primary', 'draft'))
+    await act(async () => vi.advanceTimersByTimeAsync(200))
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].values).toEqual({ primary: 'draft', secondary: '' })
+
+    await tick(() =>
+      calls[0].deferred.resolve({ primary: 'canonical', secondary: '' }),
+    )
+
+    expect(result.current.getValues()).toEqual({
+      primary: 'canonical',
+      secondary: '',
+    })
+
+    await act(async () => vi.advanceTimersByTimeAsync(200))
+    expect(calls).toHaveLength(1)
+  })
+
+  it('does not re-save after a successful reset and consumer rerenders', async () => {
+    const onSave = vi.fn(async (values: FormValues) => ({
+      ...values,
+      primary: values.primary.trim(),
+    }))
+    const { result, rerender } = renderHook(
+      ({ revision }: { revision: number }) => {
+        const form = useForm<FormValues>({
+          defaultValues: { primary: 'initial', secondary: '' },
+        })
+        useAutoSave({
+          form,
+          onSave: async (values) => {
+            void revision
+            return onSave(values)
+          },
+          delay: 200,
+        })
+        return form
+      },
+      { initialProps: { revision: 0 } },
+    )
+
+    act(() => result.current.setValue('primary', ' saved '))
+    await act(async () => vi.advanceTimersByTimeAsync(200))
+    await tick()
+
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(result.current.getValues().primary).toBe('saved')
+
+    rerender({ revision: 1 })
+    rerender({ revision: 2 })
+    await act(async () => vi.advanceTimersByTimeAsync(10_000))
+
+    expect(onSave).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps an edit made during a save and flushes it after the debounce expires', async () => {
+    const { calls, result } = setup({ primary: 'initial', secondary: '' })
+
+    act(() => result.current.setValue('primary', 'first'))
+    await act(async () => vi.advanceTimersByTimeAsync(200))
+
+    act(() => result.current.setValue('secondary', 'second'))
+    await act(async () => vi.advanceTimersByTimeAsync(200))
+
+    expect(calls).toHaveLength(1)
+
+    await tick(() =>
+      calls[0].deferred.resolve({ primary: 'first', secondary: '' }),
+    )
+
+    expect(result.current.getValues()).toEqual({
+      primary: 'first',
+      secondary: 'second',
+    })
+    expect(calls).toHaveLength(2)
+    expect(calls[1].values).toEqual({
+      primary: 'first',
+      secondary: 'second',
+    })
+  })
+
+  it('waits for the remaining debounce when a save finishes first', async () => {
+    const { calls, result } = setup({ primary: 'initial', secondary: '' })
+
+    act(() => result.current.setValue('primary', 'first'))
+    await act(async () => vi.advanceTimersByTimeAsync(200))
+
+    act(() => result.current.setValue('secondary', 'second'))
+    await tick(() =>
+      calls[0].deferred.resolve({ primary: 'first', secondary: '' }),
+    )
+
+    expect(result.current.getValues().secondary).toBe('second')
+    expect(calls).toHaveLength(1)
+
+    await act(async () => vi.advanceTimersByTimeAsync(199))
+    expect(calls).toHaveLength(1)
+
+    await act(async () => vi.advanceTimersByTimeAsync(1))
+    expect(calls).toHaveLength(2)
+    expect(calls[1].values.secondary).toBe('second')
+  })
+
+  it('coalesces multiple edits during a save into one trailing save', async () => {
+    const { calls, result } = setup({ primary: 'initial', secondary: '' })
+
+    act(() => result.current.setValue('primary', 'first'))
+    await act(async () => vi.advanceTimersByTimeAsync(200))
+
+    act(() => {
+      result.current.setValue('secondary', 'one')
+      result.current.setValue('secondary', 'two')
+      result.current.setValue('secondary', 'latest')
+    })
+    await act(async () => vi.advanceTimersByTimeAsync(200))
+    await tick(() =>
+      calls[0].deferred.resolve({ primary: 'first', secondary: '' }),
+    )
+
+    expect(calls).toHaveLength(2)
+    expect(calls[1].values.secondary).toBe('latest')
+  })
+
+  it('cancels a pending save on unmount', async () => {
+    const { calls, result, unmount } = setup({
+      primary: 'initial',
+      secondary: '',
+    })
+
+    act(() => result.current.setValue('primary', 'draft'))
+    unmount()
+    await act(async () => vi.advanceTimersByTimeAsync(200))
+
+    expect(calls).toHaveLength(0)
+  })
+})

--- a/clients/apps/web/src/hooks/useAutoSave.ts
+++ b/clients/apps/web/src/hooks/useAutoSave.ts
@@ -5,14 +5,12 @@ interface UseAutoSaveOptions<T extends FieldValues> {
   form: UseFormReturn<T>
   onSave: (data: T) => Promise<T | undefined>
   delay?: number
-  enabled?: boolean
 }
 
 export function useAutoSave<T extends FieldValues>({
   form,
   onSave,
   delay = 1000,
-  enabled = true,
 }: UseAutoSaveOptions<T>) {
   const onSaveRef = useRef(onSave)
   useEffect(() => {
@@ -25,8 +23,6 @@ export function useAutoSave<T extends FieldValues>({
   const flushRef = useRef<(() => Promise<void>) | null>(null)
 
   useEffect(() => {
-    if (!enabled) return
-
     let active = true
     const flush = async () => {
       if (isSavingRef.current || !hasPendingChangesRef.current) return
@@ -79,5 +75,5 @@ export function useAutoSave<T extends FieldValues>({
       timeoutRef.current = null
       if (flushRef.current === flush) flushRef.current = null
     }
-  }, [form, delay, enabled])
+  }, [form, delay])
 }

--- a/clients/apps/web/src/hooks/useAutoSave.ts
+++ b/clients/apps/web/src/hooks/useAutoSave.ts
@@ -3,7 +3,7 @@ import { FieldValues, UseFormReturn } from 'react-hook-form'
 
 interface UseAutoSaveOptions<T extends FieldValues> {
   form: UseFormReturn<T>
-  onSave: (data: T) => Promise<void>
+  onSave: (data: T) => Promise<T | undefined>
   delay?: number
   enabled?: boolean
 }
@@ -20,36 +20,64 @@ export function useAutoSave<T extends FieldValues>({
   }, [onSave])
 
   const isSavingRef = useRef(false)
+  const hasPendingChangesRef = useRef(false)
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const flushRef = useRef<(() => Promise<void>) | null>(null)
 
   useEffect(() => {
     if (!enabled) return
+
+    let active = true
+    const flush = async () => {
+      if (isSavingRef.current || !hasPendingChangesRef.current) return
+
+      hasPendingChangesRef.current = false
+      isSavingRef.current = true
+      try {
+        const savedValues = await onSaveRef.current(form.getValues())
+        if (
+          active &&
+          savedValues !== undefined &&
+          !hasPendingChangesRef.current
+        ) {
+          form.reset(savedValues)
+        }
+      } catch {
+        // Swallow: consumers handle their own errors via onSave.
+      } finally {
+        isSavingRef.current = false
+        if (
+          active &&
+          hasPendingChangesRef.current &&
+          timeoutRef.current === null
+        ) {
+          void flushRef.current?.()
+        }
+      }
+    }
+    flushRef.current = flush
 
     // `reset()` emits without a `name`; `field.onChange` and `setValue` both
     // set one. Filtering on `name` keeps programmatic setValue updates (e.g.
     // file uploads) while still ignoring the reset fired after a save.
     const subscription = form.watch((_value, info) => {
       if (!info.name) return
-      if (isSavingRef.current) return
 
+      hasPendingChangesRef.current = true
       if (timeoutRef.current) clearTimeout(timeoutRef.current)
-      timeoutRef.current = setTimeout(async () => {
-        if (isSavingRef.current) return
-
-        isSavingRef.current = true
-        try {
-          await onSaveRef.current(form.getValues())
-        } catch {
-          // Swallow: consumers handle their own errors via onSave.
-        } finally {
-          isSavingRef.current = false
-        }
+      timeoutRef.current = setTimeout(() => {
+        timeoutRef.current = null
+        void flushRef.current?.()
       }, delay)
     })
 
     return () => {
+      active = false
       subscription.unsubscribe()
+      hasPendingChangesRef.current = false
       if (timeoutRef.current) clearTimeout(timeoutRef.current)
+      timeoutRef.current = null
+      if (flushRef.current === flush) flushRef.current = null
     }
   }, [form, delay, enabled])
 }


### PR DESCRIPTION
## Summary

**Related Issue**: polarsource/feedback#271

Fixes the bug that `useAutoSave` threw away changes that were made during an in-flight save.

## What

`useAutosave` now has an internal mechanism for tracking if changes have been made during in-flight saves and it starts another save after the in-flight one have finished.

## Why

Users could lose data if a save takes unexpectedly long and they edit another field in the meantime.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] New functionality is covered by tests
- [x] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [x] No unrelated changes or drive-by fixes are included
