### PR TITLE
fix(subscription): clear a scheduled pause on cancellation

### DIFF
--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -2281,6 +2281,9 @@ class SubscriptionService:
         now = utc_now()
         subscription.canceled_at = now
 
+        subscription.pause_at_period_end = False
+        subscription.resumes_at = None
+
         if customer_reason:
             subscription.customer_cancellation_reason = customer_reason
 

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -2539,6 +2539,29 @@ class TestCancel:
             ) as ctx:
                 await subscription_service.cancel(session, ctx, subscription)
 
+    async def test_clears_scheduled_pause(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+    ) -> None:
+        subscription = await create_active_subscription(
+            save_fixture, product=product, customer=customer
+        )
+        subscription.pause_at_period_end = True
+        subscription.resumes_at = utc_now() + timedelta(days=30)
+        await save_fixture(subscription)
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.cancel(session, ctx, subscription)
+
+        assert updated.cancel_at_period_end is True
+        assert updated.pause_at_period_end is False
+        assert updated.resumes_at is None
+
     async def test_past_due_no_grace_cancels_at_period_end(
         self,
         session: AsyncSession,


### PR DESCRIPTION
A subscription paused then cancelled then uncancelled kept pause_at_period_end set, so it paused at period end instead of renewing.

Closes https://github.com/polarsource/feedback/issues/255

## Summary

**Related Issue**: #<!-- issue number -->

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->

## Why

<!-- Explain why this change is needed -->

## How

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancelling a subscription now clears any scheduled pause so an uncancelled subscription renews at period end. Previously, paused → cancelled → uncancelled kept the scheduled pause and paused instead of renewing.

**Review notes**
- On cancel in `_perform_cancellation`, set pause_at_period_end = False and resumes_at = None.
- Adds a test to assert scheduled pause is cleared on cancellation.
- No migration required; affects new cancellations only.

<sup>Written for commit dafebb9d81ec10ae393df19375f329d6c7b03700. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

