### PR TITLE
fix(subscription): release the scheduler lock when renewals are disabled

### DIFF
--- a/server/polar/subscription/service.py
+++ b/server/polar/subscription/service.py
@@ -884,7 +884,10 @@ class SubscriptionService:
                 subscription_id=subscription.id,
                 organization_id=subscription.organization.id,
             )
-            return subscription
+            repository = SubscriptionRepository.from_session(session)
+            return await repository.update(
+                subscription, update_dict={"scheduler_locked_at": None}
+            )
 
         cycle_at = subscription.current_period_end
         revoke = subscription.cancel_at_period_end
@@ -2139,7 +2142,10 @@ class SubscriptionService:
                 subscription_id=subscription.id,
                 organization_id=subscription.organization.id,
             )
-            return subscription
+            repository = SubscriptionRepository.from_session(session)
+            return await repository.update(
+                subscription, update_dict={"scheduler_locked_at": None}
+            )
 
         now = utc_now()
         subscription.status = SubscriptionStatus.active

--- a/server/tests/subscription/test_service.py
+++ b/server/tests/subscription/test_service.py
@@ -1197,6 +1197,35 @@ class TestApplyUpdate:
 
 @pytest.mark.asyncio
 class TestCycle:
+    async def test_renewals_disabled_releases_scheduler_lock(
+        self,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        organization.capabilities = {
+            **organization.capabilities,
+            "subscription_renewals": False,
+        }
+        await save_fixture(organization)
+        subscription = await create_active_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            scheduler_locked_at=utc_now(),
+        )
+        current_period_end = subscription.current_period_end
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.cycle(session, ctx, subscription)
+
+        assert updated.scheduler_locked_at is None
+        assert updated.current_period_end == current_period_end
+
     @pytest.mark.parametrize("cancel_at_period_end", [False, True])
     @freeze_time("2024-01-15 12:00:00")
     async def test_clamps_meter_reset_to_now_when_cycling_early(
@@ -3184,6 +3213,39 @@ class TestResume:
                 session, subscription, subscription_service
             ) as ctx:
                 await subscription_service.resume(session, ctx, subscription)
+
+    async def test_renewals_disabled_releases_scheduler_lock(
+        self,
+        frozen_time: datetime,
+        session: AsyncSession,
+        save_fixture: SaveFixture,
+        product: Product,
+        customer: Customer,
+        organization: Organization,
+    ) -> None:
+        organization.capabilities = {
+            **organization.capabilities,
+            "subscription_renewals": False,
+        }
+        await save_fixture(organization)
+        subscription = await create_subscription(
+            save_fixture,
+            product=product,
+            customer=customer,
+            status=SubscriptionStatus.paused,
+            scheduler_locked_at=frozen_time,
+        )
+        subscription.resumes_at = frozen_time
+        await save_fixture(subscription)
+
+        async with SubscriptionUpdateContext(
+            session, subscription, subscription_service
+        ) as ctx:
+            updated = await subscription_service.resume(session, ctx, subscription)
+
+        assert updated.scheduler_locked_at is None
+        assert updated.status == SubscriptionStatus.paused
+        assert updated.resumes_at == frozen_time
 
     async def test_valid(
         self,


### PR DESCRIPTION
## Summary

Closes https://github.com/polarsource/feedback/issues/260

<!-- Brief description of what this PR does -->

## What

<!-- Describe what changes you've made -->

## Why

<!-- Explain why this change is needed -->

## How

<!-- Describe the approach you took -->

## Checklist

<!-- Keep PRs small and focused. If your PR is hard to review, consider splitting it. -->

- [ ] This PR addresses a single concern (one bug fix, one feature, one refactor)
- [ ] The diff is reasonably sized and easy to review
- [ ] New functionality is covered by tests
- [ ] Linting and type checking pass (`uv run task lint && uv run task lint_types`)
- [ ] No unrelated changes or drive-by fixes are included


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Releases the subscription scheduler lock when an organization disables renewals. Previously, `cycle` and `resume` returned early and left `scheduler_locked_at` set; now they clear the lock before returning, leaving period boundaries and status unchanged.

**Details**
- In `cycle(...)` and `resume(...)`, when `organization.capabilities["subscription_renewals"]` is `False`, update the subscription to set `scheduler_locked_at=None` before returning.
- Adds tests to confirm the lock is cleared and that `current_period_end`, `status`, and `resumes_at` are unchanged.
- No API or schema changes; no migration required.

<sup>Written for commit e5e60686bb1ddff87e8c4ec84926c7c86e616541. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/polarsource/polar/pull/13693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

