### PR TITLE
org: Ensure that it's not possible to remove all admins

### DIFF
--- a/server/polar/user_organization/service.py
+++ b/server/polar/user_organization/service.py
@@ -343,29 +343,27 @@ class UserOrganizationService:
         — so we re-assert here. Rejects only when the removal would
         actually reduce admin-capable count to zero; non-admin-capable
         removals from a degraded organization are still allowed (they
-        don't make the state worse).
+        don't make the state worse). The admin-capable rows are locked
+        with `FOR UPDATE` to serialize concurrent removals.
         """
-        target_role = await session.scalar(
-            sql.select(UserOrganization.role).where(
+        result = await session.scalars(
+            sql.select(UserOrganization.user_id)
+            .where(
                 UserOrganization.organization_id == organization_id,
-                UserOrganization.user_id == user_id,
-                UserOrganization.is_deleted.is_(False),
-            )
-        )
-        if target_role not in {OrganizationRole.owner, OrganizationRole.admin}:
-            return
-
-        other_admin_capable = await session.scalar(
-            sql.select(func.count(UserOrganization.user_id)).where(
-                UserOrganization.organization_id == organization_id,
-                UserOrganization.user_id != user_id,
                 UserOrganization.role.in_(
                     [OrganizationRole.owner, OrganizationRole.admin]
                 ),
                 UserOrganization.is_deleted.is_(False),
             )
+            .order_by(UserOrganization.user_id)
+            .with_for_update()
         )
-        if (other_admin_capable or 0) == 0:
+        admin_capable_ids = set(result.all())
+        if user_id not in admin_capable_ids:
+            return
+
+        other_admin_capable_ids = admin_capable_ids - {user_id}
+        if len(other_admin_capable_ids) == 0:
             raise OrganizationWouldHaveNoAdmins(organization_id)
 
     async def remove_member_safe(

--- a/server/polar/user_organization/service.py
+++ b/server/polar/user_organization/service.py
@@ -22,6 +22,8 @@ from .repository import UserOrganizationRepository
 
 log = structlog.get_logger()
 
+ADMIN_CAPABLE_ROLES = {OrganizationRole.owner, OrganizationRole.admin}
+
 
 class UserOrganizationError(PolarError): ...
 
@@ -205,6 +207,11 @@ class UserOrganizationService:
         if user_org.role == role:
             return user_org
 
+        if user_org.role in ADMIN_CAPABLE_ROLES and role not in ADMIN_CAPABLE_ROLES:
+            await self._assert_admin_capability_after_loss(
+                session, user_id=user_id, organization_id=organization_id
+            )
+
         previous_role = user_org.role
         await session.execute(
             sql.update(UserOrganization)
@@ -296,7 +303,7 @@ class UserOrganizationService:
         user_id: UUID,
         organization_id: UUID,
     ) -> None:
-        await self._assert_admin_capability_after_removal(
+        await self._assert_admin_capability_after_loss(
             session, user_id=user_id, organization_id=organization_id
         )
 
@@ -326,7 +333,7 @@ class UserOrganizationService:
                 external_id=str(user_id),
             )
 
-    async def _assert_admin_capability_after_removal(
+    async def _assert_admin_capability_after_loss(
         self,
         session: AsyncSession,
         *,
@@ -337,22 +344,18 @@ class UserOrganizationService:
         Defense-in-depth guard for the admin-capability invariant: an
         organization always has at least one user in `role ∈ {owner, admin}`.
 
-        The owner-non-removable invariant in `remove_member_safe` already
-        covers the common case (every org has an owner who counts as
-        admin-capable), but raw `remove_member` callers bypass that check
-        — so we re-assert here. Rejects only when the removal would
-        actually reduce admin-capable count to zero; non-admin-capable
-        removals from a degraded organization are still allowed (they
+        Called before any operation that takes `user_id` out of the
+        admin-capable set (removal or demotion). Rejects only when the
+        operation would actually reduce the admin-capable count to zero;
+        operations on non-admin-capable users are always allowed (they
         don't make the state worse). The admin-capable rows are locked
-        with `FOR UPDATE` to serialize concurrent removals.
+        with `FOR UPDATE` to serialize concurrent removals and demotions.
         """
         result = await session.scalars(
             sql.select(UserOrganization.user_id)
             .where(
                 UserOrganization.organization_id == organization_id,
-                UserOrganization.role.in_(
-                    [OrganizationRole.owner, OrganizationRole.admin]
-                ),
+                UserOrganization.role.in_(ADMIN_CAPABLE_ROLES),
                 UserOrganization.is_deleted.is_(False),
             )
             .order_by(UserOrganization.user_id)

--- a/server/tests/user_organization/test_service.py
+++ b/server/tests/user_organization/test_service.py
@@ -307,6 +307,24 @@ async def _attempt_member_removal(
         return True
 
 
+async def _attempt_role_change(
+    sessionmaker: AsyncSessionMaker, user_id: UUID, organization_id: UUID
+) -> bool:
+    async with sessionmaker() as session:
+        try:
+            await user_organization_service.set_role(
+                session,
+                user_id=user_id,
+                organization_id=organization_id,
+                role=OrganizationRole.member,
+            )
+        except OrganizationWouldHaveNoAdmins:
+            await session.rollback()
+            return False
+        await session.commit()
+        return True
+
+
 @pytest.mark.asyncio
 class TestConcurrentRemoval:
     async def test_admin_capability_invariant_under_concurrency(
@@ -346,6 +364,82 @@ class TestConcurrentRemoval:
             results = await asyncio.gather(
                 _attempt_member_removal(sessionmaker, owner.id, organization.id),
                 _attempt_member_removal(sessionmaker, admin.id, organization.id),
+            )
+
+            async with sessionmaker() as session:
+                remaining = (
+                    await session.execute(
+                        select(func.count(UserOrganization.user_id)).where(
+                            UserOrganization.organization_id == organization.id,
+                            UserOrganization.role.in_(
+                                [OrganizationRole.owner, OrganizationRole.admin]
+                            ),
+                            UserOrganization.deleted_at.is_(None),
+                        )
+                    )
+                ).scalar_one()
+
+            assert results.count(True) == 1
+            assert remaining == 1
+        finally:
+            async with sessionmaker() as cleanup_session:
+                await cleanup_session.execute(
+                    delete(UserOrganization).where(
+                        UserOrganization.organization_id == organization.id
+                    )
+                )
+                await cleanup_session.execute(
+                    delete(Organization).where(Organization.id == organization.id)
+                )
+                await cleanup_session.execute(
+                    delete(Account).where(Account.id == account.id)
+                )
+                await cleanup_session.execute(
+                    delete(User).where(User.id.in_([owner.id, admin.id]))
+                )
+                await cleanup_session.commit()
+            await engine.dispose()
+
+
+@pytest.mark.asyncio
+class TestConcurrentDemotion:
+    async def test_admin_capability_invariant_under_concurrency(
+        self, worker_id: str
+    ) -> None:
+        engine = create_async_engine(
+            dsn=get_database_url(worker_id),
+            application_name=f"test_{worker_id}_set_role_concurrency",
+            pool_size=4,
+            pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
+        )
+        sessionmaker = create_async_sessionmaker(engine)
+
+        async with sessionmaker() as setup_session:
+            save_fixture = save_fixture_factory(setup_session)
+            owner = await create_user(save_fixture)
+            admin = await create_user(save_fixture)
+            account = await create_account(save_fixture, owner)
+            organization = await create_organization(save_fixture, account)
+            setup_session.add(
+                UserOrganization(
+                    user=owner,
+                    organization=organization,
+                    role=OrganizationRole.owner,
+                )
+            )
+            setup_session.add(
+                UserOrganization(
+                    user=admin,
+                    organization=organization,
+                    role=OrganizationRole.admin,
+                )
+            )
+            await setup_session.commit()
+
+        try:
+            results = await asyncio.gather(
+                _attempt_member_removal(sessionmaker, owner.id, organization.id),
+                _attempt_role_change(sessionmaker, admin.id, organization.id),
             )
 
             async with sessionmaker() as session:
@@ -435,6 +529,28 @@ class TestSetRole:
 
         assert result.role == OrganizationRole.admin
 
+    async def test_demote_last_admin_capable_rejected(
+        self,
+        save_fixture: SaveFixture,
+        session: Any,
+        organization: Organization,
+        user_second: User,
+    ) -> None:
+        relation = UserOrganization(
+            user_id=user_second.id,
+            organization_id=organization.id,
+            role=OrganizationRole.admin,
+        )
+        await save_fixture(relation)
+
+        with pytest.raises(OrganizationWouldHaveNoAdmins):
+            await user_organization_service.set_role(
+                session,
+                user_id=user_second.id,
+                organization_id=organization.id,
+                role=OrganizationRole.member,
+            )
+
     async def test_promotion_syncs_billing_member_role(
         self,
         mocker: MockerFixture,
@@ -472,6 +588,7 @@ class TestSetRole:
         session: Any,
         organization: Organization,
         user_second: User,
+        user_organization: UserOrganization,
     ) -> None:
         enqueue_update_member_mock = mocker.patch(
             "polar.user_organization.service.polar_self_service.enqueue_update_member"

--- a/server/tests/user_organization/test_service.py
+++ b/server/tests/user_organization/test_service.py
@@ -1,9 +1,17 @@
+import asyncio
 from typing import Any
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from pytest_mock import MockerFixture
+from sqlalchemy import delete, func, select
 
+from polar.config import settings
+from polar.kit.db.postgres import (
+    AsyncSessionMaker,
+    create_async_engine,
+    create_async_sessionmaker,
+)
 from polar.models import Account, Organization, User, UserOrganization
 from polar.models.member import MemberRole
 from polar.models.user import IdentityVerificationStatus
@@ -21,7 +29,16 @@ from polar.user_organization.service import (
 from polar.user_organization.service import (
     user_organization as user_organization_service,
 )
-from tests.fixtures.database import SaveFixture
+from tests.fixtures.database import (
+    SaveFixture,
+    get_database_url,
+    save_fixture_factory,
+)
+from tests.fixtures.random_objects import (
+    create_account,
+    create_organization,
+    create_user,
+)
 
 
 @pytest.mark.asyncio
@@ -271,6 +288,99 @@ class TestRemoveMember:
             session, user_second.id, organization.id
         )
         assert user_org is None
+
+
+async def _attempt_member_removal(
+    sessionmaker: AsyncSessionMaker, user_id: UUID, organization_id: UUID
+) -> bool:
+    async with sessionmaker() as session:
+        try:
+            await user_organization_service.remove_member(
+                session,
+                user_id=user_id,
+                organization_id=organization_id,
+            )
+        except OrganizationWouldHaveNoAdmins:
+            await session.rollback()
+            return False
+        await session.commit()
+        return True
+
+
+@pytest.mark.asyncio
+class TestConcurrentRemoval:
+    async def test_admin_capability_invariant_under_concurrency(
+        self, worker_id: str
+    ) -> None:
+        engine = create_async_engine(
+            dsn=get_database_url(worker_id),
+            application_name=f"test_{worker_id}_remove_member_concurrency",
+            pool_size=4,
+            pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
+        )
+        sessionmaker = create_async_sessionmaker(engine)
+
+        async with sessionmaker() as setup_session:
+            save_fixture = save_fixture_factory(setup_session)
+            owner = await create_user(save_fixture)
+            admin = await create_user(save_fixture)
+            account = await create_account(save_fixture, owner)
+            organization = await create_organization(save_fixture, account)
+            setup_session.add(
+                UserOrganization(
+                    user=owner,
+                    organization=organization,
+                    role=OrganizationRole.owner,
+                )
+            )
+            setup_session.add(
+                UserOrganization(
+                    user=admin,
+                    organization=organization,
+                    role=OrganizationRole.admin,
+                )
+            )
+            await setup_session.commit()
+
+        try:
+            results = await asyncio.gather(
+                _attempt_member_removal(sessionmaker, owner.id, organization.id),
+                _attempt_member_removal(sessionmaker, admin.id, organization.id),
+            )
+
+            async with sessionmaker() as session:
+                remaining = (
+                    await session.execute(
+                        select(func.count(UserOrganization.user_id)).where(
+                            UserOrganization.organization_id == organization.id,
+                            UserOrganization.role.in_(
+                                [OrganizationRole.owner, OrganizationRole.admin]
+                            ),
+                            UserOrganization.deleted_at.is_(None),
+                        )
+                    )
+                ).scalar_one()
+
+            assert results.count(True) == 1
+            assert remaining == 1
+        finally:
+            async with sessionmaker() as cleanup_session:
+                await cleanup_session.execute(
+                    delete(UserOrganization).where(
+                        UserOrganization.organization_id == organization.id
+                    )
+                )
+                await cleanup_session.execute(
+                    delete(Organization).where(Organization.id == organization.id)
+                )
+                await cleanup_session.execute(
+                    delete(Account).where(Account.id == account.id)
+                )
+                await cleanup_session.execute(
+                    delete(User).where(User.id.in_([owner.id, admin.id]))
+                )
+                await cleanup_session.commit()
+            await engine.dispose()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
There was a race condition which allowed you to remove all admins from an org. This prevents that.

Fixes https://github.com/polarsource/feedback/issues/274

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

