### PR TITLE
slack-benefit: Update all grants that share the channel id

### DIFF
--- a/server/polar/benefit/grant/repository.py
+++ b/server/polar/benefit/grant/repository.py
@@ -245,6 +245,32 @@ class BenefitGrantRepository(
             statement = statement.with_for_update(of=BenefitGrant)
         return await self.get_one_or_none(statement)
 
+    async def list_by_property_and_organization(
+        self,
+        organization_id: UUID,
+        key: str,
+        value: str,
+        *,
+        benefit_id: UUID | None = None,
+        for_update: bool = False,
+    ) -> Sequence[BenefitGrant]:
+        filters = [
+            BenefitGrant.properties[key].as_string() == value,
+            Benefit.organization_id == organization_id,
+        ]
+        if benefit_id is not None:
+            filters.append(BenefitGrant.benefit_id == benefit_id)
+
+        statement = (
+            self.get_base_statement()
+            .join(Benefit, BenefitGrant.benefit_id == Benefit.id)
+            .where(*filters)
+            .order_by(BenefitGrant.id)
+        )
+        if for_update:
+            statement = statement.with_for_update(of=BenefitGrant)
+        return await self.get_all(statement)
+
     async def count_granted_by_property_and_organization(
         self,
         organization_id: UUID,

--- a/server/polar/integrations/slack/service.py
+++ b/server/polar/integrations/slack/service.py
@@ -367,20 +367,20 @@ class SlackAppService:
 
         grant_repository = BenefitGrantRepository.from_session(session)
         for benefit in benefits:
-            grant = await grant_repository.get_by_property_and_organization(
+            grants = await grant_repository.list_by_property_and_organization(
                 integration.organization_id,
                 "channel_id",
                 channel_id,
                 benefit_id=benefit.id,
                 for_update=True,
             )
-            if grant is None:
-                continue
-
-            properties = dict(grant.properties or {})
-            if isinstance(connected_team_id, str):
-                properties["connected_team_id"] = connected_team_id
-            await grant_repository.update(grant, update_dict={"properties": properties})
+            for grant in grants:
+                properties = dict(grant.properties or {})
+                if isinstance(connected_team_id, str):
+                    properties["connected_team_id"] = connected_team_id
+                await grant_repository.update(
+                    grant, update_dict={"properties": properties}
+                )
 
     async def _handle_channel_id_changed(
         self,
@@ -401,19 +401,19 @@ class SlackAppService:
 
         grant_repository = BenefitGrantRepository.from_session(session)
         for benefit in benefits:
-            grant = await grant_repository.get_by_property_and_organization(
+            grants = await grant_repository.list_by_property_and_organization(
                 integration.organization_id,
                 "channel_id",
                 old_channel_id,
                 benefit_id=benefit.id,
                 for_update=True,
             )
-            if grant is None:
-                continue
-
-            properties = dict(grant.properties or {})
-            properties["channel_id"] = new_channel_id
-            await grant_repository.update(grant, update_dict={"properties": properties})
+            for grant in grants:
+                properties = dict(grant.properties or {})
+                properties["channel_id"] = new_channel_id
+                await grant_repository.update(
+                    grant, update_dict={"properties": properties}
+                )
 
     async def _validate_credentials(
         self,

--- a/server/tests/integrations/slack/test_service.py
+++ b/server/tests/integrations/slack/test_service.py
@@ -458,6 +458,54 @@ class TestHandleEvent:
         assert refreshed is not None
         assert (refreshed.properties or {}).get("connected_team_id") == "TCUST"
 
+    async def test_channel_shared_updates_all_grants_sharing_channel(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        organization: Organization,
+        customer: Customer,
+        customer_second: Customer,
+    ) -> None:
+        benefit = await _create_benefit(save_fixture, organization)
+        await _create_integration(save_fixture, organization, benefit=benefit)
+        grant = await create_benefit_grant(
+            save_fixture,
+            customer,
+            benefit,
+            properties={
+                "invited_email": "a@example.com",
+                "channel_id": "C123",
+            },
+        )
+        second_grant = await create_benefit_grant(
+            save_fixture,
+            customer_second,
+            benefit,
+            properties={
+                "invited_email": "b@example.com",
+                "channel_id": "C123",
+            },
+        )
+        await session.flush()
+        service, _client = _service_with_mock(mocker)
+
+        await service.handle_event(
+            session,
+            api_app_id="A0TESTAPPID",
+            event={
+                "type": "channel_shared",
+                "channel": "C123",
+                "connected_team_id": "TCUST",
+            },
+        )
+
+        repo = BenefitGrantRepository.from_session(session)
+        for grant_id in (grant.id, second_grant.id):
+            refreshed = await repo.get_by_id(grant_id)
+            assert refreshed is not None
+            assert (refreshed.properties or {}).get("connected_team_id") == "TCUST"
+
     async def test_channel_shared_ignores_same_channel_id_for_other_benefit(
         self,
         session: AsyncSession,
@@ -539,6 +587,48 @@ class TestHandleEvent:
         refreshed_untouched = await repo.get_by_id(untouched.id)
         assert refreshed_untouched is not None
         assert (refreshed_untouched.properties or {}).get("channel_id") == "G999"
+
+    async def test_channel_id_changed_remaps_all_grants_sharing_channel(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        mocker: MockerFixture,
+        organization: Organization,
+        customer: Customer,
+        customer_second: Customer,
+    ) -> None:
+        benefit = await _create_benefit(save_fixture, organization)
+        await _create_integration(save_fixture, organization, benefit=benefit)
+        grant = await create_benefit_grant(
+            save_fixture,
+            customer,
+            benefit,
+            properties={"invited_email": "a@example.com", "channel_id": "G123"},
+        )
+        second_grant = await create_benefit_grant(
+            save_fixture,
+            customer_second,
+            benefit,
+            properties={"invited_email": "b@example.com", "channel_id": "G123"},
+        )
+        await session.flush()
+        service, _client = _service_with_mock(mocker)
+
+        await service.handle_event(
+            session,
+            api_app_id="A0TESTAPPID",
+            event={
+                "type": "channel_id_changed",
+                "old_channel_id": "G123",
+                "new_channel_id": "C123",
+            },
+        )
+
+        repo = BenefitGrantRepository.from_session(session)
+        for grant_id in (grant.id, second_grant.id):
+            refreshed = await repo.get_by_id(grant_id)
+            assert refreshed is not None
+            assert (refreshed.properties or {}).get("channel_id") == "C123"
 
     async def test_channel_id_changed_scopes_to_integration(
         self,


### PR DESCRIPTION
Otherwise the other benefit grants will become stale and broken.

Solves https://github.com/polarsource/feedback/issues/186 as well as https://github.com/polarsource/feedback/issues/170

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Slack benefit handling to update all grants that share a channel ID, preventing stale or broken grants when channels are shared or IDs change. Fixes broken access when multiple customers share the same Slack channel.

- **Bug Fixes**
  - Updated Slack event handlers (`channel_shared`, `channel_id_changed`) to update every matching grant’s properties (`connected_team_id`, `channel_id`) instead of just one.
  - Added `list_by_property_and_organization` in `BenefitGrantRepository` to fetch all matching grants with optional `benefit_id` and `for_update` locking.
  - Added tests to cover multi-grant updates and scoping.

<sup>Written for commit 37c739ad50f6a4b6a15daa687c3db76fbb88c0a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

