### PR TITLE
fix: don't let an invalid prefilled email 500 the checkout

### DIFF
--- a/server/polar/checkout/service.py
+++ b/server/polar/checkout/service.py
@@ -59,6 +59,7 @@ from polar.kit.currency import (
     get_presentment_currency,
 )
 from polar.kit.db.locking import is_lock_not_available_error
+from polar.kit.email import EmailNotValidError, validate_email_syntax
 from polar.kit.operator import attrgetter
 from polar.kit.pagination import PaginationParams
 from polar.kit.sorting import Sorting
@@ -869,7 +870,12 @@ class CheckoutService:
         if query_prefill:
             customer_email = query_prefill.get("customer_email")
             if customer_email is not None and isinstance(customer_email, str):
-                checkout.customer_email = customer_email
+                try:
+                    validate_email_syntax(customer_email)
+                except EmailNotValidError:
+                    pass
+                else:
+                    checkout.customer_email = customer_email
 
             customer_name = query_prefill.get("customer_name")
             if customer_name is not None and isinstance(customer_name, str):

--- a/server/polar/discount/service.py
+++ b/server/polar/discount/service.py
@@ -20,7 +20,7 @@ from polar.discount.repository import (
 )
 from polar.exceptions import PolarError, PolarRequestValidationError
 from polar.kit.db.locking import is_lock_not_available_error
-from polar.kit.email import unalias_email
+from polar.kit.email import EmailNotValidError, unalias_email
 from polar.kit.pagination import PaginationParams, paginate
 from polar.kit.services import ResourceServiceReader
 from polar.kit.sorting import Sorting
@@ -483,12 +483,17 @@ class DiscountService(ResourceServiceReader[Discount]):
             else checkout.customer_email
         )
 
+        try:
+            customer_email = unalias_email(email).lower() if email else None
+        except EmailNotValidError:
+            customer_email = None
+
         repository = DiscountRedemptionRepository.from_session(session)
         count = await repository.count_redemptions_by_customer(
             discount.id,
             exclude_checkout_id=checkout.id,
             customer_id=customer_id,
-            customer_email=unalias_email(email).lower() if email else None,
+            customer_email=customer_email,
             payment_method_fingerprint=payment_method_fingerprint,
         )
         return count >= discount.max_redemptions_per_customer

--- a/server/polar/kit/email.py
+++ b/server/polar/kit/email.py
@@ -17,6 +17,7 @@ _email_dns_resolver = caching_resolver()
 validate_email = functools.partial(
     _validate_email, check_deliverability=True, dns_resolver=_email_dns_resolver
 )
+validate_email_syntax = functools.partial(_validate_email, check_deliverability=False)
 
 
 def _validate_email_dns(email: str) -> str:
@@ -41,8 +42,14 @@ def unalias_email(email: str) -> str:
     For example, `pieter+123@polar.sh` becomes `pieter@polar.sh`. The domain is
     preserved as-is. Used to compare email addresses while ignoring sub-addressing.
     """
-    parsed = _validate_email(email, check_deliverability=False)
+    parsed = validate_email_syntax(email)
     return f"{parsed.local_part.split('+', 1)[0]}@{parsed.domain}"
 
 
-__all__ = ["EmailNotValidError", "EmailStrDNS", "unalias_email", "validate_email"]
+__all__ = [
+    "EmailNotValidError",
+    "EmailStrDNS",
+    "unalias_email",
+    "validate_email",
+    "validate_email_syntax",
+]

--- a/server/tests/checkout/test_service.py
+++ b/server/tests/checkout/test_service.py
@@ -2911,6 +2911,24 @@ class TestCheckoutLinkCreate:
 
         assert checkout.discount is None
 
+    async def test_query_prefill_customer_email_invalid(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        product_one_time: Product,
+    ) -> None:
+        checkout_link = await create_checkout_link(
+            save_fixture, products=[product_one_time]
+        )
+
+        checkout = await checkout_service.checkout_link_create(
+            session,
+            checkout_link,
+            query_prefill={"customer_email": "not-an-email"},
+        )
+
+        assert checkout.customer_email is None
+
     async def test_query_prefill_amount_custom_price(
         self,
         save_fixture: SaveFixture,

--- a/server/tests/discount/test_service.py
+++ b/server/tests/discount/test_service.py
@@ -1448,6 +1448,32 @@ class TestCheckPerCustomerLimitReached:
             is False
         )
 
+    async def test_invalid_checkout_email_is_ignored(
+        self,
+        save_fixture: SaveFixture,
+        session: AsyncSession,
+        organization: Organization,
+        product: Product,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.fixed,
+            amounts={"usd": 1000},
+            duration=DiscountDuration.once,
+            organization=organization,
+            max_redemptions_per_customer=1,
+        )
+        current_checkout = await create_checkout(save_fixture, products=[product])
+        current_checkout.customer_email = "not-an-email"
+        await save_fixture(current_checkout)
+
+        assert (
+            await discount_service.check_per_customer_limit_reached(
+                session, discount, checkout=current_checkout
+            )
+            is False
+        )
+
 
 @pytest.mark.asyncio
 class TestRedeemDiscount:


### PR DESCRIPTION
`?customer_email=` on a checkout link was stored without validation. Any update to a checkout carrying a discount with a per-customer limit then crashed in `unalias_email`.

Closes https://github.com/polarsource/feedback/issues/323

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent 500 errors on checkout when a prefilled `customer_email` is invalid. We now validate and ignore bad emails, and handle them safely in per-customer discount checks.

- **Bug Fixes**
  - Validate `?customer_email=` in `checkout_link_create`; ignore invalid values.
  - In per-customer limit checks, treat invalid emails as None instead of calling `unalias_email` and crashing.
  - Add `validate_email_syntax`, update `unalias_email` to use it, and add tests for both scenarios.

<sup>Written for commit 859e19fec58dc076e858c10b31fa3a91daa43157. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

