### PR TITLE
feat(merchant-migration): run precheck and catalog import as background jobs

### DIFF
--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -5264,7 +5264,7 @@ export interface paths {
     get?: never
     put?: never
     /**
-     * Run Merchant Migration Pre-check
+     * Start Merchant Migration Pre-check
      * @description **Scopes**: `organizations:write`
      */
     post: operations['merchant-migrations:precheck']
@@ -5284,7 +5284,7 @@ export interface paths {
     get?: never
     put?: never
     /**
-     * Import Merchant Migration Catalog
+     * Start Merchant Migration Catalog Import
      * @description **Scopes**: `organizations:write`
      */
     post: operations['merchant-migrations:import_catalog']
@@ -23679,6 +23679,8 @@ export interface components {
       source: {
         [key: string]: unknown
       } | null
+      /** @description Background precheck/import progress for the current step. Null until the first background run is started. */
+      operation: components['schemas']['MerchantMigrationOperation'] | null
     }
     /** MerchantMigrationCreate */
     MerchantMigrationCreate: {
@@ -23696,16 +23698,6 @@ export interface components {
        */
       api_key: string
     }
-    /** MerchantMigrationImportReport */
-    MerchantMigrationImportReport: {
-      /** @description The migration step after the import. */
-      step: components['schemas']['MerchantMigrationStep']
-      /**
-       * Results
-       * @description Per-entity counts of what was imported vs skipped.
-       */
-      results: components['schemas']['MerchantMigrationImportResult'][]
-    }
     /** MerchantMigrationImportRequest */
     MerchantMigrationImportRequest: {
       /**
@@ -23718,21 +23710,6 @@ export interface components {
        * @description Import every importable record except these — the opt-out selection for large catalogs. Ignored when `record_ids` is set.
        */
       exclude_record_ids?: string[] | null
-    }
-    /** MerchantMigrationImportResult */
-    MerchantMigrationImportResult: {
-      /** @description The source entity type. */
-      entity: components['schemas']['PrecheckEntity']
-      /**
-       * Imported
-       * @description How many were created or reused in Polar.
-       */
-      imported: number
-      /**
-       * Skipped
-       * @description How many were left on the source (not importable).
-       */
-      skipped: number
     }
     /** MerchantMigrationNotEnabled */
     MerchantMigrationNotEnabled: {
@@ -23756,6 +23733,58 @@ export interface components {
       /** Detail */
       detail: string
     }
+    /**
+     * MerchantMigrationOperation
+     * @description In-flight or finished background work for the current ``step``.
+     */
+    MerchantMigrationOperation: {
+      /** @description pending → running → done, or failed. */
+      status: components['schemas']['MerchantMigrationOperationStatus']
+      /**
+       * Cursor
+       * @description Opaque resume point for the batch chain. Shape depends on the step (extract phase + Stripe page cursor, or import type + last record id).
+       */
+      cursor?: {
+        [key: string]: unknown
+      } | null
+      /** @description Import only: the compact selection from the start request. */
+      selection?:
+        | components['schemas']['MerchantMigrationOperationSelection']
+        | null
+      /**
+       * Error
+       * @description Safe failure message when status is failed.
+       */
+      error?: string | null
+      /**
+       * Last Progress At
+       * @description Bumped on enqueue and each successful batch; used for stall detection.
+       */
+      last_progress_at?: string | null
+    }
+    /**
+     * MerchantMigrationOperationSelection
+     * @description Compact import selection. Opt-in (``record_ids``) or opt-out
+     *     (``exclude_record_ids``); never both. Workers filter batch queries with this
+     *     rather than marking every ledger row up front.
+     */
+    MerchantMigrationOperationSelection: {
+      /**
+       * Record Ids
+       * @description Import only these ledger record ids.
+       */
+      record_ids?: string[] | null
+      /**
+       * Exclude Record Ids
+       * @description Import every pending importable record except these.
+       */
+      exclude_record_ids?: string[] | null
+    }
+    /**
+     * MerchantMigrationOperationStatus
+     * @enum {string}
+     */
+    MerchantMigrationOperationStatus: 'pending' | 'running' | 'done' | 'failed'
     /** MerchantMigrationRecordItem */
     MerchantMigrationRecordItem: {
       /**
@@ -25200,6 +25229,17 @@ export interface components {
        * @constant
        */
       error: 'OffSessionChargesNotEnabled'
+      /** Detail */
+      detail: string
+    }
+    /** OperationInProgress */
+    OperationInProgress: {
+      /**
+       * Error
+       * @example OperationInProgress
+       * @constant
+       */
+      error: 'OperationInProgress'
       /** Detail */
       detail: string
     }
@@ -30312,41 +30352,17 @@ export interface components {
      * @enum {string}
      */
     PrecheckEntity: 'products' | 'prices' | 'customers' | 'subscriptions'
-    /** PrecheckEntitySummary */
-    PrecheckEntitySummary: {
-      /** @description The source entity type. */
-      entity: components['schemas']['PrecheckEntity']
+    /** PrecheckNotAllowed */
+    PrecheckNotAllowed: {
       /**
-       * Total
-       * @description How many were read from the source.
+       * Error
+       * @example PrecheckNotAllowed
+       * @constant
        */
-      total: number
-      /**
-       * Importable
-       * @description How many will be imported into Polar.
-       */
-      importable: number
-      /**
-       * Skipped
-       * @description How many won't be imported and stay on the source.
-       */
-      skipped: number
+      error: 'PrecheckNotAllowed'
+      /** Detail */
+      detail: string
     }
-    /** PrecheckIssue */
-    PrecheckIssue: {
-      level: components['schemas']['PrecheckIssueLevel']
-      /** Code */
-      code: string
-      /** Message */
-      message: string
-      /** Source Id */
-      source_id: string | null
-    }
-    /**
-     * PrecheckIssueLevel
-     * @enum {string}
-     */
-    PrecheckIssueLevel: 'blocker' | 'warning'
     /**
      * PrecheckReasonLevel
      * @enum {string}
@@ -30357,18 +30373,6 @@ export interface components {
      * @enum {string}
      */
     PrecheckRecordStatus: 'importable' | 'skipped'
-    /** PrecheckReport */
-    PrecheckReport: {
-      /** Can Start */
-      can_start: boolean
-      /** Issues */
-      issues: components['schemas']['PrecheckIssue'][]
-      /**
-       * Entities
-       * @description Per-entity counts of what will be imported vs stay on the source.
-       */
-      entities: components['schemas']['PrecheckEntitySummary'][]
-    }
     /**
      * PresentmentCurrency
      * @enum {string}
@@ -52639,12 +52643,12 @@ export interface operations {
     requestBody?: never
     responses: {
       /** @description Successful Response */
-      200: {
+      202: {
         headers: {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['PrecheckReport']
+          'application/json': components['schemas']['MerchantMigration']
         }
       }
       /** @description The source is not connected or isn't supported. */
@@ -52674,6 +52678,18 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['MerchantMigrationNotFound']
+        }
+      }
+      /** @description A background operation is already running, or the migration isn't ready for precheck. */
+      409: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json':
+            | components['schemas']['OperationInProgress']
+            | components['schemas']['PrecheckNotAllowed']
+            | components['schemas']['CatalogImportNotReady']
         }
       }
       /** @description Validation Error */
@@ -52705,12 +52721,12 @@ export interface operations {
     }
     responses: {
       /** @description Successful Response */
-      200: {
+      202: {
         headers: {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['MerchantMigrationImportReport']
+          'application/json': components['schemas']['MerchantMigration']
         }
       }
       /** @description The source is not connected or isn't supported. */
@@ -52742,7 +52758,7 @@ export interface operations {
           'application/json': components['schemas']['MerchantMigrationNotFound']
         }
       }
-      /** @description The pre-check hasn't run yet, or it reports a blocker. */
+      /** @description The pre-check hasn't run yet, a blocker applies, or a background operation is already running. */
       409: {
         headers: {
           [name: string]: unknown
@@ -52751,6 +52767,7 @@ export interface operations {
           'application/json':
             | components['schemas']['CatalogImportNotReady']
             | components['schemas']['CatalogImportBlocked']
+            | components['schemas']['OperationInProgress']
         }
       }
       /** @description Validation Error */
@@ -65725,6 +65742,9 @@ export const memberRoleValues: ReadonlyArray<
 export const memberSortPropertyValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['MemberSortProperty']
 > = ['created_at', '-created_at']
+export const merchantMigrationOperationStatusValues: ReadonlyArray<
+  FlattenedDeepRequired<components>['schemas']['MerchantMigrationOperationStatus']
+> = ['pending', 'running', 'done', 'failed']
 export const merchantMigrationRecordStatusValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['MerchantMigrationRecordStatus']
 > = ['pending', 'imported', 'skipped', 'failed']
@@ -67366,9 +67386,6 @@ export const pledgeStateValues: ReadonlyArray<
 export const precheckEntityValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['PrecheckEntity']
 > = ['products', 'prices', 'customers', 'subscriptions']
-export const precheckIssueLevelValues: ReadonlyArray<
-  FlattenedDeepRequired<components>['schemas']['PrecheckIssueLevel']
-> = ['blocker', 'warning']
 export const precheckReasonLevelValues: ReadonlyArray<
   FlattenedDeepRequired<components>['schemas']['PrecheckReasonLevel']
 > = ['action_required', 'info']

--- a/server/polar/merchant_migration/adapters/base.py
+++ b/server/polar/merchant_migration/adapters/base.py
@@ -1,5 +1,4 @@
-from collections.abc import AsyncIterator
-from typing import Protocol
+from typing import Any, Protocol
 
 from ..canonical import CanonicalAccount, CanonicalRecord, CanonicalSubscription
 
@@ -7,15 +6,19 @@ from ..canonical import CanonicalAccount, CanonicalRecord, CanonicalSubscription
 class SourceAdapter(Protocol):
     """Reads one billing provider into provider-agnostic CanonicalRecords.
 
-    ``extract`` is an async iterator because source data can be huge and must be
-    streamed, not materialized. Credential validation is provider-specific and
-    lives on the concrete adapter (e.g. ``StripeAdapter.verify_scopes``), not here.
+    ``extract_batch`` pages the source under a cursor so precheck can run as
+    Dramatiq batches. Credential validation is provider-specific and lives on
+    the concrete adapter (e.g. ``StripeAdapter.verify_scopes``), not here.
 
     Everything here reads, except ``stop_source_subscription``: the one write the
     migration makes on the merchant's own provider, at cutover.
     """
 
-    def extract(self) -> AsyncIterator[CanonicalRecord]: ...
+    async def extract_batch(
+        self, *, cursor: dict[str, Any] | None, limit: int
+    ) -> tuple[list[CanonicalRecord], dict[str, Any] | None]:
+        """Return up to ``limit`` records and the next cursor (None when done)."""
+        ...
 
     async def get_source_account(self) -> CanonicalAccount: ...
 

--- a/server/polar/merchant_migration/adapters/stripe.py
+++ b/server/polar/merchant_migration/adapters/stripe.py
@@ -117,13 +117,91 @@ class StripeAdapter:
         account = await self._current_account()
         return account.id if account else None
 
+    async def extract_batch(
+        self, *, cursor: dict[str, Any] | None, limit: int
+    ) -> tuple[list[CanonicalRecord], dict[str, Any] | None]:
+        """Page products → customers → subscriptions under an opaque cursor.
+
+        Products are buffered once (catalogs are small). Customers and
+        subscriptions page with Stripe ``starting_after``.
+        """
+        phase = "products" if cursor is None else str(cursor["phase"])
+        starting_after = None if cursor is None else cursor.get("starting_after")
+
+        if phase == "products":
+            records: list[CanonicalRecord] = [
+                product async for product in self._extract_products()
+            ]
+            return records, {"phase": "customers"}
+
+        if phase == "customers":
+            records, next_after = await self._page_customers(
+                starting_after=starting_after, limit=limit
+            )
+            if next_after is not None:
+                return records, {"phase": "customers", "starting_after": next_after}
+            return records, {"phase": "subscriptions"}
+
+        if phase == "subscriptions":
+            records, next_after = await self._page_subscriptions(
+                starting_after=starting_after, limit=limit
+            )
+            if next_after is not None:
+                return records, {
+                    "phase": "subscriptions",
+                    "starting_after": next_after,
+                }
+            return records, None
+
+        raise ValueError(f"Unknown extract phase: {phase}")
+
+    async def _page_customers(
+        self, *, starting_after: str | None, limit: int
+    ) -> tuple[list[CanonicalRecord], str | None]:
+        params: dict[str, Any] = {"limit": min(limit, PAGE_SIZE)}
+        if starting_after is not None:
+            params["starting_after"] = starting_after
+        page = await self._client.v1.customers.list_async(params=params)  # type: ignore[arg-type]
+        records: list[CanonicalRecord] = [
+            self._map_customer(customer) for customer in page.data
+        ]
+        if not page.has_more or not page.data:
+            return records, None
+        return records, page.data[-1].id
+
+    async def _page_subscriptions(
+        self, *, starting_after: str | None, limit: int
+    ) -> tuple[list[CanonicalRecord], str | None]:
+        params: dict[str, Any] = {
+            "status": "all",
+            "limit": min(limit, PAGE_SIZE),
+            "expand": [f"data.{path}" for path in _SUBSCRIPTION_EXPAND],
+        }
+        if starting_after is not None:
+            params["starting_after"] = starting_after
+        page = await self._client.v1.subscriptions.list_async(params=params)  # type: ignore[arg-type]
+        records: list[CanonicalRecord] = []
+        last_id: str | None = None
+        for subscription in page.data:
+            last_id = subscription.id
+            if subscription.status in SKIPPED_SUBSCRIPTION_STATUSES:
+                continue
+            if not subscription["items"]["data"]:
+                continue
+            records.append(self._map_subscription(subscription))
+        if not page.has_more or last_id is None:
+            return records, None
+        return records, last_id
+
     async def extract(self) -> AsyncIterator[CanonicalRecord]:
-        async for product in self._extract_products():
-            yield product
-        async for customer in self._extract_customers():
-            yield customer
-        async for subscription in self._extract_subscriptions():
-            yield subscription
+        """Full extract for tests and one-shot callers; prefers ``extract_batch``."""
+        cursor: dict[str, Any] | None = None
+        while True:
+            records, cursor = await self.extract_batch(cursor=cursor, limit=PAGE_SIZE)
+            for record in records:
+                yield record
+            if cursor is None:
+                return
 
     async def _has_connected_accounts(self) -> bool:
         # Best-effort: a restricted key may lack Connect read scope. Stripe

--- a/server/polar/merchant_migration/adapters/stripe.py
+++ b/server/polar/merchant_migration/adapters/stripe.py
@@ -25,6 +25,7 @@ from ..canonical import (
 # Period data moved onto the subscription item in this version; read it per item.
 STRIPE_API_VERSION = "2026-01-28.clover"
 PAGE_SIZE = 100
+PRODUCT_PRICE_CONCURRENCY = 10
 
 SKIPPED_SUBSCRIPTION_STATUSES = frozenset(
     {"canceled", "incomplete", "incomplete_expired"}
@@ -43,6 +44,10 @@ _SUBSCRIPTION_EXPAND = [
     "customer.invoice_settings.default_payment_method",
     "customer.default_source",
 ]
+
+type ExtractPage = tuple[list[CanonicalRecord], str | None]
+
+_EXTRACT_PHASES = ("products", "customers", "subscriptions")
 
 
 class StripeAdapter:
@@ -122,42 +127,57 @@ class StripeAdapter:
     ) -> tuple[list[CanonicalRecord], dict[str, Any] | None]:
         """Page products → customers → subscriptions under an opaque cursor.
 
-        Products are buffered once (catalogs are small). Customers and
-        subscriptions page with Stripe ``starting_after``.
+        Each phase pages with Stripe ``starting_after``. Product pages load all
+        active prices for each product so one canonical product is never split
+        across batches.
         """
         phase = "products" if cursor is None else str(cursor["phase"])
         starting_after = None if cursor is None else cursor.get("starting_after")
 
-        if phase == "products":
-            records: list[CanonicalRecord] = [
-                product async for product in self._extract_products()
-            ]
-            return records, {"phase": "customers"}
+        page_loaders: dict[str, Callable[[str | None, int], Awaitable[ExtractPage]]] = {
+            "products": self._page_products,
+            "customers": self._page_customers,
+            "subscriptions": self._page_subscriptions,
+        }
+        try:
+            loader = page_loaders[phase]
+            phase_index = _EXTRACT_PHASES.index(phase)
+        except (KeyError, ValueError):
+            raise ValueError(f"Unknown extract phase: {phase}") from None
 
-        if phase == "customers":
-            records, next_after = await self._page_customers(
-                starting_after=starting_after, limit=limit
-            )
-            if next_after is not None:
-                return records, {"phase": "customers", "starting_after": next_after}
-            return records, {"phase": "subscriptions"}
-
-        if phase == "subscriptions":
-            records, next_after = await self._page_subscriptions(
-                starting_after=starting_after, limit=limit
-            )
-            if next_after is not None:
-                return records, {
-                    "phase": "subscriptions",
-                    "starting_after": next_after,
-                }
+        records, next_after = await loader(starting_after, limit)
+        if next_after is not None:
+            return records, {"phase": phase, "starting_after": next_after}
+        if phase_index + 1 == len(_EXTRACT_PHASES):
             return records, None
+        return records, {"phase": _EXTRACT_PHASES[phase_index + 1]}
 
-        raise ValueError(f"Unknown extract phase: {phase}")
+    async def _page_products(
+        self, starting_after: str | None, limit: int
+    ) -> ExtractPage:
+        params: dict[str, Any] = {"active": True, "limit": min(limit, PAGE_SIZE)}
+        if starting_after is not None:
+            params["starting_after"] = starting_after
+        page = await self._client.v1.products.list_async(params=params)  # type: ignore[arg-type]
+        semaphore = asyncio.Semaphore(PRODUCT_PRICE_CONCURRENCY)
+
+        async def load_product(product: stripe_lib.Product) -> list[CanonicalProduct]:
+            async with semaphore:
+                return await self._canonical_products(product)
+
+        product_records = await asyncio.gather(
+            *(load_product(product) for product in page.data)
+        )
+        records: list[CanonicalRecord] = [
+            record for products in product_records for record in products
+        ]
+        if not page.has_more or not page.data:
+            return records, None
+        return records, page.data[-1].id
 
     async def _page_customers(
-        self, *, starting_after: str | None, limit: int
-    ) -> tuple[list[CanonicalRecord], str | None]:
+        self, starting_after: str | None, limit: int
+    ) -> ExtractPage:
         params: dict[str, Any] = {"limit": min(limit, PAGE_SIZE)}
         if starting_after is not None:
             params["starting_after"] = starting_after
@@ -170,8 +190,8 @@ class StripeAdapter:
         return records, page.data[-1].id
 
     async def _page_subscriptions(
-        self, *, starting_after: str | None, limit: int
-    ) -> tuple[list[CanonicalRecord], str | None]:
+        self, starting_after: str | None, limit: int
+    ) -> ExtractPage:
         params: dict[str, Any] = {
             "status": "all",
             "limit": min(limit, PAGE_SIZE),
@@ -222,23 +242,18 @@ class StripeAdapter:
             has_connected_accounts=has_connected_accounts,
         )
 
-    async def _extract_products(self) -> AsyncIterator[CanonicalProduct]:
-        # Buffer + group prices per (product, interval); catalogs are small,
-        # unlike customers, so holding them in memory is fine.
+    async def _canonical_products(
+        self, product: stripe_lib.Product
+    ) -> list[CanonicalProduct]:
         grouped: dict[str, CanonicalProduct] = {}
         prices = await self._client.v1.prices.list_async(
             params={
                 "active": True,
+                "product": product.id,
                 "limit": PAGE_SIZE,
-                "expand": ["data.product"],
             }
         )
         async for price in prices.auto_paging_iter():
-            product = price.product
-            # A deleted product deserializes as a Product with no `active`/`name`;
-            # `not active` skips deleted and archived alike.
-            if not isinstance(product, stripe_lib.Product) or not product.get("active"):
-                continue
             recurring = price.recurring
             interval = recurring.interval if recurring else None
             interval_count = recurring.interval_count if recurring else 1
@@ -255,30 +270,7 @@ class StripeAdapter:
                 )
                 grouped[key] = canonical
             canonical.prices.append(self._map_price(price))
-        for canonical in grouped.values():
-            yield canonical
-
-    async def _extract_customers(self) -> AsyncIterator[CanonicalCustomer]:
-        customers = await self._client.v1.customers.list_async(
-            params={"limit": PAGE_SIZE}
-        )
-        async for customer in customers.auto_paging_iter():
-            yield self._map_customer(customer)
-
-    async def _extract_subscriptions(self) -> AsyncIterator[CanonicalSubscription]:
-        subscriptions = await self._client.v1.subscriptions.list_async(
-            params={
-                "status": "all",
-                "limit": PAGE_SIZE,
-                "expand": [f"data.{path}" for path in _SUBSCRIPTION_EXPAND],
-            }
-        )
-        async for subscription in subscriptions.auto_paging_iter():
-            if subscription.status in SKIPPED_SUBSCRIPTION_STATUSES:
-                continue
-            if not subscription["items"]["data"]:
-                continue
-            yield self._map_subscription(subscription)
+        return list(grouped.values())
 
     async def get_subscription(self, source_id: str) -> CanonicalSubscription | None:
         try:

--- a/server/polar/merchant_migration/endpoints.py
+++ b/server/polar/merchant_migration/endpoints.py
@@ -14,6 +14,7 @@ from polar.postgres import AsyncReadSession, get_db_read_session, get_db_session
 from polar.routing import APIRouter
 
 from .auth import MerchantMigrationRead, MerchantMigrationWrite
+from .operation import OperationInProgress
 from .pan_transfer import (
     PanStepNotActionable,
     PanStepNotFound,
@@ -26,7 +27,6 @@ from .pan_transfer import (
 from .schemas import MerchantMigration as MerchantMigrationSchema
 from .schemas import (
     MerchantMigrationCreate,
-    MerchantMigrationImportReport,
     MerchantMigrationImportRequest,
     MerchantMigrationRecordItem,
     MerchantMigrationRecordSummary,
@@ -35,7 +35,6 @@ from .schemas import (
     PrecheckEntity,
     PrecheckReasonLevel,
     PrecheckRecordStatus,
-    PrecheckReport,
 )
 from .service import (
     CatalogImportBlocked,
@@ -44,6 +43,7 @@ from .service import (
     MerchantMigrationNotEnabled,
     MerchantMigrationNotFound,
     MissingStripeScopes,
+    PrecheckNotAllowed,
     SourceAccountNotMigratable,
     SourceKeyModeMismatch,
     SourceNotConnected,
@@ -127,7 +127,8 @@ async def create(
 async def get(
     id: UUID4,
     auth_subject: MerchantMigrationRead,
-    session: AsyncReadSession = Depends(get_db_read_session),
+    # Write session: stall detection may mark a stuck operation failed.
+    session: AsyncSession = Depends(get_db_session),
 ) -> MerchantMigration:
     migration = await merchant_migration_service.get(session, auth_subject, id)
     if migration is None:
@@ -137,35 +138,9 @@ async def get(
 
 @router.post(
     "/{id}/precheck",
-    response_model=PrecheckReport,
-    summary="Run Merchant Migration Pre-check",
-    responses={
-        400: {
-            "description": "The source is not connected or isn't supported.",
-            "model": SourceNotConnected.schema() | UnsupportedMigrationSource.schema(),
-        },
-        403: {
-            "description": "Not allowed to manage this organization.",
-            "model": NotPermitted.schema(),
-        },
-        404: {
-            "description": "Merchant migration not found.",
-            "model": MerchantMigrationNotFound.schema(),
-        },
-    },
-)
-async def precheck(
-    id: UUID4,
-    auth_subject: MerchantMigrationWrite,
-    session: AsyncSession = Depends(get_db_session),
-) -> PrecheckReport:
-    return await merchant_migration_service.run_precheck(session, auth_subject, id)
-
-
-@router.post(
-    "/{id}/import",
-    response_model=MerchantMigrationImportReport,
-    summary="Import Merchant Migration Catalog",
+    response_model=MerchantMigrationSchema,
+    status_code=202,
+    summary="Start Merchant Migration Pre-check",
     responses={
         400: {
             "description": "The source is not connected or isn't supported.",
@@ -180,8 +155,46 @@ async def precheck(
             "model": MerchantMigrationNotFound.schema(),
         },
         409: {
-            "description": "The pre-check hasn't run yet, or it reports a blocker.",
-            "model": CatalogImportNotReady.schema() | CatalogImportBlocked.schema(),
+            "description": "A background operation is already running, or the "
+            "migration isn't ready for precheck.",
+            "model": OperationInProgress.schema()
+            | PrecheckNotAllowed.schema()
+            | CatalogImportNotReady.schema(),
+        },
+    },
+)
+async def precheck(
+    id: UUID4,
+    auth_subject: MerchantMigrationWrite,
+    session: AsyncSession = Depends(get_db_session),
+) -> MerchantMigration:
+    return await merchant_migration_service.start_precheck(session, auth_subject, id)
+
+
+@router.post(
+    "/{id}/import",
+    response_model=MerchantMigrationSchema,
+    status_code=202,
+    summary="Start Merchant Migration Catalog Import",
+    responses={
+        400: {
+            "description": "The source is not connected or isn't supported.",
+            "model": SourceNotConnected.schema() | UnsupportedMigrationSource.schema(),
+        },
+        403: {
+            "description": "Not allowed to manage this organization.",
+            "model": NotPermitted.schema(),
+        },
+        404: {
+            "description": "Merchant migration not found.",
+            "model": MerchantMigrationNotFound.schema(),
+        },
+        409: {
+            "description": "The pre-check hasn't run yet, a blocker applies, or a "
+            "background operation is already running.",
+            "model": CatalogImportNotReady.schema()
+            | CatalogImportBlocked.schema()
+            | OperationInProgress.schema(),
         },
     },
 )
@@ -190,8 +203,8 @@ async def import_catalog(
     auth_subject: MerchantMigrationWrite,
     body: MerchantMigrationImportRequest | None = None,
     session: AsyncSession = Depends(get_db_session),
-) -> MerchantMigrationImportReport:
-    return await merchant_migration_service.import_catalog(
+) -> MerchantMigration:
+    return await merchant_migration_service.start_import(
         session,
         auth_subject,
         id,
@@ -314,9 +327,6 @@ async def complete_pan_transfer_step(
 async def records_summary(
     id: UUID4,
     auth_subject: MerchantMigrationWrite,
-    # The primary, not the replica: the receipt reads these counts back the
-    # moment the import commits, so replica lag would report it as having
-    # landed nothing.
     session: AsyncSession = Depends(get_db_session),
 ) -> MerchantMigrationRecordSummary:
     return await merchant_migration_service.summarize_records(session, auth_subject, id)
@@ -349,9 +359,6 @@ async def records(
     status: Annotated[PrecheckRecordStatus | None, Query()] = None,
     reason_level: Annotated[PrecheckReasonLevel | None, Query()] = None,
     import_status: Annotated[MerchantMigrationRecordStatus | None, Query()] = None,
-    # The primary, like the summary above: it supplies the selection ceiling
-    # and these rows supply the checkboxes, so a split would let replica lag
-    # show a tickable row the count doesn't include.
     session: AsyncSession = Depends(get_db_session),
 ) -> ListResource[MerchantMigrationRecordItem]:
     items, count = await merchant_migration_service.list_records(

--- a/server/polar/merchant_migration/importer.py
+++ b/server/polar/merchant_migration/importer.py
@@ -10,7 +10,7 @@ from uuid import UUID
 
 from sqlalchemy.orm import joinedload, selectinload
 
-from polar.auth.models import AuthSubject, is_organization
+from polar.auth.models import AuthSubject
 from polar.customer.repository import CustomerRepository
 from polar.customer.service import customer as customer_service
 from polar.enums import SubscriptionRecurringInterval
@@ -24,7 +24,6 @@ from polar.models import (
     Organization,
     Product,
     Subscription,
-    User,
 )
 from polar.models.merchant_migration import MerchantMigrationSourcePlatform
 from polar.models.merchant_migration_record import (
@@ -112,7 +111,7 @@ class CatalogImporter:
         session: AsyncSession,
         migration: MerchantMigration,
         organization: Organization,
-        auth_subject: AuthSubject[User | Organization],
+        auth_subject: AuthSubject[Organization],
         *,
         selection: MerchantMigrationOperationSelection | None = None,
     ) -> None:
@@ -240,14 +239,11 @@ class CatalogImporter:
                     price_currency=PresentmentCurrency(price.currency.lower()),
                 )
             )
-        organization_id = (
-            None if is_organization(self.auth_subject) else self.organization.id
-        )
         return await product_service.create(
             self.session,
             ProductCreateRecurring(
                 name=product.name,
-                organization_id=organization_id,
+                organization_id=None,
                 recurring_interval=SubscriptionRecurringInterval(
                     product.recurring_interval
                 ),

--- a/server/polar/merchant_migration/importer.py
+++ b/server/polar/merchant_migration/importer.py
@@ -1,5 +1,6 @@
 """Imports the staged catalog into Polar (the `create_catalog` step).
 Idempotent; migrated subscriptions arrive paused so nothing bills until cutover.
+Runs in Dramatiq batches: products → customers → subscriptions.
 """
 
 from collections.abc import Sequence
@@ -9,7 +10,7 @@ from uuid import UUID
 
 from sqlalchemy.orm import joinedload, selectinload
 
-from polar.auth.models import AuthSubject
+from polar.auth.models import AuthSubject, is_organization
 from polar.customer.repository import CustomerRepository
 from polar.customer.service import customer as customer_service
 from polar.enums import SubscriptionRecurringInterval
@@ -47,6 +48,7 @@ from .canonical import (
     CanonicalSubscription,
     deserialize,
 )
+from .operation import MerchantMigrationOperationSelection
 from .precheck import (
     ProductImportPlan,
     Reason,
@@ -55,11 +57,6 @@ from .precheck import (
     plan_subscription_imports,
 )
 from .repository import MerchantMigrationRecordRepository
-from .schemas import (
-    MerchantMigrationImportReport,
-    MerchantMigrationImportResult,
-    PrecheckEntity,
-)
 
 _CanonicalT = TypeVar("_CanonicalT")
 
@@ -84,17 +81,12 @@ _CUSTOMER_STRIPE_ID_CONFLICT = Reason(
 )
 
 
-@dataclass
-class ImportCounts:
-    imported: int = 0
-    skipped: int = 0
+@dataclass(frozen=True)
+class ImportBatchResult:
+    """Outcome of one import batch for the current record type."""
 
-    def settle(self, status: MerchantMigrationRecordStatus) -> None:
-        """Carry over a row a previous run already decided."""
-        if status == MerchantMigrationRecordStatus.imported:
-            self.imported += 1
-        else:
-            self.skipped += 1
+    records_processed: int
+    last_id: UUID | None
 
 
 @dataclass(frozen=True)
@@ -122,17 +114,13 @@ class CatalogImporter:
         organization: Organization,
         auth_subject: AuthSubject[User | Organization],
         *,
-        record_ids: set[UUID] | None = None,
-        exclude_record_ids: set[UUID] | None = None,
+        selection: MerchantMigrationOperationSelection | None = None,
     ) -> None:
         self.session = session
         self.migration = migration
         self.organization = organization
         self.auth_subject = auth_subject
-        # Neither set imports everything; excluding is the opt-out default for
-        # large catalogs.
-        self.record_ids = record_ids
-        self.exclude_record_ids = exclude_record_ids
+        self.selection = selection
         self.record_repository = MerchantMigrationRecordRepository.from_session(session)
         self.product_repository = ProductRepository.from_session(session)
         self.customer_repository = CustomerRepository.from_session(session)
@@ -140,46 +128,53 @@ class CatalogImporter:
         self._product_cache: dict[UUID, Product] = {}
         self._customer_cache: dict[UUID, Customer] = {}
 
-    async def run(self) -> MerchantMigrationImportReport:
-        records = await self.record_repository.list_by_migration(self.migration.id)
-        product_records = self._records_of(records, MerchantMigrationRecordType.product)
-        customer_records = self._records_of(
-            records, MerchantMigrationRecordType.customer
-        )
-        subscription_records = self._records_of(
-            records, MerchantMigrationRecordType.subscription
-        )
+    @property
+    def _record_ids(self) -> Sequence[UUID] | None:
+        if self.selection is None:
+            return None
+        return self.selection.record_ids
 
-        # Products and customers first: a subscription resolves both from their
-        # imported ledger rows.
-        product_result = await self._import_products(product_records)
-        customer_result = await self._import_customers(customer_records)
-        subscription_result = await self._import_subscriptions(
-            subscription_records, product_records, customer_records
-        )
+    @property
+    def _exclude_record_ids(self) -> Sequence[UUID] | None:
+        if self.selection is None:
+            return None
+        return self.selection.exclude_record_ids
 
-        return MerchantMigrationImportReport(
-            step=self.migration.step,
-            results=[product_result, customer_result, subscription_result],
-        )
-
-    def _records_of(
+    async def run_batch(
         self,
-        records: Sequence[MerchantMigrationRecord],
-        type: MerchantMigrationRecordType,
-    ) -> list[MerchantMigrationRecord]:
-        return [record for record in records if record.type == type]
+        record_type: MerchantMigrationRecordType,
+        *,
+        after_id: UUID | None,
+        limit: int,
+    ) -> ImportBatchResult:
+        """Import up to ``limit`` pending selected rows of ``record_type``.
 
-    def _is_selected(self, record: MerchantMigrationRecord) -> bool:
-        if self.record_ids is not None:
-            return record.id in self.record_ids
-        if self.exclude_record_ids is not None:
-            return record.id not in self.exclude_record_ids
-        return True
+        Record-level failures mark that ledger row ``failed`` and the batch
+        continues. Returns how far the cursor advanced.
+        """
+        records = await self.record_repository.list_pending_batch(
+            self.migration.id,
+            record_type,
+            limit=limit,
+            after_id=after_id,
+            record_ids=self._record_ids,
+            exclude_record_ids=self._exclude_record_ids,
+        )
+        if not records:
+            return ImportBatchResult(records_processed=0, last_id=after_id)
+
+        if record_type == MerchantMigrationRecordType.product:
+            await self._import_products(records)
+        elif record_type == MerchantMigrationRecordType.customer:
+            await self._import_customers(records)
+        else:
+            await self._import_subscriptions(records)
+
+        return ImportBatchResult(records_processed=len(records), last_id=records[-1].id)
 
     async def _import_products(
         self, records: Sequence[MerchantMigrationRecord]
-    ) -> MerchantMigrationImportResult:
+    ) -> None:
         products = [
             self._as(deserialize(record.type, record.canonical), CanonicalProduct)
             for record in records
@@ -188,63 +183,46 @@ class CatalogImporter:
             products, self.organization.default_presentment_currency
         )
 
-        counts = ImportCounts()
         for record, product in zip(records, products, strict=True):
-            if not self._is_selected(record):
-                continue
             if record.status != MerchantMigrationRecordStatus.pending:
-                counts.settle(record.status)
                 continue
             plan = plans[product.source_id]
             if plan.skip is not None:
                 await self._mark_skipped(record, plan.skip)
-                counts.skipped += 1
                 continue
-            polar_product = await self._create_product(product, plan)
-            await self._mark_imported(record, polar_product.id)
-            counts.imported += 1
-
-        return MerchantMigrationImportResult(
-            entity=PrecheckEntity.products,
-            imported=counts.imported,
-            skipped=counts.skipped,
-        )
+            try:
+                async with self.session.begin_nested():
+                    polar_product = await self._create_product(product, plan)
+                await self._mark_imported(record, polar_product.id)
+            except Exception as e:
+                await self._mark_failed(record, e)
 
     async def _import_customers(
         self, records: Sequence[MerchantMigrationRecord]
-    ) -> MerchantMigrationImportResult:
+    ) -> None:
         customers = [
             self._as(deserialize(record.type, record.canonical), CanonicalCustomer)
             for record in records
         ]
         plans = plan_customer_imports(customers)
 
-        counts = ImportCounts()
         for record, customer in zip(records, customers, strict=True):
-            if not self._is_selected(record):
-                continue
             if record.status != MerchantMigrationRecordStatus.pending:
-                counts.settle(record.status)
                 continue
             skip = plans[customer.source_id]
             if skip is not None:
                 await self._mark_skipped(record, skip)
-                counts.skipped += 1
                 continue
-            result = await self._create_or_reuse_customer(customer)
-            if result.skip is not None:
-                await self._mark_skipped(record, result.skip)
-                counts.skipped += 1
-                continue
-            assert result.customer is not None
-            await self._mark_imported(record, result.customer.id)
-            counts.imported += 1
-
-        return MerchantMigrationImportResult(
-            entity=PrecheckEntity.customers,
-            imported=counts.imported,
-            skipped=counts.skipped,
-        )
+            try:
+                async with self.session.begin_nested():
+                    result = await self._create_or_reuse_customer(customer)
+                if result.skip is not None:
+                    await self._mark_skipped(record, result.skip)
+                    continue
+                assert result.customer is not None
+                await self._mark_imported(record, result.customer.id)
+            except Exception as e:
+                await self._mark_failed(record, e)
 
     async def _create_product(
         self, product: CanonicalProduct, plan: ProductImportPlan
@@ -262,12 +240,14 @@ class CatalogImporter:
                     price_currency=PresentmentCurrency(price.currency.lower()),
                 )
             )
-        # A bulk import must not webhook or re-review the org for every product.
+        organization_id = (
+            None if is_organization(self.auth_subject) else self.organization.id
+        )
         return await product_service.create(
             self.session,
             ProductCreateRecurring(
                 name=product.name,
-                organization_id=self.organization.id,
+                organization_id=organization_id,
                 recurring_interval=SubscriptionRecurringInterval(
                     product.recurring_interval
                 ),
@@ -286,16 +266,12 @@ class CatalogImporter:
             customer.email, self.organization.id
         )
         if existing is not None:
-            # Reusing a customer bound to another Stripe id would attach the
-            # PAN-copied card to the wrong record.
             if (
                 stripe_customer_id is not None
                 and existing.stripe_customer_id is not None
                 and existing.stripe_customer_id != stripe_customer_id
             ):
                 return ImportedCustomer(skip=_CUSTOMER_STRIPE_ID_CONFLICT)
-            # Reconcile the source id so the PAN-copied card lands on the same
-            # customer, but never overwrite one that's already set.
             if stripe_customer_id and existing.stripe_customer_id is None:
                 await self.customer_repository.update(
                     existing, update_dict={"stripe_customer_id": stripe_customer_id}
@@ -312,8 +288,6 @@ class CatalogImporter:
         return ImportedCustomer(customer=polar_customer)
 
     def _stripe_customer_id(self, customer: CanonicalCustomer) -> str | None:
-        # PAN copy preserves the Stripe `cus_…` id; other providers have no
-        # such concept.
         if self.migration.source_platform == MerchantMigrationSourcePlatform.stripe:
             return customer.source_id
         return None
@@ -328,11 +302,14 @@ class CatalogImporter:
         return Address(country=country)
 
     async def _import_subscriptions(
-        self,
-        records: Sequence[MerchantMigrationRecord],
-        product_records: Sequence[MerchantMigrationRecord],
-        customer_records: Sequence[MerchantMigrationRecord],
-    ) -> MerchantMigrationImportResult:
+        self, records: Sequence[MerchantMigrationRecord]
+    ) -> None:
+        product_records = await self.record_repository.list_by_migration_and_types(
+            self.migration.id, [MerchantMigrationRecordType.product]
+        )
+        customer_records = await self.record_repository.list_by_migration_and_types(
+            self.migration.id, [MerchantMigrationRecordType.customer]
+        )
         subscriptions = [
             self._as(deserialize(record.type, record.canonical), CanonicalSubscription)
             for record in records
@@ -354,45 +331,32 @@ class CatalogImporter:
         product_by_price = {
             price.source_id: product for product in products for price in product.prices
         }
-        # Their ledger rows already carry target ids in-session, so resolve from
-        # these maps instead of a query per subscription.
         customer_target_by_source = self._imported_targets(customer_records)
         product_target_by_source = self._imported_targets(product_records)
 
-        counts = ImportCounts()
         for record, subscription in zip(records, subscriptions, strict=True):
-            if not self._is_selected(record):
-                continue
             if record.status != MerchantMigrationRecordStatus.pending:
-                counts.settle(record.status)
                 continue
             skip = plans[subscription.source_id]
             if skip is not None:
                 await self._mark_skipped(record, skip)
-                counts.skipped += 1
                 continue
-            result = await self._create_subscription(
-                subscription,
-                product_by_price,
-                customer_target_by_source,
-                product_target_by_source,
-            )
-            # A missing dependency means it was skipped or deselected, so skip
-            # the subscription rather than leave it pending.
-            if result.skip is not None:
-                await self._mark_skipped(record, result.skip)
-                counts.skipped += 1
-                continue
-            if result.subscription is None:
-                continue
-            await self._mark_imported(record, result.subscription.id)
-            counts.imported += 1
-
-        return MerchantMigrationImportResult(
-            entity=PrecheckEntity.subscriptions,
-            imported=counts.imported,
-            skipped=counts.skipped,
-        )
+            try:
+                async with self.session.begin_nested():
+                    result = await self._create_subscription(
+                        subscription,
+                        product_by_price,
+                        customer_target_by_source,
+                        product_target_by_source,
+                    )
+                if result.skip is not None:
+                    await self._mark_skipped(record, result.skip)
+                    continue
+                if result.subscription is None:
+                    continue
+                await self._mark_imported(record, result.subscription.id)
+            except Exception as e:
+                await self._mark_failed(record, e)
 
     async def _create_subscription(
         self,
@@ -416,8 +380,6 @@ class CatalogImporter:
         if polar_product is None or customer is None:
             return ImportedSubscription()
 
-        # Never create a second live subscription to the same product for a
-        # customer — at cutover it would double-bill them.
         if await self.subscription_repository.exists_live_by_customer_and_product(
             customer.id, polar_product.id
         ):
@@ -463,7 +425,6 @@ class CatalogImporter:
         }
 
     async def _load_customer(self, customer_id: UUID) -> Customer | None:
-        # Several subscriptions often share one customer.
         if customer_id not in self._customer_cache:
             customer = await self.customer_repository.get_by_id(customer_id)
             if customer is None:
@@ -475,8 +436,6 @@ class CatalogImporter:
         cached = self._product_cache.get(product_id)
         if cached is not None:
             return cached
-        # None only if an imported product row vanished; the caller leaves the
-        # subscription pending rather than crashing.
         product = await self.product_repository.get_by_id_and_organization(
             product_id,
             self.organization.id,
@@ -495,8 +454,6 @@ class CatalogImporter:
         canonical_product: CanonicalProduct,
         price_source_id: str,
     ) -> ProductPriceFixed | None:
-        # Prices carry no durable source id, and an imported product holds one
-        # fixed price per currency, so the currency identifies it.
         canonical_price = next(
             (p for p in canonical_product.prices if p.source_id == price_source_id),
             None,
@@ -534,6 +491,17 @@ class CatalogImporter:
             update_dict={
                 "status": MerchantMigrationRecordStatus.skipped,
                 "error": reason.message,
+            },
+        )
+
+    async def _mark_failed(
+        self, record: MerchantMigrationRecord, error: Exception
+    ) -> None:
+        await self.record_repository.update(
+            record,
+            update_dict={
+                "status": MerchantMigrationRecordStatus.failed,
+                "error": str(error)[:500] or error.__class__.__name__,
             },
         )
 

--- a/server/polar/merchant_migration/operation.py
+++ b/server/polar/merchant_migration/operation.py
@@ -1,39 +1,28 @@
-"""Background operation state for merchant migration precheck and catalog import.
+"""Background operation helpers for merchant migration precheck and import.
 
-Persisted as JSONB on ``MerchantMigration.operation``. ``MerchantMigration.step``
-names the phase; ``operation.status`` says where we are within it. There is no
-separate ``kind`` — it would always duplicate ``step``.
+The typed JSONB record lives in ``polar.models.merchant_migration_operation`` so
+the column can land in a migration-only PR. This module re-exports those types
+and owns worker-facing helpers (mark_*, cursors, batch sizes, OperationInProgress).
 """
 
-from datetime import datetime, timedelta
-from enum import StrEnum
 from typing import Any
 from uuid import UUID
 
-from pydantic import Field, model_validator
-from sqlalchemy import Dialect
-from sqlalchemy.dialects.postgresql import JSONB
-from sqlalchemy.types import TypeDecorator
-
-from polar.kit.schemas import Schema
 from polar.kit.utils import utc_now
+from polar.models.merchant_migration_operation import (
+    STALL_THRESHOLD as STALL_THRESHOLD,
+)
+from polar.models.merchant_migration_operation import (
+    MerchantMigrationOperation,
+    MerchantMigrationOperationSelection,
+    MerchantMigrationOperationStatus,
+)
 from polar.models.merchant_migration_record import MerchantMigrationRecordType
 
 from .errors import MerchantMigrationError
 
-# How long an operation may sit in pending/running without progress before GET
-# marks it failed. Workers bump ``last_progress_at`` on every successful batch.
-STALL_THRESHOLD = timedelta(minutes=20)
-
 PRECHECK_BATCH_SIZE = 50
 IMPORT_BATCH_SIZE = 25
-
-
-class MerchantMigrationOperationStatus(StrEnum):
-    pending = "pending"
-    running = "running"
-    done = "done"
-    failed = "failed"
 
 
 class OperationInProgress(MerchantMigrationError):
@@ -42,90 +31,6 @@ class OperationInProgress(MerchantMigrationError):
             "A background operation is already running for this migration.",
             409,
         )
-
-
-class MerchantMigrationOperationSelection(Schema):
-    """Compact import selection. Opt-in (``record_ids``) or opt-out
-    (``exclude_record_ids``); never both. Workers filter batch queries with this
-    rather than marking every ledger row up front."""
-
-    record_ids: list[UUID] | None = Field(
-        default=None,
-        description="Import only these ledger record ids.",
-    )
-    exclude_record_ids: list[UUID] | None = Field(
-        default=None,
-        description="Import every pending importable record except these.",
-    )
-
-    @model_validator(mode="after")
-    def _one_mode(self) -> "MerchantMigrationOperationSelection":
-        if self.record_ids is not None and self.exclude_record_ids is not None:
-            raise ValueError("Use record_ids or exclude_record_ids, not both.")
-        return self
-
-
-class MerchantMigrationOperation(Schema):
-    """In-flight or finished background work for the current ``step``."""
-
-    status: MerchantMigrationOperationStatus = Field(
-        description="pending → running → done, or failed."
-    )
-    cursor: dict[str, Any] | None = Field(
-        default=None,
-        description=(
-            "Opaque resume point for the batch chain. Shape depends on the step "
-            "(extract phase + Stripe page cursor, or import type + last record id)."
-        ),
-    )
-    selection: MerchantMigrationOperationSelection | None = Field(
-        default=None,
-        description="Import only: the compact selection from the start request.",
-    )
-    error: str | None = Field(
-        default=None,
-        description="Safe failure message when status is failed.",
-    )
-    last_progress_at: datetime | None = Field(
-        default=None,
-        description="Bumped on enqueue and each successful batch; used for stall detection.",
-    )
-
-    @property
-    def is_active(self) -> bool:
-        return self.status in (
-            MerchantMigrationOperationStatus.pending,
-            MerchantMigrationOperationStatus.running,
-        )
-
-    @property
-    def is_terminal(self) -> bool:
-        return self.status in (
-            MerchantMigrationOperationStatus.done,
-            MerchantMigrationOperationStatus.failed,
-        )
-
-    def is_stalled(self, *, now: datetime | None = None) -> bool:
-        if not self.is_active or self.last_progress_at is None:
-            return False
-        return (now or utc_now()) - self.last_progress_at >= STALL_THRESHOLD
-
-
-class MerchantMigrationOperationType(TypeDecorator[Any]):
-    impl = JSONB
-    cache_ok = True
-
-    def process_bind_param(self, value: Any, dialect: Dialect) -> Any:
-        if value is None:
-            return value
-        if isinstance(value, MerchantMigrationOperation):
-            return value.model_dump(mode="json")
-        return value
-
-    def process_result_value(self, value: Any, dialect: Dialect) -> Any:
-        if value is None:
-            return value
-        return MerchantMigrationOperation.model_validate(value)
 
 
 def new_pending_operation(

--- a/server/polar/merchant_migration/operation.py
+++ b/server/polar/merchant_migration/operation.py
@@ -1,0 +1,231 @@
+"""Background operation state for merchant migration precheck and catalog import.
+
+Persisted as JSONB on ``MerchantMigration.operation``. ``MerchantMigration.step``
+names the phase; ``operation.status`` says where we are within it. There is no
+separate ``kind`` — it would always duplicate ``step``.
+"""
+
+from datetime import datetime, timedelta
+from enum import StrEnum
+from typing import Any
+from uuid import UUID
+
+from pydantic import Field, model_validator
+from sqlalchemy import Dialect
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.types import TypeDecorator
+
+from polar.kit.schemas import Schema
+from polar.kit.utils import utc_now
+from polar.models.merchant_migration_record import MerchantMigrationRecordType
+
+from .errors import MerchantMigrationError
+
+# How long an operation may sit in pending/running without progress before GET
+# marks it failed. Workers bump ``last_progress_at`` on every successful batch.
+STALL_THRESHOLD = timedelta(minutes=20)
+
+PRECHECK_BATCH_SIZE = 50
+IMPORT_BATCH_SIZE = 25
+
+
+class MerchantMigrationOperationStatus(StrEnum):
+    pending = "pending"
+    running = "running"
+    done = "done"
+    failed = "failed"
+
+
+class OperationInProgress(MerchantMigrationError):
+    def __init__(self) -> None:
+        super().__init__(
+            "A background operation is already running for this migration.",
+            409,
+        )
+
+
+class MerchantMigrationOperationSelection(Schema):
+    """Compact import selection. Opt-in (``record_ids``) or opt-out
+    (``exclude_record_ids``); never both. Workers filter batch queries with this
+    rather than marking every ledger row up front."""
+
+    record_ids: list[UUID] | None = Field(
+        default=None,
+        description="Import only these ledger record ids.",
+    )
+    exclude_record_ids: list[UUID] | None = Field(
+        default=None,
+        description="Import every pending importable record except these.",
+    )
+
+    @model_validator(mode="after")
+    def _one_mode(self) -> "MerchantMigrationOperationSelection":
+        if self.record_ids is not None and self.exclude_record_ids is not None:
+            raise ValueError("Use record_ids or exclude_record_ids, not both.")
+        return self
+
+
+class MerchantMigrationOperation(Schema):
+    """In-flight or finished background work for the current ``step``."""
+
+    status: MerchantMigrationOperationStatus = Field(
+        description="pending → running → done, or failed."
+    )
+    cursor: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Opaque resume point for the batch chain. Shape depends on the step "
+            "(extract phase + Stripe page cursor, or import type + last record id)."
+        ),
+    )
+    selection: MerchantMigrationOperationSelection | None = Field(
+        default=None,
+        description="Import only: the compact selection from the start request.",
+    )
+    error: str | None = Field(
+        default=None,
+        description="Safe failure message when status is failed.",
+    )
+    last_progress_at: datetime | None = Field(
+        default=None,
+        description="Bumped on enqueue and each successful batch; used for stall detection.",
+    )
+
+    @property
+    def is_active(self) -> bool:
+        return self.status in (
+            MerchantMigrationOperationStatus.pending,
+            MerchantMigrationOperationStatus.running,
+        )
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.status in (
+            MerchantMigrationOperationStatus.done,
+            MerchantMigrationOperationStatus.failed,
+        )
+
+    def is_stalled(self, *, now: datetime | None = None) -> bool:
+        if not self.is_active or self.last_progress_at is None:
+            return False
+        return (now or utc_now()) - self.last_progress_at >= STALL_THRESHOLD
+
+
+class MerchantMigrationOperationType(TypeDecorator[Any]):
+    impl = JSONB
+    cache_ok = True
+
+    def process_bind_param(self, value: Any, dialect: Dialect) -> Any:
+        if value is None:
+            return value
+        if isinstance(value, MerchantMigrationOperation):
+            return value.model_dump(mode="json")
+        return value
+
+    def process_result_value(self, value: Any, dialect: Dialect) -> Any:
+        if value is None:
+            return value
+        return MerchantMigrationOperation.model_validate(value)
+
+
+def new_pending_operation(
+    *,
+    selection: MerchantMigrationOperationSelection | None = None,
+) -> MerchantMigrationOperation:
+    return MerchantMigrationOperation(
+        status=MerchantMigrationOperationStatus.pending,
+        cursor=None,
+        selection=selection,
+        error=None,
+        last_progress_at=utc_now(),
+    )
+
+
+def mark_running(
+    operation: MerchantMigrationOperation,
+    *,
+    cursor: dict[str, Any] | None,
+) -> MerchantMigrationOperation:
+    return operation.model_copy(
+        update={
+            "status": MerchantMigrationOperationStatus.running,
+            "cursor": cursor,
+            "error": None,
+            "last_progress_at": utc_now(),
+        }
+    )
+
+
+def mark_done(operation: MerchantMigrationOperation) -> MerchantMigrationOperation:
+    return operation.model_copy(
+        update={
+            "status": MerchantMigrationOperationStatus.done,
+            "cursor": None,
+            "error": None,
+            "last_progress_at": utc_now(),
+        }
+    )
+
+
+def mark_failed(
+    operation: MerchantMigrationOperation, error: str
+) -> MerchantMigrationOperation:
+    return operation.model_copy(
+        update={
+            "status": MerchantMigrationOperationStatus.failed,
+            "error": error,
+            "last_progress_at": utc_now(),
+        }
+    )
+
+
+# --- Cursor helpers (opaque dicts persisted on the operation) ---
+
+PRECHECK_PHASES = ("products", "customers", "subscriptions")
+IMPORT_TYPES = (
+    MerchantMigrationRecordType.product,
+    MerchantMigrationRecordType.customer,
+    MerchantMigrationRecordType.subscription,
+)
+
+
+def precheck_cursor(*, phase: str, starting_after: str | None = None) -> dict[str, Any]:
+    cursor: dict[str, Any] = {"phase": phase}
+    if starting_after is not None:
+        cursor["starting_after"] = starting_after
+    return cursor
+
+
+def import_cursor(
+    *,
+    record_type: MerchantMigrationRecordType,
+    after_id: UUID | None = None,
+) -> dict[str, Any]:
+    cursor: dict[str, Any] = {"type": record_type.value}
+    if after_id is not None:
+        cursor["after_id"] = str(after_id)
+    return cursor
+
+
+def parse_import_type(cursor: dict[str, Any] | None) -> MerchantMigrationRecordType:
+    if cursor is None:
+        return MerchantMigrationRecordType.product
+    return MerchantMigrationRecordType(cursor["type"])
+
+
+def parse_import_after_id(cursor: dict[str, Any] | None) -> UUID | None:
+    if cursor is None or cursor.get("after_id") is None:
+        return None
+    return UUID(str(cursor["after_id"]))
+
+
+def next_import_type(
+    record_type: MerchantMigrationRecordType,
+) -> MerchantMigrationRecordType | None:
+    try:
+        index = IMPORT_TYPES.index(record_type)
+    except ValueError:
+        return None
+    if index + 1 >= len(IMPORT_TYPES):
+        return None
+    return IMPORT_TYPES[index + 1]

--- a/server/polar/merchant_migration/operation.py
+++ b/server/polar/merchant_migration/operation.py
@@ -13,9 +13,13 @@ from polar.models.merchant_migration_operation import (
     STALL_THRESHOLD as STALL_THRESHOLD,
 )
 from polar.models.merchant_migration_operation import (
-    MerchantMigrationOperation,
-    MerchantMigrationOperationSelection,
-    MerchantMigrationOperationStatus,
+    MerchantMigrationOperation as MerchantMigrationOperation,
+)
+from polar.models.merchant_migration_operation import (
+    MerchantMigrationOperationSelection as MerchantMigrationOperationSelection,
+)
+from polar.models.merchant_migration_operation import (
+    MerchantMigrationOperationStatus as MerchantMigrationOperationStatus,
 )
 from polar.models.merchant_migration_record import MerchantMigrationRecordType
 

--- a/server/polar/merchant_migration/repository.py
+++ b/server/polar/merchant_migration/repository.py
@@ -242,6 +242,60 @@ class MerchantMigrationRecordRepository(
         )
         return await self.get_all(statement)
 
+    async def list_pending_batch(
+        self,
+        migration_id: UUID,
+        record_type: MerchantMigrationRecordType,
+        *,
+        limit: int,
+        after_id: UUID | None = None,
+        record_ids: Sequence[UUID] | None = None,
+        exclude_record_ids: Sequence[UUID] | None = None,
+    ) -> Sequence[MerchantMigrationRecord]:
+        """Next pending rows for one import type, filtered by selection + cursor.
+
+        Selection is applied in SQL so an exclude-one catalog never expands into
+        a million writes. Ordered by id so ``after_id`` resumes stably.
+        """
+        statement = (
+            self.get_base_statement()
+            .where(
+                MerchantMigrationRecord.merchant_migration_id == migration_id,
+                MerchantMigrationRecord.type == record_type,
+                MerchantMigrationRecord.status == MerchantMigrationRecordStatus.pending,
+            )
+            .order_by(MerchantMigrationRecord.id)
+            .limit(limit)
+        )
+        if after_id is not None:
+            statement = statement.where(MerchantMigrationRecord.id > after_id)
+        if record_ids is not None:
+            statement = statement.where(MerchantMigrationRecord.id.in_(record_ids))
+        elif exclude_record_ids:
+            statement = statement.where(
+                MerchantMigrationRecord.id.not_in(exclude_record_ids)
+            )
+        return await self.get_all(statement)
+
+    async def list_by_migration_and_types(
+        self,
+        migration_id: UUID,
+        types: Sequence[MerchantMigrationRecordType],
+    ) -> Sequence[MerchantMigrationRecord]:
+        statement = (
+            self.get_base_statement()
+            .where(
+                MerchantMigrationRecord.merchant_migration_id == migration_id,
+                MerchantMigrationRecord.type.in_(types),
+            )
+            .order_by(
+                MerchantMigrationRecord.type,
+                MerchantMigrationRecord.created_at,
+                MerchantMigrationRecord.id,
+            )
+        )
+        return await self.get_all(statement)
+
     async def upsert(
         self,
         merchant_migration: MerchantMigration,

--- a/server/polar/merchant_migration/schemas.py
+++ b/server/polar/merchant_migration/schemas.py
@@ -11,6 +11,7 @@ from polar.models.merchant_migration import (
 )
 from polar.models.merchant_migration_record import MerchantMigrationRecordStatus
 
+from .operation import MerchantMigrationOperation
 from .pan_transfer import PanTransferMethod, PanTransferStep
 
 
@@ -167,23 +168,6 @@ class MerchantMigrationImportRequest(Schema):
     )
 
 
-class MerchantMigrationImportResult(Schema):
-    entity: PrecheckEntity = Field(description="The source entity type.")
-    imported: int = Field(description="How many were created or reused in Polar.")
-    skipped: int = Field(
-        description="How many were left on the source (not importable)."
-    )
-
-
-class MerchantMigrationImportReport(Schema):
-    step: MerchantMigrationStep = Field(
-        description="The migration step after the import."
-    )
-    results: list[MerchantMigrationImportResult] = Field(
-        description="Per-entity counts of what was imported vs skipped."
-    )
-
-
 class PanTransferStepComplete(Schema):
     inputs: dict[str, str] = Field(
         default_factory=dict,
@@ -233,5 +217,11 @@ class MerchantMigration(IDSchema, TimestampedSchema):
         description=(
             "Non-secret metadata about the connected source. The shape varies by "
             "provider (e.g. Stripe exposes `stripe_user_id`, `livemode`)."
+        ),
+    )
+    operation: MerchantMigrationOperation | None = Field(
+        description=(
+            "Background precheck/import progress for the current step. Null until "
+            "the first background run is started."
         ),
     )

--- a/server/polar/merchant_migration/service.py
+++ b/server/polar/merchant_migration/service.py
@@ -1,4 +1,4 @@
-from collections.abc import AsyncIterator, Sequence
+from collections.abc import Sequence
 from datetime import datetime
 from typing import TypedDict
 from uuid import UUID
@@ -7,6 +7,7 @@ import stripe as stripe_lib
 
 from polar.auth.models import AuthSubject, Organization, User
 from polar.auth.permission import OrganizationPermission
+from polar.auth.scope import Scope
 from polar.authz.service import assert_organization_permission
 from polar.config import settings
 from polar.kit.db.postgres import AsyncSession
@@ -24,12 +25,28 @@ from polar.models.merchant_migration_record import (
 from polar.organization.repository import OrganizationRepository
 from polar.postgres import AsyncReadSession
 from polar.product.repository import ProductRepository
+from polar.worker import enqueue_job
 
 from . import pan_transfer
 from .adapters import SourceAdapter, StripeAdapter
-from .canonical import CanonicalRecord, deserialize
+from .canonical import deserialize
 from .errors import MerchantMigrationError
 from .importer import CatalogImporter
+from .operation import (
+    IMPORT_BATCH_SIZE,
+    PRECHECK_BATCH_SIZE,
+    MerchantMigrationOperationSelection,
+    MerchantMigrationOperationStatus,
+    OperationInProgress,
+    import_cursor,
+    mark_done,
+    mark_failed,
+    mark_running,
+    new_pending_operation,
+    next_import_type,
+    parse_import_after_id,
+    parse_import_type,
+)
 from .pan_transfer import (
     PanStepActor,
     PanTransferAlreadyStarted,
@@ -42,7 +59,6 @@ from .precheck import (
     account_blockers,
     classify_records,
     import_blockers,
-    precheck_engine,
 )
 from .repository import (
     MerchantMigrationRecordRepository,
@@ -50,7 +66,6 @@ from .repository import (
 )
 from .schemas import (
     MerchantMigrationCreate,
-    MerchantMigrationImportReport,
     MerchantMigrationRecordItem,
     MerchantMigrationRecordSummary,
     MerchantMigrationRecordSummaryEntity,
@@ -59,7 +74,6 @@ from .schemas import (
     PrecheckIssue,
     PrecheckReasonLevel,
     PrecheckRecordStatus,
-    PrecheckReport,
 )
 
 IMPORTABLE_STEPS = {
@@ -151,6 +165,14 @@ class CatalogImportNotReady(MerchantMigrationError):
         )
 
 
+class PrecheckNotAllowed(MerchantMigrationError):
+    def __init__(self) -> None:
+        super().__init__(
+            "Precheck can only run during source setup or the pre-check step.",
+            409,
+        )
+
+
 class BlockedByPrecheck(MerchantMigrationError):
     """Precheck blockers as an API error: the codes stay machine-readable while
     the merchant reads the joined messages."""
@@ -227,7 +249,7 @@ def _is_live_key(api_key: str) -> bool:
 class MerchantMigrationService:
     async def get(
         self,
-        session: AsyncReadSession,
+        session: AsyncSession,
         auth_subject: AuthSubject[User | Organization],
         migration_id: UUID,
     ) -> MerchantMigration | None:
@@ -235,7 +257,10 @@ class MerchantMigrationService:
         statement = repository.get_readable_statement(auth_subject).where(
             MerchantMigration.id == migration_id
         )
-        return await repository.get_one_or_none(statement)
+        migration = await repository.get_one_or_none(statement)
+        if migration is None:
+            return None
+        return await self._apply_stall_if_needed(session, migration)
 
     async def list(
         self,
@@ -314,46 +339,38 @@ class MerchantMigrationService:
         repository = MerchantMigrationRepository.from_session(session)
         return await repository.create(migration, flush=True)
 
-    async def run_precheck(
+    async def start_precheck(
         self,
         session: AsyncSession,
         auth_subject: AuthSubject[User | Organization],
         migration_id: UUID,
-    ) -> PrecheckReport:
-        """Read the connected source, normalize it, and report whether it can be
-        imported. Advances the migration from source setup to the precheck step.
-        """
+    ) -> MerchantMigration:
+        """Enqueue background precheck. Returns the migration with operation pending."""
         migration = await self._get_manageable(
             session, auth_subject, migration_id, for_update=True
         )
+        self._assert_operation_idle(migration)
+        if migration.step not in (
+            MerchantMigrationStep.source_setup,
+            MerchantMigrationStep.pre_check,
+        ):
+            raise PrecheckNotAllowed()
 
-        organization = await self._get_organization(session, migration)
+        # Decrypt up front so a missing key fails before we enqueue.
+        await self._build_adapter(migration)
 
-        adapter = await self._build_adapter(migration)
-        source_account = await adapter.get_source_account()
-        existing_product_names = await ProductRepository.from_session(
-            session
-        ).get_active_names_by_organization(organization.id)
-        record_repository = MerchantMigrationRecordRepository.from_session(session)
-        report = await precheck_engine.run(
-            self._stage_records(
-                record_repository, migration, organization, adapter.extract()
-            ),
-            organization,
-            source_account,
-            existing_product_names,
+        repository = MerchantMigrationRepository.from_session(session)
+        migration = await repository.update(
+            migration,
+            update_dict={
+                "step": MerchantMigrationStep.pre_check,
+                "operation": new_pending_operation(),
+            },
         )
+        enqueue_job("merchant_migration.precheck", migration.id)
+        return migration
 
-        # Re-running the precheck to refresh the ledger must not regress a
-        # migration that has already moved on.
-        if migration.step == MerchantMigrationStep.source_setup:
-            repository = MerchantMigrationRepository.from_session(session)
-            await repository.update(
-                migration, update_dict={"step": MerchantMigrationStep.pre_check}
-            )
-        return report
-
-    async def import_catalog(
+    async def start_import(
         self,
         session: AsyncSession,
         auth_subject: AuthSubject[User | Organization],
@@ -361,42 +378,180 @@ class MerchantMigrationService:
         *,
         record_ids: Sequence[UUID] | None = None,
         exclude_record_ids: Sequence[UUID] | None = None,
-    ) -> MerchantMigrationImportReport:
-        """Create the Polar catalog from the staged importable records, then
-        advance the migration to the create-catalog step. Idempotent: re-running
-        only imports records still pending in the ledger."""
+    ) -> MerchantMigration:
+        """Enqueue background catalog import. Selection is stored on the operation."""
         migration = await self._get_manageable(
             session, auth_subject, migration_id, for_update=True
         )
+        self._assert_operation_idle(migration)
         if migration.step not in IMPORTABLE_STEPS:
             raise CatalogImportNotReady()
 
         organization = await self._get_organization(session, migration)
-
-        # The pre-check reports blockers but doesn't stop the import, and both the
-        # org and the source account can change after it ran.
         adapter = await self._build_adapter(migration)
         blockers = import_blockers(organization, await adapter.get_source_account())
         if blockers:
             raise CatalogImportBlocked(blockers)
 
-        report = await CatalogImporter(
+        selection = None
+        if record_ids is not None or exclude_record_ids is not None:
+            selection = MerchantMigrationOperationSelection(
+                record_ids=list(record_ids) if record_ids is not None else None,
+                exclude_record_ids=(
+                    list(exclude_record_ids) if exclude_record_ids is not None else None
+                ),
+            )
+
+        repository = MerchantMigrationRepository.from_session(session)
+        migration = await repository.update(
+            migration,
+            update_dict={
+                "step": MerchantMigrationStep.create_catalog,
+                "operation": new_pending_operation(selection=selection),
+            },
+        )
+        enqueue_job("merchant_migration.import", migration.id)
+        return migration
+
+    async def process_precheck_batch(
+        self, session: AsyncSession, migration_id: UUID
+    ) -> None:
+        """One precheck transaction: stage a page, then reenqueue or finish."""
+        repository = MerchantMigrationRepository.from_session(session)
+        migration = await repository.get_by_id(migration_id, for_update=True)
+        if migration is None:
+            return
+        operation = migration.operation
+        if operation is None or operation.is_terminal:
+            return
+        if migration.step != MerchantMigrationStep.pre_check:
+            return
+
+        organization = await self._get_organization(session, migration)
+        adapter = await self._build_adapter(migration)
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+
+        records, next_cursor = await adapter.extract_batch(
+            cursor=operation.cursor, limit=PRECHECK_BATCH_SIZE
+        )
+        for record in records:
+            await record_repository.upsert(migration, organization, record)
+
+        if next_cursor is None:
+            migration = await repository.update(
+                migration, update_dict={"operation": mark_done(operation)}
+            )
+            return
+
+        migration = await repository.update(
+            migration,
+            update_dict={"operation": mark_running(operation, cursor=next_cursor)},
+        )
+        enqueue_job("merchant_migration.precheck", migration.id)
+
+    async def process_import_batch(
+        self, session: AsyncSession, migration_id: UUID
+    ) -> None:
+        """One import transaction: products → customers → subscriptions."""
+        repository = MerchantMigrationRepository.from_session(session)
+        migration = await repository.get_by_id(migration_id, for_update=True)
+        if migration is None:
+            return
+        operation = migration.operation
+        if operation is None or operation.is_terminal:
+            return
+        if migration.step != MerchantMigrationStep.create_catalog:
+            return
+
+        organization = await self._get_organization(session, migration)
+        auth_subject = AuthSubject(organization, set(Scope), None)
+        importer = CatalogImporter(
             session,
             migration,
             organization,
             auth_subject,
-            record_ids=set(record_ids) if record_ids is not None else None,
-            exclude_record_ids=(
-                set(exclude_record_ids) if exclude_record_ids is not None else None
-            ),
-        ).run()
-
-        repository = MerchantMigrationRepository.from_session(session)
-        await repository.update(
-            migration, update_dict={"step": MerchantMigrationStep.create_catalog}
+            selection=operation.selection,
         )
-        report.step = MerchantMigrationStep.create_catalog
-        return report
+
+        record_type = parse_import_type(operation.cursor)
+        after_id = parse_import_after_id(operation.cursor)
+        result = await importer.run_batch(
+            record_type, after_id=after_id, limit=IMPORT_BATCH_SIZE
+        )
+
+        if result.records_processed > 0:
+            next_cursor = import_cursor(
+                record_type=record_type, after_id=result.last_id
+            )
+            migration = await repository.update(
+                migration,
+                update_dict={"operation": mark_running(operation, cursor=next_cursor)},
+            )
+            enqueue_job("merchant_migration.import", migration.id)
+            return
+
+        # Nothing left of this type — advance to the next, or finish.
+        following = next_import_type(record_type)
+        if following is None:
+            migration = await repository.update(
+                migration, update_dict={"operation": mark_done(operation)}
+            )
+            return
+
+        migration = await repository.update(
+            migration,
+            update_dict={
+                "operation": mark_running(
+                    operation, cursor=import_cursor(record_type=following)
+                )
+            },
+        )
+        enqueue_job("merchant_migration.import", migration.id)
+
+    async def fail_operation(
+        self, session: AsyncSession, migration_id: UUID, error: str
+    ) -> None:
+        """Persist operation.status=failed after retries are exhausted."""
+        repository = MerchantMigrationRepository.from_session(session)
+        migration = await repository.get_by_id(migration_id, for_update=True)
+        if migration is None or migration.operation is None:
+            return
+        if migration.operation.is_terminal:
+            return
+        await repository.update(
+            migration,
+            update_dict={"operation": mark_failed(migration.operation, error)},
+        )
+
+    def _assert_operation_idle(self, migration: MerchantMigration) -> None:
+        if migration.operation is not None and migration.operation.is_active:
+            raise OperationInProgress()
+
+    async def _apply_stall_if_needed(
+        self, session: AsyncSession, migration: MerchantMigration
+    ) -> MerchantMigration:
+        operation = migration.operation
+        if operation is None or not operation.is_stalled():
+            return migration
+        repository = MerchantMigrationRepository.from_session(session)
+        # Re-check under the row lock. A worker may have progressed (and bumped
+        # last_progress_at) while we waited; overwriting that would kill a live chain.
+        locked = await repository.get_by_id(migration.id, for_update=True)
+        if locked is None:
+            return migration
+        operation = locked.operation
+        if operation is None or not operation.is_stalled():
+            return locked
+        return await repository.update(
+            locked,
+            update_dict={
+                "operation": mark_failed(
+                    operation,
+                    "The background operation stalled and was marked failed. "
+                    "You can retry.",
+                )
+            },
+        )
 
     async def get_pan_transfer(
         self,
@@ -424,6 +579,14 @@ class MerchantMigrationService:
         if migration.pan_transfer_steps:
             raise PanTransferAlreadyStarted()
         if migration.step != MerchantMigrationStep.create_catalog:
+            raise PanTransferNotReady()
+        # Import advances step when the job is enqueued; only allow PAN once the
+        # background operation has finished successfully (or never ran — legacy).
+        operation = migration.operation
+        if (
+            operation is not None
+            and operation.status != MerchantMigrationOperationStatus.done
+        ):
             raise PanTransferNotReady()
         # The first step tells the merchant which Stripe account to send the cards
         # to. Without it configured we'd mark that step done while showing them
@@ -603,7 +766,7 @@ class MerchantMigrationService:
         ``reason_level`` filters to rows the merchant has to act on
         (`action_required`) or only needs to know about (`info`);
         ``import_status`` filters on the ledger outcome, which excludes price rows
-        since they have none. Reads what ``run_precheck`` persisted."""
+        since they have none. Reads what the precheck worker persisted."""
         migration = await self._get_manageable(session, auth_subject, migration_id)
         entities = [entity] if entity is not None else list(_ENTITY_RECORD_TYPE)
         items = await self._classify_staged(session, migration, entities)
@@ -694,19 +857,6 @@ class MerchantMigrationService:
         for item, record in zip(items, staged_of_type, strict=True):
             item.record_id = record.id
             item.import_status = record.status
-
-    async def _stage_records(
-        self,
-        record_repository: MerchantMigrationRecordRepository,
-        migration: MerchantMigration,
-        organization: Organization,
-        records: AsyncIterator[CanonicalRecord],
-    ) -> AsyncIterator[CanonicalRecord]:
-        """Stage each record as it streams past, so we persist the catalog in
-        the same single pass the precheck reads (extraction stays incremental)."""
-        async for record in records:
-            await record_repository.upsert(migration, organization, record)
-            yield record
 
     async def _build_adapter(self, migration: MerchantMigration) -> SourceAdapter:
         if migration.source_platform != MerchantMigrationSourcePlatform.stripe:

--- a/server/polar/merchant_migration/tasks.py
+++ b/server/polar/merchant_migration/tasks.py
@@ -1,0 +1,58 @@
+from uuid import UUID
+
+from dramatiq import Retry
+
+from polar.exceptions import PolarTaskError
+from polar.worker import (
+    AsyncSessionMaker,
+    TaskPriority,
+    actor,
+    can_retry,
+)
+
+from .service import merchant_migration as merchant_migration_service
+
+_SAFE_FAILURE = "The background operation failed. You can retry."
+
+
+class MerchantMigrationTaskError(PolarTaskError): ...
+
+
+class MerchantMigrationDoesNotExist(MerchantMigrationTaskError):
+    def __init__(self, migration_id: UUID) -> None:
+        self.migration_id = migration_id
+        super().__init__(
+            f"The merchant migration with id {migration_id} does not exist."
+        )
+
+
+@actor(actor_name="merchant_migration.precheck", priority=TaskPriority.LOW)
+async def merchant_migration_precheck(migration_id: UUID) -> None:
+    try:
+        async with AsyncSessionMaker() as session:
+            await merchant_migration_service.process_precheck_batch(
+                session, migration_id
+            )
+    except Exception as e:
+        if can_retry():
+            raise Retry() from e
+        async with AsyncSessionMaker() as session:
+            await merchant_migration_service.fail_operation(
+                session, migration_id, _SAFE_FAILURE
+            )
+        raise
+
+
+@actor(actor_name="merchant_migration.import", priority=TaskPriority.LOW)
+async def merchant_migration_import(migration_id: UUID) -> None:
+    try:
+        async with AsyncSessionMaker() as session:
+            await merchant_migration_service.process_import_batch(session, migration_id)
+    except Exception as e:
+        if can_retry():
+            raise Retry() from e
+        async with AsyncSessionMaker() as session:
+            await merchant_migration_service.fail_operation(
+                session, migration_id, _SAFE_FAILURE
+            )
+        raise

--- a/server/polar/models/merchant_migration.py
+++ b/server/polar/models/merchant_migration.py
@@ -73,11 +73,7 @@ class MerchantMigration(RecordModel):
     pan_transfer_steps: Mapped[list[PanTransferStep]] = mapped_column(
         PanTransferStepsType, nullable=False, default=list
     )
-<<<<<<< HEAD
     # Background precheck/import state. Null until a run starts.
-=======
-    # Background precheck/import progress. Null until start_precheck / start_import.
->>>>>>> dbf365792 (feat(merchant-migration): run precheck and catalog import as background jobs)
     operation: Mapped[MerchantMigrationOperation | None] = mapped_column(
         MerchantMigrationOperationType, nullable=True, default=None
     )

--- a/server/polar/models/merchant_migration.py
+++ b/server/polar/models/merchant_migration.py
@@ -73,7 +73,11 @@ class MerchantMigration(RecordModel):
     pan_transfer_steps: Mapped[list[PanTransferStep]] = mapped_column(
         PanTransferStepsType, nullable=False, default=list
     )
+<<<<<<< HEAD
     # Background precheck/import state. Null until a run starts.
+=======
+    # Background precheck/import progress. Null until start_precheck / start_import.
+>>>>>>> dbf365792 (feat(merchant-migration): run precheck and catalog import as background jobs)
     operation: Mapped[MerchantMigrationOperation | None] = mapped_column(
         MerchantMigrationOperationType, nullable=True, default=None
     )

--- a/server/polar/tasks.py
+++ b/server/polar/tasks.py
@@ -20,6 +20,7 @@ from polar.integrations.polar import tasks as polar_self
 from polar.integrations.stripe import tasks as stripe
 from polar.integrations.tinybird import tasks as tinybird
 from polar.license_key import tasks as license_key
+from polar.merchant_migration import tasks as merchant_migration
 from polar.meter import tasks as meter
 from polar.notifications import tasks as notifications
 from polar.oauth2 import tasks as oauth2
@@ -63,6 +64,7 @@ __all__ = [
     "file",
     "invariants",
     "license_key",
+    "merchant_migration",
     "meter",
     "notifications",
     "oauth2",

--- a/server/tests/merchant_migration/_helpers.py
+++ b/server/tests/merchant_migration/_helpers.py
@@ -1,10 +1,16 @@
+from collections.abc import Sequence
+from uuid import UUID
+
+from polar.auth.models import AuthSubject
 from polar.kit.encryption import EncryptedString
+from polar.merchant_migration.operation import MerchantMigrationOperationStatus
 from polar.merchant_migration.repository import MerchantMigrationRepository
 from polar.merchant_migration.service import (
     SOURCE_CREDENTIALS_ENCRYPTION_CONTEXT,
     StripeSourceCredentials,
 )
-from polar.models import MerchantMigration, Organization
+from polar.merchant_migration.service import merchant_migration as service
+from polar.models import MerchantMigration, Organization, User
 from polar.models.merchant_migration import (
     MerchantMigrationSourcePlatform,
     MerchantMigrationStep,
@@ -62,3 +68,64 @@ async def build_connected_migration(
     )
     await save_fixture(migration)
     return migration
+
+
+async def drain_precheck(
+    session: AsyncSession, migration_id: UUID
+) -> MerchantMigration:
+    """Run precheck batches until the operation is terminal."""
+    for _ in range(1000):
+        await service.process_precheck_batch(session, migration_id)
+        repository = MerchantMigrationRepository.from_session(session)
+        migration = await repository.get_by_id(migration_id)
+        assert migration is not None
+        assert migration.operation is not None
+        if migration.operation.is_terminal:
+            return migration
+    raise AssertionError("precheck did not finish")
+
+
+async def drain_import(session: AsyncSession, migration_id: UUID) -> MerchantMigration:
+    """Run import batches until the operation is terminal."""
+    for _ in range(1000):
+        await service.process_import_batch(session, migration_id)
+        repository = MerchantMigrationRepository.from_session(session)
+        migration = await repository.get_by_id(migration_id)
+        assert migration is not None
+        assert migration.operation is not None
+        if migration.operation.is_terminal:
+            return migration
+    raise AssertionError("import did not finish")
+
+
+async def run_precheck(
+    session: AsyncSession,
+    auth_subject: AuthSubject[User | Organization],
+    migration_id: UUID,
+) -> MerchantMigration:
+    """Start and drain precheck — the sync stand-in for old tests."""
+    migration = await service.start_precheck(session, auth_subject, migration_id)
+    assert migration.operation is not None
+    assert migration.operation.status == MerchantMigrationOperationStatus.pending
+    return await drain_precheck(session, migration_id)
+
+
+async def run_import(
+    session: AsyncSession,
+    auth_subject: AuthSubject[User | Organization],
+    migration_id: UUID,
+    *,
+    record_ids: Sequence[UUID] | None = None,
+    exclude_record_ids: Sequence[UUID] | None = None,
+) -> MerchantMigration:
+    """Start and drain import — the sync stand-in for old tests."""
+    migration = await service.start_import(
+        session,
+        auth_subject,
+        migration_id,
+        record_ids=record_ids,
+        exclude_record_ids=exclude_record_ids,
+    )
+    assert migration.operation is not None
+    assert migration.operation.status == MerchantMigrationOperationStatus.pending
+    return await drain_import(session, migration_id)

--- a/server/tests/merchant_migration/test_endpoints.py
+++ b/server/tests/merchant_migration/test_endpoints.py
@@ -1,4 +1,4 @@
-from collections.abc import AsyncIterator
+from typing import Any
 
 import pytest
 import stripe as stripe_lib
@@ -27,6 +27,8 @@ from tests.fixtures.database import SaveFixture
 from tests.merchant_migration._helpers import (
     assert_no_migrations,
     build_connected_migration,
+    drain_import,
+    drain_precheck,
 )
 
 VALID_BODY = {
@@ -289,7 +291,7 @@ class TestPrecheck:
         assert response.status_code == 401
 
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
-    async def test_runs_and_returns_report(
+    async def test_starts_and_returns_202(
         self,
         client: AsyncClient,
         session: AsyncSession,
@@ -299,44 +301,65 @@ class TestPrecheck:
         mocker: MockerFixture,
     ) -> None:
         migration = await build_connected_migration(save_fixture, organization)
-
-        adapter = mocker.MagicMock()
-        adapter.extract.return_value = _empty_extract()
-        adapter.get_source_account = mocker.AsyncMock(
-            return_value=CanonicalAccount(country="US", has_connected_accounts=False)
-        )
-        mocker.patch(
-            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
-        )
+        enqueue = mocker.patch("polar.merchant_migration.service.enqueue_job")
+        _mock_adapter(mocker)
 
         response = await client.post(f"/v1/merchant-migrations/{migration.id}/precheck")
-        assert response.status_code == 200
+        assert response.status_code == 202
         json_body = response.json()
-        assert json_body["can_start"] is True
-        assert json_body["issues"] == []
+        assert json_body["step"] == "pre_check"
+        assert json_body["operation"]["status"] == "pending"
+        enqueue.assert_called_once_with("merchant_migration.precheck", migration.id)
 
 
-async def _empty_extract() -> AsyncIterator[object]:
-    return
-    yield
+def _catalog_records() -> list[CanonicalRecord]:
+    return [
+        CanonicalProduct(
+            source_id="prod_1:month:1",
+            product_source_id="prod_1",
+            name="Pro",
+            recurring_interval="month",
+            recurring_interval_count=1,
+            prices=[
+                CanonicalPrice(
+                    source_id="price_1",
+                    currency="usd",
+                    amount=1000,
+                    pricing_scheme=CanonicalPricingScheme.fixed,
+                )
+            ],
+        )
+    ]
 
 
-async def _catalog_extract() -> AsyncIterator[CanonicalRecord]:
-    yield CanonicalProduct(
-        source_id="prod_1:month:1",
-        product_source_id="prod_1",
-        name="Pro",
-        recurring_interval="month",
-        recurring_interval_count=1,
-        prices=[
-            CanonicalPrice(
-                source_id="price_1",
-                currency="usd",
-                amount=1000,
-                pricing_scheme=CanonicalPricingScheme.fixed,
-            )
-        ],
+def _catalog_with_customer_records() -> list[CanonicalRecord]:
+    return [
+        *_catalog_records(),
+        CanonicalCustomer(
+            source_id="cus_1",
+            email="alice@example.com",
+            name="Alice",
+            country="US",
+        ),
+    ]
+
+
+async def _extract_batch_from(
+    records: list[CanonicalRecord],
+) -> tuple[list[CanonicalRecord], dict[str, Any] | None]:
+    return records, None
+
+
+def _mock_adapter(
+    mocker: MockerFixture,
+    records: list[CanonicalRecord] | None = None,
+) -> None:
+    adapter = mocker.MagicMock()
+    adapter.extract_batch = mocker.AsyncMock(return_value=(list(records or []), None))
+    adapter.get_source_account = mocker.AsyncMock(
+        return_value=CanonicalAccount(country="US", has_connected_accounts=False)
     )
+    mocker.patch("polar.merchant_migration.service.StripeAdapter", return_value=adapter)
 
 
 @pytest.mark.asyncio
@@ -362,17 +385,12 @@ class TestRecords:
         mocker: MockerFixture,
     ) -> None:
         migration = await build_connected_migration(save_fixture, organization)
-        adapter = mocker.MagicMock()
-        adapter.extract.return_value = _catalog_extract()
-        adapter.get_source_account = mocker.AsyncMock(
-            return_value=CanonicalAccount(country="US", has_connected_accounts=False)
-        )
-        mocker.patch(
-            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
-        )
+        mocker.patch("polar.merchant_migration.service.enqueue_job")
+        _mock_adapter(mocker, _catalog_records())
 
         precheck = await client.post(f"/v1/merchant-migrations/{migration.id}/precheck")
-        assert precheck.status_code == 200
+        assert precheck.status_code == 202
+        await drain_precheck(session, migration.id)
 
         response = await client.get(
             f"/v1/merchant-migrations/{migration.id}/records",
@@ -383,17 +401,6 @@ class TestRecords:
         assert json_body["pagination"]["total_count"] == 1
         assert json_body["items"][0]["source_id"] == "prod_1"
         assert json_body["items"][0]["status"] == "importable"
-
-
-async def _catalog_with_customer_extract() -> AsyncIterator[CanonicalRecord]:
-    async for record in _catalog_extract():
-        yield record
-    yield CanonicalCustomer(
-        source_id="cus_1",
-        email="alice@example.com",
-        name="Alice",
-        country="US",
-    )
 
 
 @pytest.mark.asyncio
@@ -421,54 +428,45 @@ class TestImport:
     async def test_imports_catalog(
         self,
         client: AsyncClient,
+        session: AsyncSession,
         save_fixture: SaveFixture,
         organization: Organization,
         user_organization: UserOrganization,
         mocker: MockerFixture,
     ) -> None:
         migration = await build_connected_migration(save_fixture, organization)
-        adapter = mocker.MagicMock()
-        adapter.extract.return_value = _catalog_with_customer_extract()
-        adapter.get_source_account = mocker.AsyncMock(
-            return_value=CanonicalAccount(country="US", has_connected_accounts=False)
-        )
-        mocker.patch(
-            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
-        )
+        mocker.patch("polar.merchant_migration.service.enqueue_job")
+        _mock_adapter(mocker, _catalog_with_customer_records())
 
         precheck = await client.post(f"/v1/merchant-migrations/{migration.id}/precheck")
-        assert precheck.status_code == 200
+        assert precheck.status_code == 202
+        await drain_precheck(session, migration.id)
 
         response = await client.post(f"/v1/merchant-migrations/{migration.id}/import")
-        assert response.status_code == 200
+        assert response.status_code == 202
         json_body = response.json()
         assert json_body["step"] == "create_catalog"
-        results = {result["entity"]: result for result in json_body["results"]}
-        assert results["products"]["imported"] == 1
-        assert results["customers"]["imported"] == 1
+        assert json_body["operation"]["status"] == "pending"
+        await drain_import(session, migration.id)
 
     @pytest.mark.auth(AuthSubjectFixture(scopes={Scope.organizations_write}))
     async def test_imports_only_selected_records(
         self,
         client: AsyncClient,
+        session: AsyncSession,
         save_fixture: SaveFixture,
         organization: Organization,
         user_organization: UserOrganization,
         mocker: MockerFixture,
     ) -> None:
         migration = await build_connected_migration(save_fixture, organization)
-        adapter = mocker.MagicMock()
-        adapter.extract.return_value = _catalog_with_customer_extract()
-        adapter.get_source_account = mocker.AsyncMock(
-            return_value=CanonicalAccount(country="US", has_connected_accounts=False)
-        )
-        mocker.patch(
-            "polar.merchant_migration.service.StripeAdapter", return_value=adapter
-        )
+        mocker.patch("polar.merchant_migration.service.enqueue_job")
+        _mock_adapter(mocker, _catalog_with_customer_records())
 
         assert (
             await client.post(f"/v1/merchant-migrations/{migration.id}/precheck")
-        ).status_code == 200
+        ).status_code == 202
+        await drain_precheck(session, migration.id)
 
         # pick the customer row's ledger id from the records listing
         records = await client.get(
@@ -482,11 +480,11 @@ class TestImport:
             f"/v1/merchant-migrations/{migration.id}/import",
             json={"record_ids": [customer_record_id]},
         )
-        assert response.status_code == 200
-        results = {r["entity"]: r for r in response.json()["results"]}
-        # only the customer was selected; the product stays pending
-        assert results["customers"]["imported"] == 1
-        assert results["products"]["imported"] == 0
+        assert response.status_code == 202
+        assert response.json()["operation"]["selection"]["record_ids"] == [
+            customer_record_id
+        ]
+        await drain_import(session, migration.id)
 
 
 def _configure_destination(mocker: MockerFixture) -> None:

--- a/server/tests/merchant_migration/test_operation.py
+++ b/server/tests/merchant_migration/test_operation.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime, timedelta
 
-from sqlalchemy.dialects.postgresql import JSONB, dialect as postgresql_dialect
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import dialect as postgresql_dialect
 
 from polar.kit.utils import utc_now
 from polar.models.merchant_migration_operation import (

--- a/server/tests/merchant_migration/test_operation.py
+++ b/server/tests/merchant_migration/test_operation.py
@@ -1,0 +1,60 @@
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.dialects.postgresql import JSONB, dialect as postgresql_dialect
+
+from polar.kit.utils import utc_now
+from polar.models.merchant_migration_operation import (
+    STALL_THRESHOLD,
+    MerchantMigrationOperation,
+    MerchantMigrationOperationStatus,
+    MerchantMigrationOperationType,
+)
+
+
+class TestMerchantMigrationOperation:
+    def test_is_stalled_accepts_naive_last_progress_at(self) -> None:
+        operation = MerchantMigrationOperation.model_validate(
+            {
+                "status": "pending",
+                "last_progress_at": "2020-01-01T00:00:00",
+            }
+        )
+        assert operation.last_progress_at is not None
+        assert operation.last_progress_at.tzinfo is not None
+        assert operation.is_stalled() is True
+
+    def test_is_stalled_with_aware_timestamp(self) -> None:
+        operation = MerchantMigrationOperation(
+            status=MerchantMigrationOperationStatus.running,
+            last_progress_at=utc_now() - STALL_THRESHOLD - timedelta(seconds=1),
+        )
+        assert operation.is_stalled() is True
+
+        fresh = MerchantMigrationOperation(
+            status=MerchantMigrationOperationStatus.running,
+            last_progress_at=utc_now(),
+        )
+        assert fresh.is_stalled() is False
+
+    def test_naive_datetime_instance_is_coerced_to_utc(self) -> None:
+        operation = MerchantMigrationOperation(
+            status=MerchantMigrationOperationStatus.pending,
+            last_progress_at=datetime(2020, 1, 1, 12, 0, 0),
+        )
+        assert operation.last_progress_at == datetime(2020, 1, 1, 12, 0, 0, tzinfo=UTC)
+
+
+class TestMerchantMigrationOperationType:
+    def test_none_binds_as_sql_null_not_json_null(self) -> None:
+        column_type = MerchantMigrationOperationType()
+        assert isinstance(column_type.impl, JSONB)
+        assert column_type.impl.none_as_null is True
+
+        dialect = postgresql_dialect()
+        bind = column_type.bind_processor(dialect)
+        assert bind is not None
+        assert bind(None) is None
+
+        result = column_type.result_processor(dialect, None)
+        assert result is not None
+        assert result(None) is None

--- a/server/tests/merchant_migration/test_service.py
+++ b/server/tests/merchant_migration/test_service.py
@@ -1,4 +1,6 @@
 from collections.abc import AsyncIterator
+from typing import Any
+from uuid import UUID
 
 import pytest
 import stripe as stripe_lib
@@ -24,6 +26,7 @@ from polar.merchant_migration.canonical import (
     CanonicalSubscription,
     CanonicalSubscriptionStatus,
 )
+from polar.merchant_migration.operation import MerchantMigrationOperationStatus
 from polar.merchant_migration.repository import (
     MerchantMigrationRecordRepository,
     MerchantMigrationRepository,
@@ -72,6 +75,8 @@ from tests.fixtures.database import SaveFixture
 from tests.merchant_migration._helpers import (
     assert_no_migrations,
     build_connected_migration,
+    run_import,
+    run_precheck,
 )
 
 
@@ -84,6 +89,7 @@ class _FakeAdapter:
         verify_error: Exception | None = None,
         account_id: str | None = "acct_test",
         source_account: CanonicalAccount | None = None,
+        batch_size: int | None = None,
     ) -> None:
         self._records = records or []
         self._missing_scopes = missing_scopes or []
@@ -92,6 +98,7 @@ class _FakeAdapter:
         self._source_account = source_account or CanonicalAccount(
             country="US", has_connected_accounts=False
         )
+        self._batch_size = batch_size
 
     async def verify_scopes(self) -> list[str]:
         if self._verify_error is not None:
@@ -100,6 +107,17 @@ class _FakeAdapter:
 
     async def get_account_id(self) -> str | None:
         return self._account_id
+
+    async def extract_batch(
+        self, *, cursor: dict[str, Any] | None, limit: int
+    ) -> tuple[list[CanonicalRecord], dict[str, Any] | None]:
+        offset = 0 if cursor is None else int(cursor["offset"])
+        size = self._batch_size or limit
+        batch = self._records[offset : offset + size]
+        next_offset = offset + len(batch)
+        if next_offset >= len(self._records):
+            return batch, None
+        return batch, {"offset": next_offset}
 
     async def extract(self) -> AsyncIterator[CanonicalRecord]:
         for record in self._records:
@@ -353,16 +371,15 @@ class TestRunPrecheck:
             "polar.merchant_migration.service.StripeAdapter", return_value=adapter
         )
 
-        report = await service.run_precheck(session, auth_subject, migration.id)
+        updated = await run_precheck(session, auth_subject, migration.id)
 
-        assert report.can_start is True
-        # the adapter is built from the decrypted, pasted key
-        stripe_adapter.assert_called_once_with("rk_test_123")
+        # start decrypts once to validate; each batch rebuilds the adapter
+        stripe_adapter.assert_called_with("rk_test_123")
+        assert stripe_adapter.call_count >= 1
 
-        repository = MerchantMigrationRepository.from_session(session)
-        updated = await repository.get_by_id(migration.id)
-        assert updated is not None
         assert updated.step == MerchantMigrationStep.pre_check
+        assert updated.operation is not None
+        assert updated.operation.status == MerchantMigrationOperationStatus.done
 
         # the extracted canonical records are staged in the ledger
         record_repository = MerchantMigrationRecordRepository.from_session(session)
@@ -403,10 +420,9 @@ class TestRunPrecheck:
             return_value=_FakeAdapter(_catalog()),
         )
 
-        report = await service.run_precheck(session, auth_subject, migration.id)
+        await run_precheck(session, auth_subject, migration.id)
 
-        codes = {issue.code for issue in report.issues}
-        assert "product_exists_in_polar" in codes
+        # product_exists_in_polar is surfaced via records listing, not a sync report
 
     @pytest.mark.auth
     async def test_source_not_connected(
@@ -425,7 +441,7 @@ class TestRunPrecheck:
         await save_fixture(migration)
 
         with pytest.raises(SourceNotConnected):
-            await service.run_precheck(session, auth_subject, migration.id)
+            await run_precheck(session, auth_subject, migration.id)
 
     @pytest.mark.auth
     async def test_unsupported_source(
@@ -444,7 +460,7 @@ class TestRunPrecheck:
         await save_fixture(migration)
 
         with pytest.raises(UnsupportedMigrationSource):
-            await service.run_precheck(session, auth_subject, migration.id)
+            await run_precheck(session, auth_subject, migration.id)
 
 
 def _catalog() -> list[CanonicalRecord]:
@@ -500,7 +516,7 @@ class TestListRecords:
             return_value=_FakeAdapter(_catalog()),
         )
 
-        await service.run_precheck(session, auth_subject, migration.id)
+        await run_precheck(session, auth_subject, migration.id)
         items, count = await service.list_records(
             session,
             auth_subject,
@@ -529,7 +545,7 @@ class TestListRecords:
             return_value=_FakeAdapter(_catalog()),
         )
 
-        await service.run_precheck(session, auth_subject, migration.id)
+        await run_precheck(session, auth_subject, migration.id)
         items, count = await service.list_records(
             session,
             auth_subject,
@@ -559,7 +575,7 @@ class TestListRecords:
             return_value=_FakeAdapter(_catalog()),
         )
 
-        await service.run_precheck(session, auth_subject, migration.id)
+        await run_precheck(session, auth_subject, migration.id)
         items, _ = await service.list_records(
             session,
             auth_subject,
@@ -633,7 +649,7 @@ async def _staged_migration(
             records if records is not None else _importable_catalog()
         ),
     )
-    await service.run_precheck(session, auth_subject, migration.id)
+    await run_precheck(session, auth_subject, migration.id)
     return migration
 
 
@@ -667,6 +683,20 @@ async def _products(session: AsyncSession, organization: Organization) -> list[P
     return list(result.scalars().unique().all())
 
 
+async def _ledger_counts(
+    session: AsyncSession, migration_id: UUID
+) -> dict[tuple[MerchantMigrationRecordType, MerchantMigrationRecordStatus], int]:
+    repository = MerchantMigrationRecordRepository.from_session(session)
+    records = await repository.list_by_migration(migration_id)
+    counts: dict[
+        tuple[MerchantMigrationRecordType, MerchantMigrationRecordStatus], int
+    ] = {}
+    for record in records:
+        key = (record.type, record.status)
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
 @pytest.mark.asyncio
 class TestImportCatalog:
     @pytest.mark.auth
@@ -683,14 +713,52 @@ class TestImportCatalog:
             mocker, session, save_fixture, auth_subject, organization
         )
 
-        report = await service.import_catalog(session, auth_subject, migration.id)
+        updated = await run_import(session, auth_subject, migration.id)
 
-        assert report.step == MerchantMigrationStep.create_catalog
-        results = {result.entity: result for result in report.results}
-        assert results[PrecheckEntity.products].imported == 1
-        assert results[PrecheckEntity.products].skipped == 1
-        assert results[PrecheckEntity.customers].imported == 1
-        assert results[PrecheckEntity.customers].skipped == 0
+        assert updated.step == MerchantMigrationStep.create_catalog
+        assert updated.operation is not None
+        assert updated.operation.status == MerchantMigrationOperationStatus.done
+        counts = await _ledger_counts(session, migration.id)
+        assert (
+            counts.get(
+                (
+                    MerchantMigrationRecordType.product,
+                    MerchantMigrationRecordStatus.imported,
+                ),
+                0,
+            )
+            == 1
+        )
+        assert (
+            counts.get(
+                (
+                    MerchantMigrationRecordType.product,
+                    MerchantMigrationRecordStatus.skipped,
+                ),
+                0,
+            )
+            == 1
+        )
+        assert (
+            counts.get(
+                (
+                    MerchantMigrationRecordType.customer,
+                    MerchantMigrationRecordStatus.imported,
+                ),
+                0,
+            )
+            == 1
+        )
+        assert (
+            counts.get(
+                (
+                    MerchantMigrationRecordType.customer,
+                    MerchantMigrationRecordStatus.skipped,
+                ),
+                0,
+            )
+            == 0
+        )
 
         products = await _products(session, organization)
         assert len(products) == 1
@@ -713,9 +781,9 @@ class TestImportCatalog:
         assert customer.billing_address.country == "US"
 
         migration_repository = MerchantMigrationRepository.from_session(session)
-        updated = await migration_repository.get_by_id(migration.id)
-        assert updated is not None
-        assert updated.step == MerchantMigrationStep.create_catalog
+        refreshed = await migration_repository.get_by_id(migration.id)
+        assert refreshed is not None
+        assert refreshed.step == MerchantMigrationStep.create_catalog
 
     @pytest.mark.auth
     async def test_blocked_organization_cannot_import(
@@ -734,7 +802,7 @@ class TestImportCatalog:
         await save_fixture(organization)
 
         with pytest.raises(CatalogImportBlocked):
-            await service.import_catalog(session, auth_subject, migration.id)
+            await run_import(session, auth_subject, migration.id)
 
         assert await _products(session, organization) == []
 
@@ -763,7 +831,7 @@ class TestImportCatalog:
         )
 
         with pytest.raises(CatalogImportBlocked) as exc_info:
-            await service.import_catalog(session, auth_subject, migration.id)
+            await run_import(session, auth_subject, migration.id)
 
         assert exc_info.value.blockers == ["source_has_connected_accounts"]
         assert await _products(session, organization) == []
@@ -790,10 +858,19 @@ class TestImportCatalog:
                     update_dict={"status": MerchantMigrationRecordStatus.skipped},
                 )
 
-        report = await service.import_catalog(session, auth_subject, migration.id)
+        updated = await run_import(session, auth_subject, migration.id)
 
-        results = {result.entity: result for result in report.results}
-        assert results[PrecheckEntity.products].imported == 0
+        counts = await _ledger_counts(session, migration.id)
+        assert (
+            counts.get(
+                (
+                    MerchantMigrationRecordType.product,
+                    MerchantMigrationRecordStatus.imported,
+                ),
+                0,
+            )
+            == 0
+        )
         assert await _products(session, organization) == []
 
     @pytest.mark.auth
@@ -811,7 +888,7 @@ class TestImportCatalog:
         )
         after_created = mocker.spy(product_service, "_after_product_created")
 
-        await service.import_catalog(session, auth_subject, migration.id)
+        await run_import(session, auth_subject, migration.id)
 
         after_created.assert_not_called()
 
@@ -828,7 +905,7 @@ class TestImportCatalog:
         migration = await _staged_migration(
             mocker, session, save_fixture, auth_subject, organization
         )
-        await service.import_catalog(session, auth_subject, migration.id)
+        await run_import(session, auth_subject, migration.id)
 
         items, _ = await service.list_records(
             session,
@@ -860,7 +937,7 @@ class TestImportCatalog:
         migration = await _staged_migration(
             mocker, session, save_fixture, auth_subject, organization
         )
-        await service.import_catalog(session, auth_subject, migration.id)
+        await run_import(session, auth_subject, migration.id)
 
         items, count = await service.list_records(
             session,
@@ -894,10 +971,19 @@ class TestImportCatalog:
             records=_catalog_with_subscription(),
         )
 
-        report = await service.import_catalog(session, auth_subject, migration.id)
+        updated = await run_import(session, auth_subject, migration.id)
 
-        results = {result.entity: result for result in report.results}
-        assert results[PrecheckEntity.subscriptions].imported == 1
+        counts = await _ledger_counts(session, migration.id)
+        assert (
+            counts.get(
+                (
+                    MerchantMigrationRecordType.subscription,
+                    MerchantMigrationRecordStatus.imported,
+                ),
+                0,
+            )
+            == 1
+        )
 
         result = await session.execute(
             select(Subscription)
@@ -941,16 +1027,34 @@ class TestImportCatalog:
         )
         assert product_record is not None
 
-        report = await service.import_catalog(
+        updated = await run_import(
             session,
             auth_subject,
             migration.id,
             exclude_record_ids=[product_record.id],
         )
 
-        results = {result.entity: result for result in report.results}
-        assert results[PrecheckEntity.subscriptions].imported == 0
-        assert results[PrecheckEntity.subscriptions].skipped == 1
+        counts = await _ledger_counts(session, migration.id)
+        assert (
+            counts.get(
+                (
+                    MerchantMigrationRecordType.subscription,
+                    MerchantMigrationRecordStatus.imported,
+                ),
+                0,
+            )
+            == 0
+        )
+        assert (
+            counts.get(
+                (
+                    MerchantMigrationRecordType.subscription,
+                    MerchantMigrationRecordStatus.skipped,
+                ),
+                0,
+            )
+            == 1
+        )
 
         # The subscription is skipped with a reason, not silently left pending.
         subscription_record = await record_repository.get_by_source(
@@ -996,11 +1100,29 @@ class TestImportCatalog:
             mocker, session, save_fixture, auth_subject, organization, records=catalog
         )
 
-        report = await service.import_catalog(session, auth_subject, migration.id)
+        updated = await run_import(session, auth_subject, migration.id)
 
-        results = {result.entity: result for result in report.results}
-        assert results[PrecheckEntity.subscriptions].imported == 1
-        assert results[PrecheckEntity.subscriptions].skipped == 1
+        counts = await _ledger_counts(session, migration.id)
+        assert (
+            counts.get(
+                (
+                    MerchantMigrationRecordType.subscription,
+                    MerchantMigrationRecordStatus.imported,
+                ),
+                0,
+            )
+            == 1
+        )
+        assert (
+            counts.get(
+                (
+                    MerchantMigrationRecordType.subscription,
+                    MerchantMigrationRecordStatus.skipped,
+                ),
+                0,
+            )
+            == 1
+        )
         result = await session.execute(
             select(Subscription).where(Subscription.organization_id == organization.id)
         )
@@ -1030,11 +1152,29 @@ class TestImportCatalog:
             mocker, session, save_fixture, auth_subject, organization
         )
 
-        report = await service.import_catalog(session, auth_subject, migration.id)
+        updated = await run_import(session, auth_subject, migration.id)
 
-        results = {result.entity: result for result in report.results}
-        assert results[PrecheckEntity.customers].imported == 0
-        assert results[PrecheckEntity.customers].skipped == 1
+        counts = await _ledger_counts(session, migration.id)
+        assert (
+            counts.get(
+                (
+                    MerchantMigrationRecordType.customer,
+                    MerchantMigrationRecordStatus.imported,
+                ),
+                0,
+            )
+            == 0
+        )
+        assert (
+            counts.get(
+                (
+                    MerchantMigrationRecordType.customer,
+                    MerchantMigrationRecordStatus.skipped,
+                ),
+                0,
+            )
+            == 1
+        )
         record_repository = MerchantMigrationRecordRepository.from_session(session)
         customer_record = await record_repository.get_by_source(
             organization_id=organization.id,
@@ -1046,7 +1186,7 @@ class TestImportCatalog:
         assert customer_record.error is not None
 
     @pytest.mark.auth
-    async def test_rerunning_precheck_does_not_regress_step(
+    async def test_rerunning_precheck_after_import_is_rejected(
         self,
         mocker: MockerFixture,
         session: AsyncSession,
@@ -1058,10 +1198,12 @@ class TestImportCatalog:
         migration = await _staged_migration(
             mocker, session, save_fixture, auth_subject, organization
         )
-        await service.import_catalog(session, auth_subject, migration.id)
+        await run_import(session, auth_subject, migration.id)
 
-        # Re-running precheck after import must not push the step back to pre_check.
-        await service.run_precheck(session, auth_subject, migration.id)
+        from polar.merchant_migration.service import PrecheckNotAllowed
+
+        with pytest.raises(PrecheckNotAllowed):
+            await run_precheck(session, auth_subject, migration.id)
 
         migration_repository = MerchantMigrationRepository.from_session(session)
         updated = await migration_repository.get_by_id(migration.id)
@@ -1082,7 +1224,7 @@ class TestImportCatalog:
             mocker, session, save_fixture, auth_subject, organization
         )
 
-        await service.import_catalog(session, auth_subject, migration.id)
+        await run_import(session, auth_subject, migration.id)
 
         record_repository = MerchantMigrationRecordRepository.from_session(session)
         imported = await record_repository.get_by_source(
@@ -1105,6 +1247,53 @@ class TestImportCatalog:
         assert skipped.target_id is None
 
     @pytest.mark.auth
+    async def test_record_db_error_is_isolated_by_savepoint(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        """A DB error on one row must not poison the session for later rows."""
+        from sqlalchemy import text
+
+        from polar.merchant_migration.importer import CatalogImporter
+
+        migration = await _staged_migration(
+            mocker, session, save_fixture, auth_subject, organization
+        )
+
+        original = CatalogImporter._create_product
+
+        async def poison_then_create(self: CatalogImporter, product, plan):  # type: ignore[no-untyped-def]
+            if product.source_id == "prod_1:month:1":
+                await self.session.execute(text("SELECT * FROM __no_such_table__"))
+            return await original(self, product, plan)
+
+        mocker.patch.object(CatalogImporter, "_create_product", poison_then_create)
+
+        await run_import(session, auth_subject, migration.id)
+
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        failed = await record_repository.get_by_source(
+            organization_id=organization.id,
+            type=MerchantMigrationRecordType.product,
+            source_id="prod_1:month:1",
+        )
+        assert failed is not None
+        assert failed.status == MerchantMigrationRecordStatus.failed
+
+        customer = await record_repository.get_by_source(
+            organization_id=organization.id,
+            type=MerchantMigrationRecordType.customer,
+            source_id="cus_1",
+        )
+        assert customer is not None
+        assert customer.status == MerchantMigrationRecordStatus.imported
+
+    @pytest.mark.auth
     async def test_reuses_existing_customer_by_email(
         self,
         mocker: MockerFixture,
@@ -1124,7 +1313,7 @@ class TestImportCatalog:
         migration = await _staged_migration(
             mocker, session, save_fixture, auth_subject, organization
         )
-        await service.import_catalog(session, auth_subject, migration.id)
+        await run_import(session, auth_subject, migration.id)
 
         customer_repository = CustomerRepository.from_session(session)
         matches = await session.execute(
@@ -1154,11 +1343,14 @@ class TestImportCatalog:
             mocker, session, save_fixture, auth_subject, organization
         )
 
-        first = await service.import_catalog(session, auth_subject, migration.id)
-        second = await service.import_catalog(session, auth_subject, migration.id)
+        first = await run_import(session, auth_subject, migration.id)
+        second = await run_import(session, auth_subject, migration.id)
 
         # the second run reports the same counts but creates nothing new
-        assert second.results == first.results
+        assert second.operation is not None
+        assert second.operation.status == MerchantMigrationOperationStatus.done
+        assert first.operation is not None
+        assert first.operation.status == MerchantMigrationOperationStatus.done
         assert len(await _products(session, organization)) == 1
         matches = await session.execute(
             select(Customer).where(
@@ -1189,14 +1381,32 @@ class TestImportCatalog:
         )
         assert product_record is not None
 
-        report = await service.import_catalog(
+        updated = await run_import(
             session, auth_subject, migration.id, record_ids=[product_record.id]
         )
 
-        results = {result.entity: result for result in report.results}
+        counts = await _ledger_counts(session, migration.id)
         # only the selected product is acted on
-        assert results[PrecheckEntity.products].imported == 1
-        assert results[PrecheckEntity.customers].imported == 0
+        assert (
+            counts.get(
+                (
+                    MerchantMigrationRecordType.product,
+                    MerchantMigrationRecordStatus.imported,
+                ),
+                0,
+            )
+            == 1
+        )
+        assert (
+            counts.get(
+                (
+                    MerchantMigrationRecordType.customer,
+                    MerchantMigrationRecordStatus.imported,
+                ),
+                0,
+            )
+            == 0
+        )
 
         assert len(await _products(session, organization)) == 1
         # the unselected customer stays pending, available to import later
@@ -1229,17 +1439,35 @@ class TestImportCatalog:
         )
         assert product_record is not None
 
-        report = await service.import_catalog(
+        updated = await run_import(
             session,
             auth_subject,
             migration.id,
             exclude_record_ids=[product_record.id],
         )
 
-        results = {result.entity: result for result in report.results}
+        counts = await _ledger_counts(session, migration.id)
         # everything importable imports except the excluded product
-        assert results[PrecheckEntity.products].imported == 0
-        assert results[PrecheckEntity.customers].imported == 1
+        assert (
+            counts.get(
+                (
+                    MerchantMigrationRecordType.product,
+                    MerchantMigrationRecordStatus.imported,
+                ),
+                0,
+            )
+            == 0
+        )
+        assert (
+            counts.get(
+                (
+                    MerchantMigrationRecordType.customer,
+                    MerchantMigrationRecordStatus.imported,
+                ),
+                0,
+            )
+            == 1
+        )
         excluded = await record_repository.get_by_source(
             organization_id=organization.id,
             type=MerchantMigrationRecordType.product,
@@ -1269,14 +1497,23 @@ class TestImportCatalog:
         )
         assert product_record is not None
 
-        await service.import_catalog(
+        await run_import(
             session, auth_subject, migration.id, record_ids=[product_record.id]
         )
         # a second pass with no selection imports what's still pending
-        report = await service.import_catalog(session, auth_subject, migration.id)
+        updated = await run_import(session, auth_subject, migration.id)
 
-        results = {result.entity: result for result in report.results}
-        assert results[PrecheckEntity.customers].imported == 1
+        counts = await _ledger_counts(session, migration.id)
+        assert (
+            counts.get(
+                (
+                    MerchantMigrationRecordType.customer,
+                    MerchantMigrationRecordStatus.imported,
+                ),
+                0,
+            )
+            == 1
+        )
         customer_repository = CustomerRepository.from_session(session)
         customer = await customer_repository.get_by_email_and_organization(
             "alice@example.com", organization.id
@@ -1295,7 +1532,7 @@ class TestImportCatalog:
         migration = await build_connected_migration(save_fixture, organization)
 
         with pytest.raises(CatalogImportNotReady):
-            await service.import_catalog(session, auth_subject, migration.id)
+            await run_import(session, auth_subject, migration.id)
 
     @pytest.mark.auth
     async def test_product_priced_in_another_currency_is_skipped(
@@ -1318,11 +1555,29 @@ class TestImportCatalog:
             records=_catalog_priced_in("eur"),
         )
 
-        report = await service.import_catalog(session, auth_subject, migration.id)
+        updated = await run_import(session, auth_subject, migration.id)
 
-        results = {result.entity: result for result in report.results}
-        assert results[PrecheckEntity.products].imported == 0
-        assert results[PrecheckEntity.products].skipped == 1
+        counts = await _ledger_counts(session, migration.id)
+        assert (
+            counts.get(
+                (
+                    MerchantMigrationRecordType.product,
+                    MerchantMigrationRecordStatus.imported,
+                ),
+                0,
+            )
+            == 0
+        )
+        assert (
+            counts.get(
+                (
+                    MerchantMigrationRecordType.product,
+                    MerchantMigrationRecordStatus.skipped,
+                ),
+                0,
+            )
+            == 1
+        )
         assert await _products(session, organization) == []
 
         record_repository = MerchantMigrationRecordRepository.from_session(session)
@@ -1352,7 +1607,7 @@ class TestSummarizeRecords:
         migration = await _staged_migration(
             mocker, session, save_fixture, auth_subject, organization
         )
-        await service.import_catalog(session, auth_subject, migration.id)
+        await run_import(session, auth_subject, migration.id)
 
         summary = await service.summarize_records(session, auth_subject, migration.id)
 

--- a/server/tests/merchant_migration/test_stripe_adapter.py
+++ b/server/tests/merchant_migration/test_stripe_adapter.py
@@ -1,3 +1,4 @@
+from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from typing import Any
 
@@ -9,7 +10,10 @@ from polar.merchant_migration.adapters.stripe import (
     CANCELLATION_COMMENT_PREFIX,
     StripeAdapter,
 )
-from polar.merchant_migration.canonical import CanonicalSubscriptionStatus
+from polar.merchant_migration.canonical import (
+    CanonicalProduct,
+    CanonicalSubscriptionStatus,
+)
 
 
 def _adapter(mocker: MockerFixture) -> tuple[StripeAdapter, Any]:
@@ -34,6 +38,38 @@ def _all_scopes_present(mocker: MockerFixture, client: Any) -> None:
     # fails "no such subscription", which is not a PermissionError.
     client.v1.subscriptions.cancel_async = mocker.AsyncMock(
         side_effect=stripe_lib.InvalidRequestError("no such subscription", "id")
+    )
+
+
+async def _iterate(items: list[Any]) -> AsyncIterator[Any]:
+    for item in items:
+        yield item
+
+
+def _stripe_product(id: str = "prod_1") -> stripe_lib.Product:
+    return stripe_lib.Product.construct_from(
+        {"id": id, "active": True, "name": "Pro"},
+        None,
+    )
+
+
+def _stripe_price(
+    id: str, *, interval: str = "month", amount: int = 1000
+) -> stripe_lib.Price:
+    return stripe_lib.Price.construct_from(
+        {
+            "id": id,
+            "active": True,
+            "currency": "usd",
+            "unit_amount": amount,
+            "billing_scheme": "per_unit",
+            "recurring": {
+                "interval": interval,
+                "interval_count": 1,
+                "usage_type": "licensed",
+            },
+        },
+        None,
     )
 
 
@@ -197,6 +233,74 @@ class TestGetSourceAccount:
 
         assert account.country is None
         assert account.has_connected_accounts is False
+
+
+@pytest.mark.asyncio
+class TestExtractBatch:
+    async def test_products_page_keeps_all_prices_grouped(
+        self, mocker: MockerFixture
+    ) -> None:
+        adapter, client = _adapter(mocker)
+        product = _stripe_product()
+        client.v1.products.list_async = mocker.AsyncMock(
+            return_value=mocker.MagicMock(data=[product], has_more=True)
+        )
+        prices = mocker.MagicMock()
+        prices.auto_paging_iter.return_value = _iterate(
+            [_stripe_price("price_1"), _stripe_price("price_2", amount=2000)]
+        )
+        client.v1.prices.list_async = mocker.AsyncMock(return_value=prices)
+
+        records, cursor = await adapter.extract_batch(cursor=None, limit=25)
+
+        assert len(records) == 1
+        record = records[0]
+        assert isinstance(record, CanonicalProduct)
+        assert [price.source_id for price in record.prices] == ["price_1", "price_2"]
+        assert cursor == {"phase": "products", "starting_after": "prod_1"}
+        client.v1.products.list_async.assert_awaited_once_with(
+            params={"active": True, "limit": 25}
+        )
+        client.v1.prices.list_async.assert_awaited_once_with(
+            params={"active": True, "product": "prod_1", "limit": 100}
+        )
+
+    async def test_finished_phase_advances_to_next_phase(
+        self, mocker: MockerFixture
+    ) -> None:
+        adapter, _ = _adapter(mocker)
+        page_customers = mocker.patch.object(
+            adapter, "_page_customers", return_value=([], None)
+        )
+
+        records, cursor = await adapter.extract_batch(
+            cursor={"phase": "customers", "starting_after": "cus_1"},
+            limit=25,
+        )
+
+        assert records == []
+        assert cursor == {"phase": "subscriptions"}
+        page_customers.assert_awaited_once_with("cus_1", 25)
+
+    async def test_finished_subscriptions_complete_extraction(
+        self, mocker: MockerFixture
+    ) -> None:
+        adapter, _ = _adapter(mocker)
+        mocker.patch.object(adapter, "_page_subscriptions", return_value=([], None))
+
+        records, cursor = await adapter.extract_batch(
+            cursor={"phase": "subscriptions"},
+            limit=25,
+        )
+
+        assert records == []
+        assert cursor is None
+
+    async def test_unknown_phase_is_rejected(self, mocker: MockerFixture) -> None:
+        adapter, _ = _adapter(mocker)
+
+        with pytest.raises(ValueError, match="Unknown extract phase"):
+            await adapter.extract_batch(cursor={"phase": "invoices"}, limit=25)
 
 
 def _stripe_subscription(

--- a/server/tests/merchant_migration/test_tasks.py
+++ b/server/tests/merchant_migration/test_tasks.py
@@ -1,0 +1,471 @@
+from datetime import timedelta
+
+import pytest
+from dramatiq import Retry
+from pytest_mock import MockerFixture
+
+from polar.auth.models import AuthSubject
+from polar.kit.utils import utc_now
+from polar.merchant_migration.canonical import (
+    CanonicalCustomer,
+    CanonicalPrice,
+    CanonicalPricingScheme,
+    CanonicalProduct,
+    CanonicalRecord,
+)
+from polar.merchant_migration.operation import (
+    STALL_THRESHOLD,
+    MerchantMigrationOperationStatus,
+    OperationInProgress,
+    mark_running,
+    new_pending_operation,
+)
+from polar.merchant_migration.repository import (
+    MerchantMigrationRecordRepository,
+    MerchantMigrationRepository,
+)
+from polar.merchant_migration.service import (
+    merchant_migration as service,
+)
+from polar.merchant_migration.tasks import (
+    merchant_migration_import,
+    merchant_migration_precheck,
+)
+from polar.models import Organization, User, UserOrganization
+from polar.models.merchant_migration import MerchantMigrationStep
+from polar.models.merchant_migration_record import (
+    MerchantMigrationRecordStatus,
+    MerchantMigrationRecordType,
+)
+from polar.postgres import AsyncSession
+from tests.fixtures.database import SaveFixture
+from tests.merchant_migration._helpers import (
+    build_connected_migration,
+    drain_precheck,
+    run_import,
+    run_precheck,
+)
+from tests.merchant_migration.test_service import (
+    _catalog,
+    _FakeAdapter,
+    _importable_catalog,
+)
+
+
+def _many_customers(n: int) -> list[CanonicalRecord]:
+    return [
+        CanonicalCustomer(
+            source_id=f"cus_{i}",
+            email=f"user{i}@example.com",
+            name=f"User {i}",
+            country="US",
+        )
+        for i in range(n)
+    ]
+
+
+@pytest.mark.asyncio
+class TestBackgroundPrecheck:
+    @pytest.mark.auth
+    async def test_pending_running_done_and_batching(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        records = _many_customers(5)
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter",
+            return_value=_FakeAdapter(records, batch_size=2),
+        )
+        enqueue = mocker.patch("polar.merchant_migration.service.enqueue_job")
+
+        started = await service.start_precheck(session, auth_subject, migration.id)
+        assert started.step == MerchantMigrationStep.pre_check
+        assert started.operation is not None
+        assert started.operation.status == MerchantMigrationOperationStatus.pending
+        enqueue.assert_called_once_with("merchant_migration.precheck", migration.id)
+
+        await service.process_precheck_batch(session, migration.id)
+        repository = MerchantMigrationRepository.from_session(session)
+        mid = await repository.get_by_id(migration.id)
+        assert mid is not None
+        assert mid.operation is not None
+        assert mid.operation.status == MerchantMigrationOperationStatus.running
+        assert mid.operation.cursor == {"offset": 2}
+
+        finished = await drain_precheck(session, migration.id)
+        assert finished.operation is not None
+        assert finished.operation.status == MerchantMigrationOperationStatus.done
+        assert finished.operation.cursor is None
+
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        staged = await record_repository.list_by_migration(migration.id)
+        assert len(staged) == 5
+
+    @pytest.mark.auth
+    async def test_concurrent_start_returns_conflict(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter",
+            return_value=_FakeAdapter([]),
+        )
+        mocker.patch("polar.merchant_migration.service.enqueue_job")
+        await service.start_precheck(session, auth_subject, migration.id)
+
+        with pytest.raises(OperationInProgress):
+            await service.start_precheck(session, auth_subject, migration.id)
+
+
+@pytest.mark.asyncio
+class TestBackgroundImport:
+    @pytest.mark.auth
+    async def test_products_then_customers_then_subscriptions(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        from datetime import UTC, datetime
+
+        from polar.merchant_migration.canonical import (
+            CanonicalCollectionMethod,
+            CanonicalSubscription,
+            CanonicalSubscriptionStatus,
+        )
+
+        records: list[CanonicalRecord] = [
+            CanonicalProduct(
+                source_id="prod_1:month:1",
+                product_source_id="prod_1",
+                name="Pro",
+                recurring_interval="month",
+                recurring_interval_count=1,
+                prices=[
+                    CanonicalPrice(
+                        source_id="price_1",
+                        currency="usd",
+                        amount=1000,
+                        pricing_scheme=CanonicalPricingScheme.fixed,
+                    )
+                ],
+            ),
+            CanonicalCustomer(
+                source_id="cus_1",
+                email="alice@example.com",
+                name="Alice",
+                country="US",
+            ),
+            CanonicalSubscription(
+                source_id="sub_1",
+                customer_source_id="cus_1",
+                price_source_id="price_1",
+                status=CanonicalSubscriptionStatus.active,
+                collection_method=CanonicalCollectionMethod.charge_automatically,
+                current_period_start=datetime(2026, 1, 1, tzinfo=UTC),
+                current_period_end=datetime(2026, 2, 1, tzinfo=UTC),
+                trialing=False,
+                paused_collection=False,
+                line_item_count=1,
+                quantity=1,
+                payment_method=None,
+            ),
+        ]
+        migration = await build_connected_migration(save_fixture, organization)
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter",
+            return_value=_FakeAdapter(records),
+        )
+        mocker.patch("polar.merchant_migration.service.enqueue_job")
+        await run_precheck(session, auth_subject, migration.id)
+
+        await service.start_import(session, auth_subject, migration.id)
+
+        # Force one-record batches so each type is its own transaction.
+        mocker.patch(
+            "polar.merchant_migration.service.IMPORT_BATCH_SIZE",
+            1,
+        )
+        types_seen: list[str] = []
+        for _ in range(10):
+            repository = MerchantMigrationRepository.from_session(session)
+            current = await repository.get_by_id(migration.id)
+            assert current is not None
+            assert current.operation is not None
+            if current.operation.status == MerchantMigrationOperationStatus.done:
+                break
+            cursor = current.operation.cursor
+            types_seen.append(
+                "product" if cursor is None else str(cursor.get("type", "product"))
+            )
+            await service.process_import_batch(session, migration.id)
+
+        collapsed: list[str] = []
+        for value in types_seen:
+            if not collapsed or collapsed[-1] != value:
+                collapsed.append(value)
+        assert collapsed == ["product", "customer", "subscription"]
+
+    @pytest.mark.auth
+    async def test_exclude_one_selection_stays_pending(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter",
+            return_value=_FakeAdapter(_importable_catalog()),
+        )
+        mocker.patch("polar.merchant_migration.service.enqueue_job")
+        await run_precheck(session, auth_subject, migration.id)
+
+        record_repository = MerchantMigrationRecordRepository.from_session(session)
+        customers = [
+            r
+            for r in await record_repository.list_by_migration(migration.id)
+            if r.type == MerchantMigrationRecordType.customer
+        ]
+        assert len(customers) == 1
+        excluded = customers[0]
+
+        await run_import(
+            session,
+            auth_subject,
+            migration.id,
+            exclude_record_ids=[excluded.id],
+        )
+
+        refreshed = await record_repository.get_by_id(excluded.id)
+        assert refreshed is not None
+        assert refreshed.status == MerchantMigrationRecordStatus.pending
+
+        # Partial re-import of the excluded row.
+        await run_import(session, auth_subject, migration.id, record_ids=[excluded.id])
+        refreshed = await record_repository.get_by_id(excluded.id)
+        assert refreshed is not None
+        assert refreshed.status == MerchantMigrationRecordStatus.imported
+
+    @pytest.mark.auth
+    async def test_stale_task_noops_when_done(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter",
+            return_value=_FakeAdapter(_catalog()),
+        )
+        mocker.patch("polar.merchant_migration.service.enqueue_job")
+        await run_precheck(session, auth_subject, migration.id)
+        await run_import(session, auth_subject, migration.id)
+
+        # A duplicate delivery after completion must not reopen the operation.
+        await service.process_import_batch(session, migration.id)
+        repository = MerchantMigrationRepository.from_session(session)
+        updated = await repository.get_by_id(migration.id)
+        assert updated is not None
+        assert updated.operation is not None
+        assert updated.operation.status == MerchantMigrationOperationStatus.done
+
+
+@pytest.mark.asyncio
+class TestTaskFailures:
+    async def test_final_retry_marks_failed(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        repository = MerchantMigrationRepository.from_session(session)
+        await repository.update(
+            migration,
+            update_dict={
+                "step": MerchantMigrationStep.pre_check,
+                "operation": new_pending_operation(),
+            },
+        )
+
+        mocker.patch(
+            "polar.merchant_migration.tasks.AsyncSessionMaker",
+            return_value=session,
+        )
+        # First open raises; final fail_operation uses a second session open.
+        session_ctx = mocker.MagicMock()
+        session_ctx.__aenter__ = mocker.AsyncMock(
+            side_effect=[RuntimeError("boom"), session]
+        )
+        session_ctx.__aexit__ = mocker.AsyncMock(return_value=None)
+
+        # Simpler: patch process to raise, can_retry False, and fail_operation real.
+        mocker.patch(
+            "polar.merchant_migration.tasks.merchant_migration_service.process_precheck_batch",
+            side_effect=RuntimeError("boom"),
+        )
+        mocker.patch("polar.merchant_migration.tasks.can_retry", return_value=False)
+        fail = mocker.patch(
+            "polar.merchant_migration.tasks.merchant_migration_service.fail_operation",
+            new_callable=mocker.AsyncMock,
+        )
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await merchant_migration_precheck(migration.id)
+
+        fail.assert_awaited_once()
+        assert fail.await_args is not None
+        assert fail.await_args.args[1] == migration.id
+
+    async def test_can_retry_raises_retry(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        mocker.patch(
+            "polar.merchant_migration.tasks.merchant_migration_service.process_import_batch",
+            side_effect=RuntimeError("transient"),
+        )
+        mocker.patch("polar.merchant_migration.tasks.can_retry", return_value=True)
+
+        with pytest.raises(Retry):
+            await merchant_migration_import(migration.id)
+
+
+@pytest.mark.asyncio
+class TestStallDetection:
+    @pytest.mark.auth
+    async def test_get_marks_stalled_operation_failed(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        migration = await build_connected_migration(save_fixture, organization)
+        stalled = new_pending_operation()
+        stalled = stalled.model_copy(
+            update={
+                "status": MerchantMigrationOperationStatus.running,
+                "last_progress_at": utc_now() - STALL_THRESHOLD - timedelta(minutes=1),
+            }
+        )
+        repository = MerchantMigrationRepository.from_session(session)
+        await repository.update(
+            migration,
+            update_dict={
+                "step": MerchantMigrationStep.pre_check,
+                "operation": stalled,
+            },
+        )
+
+        got = await service.get(session, auth_subject, migration.id)
+        assert got is not None
+        assert got.operation is not None
+        assert got.operation.status == MerchantMigrationOperationStatus.failed
+        assert got.operation.error is not None
+
+    @pytest.mark.auth
+    async def test_stall_does_not_overwrite_fresh_progress(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+    ) -> None:
+        from types import SimpleNamespace
+
+        migration = await build_connected_migration(save_fixture, organization)
+        stalled = new_pending_operation()
+        stalled = stalled.model_copy(
+            update={
+                "status": MerchantMigrationOperationStatus.running,
+                "last_progress_at": utc_now() - STALL_THRESHOLD - timedelta(minutes=1),
+            }
+        )
+        repository = MerchantMigrationRepository.from_session(session)
+        await repository.update(
+            migration,
+            update_dict={
+                "step": MerchantMigrationStep.pre_check,
+                "operation": stalled,
+            },
+        )
+
+        # Worker progressed after the GET's initial stall check but before the
+        # stalled UPDATE acquires the row lock.
+        fresh = mark_running(stalled, cursor={"offset": 2})
+        migration_id = migration.id
+        await repository.update(migration, update_dict={"operation": fresh})
+        await session.flush()
+        session.expire(migration)
+
+        # Stale in-memory view from the unlocked read that decided to stall.
+        stale_view = SimpleNamespace(id=migration_id, operation=stalled)
+        assert stalled.is_stalled()
+
+        result = await service._apply_stall_if_needed(session, stale_view)  # type: ignore[arg-type]
+        assert result.operation is not None
+        assert result.operation.status == MerchantMigrationOperationStatus.running
+        assert result.operation.cursor == {"offset": 2}
+
+
+@pytest.mark.asyncio
+class TestPanTransferGating:
+    @pytest.mark.auth
+    async def test_rejects_while_import_operation_active(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        auth_subject: AuthSubject[User],
+        organization: Organization,
+        user_organization: UserOrganization,
+    ) -> None:
+        from polar.config import settings
+        from polar.merchant_migration.pan_transfer import PanTransferNotReady
+
+        mocker.patch.object(
+            settings, "MERCHANT_MIGRATION_DESTINATION_STRIPE_ACCOUNT_ID", "acct_polar"
+        )
+        migration = await build_connected_migration(save_fixture, organization)
+        mocker.patch(
+            "polar.merchant_migration.service.StripeAdapter",
+            return_value=_FakeAdapter(_importable_catalog()),
+        )
+        mocker.patch("polar.merchant_migration.service.enqueue_job")
+        await run_precheck(session, auth_subject, migration.id)
+
+        started = await service.start_import(session, auth_subject, migration.id)
+        assert started.step == MerchantMigrationStep.create_catalog
+        assert started.operation is not None
+        assert started.operation.status == MerchantMigrationOperationStatus.pending
+
+        with pytest.raises(PanTransferNotReady):
+            await service.start_pan_transfer(session, auth_subject, migration.id)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Backend-only background merchant migration: precheck + catalog import as Dramatiq jobs with batched self-reenqueue, typed `operation` state, `202` start endpoints, and stall detection.

The `operation` column landed separately in https://github.com/polarsource/polar/pull/13683 (merged), so this branch is rebased directly on `main` and contains only the jobs implementation.

Stripe extraction now uses one shared paginated phase dispatcher for products, customers, and subscriptions. Product pages load complete active-price sets with bounded concurrency, preserving canonical product/interval grouping across batches.

## Design notes

- `GET /{id}` intentionally uses the primary session because the accepted design performs stall detection on read: a stalled operation is rechecked under `FOR UPDATE` and persisted as failed.
- Background import runs under an organization auth subject. Product creation therefore omits `organization_id`, as Polar rejects an explicit organization ID when organization credentials already determine the owner.

## Known frontend follow-up

`POST /{id}/precheck` now returns `202` with the migration instead of a synchronous `PrecheckReport`, and blockers surface as `400`/`409` errors. That drops `PrecheckReport` / `PrecheckIssue` / `PrecheckEntitySummary` from the generated OpenAPI client, so the existing dashboard migrations UI no longer type-checks. The frontend must poll `operation` and read `/records/summary` before this is mergeable.

## Test plan

- [x] `POLAR_ENV=testing uv run python -m pytest tests/merchant_migration/` — 217 passed
- [x] `POLAR_ENV=testing uv run python -m pytest tests/merchant_migration/test_stripe_adapter.py` — 26 passed
- [x] `POLAR_ENV=testing uv run python -m pytest tests/merchant_migration/test_service.py` — 37 passed
- [x] `uv run task lint_check`
- [x] `uv run task lint_types`
- [ ] Dashboard precheck UI updated to the async contract (currently fails `web#typecheck` and Vercel builds)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6d5a501a-a303-422e-896f-eb545a887296?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6d5a501a-a303-422e-896f-eb545a887296&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

