### PR TITLE
fix(customer-portal): require a payment method to resume

### DIFF
--- a/clients/apps/web/src/components/CustomerPortal/CustomerPortalSubscription.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerPortalSubscription.tsx
@@ -74,7 +74,7 @@ const CustomerPortalSubscription = ({
   const pauseSubscription = useCustomerPauseSubscription(api)
   const resumeSubscription = useCustomerResumeSubscription(api)
   const { withPaymentMethod, isPending: paymentMethodsPending } =
-    useRequirePaymentMethod(api, customerSessionToken)
+    useRequirePaymentMethod(api, customerSessionToken, subscription)
 
   const pendingUpdate = subscription.pending_update
   const pendingProduct = products.find(

--- a/clients/apps/web/src/components/CustomerPortal/CustomerPortalSubscription.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/CustomerPortalSubscription.tsx
@@ -9,6 +9,7 @@ import {
   useCustomerResumeSubscription,
   usePortalAuthenticatedUser,
 } from '@/hooks/queries/customerPortal'
+import { useRequirePaymentMethod } from '@/hooks/useRequirePaymentMethod'
 import { extractApiErrorMessage } from '@/utils/api/errors'
 import { hasBillingPermission } from '@/utils/customerPortal'
 import { Client, schemas } from '@polar-sh/client'
@@ -72,6 +73,8 @@ const CustomerPortalSubscription = ({
   const clearPendingUpdate = useCustomerClearPendingSubscriptionUpdate(api)
   const pauseSubscription = useCustomerPauseSubscription(api)
   const resumeSubscription = useCustomerResumeSubscription(api)
+  const { withPaymentMethod, isPending: paymentMethodsPending } =
+    useRequirePaymentMethod(api, customerSessionToken)
 
   const pendingUpdate = subscription.pending_update
   const pendingProduct = products.find(
@@ -128,21 +131,22 @@ const CustomerPortalSubscription = ({
     }
   }
 
-  const handleResume = async () => {
-    try {
-      await resumeSubscription.mutateAsync({ id: subscription.id })
-      router.refresh()
-      toast({
-        title: 'Subscription Resumed',
-        description: 'Your subscription has been resumed.',
-      })
-    } catch (error) {
-      toast({
-        title: 'Error',
-        description: `Failed to resume the subscription: ${extractApiErrorMessage(error as Record<string, unknown>)}`,
-      })
-    }
-  }
+  const handleResume = async () =>
+    withPaymentMethod(async () => {
+      try {
+        await resumeSubscription.mutateAsync({ id: subscription.id })
+        router.refresh()
+        toast({
+          title: 'Subscription Resumed',
+          description: 'Your subscription has been resumed.',
+        })
+      } catch (error) {
+        toast({
+          title: 'Error',
+          description: `Failed to resume the subscription: ${extractApiErrorMessage(error as Record<string, unknown>)}`,
+        })
+      }
+    })
 
   return (
     <div className="flex flex-col gap-8">
@@ -303,7 +307,8 @@ const CustomerPortalSubscription = ({
                 variant="secondary"
                 fullWidth
                 onClick={handleResume}
-                loading={resumeSubscription.isPending}
+                loading={resumeSubscription.isPending || paymentMethodsPending}
+                disabled={resumeSubscription.isPending || paymentMethodsPending}
                 aria-label="Resume subscription"
               >
                 Resume Subscription

--- a/clients/apps/web/src/components/CustomerPortal/UncancelSubscriptionButton.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/UncancelSubscriptionButton.tsx
@@ -19,7 +19,7 @@ const UncancelSubscriptionButton = ({
 }) => {
   const uncancelSubscription = useCustomerUncancelSubscription(api)
   const { withPaymentMethod, isPending: paymentMethodsPending } =
-    useRequirePaymentMethod(api, customerSessionToken)
+    useRequirePaymentMethod(api, customerSessionToken, subscription)
 
   const uncancel = async () => {
     const { error } = await uncancelSubscription.mutateAsync({

--- a/clients/apps/web/src/components/CustomerPortal/UncancelSubscriptionButton.tsx
+++ b/clients/apps/web/src/components/CustomerPortal/UncancelSubscriptionButton.tsx
@@ -1,15 +1,10 @@
 'use client'
 
 import { toast } from '@/components/Toast/use-toast'
-import {
-  useCustomerPaymentMethods,
-  useCustomerUncancelSubscription,
-} from '@/hooks/queries/customerPortal'
-import { PolarEmbedPaymentMethod } from '@polar-sh/checkout/payment-method'
+import { useCustomerUncancelSubscription } from '@/hooks/queries/customerPortal'
+import { useRequirePaymentMethod } from '@/hooks/useRequirePaymentMethod'
 import type { Client, schemas } from '@polar-sh/client'
 import { Button } from '@polar-sh/orbit'
-import { useQueryClient } from '@tanstack/react-query'
-import { useTheme } from 'next-themes'
 
 const UncancelSubscriptionButton = ({
   api,
@@ -22,11 +17,9 @@ const UncancelSubscriptionButton = ({
   customerSessionToken: string
   onUncancelled: () => Promise<void>
 }) => {
-  const theme = useTheme()
-  const queryClient = useQueryClient()
   const uncancelSubscription = useCustomerUncancelSubscription(api)
-  const { data: paymentMethods, isPending: paymentMethodsPending } =
-    useCustomerPaymentMethods(api)
+  const { withPaymentMethod, isPending: paymentMethodsPending } =
+    useRequirePaymentMethod(api, customerSessionToken)
 
   const uncancel = async () => {
     const { error } = await uncancelSubscription.mutateAsync({
@@ -46,27 +39,9 @@ const UncancelSubscriptionButton = ({
     await onUncancelled()
   }
 
-  const onClick = async () => {
-    if (paymentMethods && paymentMethods.items.length > 0) {
-      await uncancel()
-      return
-    }
-
-    const embed = await PolarEmbedPaymentMethod.create({
-      sessionToken: customerSessionToken,
-      theme: theme.resolvedTheme === 'dark' ? 'dark' : 'light',
-    })
-    embed.addEventListener('success', async () => {
-      await queryClient.invalidateQueries({
-        queryKey: ['customer_payment_methods'],
-      })
-      await uncancel()
-    })
-  }
-
   return (
     <Button
-      onClick={onClick}
+      onClick={() => withPaymentMethod(uncancel)}
       loading={uncancelSubscription.isPending || paymentMethodsPending}
       disabled={uncancelSubscription.isPending || paymentMethodsPending}
     >

--- a/clients/apps/web/src/hooks/useRequirePaymentMethod.ts
+++ b/clients/apps/web/src/hooks/useRequirePaymentMethod.ts
@@ -5,10 +5,6 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useTheme } from 'next-themes'
 import { useCallback } from 'react'
 
-/**
- * Runs an action that will charge the customer, asking for a card first when
- * none is on file.
- */
 export const useRequirePaymentMethod = (
   api: Client,
   customerSessionToken: string,

--- a/clients/apps/web/src/hooks/useRequirePaymentMethod.ts
+++ b/clients/apps/web/src/hooks/useRequirePaymentMethod.ts
@@ -1,0 +1,42 @@
+import { useCustomerPaymentMethods } from '@/hooks/queries/customerPortal'
+import { PolarEmbedPaymentMethod } from '@polar-sh/checkout/payment-method'
+import type { Client } from '@polar-sh/client'
+import { useQueryClient } from '@tanstack/react-query'
+import { useTheme } from 'next-themes'
+import { useCallback } from 'react'
+
+/**
+ * Runs an action that will charge the customer, asking for a card first when
+ * none is on file.
+ */
+export const useRequirePaymentMethod = (
+  api: Client,
+  customerSessionToken: string,
+) => {
+  const theme = useTheme()
+  const queryClient = useQueryClient()
+  const { data: paymentMethods, isPending } = useCustomerPaymentMethods(api)
+
+  const withPaymentMethod = useCallback(
+    async (action: () => Promise<void>) => {
+      if (paymentMethods && paymentMethods.items.length > 0) {
+        await action()
+        return
+      }
+
+      const embed = await PolarEmbedPaymentMethod.create({
+        sessionToken: customerSessionToken,
+        theme: theme.resolvedTheme === 'dark' ? 'dark' : 'light',
+      })
+      embed.addEventListener('success', async () => {
+        await queryClient.invalidateQueries({
+          queryKey: ['customer_payment_methods'],
+        })
+        await action()
+      })
+    },
+    [paymentMethods, customerSessionToken, theme.resolvedTheme, queryClient],
+  )
+
+  return { withPaymentMethod, isPending }
+}

--- a/clients/apps/web/src/hooks/useRequirePaymentMethod.ts
+++ b/clients/apps/web/src/hooks/useRequirePaymentMethod.ts
@@ -1,6 +1,7 @@
 import { useCustomerPaymentMethods } from '@/hooks/queries/customerPortal'
+import { isFreePrice } from '@/utils/product'
 import { PolarEmbedPaymentMethod } from '@polar-sh/checkout/payment-method'
-import type { Client } from '@polar-sh/client'
+import type { Client, schemas } from '@polar-sh/client'
 import { useQueryClient } from '@tanstack/react-query'
 import { useTheme } from 'next-themes'
 import { useCallback } from 'react'
@@ -8,14 +9,17 @@ import { useCallback } from 'react'
 export const useRequirePaymentMethod = (
   api: Client,
   customerSessionToken: string,
+  subscription: schemas['CustomerSubscription'],
 ) => {
   const theme = useTheme()
   const queryClient = useQueryClient()
   const { data: paymentMethods, isPending } = useCustomerPaymentMethods(api)
 
+  const required = !subscription.prices.every(isFreePrice)
+
   const withPaymentMethod = useCallback(
     async (action: () => Promise<void>) => {
-      if (paymentMethods && paymentMethods.items.length > 0) {
+      if (!required || (paymentMethods && paymentMethods.items.length > 0)) {
         await action()
         return
       }
@@ -31,8 +35,14 @@ export const useRequirePaymentMethod = (
         await action()
       })
     },
-    [paymentMethods, customerSessionToken, theme.resolvedTheme, queryClient],
+    [
+      required,
+      paymentMethods,
+      customerSessionToken,
+      theme.resolvedTheme,
+      queryClient,
+    ],
   )
 
-  return { withPaymentMethod, isPending }
+  return { withPaymentMethod, isPending: required && isPending }
 }

--- a/clients/packages/client/src/v1.ts
+++ b/clients/packages/client/src/v1.ts
@@ -29835,6 +29835,17 @@ export interface components {
       /** Detail */
       detail: string
     }
+    /** PaymentMethodRequired */
+    PaymentMethodRequired: {
+      /**
+       * Error
+       * @example PaymentMethodRequired
+       * @constant
+       */
+      error: 'PaymentMethodRequired'
+      /** Detail */
+      detail: string
+    }
     /** PaymentMethodSetupFailed */
     PaymentMethodSetupFailed: {
       /**
@@ -35928,17 +35939,6 @@ export interface components {
        * @constant
        */
       error: 'Unauthorized'
-      /** Detail */
-      detail: string
-    }
-    /** UncancelWithoutPaymentMethod */
-    UncancelWithoutPaymentMethod: {
-      /**
-       * Error
-       * @example UncancelWithoutPaymentMethod
-       * @constant
-       */
-      error: 'UncancelWithoutPaymentMethod'
       /** Detail */
       detail: string
     }
@@ -51853,13 +51853,13 @@ export interface operations {
           'application/json': components['schemas']['ResourceNotFound']
         }
       }
-      /** @description The subscription has no payment method to renew with. */
+      /** @description The subscription has no payment method to charge. */
       409: {
         headers: {
           [name: string]: unknown
         }
         content: {
-          'application/json': components['schemas']['UncancelWithoutPaymentMethod']
+          'application/json': components['schemas']['PaymentMethodRequired']
         }
       }
       /** @description Validation Error */

--- a/server/polar/customer_portal/endpoints/subscription.py
+++ b/server/polar/customer_portal/endpoints/subscription.py
@@ -35,8 +35,8 @@ from ..schemas.subscription import (
 from ..service.subscription import (
     CustomerSubscriptionSortProperty,
     PauseResumeNotAllowed,
+    PaymentMethodRequired,
     RevokeNotAllowed,
-    UncancelWithoutPaymentMethod,
     UpdateSubscriptionPlanNotAllowed,
     UpdateSubscriptionSeatsNotAllowed,
 )
@@ -236,8 +236,8 @@ async def preview_change(
         },
         404: SubscriptionNotFound,
         409: {
-            "description": "The subscription has no payment method to renew with.",
-            "model": UncancelWithoutPaymentMethod.schema(),
+            "description": "The subscription has no payment method to charge.",
+            "model": PaymentMethodRequired.schema(),
         },
     },
 )

--- a/server/polar/customer_portal/service/subscription.py
+++ b/server/polar/customer_portal/service/subscription.py
@@ -294,6 +294,19 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
                 allowed_visibilities=frozenset({Visibility.public}),
             )
 
+    async def resume(
+        self,
+        session: AsyncSession,
+        subscription: Subscription,
+    ) -> Subscription:
+        if subscription.can_resume():
+            await self._require_payment_method(session, subscription, "resuming")
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            return await subscription_service.resume(session, ctx, subscription)
+
     async def uncancel(
         self,
         session: AsyncSession,
@@ -310,19 +323,6 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
                 ctx,
                 subscription,
             )
-
-    async def resume(
-        self,
-        session: AsyncSession,
-        subscription: Subscription,
-    ) -> Subscription:
-        if subscription.can_resume():
-            await self._require_payment_method(session, subscription, "resuming")
-
-        async with SubscriptionUpdateContext(
-            session, subscription, subscription_service
-        ) as ctx:
-            return await subscription_service.resume(session, ctx, subscription)
 
     async def cancel(
         self,

--- a/server/polar/customer_portal/service/subscription.py
+++ b/server/polar/customer_portal/service/subscription.py
@@ -68,10 +68,10 @@ class RevokeNotAllowed(CustomerSubscriptionError):
         )
 
 
-class UncancelWithoutPaymentMethod(CustomerSubscriptionError):
-    def __init__(self) -> None:
+class PaymentMethodRequired(CustomerSubscriptionError):
+    def __init__(self, action: str) -> None:
         super().__init__(
-            "Add a payment method before uncancelling this subscription.",
+            f"Add a payment method before {action} this subscription.",
             409,
         )
 
@@ -233,10 +233,7 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
             if not organization.customer_portal_subscription_pause:
                 raise PauseResumeNotAllowed()
 
-            async with SubscriptionUpdateContext(
-                session, subscription, subscription_service
-            ) as ctx:
-                return await subscription_service.resume(session, ctx, subscription)
+            return await self.resume(session, subscription)
 
         cancel = updates.cancel_at_period_end is True
         uncancel = updates.cancel_at_period_end is False
@@ -303,11 +300,7 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
         subscription: Subscription,
     ) -> Subscription:
         if subscription.can_uncancel():
-            payment_method = await payment_method_service.get_customer_payment_method(
-                session, subscription.customer
-            )
-            if payment_method is None:
-                raise UncancelWithoutPaymentMethod()
+            await self._require_payment_method(session, subscription, "uncancelling")
 
         async with SubscriptionUpdateContext(
             session, subscription, subscription_service
@@ -317,6 +310,19 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
                 ctx,
                 subscription,
             )
+
+    async def resume(
+        self,
+        session: AsyncSession,
+        subscription: Subscription,
+    ) -> Subscription:
+        if subscription.can_resume():
+            await self._require_payment_method(session, subscription, "resuming")
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            return await subscription_service.resume(session, ctx, subscription)
 
     async def cancel(
         self,
@@ -364,6 +370,15 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
                 customer_reason=reason,
                 customer_comment=comment,
             )
+
+    async def _require_payment_method(
+        self, session: AsyncSession, subscription: Subscription, action: str
+    ) -> None:
+        payment_method = await payment_method_service.get_customer_payment_method(
+            session, subscription.customer
+        )
+        if payment_method is None:
+            raise PaymentMethodRequired(action)
 
     def _get_readable_subscription_statement(
         self, auth_subject: AuthSubject[Customer | Member]

--- a/server/polar/customer_portal/service/subscription.py
+++ b/server/polar/customer_portal/service/subscription.py
@@ -374,6 +374,9 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
     async def _require_payment_method(
         self, session: AsyncSession, subscription: Subscription, action: str
     ) -> None:
+        if all(price.is_free for price in subscription.prices):
+            return
+
         payment_method = await payment_method_service.get_customer_payment_method(
             session, subscription.customer
         )

--- a/server/polar/customer_portal/service/subscription.py
+++ b/server/polar/customer_portal/service/subscription.py
@@ -299,7 +299,10 @@ class CustomerSubscriptionService(ResourceServiceReader[Subscription]):
         session: AsyncSession,
         subscription: Subscription,
     ) -> Subscription:
-        if subscription.can_resume():
+        if (
+            subscription.can_resume()
+            and subscription.organization.can_renew_subscriptions
+        ):
             await self._require_payment_method(session, subscription, "resuming")
 
         async with SubscriptionUpdateContext(

--- a/server/tests/customer_portal/service/test_subscription.py
+++ b/server/tests/customer_portal/service/test_subscription.py
@@ -611,6 +611,41 @@ class TestUpdatePause:
 
         assert updated.status == SubscriptionStatus.active
 
+    async def test_resume_without_payment_method_renewals_disabled(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        organization.customer_portal_settings = {
+            **organization.customer_portal_settings,
+            "subscription": {
+                **organization.customer_portal_settings["subscription"],
+                "pause": True,
+            },
+        }
+        organization.capabilities = {
+            **organization.capabilities,
+            "subscription_renewals": False,
+        }
+        await save_fixture(organization)
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+
+        updated = await customer_subscription_service.update(
+            session,
+            subscription,
+            updates=CustomerSubscriptionResume(resume=True),
+        )
+
+        assert updated.status == SubscriptionStatus.paused
+
     async def test_resume_allowed(
         self,
         session: AsyncSession,

--- a/server/tests/customer_portal/service/test_subscription.py
+++ b/server/tests/customer_portal/service/test_subscription.py
@@ -14,6 +14,7 @@ from polar.customer_portal.schemas.subscription import (
 )
 from polar.customer_portal.service.subscription import (
     PauseResumeNotAllowed,
+    PaymentMethodRequired,
     UpdateSubscriptionPlanNotAllowed,
     UpdateSubscriptionSeatsNotAllowed,
 )
@@ -38,6 +39,7 @@ from tests.fixtures.auth import AuthSubjectFixture
 from tests.fixtures.database import SaveFixture
 from tests.fixtures.random_objects import (
     create_active_subscription,
+    create_payment_method,
     create_product,
     create_subscription,
 )
@@ -548,6 +550,36 @@ class TestUpdatePause:
                 updates=CustomerSubscriptionResume(resume=True),
             )
 
+    async def test_resume_without_payment_method(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        organization.customer_portal_settings = {
+            **organization.customer_portal_settings,
+            "subscription": {
+                **organization.customer_portal_settings["subscription"],
+                "pause": True,
+            },
+        }
+        await save_fixture(organization)
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+
+        with pytest.raises(PaymentMethodRequired):
+            await customer_subscription_service.update(
+                session,
+                subscription,
+                updates=CustomerSubscriptionResume(resume=True),
+            )
+
     async def test_resume_allowed(
         self,
         session: AsyncSession,
@@ -564,6 +596,7 @@ class TestUpdatePause:
             },
         }
         await save_fixture(organization)
+        await create_payment_method(save_fixture, customer)
         subscription = await create_subscription(
             save_fixture,
             product=product,

--- a/server/tests/customer_portal/service/test_subscription.py
+++ b/server/tests/customer_portal/service/test_subscription.py
@@ -580,6 +580,37 @@ class TestUpdatePause:
                 updates=CustomerSubscriptionResume(resume=True),
             )
 
+    async def test_resume_free_subscription_without_payment_method(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        organization: Organization,
+        product_recurring_free_price: Product,
+        customer: Customer,
+    ) -> None:
+        organization.customer_portal_settings = {
+            **organization.customer_portal_settings,
+            "subscription": {
+                **organization.customer_portal_settings["subscription"],
+                "pause": True,
+            },
+        }
+        await save_fixture(organization)
+        subscription = await create_subscription(
+            save_fixture,
+            product=product_recurring_free_price,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+        )
+
+        updated = await customer_subscription_service.update(
+            session,
+            subscription,
+            updates=CustomerSubscriptionResume(resume=True),
+        )
+
+        assert updated.status == SubscriptionStatus.active
+
     async def test_resume_allowed(
         self,
         session: AsyncSession,


### PR DESCRIPTION
## Summary

Followup of https://github.com/polarsource/polar/pull/13664

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a saved payment method to resume or uncancel subscriptions when the plan is paid and renewals are enabled. Previously only uncancel enforced this; the API now returns PaymentMethodRequired (409) instead of UncancelWithoutPaymentMethod.

**Details**
- Introduces `useRequirePaymentMethod` to gate Resume/Uncancel and embed `@polar-sh/checkout/payment-method` when needed.
- Skips the check for free subscriptions and for resume when renewals are disabled.
- Disables buttons and shows loading while checking/adding a payment method.
- Server: adds PaymentMethodRequired and updates 409 to “no payment method to charge.”
- Client SDK `@polar-sh/client`: adds PaymentMethodRequired and maps 409 to it; tests cover resume without/with a method, free plans, and renewals-off.

**Migration**
- Replace handling of UncancelWithoutPaymentMethod with PaymentMethodRequired for 409 responses in customer-portal subscription operations.
- If you pattern-match SDK error types from `@polar-sh/client`, update to PaymentMethodRequired.

<sup>Written for commit 5e47aecbaf619996deac5ca6c31016950560a07d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

