### PR TITLE
Remove default cancellation reason selection

### DIFF
--- a/clients/apps/web/src/components/CustomerPortal/CustomerCancellationModal.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerCancellationModal.tsx
@@ -174,7 +174,7 @@ const CustomerCancellationModal = ({
                   <FormItem>
                     <FormControl>
                       <RadioGroup
-                        value={field.value ?? 'other'}
+                        value={field.value ?? undefined}
                         onValueChange={onReasonSelect}
                       >
                         <CancellationReasonRadio


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Related Issue**: Detail bug https://github.com/polarsource/feedback/issues/289#issue-4908588686

Removes the misleading visual default from the customer cancellation form. (Instead of issue suggestion of forcing 'other' which would affect the stats)

## What

The cancellation reason radio group now renders with no selected value when the form value is unset.

## Why

The UI previously showed `Other` as selected while the form still held `undefined`, causing the submitted cancellation reason to differ from what the customer saw.

## How

Pass the optional form value directly to the radio group instead of falling back to `other`.

## Validation

- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- Manually opened a seeded customer subscription cancellation modal and confirmed all reasons initially render unselected, selecting `Other` still works, and closing the modal leaves the subscription active.

[cancellation_reason_requires_explicit_selection.mp4](https://cursor.com/agents/bc-81f936a4-bf79-4059-81a6-b7cec1fc02c8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcancellation_reason_requires_explicit_selection.mp4)

## Checklist

- [x] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [x] The diff is reasonably sized and easy to review
- [x] Existing behavior is covered by automated checks and a manual regression walkthrough
- [x] Linting and type checking pass
- [x] No unrelated changes or drive-by fixes are included

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81f936a4-bf79-4059-81a6-b7cec1fc02c8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81f936a4-bf79-4059-81a6-b7cec1fc02c8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

