### PR TITLE
server/order: stop the stale payment lock sweep from scanning every order

### DIFF
--- a/server/polar/order/repository.py
+++ b/server/polar/order/repository.py
@@ -389,7 +389,8 @@ class OrderRepository(
     async def stream_stale_payment_lock(self) -> AsyncGenerator[Order, None]:
         statement = (
             self.get_base_statement()
-            .where(Order.is_payment_lock_stale.is_(True))
+            # Bare, not `.is_(True)`: the `IS TRUE` wrapper defeats the partial index.
+            .where(Order.is_payment_lock_stale)
             .order_by(Order.payment_lock_acquired_at.asc())
         )
         async for order in self.stream(statement):

--- a/server/polar/order/tasks.py
+++ b/server/polar/order/tasks.py
@@ -310,6 +310,12 @@ async def process_stale_payment_lock(order_id: uuid.UUID) -> None:
             log.info("Order payment lock is not stale, skipping", order_id=order.id)
             return
 
+        log.warning(
+            "Releasing stale payment lock",
+            order_id=order.id,
+            payment_lock_acquired_at=order.payment_lock_acquired_at,
+        )
+
         # Treat stale payment locks as manual retry payment failures,
         # so the lock is released, but the dunning sequence is untouched.
         await order_service.handle_payment_failure(session, order, skip_dunning=True)

--- a/server/tests/order/test_repository.py
+++ b/server/tests/order/test_repository.py
@@ -1,0 +1,38 @@
+from collections.abc import AsyncGenerator
+
+import pytest
+from pytest_mock import MockerFixture
+from sqlalchemy import Select
+from sqlalchemy.dialects import postgresql
+
+from polar.models import Order
+from polar.order.repository import OrderRepository
+from polar.postgres import AsyncSession
+
+
+@pytest.mark.asyncio
+class TestStreamStalePaymentLock:
+    async def test_predicate_stays_indexable(
+        self, mocker: MockerFixture, session: AsyncSession
+    ) -> None:
+        captured: list[Select[tuple[Order]]] = []
+
+        async def capture(
+            self: OrderRepository, statement: Select[tuple[Order]]
+        ) -> AsyncGenerator[Order, None]:
+            captured.append(statement)
+            empty: list[Order] = []
+            for order in empty:
+                yield order
+
+        mocker.patch.object(OrderRepository, "stream", capture)
+
+        repository = OrderRepository.from_session(session)
+        async for _ in repository.stream_stale_payment_lock():
+            pass
+
+        compiled = str(captured[0].compile(dialect=postgresql.dialect()))
+        # Wrapping the comparison in `IS TRUE` costs us
+        # ix_orders_payment_lock_acquired_at and scans every order.
+        assert "IS true" not in compiled
+        assert "orders.payment_lock_acquired_at <= now()" in compiled


### PR DESCRIPTION
## Summary

The hourly stale payment lock sweep has been timing out since Jul 29 — 137 failures.
A timeout enqueues nothing, so stale locks go unreleased.
https://logfire-us.pydantic.dev/polar/polar/?q=span_name+like+%27%25stale_payment_lock%25%27&since=2026-07-29T00%3A00%3A00Z

`Order.is_payment_lock_stale.is_(True)` renders as `(payment_lock_acquired_at <= now() - interval '1 hour') IS TRUE`. Postgres won't match that against `ix_orders_payment_lock_acquired_at` and falls back to a parallel sequential scan of all 5.3M orders.

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the hourly stale payment lock sweep from scanning every order by making the predicate indexable. Previously the query rendered with IS TRUE, Postgres skipped the partial index, and the sweep often timed out and released no locks. Now the sweep uses the bare predicate, performs an index scan, and logs each release.

- The repository uses `Order.is_payment_lock_stale` directly to match the partial index and order by `payment_lock_acquired_at`.
- The task logs a warning when releasing a stale lock with `order_id` and `payment_lock_acquired_at`.
- A test pins the SQL shape to keep the predicate indexable and prevent regressions.

<sup>Written for commit bdc9f2b9d5df118343b7618914b801846be950e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

