### PR TITLE
server/benefit/grant: allow to revoke soft deleted benefits and acquire lock on grant rows

### DIFF
--- a/server/polar/benefit/grant/repository.py
+++ b/server/polar/benefit/grant/repository.py
@@ -3,6 +3,7 @@ from typing import Unpack
 from uuid import UUID
 
 from sqlalchemy import Select, func, select
+from sqlalchemy.orm import joinedload
 
 from polar.authz.types import AccessibleOrganizationID
 from polar.kit.repository import (
@@ -49,6 +50,8 @@ class BenefitGrantRepository(
         customer: Customer,
         benefit: Benefit,
         member: Member | None = None,
+        *,
+        for_update: bool = False,
         **scope: Unpack[BenefitGrantScope],
     ) -> BenefitGrant | None:
         statement = self.get_base_statement().where(
@@ -58,6 +61,8 @@ class BenefitGrantRepository(
             BenefitGrant.is_deleted.is_(False),
             BenefitGrant.scope == scope,
         )
+        if for_update:
+            statement = statement.with_for_update(of=BenefitGrant)
         return await self.get_one_or_none(statement)
 
     async def list_granted_by_scope(
@@ -314,3 +319,10 @@ class BenefitGrantRepository(
                 return BenefitGrant.granted_at
             case BenefitGrantSortProperty.revoked_at:
                 return BenefitGrant.revoked_at
+
+    def get_eager_options(self) -> Options:
+        return (
+            joinedload(BenefitGrant.customer),
+            joinedload(BenefitGrant.benefit).joinedload(Benefit.organization),
+            joinedload(BenefitGrant.member),
+        )

--- a/server/polar/benefit/grant/service.py
+++ b/server/polar/benefit/grant/service.py
@@ -1,6 +1,6 @@
 import builtins
 from collections.abc import Sequence
-from typing import Any, Literal, TypeVar, Unpack, overload
+from typing import Literal, Unpack
 from uuid import UUID
 
 import dramatiq
@@ -19,7 +19,6 @@ from polar.event.system import BenefitGrantMetadata, SystemEvent, build_system_e
 from polar.eventstream.service import publish as eventstream_publish
 from polar.exceptions import PolarError
 from polar.kit.pagination import PaginationParams, paginate
-from polar.kit.services import ResourceServiceReader
 from polar.kit.sorting import Sorting
 from polar.logging import Logger
 from polar.member.repository import MemberRepository
@@ -34,7 +33,7 @@ from polar.models import (
 )
 from polar.models.benefit_grant import BenefitGrantScope
 from polar.models.webhook_endpoint import WebhookEventType
-from polar.postgres import AsyncSession, sql
+from polar.postgres import AsyncSession
 from polar.redis import Redis
 from polar.webhook.service import webhook as webhook_service
 from polar.worker import can_retry, enqueue_job
@@ -51,67 +50,11 @@ from .sorting import BenefitGrantSortProperty
 
 log: Logger = structlog.get_logger()
 
-BG = TypeVar("BG", bound=BenefitGrant)
-
 
 class BenefitGrantError(PolarError): ...
 
 
-class BenefitGrantService(ResourceServiceReader[BenefitGrant]):
-    @overload
-    async def get(
-        self,
-        session: AsyncSession,
-        id: UUID,
-        allow_deleted: bool = False,
-        loaded: bool = False,
-        *,
-        class_: None = None,
-        options: Sequence[sql.ExecutableOption] | None = None,
-    ) -> BenefitGrant | None: ...
-
-    @overload
-    async def get(
-        self,
-        session: AsyncSession,
-        id: UUID,
-        allow_deleted: bool = False,
-        loaded: bool = False,
-        *,
-        class_: type[BG] | None = None,
-        options: Sequence[sql.ExecutableOption] | None = None,
-    ) -> BG | None: ...
-
-    async def get(
-        self,
-        session: AsyncSession,
-        id: UUID,
-        allow_deleted: bool = False,
-        loaded: bool = False,
-        *,
-        class_: Any = None,
-        options: Sequence[sql.ExecutableOption] | None = None,
-    ) -> Any | None:
-        if class_ is None:
-            class_ = BenefitGrant
-
-        query = select(class_).where(class_.id == id)
-        if not allow_deleted:
-            query = query.where(class_.is_deleted.is_(False))
-
-        if loaded:
-            query = query.options(
-                joinedload(BenefitGrant.customer),
-                joinedload(BenefitGrant.benefit).joinedload(Benefit.organization),
-                joinedload(BenefitGrant.member),
-            )
-
-        if options is not None:
-            query = query.options(*options)
-
-        res = await session.execute(query)
-        return res.unique().scalar_one_or_none()
-
+class BenefitGrantService:
     async def list(
         self,
         session: AsyncSession,
@@ -214,7 +157,7 @@ class BenefitGrantService(ResourceServiceReader[BenefitGrant]):
 
         repository = BenefitGrantRepository.from_session(session)
         grant = await repository.get_by_benefit_and_scope(
-            customer, benefit, member=member, **scope
+            customer, benefit, member=member, for_update=True, **scope
         )
 
         if grant is None:
@@ -303,7 +246,7 @@ class BenefitGrantService(ResourceServiceReader[BenefitGrant]):
 
         repository = BenefitGrantRepository.from_session(session)
         grant = await repository.get_by_benefit_and_scope(
-            customer, benefit, member=member, **scope
+            customer, benefit, member=member, for_update=True, **scope
         )
 
         if grant is None:
@@ -739,11 +682,14 @@ class BenefitGrantService(ResourceServiceReader[BenefitGrant]):
         ],
         previous_grant_properties: BenefitGrantProperties,
     ) -> None:
-        loaded = await self.get(session, grant.id, loaded=True)
+        repository = BenefitGrantRepository.from_session(session)
+        loaded = await repository.get_by_id(
+            grant.id, options=repository.get_eager_options()
+        )
         assert loaded is not None
         loaded.previous_properties = previous_grant_properties
         await webhook_service.send(session, benefit.organization, event_type, loaded)
         enqueue_job("customer.state_changed", grant.customer_id)
 
 
-benefit_grant = BenefitGrantService(BenefitGrant)
+benefit_grant = BenefitGrantService()

--- a/server/polar/benefit/tasks.py
+++ b/server/polar/benefit/tasks.py
@@ -5,6 +5,7 @@ from typing import Literal, Unpack
 import structlog
 from dramatiq import Retry
 
+from polar.benefit.grant.repository import BenefitGrantRepository
 from polar.benefit.repository import BenefitRepository
 from polar.customer.repository import CustomerRepository
 from polar.exceptions import PolarTaskError
@@ -192,7 +193,11 @@ async def benefit_revoke(
 
         benefit_repository = BenefitRepository.from_session(session)
         benefit = await benefit_repository.get_by_id(
-            benefit_id, options=benefit_repository.get_eager_options()
+            benefit_id,
+            # It's common for a benefit to be removed from a product and deleted quickly
+            # in a row, so we allow deleted benefits to be processed for revocation tasks
+            include_deleted=True,
+            options=benefit_repository.get_eager_options(),
         )
         if benefit is None:
             if get_message_timestamp() < datetime.datetime(
@@ -248,8 +253,11 @@ async def benefit_revoke(
 @actor(actor_name="benefit.update", priority=TaskPriority.MEDIUM)
 async def benefit_update(benefit_grant_id: uuid.UUID) -> None:
     async with AsyncSessionMaker() as session:
-        benefit_grant = await benefit_grant_service.get(
-            session, benefit_grant_id, loaded=True
+        benefit_grant_repository = BenefitGrantRepository.from_session(session)
+        benefit_grant = await benefit_grant_repository.get_by_id(
+            benefit_grant_id,
+            options=benefit_grant_repository.get_eager_options(),
+            for_update=True,
         )
         if benefit_grant is None:
             raise BenefitGrantDoesNotExist(benefit_grant_id)
@@ -280,8 +288,11 @@ async def enqueue_benefit_grant_cycles(**scope: Unpack[BenefitGrantScopeArgs]) -
 @actor(actor_name="benefit.cycle", priority=TaskPriority.MEDIUM)
 async def benefit_cycle(benefit_grant_id: uuid.UUID) -> None:
     async with AsyncSessionMaker() as session:
-        benefit_grant = await benefit_grant_service.get(
-            session, benefit_grant_id, loaded=True
+        benefit_grant_repository = BenefitGrantRepository.from_session(session)
+        benefit_grant = await benefit_grant_repository.get_by_id(
+            benefit_grant_id,
+            options=benefit_grant_repository.get_eager_options(),
+            for_update=True,
         )
         if benefit_grant is None:
             raise BenefitGrantDoesNotExist(benefit_grant_id)
@@ -331,8 +342,11 @@ async def benefit_revoke_customer(customer_id: uuid.UUID) -> None:
 @actor(actor_name="benefit.delete_grant", priority=TaskPriority.MEDIUM)
 async def benefit_delete_grant(benefit_grant_id: uuid.UUID) -> None:
     async with AsyncSessionMaker() as session:
-        benefit_grant = await benefit_grant_service.get(
-            session, benefit_grant_id, loaded=True
+        benefit_grant_repository = BenefitGrantRepository.from_session(session)
+        benefit_grant = await benefit_grant_repository.get_by_id(
+            benefit_grant_id,
+            options=benefit_grant_repository.get_eager_options(),
+            for_update=True,
         )
         if benefit_grant is None:
             raise BenefitGrantDoesNotExist(benefit_grant_id)

--- a/server/tests/benefit/grant/test_service.py
+++ b/server/tests/benefit/grant/test_service.py
@@ -823,12 +823,8 @@ class TestUpdateBenefitGrant:
         grant.set_granted()
         await save_fixture(grant)
 
-        # load
-        grant_loaded = await benefit_grant_service.get(session, grant.id, loaded=True)
-        assert grant_loaded
-
         updated_grant = await benefit_grant_service.update_benefit_grant(
-            session, redis, grant_loaded
+            session, redis, grant
         )
 
         assert updated_grant.id == grant.id
@@ -858,12 +854,8 @@ class TestUpdateBenefitGrant:
             error_message
         )
 
-        # load
-        grant_loaded = await benefit_grant_service.get(session, grant.id, loaded=True)
-        assert grant_loaded
-
         updated_grant = await benefit_grant_service.update_benefit_grant(
-            session, redis, grant_loaded
+            session, redis, grant
         )
 
         assert not updated_grant.is_granted
@@ -897,11 +889,8 @@ class TestUpdateBenefitGrant:
             error_message, grant_properties=grant_properties
         )
 
-        grant_loaded = await benefit_grant_service.get(session, grant.id, loaded=True)
-        assert grant_loaded
-
         updated_grant = await benefit_grant_service.update_benefit_grant(
-            session, redis, grant_loaded
+            session, redis, grant
         )
 
         assert not updated_grant.is_granted
@@ -1158,12 +1147,8 @@ class TestDeleteBenefitGrant:
         grant.set_granted()
         await save_fixture(grant)
 
-        # load
-        grant_loaded = await benefit_grant_service.get(session, grant.id)
-        assert grant_loaded
-
         updated_grant = await benefit_grant_service.delete_benefit_grant(
-            session, redis, grant_loaded
+            session, redis, grant
         )
 
         assert updated_grant.id == grant.id
@@ -1191,12 +1176,8 @@ class TestDeleteBenefitGrant:
         grant.set_granted()
         await save_fixture(grant)
 
-        # load
-        grant_loaded = await benefit_grant_service.get(session, grant.id)
-        assert grant_loaded
-
         updated_grant = await benefit_grant_service.delete_benefit_grant(
-            session, redis, grant_loaded
+            session, redis, grant
         )
 
         assert updated_grant.id == grant.id
@@ -1250,12 +1231,8 @@ class TestDeleteBenefitGrant:
         await member_repository.soft_delete(member)
         await session.flush()
 
-        # load the grant as the task does
-        grant_loaded = await benefit_grant_service.get(session, grant.id)
-        assert grant_loaded
-
         updated_grant = await benefit_grant_service.delete_benefit_grant(
-            session, redis, grant_loaded
+            session, redis, grant
         )
 
         assert updated_grant.id == grant.id

--- a/server/tests/benefit/strategies/test_license_keys.py
+++ b/server/tests/benefit/strategies/test_license_keys.py
@@ -4,6 +4,7 @@ from uuid import UUID
 import pytest
 from dateutil.relativedelta import relativedelta
 
+from polar.benefit.grant.repository import BenefitGrantRepository
 from polar.benefit.grant.service import benefit_grant as benefit_grant_service
 from polar.benefit.strategies.license_keys.properties import (
     BenefitGrantLicenseKeysProperties,
@@ -122,7 +123,10 @@ class TestGrantExpiration:
         session.add(license_key)
         await session.flush()
 
-        loaded_grant = await benefit_grant_service.get(session, grant.id, loaded=True)
+        benefit_grant_repository = BenefitGrantRepository.from_session(session)
+        loaded_grant = await benefit_grant_repository.get_by_id(
+            grant.id, options=benefit_grant_repository.get_eager_options()
+        )
         assert loaded_grant is not None
         await benefit_grant_service.update_benefit_grant(session, redis, loaded_grant)
 

--- a/server/tests/benefit/test_tasks.py
+++ b/server/tests/benefit/test_tasks.py
@@ -165,6 +165,32 @@ class TestBenefitRevoke:
 
         revoke_benefit_mock.assert_called_once()
 
+    async def test_soft_deleted_benefit(
+        self,
+        mocker: MockerFixture,
+        save_fixture: SaveFixture,
+        subscription: Subscription,
+        customer: Customer,
+        benefit_organization: Benefit,
+        session: AsyncSession,
+    ) -> None:
+        revoke_benefit_mock = mocker.patch.object(
+            benefit_grant_service,
+            "revoke_benefit",
+            spec=BenefitGrantService.revoke_benefit,
+        )
+
+        benefit_organization.set_deleted_at()
+        await save_fixture(benefit_organization)
+
+        await benefit_revoke(
+            customer.id,
+            benefit_organization.id,
+            subscription_id=subscription.id,
+        )
+
+        revoke_benefit_mock.assert_called_once()
+
     async def test_retry(
         self,
         mocker: MockerFixture,


### PR DESCRIPTION

We were still experiencing cases where `benefit.revoke` hits a benefit not found error because it was soft deleted. It can happen because it's quite common to have in a quick succession a benefit removed from a product (triggering `benefit.revoke`) and then a benefit deletion (triggering `benefit.delete_grant`). To avoid that, we now consider soft deleted benefits as valid for revocation.

We also take this occasion to properly acquire rows locks on the grant rows when revoking a benefit, to avoid race conditions with concurrent revocations or deletions.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/polarsource/polar/pull/13688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

