### PR TITLE
fix(subscription): clear an expired discount when resuming

### DIFF
--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -980,17 +980,7 @@ class SubscriptionService:
                     )
                 )
 
-            # Check if discount is still applicable
-            if subscription.discount is not None:
-                # Set discount_applied_at on first use (when discount is actually applied to a cycle)
-                if subscription.discount_applied_at is None:
-                    subscription.discount_applied_at = subscription.current_period_start
-
-                if subscription.discount.is_repetition_expired(
-                    subscription.discount_applied_at,
-                    subscription.current_period_start,
-                ):
-                    subscription.discount = None
+            self._clear_expired_discount(subscription)
 
             await self._create_cycle_billing_entries(session, subscription)
 
@@ -1036,6 +1026,19 @@ class SubscriptionService:
         )
 
         return subscription
+
+    def _clear_expired_discount(self, subscription: Subscription) -> None:
+        if subscription.discount is None:
+            return
+
+        if subscription.discount_applied_at is None:
+            subscription.discount_applied_at = subscription.current_period_start
+
+        if subscription.discount.is_repetition_expired(
+            subscription.discount_applied_at,
+            subscription.current_period_start,
+        ):
+            subscription.discount = None
 
     async def _create_cycle_billing_entries(
         self, session: AsyncSession, subscription: Subscription
@@ -2156,6 +2159,8 @@ class SubscriptionService:
             )
         )
         subscription.initialize_meter_period(now)
+
+        self._clear_expired_discount(subscription)
 
         await self.reset_meters(session, subscription, reset_at=now)
         await self.enqueue_benefits_grants(session, subscription)

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -3233,6 +3233,55 @@ class TestResume:
         )
         assert_hooks_called_once(subscription_hooks, {"updated", "resumed"})
 
+    async def test_expired_discount_is_cleared(
+        self,
+        frozen_time: datetime,
+        mocker: MockerFixture,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        enqueue_job_mock: MagicMock,
+        enqueue_benefits_grants_mock: MagicMock,
+        product: Product,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        discount = await create_discount(
+            save_fixture,
+            type=DiscountType.percentage,
+            basis_points=10_000,
+            duration=DiscountDuration.once,
+            organization=organization,
+        )
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+            discount=discount,
+        )
+        subscription.discount_applied_at = frozen_time - timedelta(days=40)
+        subscription.paused_at = frozen_time - timedelta(days=10)
+        subscription.resumes_at = frozen_time
+        await save_fixture(subscription)
+        mocker.patch.object(subscription_service, "reset_meters")
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.resume(session, ctx, subscription)
+
+        assert updated.discount is None
+
+        billing_entry_repository = BillingEntryRepository.from_session(session)
+        billing_entries = await billing_entry_repository.get_pending_by_subscription(
+            subscription.id
+        )
+        cycle_entries = [
+            entry for entry in billing_entries if entry.type == BillingEntryType.cycle
+        ]
+        assert len(cycle_entries) == 1
+        assert cycle_entries[0].discount is None
+
 
 async def create_event_billing_entry(
     save_fixture: SaveFixture,


### PR DESCRIPTION
## Summary

Closes https://github.com/polarsource/feedback/issues/258

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears expired discounts when resuming a paused subscription to prevent applying lapsed promotions. Previously, resume kept the attached discount even if its repetition had expired; now resume drops it before creating cycle billing entries.

- Centralizes the discount expiry check and uses it in both cycle processing and resume (no behavior change for active cycles).
- Adds a test that resumes a paused subscription with an expired once discount and verifies the cycle billing entry has no discount.
- No migration or API changes.

<sup>Written for commit 3c316d760e3ebfd211d2383fa18853281e53c5a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

