### PR TITLE
server/stripe: handle case where payment method is attached to several customers

### DIFF
--- a/server/polar/integrations/stripe/tasks.py
+++ b/server/polar/integrations/stripe/tasks.py
@@ -407,14 +407,13 @@ async def payment_method_detached(event_id: uuid.UUID) -> None:
                 stripe_lib.PaymentMethod, event.stripe_data.data.object
             )
             repository = PaymentMethodRepository.from_session(session)
-            payment_method = await repository.get_by_processor_id(
+            payment_methods = await repository.get_all_by_processor_id(
                 PaymentProcessor.stripe,
                 stripe_payment_method.id,
                 options=repository.get_eager_options(),
             )
-            if payment_method is None:
-                return
-            await payment_method_service.delete(session, payment_method, force=True)
+            for payment_method in payment_methods:
+                await payment_method_service.delete(session, payment_method, force=True)
 
 
 @actor(
@@ -429,16 +428,15 @@ async def payment_method_automatically_updated(event_id: uuid.UUID) -> None:
                 stripe_lib.PaymentMethod, event.stripe_data.data.object
             )
             repository = PaymentMethodRepository.from_session(session)
-            payment_method = await repository.get_by_processor_id(
+            payment_methods = await repository.get_all_by_processor_id(
                 PaymentProcessor.stripe,
                 stripe_payment_method.id,
                 options=repository.get_eager_options(),
             )
-            if payment_method is None:
-                return
-            await payment_method_service.upsert_from_stripe(
-                session, payment_method.customer, stripe_payment_method
-            )
+            for payment_method in payment_methods:
+                await payment_method_service.upsert_from_stripe(
+                    session, payment_method.customer, stripe_payment_method
+                )
 
 
 @actor(

--- a/server/polar/payment_method/repository.py
+++ b/server/polar/payment_method/repository.py
@@ -81,13 +81,13 @@ class PaymentMethodRepository(
     ) -> Select[tuple[PaymentMethod]]:
         return self.get_base_statement().where(PaymentMethod.customer_id == customer_id)
 
-    async def get_by_processor_id(
+    async def get_all_by_processor_id(
         self,
         processor: PaymentProcessor,
         processor_id: str,
         *,
         options: Options = (),
-    ) -> PaymentMethod | None:
+    ) -> Sequence[PaymentMethod]:
         statement = (
             self.get_base_statement()
             .where(
@@ -96,7 +96,7 @@ class PaymentMethodRepository(
             )
             .options(*options)
         )
-        return await self.get_one_or_none(statement)
+        return await self.get_all(statement)
 
     async def list_by_customer(
         self,
@@ -104,15 +104,14 @@ class PaymentMethodRepository(
         *,
         exclude_id: UUID | None = None,
         options: Options = (),
-    ) -> list[PaymentMethod]:
+    ) -> Sequence[PaymentMethod]:
         statement = self.get_base_statement().where(
             PaymentMethod.customer_id == customer_id
         )
         if exclude_id is not None:
             statement = statement.where(PaymentMethod.id != exclude_id)
         statement = statement.options(*options)
-        result = await self.session.execute(statement)
-        return list(result.scalars().all())
+        return await self.get_all(statement)
 
     async def get_cards_needing_expiration_reminder(
         self,

--- a/server/tests/integrations/stripe/test_tasks.py
+++ b/server/tests/integrations/stripe/test_tasks.py
@@ -382,10 +382,10 @@ class TestPaymentMethodDetached:
 
         # Then: Payment method is soft-deleted and unlinked from the customer
         pm_repo = PaymentMethodRepository.from_session(session)
-        stored = await pm_repo.get_by_processor_id(
+        stored = await pm_repo.get_all_by_processor_id(
             PaymentProcessor.stripe, "pm_detach_test"
         )
-        assert stored is None
+        assert len(stored) == 0
 
         customer_repo = CustomerRepository.from_session(session)
         refreshed_customer = await customer_repo.get_by_id(customer.id)
@@ -448,9 +448,11 @@ class TestPaymentMethodAutomaticallyUpdated:
         await payment_method_automatically_updated(uuid.uuid4())
 
         repository = PaymentMethodRepository.from_session(session)
-        payment_method = await repository.get_by_processor_id(
+        payment_methods = await repository.get_all_by_processor_id(
             PaymentProcessor.stripe, "pm_update_test"
         )
+        assert len(payment_methods) == 1
+        payment_method = payment_methods[0]
         assert payment_method is not None
         assert payment_method.method_metadata == {
             "brand": "mastercard",


### PR DESCRIPTION

For some very old customers, we might have the same payment method attached to several customers. Back in the days, customers (actually, there were also User) were not isolated per organization: they were all under the Polar umbrella, and they could purchase things from different organizations under the same account.

When we migrated to the new system, we created a new customer for each organization, and create copy of their payment methods on each one.

Therefore, when we handle a Stripe webhook about payment methods, we need to handle if this payment method is attached to several customers, and update all of them.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

