### PR TITLE
seats: Ensure that concurrent customer requests doesn't fail

### DIFF
--- a/server/polar/customer_seat/service.py
+++ b/server/polar/customer_seat/service.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import structlog
 from sqlalchemy import inspect as sa_inspect
+from sqlalchemy.exc import IntegrityError
 
 from polar.auth.models import AuthSubject
 from polar.authz.service import get_accessible_org_ids
@@ -839,15 +840,22 @@ class SeatService:
                 customer_id, organization_id
             )
 
-        if not customer and not email:
-            raise CustomerNotFound(external_customer_id or str(customer_id))
-        elif not customer:
+        if not customer:
+            if not email:
+                raise CustomerNotFound(external_customer_id or str(customer_id))
             customer = Customer(
                 organization_id=organization_id,
                 email=email,
             )
-            session.add(customer)
-            await session.flush()
+            try:
+                async with session.begin_nested():
+                    customer = await customer_repository.create(customer, flush=True)
+            except IntegrityError:
+                customer = await customer_repository.get_by_email_and_organization(
+                    email, organization_id
+                )
+                if customer is None:
+                    raise
         return customer
 
     async def _get_or_create_member_for_seat(

--- a/server/tests/customer_seat/test_service.py
+++ b/server/tests/customer_seat/test_service.py
@@ -1,11 +1,15 @@
 import asyncio
 import uuid
 from datetime import UTC, datetime, timedelta
+from typing import Any
 from unittest.mock import patch
 
 import pytest
+from pytest_mock import MockerFixture
+from sqlalchemy.exc import IntegrityError
 
 from polar.auth.models import AuthSubject
+from polar.customer.repository import CustomerRepository
 from polar.customer_seat.service import (
     CustomerNotFound,
     FeatureNotEnabled,
@@ -336,6 +340,54 @@ class TestAssignSeat:
             seat.customer.organization_id
             == subscription_with_seats.product.organization_id
         )
+
+    @pytest.mark.asyncio
+    async def test_assign_seat_customer_creation_race(
+        self,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        subscription_with_seats: Subscription,
+    ) -> None:
+        existing = await create_customer(
+            save_fixture,
+            organization=subscription_with_seats.product.organization,
+            email="race@example.com",
+        )
+
+        create_call_count = 0
+
+        async def mock_create(self: Any, model: Any, flush: bool = False) -> None:
+            nonlocal create_call_count
+            create_call_count += 1
+            raise IntegrityError(
+                "duplicate", params=None, orig=Exception("unique violation")
+            )
+
+        mocker.patch.object(CustomerRepository, "create", mock_create)
+
+        original_get = CustomerRepository.get_by_email_and_organization
+        get_call_count = 0
+
+        async def mock_get(
+            self: Any, email: str, organization_id: uuid.UUID
+        ) -> Customer | None:
+            nonlocal get_call_count
+            get_call_count += 1
+            if get_call_count == 1:
+                return None
+            return await original_get(self, email, organization_id)
+
+        mocker.patch.object(
+            CustomerRepository, "get_by_email_and_organization", mock_get
+        )
+
+        seat = await seat_service.assign_seat(
+            session, subscription_with_seats, email="race@example.com"
+        )
+
+        assert seat.customer_id == existing.id
+        assert create_call_count == 1
 
     @pytest.mark.asyncio
     async def test_assign_seat_token_expiration(


### PR DESCRIPTION
If two requests find that a customer doesn't exist, both try to create it whereas we can let it return the concurrently created customer instead.

Fixes https://github.com/polarsource/feedback/issues/268

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

